### PR TITLE
fix: add hub label to agent log entries for Cloud Logging visibility

### DIFF
--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -2032,6 +2032,11 @@ func (d *HTTPAgentDispatcher) DispatchAgentRestart(ctx context.Context, agent *s
 	if d.hubEndpoint != "" {
 		resolvedEnv["SCION_HUB_ENDPOINT"] = d.hubEndpoint
 	}
+	// Include hub name so agents can label their Cloud Logging entries with
+	// the hub identity, matching the hub-scoped log query filter (labels.hub).
+	if d.hubName != "" {
+		resolvedEnv["SCION_HUB_NAME"] = d.hubName
+	}
 
 	// Inject canonical workspace sharing mode and git-ness so the broker can
 	// surface them in the container env on the restart path.  Follows the same

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -141,6 +141,7 @@ type HTTPAgentDispatcher struct {
 	authzService      *AuthzService        // Optional authz service for progeny secret verification
 	githubAppMinter   GitHubAppTokenMinter // Optional GitHub App token minter
 	hubEndpoint       string               // Hub endpoint URL for agents to call back
+	hubName           string               // Hub display name for agent log labeling
 	hubID             string               // Hub instance ID for hub-scoped queries
 	devAuthToken      string               // Dev auth token to inject into agent env (dev-auth mode only)
 	transportMinter   TransportTokenMinter // Optional transport token minter for OIDC dispatch
@@ -203,6 +204,13 @@ func (d *HTTPAgentDispatcher) SetTokenGenerator(gen AgentTokenGenerator) {
 // SetHubEndpoint sets the Hub endpoint URL that agents will use to call back.
 func (d *HTTPAgentDispatcher) SetHubEndpoint(endpoint string) {
 	d.hubEndpoint = endpoint
+}
+
+// SetHubName sets the hub display name for agent log labeling.
+// When set, agents receive SCION_HUB_NAME so their Cloud Logging entries
+// carry a "hub" label matching the hub-scoped log query filter.
+func (d *HTTPAgentDispatcher) SetHubName(name string) {
+	d.hubName = name
 }
 
 // SetSecretBackend sets the secret backend for resolving secrets.
@@ -524,6 +532,12 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 	}
 	injectModelEnv(req.ResolvedEnv, agent.AppliedConfig)
 	injectThinkingLevelEnv(req.ResolvedEnv, agent.AppliedConfig)
+
+	// Inject hub name so agents can label their Cloud Logging entries with the
+	// hub identity, matching the hub-scoped log query filter (labels.hub).
+	if d.hubName != "" {
+		req.ResolvedEnv["SCION_HUB_NAME"] = d.hubName
+	}
 
 	// Resolve env vars from Hub storage (user/project/broker scopes) and merge.
 	// Storage env vars fill in keys not already set (with a non-empty value)
@@ -1750,6 +1764,11 @@ func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *sto
 	// brokers. Including it here ensures the broker always has the endpoint.
 	if d.hubEndpoint != "" {
 		resolvedEnv["SCION_HUB_ENDPOINT"] = d.hubEndpoint
+	}
+	// Include hub name so agents can label their Cloud Logging entries with
+	// the hub identity, matching the hub-scoped log query filter (labels.hub).
+	if d.hubName != "" {
+		resolvedEnv["SCION_HUB_NAME"] = d.hubName
 	}
 
 	// Inject canonical workspace sharing mode and git-ness so the broker can

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -4226,3 +4226,202 @@ func TestDispatchFinalizeEnv_NoAsNeededMatches(t *testing.T) {
 		t.Errorf("expected 1 CreateAgentWithGather call, got %d", callCount)
 	}
 }
+
+// TestDispatchAgentStart_IncludesHubName verifies that when hubName is set on
+// the dispatcher, SCION_HUB_NAME is injected into resolvedEnv for DispatchAgentStart.
+func TestDispatchAgentStart_IncludesHubName(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-hubname-start"),
+		Name:     "test-broker",
+		Slug:     "test-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	dispatcher.SetHubName("my-test-hub")
+
+	agent := &store.Agent{
+		ID:              tid("agent-hubname-start"),
+		Name:            "hubname-start-agent",
+		Slug:            "hubname-start-agent",
+		ProjectID:       tid("project-hubname-start"),
+		OwnerID:         tid("user-hubname-start"),
+		RuntimeBrokerID: tid("broker-hubname-start"),
+		AppliedConfig: &store.AgentAppliedConfig{
+			HarnessConfig: "claude",
+		},
+	}
+
+	err := dispatcher.DispatchAgentStart(ctx, agent, "", false)
+	if err != nil {
+		t.Fatalf("DispatchAgentStart failed: %v", err)
+	}
+
+	if !mockClient.startCalled {
+		t.Fatal("expected StartAgent to be called")
+	}
+
+	if mockClient.lastResolvedEnv == nil {
+		t.Fatal("expected resolvedEnv to be non-nil")
+	}
+
+	if got, ok := mockClient.lastResolvedEnv["SCION_HUB_NAME"]; !ok {
+		t.Error("SCION_HUB_NAME missing from resolvedEnv — hubName not injected on start path")
+	} else if got != "my-test-hub" {
+		t.Errorf("SCION_HUB_NAME = %q, want %q", got, "my-test-hub")
+	}
+}
+
+// TestDispatchAgentStart_OmitsHubNameWhenEmpty verifies that when hubName is
+// NOT set on the dispatcher, SCION_HUB_NAME is absent from resolvedEnv.
+func TestDispatchAgentStart_OmitsHubNameWhenEmpty(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-hubname-empty"),
+		Name:     "test-broker",
+		Slug:     "test-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	// No SetHubName call — hubName stays empty.
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+
+	agent := &store.Agent{
+		ID:              tid("agent-hubname-empty"),
+		Name:            "hubname-empty-agent",
+		Slug:            "hubname-empty-agent",
+		ProjectID:       tid("project-hubname-empty"),
+		OwnerID:         tid("user-hubname-empty"),
+		RuntimeBrokerID: tid("broker-hubname-empty"),
+		AppliedConfig: &store.AgentAppliedConfig{
+			HarnessConfig: "claude",
+		},
+	}
+
+	err := dispatcher.DispatchAgentStart(ctx, agent, "", false)
+	if err != nil {
+		t.Fatalf("DispatchAgentStart failed: %v", err)
+	}
+
+	if !mockClient.startCalled {
+		t.Fatal("expected StartAgent to be called")
+	}
+
+	if _, ok := mockClient.lastResolvedEnv["SCION_HUB_NAME"]; ok {
+		t.Error("SCION_HUB_NAME should not be present when hubName is empty")
+	}
+}
+
+// TestDispatchAgentRestart_IncludesHubName verifies that SCION_HUB_NAME is
+// injected into resolvedEnv on the restart path when hubName is set.
+func TestDispatchAgentRestart_IncludesHubName(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-hubname-restart"),
+		Name:     "test-broker",
+		Slug:     "test-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	dispatcher.SetHubName("restart-hub")
+
+	agent := &store.Agent{
+		ID:              tid("agent-hubname-restart"),
+		Name:            "hubname-restart-agent",
+		Slug:            "hubname-restart-agent",
+		ProjectID:       tid("project-hubname-restart"),
+		OwnerID:         tid("user-hubname-restart"),
+		RuntimeBrokerID: tid("broker-hubname-restart"),
+		AppliedConfig:   &store.AgentAppliedConfig{},
+	}
+
+	err := dispatcher.DispatchAgentRestart(ctx, agent)
+	if err != nil {
+		t.Fatalf("DispatchAgentRestart failed: %v", err)
+	}
+
+	if !mockClient.restartCalled {
+		t.Fatal("expected RestartAgent to be called")
+	}
+
+	env := mockClient.lastRestartResolvedEnv
+	if got, ok := env["SCION_HUB_NAME"]; !ok {
+		t.Error("SCION_HUB_NAME missing from restart resolvedEnv — hubName not injected on restart path")
+	} else if got != "restart-hub" {
+		t.Errorf("SCION_HUB_NAME = %q, want %q", got, "restart-hub")
+	}
+}
+
+// TestDispatchAgentCreate_IncludesHubName verifies that SCION_HUB_NAME is
+// injected into the create request's resolvedEnv when hubName is set.
+func TestDispatchAgentCreate_IncludesHubName(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-hubname-create"),
+		Name:     "test-broker",
+		Slug:     "test-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+	dispatcher.SetHubName("create-hub")
+
+	agent := &store.Agent{
+		ID:              tid("agent-hubname-create"),
+		Name:            "hubname-create-agent",
+		Slug:            "hubname-create-agent",
+		ProjectID:       tid("project-hubname-create"),
+		OwnerID:         tid("user-hubname-create"),
+		RuntimeBrokerID: tid("broker-hubname-create"),
+		AppliedConfig: &store.AgentAppliedConfig{
+			HarnessConfig: "claude",
+			Task:          "test task",
+		},
+	}
+
+	err := dispatcher.DispatchAgentCreate(ctx, agent)
+	if err != nil {
+		t.Fatalf("DispatchAgentCreate failed: %v", err)
+	}
+
+	if !mockClient.createCalled {
+		t.Fatal("expected CreateAgent to be called")
+	}
+
+	env := mockClient.lastCreateReq.ResolvedEnv
+	if got, ok := env["SCION_HUB_NAME"]; !ok {
+		t.Error("SCION_HUB_NAME missing from create request resolvedEnv — hubName not injected on create path")
+	} else if got != "create-hub" {
+		t.Errorf("SCION_HUB_NAME = %q, want %q", got, "create-hub")
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2008,6 +2008,11 @@ func (s *Server) CreateAuthenticatedDispatcher() *HTTPAgentDispatcher {
 		slog.Info("Configure via: hub.endpoint in server.yaml or SCION_SERVER_HUB_ENDPOINT env var")
 	}
 
+	// Set Hub name so agent log entries carry the hub label.
+	if s.config.HubName != "" {
+		dispatcher.SetHubName(s.config.HubName)
+	}
+
 	// Pass hub ID and secret backend to dispatcher if configured
 	dispatcher.SetHubID(s.hubID)
 	if s.secretBackend != nil {

--- a/pkg/sciontool/telemetry/gcp_exporter.go
+++ b/pkg/sciontool/telemetry/gcp_exporter.go
@@ -14,6 +14,7 @@ import (
 	mexporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric"
 	texporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/log"
+	scionlog "github.com/GoogleCloudPlatform/scion/pkg/util/logging"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -103,6 +104,9 @@ func NewGCPExporter(config *Config) (*GCPExporter, error) {
 	} else if projectID == "" && legacyProjectID != "" {
 		commonLabels["project_id"] = legacyProjectID
 	}
+	if hubName := os.Getenv("SCION_HUB_NAME"); hubName != "" {
+		commonLabels["hub"] = hubName
+	}
 
 	var loggerOpts []logging.LoggerOption
 	if len(commonLabels) > 0 {
@@ -113,7 +117,7 @@ func NewGCPExporter(config *Config) (*GCPExporter, error) {
 		traceExporter:  traceExp,
 		metricExporter: metricExporter,
 		logClient:      logClient,
-		logger:         logClient.Logger("scion-agents", loggerOpts...),
+		logger:         logClient.Logger(scionlog.AgentLogID, loggerOpts...),
 		projectID:      config.ProjectID,
 		metricsDebug:   config.MetricsDebug,
 	}, nil


### PR DESCRIPTION
Agent logs (scion-agents) were invisible in the diagnostics UI because agent containers did not set a hub label on their Cloud Logging entries. The hub-scoped filter (labels.hub) silently excluded all agent telemetry.

Fix plumbs the hub name from the hub server through the dispatcher to agent containers:

1. **Hub dispatcher** (pkg/hub/httpdispatcher.go): Added hubName field and SetHubName setter. Injects SCION_HUB_NAME into resolved env on all three dispatch paths (create, start, restart).
2. **Hub server** (pkg/hub/server.go): Wires SetHubName from config in CreateAuthenticatedDispatcher.
3. **GCPExporter** (pkg/sciontool/telemetry/gcp_exporter.go): Reads SCION_HUB_NAME and adds it as commonLabels["hub"] so agent Cloud Logging entries carry the hub label. Also replaced hardcoded "scion-agents" with logging.AgentLogID constant.
4. **Tests** (pkg/hub/httpdispatcher_test.go): 4 new tests covering all three dispatch paths plus negative case.

Key files:
- pkg/hub/httpdispatcher.go
- pkg/hub/httpdispatcher_test.go
- pkg/hub/server.go
- pkg/sciontool/telemetry/gcp_exporter.go

Related: ptone/scion branch scion/fix-agent-log-labels