### PR TITLE
docs: add PAGE_TITLES documentation and root AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Scion Repository - Agent Instructions
+
+This is the Scion agent orchestration platform repository. Subdirectories contain domain-specific agent instructions for their respective areas of the codebase.
+
+## Agent Instruction Files
+
+| Path | Domain |
+|------|--------|
+| [`web/AGENTS.md`](web/AGENTS.md) | Web frontend (Lit components, Shoelace, Vite build) |
+| [`docs-site/AGENTS.md`](docs-site/AGENTS.md) | Documentation site |
+
+## Before You Start
+
+- If you are working on **web content**, review `web/AGENTS.md` before making changes.
+- If you are working on the **documentation site**, review `docs-site/AGENTS.md` before making changes.
+- Check the project root `CLAUDE.md` for build commands, architecture notes, and coding conventions.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -167,7 +167,7 @@ All icons use the Shoelace `<sl-icon>` component, which provides [Bootstrap Icon
 
 The `PAGE_TITLES` map in `web/src/components/app-shell.ts` controls the h1 header text displayed on each page. It maps route paths to display titles (e.g. `'/health': 'Health'`).
 
-**When adding a new route, you MUST add an entry to `PAGE_TITLES`.** If a route is missing from this map, the page header will display "Page Not Found" even though the page itself renders correctly. This is a common pitfall — the page works but the header is wrong, which confuses users.
+**When adding a new route, you MUST add an entry to PAGE_TITLES (or handle it in the pattern matches of getPageTitle()).** If a route is missing from both, the page header will display "Page Not Found" even though the page itself renders correctly. This is a common pitfall — the page works but the header is wrong, which confuses users.
 
 ## Key Patterns
 

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -163,6 +163,12 @@ All icons use the Shoelace `<sl-icon>` component, which provides [Bootstrap Icon
 | **Back/Return** | `arrow-left-circle` | Return links |
 | **Recent activity** | `clock-history` | Dashboard activity section |
 
+## Page Title Registration
+
+The `PAGE_TITLES` map in `web/src/components/app-shell.ts` controls the h1 header text displayed on each page. It maps route paths to display titles (e.g. `'/health': 'Health'`).
+
+**When adding a new route, you MUST add an entry to `PAGE_TITLES`.** If a route is missing from this map, the page header will display "Page Not Found" even though the page itself renders correctly. This is a common pitfall — the page works but the header is wrong, which confuses users.
+
 ## Key Patterns
 
 ### Creating Lit Components


### PR DESCRIPTION
Adds documentation to help agents avoid the PAGE_TITLES pitfall:

1. **web/AGENTS.md** - New "Page Title Registration" section documenting the PAGE_TITLES map in app-shell.ts. Notes that new routes MUST be added to this map or the page header shows "Page Not Found".

2. **AGENTS.md** (root) - New index file listing domain-specific agent instruction files (web/AGENTS.md, docs-site/AGENTS.md) and directing agents to review the relevant file before making changes.

Documentation-only, no code changes.

Related: ptone/scion#810