### PR TITLE
fix: add gcp.project_id resource attribute for trace correlation

### DIFF
--- a/pkg/sciontool/telemetry/providers.go
+++ b/pkg/sciontool/telemetry/providers.go
@@ -100,7 +100,7 @@ func buildResource(ctx context.Context) (*resource.Resource, error) {
 			attribute.String("scion.broker", broker),
 		))
 	}
-	if gcpProjectID := os.Getenv("SCION_GCP_PROJECT_ID"); gcpProjectID != "" {
+	if gcpProjectID := os.Getenv(EnvProjectID); gcpProjectID != "" {
 		attrs = append(attrs, resource.WithAttributes(
 			attribute.String("gcp.project_id", gcpProjectID),
 		))

--- a/pkg/sciontool/telemetry/providers.go
+++ b/pkg/sciontool/telemetry/providers.go
@@ -100,6 +100,11 @@ func buildResource(ctx context.Context) (*resource.Resource, error) {
 			attribute.String("scion.broker", broker),
 		))
 	}
+	if gcpProjectID := os.Getenv("SCION_GCP_PROJECT_ID"); gcpProjectID != "" {
+		attrs = append(attrs, resource.WithAttributes(
+			attribute.String("gcp.project_id", gcpProjectID),
+		))
+	}
 	res, err := resource.New(ctx, attrs...)
 	if err != nil {
 		return nil, fmt.Errorf("creating resource: %w", err)


### PR DESCRIPTION
Agent log entries in Cloud Logging have degraded trace correlation - trace IDs appear as raw hex strings instead of clickable Cloud Trace links.

protoLogToCloudEntry() checks for gcp.project_id in OTel resource attributes to build full projects/<id>/traces/<hex> references, but buildResource() never set this attribute despite having the GCP project ID available via SCION_GCP_PROJECT_ID.

Fix adds gcp.project_id to the OTel resource in buildResource().

Single file change: pkg/sciontool/telemetry/providers.go

Related: ptone/scion#818