### PR TITLE
fix: demote broker auth_success log level from Info to Debug

### DIFF
--- a/pkg/hub/audit.go
+++ b/pkg/hub/audit.go
@@ -221,6 +221,8 @@ func (l *LogAuditLogger) LogBrokerAuthEvent(ctx context.Context, event *BrokerAu
 	level := slog.LevelInfo
 	if !event.Success {
 		level = slog.LevelWarn
+	} else if event.EventType == BrokerAuthEventAuthSuccess {
+		level = slog.LevelDebug
 	}
 
 	attrs := []slog.Attr{


### PR DESCRIPTION
Broker auth_success events fire on every broker-authenticated HTTP request (every few seconds per hub), producing high-volume log noise at Info level.

Demotes auth_success to Debug while preserving:
- Warn for auth_failure (security-relevant)
- Info for admin events (register, deregister, join, rotate, revoke, link, unlink)

Single file change: pkg/hub/audit.go

Related: ptone/scion#813