### PR TITLE
fix(agent): guard terminal-state persist behind file-existence check

### DIFF
--- a/pkg/agent/list.go
+++ b/pkg/agent/list.go
@@ -121,7 +121,7 @@ func (m *AgentManager) List(ctx context.Context, filter map[string]string) ([]ap
 				agents[i].Activity = ""
 				// Best-effort convergence: only persist if on-disk state
 				// differs from the terminal phase we want to record.
-				if parsedInfo == nil || parsedInfo.Phase != terminalPhase || parsedInfo.Activity != "" {
+				if parsedInfo != nil && (parsedInfo.Phase != terminalPhase || parsedInfo.Activity != "") {
 					if err := persistAgentInfoState(agentInfoJSON, terminalPhase, ""); err != nil {
 						slog.Debug("failed to persist terminal agent state", "path", agentInfoJSON, "err", err)
 					}


### PR DESCRIPTION
## Summary

Guards terminal-state persist behind a file-existence check in pkg/agent/list.go. Flips the nil check from parsedInfo == nil || to parsedInfo != nil && so the persist only runs when the parsed info file actually exists, eliminating guaranteed-to-fail os.ReadFile calls and debug log noise.

One-line change (+1/-1).

Ref: ptone/scion#811