### PR TITLE
fix(hub): clean up host directory when shared dir is deleted via API

### DIFF
--- a/pkg/hub/handlers_shared_dirs.go
+++ b/pkg/hub/handlers_shared_dirs.go
@@ -183,14 +183,21 @@ func (s *Server) handleProjectSharedDirByName(w http.ResponseWriter, r *http.Req
 		// co-located broker), we log and continue — the DB record is already
 		// removed.
 		resolution, resolveErr := s.resolveSharedDirPath(ctx, project, name)
-		if resolveErr == nil && resolution.IsLocal {
+		switch {
+		case resolveErr != nil:
+			slog.WarnContext(ctx, "could not resolve shared directory host path for cleanup",
+				"project_id", projectID, "name", name, "error", resolveErr)
+		case !resolution.IsLocal:
+			slog.WarnContext(ctx, "shared directory path is not local, skipping host cleanup",
+				"project_id", projectID, "name", name)
+		case resolution.Path == "" || resolution.Path == "/":
+			slog.WarnContext(ctx, "resolved shared directory path is empty or root, skipping removal",
+				"project_id", projectID, "name", name, "path", resolution.Path)
+		default:
 			if removeErr := os.RemoveAll(resolution.Path); removeErr != nil {
 				slog.WarnContext(ctx, "failed to remove shared directory host path",
 					"project_id", projectID, "name", name, "path", resolution.Path, "error", removeErr)
 			}
-		} else if resolveErr != nil {
-			slog.WarnContext(ctx, "could not resolve shared directory host path for cleanup",
-				"project_id", projectID, "name", name, "error", resolveErr)
 		}
 
 		s.events.PublishProjectUpdated(ctx, project)

--- a/pkg/hub/handlers_shared_dirs.go
+++ b/pkg/hub/handlers_shared_dirs.go
@@ -15,7 +15,9 @@
 package hub
 
 import (
+	"log/slog"
 	"net/http"
+	"os"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -172,6 +174,23 @@ func (s *Server) handleProjectSharedDirByName(w http.ResponseWriter, r *http.Req
 		if err := s.store.UpdateProject(ctx, project); err != nil {
 			writeErrorFromErr(w, err, "")
 			return
+		}
+
+		// Best-effort host directory cleanup. The CLI does this via
+		// config.RemoveSharedDir(); the hub resolves the host path through
+		// its co-located broker (or hub-managed project path) and removes
+		// the directory directly. If the path cannot be resolved (e.g. no
+		// co-located broker), we log and continue — the DB record is already
+		// removed.
+		resolution, resolveErr := s.resolveSharedDirPath(ctx, project, name)
+		if resolveErr == nil && resolution.IsLocal {
+			if removeErr := os.RemoveAll(resolution.Path); removeErr != nil {
+				slog.WarnContext(ctx, "failed to remove shared directory host path",
+					"project_id", projectID, "name", name, "path", resolution.Path, "error", removeErr)
+			}
+		} else if resolveErr != nil {
+			slog.WarnContext(ctx, "could not resolve shared directory host path for cleanup",
+				"project_id", projectID, "name", name, "error", resolveErr)
 		}
 
 		s.events.PublishProjectUpdated(ctx, project)


### PR DESCRIPTION
## Summary

The hub API delete handler for shared directories only removed the DB record, leaving the host directory as an orphan. The CLI path correctly called RemoveSharedDir() but the API path did not.

Adds best-effort host directory cleanup to the hub API shared-dir delete handler using the existing resolveSharedDirPath() method. For co-located broker deployments (workstation mode), the path is resolved and removed. For distributed deployments where the path cannot be resolved locally, a warning is logged.

Ref: ptone/scion#821

## Test plan

- go build ./cmd/... passes
- go vet ./pkg/hub/... clean
- go test ./pkg/hub/... -short passes