### PR TITLE
feat(antigravity): add ADC auth support and bump AGY CLI to 1.1.10

### DIFF
--- a/harnesses/antigravity/Dockerfile
+++ b/harnesses/antigravity/Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir -p /home/scion/.gemini/antigravity-cli \
   && chown -R scion:scion /home/scion/.gemini /home/scion/.agents
 
 # Pin the CLI to a specific release version.
-ARG AGY_VERSION=1.1.0
+ARG AGY_VERSION=1.1.10
 
 RUN ARCH=$(case "${TARGETARCH:-amd64}" in amd64) echo "x64";; arm64) echo "arm64";; *) echo "${TARGETARCH}";; esac) \
   && curl -fsSL -o /tmp/cli.tar.gz \

--- a/harnesses/antigravity/config.yaml
+++ b/harnesses/antigravity/config.yaml
@@ -61,6 +61,7 @@ capabilities:
     auth_file: { support: "yes", reason: "Via AGY_TOKEN file secret at ~/.gemini/antigravity-cli/antigravity-oauth-token" }
     oauth_token: { support: "no", reason: "AGY uses file-based OAuth token, not raw token injection" }
     vertex_ai: { support: "yes", reason: "Enterprise/GCP mode via AGY_TOKEN + GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_LOCATION" }
+    adc: { support: "yes", reason: "ADC via AGY_ADC_AUTH env, requires AGY CLI >= 1.1.10" }
 
 no_auth:
   behavior: drop-to-shell
@@ -89,6 +90,20 @@ auth:
           type: file
           description: "Antigravity OAuth token JSON file"
           target_suffix: "/.gemini/antigravity-cli/antigravity-oauth-token"
+    adc:
+      required_env:
+        - any_of: ["GOOGLE_CLOUD_PROJECT"]
+        - any_of: ["GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION"]
+      required_files:
+        - name: gcloud-adc
+          type: file
+          description: "Google Cloud Application Default Credentials (ADC) file for ADC authentication"
+          field: GoogleAppCredentials
+          alternative_env_keys: ["GOOGLE_APPLICATION_CREDENTIALS"]
+          skipped_when_gcp_service_account_assigned: true
+          required: true
   autodetect:
     env:
       AGY_TOKEN: oauth-token
+    files:
+      gcloud-adc: adc

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import subprocess
 import sys
 from typing import Any
 
@@ -56,6 +57,18 @@ AGY_MCP_MAPPING: dict[str, Any] = {
     },
 }
 
+def _get_agy_version() -> tuple[int, ...] | None:
+    """Parse AGY CLI version into a comparable tuple, e.g. (1, 1, 10)."""
+    try:
+        out = subprocess.check_output(
+            ["agy", "--version"], text=True, timeout=5
+        ).strip()
+        parts = out.split(".")
+        return tuple(int(p) for p in parts)
+    except (subprocess.SubprocessError, ValueError):
+        return None
+
+
 ANTIGRAVITY_AUTH = scion_harness.AuthSpec(
     "antigravity",
     [
@@ -65,6 +78,13 @@ ANTIGRAVITY_AUTH = scion_harness.AuthSpec(
             any_of=["GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION"],
             env_fallback=True,
             hint="set AGY_TOKEN, GOOGLE_CLOUD_PROJECT, and GOOGLE_CLOUD_LOCATION",
+        ),
+        scion_harness.env_method(
+            "adc",
+            all_of=["GOOGLE_CLOUD_PROJECT"],
+            any_of=["GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION"],
+            env_fallback=True,
+            hint="set GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION with gcloud-adc file",
         ),
         scion_harness.env_method(
             "oauth-token",
@@ -114,7 +134,44 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     method = resolved.method
 
     has_token = False
-    if method in ("oauth-token", "vertex-ai"):
+    is_adc = False
+    env_overlay: dict[str, str] = {}
+
+    if method == "adc":
+        # ADC auth: validate version and wire ADC environment.
+        ver = _get_agy_version()
+        if ver is None or ver < (1, 1, 10):
+            ver_str = ".".join(str(v) for v in ver) if ver else "unknown"
+            raise scion_harness.ProvisionError(
+                f"ADC auth requires AGY CLI >= 1.1.10, found {ver_str}"
+            )
+        is_adc = True
+        has_token = False
+        env_overlay["AGY_ADC_AUTH"] = "true"
+
+        # Resolve GOOGLE_APPLICATION_CREDENTIALS from staged file secret or env.
+        gac_path = ctx.file_secret_files.get("gcloud-adc")
+        if gac_path:
+            env_overlay["GOOGLE_APPLICATION_CREDENTIALS"] = scion_harness.expand_path(gac_path)
+        else:
+            gac_env = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
+            if gac_env:
+                env_overlay["GOOGLE_APPLICATION_CREDENTIALS"] = gac_env
+
+        # Resolve GCP project/location (same pattern as vertex-ai).
+        project = ctx.read_secret("GOOGLE_CLOUD_PROJECT", env_fallback=True)
+        if project:
+            env_overlay["GOOGLE_CLOUD_PROJECT"] = project
+        location = (
+            ctx.read_secret("GOOGLE_CLOUD_LOCATION", env_fallback=True)
+            or ctx.read_secret("GOOGLE_CLOUD_REGION", env_fallback=True)
+        )
+        if location:
+            env_overlay["GOOGLE_CLOUD_LOCATION"] = location
+
+        ctx.info(f"ADC auth: AGY version {'.'.join(str(v) for v in ver)}")
+
+    elif method in ("oauth-token", "vertex-ai"):
         token_raw = _read_agy_token(ctx)
         if not token_raw:
             oauth_token_path = os.path.join(
@@ -150,7 +207,8 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
             )
         has_token = True
 
-    is_enterprise = method == "vertex-ai"
+    # ADC and vertex-ai are both enterprise/GCP modes.
+    is_enterprise = method in ("vertex-ai", "adc")
 
     instructions_file = ctx.harness_config.get("instructions_file") or "GEMINI.md"
     model = (
@@ -167,8 +225,8 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     else:
         ctx.info(f"model={model} thinking_level=unset (using AGY default)")
 
-    _generate_wrapper_script(ctx.home, has_token, is_enterprise, thinking_tier=thinking_tier)
-    ctx.write_outputs(resolved, env={})
+    _generate_wrapper_script(ctx.home, has_token, is_enterprise, is_adc=is_adc, thinking_tier=thinking_tier)
+    ctx.write_outputs(resolved, env=env_overlay)
     _copy_instructions(ctx.bundle_dir, ctx.home, instructions_file)
     _generate_hooks_json(ctx.home)
     _prestage_onboarding(
@@ -265,6 +323,7 @@ def _generate_hooks_json(home: str) -> None:
 
 def _generate_wrapper_script(
     home: str, has_token: bool, is_enterprise: bool,
+    is_adc: bool = False,
     thinking_tier: str | None = None,
 ) -> None:
     """Generate agy-wrapper.sh that inits keyring and execs AGY.
@@ -280,6 +339,10 @@ def _generate_wrapper_script(
     GCP/enterprise settings are also patched here at runtime for the same
     reason — GOOGLE_CLOUD_PROJECT/GOOGLE_CLOUD_LOCATION and AGY_USE_GCP
     are only available in the child environment.
+
+    When is_adc=True, keyring/DBUS init and token injection are skipped
+    because ADC auth uses GOOGLE_APPLICATION_CREDENTIALS instead of the
+    keyring-based OAuth flow. GCP settings patching still runs.
     """
     secret_path = os.path.join(
         home, ".scion", "harness", "secrets", "AGY_TOKEN"
@@ -295,7 +358,7 @@ def _generate_wrapper_script(
     )
 
     # Enterprise marker: provisioner writes this when explicit vertex-ai
-    # is selected. The wrapper checks both this file and AGY_USE_GCP env.
+    # or adc is selected. The wrapper checks both this file and AGY_USE_GCP env.
     enterprise_marker = os.path.join(
         home, ".scion", "harness", ".enterprise-mode"
     )
@@ -305,14 +368,23 @@ def _generate_wrapper_script(
             f.write("1")
     elif os.path.exists(enterprise_marker):
         # Idempotent reprovision: if the auth mode switched away from
-        # vertex-ai (e.g. to oauth-token), remove the stale marker so the
+        # vertex-ai/adc (e.g. to oauth-token), remove the stale marker so the
         # wrapper does not keep running in enterprise/GCP mode.
         os.remove(enterprise_marker)
 
-    script = f"""#!/bin/bash
-# Generated by antigravity provision.py {PROVISION_VERSION}
-set -e
+    # Build keyring/token injection block — skipped for ADC auth since ADC
+    # uses GOOGLE_APPLICATION_CREDENTIALS, not the keyring-based OAuth flow.
+    if is_adc:
+        keyring_block = """
+# ADC auth: skip keyring/DBUS init and token injection.
+# ADC uses GOOGLE_APPLICATION_CREDENTIALS, not the keyring-based OAuth flow.
+echo "agy-wrapper: ADC auth mode — skipping keyring initialization" >&2
 
+# Export AGY_ADC_AUTH for the AGY process
+export AGY_ADC_AUTH=true
+"""
+    else:
+        keyring_block = f"""
 # Initialize DBUS session bus
 eval $(dbus-launch --sh-syntax)
 export DBUS_SESSION_BUS_ADDRESS
@@ -350,9 +422,14 @@ elif [ -n "${{AGY_TOKEN:-}}" ]; then
 else
     echo "agy-wrapper: no token available, AGY will prompt for login" >&2
 fi
+"""
 
+    script = f"""#!/bin/bash
+# Generated by antigravity provision.py {PROVISION_VERSION}
+set -e
+{keyring_block}
 # GCP/enterprise mode: patch settings.json with gcp block and mark
-# enterprise onboarding complete. Triggered by explicit vertex-ai auth
+# enterprise onboarding complete. Triggered by explicit vertex-ai/adc auth
 # (marker file) or AGY_USE_GCP=true env var.
 _use_gcp=false
 if [ -f "{enterprise_marker}" ]; then

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -146,7 +146,6 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
                 f"ADC auth requires AGY CLI >= 1.1.10, found {ver_str}"
             )
         is_adc = True
-        has_token = False
         env_overlay["AGY_ADC_AUTH"] = "true"
 
         # Resolve GOOGLE_APPLICATION_CREDENTIALS from staged file secret or env.
@@ -380,7 +379,9 @@ def _generate_wrapper_script(
 # ADC uses GOOGLE_APPLICATION_CREDENTIALS, not the keyring-based OAuth flow.
 echo "agy-wrapper: ADC auth mode — skipping keyring initialization" >&2
 
-# Export AGY_ADC_AUTH for the AGY process
+# Export AGY_ADC_AUTH for the AGY process. Belt-and-suspenders: env_overlay
+# sets this via env.json, but we also export it here as a backup so the
+# variable is guaranteed present even if env.json injection is skipped.
 export AGY_ADC_AUTH=true
 """
     else:


### PR DESCRIPTION
Add Application Default Credentials (ADC) as a new auth type for the antigravity harness, and bump the AGY CLI from 1.1.0 to 1.1.10 (which introduced ADC support).

ADC is a completely independent auth path from the existing keyring/OAuth flow — it uses the AGY_ADC_AUTH env var and standard Google Cloud credentials (application_default_credentials.json) instead of requiring an AGY_TOKEN.

Changes:
- Dockerfile: bump AGY_VERSION from 1.1.0 to 1.1.10
- config.yaml: add adc auth type with gcloud-adc file requirement, autodetect entry, capability
- provision.py: add _get_agy_version() runtime check (>= 1.1.10), adc method to AuthSpec, ADC handling with AGY_ADC_AUTH=true env overlay and GOOGLE_APPLICATION_CREDENTIALS resolution, wrapper script skips keyring/DBUS for ADC while keeping GCP settings patching

Auth method precedence: vertex-ai (requires AGY_TOKEN + project) > adc (requires gcloud-adc + project) > oauth-token (requires AGY_TOKEN only). Users who want ADC simply don't stage AGY_TOKEN.

No breaking changes between AGY 1.1.0 and 1.1.10. Existing oauth-token and vertex-ai auth paths are unchanged.

Ref: ptone/scion#823
