### PR TITLE
fix(telemetry): remove grove labels and deduplicate Cloud Logging labels

### DIFF
--- a/pkg/sciontool/telemetry/gcp_exporter.go
+++ b/pkg/sciontool/telemetry/gcp_exporter.go
@@ -85,25 +85,10 @@ func NewGCPExporter(config *Config) (*GCPExporter, error) {
 		metricExporter = newDebugMetricExporter(metricExporter)
 	}
 
-	// Build common labels for agent identification
+	// Build common labels for agent identification.
+	// Most identifiers are carried as OTel resource attributes (see providers.go);
+	// only hub has no resource-attribute equivalent.
 	commonLabels := map[string]string{}
-	if agentID := os.Getenv("SCION_AGENT_ID"); agentID != "" {
-		commonLabels["agent_id"] = agentID
-	}
-	legacyProjectID := os.Getenv("SCION_GROVE_ID")
-	projectID := os.Getenv("SCION_PROJECT_ID")
-	if legacyProjectID != "" {
-		commonLabels["grove_id"] = legacyProjectID
-	}
-	if projectID != "" {
-		commonLabels["project_id"] = projectID
-	}
-	// Ensure both are set if either is available for transition
-	if legacyProjectID == "" && projectID != "" {
-		commonLabels["grove_id"] = projectID
-	} else if projectID == "" && legacyProjectID != "" {
-		commonLabels["project_id"] = legacyProjectID
-	}
 	if hubName := os.Getenv("SCION_HUB_NAME"); hubName != "" {
 		commonLabels["hub"] = hubName
 	}

--- a/pkg/sciontool/telemetry/providers.go
+++ b/pkg/sciontool/telemetry/providers.go
@@ -63,6 +63,11 @@ func buildResource(ctx context.Context) (*resource.Resource, error) {
 	if agentID := os.Getenv("SCION_AGENT_ID"); agentID != "" {
 		attrs = append(attrs, resource.WithAttributes(semconv.ServiceInstanceID(agentID)))
 	}
+	if agentSlug := os.Getenv("SCION_AGENT_SLUG"); agentSlug != "" {
+		attrs = append(attrs, resource.WithAttributes(
+			attribute.String("scion.agent.slug", agentSlug),
+		))
+	}
 	projectID := os.Getenv("SCION_PROJECT_ID")
 	if projectID == "" {
 		projectID = os.Getenv("SCION_GROVE_ID") // fallback for older dispatchers

--- a/pkg/sciontool/telemetry/providers.go
+++ b/pkg/sciontool/telemetry/providers.go
@@ -63,26 +63,13 @@ func buildResource(ctx context.Context) (*resource.Resource, error) {
 	if agentID := os.Getenv("SCION_AGENT_ID"); agentID != "" {
 		attrs = append(attrs, resource.WithAttributes(semconv.ServiceInstanceID(agentID)))
 	}
-	legacyProjectID := os.Getenv("SCION_GROVE_ID")
 	projectID := os.Getenv("SCION_PROJECT_ID")
-	if legacyProjectID != "" {
-		attrs = append(attrs, resource.WithAttributes(
-			attribute.String("scion.grove.id", legacyProjectID),
-		))
+	if projectID == "" {
+		projectID = os.Getenv("SCION_GROVE_ID") // fallback for older dispatchers
 	}
 	if projectID != "" {
 		attrs = append(attrs, resource.WithAttributes(
 			attribute.String("scion.project.id", projectID),
-		))
-	}
-	// Ensure both are set if either is available for transition
-	if legacyProjectID == "" && projectID != "" {
-		attrs = append(attrs, resource.WithAttributes(
-			attribute.String("scion.grove.id", projectID),
-		))
-	} else if projectID == "" && legacyProjectID != "" {
-		attrs = append(attrs, resource.WithAttributes(
-			attribute.String("scion.project.id", legacyProjectID),
 		))
 	}
 	if harness := os.Getenv("SCION_HARNESS"); harness != "" {


### PR DESCRIPTION
Agent Cloud Logging entries had 4 copies of the project ID and 2 copies of the agent ID across commonLabels and OTel resource attributes. Also carried legacy "grove" naming.

Changes:
- gcp_exporter.go: Removed agent_id, grove_id, project_id from commonLabels. Only hub remains (no resource-attr equivalent).
- providers.go: Removed scion.grove.id resource attribute and dual-set transition logic. SCION_GROVE_ID still read as fallback for older dispatchers but only emits the canonical scion.project.id.

Final label set (no duplicates): hub, scion.project.id, scion.broker, scion.harness, scion.model, service.name, service.instance.id, gcp.project_id, trace_id

Net: -33 lines, +5 lines.

Related: ptone/scion#827