### PR TITLE
fix(schema): add adc to harness auth type enums

### DIFF
--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -305,8 +305,8 @@
         },
         "auth_selected_type": {
           "type": "string",
-          "enum": ["api-key", "oauth-token", "auth-file", "vertex-ai", "none"],
-          "description": "Authentication mechanism to use (e.g., api-key, oauth-token, vertex-ai, auth-file, none)."
+          "enum": ["api-key", "oauth-token", "auth-file", "vertex-ai", "adc", "none"],
+          "description": "Authentication mechanism to use (e.g., api-key, oauth-token, vertex-ai, auth-file, adc, none)."
         },
         "secrets": {
           "type": "array",
@@ -549,7 +549,8 @@
             "api_key": { "$ref": "#/$defs/capabilityField" },
             "auth_file": { "$ref": "#/$defs/capabilityField" },
             "oauth_token": { "$ref": "#/$defs/capabilityField" },
-            "vertex_ai": { "$ref": "#/$defs/capabilityField" }
+            "vertex_ai": { "$ref": "#/$defs/capabilityField" },
+            "adc": { "$ref": "#/$defs/capabilityField" }
           },
           "additionalProperties": false
         },
@@ -572,7 +573,7 @@
       "properties": {
         "default_type": {
           "type": "string",
-          "enum": ["api-key", "oauth-token", "auth-file", "vertex-ai"]
+          "enum": ["api-key", "oauth-token", "auth-file", "vertex-ai", "adc"]
         },
         "types": {
           "type": "object",
@@ -631,14 +632,14 @@
           "type": "object",
           "additionalProperties": {
             "type": "string",
-            "enum": ["api-key", "oauth-token", "auth-file", "vertex-ai"]
+            "enum": ["api-key", "oauth-token", "auth-file", "vertex-ai", "adc"]
           }
         },
         "files": {
           "type": "object",
           "additionalProperties": {
             "type": "string",
-            "enum": ["api-key", "oauth-token", "auth-file", "vertex-ai"]
+            "enum": ["api-key", "oauth-token", "auth-file", "vertex-ai", "adc"]
           }
         }
       },
@@ -702,7 +703,7 @@
         "resources": { "$ref": "#/$defs/resourceSpec" },
         "auth_selected_type": {
           "type": "string",
-          "enum": ["api-key", "oauth-token", "auth-file", "vertex-ai"]
+          "enum": ["api-key", "oauth-token", "auth-file", "vertex-ai", "adc"]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
P0 CI fix — PR #1047 (antigravity ADC auth) added adc as a new harness auth type but did not update the JSON schema validation enums in settings-v1.schema.json. This causes TestBundleInstall_Antigravity to fail, breaking Build & Test on every PR against main.

Fix: add "adc" to all six auth-type enum/property locations in settings-v1.schema.json:
- auth_selected_type enum (2 locations)
- capabilities.auth properties
- harnessAuthMetadata.default_type enum
- harnessAuthAutodetect.env additionalProperties enum
- harnessAuthAutodetect.files additionalProperties enum

Tests verified: TestBundleInstall_Antigravity, pkg/config, pkg/harness all pass.

Ref: ptone/scion#828
