### PR TITLE
fix(plugin): resolve RPC bootstrap race condition on broker restart

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -231,7 +231,11 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 			b.sendQueue = nil
 			b.subs = make(map[string]bool)
 			b.gatewayConnected = false
-			b.bootstrapDone = false // allow bootstrap to re-run
+			b.bootstrapDone = false
+			// Release lock while closing old resources — session.Close() sleeps
+			// for 1s internally, and store/sendQueue may block on cleanup.
+			// Matches the pattern in Close() (lines 802-831).
+			b.mu.Unlock()
 			if closeErr := oldSession.Close(); closeErr != nil {
 				b.log.Warn("Failed to close old discord session on reconfigure", "error", closeErr)
 			}
@@ -243,6 +247,7 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 					b.log.Warn("Failed to close old store on reconfigure", "error", closeErr)
 				}
 			}
+			b.mu.Lock()
 		}
 
 		// Create a discordgo session but do NOT open the gateway yet.
@@ -410,6 +415,7 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 		// Host callbacks are wired after Configure() returns, so we defer
 		// the request in a goroutine that retries until they're available.
 		if !b.bootstrapDone {
+			b.bootstrapDone = true // set immediately to prevent duplicate goroutines
 			go func() {
 				for i := 0; i < 20; i++ {
 					time.Sleep(500 * time.Millisecond)
@@ -423,13 +429,14 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 						b.log.Warn("Failed to request bootstrap subscription", "error", err)
 						continue
 					}
-					b.mu.Lock()
-					b.bootstrapDone = true
-					b.mu.Unlock()
 					b.log.Info("Requested bootstrap subscription for Discord Gateway")
 					return
 				}
 				b.log.Error("Bootstrap subscription timed out — host callbacks never became available")
+				// Reset flag so a future Configure can retry bootstrap.
+				b.mu.Lock()
+				b.bootstrapDone = false
+				b.mu.Unlock()
 			}()
 		}
 	}

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -220,16 +220,29 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 	// Phase 1: Bot token configuration.
 	botToken, hasBotToken := config["bot_token"]
 	if hasBotToken && botToken != "" {
-		// Close old session if one exists (handles Restart/reconfigure).
+		// Close old session, store, and sendQueue if they exist (handles Restart/reconfigure).
 		// Clearing subs ensures Subscribe("*") triggers startGateway() on the new session.
 		if b.session != nil {
 			oldSession := b.session
+			oldStore := b.store
+			oldSendQueue := b.sendQueue
 			b.session = nil
+			b.store = nil
+			b.sendQueue = nil
 			b.subs = make(map[string]bool)
 			b.gatewayConnected = false
 			b.bootstrapDone = false // allow bootstrap to re-run
-			// session.Close() is safe to call under lock — it just closes the websocket.
-			_ = oldSession.Close()
+			if closeErr := oldSession.Close(); closeErr != nil {
+				b.log.Warn("Failed to close old discord session on reconfigure", "error", closeErr)
+			}
+			if oldSendQueue != nil {
+				oldSendQueue.Close()
+			}
+			if oldStore != nil {
+				if closeErr := oldStore.Close(); closeErr != nil {
+					b.log.Warn("Failed to close old store on reconfigure", "error", closeErr)
+				}
+			}
 		}
 
 		// Create a discordgo session but do NOT open the gateway yet.

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -155,6 +155,7 @@ type DiscordBroker struct {
 	webhooks  *WebhookManager
 
 	gatewayConnected bool // set true in handleReady, false on disconnect
+	bootstrapDone    bool // set true after first successful bootstrap subscription
 
 	threadParents map[string]string // channelID -> parentID (cached thread lookups)
 
@@ -219,6 +220,18 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 	// Phase 1: Bot token configuration.
 	botToken, hasBotToken := config["bot_token"]
 	if hasBotToken && botToken != "" {
+		// Close old session if one exists (handles Restart/reconfigure).
+		// Clearing subs ensures Subscribe("*") triggers startGateway() on the new session.
+		if b.session != nil {
+			oldSession := b.session
+			b.session = nil
+			b.subs = make(map[string]bool)
+			b.gatewayConnected = false
+			b.bootstrapDone = false // allow bootstrap to re-run
+			// session.Close() is safe to call under lock — it just closes the websocket.
+			_ = oldSession.Close()
+		}
+
 		// Create a discordgo session but do NOT open the gateway yet.
 		// Gateway connection happens on first Subscribe().
 		session, err := discordgo.New("Bot " + botToken)
@@ -383,24 +396,29 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 		// Subscribe(), which triggers startGateway() on the first call.
 		// Host callbacks are wired after Configure() returns, so we defer
 		// the request in a goroutine that retries until they're available.
-		go func() {
-			for i := 0; i < 20; i++ {
-				time.Sleep(500 * time.Millisecond)
-				b.mu.RLock()
-				hc := b.hostCallbacks
-				b.mu.RUnlock()
-				if hc == nil {
-					continue
+		if !b.bootstrapDone {
+			go func() {
+				for i := 0; i < 20; i++ {
+					time.Sleep(500 * time.Millisecond)
+					b.mu.RLock()
+					hc := b.hostCallbacks
+					b.mu.RUnlock()
+					if hc == nil {
+						continue
+					}
+					if err := hc.RequestSubscription(projectcompat.AllProjectsPattern()); err != nil {
+						b.log.Warn("Failed to request bootstrap subscription", "error", err)
+						continue
+					}
+					b.mu.Lock()
+					b.bootstrapDone = true
+					b.mu.Unlock()
+					b.log.Info("Requested bootstrap subscription for Discord Gateway")
+					return
 				}
-				if err := hc.RequestSubscription(projectcompat.AllProjectsPattern()); err != nil {
-					b.log.Warn("Failed to request bootstrap subscription", "error", err)
-					continue
-				}
-				b.log.Info("Requested bootstrap subscription for Discord Gateway")
-				return
-			}
-			b.log.Error("Bootstrap subscription timed out — host callbacks never became available")
-		}()
+				b.log.Error("Bootstrap subscription timed out — host callbacks never became available")
+			}()
+		}
 	}
 
 	return nil

--- a/extras/scion-discord/internal/discord/broker_test.go
+++ b/extras/scion-discord/internal/discord/broker_test.go
@@ -1643,3 +1643,54 @@ func TestDownloadDiscordAttachment_CustomPath_CreatesSubdir(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, fileContent, data)
 }
+
+// --- RPC bootstrap regression tests ---
+
+func TestConfigure_SessionReplacement_ClearsSubs(t *testing.T) {
+	b := &DiscordBroker{
+		log:              discardLogger(),
+		session:          &discordgo.Session{}, // simulate existing session
+		subs:             map[string]bool{"*": true},
+		sentIDs:          make(map[string]time.Time),
+		gatewayConnected: true,
+		bootstrapDone:    true,
+	}
+
+	// Calling Configure with bot_token should close old session and clear subs.
+	err := b.Configure(map[string]string{
+		"bot_token": "Bot fake-token-for-test",
+	})
+	require.NoError(t, err)
+
+	// After Phase 1 reconfigure:
+	// - Old subs should be cleared (so Subscribe("*") would trigger startGateway)
+	// - gatewayConnected should be reset
+	// - bootstrapDone should be reset
+	assert.Empty(t, b.subs, "subs should be cleared after session replacement")
+	assert.False(t, b.gatewayConnected, "gatewayConnected should be reset")
+	assert.False(t, b.bootstrapDone, "bootstrapDone should be reset")
+	assert.NotNil(t, b.session, "new session should be created")
+}
+
+func TestConfigure_BootstrapSkippedWhenDone(t *testing.T) {
+	b := &DiscordBroker{
+		log:           discardLogger(),
+		subs:          make(map[string]bool),
+		sentIDs:       make(map[string]time.Time),
+		bootstrapDone: true,
+		hubURL:        "http://localhost:8080",
+		hmacKey:       "test-key",
+		brokerID:      "test-broker",
+	}
+
+	// Configure Phase 2 (hub_url present) should skip bootstrap goroutine
+	// because bootstrapDone is already true.
+	err := b.Configure(map[string]string{
+		"hub_url":  "http://localhost:8080",
+		"hmac_key": "test-key",
+	})
+	require.NoError(t, err)
+
+	// bootstrapDone should still be true (not reset by Phase 2 alone).
+	assert.True(t, b.bootstrapDone, "bootstrapDone should remain true when no session replacement")
+}

--- a/pkg/plugin/broker_plugin.go
+++ b/pkg/plugin/broker_plugin.go
@@ -193,19 +193,22 @@ func (p *BrokerPlugin) Client(broker *goplugin.MuxBroker, c *rpc.Client) (interf
 // BrokerRPCServer wraps a MessageBrokerPluginInterface to serve RPC requests.
 // This runs inside the plugin binary.
 type BrokerRPCServer struct {
-	Impl      MessageBrokerPluginInterface
-	muxBroker *goplugin.MuxBroker
+	Impl                   MessageBrokerPluginInterface
+	muxBroker              *goplugin.MuxBroker
+	hostCallbacksConnected bool
 }
 
 func (s *BrokerRPCServer) Configure(args *ConfigureArgs, _ *struct{}) error {
 	// If the host indicated that callbacks are available, establish the
 	// reverse RPC channel and inject it into the plugin implementation.
-	if args.Config != nil && args.Config[hostCallbacksConfigKey] == "true" && s.muxBroker != nil {
+	if args.Config != nil && args.Config[hostCallbacksConfigKey] == "true" &&
+		s.muxBroker != nil && !s.hostCallbacksConnected {
 		conn, err := s.muxBroker.Dial(hostCallbacksMuxID)
 		if err != nil {
 			slog.Warn("failed to dial host callbacks reverse channel",
 				"error", err, "mux_id", hostCallbacksMuxID)
 		} else {
+			s.hostCallbacksConnected = true
 			callbacks := &HostCallbacksRPCClient{client: rpc.NewClient(conn)}
 			if aware, ok := s.Impl.(HostCallbacksAware); ok {
 				aware.SetHostCallbacks(callbacks)

--- a/pkg/plugin/broker_plugin_test.go
+++ b/pkg/plugin/broker_plugin_test.go
@@ -208,3 +208,21 @@ func TestBrokerPluginAdapter_Close(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, mock.closed)
 }
+
+func TestBrokerRPCServer_HostCallbacksConnectedGuard(t *testing.T) {
+	mock := &mockBrokerPlugin{}
+	server := &BrokerRPCServer{Impl: mock, muxBroker: nil}
+
+	// First Configure with _host_callbacks=true but nil muxBroker:
+	// should not set hostCallbacksConnected (Dial is skipped when muxBroker is nil).
+	args := &ConfigureArgs{Config: map[string]string{
+		hostCallbacksConfigKey: "true",
+		"some_key":             "some_value",
+	}}
+	err := server.Configure(args, nil)
+	require.NoError(t, err)
+	assert.False(t, server.hostCallbacksConnected, "should not be connected when muxBroker is nil")
+
+	// Verify Configure still passed through to Impl.
+	assert.Equal(t, args.Config, mock.configured)
+}


### PR DESCRIPTION
Fixes Discord plugin death after web UI Restart or Update button is used. Three interacting bugs:

1. MuxBroker double-Dial stall: BrokerRPCServer.Configure() tried Dial(1) on every reconfigure, but AcceptAndServe(1) is one-shot. Added hostCallbacksConnected guard (broker_plugin.go). Fixes all broker plugins.

2. Session replacement without gateway restart: DiscordBroker.Configure() Phase 1 overwrote session without closing or clearing subs. Now closes old session/store/sendQueue and resets state (broker.go).

3. Bootstrap goroutine accumulation: Added bootstrapDone guard that resets on session replacement (broker.go).

Observed on 3 hubs in 48 hours. Only workaround was full hub restart.

Fork PR: https://github.com/ptone/scion/pull/834