### PR TITLE
fix(web): hide graph-view button on skills page

### DIFF
--- a/web/src/components/pages/skills.ts
+++ b/web/src/components/pages/skills.ts
@@ -335,6 +335,7 @@ export class ScionPageSkills extends LitElement {
         <div class="header-actions">
           <scion-view-toggle
             .view=${this.viewMode}
+            .showGraph=${false}
             storageKey="scion-view-skills"
             @view-change=${this.onViewChange}
           ></scion-view-toggle>

--- a/web/src/components/pages/skills.ts
+++ b/web/src/components/pages/skills.ts
@@ -202,6 +202,9 @@ export class ScionPageSkills extends LitElement {
     const stored = localStorage.getItem('scion-view-skills') as ViewMode | null;
     if (stored === 'grid' || stored === 'list') {
       this.viewMode = stored;
+    } else {
+      this.viewMode = 'grid';
+      localStorage.setItem('scion-view-skills', 'grid');
     }
 
     const storedSort = localStorage.getItem('scion-sort-skills');


### PR DESCRIPTION
## Summary

The /skills page showed a graph-view toggle button, but there is no graph view for skills. Adds .showGraph=false to the scion-view-toggle component to hide it.

Ref: ptone/scion#830

## Test plan

- npm run build passes
- Manual: verify /skills page shows only grid/list toggle, no graph button