### PR TITLE
fix(antigravity): rework ADC auth under vertex-ai type

### DIFF
--- a/harnesses/antigravity/config.yaml
+++ b/harnesses/antigravity/config.yaml
@@ -60,8 +60,7 @@ capabilities:
     api_key: { support: "no", reason: "AGY uses OAuth, not API keys" }
     auth_file: { support: "yes", reason: "Via AGY_TOKEN file secret at ~/.gemini/antigravity-cli/antigravity-oauth-token" }
     oauth_token: { support: "no", reason: "AGY uses file-based OAuth token, not raw token injection" }
-    vertex_ai: { support: "yes", reason: "Enterprise/GCP mode via AGY_TOKEN + GOOGLE_CLOUD_PROJECT + GOOGLE_CLOUD_LOCATION" }
-    adc: { support: "yes", reason: "ADC via AGY_ADC_AUTH env, requires AGY CLI >= 1.1.10" }
+    vertex_ai: { support: "yes", reason: "GCP mode via ADC (GOOGLE_APPLICATION_CREDENTIALS) + GOOGLE_CLOUD_PROJECT, requires AGY CLI >= 1.1.10" }
 
 no_auth:
   behavior: drop-to-shell
@@ -86,18 +85,9 @@ auth:
         - any_of: ["GOOGLE_CLOUD_PROJECT"]
         - any_of: ["GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION"]
       required_files:
-        - name: AGY_TOKEN
-          type: file
-          description: "Antigravity OAuth token JSON file"
-          target_suffix: "/.gemini/antigravity-cli/antigravity-oauth-token"
-    adc:
-      required_env:
-        - any_of: ["GOOGLE_CLOUD_PROJECT"]
-        - any_of: ["GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION"]
-      required_files:
         - name: gcloud-adc
           type: file
-          description: "Google Cloud Application Default Credentials (ADC) file for ADC authentication"
+          description: "Google Cloud Application Default Credentials (ADC) file for vertex-ai authentication"
           field: GoogleAppCredentials
           alternative_env_keys: ["GOOGLE_APPLICATION_CREDENTIALS"]
           skipped_when_gcp_service_account_assigned: true
@@ -105,5 +95,6 @@ auth:
   autodetect:
     env:
       AGY_TOKEN: oauth-token
+      GOOGLE_CLOUD_PROJECT: vertex-ai
     files:
-      gcloud-adc: adc
+      gcloud-adc: vertex-ai

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -74,17 +74,10 @@ ANTIGRAVITY_AUTH = scion_harness.AuthSpec(
     [
         scion_harness.env_method(
             "vertex-ai",
-            all_of=["AGY_TOKEN", "GOOGLE_CLOUD_PROJECT"],
-            any_of=["GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION"],
-            env_fallback=True,
-            hint="set AGY_TOKEN, GOOGLE_CLOUD_PROJECT, and GOOGLE_CLOUD_LOCATION",
-        ),
-        scion_harness.env_method(
-            "adc",
             all_of=["GOOGLE_CLOUD_PROJECT"],
             any_of=["GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION"],
             env_fallback=True,
-            hint="set GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION with gcloud-adc file",
+            hint="set GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION with gcloud-adc",
         ),
         scion_harness.env_method(
             "oauth-token",
@@ -137,13 +130,13 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     is_adc = False
     env_overlay: dict[str, str] = {}
 
-    if method == "adc":
-        # ADC auth: validate version and wire ADC environment.
+    if method == "vertex-ai":
+        # vertex-ai is now the ADC path: validate version and wire ADC environment.
         ver = _get_agy_version()
         if ver is None or ver < (1, 1, 10):
             ver_str = ".".join(str(v) for v in ver) if ver else "unknown"
             raise scion_harness.ProvisionError(
-                f"ADC auth requires AGY CLI >= 1.1.10, found {ver_str}"
+                f"vertex-ai auth requires AGY CLI >= 1.1.10, found {ver_str}"
             )
         is_adc = True
         env_overlay["AGY_ADC_AUTH"] = "true"
@@ -157,7 +150,7 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
             if gac_env:
                 env_overlay["GOOGLE_APPLICATION_CREDENTIALS"] = gac_env
 
-        # Resolve GCP project/location (same pattern as vertex-ai).
+        # Resolve GCP project/location.
         project = ctx.read_secret("GOOGLE_CLOUD_PROJECT", env_fallback=True)
         if project:
             env_overlay["GOOGLE_CLOUD_PROJECT"] = project
@@ -168,9 +161,9 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
         if location:
             env_overlay["GOOGLE_CLOUD_LOCATION"] = location
 
-        ctx.info(f"ADC auth: AGY version {'.'.join(str(v) for v in ver)}")
+        ctx.info(f"vertex-ai ADC auth: AGY version {'.'.join(str(v) for v in ver)}")
 
-    elif method in ("oauth-token", "vertex-ai"):
+    elif method == "oauth-token":
         token_raw = _read_agy_token(ctx)
         if not token_raw:
             oauth_token_path = os.path.join(
@@ -206,8 +199,11 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
             )
         has_token = True
 
-    # ADC and vertex-ai are both enterprise/GCP modes.
-    is_enterprise = method in ("vertex-ai", "adc")
+    # vertex-ai is enterprise/GCP mode. oauth-token is also enterprise when
+    # GOOGLE_CLOUD_PROJECT is present (wrapper script handles GCP settings).
+    is_enterprise = method == "vertex-ai" or (
+        method == "oauth-token" and bool(os.environ.get("GOOGLE_CLOUD_PROJECT"))
+    )
 
     instructions_file = ctx.harness_config.get("instructions_file") or "GEMINI.md"
     model = (
@@ -339,9 +335,9 @@ def _generate_wrapper_script(
     reason — GOOGLE_CLOUD_PROJECT/GOOGLE_CLOUD_LOCATION and AGY_USE_GCP
     are only available in the child environment.
 
-    When is_adc=True, keyring/DBUS init and token injection are skipped
-    because ADC auth uses GOOGLE_APPLICATION_CREDENTIALS instead of the
-    keyring-based OAuth flow. GCP settings patching still runs.
+    When is_adc=True (vertex-ai auth), keyring/DBUS init and token injection
+    are skipped because ADC auth uses GOOGLE_APPLICATION_CREDENTIALS instead
+    of the keyring-based OAuth flow. GCP settings patching still runs.
     """
     secret_path = os.path.join(
         home, ".scion", "harness", "secrets", "AGY_TOKEN"
@@ -356,8 +352,9 @@ def _generate_wrapper_script(
         home, ".gemini", "antigravity-cli", "cache", "onboarding.json"
     )
 
-    # Enterprise marker: provisioner writes this when explicit vertex-ai
-    # or adc is selected. The wrapper checks both this file and AGY_USE_GCP env.
+    # Enterprise marker: provisioner writes this when vertex-ai is selected
+    # or oauth-token has GOOGLE_CLOUD_PROJECT. The wrapper checks both this
+    # file and AGY_USE_GCP env.
     enterprise_marker = os.path.join(
         home, ".scion", "harness", ".enterprise-mode"
     )
@@ -367,8 +364,8 @@ def _generate_wrapper_script(
             f.write("1")
     elif os.path.exists(enterprise_marker):
         # Idempotent reprovision: if the auth mode switched away from
-        # vertex-ai/adc (e.g. to oauth-token), remove the stale marker so the
-        # wrapper does not keep running in enterprise/GCP mode.
+        # enterprise (e.g. to plain oauth-token), remove the stale marker so
+        # the wrapper does not keep running in enterprise/GCP mode.
         os.remove(enterprise_marker)
 
     # Build keyring/token injection block — skipped for ADC auth since ADC
@@ -430,7 +427,7 @@ fi
 set -e
 {keyring_block}
 # GCP/enterprise mode: patch settings.json with gcp block and mark
-# enterprise onboarding complete. Triggered by explicit vertex-ai/adc auth
+# enterprise onboarding complete. Triggered by explicit vertex-ai auth
 # (marker file) or AGY_USE_GCP=true env var.
 _use_gcp=false
 if [ -f "{enterprise_marker}" ]; then

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -201,9 +201,20 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
 
     # vertex-ai is enterprise/GCP mode. oauth-token is also enterprise when
     # GOOGLE_CLOUD_PROJECT is present (wrapper script handles GCP settings).
+    # Use ctx.read_secret so staged secrets are checked, not just os.environ.
+    project = ctx.read_secret("GOOGLE_CLOUD_PROJECT", env_fallback=True)
     is_enterprise = method == "vertex-ai" or (
-        method == "oauth-token" and bool(os.environ.get("GOOGLE_CLOUD_PROJECT"))
+        method == "oauth-token" and bool(project)
     )
+    if is_enterprise and method == "oauth-token":
+        if project:
+            env_overlay["GOOGLE_CLOUD_PROJECT"] = project
+        location = (
+            ctx.read_secret("GOOGLE_CLOUD_LOCATION", env_fallback=True)
+            or ctx.read_secret("GOOGLE_CLOUD_REGION", env_fallback=True)
+        )
+        if location:
+            env_overlay["GOOGLE_CLOUD_LOCATION"] = location
 
     instructions_file = ctx.harness_config.get("instructions_file") or "GEMINI.md"
     model = (


### PR DESCRIPTION
Rework antigravity ADC auth to live under the existing vertex-ai type instead of a separate top-level adc type. This fixes the P0 CI break (TestBundleInstall_Antigravity schema validation failure) and corrects the design from PR #1047.

Design change:
- vertex-ai = gcloud-adc + project + location (ADC via AGY_ADC_AUTH, consistent with claude/hermes harnesses). No AGY_TOKEN needed.
- oauth-token = AGY_TOKEN file (harness credential for the keyring OAuth flow, unchanged)
- The standalone adc auth type is removed entirely

Changes:
- config.yaml: remove adc type, redefine vertex-ai to use gcloud-adc file (matching claude harness pattern), update autodetect and capabilities
- provision.py: remove adc AuthSpec method, vertex-ai no longer requires AGY_TOKEN, vertex-ai uses ADC flow (AGY_ADC_AUTH=true), oauth-token uses keyring flow, updated is_enterprise logic

This also fixes the P0 CI blocker — removing the adc value from config.yaml means the schema validation passes without needing to add adc to the schema enums. Supersedes upstream PR #1050 (which should be closed).

Tests pass: TestBundleInstall_Antigravity, pkg/config, pkg/harness.

Ref: ptone/scion#832
