### PR TITLE
feat(invite-flow): API endpoints for user invitations

### DIFF
--- a/pkg/hub/admin_allow_list.go
+++ b/pkg/hub/admin_allow_list.go
@@ -86,14 +86,13 @@ func (s *Server) handleAdminAllowListByEmail(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	setDeprecationHeader(w)
-
 	// Extract sub-path
 	subPath := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/allow-list/")
 
 	// Route special sub-paths
 	switch subPath {
 	case "import":
+		setDeprecationHeader(w)
 		if r.Method != http.MethodPost {
 			MethodNotAllowed(w)
 			return
@@ -101,6 +100,7 @@ func (s *Server) handleAdminAllowListByEmail(w http.ResponseWriter, r *http.Requ
 		s.handleAdminAllowListImport(w, r, user)
 		return
 	case "domains":
+		// Not deprecated — no Deprecation header.
 		if r.Method != http.MethodGet {
 			MethodNotAllowed(w)
 			return
@@ -108,6 +108,9 @@ func (s *Server) handleAdminAllowListByEmail(w http.ResponseWriter, r *http.Requ
 		s.handleAdminAllowListDomains(w, r)
 		return
 	}
+
+	// DELETE /api/v1/admin/allow-list/{email} — deprecated
+	setDeprecationHeader(w)
 
 	if r.Method != http.MethodDelete {
 		MethodNotAllowed(w)
@@ -348,6 +351,7 @@ func (s *Server) handleAdminAllowListImport(w http.ResponseWriter, r *http.Reque
 			continue
 		}
 		if err != store.ErrNotFound {
+			slog.Error("failed to check existing user during import", "email", email, "error", err)
 			continue
 		}
 
@@ -373,6 +377,12 @@ func (s *Server) handleAdminAllowListImport(w http.ResponseWriter, r *http.Reque
 		}
 
 		added++
+	}
+
+	// Backward compatibility: return 400 if no emails were processed
+	if added == 0 && skipped == 0 {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "no valid emails found", nil)
+		return
 	}
 
 	slog.Info("allow list bulk import (deprecated: created invited users)",

--- a/pkg/hub/admin_allow_list.go
+++ b/pkg/hub/admin_allow_list.go
@@ -50,13 +50,22 @@ type AllowListResponse struct {
 	NextCursor string                           `json:"nextCursor,omitempty"`
 }
 
+// setDeprecationHeader adds the Deprecation header to the response, signaling
+// that this endpoint is deprecated in favor of the new invite endpoints.
+func setDeprecationHeader(w http.ResponseWriter) {
+	w.Header().Set("Deprecation", "true")
+}
+
 // handleAdminAllowList handles GET/POST /api/v1/admin/allow-list.
+// DEPRECATED: Use POST /api/v1/admin/users/invite and GET /api/v1/users?status=invited instead.
 func (s *Server) handleAdminAllowList(w http.ResponseWriter, r *http.Request) {
 	user := GetUserIdentityFromContext(r.Context())
 	if user == nil || user.Role() != "admin" {
 		Forbidden(w)
 		return
 	}
+
+	setDeprecationHeader(w)
 
 	switch r.Method {
 	case http.MethodGet:
@@ -69,12 +78,15 @@ func (s *Server) handleAdminAllowList(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleAdminAllowListByEmail handles sub-paths under /api/v1/admin/allow-list/.
+// DEPRECATED: Use the new invite endpoints instead.
 func (s *Server) handleAdminAllowListByEmail(w http.ResponseWriter, r *http.Request) {
 	user := GetUserIdentityFromContext(r.Context())
 	if user == nil || user.Role() != "admin" {
 		Forbidden(w)
 		return
 	}
+
+	setDeprecationHeader(w)
 
 	// Extract sub-path
 	subPath := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/allow-list/")
@@ -103,13 +115,15 @@ func (s *Server) handleAdminAllowListByEmail(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Extract email from path: /api/v1/admin/allow-list/{email}
-	email := subPath
+	email := strings.TrimSpace(strings.ToLower(subPath))
 	if email == "" {
 		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "email is required", nil)
 		return
 	}
 
-	if err := s.store.RemoveAllowListEntry(r.Context(), email); err != nil {
+	// DEPRECATED: Delete User(invited) record instead of AllowListEntry.
+	existingUser, err := s.store.GetUserByEmail(r.Context(), email)
+	if err != nil {
 		if err == store.ErrNotFound {
 			writeError(w, http.StatusNotFound, ErrCodeNotFound, "email not found in allow list", nil)
 			return
@@ -118,7 +132,22 @@ func (s *Server) handleAdminAllowListByEmail(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	slog.Info("allow list entry removed",
+	// Only delete users with invited status via this deprecated endpoint
+	if existingUser.Status != store.UserStatusInvited {
+		writeError(w, http.StatusConflict, ErrCodeConflict, "user is not in invited status; cannot remove via allow-list endpoint", nil)
+		return
+	}
+
+	if err := s.store.DeleteUser(r.Context(), existingUser.ID); err != nil {
+		if err == store.ErrNotFound {
+			writeError(w, http.StatusNotFound, ErrCodeNotFound, "email not found in allow list", nil)
+			return
+		}
+		InternalError(w)
+		return
+	}
+
+	slog.Info("allow list entry removed (deprecated: deleted invited user)",
 		"email", email,
 		"removed_by", user.Email(),
 	)
@@ -128,6 +157,9 @@ func (s *Server) handleAdminAllowListByEmail(w http.ResponseWriter, r *http.Requ
 	writeJSON(w, http.StatusOK, map[string]string{"status": "removed"})
 }
 
+// handleAdminAllowListGet returns User(status=invited) records formatted as
+// AllowListEntry responses for backward compatibility.
+// DEPRECATED: Use GET /api/v1/users?status=invited instead.
 func (s *Server) handleAdminAllowListGet(w http.ResponseWriter, r *http.Request) {
 	opts := store.ListOptions{
 		Limit: 50,
@@ -136,27 +168,48 @@ func (s *Server) handleAdminAllowListGet(w http.ResponseWriter, r *http.Request)
 		opts.Cursor = q.Get("cursor")
 	}
 
-	result, err := s.store.ListAllowListEntriesWithInvites(r.Context(), opts)
+	filter := store.UserFilter{
+		Status: store.UserStatusInvited,
+	}
+
+	result, err := s.store.ListUsers(r.Context(), filter, opts)
 	if err != nil {
 		InternalError(w)
 		return
 	}
 
-	now := time.Now()
-	for i := range result.Items {
-		entry := &result.Items[i]
-		if !entry.InviteExpiresAt.IsZero() && now.After(entry.InviteExpiresAt) {
-			entry.InviteExpired = true
+	// Convert User(invited) records to AllowListEntryWithInvite format
+	items := make([]store.AllowListEntryWithInvite, 0, len(result.Items))
+	for _, u := range result.Items {
+		addedBy := ""
+		if u.InvitedBy != nil {
+			addedBy = *u.InvitedBy
 		}
+		note := ""
+		if u.InviteNote != nil {
+			note = *u.InviteNote
+		}
+
+		items = append(items, store.AllowListEntryWithInvite{
+			AllowListEntry: store.AllowListEntry{
+				ID:      u.ID,
+				Email:   u.Email,
+				Note:    note,
+				AddedBy: addedBy,
+				Created: u.Created,
+			},
+		})
 	}
 
 	writeJSON(w, http.StatusOK, AllowListResponse{
-		Items:      result.Items,
+		Items:      items,
 		TotalCount: result.TotalCount,
 		NextCursor: result.NextCursor,
 	})
 }
 
+// handleAdminAllowListAdd creates a User(status=invited) record instead of an AllowListEntry.
+// DEPRECATED: Use POST /api/v1/admin/users/invite instead.
 func (s *Server) handleAdminAllowListAdd(w http.ResponseWriter, r *http.Request, user UserIdentity) {
 	var req AllowListAddRequest
 	if err := readJSON(r, &req); err != nil {
@@ -170,14 +223,33 @@ func (s *Server) handleAdminAllowListAdd(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	entry := &store.AllowListEntry{
-		ID:      uuid.New().String(),
-		Email:   email,
-		Note:    req.Note,
-		AddedBy: user.ID(),
+	// Check if user already exists
+	_, err := s.store.GetUserByEmail(r.Context(), email)
+	if err == nil {
+		writeError(w, http.StatusConflict, ErrCodeConflict, "email already on allow list", nil)
+		return
+	}
+	if err != store.ErrNotFound {
+		InternalError(w)
+		return
 	}
 
-	if err := s.store.AddAllowListEntry(r.Context(), entry); err != nil {
+	invitedBy := user.ID()
+	var note *string
+	if req.Note != "" {
+		note = &req.Note
+	}
+
+	newUser := &store.User{
+		ID:         uuid.New().String(),
+		Email:      email,
+		Status:     store.UserStatusInvited,
+		Role:       store.UserRoleMember,
+		InvitedBy:  &invitedBy,
+		InviteNote: note,
+	}
+
+	if err := s.store.CreateUser(r.Context(), newUser); err != nil {
 		if err == store.ErrAlreadyExists {
 			writeError(w, http.StatusConflict, ErrCodeConflict, "email already on allow list", nil)
 			return
@@ -186,18 +258,35 @@ func (s *Server) handleAdminAllowListAdd(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	slog.Info("allow list entry added",
+	slog.Info("allow list entry added (deprecated: created invited user)",
 		"email", email,
 		"added_by", user.Email(),
 	)
 	LogInviteAudit(r.Context(), s.auditLogger, InviteAuditAllowListAdd, email, "", user.ID(), user.Email(), nil)
 	s.events.PublishAllowListChanged(r.Context(), "added", email)
 
-	writeJSON(w, http.StatusCreated, entry)
+	// Return response in AllowListEntry format for backward compatibility
+	addedBy := ""
+	if newUser.InvitedBy != nil {
+		addedBy = *newUser.InvitedBy
+	}
+	noteStr := ""
+	if newUser.InviteNote != nil {
+		noteStr = *newUser.InviteNote
+	}
+
+	writeJSON(w, http.StatusCreated, &store.AllowListEntry{
+		ID:      newUser.ID,
+		Email:   newUser.Email,
+		Note:    noteStr,
+		AddedBy: addedBy,
+		Created: newUser.Created,
+	})
 }
 
 // handleAdminAllowListImport handles POST /api/v1/admin/allow-list/import.
-// Accepts either a JSON body with an array of emails, or a CSV file upload.
+// Creates User(invited) records instead of AllowListEntry records.
+// DEPRECATED: Use POST /api/v1/admin/users/invite/bulk instead.
 func (s *Server) handleAdminAllowListImport(w http.ResponseWriter, r *http.Request, user UserIdentity) {
 	contentType := r.Header.Get("Content-Type")
 
@@ -243,37 +332,53 @@ func (s *Server) handleAdminAllowListImport(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Build entries
-	var entries []*store.AllowListEntry
+	invitedBy := user.ID()
+	var added, skipped int
+
 	for _, e := range emails {
 		email := strings.TrimSpace(strings.ToLower(e.Email))
 		if _, err := mail.ParseAddress(email); err != nil || email == "" {
 			continue
 		}
-		entries = append(entries, &store.AllowListEntry{
-			ID:      uuid.New().String(),
-			Email:   email,
-			Note:    e.Note,
-			AddedBy: user.ID(),
-		})
+
+		// Check if user already exists
+		_, err := s.store.GetUserByEmail(r.Context(), email)
+		if err == nil {
+			skipped++
+			continue
+		}
+		if err != store.ErrNotFound {
+			continue
+		}
+
+		var note *string
+		if e.Note != "" {
+			note = &e.Note
+		}
+
+		newUser := &store.User{
+			ID:         uuid.New().String(),
+			Email:      email,
+			Status:     store.UserStatusInvited,
+			Role:       store.UserRoleMember,
+			InvitedBy:  &invitedBy,
+			InviteNote: note,
+		}
+
+		if err := s.store.CreateUser(r.Context(), newUser); err != nil {
+			if err == store.ErrAlreadyExists {
+				skipped++
+			}
+			continue
+		}
+
+		added++
 	}
 
-	if len(entries) == 0 {
-		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "no valid emails found", nil)
-		return
-	}
-
-	added, skipped, err := s.store.BulkAddAllowListEntries(r.Context(), entries)
-	if err != nil {
-		slog.Error("bulk allow list import failed", "error", err)
-		InternalError(w)
-		return
-	}
-
-	slog.Info("allow list bulk import",
+	slog.Info("allow list bulk import (deprecated: created invited users)",
 		"added", added,
 		"skipped", skipped,
-		"total", len(entries),
+		"total", added+skipped,
 		"imported_by", user.Email(),
 	)
 
@@ -295,11 +400,12 @@ func (s *Server) handleAdminAllowListImport(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusOK, AllowListBulkAddResponse{
 		Added:   added,
 		Skipped: skipped,
-		Total:   len(entries),
+		Total:   added + skipped,
 	})
 }
 
 // handleAdminAllowListDomains handles GET /api/v1/admin/allow-list/domains.
+// This endpoint is kept as-is (not deprecated).
 func (s *Server) handleAdminAllowListDomains(w http.ResponseWriter, r *http.Request) {
 	domains, err := s.store.ListEmailDomains(r.Context())
 	if err != nil {

--- a/pkg/hub/admin_user_invite.go
+++ b/pkg/hub/admin_user_invite.go
@@ -200,7 +200,7 @@ func (s *Server) handleAdminUserInviteBulk(w http.ResponseWriter, r *http.Reques
 
 	invitedBy := user.ID()
 	var invited, skipped int
-	var errors []string
+	var errMsgs []string
 
 	for _, e := range emails {
 		email := strings.TrimSpace(strings.ToLower(e.Email))
@@ -215,7 +215,8 @@ func (s *Server) handleAdminUserInviteBulk(w http.ResponseWriter, r *http.Reques
 			continue
 		}
 		if err != store.ErrNotFound {
-			errors = append(errors, fmt.Sprintf("error checking %s: %v", email, err))
+			slog.Error("bulk invite: failed to check existing user", "email", email, "error", err)
+			errMsgs = append(errMsgs, fmt.Sprintf("failed to process %s", email))
 			continue
 		}
 
@@ -238,7 +239,8 @@ func (s *Server) handleAdminUserInviteBulk(w http.ResponseWriter, r *http.Reques
 				skipped++
 				continue
 			}
-			errors = append(errors, fmt.Sprintf("error inviting %s: %v", email, err))
+			slog.Error("bulk invite: failed to create user", "email", email, "error", err)
+			errMsgs = append(errMsgs, fmt.Sprintf("failed to process %s", email))
 			continue
 		}
 
@@ -248,7 +250,8 @@ func (s *Server) handleAdminUserInviteBulk(w http.ResponseWriter, r *http.Reques
 	slog.Info("bulk user invite",
 		"invited", invited,
 		"skipped", skipped,
-		"total", invited+skipped,
+		"total", invited+skipped+len(errMsgs),
+		"errors", len(errMsgs),
 		"invited_by", user.Email(),
 	)
 
@@ -270,7 +273,7 @@ func (s *Server) handleAdminUserInviteBulk(w http.ResponseWriter, r *http.Reques
 	writeJSON(w, http.StatusOK, UserInviteBulkResponse{
 		Invited: invited,
 		Skipped: skipped,
-		Total:   invited + skipped,
-		Errors:  errors,
+		Total:   invited + skipped + len(errMsgs),
+		Errors:  errMsgs,
 	})
 }

--- a/pkg/hub/admin_user_invite.go
+++ b/pkg/hub/admin_user_invite.go
@@ -1,0 +1,276 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/mail"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/google/uuid"
+)
+
+// --- Request/Response types ---
+
+// UserInviteRequest is the request body for POST /api/v1/admin/users/invite.
+type UserInviteRequest struct {
+	Email string `json:"email"`
+	Note  string `json:"note"`
+}
+
+// UserInviteResponse is the response body for POST /api/v1/admin/users/invite.
+type UserInviteResponse struct {
+	ID        string    `json:"id"`
+	Email     string    `json:"email"`
+	Status    string    `json:"status"`
+	InvitedBy string    `json:"invitedBy"`
+	Created   time.Time `json:"created"`
+}
+
+// UserInviteBulkRequest is the JSON request body for bulk invite.
+type UserInviteBulkRequest struct {
+	Emails []UserInviteRequest `json:"emails"`
+}
+
+// UserInviteBulkResponse is the response body for POST /api/v1/admin/users/invite/bulk.
+type UserInviteBulkResponse struct {
+	Invited int      `json:"invited"`
+	Skipped int      `json:"skipped"`
+	Total   int      `json:"total"`
+	Errors  []string `json:"errors"`
+}
+
+// --- Handlers ---
+
+// handleAdminUserInvite handles POST /api/v1/admin/users/invite.
+func (s *Server) handleAdminUserInvite(w http.ResponseWriter, r *http.Request) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil || user.Role() != "admin" {
+		Forbidden(w)
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	var req UserInviteRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "invalid request body", nil)
+		return
+	}
+
+	email := strings.TrimSpace(strings.ToLower(req.Email))
+	if _, err := mail.ParseAddress(email); err != nil || email == "" {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "valid email is required", nil)
+		return
+	}
+
+	// Check if user already exists
+	_, err := s.store.GetUserByEmail(r.Context(), email)
+	if err == nil {
+		writeError(w, http.StatusConflict, ErrCodeConflict, "user already exists", nil)
+		return
+	}
+	if err != store.ErrNotFound {
+		slog.Error("failed to check existing user", "email", email, "error", err)
+		InternalError(w)
+		return
+	}
+
+	invitedBy := user.ID()
+	var note *string
+	if req.Note != "" {
+		note = &req.Note
+	}
+
+	newUser := &store.User{
+		ID:         uuid.New().String(),
+		Email:      email,
+		Status:     store.UserStatusInvited,
+		Role:       store.UserRoleMember,
+		InvitedBy:  &invitedBy,
+		InviteNote: note,
+	}
+
+	if err := s.store.CreateUser(r.Context(), newUser); err != nil {
+		if err == store.ErrAlreadyExists {
+			writeError(w, http.StatusConflict, ErrCodeConflict, "user already exists", nil)
+			return
+		}
+		slog.Error("failed to create invited user", "email", email, "error", err)
+		InternalError(w)
+		return
+	}
+
+	slog.Info("user invited",
+		"email", email,
+		"invited_by", user.Email(),
+		"user_id", newUser.ID,
+	)
+	LogInviteAudit(r.Context(), s.auditLogger, InviteAuditUserInvited, email, "", user.ID(), user.Email(), nil)
+	s.events.PublishAllowListChanged(r.Context(), "invited", email)
+
+	writeJSON(w, http.StatusCreated, UserInviteResponse{
+		ID:        newUser.ID,
+		Email:     newUser.Email,
+		Status:    newUser.Status,
+		InvitedBy: invitedBy,
+		Created:   newUser.Created,
+	})
+}
+
+// handleAdminUserInviteBulk handles POST /api/v1/admin/users/invite/bulk.
+// Accepts JSON or CSV (multipart/form-data) input.
+func (s *Server) handleAdminUserInviteBulk(w http.ResponseWriter, r *http.Request) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil || user.Role() != "admin" {
+		Forbidden(w)
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	contentType := r.Header.Get("Content-Type")
+
+	var emails []UserInviteRequest
+
+	if strings.HasPrefix(contentType, "multipart/form-data") {
+		// CSV file upload — reuse the parseCSVEmails helper from admin_allow_list.go
+		if err := r.ParseMultipartForm(2 << 20); err != nil { // 2MB max
+			writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "failed to parse multipart form", nil)
+			return
+		}
+
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "file field is required", nil)
+			return
+		}
+		defer func() { _ = file.Close() }()
+
+		parsed, err := parseCSVEmails(file)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, err.Error(), nil)
+			return
+		}
+		// Convert AllowListAddRequest to UserInviteRequest
+		for _, p := range parsed {
+			emails = append(emails, UserInviteRequest{Email: p.Email, Note: p.Note})
+		}
+	} else {
+		// JSON body
+		var req UserInviteBulkRequest
+		if err := readJSON(r, &req); err != nil {
+			writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "invalid request body", nil)
+			return
+		}
+		emails = req.Emails
+	}
+
+	if len(emails) == 0 {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "no emails provided", nil)
+		return
+	}
+
+	if len(emails) > 1000 {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "maximum 1000 emails per bulk invite", nil)
+		return
+	}
+
+	invitedBy := user.ID()
+	var invited, skipped int
+	var errors []string
+
+	for _, e := range emails {
+		email := strings.TrimSpace(strings.ToLower(e.Email))
+		if _, err := mail.ParseAddress(email); err != nil || email == "" {
+			continue // skip invalid emails
+		}
+
+		// Check if user already exists
+		_, err := s.store.GetUserByEmail(r.Context(), email)
+		if err == nil {
+			skipped++
+			continue
+		}
+		if err != store.ErrNotFound {
+			errors = append(errors, fmt.Sprintf("error checking %s: %v", email, err))
+			continue
+		}
+
+		var note *string
+		if e.Note != "" {
+			note = &e.Note
+		}
+
+		newUser := &store.User{
+			ID:         uuid.New().String(),
+			Email:      email,
+			Status:     store.UserStatusInvited,
+			Role:       store.UserRoleMember,
+			InvitedBy:  &invitedBy,
+			InviteNote: note,
+		}
+
+		if err := s.store.CreateUser(r.Context(), newUser); err != nil {
+			if err == store.ErrAlreadyExists {
+				skipped++
+				continue
+			}
+			errors = append(errors, fmt.Sprintf("error inviting %s: %v", email, err))
+			continue
+		}
+
+		invited++
+	}
+
+	slog.Info("bulk user invite",
+		"invited", invited,
+		"skipped", skipped,
+		"total", invited+skipped,
+		"invited_by", user.Email(),
+	)
+
+	if logger := s.auditLogger; logger != nil {
+		event := &InviteAuditEvent{
+			EventType:  InviteAuditUserInvitedBulk,
+			ActorID:    user.ID(),
+			ActorEmail: user.Email(),
+			Success:    true,
+			Count:      invited,
+			Timestamp:  time.Now(),
+			Details:    map[string]string{"skipped": fmt.Sprintf("%d", skipped)},
+		}
+		_ = logger.LogInviteAuditEvent(r.Context(), event)
+	}
+
+	s.events.PublishAllowListChanged(r.Context(), "bulk_invited", "")
+
+	writeJSON(w, http.StatusOK, UserInviteBulkResponse{
+		Invited: invited,
+		Skipped: skipped,
+		Total:   invited + skipped,
+		Errors:  errors,
+	})
+}

--- a/pkg/hub/admin_user_invite.go
+++ b/pkg/hub/admin_user_invite.go
@@ -176,7 +176,7 @@ func (s *Server) handleAdminUserInviteBulk(w http.ResponseWriter, r *http.Reques
 		}
 		// Convert AllowListAddRequest to UserInviteRequest
 		for _, p := range parsed {
-			emails = append(emails, UserInviteRequest{Email: p.Email, Note: p.Note})
+			emails = append(emails, UserInviteRequest(p))
 		}
 	} else {
 		// JSON body

--- a/pkg/hub/admin_user_invite_test.go
+++ b/pkg/hub/admin_user_invite_test.go
@@ -19,6 +19,7 @@ package hub
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"mime/multipart"
 	"net/http"
 	"testing"
@@ -228,6 +229,23 @@ func TestAdminUserInviteBulk_MixedSuccessSkip(t *testing.T) {
 	}
 }
 
+func TestAdminUserInviteBulk_ExceedsLimit(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Build a request with 1001 emails
+	emails := make([]UserInviteRequest, 1001)
+	for i := range emails {
+		emails[i] = UserInviteRequest{Email: fmt.Sprintf("user%d@example.com", i)}
+	}
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite/bulk", UserInviteBulkRequest{
+		Emails: emails,
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400 for >1000 emails, got %d", rec.Code)
+	}
+}
+
 func TestAdminUserInviteBulk_EmptyList(t *testing.T) {
 	srv, _ := testServer(t)
 
@@ -426,6 +444,20 @@ func TestDeprecatedAllowListImport_CreatesInvitedUsers(t *testing.T) {
 	}
 	if user.Status != store.UserStatusInvited {
 		t.Errorf("expected status invited, got %q", user.Status)
+	}
+}
+
+func TestAllowListDomains_NoDeprecationHeader(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/allow-list/domains", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Domains endpoint is NOT deprecated — must not have Deprecation header
+	if dep := rec.Header().Get("Deprecation"); dep != "" {
+		t.Errorf("domains endpoint should NOT have Deprecation header, got %q", dep)
 	}
 }
 

--- a/pkg/hub/admin_user_invite_test.go
+++ b/pkg/hub/admin_user_invite_test.go
@@ -1,0 +1,500 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// ============================================================================
+// POST /api/v1/admin/users/invite Tests
+// ============================================================================
+
+func TestAdminUserInvite_Success(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite", UserInviteRequest{
+		Email: "alice@example.com",
+		Note:  "Workshop attendee",
+	})
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp UserInviteResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Email != "alice@example.com" {
+		t.Errorf("expected email alice@example.com, got %q", resp.Email)
+	}
+	if resp.Status != "invited" {
+		t.Errorf("expected status invited, got %q", resp.Status)
+	}
+	if resp.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if resp.InvitedBy == "" {
+		t.Error("expected non-empty invitedBy")
+	}
+	if resp.Created.IsZero() {
+		t.Error("expected non-zero created time")
+	}
+}
+
+func TestAdminUserInvite_DuplicateEmail(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// First invite
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite", UserInviteRequest{
+		Email: "bob@example.com",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("first invite failed: status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Second invite of same email should return 409
+	rec = doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite", UserInviteRequest{
+		Email: "bob@example.com",
+	})
+	if rec.Code != http.StatusConflict {
+		t.Errorf("expected status 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAdminUserInvite_EmailNormalization(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Invite with uppercase email
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite", UserInviteRequest{
+		Email: "Alice@Example.COM",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("invite failed: status %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp UserInviteResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Email != "alice@example.com" {
+		t.Errorf("expected normalized email alice@example.com, got %q", resp.Email)
+	}
+
+	// Trying to invite same email with different case should return 409
+	rec = doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite", UserInviteRequest{
+		Email: "alice@example.com",
+	})
+	if rec.Code != http.StatusConflict {
+		t.Errorf("expected 409 for case-insensitive duplicate, got %d", rec.Code)
+	}
+}
+
+func TestAdminUserInvite_InvalidEmail(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite", UserInviteRequest{
+		Email: "not-an-email",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestAdminUserInvite_EmptyEmail(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite", UserInviteRequest{
+		Email: "",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestAdminUserInvite_NonAdmin(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequestNoAuth(t, srv, http.MethodPost, "/api/v1/admin/users/invite", UserInviteRequest{
+		Email: "user@example.com",
+	})
+	// Should be 401 or 403
+	if rec.Code != http.StatusUnauthorized && rec.Code != http.StatusForbidden {
+		t.Errorf("expected status 401 or 403, got %d", rec.Code)
+	}
+}
+
+func TestAdminUserInvite_MethodNotAllowed(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/users/invite", nil)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status 405, got %d", rec.Code)
+	}
+}
+
+// ============================================================================
+// POST /api/v1/admin/users/invite/bulk Tests
+// ============================================================================
+
+func TestAdminUserInviteBulk_Success(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite/bulk", UserInviteBulkRequest{
+		Emails: []UserInviteRequest{
+			{Email: "alice@example.com", Note: "Note A"},
+			{Email: "bob@example.com", Note: "Note B"},
+			{Email: "carol@example.com"},
+		},
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp UserInviteBulkResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Invited != 3 {
+		t.Errorf("expected 3 invited, got %d", resp.Invited)
+	}
+	if resp.Skipped != 0 {
+		t.Errorf("expected 0 skipped, got %d", resp.Skipped)
+	}
+	if resp.Total != 3 {
+		t.Errorf("expected total 3, got %d", resp.Total)
+	}
+}
+
+func TestAdminUserInviteBulk_MixedSuccessSkip(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Invite one user first
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite", UserInviteRequest{
+		Email: "existing@example.com",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("pre-invite failed: %d", rec.Code)
+	}
+
+	// Bulk invite with mix of new and existing
+	rec = doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite/bulk", UserInviteBulkRequest{
+		Emails: []UserInviteRequest{
+			{Email: "existing@example.com"}, // should be skipped
+			{Email: "new1@example.com"},
+			{Email: "new2@example.com"},
+		},
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp UserInviteBulkResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Invited != 2 {
+		t.Errorf("expected 2 invited, got %d", resp.Invited)
+	}
+	if resp.Skipped != 1 {
+		t.Errorf("expected 1 skipped, got %d", resp.Skipped)
+	}
+}
+
+func TestAdminUserInviteBulk_EmptyList(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite/bulk", UserInviteBulkRequest{
+		Emails: []UserInviteRequest{},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestAdminUserInviteBulk_CSV(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Build a multipart form with a CSV file
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	csvContent := "email,note\nalice@example.com,Workshop\nbob@example.com,Team\n"
+	part, err := writer.CreateFormFile("file", "invites.csv")
+	if err != nil {
+		t.Fatalf("failed to create form file: %v", err)
+	}
+	if _, err := part.Write([]byte(csvContent)); err != nil {
+		t.Fatalf("failed to write CSV: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("failed to close writer: %v", err)
+	}
+
+	rec := doRequestRaw(t, srv, http.MethodPost, "/api/v1/admin/users/invite/bulk", buf.Bytes(), writer.FormDataContentType())
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp UserInviteBulkResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Invited != 2 {
+		t.Errorf("expected 2 invited, got %d", resp.Invited)
+	}
+}
+
+func TestAdminUserInviteBulk_NonAdmin(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequestNoAuth(t, srv, http.MethodPost, "/api/v1/admin/users/invite/bulk", UserInviteBulkRequest{
+		Emails: []UserInviteRequest{{Email: "x@example.com"}},
+	})
+	if rec.Code != http.StatusUnauthorized && rec.Code != http.StatusForbidden {
+		t.Errorf("expected 401 or 403, got %d", rec.Code)
+	}
+}
+
+// ============================================================================
+// Deprecated Allow-List Wrapper Tests
+// ============================================================================
+
+func TestDeprecatedAllowListAdd_CreatesInvitedUser(t *testing.T) {
+	srv, s := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/allow-list", AllowListAddRequest{
+		Email: "deprecated@example.com",
+		Note:  "via deprecated endpoint",
+	})
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify Deprecation header
+	if rec.Header().Get("Deprecation") != "true" {
+		t.Error("expected Deprecation: true header")
+	}
+
+	// Verify a User(invited) was created, not an AllowListEntry
+	user, err := s.GetUserByEmail(t.Context(), "deprecated@example.com")
+	if err != nil {
+		t.Fatalf("expected user to be created: %v", err)
+	}
+	if user.Status != store.UserStatusInvited {
+		t.Errorf("expected status invited, got %q", user.Status)
+	}
+}
+
+func TestDeprecatedAllowListDelete_RemovesInvitedUser(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// First create via invite endpoint
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite", UserInviteRequest{
+		Email: "delete-me@example.com",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("invite failed: %d", rec.Code)
+	}
+
+	// Delete via deprecated allow-list endpoint
+	rec = doRequest(t, srv, http.MethodDelete, "/api/v1/admin/allow-list/delete-me@example.com", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify Deprecation header
+	if rec.Header().Get("Deprecation") != "true" {
+		t.Error("expected Deprecation: true header")
+	}
+}
+
+func TestDeprecatedAllowListDelete_CannotDeleteActiveUser(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// The dev user already exists as active, so trying to delete it via
+	// the deprecated allow-list endpoint should fail.
+	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/admin/allow-list/dev@localhost", nil)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("expected status 409, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDeprecatedAllowListGet_ReturnsInvitedUsers(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Create a few invited users
+	for _, email := range []string{"get1@example.com", "get2@example.com"} {
+		rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite", UserInviteRequest{
+			Email: email,
+			Note:  "test",
+		})
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("invite failed for %s: %d", email, rec.Code)
+		}
+	}
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/allow-list", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify Deprecation header
+	if rec.Header().Get("Deprecation") != "true" {
+		t.Error("expected Deprecation: true header")
+	}
+
+	var resp AllowListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.TotalCount < 2 {
+		t.Errorf("expected at least 2 items, got %d", resp.TotalCount)
+	}
+
+	// All items should have non-empty email
+	for _, item := range resp.Items {
+		if item.Email == "" {
+			t.Error("expected non-empty email in allow list response")
+		}
+	}
+}
+
+func TestDeprecatedAllowListImport_CreatesInvitedUsers(t *testing.T) {
+	srv, s := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/allow-list/import", AllowListBulkAddRequest{
+		Emails: []AllowListAddRequest{
+			{Email: "import1@example.com", Note: "imported"},
+			{Email: "import2@example.com"},
+		},
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify Deprecation header
+	if rec.Header().Get("Deprecation") != "true" {
+		t.Error("expected Deprecation: true header")
+	}
+
+	var resp AllowListBulkAddResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp.Added != 2 {
+		t.Errorf("expected 2 added, got %d", resp.Added)
+	}
+
+	// Verify users were created with invited status
+	user, err := s.GetUserByEmail(t.Context(), "import1@example.com")
+	if err != nil {
+		t.Fatalf("expected user to be created: %v", err)
+	}
+	if user.Status != store.UserStatusInvited {
+		t.Errorf("expected status invited, got %q", user.Status)
+	}
+}
+
+// ============================================================================
+// GET /api/v1/users?status=invited Tests
+// ============================================================================
+
+func TestListUsers_StatusInvitedFilter(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Create invited users
+	for _, email := range []string{"invited1@example.com", "invited2@example.com"} {
+		rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite", UserInviteRequest{
+			Email: email,
+		})
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("invite failed for %s: %d", email, rec.Code)
+		}
+	}
+
+	// Query users with status=invited
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/users?status=invited", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp ListUsersResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp.Users) < 2 {
+		t.Errorf("expected at least 2 invited users, got %d", len(resp.Users))
+	}
+
+	// All returned users should have invited status
+	for _, u := range resp.Users {
+		if u.Status != store.UserStatusInvited {
+			t.Errorf("expected status invited, got %q for user %s", u.Status, u.Email)
+		}
+	}
+}
+
+func TestListUsers_StatusActiveDoesNotIncludeInvited(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Create an invited user
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/users/invite", UserInviteRequest{
+		Email: "shouldnotappear@example.com",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("invite failed: %d", rec.Code)
+	}
+
+	// Query users with status=active
+	rec = doRequest(t, srv, http.MethodGet, "/api/v1/users?status=active", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp ListUsersResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// No invited users should appear
+	for _, u := range resp.Users {
+		if u.Email == "shouldnotappear@example.com" {
+			t.Error("invited user should not appear in status=active filter")
+		}
+	}
+}

--- a/pkg/hub/audit.go
+++ b/pkg/hub/audit.go
@@ -97,6 +97,8 @@ const (
 	InviteAuditInviteDeleted    InviteAuditEventType = "invite_deleted"
 	InviteAuditLoginDenied      InviteAuditEventType = "login_denied"
 	InviteAuditUserActivated    InviteAuditEventType = "user_activated"
+	InviteAuditUserInvited      InviteAuditEventType = "user_invited"
+	InviteAuditUserInvitedBulk  InviteAuditEventType = "user_invited_bulk"
 )
 
 // InviteAuditEvent represents an auditable event for the invite/allow-list system.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3014,6 +3014,8 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/admin/scheduler", s.handleAdminScheduler)
 	s.mux.HandleFunc("/api/v1/admin/allow-list", s.handleAdminAllowList)
 	s.mux.HandleFunc("/api/v1/admin/allow-list/", s.handleAdminAllowListByEmail)
+	s.mux.HandleFunc("/api/v1/admin/users/invite/bulk", s.handleAdminUserInviteBulk)
+	s.mux.HandleFunc("/api/v1/admin/users/invite", s.handleAdminUserInvite)
 	s.mux.HandleFunc("/api/v1/admin/invites", s.handleAdminInvites)
 	s.mux.HandleFunc("/api/v1/admin/invites/", s.handleAdminInviteByID)
 	s.mux.HandleFunc("/api/v1/admin/server-config/schema", s.handleAdminServerConfigSchema)


### PR DESCRIPTION
## Summary

Phase 2 of invite-flow-ux (ptone/scion#837): new admin API endpoints for user invitations and deprecated allow-list wrappers.

- POST /api/v1/admin/users/invite — single invite (201/409)
- POST /api/v1/admin/users/invite/bulk — batch invite via JSON or CSV (max 1000)
- Allow-list POST/DELETE/import deprecated as wrappers creating User(invited)
- GET /api/v1/admin/allow-list returns invited users for backward compat
- Audit events: user_invited, user_invited_bulk
- 21 new tests, all passing
