### PR TITLE
feat(auth): support GKE/GCLB IAP audiences in HA preflight

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -951,11 +951,11 @@ func validateHostedHAPreflight(cfg *config.GlobalConfig) error {
 		return fmt.Errorf("hosted HA deployment requires server.auth.transport.oidc_audience")
 	}
 	// Note: transport.oidc_audience and proxy.iap.audience are intentionally
-	// allowed to differ. proxy.iap.audience is the Cloud Run native IAP
-	// audience path used for validating incoming IAP-signed JWTs, while
+	// allowed to differ. proxy.iap.audience is the IAP audience resource path
+	// (Cloud Run or GCLB) used for validating incoming IAP-signed JWTs, while
 	// transport.oidc_audience is the audience minted into OIDC tokens for
 	// dispatched agents (typically the IAP OAuth client ID). IAP requires
-	// the OAuth client ID format for token validation, not the Cloud Run path.
+	// the OAuth client ID format for token validation, not the resource path.
 	if strings.TrimSpace(cfg.Auth.Transport.PlatformAuthSA) == "" {
 		return fmt.Errorf("hosted HA deployment requires server.auth.transport.platform_auth_sa")
 	}

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -923,7 +923,7 @@ func validateHostedHAPreflight(cfg *config.GlobalConfig) error {
 	}
 
 	if cfg.Auth.Mode != "proxy" {
-		return fmt.Errorf("hosted HA deployment requires server.auth.mode=proxy for Cloud Run IAP; got %q", cfg.Auth.Mode)
+		return fmt.Errorf("hosted HA deployment requires server.auth.mode=proxy for IAP authentication; got %q", cfg.Auth.Mode)
 	}
 	if cfg.Auth.Proxy == nil || cfg.Auth.Proxy.Provider != "iap" {
 		provider := ""
@@ -936,8 +936,8 @@ func validateHostedHAPreflight(cfg *config.GlobalConfig) error {
 		return fmt.Errorf("hosted HA deployment requires server.auth.proxy.iap.audience")
 	}
 	proxyAudience := strings.TrimRight(strings.TrimSpace(cfg.Auth.Proxy.IAP.Audience), "/")
-	if !isCloudRunIAPAudience(proxyAudience) {
-		return fmt.Errorf("hosted HA deployment requires a Cloud Run native IAP audience (/projects/<number>/locations/<region>/services/<service>); got %q", proxyAudience)
+	if !isSupportedIAPAudience(proxyAudience) {
+		return fmt.Errorf("hosted HA deployment requires a supported IAP audience: Cloud Run (/projects/<number>/locations/<region>/services/<service>) or GCLB (/projects/<number>/global/backendServices/<id>); got %q", proxyAudience)
 	}
 
 	if cfg.Auth.Transport == nil {
@@ -963,15 +963,32 @@ func validateHostedHAPreflight(cfg *config.GlobalConfig) error {
 	return nil
 }
 
-func isCloudRunIAPAudience(audience string) bool {
+// isSupportedIAPAudience returns true when audience is a recognised IAP
+// audience path.  Two formats are accepted:
+//
+//   - Cloud Run:  /projects/<number>/locations/<region>/services/<service>
+//   - GCLB:       /projects/<number>/global/backendServices/<id>
+//
+// Everything else is rejected (fail-closed).
+func isSupportedIAPAudience(audience string) bool {
 	parts := strings.Split(strings.TrimSpace(audience), "/")
-	if len(parts) != 7 {
-		return false
-	}
-	return parts[0] == "" &&
+	// Cloud Run format: 7 parts ["", "projects", <n>, "locations", <r>, "services", <s>]
+	if len(parts) == 7 &&
+		parts[0] == "" &&
 		parts[1] == "projects" && parts[2] != "" &&
 		parts[3] == "locations" && parts[4] != "" &&
-		parts[5] == "services" && parts[6] != ""
+		parts[5] == "services" && parts[6] != "" {
+		return true
+	}
+	// GCLB backend-service format: 6 parts ["", "projects", <n>, "global", "backendServices", <id>]
+	if len(parts) == 6 &&
+		parts[0] == "" &&
+		parts[1] == "projects" && parts[2] != "" &&
+		parts[3] == "global" &&
+		parts[4] == "backendServices" && parts[5] != "" {
+		return true
+	}
+	return false
 }
 
 // checkServerPorts checks that required server ports are available.
@@ -1237,6 +1254,12 @@ func resolveHubEndpoint(cfg *config.GlobalConfig, brokerSettings *config.Setting
 		if cloudRunURL := iapAudienceToCloudRunURL(cfg.Auth.Proxy.IAP.Audience); cloudRunURL != "" {
 			log.Printf("Hub endpoint derived from IAP audience: %s", cloudRunURL)
 			return cloudRunURL
+		}
+		// GCLB/GKE audiences cannot be used to derive a URL; warn if no
+		// explicit base URL was provided (all earlier return paths above
+		// would have caught an explicit one).
+		if isSupportedIAPAudience(strings.TrimRight(strings.TrimSpace(cfg.Auth.Proxy.IAP.Audience), "/")) {
+			log.Println("Warning: GKE/GCLB IAP audience detected but SCION_SERVER_BASE_URL not set; hub endpoint will fall back to localhost which is likely unreachable from dispatched agents")
 		}
 	}
 

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -939,6 +939,11 @@ func validateHostedHAPreflight(cfg *config.GlobalConfig) error {
 	if !isSupportedIAPAudience(proxyAudience) {
 		return fmt.Errorf("hosted HA deployment requires a supported IAP audience: Cloud Run (/projects/<number>/locations/<region>/services/<service>) or GCLB (/projects/<number>/global/backendServices/<id>); got %q", proxyAudience)
 	}
+	// Normalize the audience in-place so downstream consumers (IAP JWT
+	// validation, endpoint derivation) see the trimmed value.  Without this
+	// a trailing slash would pass preflight but cause a runtime audience
+	// mismatch in IAP token verification.
+	cfg.Auth.Proxy.IAP.Audience = proxyAudience
 
 	if cfg.Auth.Transport == nil {
 		return fmt.Errorf("hosted HA deployment requires server.auth.transport; do not use server.transport")

--- a/cmd/server_foreground_test.go
+++ b/cmd/server_foreground_test.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"testing"
 
-	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -124,72 +123,36 @@ func TestIapAudienceToCloudRunURL(t *testing.T) {
 	}
 }
 
-// validHAConfig returns a fully-valid HA config that passes all preflight
-// checks. Tests modify individual fields to exercise specific validation paths.
-func validHAConfig(audience string) *config.GlobalConfig {
-	return &config.GlobalConfig{
-		Database: config.DatabaseConfig{
-			Driver: "postgres",
-			URL:    "postgres://localhost/scion",
-		},
-		Storage: config.StorageConfig{
-			Provider: "gcs",
-			Bucket:   "test-bucket",
-		},
-		Auth: config.DevAuthConfig{
-			Mode: "proxy",
-			Proxy: &config.ProxyAuthConfig{
-				Provider: "iap",
-				IAP: &config.IAPAuthConfig{
-					Audience: audience,
-				},
-			},
-			Transport: &config.TransportAuthConfig{
-				Mode:           "iap",
-				OIDCAudience:   "client-id.apps.googleusercontent.com",
-				PlatformAuthSA: "sa@project.iam.gserviceaccount.com",
-			},
-		},
-	}
-}
-
 func TestValidateHostedHAPreflight(t *testing.T) {
-	// Save and restore globals that validateHostedHAPreflight depends on.
-	origHostedMode := hostedMode
-	origEnableHub := enableHub
-	origSessionSecret := webSessionSecret
-	t.Cleanup(func() {
-		hostedMode = origHostedMode
-		enableHub = origEnableHub
-		webSessionSecret = origSessionSecret
-	})
-
-	// Set globals so hostedHAGuardsRequired returns true.
-	hostedMode = true
-	enableHub = true
-	webSessionSecret = "test-secret"
+	// Uses validHostedHAConfig (defined in server_ha_preflight_test.go)
+	// and withHostedHAGuards to set the required package-level globals.
 
 	t.Run("GCLB audience passes", func(t *testing.T) {
-		cfg := validHAConfig("/projects/123/global/backendServices/456")
-		err := validateHostedHAPreflight(cfg)
-		require.NoError(t, err)
+		withHostedHAGuards(t)
+		cfg := validHostedHAConfig()
+		cfg.Auth.Proxy.IAP.Audience = "/projects/123/global/backendServices/456"
+		require.NoError(t, validateHostedHAPreflight(cfg))
 	})
 
 	t.Run("Cloud Run audience passes", func(t *testing.T) {
-		cfg := validHAConfig("/projects/123/locations/us-central1/services/my-svc")
-		err := validateHostedHAPreflight(cfg)
-		require.NoError(t, err)
+		withHostedHAGuards(t)
+		cfg := validHostedHAConfig()
+		require.NoError(t, validateHostedHAPreflight(cfg))
 	})
 
 	t.Run("malformed audience fails", func(t *testing.T) {
-		cfg := validHAConfig("/projects/123/foo/bar")
+		withHostedHAGuards(t)
+		cfg := validHostedHAConfig()
+		cfg.Auth.Proxy.IAP.Audience = "/projects/123/foo/bar"
 		err := validateHostedHAPreflight(cfg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "supported IAP audience")
 	})
 
 	t.Run("empty audience fails", func(t *testing.T) {
-		cfg := validHAConfig("")
+		withHostedHAGuards(t)
+		cfg := validHostedHAConfig()
+		cfg.Auth.Proxy.IAP.Audience = ""
 		err := validateHostedHAPreflight(cfg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "server.auth.proxy.iap.audience")

--- a/cmd/server_foreground_test.go
+++ b/cmd/server_foreground_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsSupportedIAPAudience(t *testing.T) {
+	tests := []struct {
+		name     string
+		audience string
+		want     bool
+	}{
+		{
+			name:     "cloud run format",
+			audience: "/projects/123/locations/us-central1/services/my-svc",
+			want:     true,
+		},
+		{
+			name:     "GCLB backend-service format",
+			audience: "/projects/123/global/backendServices/456",
+			want:     true,
+		},
+		{
+			name:     "GCLB with alphanumeric id",
+			audience: "/projects/999/global/backendServices/my-backend",
+			want:     true,
+		},
+		{
+			name:     "malformed path",
+			audience: "/projects/123/foo/bar",
+			want:     false,
+		},
+		{
+			name:     "empty string",
+			audience: "",
+			want:     false,
+		},
+		{
+			name:     "random string",
+			audience: "not-a-valid-audience",
+			want:     false,
+		},
+		{
+			name:     "cloud run missing service name",
+			audience: "/projects/123/locations/us-central1/services/",
+			want:     false,
+		},
+		{
+			name:     "GCLB missing id",
+			audience: "/projects/123/global/backendServices/",
+			want:     false,
+		},
+		{
+			name:     "too many segments",
+			audience: "/projects/123/global/backendServices/456/extra",
+			want:     false,
+		},
+		{
+			name:     "cloud run with trailing slash stripped",
+			audience: "/projects/123/locations/us-central1/services/my-svc/",
+			want:     false, // trailing slash produces empty last part
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSupportedIAPAudience(tt.audience)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIapAudienceToCloudRunURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		audience string
+		want     string
+	}{
+		{
+			name:     "valid cloud run audience",
+			audience: "/projects/123456/locations/us-central1/services/my-svc",
+			want:     "https://my-svc-123456.us-central1.run.app",
+		},
+		{
+			name:     "GCLB audience returns empty",
+			audience: "/projects/123/global/backendServices/456",
+			want:     "",
+		},
+		{
+			name:     "malformed returns empty",
+			audience: "/projects/123/foo/bar",
+			want:     "",
+		},
+		{
+			name:     "empty returns empty",
+			audience: "",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := iapAudienceToCloudRunURL(tt.audience)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// validHAConfig returns a fully-valid HA config that passes all preflight
+// checks. Tests modify individual fields to exercise specific validation paths.
+func validHAConfig(audience string) *config.GlobalConfig {
+	return &config.GlobalConfig{
+		Database: config.DatabaseConfig{
+			Driver: "postgres",
+			URL:    "postgres://localhost/scion",
+		},
+		Storage: config.StorageConfig{
+			Provider: "gcs",
+			Bucket:   "test-bucket",
+		},
+		Auth: config.DevAuthConfig{
+			Mode: "proxy",
+			Proxy: &config.ProxyAuthConfig{
+				Provider: "iap",
+				IAP: &config.IAPAuthConfig{
+					Audience: audience,
+				},
+			},
+			Transport: &config.TransportAuthConfig{
+				Mode:           "iap",
+				OIDCAudience:   "client-id.apps.googleusercontent.com",
+				PlatformAuthSA: "sa@project.iam.gserviceaccount.com",
+			},
+		},
+	}
+}
+
+func TestValidateHostedHAPreflight(t *testing.T) {
+	// Save and restore globals that validateHostedHAPreflight depends on.
+	origHostedMode := hostedMode
+	origEnableHub := enableHub
+	origSessionSecret := webSessionSecret
+	t.Cleanup(func() {
+		hostedMode = origHostedMode
+		enableHub = origEnableHub
+		webSessionSecret = origSessionSecret
+	})
+
+	// Set globals so hostedHAGuardsRequired returns true.
+	hostedMode = true
+	enableHub = true
+	webSessionSecret = "test-secret"
+
+	t.Run("GCLB audience passes", func(t *testing.T) {
+		cfg := validHAConfig("/projects/123/global/backendServices/456")
+		err := validateHostedHAPreflight(cfg)
+		require.NoError(t, err)
+	})
+
+	t.Run("Cloud Run audience passes", func(t *testing.T) {
+		cfg := validHAConfig("/projects/123/locations/us-central1/services/my-svc")
+		err := validateHostedHAPreflight(cfg)
+		require.NoError(t, err)
+	})
+
+	t.Run("malformed audience fails", func(t *testing.T) {
+		cfg := validHAConfig("/projects/123/foo/bar")
+		err := validateHostedHAPreflight(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "supported IAP audience")
+	})
+
+	t.Run("empty audience fails", func(t *testing.T) {
+		cfg := validHAConfig("")
+		err := validateHostedHAPreflight(cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "server.auth.proxy.iap.audience")
+	})
+}

--- a/cmd/server_foreground_test.go
+++ b/cmd/server_foreground_test.go
@@ -157,4 +157,13 @@ func TestValidateHostedHAPreflight(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "server.auth.proxy.iap.audience")
 	})
+
+	t.Run("trailing slash is normalized in config", func(t *testing.T) {
+		withHostedHAGuards(t)
+		cfg := validHostedHAConfig()
+		cfg.Auth.Proxy.IAP.Audience = "/projects/123/global/backendServices/456/"
+		require.NoError(t, validateHostedHAPreflight(cfg))
+		assert.Equal(t, "/projects/123/global/backendServices/456", cfg.Auth.Proxy.IAP.Audience,
+			"preflight should strip trailing slash so downstream IAP validation uses the canonical audience")
+	})
 }

--- a/cmd/server_ha_preflight_test.go
+++ b/cmd/server_ha_preflight_test.go
@@ -251,7 +251,7 @@ func TestNewEventPublisherFallsBackOutsideHostedHA(t *testing.T) {
 	require.IsType(t, &hub.ChannelEventPublisher{}, pub)
 }
 
-func TestCloudRunIAPAudienceShape(t *testing.T) {
+func TestIAPAudienceShape(t *testing.T) {
 	require.True(t, isSupportedIAPAudience("/projects/123/locations/us-central1/services/scion"))
 	require.True(t, isSupportedIAPAudience("/projects/123/global/backendServices/456"))
 	require.False(t, isSupportedIAPAudience(strings.TrimSpace("")))

--- a/cmd/server_ha_preflight_test.go
+++ b/cmd/server_ha_preflight_test.go
@@ -89,14 +89,9 @@ func TestValidateHostedHAPreflightRejectsUnsafeBackends(t *testing.T) {
 			},
 			wantErr: "requires server.auth.transport.mode=iap",
 		},
-		{
-			name: "backend service audience",
-			mutate: func(cfg *config.GlobalConfig) {
-				cfg.Auth.Proxy.IAP.Audience = "/projects/123456789/global/backendServices/987654321"
-				cfg.Auth.Transport.OIDCAudience = cfg.Auth.Proxy.IAP.Audience
-			},
-			wantErr: "Cloud Run native IAP audience",
-		},
+		// Note: "backend service audience" case was moved to
+		// TestValidateHostedHAPreflightAcceptsGCLBAudience because GCLB
+		// backend-service audiences are now accepted (GKE HA support).
 		// Note: "transport audience mismatch" case was removed because PR #814
 		// intentionally decoupled transport.oidc_audience from proxy.iap.audience.
 		// transport.oidc_audience is the IAP OAuth client ID used for minting OIDC
@@ -115,6 +110,15 @@ func TestValidateHostedHAPreflightRejectsUnsafeBackends(t *testing.T) {
 			require.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
+}
+
+func TestValidateHostedHAPreflightAcceptsGCLBAudience(t *testing.T) {
+	withHostedHAGuards(t)
+	cfg := validHostedHAConfig()
+	cfg.Auth.Proxy.IAP.Audience = "/projects/123456789/global/backendServices/987654321"
+	cfg.Auth.Transport.OIDCAudience = cfg.Auth.Proxy.IAP.Audience
+
+	require.NoError(t, validateHostedHAPreflight(cfg))
 }
 
 func TestValidateHostedHAPreflightRequiresSessionSecret(t *testing.T) {
@@ -248,7 +252,7 @@ func TestNewEventPublisherFallsBackOutsideHostedHA(t *testing.T) {
 }
 
 func TestCloudRunIAPAudienceShape(t *testing.T) {
-	require.True(t, isCloudRunIAPAudience("/projects/123/locations/us-central1/services/scion"))
-	require.False(t, isCloudRunIAPAudience("/projects/123/global/backendServices/456"))
-	require.False(t, isCloudRunIAPAudience(strings.TrimSpace("")))
+	require.True(t, isSupportedIAPAudience("/projects/123/locations/us-central1/services/scion"))
+	require.True(t, isSupportedIAPAudience("/projects/123/global/backendServices/456"))
+	require.False(t, isSupportedIAPAudience(strings.TrimSpace("")))
 }


### PR DESCRIPTION
## Summary

Extends the HA preflight validation to accept GKE/GCLB backend-service IAP audience format alongside the existing Cloud Run format, enabling HA Hub deployment on GKE behind GCLB+IAP.

Ref: GoogleCloudPlatform/scion#870

- Renamed isCloudRunIAPAudience to isSupportedIAPAudience, accepts both formats
- GCLB format: /projects/<number>/global/backendServices/<id>
- Fail-closed preserved: malformed audiences still rejected
- resolveHubEndpoint warns when GCLB audience detected without SCION_SERVER_BASE_URL
- Error messages updated to be platform-agnostic
- Comprehensive tests for both formats + malformed rejection
