### PR TITLE
docs: nightly documentation update for Aug 6 changelog

### DIFF
--- a/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
+++ b/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
@@ -81,10 +81,23 @@ server:
 
 The `audience` value must match the audience claim (`aud`) in the IAP-signed JWT. The format depends on the backend type:
 
+- **Cloud Run**: `/projects/<PROJECT_NUMBER>/locations/<REGION>/services/<SERVICE_NAME>`
 - **GCE/GKE backend service**: `/projects/<PROJECT_NUMBER>/global/backendServices/<BACKEND_SERVICE_ID>`
 - **App Engine**: `/projects/<PROJECT_NUMBER>/apps/<PROJECT_ID>`
 
 You can find this value in the Google Cloud Console under **Security → Identity-Aware Proxy** → select your backend → **Signed Header JWT Audience**.
+
+:::note[Preflight Validation & Normalization]
+During startup in Hosted HA mode, Scion performs strict preflight checks to validate and normalize the `audience` configuration:
+1. **Normalization**: Any leading/trailing whitespaces or trailing slashes are trimmed, and the normalized audience is written back to the configuration in-place. This prevents runtime signature verification failures caused by minor formatting differences.
+2. **Format Enforcement**: The audience path must follow either the Cloud Run format or the GCLB/GKE backend service format. Other formats are rejected (fail-closed) with a detailed startup error.
+3. **Endpoint Derivation Warning**:
+   - For **Cloud Run** audiences, Scion can automatically derive the Hub's public URL format from the audience.
+   - For **GCLB/GKE** backend-service audiences, Scion *cannot* automatically derive the public endpoint URL because a backend service ID does not contain regional or routing information. You **must explicitly configure the public URL** using the `SCION_SERVER_BASE_URL` environment variable (or `server.hub.public_url` / `SCION_SERVER_HUB_PUBLIC_URL`). If missing, Scion will log a warning at startup and fall back to `localhost`, which is likely unreachable from dispatched agents:
+     ```
+     Warning: GKE/GCLB IAP audience detected but SCION_SERVER_BASE_URL not set; hub endpoint will fall back to localhost which is likely unreachable from dispatched agents
+     ```
+:::
 
 #### Issuer and JWKS overrides
 

--- a/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
+++ b/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
@@ -53,10 +53,10 @@ server:
       provider: iap
       iap:
         # MANDATORY — the IAP audience for your backend.
-        # GCE/GKE backend service format:
+        # Cloud Run format:
+        #   /projects/<PROJECT_NUMBER>/locations/<REGION>/services/<SERVICE_NAME>
+        # GCE/GKE backend service (GCLB) format:
         #   /projects/<PROJECT_NUMBER>/global/backendServices/<BACKEND_SERVICE_ID>
-        # App Engine format:
-        #   /projects/<PROJECT_NUMBER>/apps/<PROJECT_ID>
         audience: "/projects/123456789/global/backendServices/987654321"
 
         # Optional overrides (defaults are correct for production IAP):
@@ -82,8 +82,7 @@ server:
 The `audience` value must match the audience claim (`aud`) in the IAP-signed JWT. The format depends on the backend type:
 
 - **Cloud Run**: `/projects/<PROJECT_NUMBER>/locations/<REGION>/services/<SERVICE_NAME>`
-- **GCE/GKE backend service**: `/projects/<PROJECT_NUMBER>/global/backendServices/<BACKEND_SERVICE_ID>`
-- **App Engine**: `/projects/<PROJECT_NUMBER>/apps/<PROJECT_ID>`
+- **GCE/GKE backend service (GCLB)**: `/projects/<PROJECT_NUMBER>/global/backendServices/<BACKEND_SERVICE_ID>`
 
 You can find this value in the Google Cloud Console under **Security → Identity-Aware Proxy** → select your backend → **Signed Header JWT Audience**.
 

--- a/docs-site/src/content/docs/reference/server-config.md
+++ b/docs-site/src/content/docs/reference/server-config.md
@@ -98,9 +98,27 @@ Persistence settings for the Hub.
 
 | Field | Type | Default | Description |
 | :--- | :--- | :--- | :--- |
-| `dev_mode` | bool | `false` | Enable insecure development authentication. |
+| `mode` | string | `"oauth"` | Selects the exclusive human auth mode: `"oauth"` (default), `"proxy"`, or `"dev"`. |
+| `dev_mode` | bool | `false` | Enable insecure development authentication (used in `"dev"` mode). |
 | `dev_token` | string | | Static token for dev mode. |
 | `authorized_domains` | list | `[]` | Limit access to specific email domains. |
+
+### Proxy Auth (`server.auth.proxy`)
+
+Proxy authentication configuration (consulted when `server.auth.mode` is set to `"proxy"`). See [Proxy Auth (Google IAP)](/scion/hosted/ha/auth-proxy-iap/) for the full deployment guide.
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `provider` | string | | Selects the proxy auth provider: `"iap"` or `"header"`. |
+| `require_trusted_proxy_ip` | bool | `false` | Enables defense-in-depth IP allowlisting. Uses the trusted_proxies CIDR list. |
+
+#### Google IAP Settings (`server.auth.proxy.iap`)
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `audience` | string | | **MANDATORY for IAP.** The expected audience claim (`aud`) in the IAP-signed JWT assertion. Supported formats are Cloud Run native path or GCE/GKE GCLB backend service path. |
+| `issuer` | string | `"https://cloud.google.com/iap"` | The expected JWT issuer. Override only for mock/testing setups. |
+| `jwks_url` | string | `"https://www.gstatic.com/iap/verify/public_key-jwk"` | The URL to retrieve public keys for signature verification. Override only for testing. |
 
 ### Transport Auth (`server.auth.transport`)
 
@@ -234,7 +252,10 @@ When `server.hub.public_url` is not explicitly set, the Hub endpoint injected in
 1. `SCION_SERVER_HUB_PUBLIC_URL` or `server.hub.public_url` — explicit Hub public URL.
 2. Project-level `hub.endpoint` setting.
 3. `SCION_SERVER_BASE_URL` — the server's public base URL (also used for OAuth redirects).
-4. Auto-computed `http://localhost:{port}` (last resort).
+4. **IAP Audience Derivation** (in Hosted HA mode with IAP authentication):
+   - For **Cloud Run** IAP audiences (`/projects/<number>/locations/<region>/services/<service>`), Scion can auto-derive the Hub's URL (e.g., `https://<service>-<number>.<region>.run.app`).
+   - For **GKE/GCLB** backend-service IAP audiences (`/projects/<number>/global/backendServices/<id>`), a URL cannot be derived from the ID. If `SCION_SERVER_BASE_URL` (or other explicit URL settings) is not set, Scion will log a warning at startup and fall back to `localhost`, which is likely unreachable from dispatched agents.
+5. Auto-computed `http://localhost:{port}` (last resort).
 
 For local development where the Hub runs on `localhost` but agents are in containers, set `server.broker.container_hub_endpoint` to a container-accessible address like `http://host.containers.internal:8080`.
 

--- a/docs-site/src/content/docs/reference/server-config.md
+++ b/docs-site/src/content/docs/reference/server-config.md
@@ -253,7 +253,7 @@ When `server.hub.public_url` is not explicitly set, the Hub endpoint injected in
 2. Project-level `hub.endpoint` setting.
 3. `SCION_SERVER_BASE_URL` — the server's public base URL (also used for OAuth redirects).
 4. **IAP Audience Derivation** (in Hosted HA mode with IAP authentication):
-   - For **Cloud Run** IAP audiences (`/projects/<number>/locations/<region>/services/<service>`), Scion can auto-derive the Hub's URL (e.g., `https://<service>-<number>.<region>.run.app`).
+   - For **Cloud Run** IAP audiences (`/projects/<number>/locations/<region>/services/<service>`), Scion can auto-derive the Hub's URL using the legacy Cloud Run URL format (`https://<service>-<number>.<region>.run.app`). Newer Cloud Run services use a different URL format (`https://<service>-<hash>-<region>.a.run.app`) where the hash cannot be derived from the project number — for those services, set `SCION_SERVER_BASE_URL` explicitly instead of relying on auto-derivation.
    - For **GKE/GCLB** backend-service IAP audiences (`/projects/<number>/global/backendServices/<id>`), a URL cannot be derived from the ID. If `SCION_SERVER_BASE_URL` (or other explicit URL settings) is not set, Scion will log a warning at startup and fall back to `localhost`, which is likely unreachable from dispatched agents.
 5. Auto-computed `http://localhost:{port}` (last resort).
 


### PR DESCRIPTION
## Summary

Nightly documentation update covering the Aug 6 changelog.

- Documented GKE/GCLB IAP audience validation and URL auto-derivation
- Added Google IAP proxy configuration section to server-config reference
- Covers Cloud Run vs GCLB audience formats, preflight validation, startup fallback

2 files changed, 36 insertions, 2 deletions.
