### PR TITLE
fix: persist message_broker.types across update/restart/rebuild

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -445,11 +445,13 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 				for name := range vs.Server.Plugins.Broker {
 					if !typesSet[name] {
 						vs.Server.MessageBroker.Types = append(vs.Server.MessageBroker.Types, name)
+						hub.SettingsWriteMu.Lock()
 						if err := config.AddPluginToMessageBrokerTypes(name); err != nil {
 							log.Printf("Warning: failed to persist %s to message_broker.types: %v", name, err)
 						} else {
 							log.Printf("NOTICE: auto-added %q to message_broker.types (was configured but missing)", name)
 						}
+						hub.SettingsWriteMu.Unlock()
 					}
 				}
 			}

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -430,28 +430,28 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 				}
 				if !vs.Server.MessageBroker.Enabled {
 					vs.Server.MessageBroker.Enabled = true
-					seen := make(map[string]bool, len(vs.Server.MessageBroker.Types))
-					for _, t := range vs.Server.MessageBroker.Types {
-						seen[t] = true
-					}
-					for name := range vs.Server.Plugins.Broker {
-						if !seen[name] {
-							vs.Server.MessageBroker.Types = append(vs.Server.MessageBroker.Types, name)
-							seen[name] = true
-						}
-					}
-					log.Printf("Auto-enabled message broker for configured broker plugin(s): %v", vs.Server.MessageBroker.Types)
+					log.Printf("Auto-enabled message broker for configured broker plugin(s)")
 				}
 			}
 
-			// Auto-populate: if message_broker.enabled but types is empty while
-			// broker plugins exist, populate types from the plugin list.
-			if vs.Server.Plugins != nil && vs.Server.MessageBroker != nil &&
-				vs.Server.MessageBroker.Enabled && len(vs.Server.MessageBroker.Types) == 0 && len(vs.Server.Plugins.Broker) > 0 {
-				for name := range vs.Server.Plugins.Broker {
-					vs.Server.MessageBroker.Types = append(vs.Server.MessageBroker.Types, name)
+			// Reconcile: ensure every configured broker plugin is listed in
+			// message_broker.types (in-memory AND on disk). Covers both empty
+			// and partially-populated type lists.
+			if vs.Server.Plugins != nil && vs.Server.MessageBroker != nil && len(vs.Server.Plugins.Broker) > 0 {
+				typesSet := make(map[string]bool, len(vs.Server.MessageBroker.Types))
+				for _, t := range vs.Server.MessageBroker.Types {
+					typesSet[t] = true
 				}
-				log.Printf("NOTICE: message_broker.types was empty — auto-populated from plugins: %v", vs.Server.MessageBroker.Types)
+				for name := range vs.Server.Plugins.Broker {
+					if !typesSet[name] {
+						vs.Server.MessageBroker.Types = append(vs.Server.MessageBroker.Types, name)
+						if err := config.AddPluginToMessageBrokerTypes(name); err != nil {
+							log.Printf("Warning: failed to persist %s to message_broker.types: %v", name, err)
+						} else {
+							log.Printf("NOTICE: auto-added %q to message_broker.types (was configured but missing)", name)
+						}
+					}
+				}
 			}
 
 			// Warn on plugin-not-in-types

--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -500,7 +500,7 @@ func AddPluginToSettings(pluginName, configFilePath string) error {
 // AddPluginToMessageBrokerTypes appends pluginName to
 // server.message_broker.types in the global settings.yaml if it is not already
 // present. It also ensures that message_broker.enabled is true. The caller is
-// responsible for serialising concurrent writes (settingsWriteMu).
+// responsible for serialising concurrent writes (hub.SettingsWriteMu).
 func AddPluginToMessageBrokerTypes(pluginName string) error {
 	globalDir, err := GetGlobalDir()
 	if err != nil {

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -601,6 +601,15 @@ func (s *Server) handleUpdateIntegrationConfig(w http.ResponseWriter, r *http.Re
 		}
 	}
 
+	// Ensure the plugin is listed in message_broker.types on disk so it
+	// survives future restarts/rebuilds that re-read settings.yaml.
+	settingsWriteMu.Lock()
+	if err := config.AddPluginToMessageBrokerTypes(name); err != nil {
+		slog.Warn("Failed to ensure plugin in message_broker.types", "plugin", name, "error", err)
+		// Non-fatal — continue with the config update.
+	}
+	settingsWriteMu.Unlock()
+
 	// Reconfigure the running integration with updated config.
 	// For HA integrations the DB write + NOTIFY is the reconfigure path —
 	// pushing a hub-side merge over gRPC would race with the DB-backed reload.
@@ -642,6 +651,15 @@ func (s *Server) handleRestartIntegration(w http.ResponseWriter, r *http.Request
 		NotFound(w, "integration")
 		return
 	}
+
+	// Ensure the plugin is listed in message_broker.types on disk so it
+	// survives future restarts/rebuilds that re-read settings.yaml.
+	settingsWriteMu.Lock()
+	if err := config.AddPluginToMessageBrokerTypes(name); err != nil {
+		slog.Warn("Failed to ensure plugin in message_broker.types", "plugin", name, "error", err)
+		// Non-fatal — continue with the restart.
+	}
+	settingsWriteMu.Unlock()
 
 	// reconfigureIntegration pushes new config to the running plugin process
 	// (via ReplaceBrokerConfig) without killing it, so the existing spoke's
@@ -753,6 +771,15 @@ func (s *Server) handleUpdateIntegration(w http.ResponseWriter, r *http.Request,
 		return
 	}
 	defer releasePluginBuildLock(name)
+
+	// Ensure the plugin is listed in message_broker.types on disk so it
+	// survives future restarts/rebuilds that re-read settings.yaml.
+	settingsWriteMu.Lock()
+	if err := config.AddPluginToMessageBrokerTypes(name); err != nil {
+		slog.Warn("Failed to ensure plugin in message_broker.types", "plugin", name, "error", err)
+		// Non-fatal — continue with the update.
+	}
+	settingsWriteMu.Unlock()
 
 	if err := mgr.UpdatePlugin(name, repoPath); err != nil {
 		slog.Error("Failed to update integration", "plugin", name, "error", err)
@@ -1138,6 +1165,15 @@ func (s *Server) handleRebuildSelfManaged(w http.ResponseWriter, _ *http.Request
 
 	slog.Info("Self-managed plugin binary rebuilt successfully",
 		"plugin", kp.Name, "binary", binaryPath)
+
+	// Ensure the plugin is listed in message_broker.types on disk so it
+	// survives future restarts/rebuilds that re-read settings.yaml.
+	settingsWriteMu.Lock()
+	if err := config.AddPluginToMessageBrokerTypes(kp.Name); err != nil {
+		slog.Warn("Failed to ensure plugin in message_broker.types", "plugin", kp.Name, "error", err)
+		// Non-fatal — continue with the rebuild response.
+	}
+	settingsWriteMu.Unlock()
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"status":      "rebuilt",

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -186,8 +186,8 @@ func lookupKnownPlugin(name string) *KnownPlugin {
 	return nil
 }
 
-// settingsWriteMu guards concurrent writes to settings.yaml.
-var settingsWriteMu sync.Mutex
+// SettingsWriteMu guards concurrent writes to settings.yaml.
+var SettingsWriteMu sync.Mutex
 
 // pluginBuildMu guards concurrent build operations per plugin name.
 var pluginBuildMu sync.Map
@@ -603,12 +603,12 @@ func (s *Server) handleUpdateIntegrationConfig(w http.ResponseWriter, r *http.Re
 
 	// Ensure the plugin is listed in message_broker.types on disk so it
 	// survives future restarts/rebuilds that re-read settings.yaml.
-	settingsWriteMu.Lock()
+	SettingsWriteMu.Lock()
 	if err := config.AddPluginToMessageBrokerTypes(name); err != nil {
 		slog.Warn("Failed to ensure plugin in message_broker.types", "plugin", name, "error", err)
 		// Non-fatal — continue with the config update.
 	}
-	settingsWriteMu.Unlock()
+	SettingsWriteMu.Unlock()
 
 	// Reconfigure the running integration with updated config.
 	// For HA integrations the DB write + NOTIFY is the reconfigure path —
@@ -654,12 +654,12 @@ func (s *Server) handleRestartIntegration(w http.ResponseWriter, r *http.Request
 
 	// Ensure the plugin is listed in message_broker.types on disk so it
 	// survives future restarts/rebuilds that re-read settings.yaml.
-	settingsWriteMu.Lock()
+	SettingsWriteMu.Lock()
 	if err := config.AddPluginToMessageBrokerTypes(name); err != nil {
 		slog.Warn("Failed to ensure plugin in message_broker.types", "plugin", name, "error", err)
 		// Non-fatal — continue with the restart.
 	}
-	settingsWriteMu.Unlock()
+	SettingsWriteMu.Unlock()
 
 	// reconfigureIntegration pushes new config to the running plugin process
 	// (via ReplaceBrokerConfig) without killing it, so the existing spoke's
@@ -774,12 +774,12 @@ func (s *Server) handleUpdateIntegration(w http.ResponseWriter, r *http.Request,
 
 	// Ensure the plugin is listed in message_broker.types on disk so it
 	// survives future restarts/rebuilds that re-read settings.yaml.
-	settingsWriteMu.Lock()
+	SettingsWriteMu.Lock()
 	if err := config.AddPluginToMessageBrokerTypes(name); err != nil {
 		slog.Warn("Failed to ensure plugin in message_broker.types", "plugin", name, "error", err)
 		// Non-fatal — continue with the update.
 	}
-	settingsWriteMu.Unlock()
+	SettingsWriteMu.Unlock()
 
 	if err := mgr.UpdatePlugin(name, repoPath); err != nil {
 		slog.Error("Failed to update integration", "plugin", name, "error", err)
@@ -891,12 +891,12 @@ func (s *Server) handleInstallIntegration(w http.ResponseWriter, r *http.Request
 		slog.Info("Plugin config file already exists, preserving", "plugin", name, "path", resolvedConfigPath)
 	}
 
-	settingsWriteMu.Lock()
+	SettingsWriteMu.Lock()
 	err = config.AddPluginToSettings(name, configFilePath)
 	if err == nil {
 		err = config.AddPluginToMessageBrokerTypes(name)
 	}
-	settingsWriteMu.Unlock()
+	SettingsWriteMu.Unlock()
 	if err != nil {
 		slog.Error("Failed to add plugin to settings.yaml", "plugin", name, "error", err)
 		InternalError(w)
@@ -1005,13 +1005,13 @@ func (s *Server) handleInstallSelfManaged(w http.ResponseWriter, r *http.Request
 
 	// 3. Register in settings.yaml with self-managed fields and broker type
 	//    in a single read-modify-write cycle.
-	settingsWriteMu.Lock()
+	SettingsWriteMu.Lock()
 	err = config.AddSelfManagedPluginWithBrokerType(config.SelfManagedPluginEntry{
 		Name:       name,
 		Address:    "localhost:9090",
 		ConfigFile: adminConfigPath,
 	})
-	settingsWriteMu.Unlock()
+	SettingsWriteMu.Unlock()
 	if err != nil {
 		slog.Error("Failed to add self-managed plugin to settings.yaml", "plugin", name, "error", err)
 		InternalError(w)
@@ -1168,12 +1168,12 @@ func (s *Server) handleRebuildSelfManaged(w http.ResponseWriter, _ *http.Request
 
 	// Ensure the plugin is listed in message_broker.types on disk so it
 	// survives future restarts/rebuilds that re-read settings.yaml.
-	settingsWriteMu.Lock()
+	SettingsWriteMu.Lock()
 	if err := config.AddPluginToMessageBrokerTypes(kp.Name); err != nil {
 		slog.Warn("Failed to ensure plugin in message_broker.types", "plugin", kp.Name, "error", err)
 		// Non-fatal — continue with the rebuild response.
 	}
-	settingsWriteMu.Unlock()
+	SettingsWriteMu.Unlock()
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"status":      "rebuilt",


### PR DESCRIPTION
AddPluginToMessageBrokerTypes was only called during the install flow. Update, restart, config-update, and rebuild handlers did not call it, so if settings.yaml was overwritten (hub rebuild, manual edit, backup restore), plugins would load but silently stop routing messages.

Additionally, the startup auto-populate only fired when the types list was completely empty and only modified the in-memory struct without persisting to disk.

Changes:
- Add AddPluginToMessageBrokerTypes calls (non-fatal, under settingsWriteMu) to handleRestartIntegration, handleUpdateIntegration, handleUpdateIntegrationConfig, and handleRebuildSelfManaged
- Replace startup auto-populate with full reconciliation that handles partial type lists and persists missing entries to settings.yaml via AddPluginToMessageBrokerTypes

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
