### PR TITLE
fix(a2a-bridge): incorporate caller identity into ScopedTaskStore ownership key

### DIFF
--- a/extras/scion-a2a-bridge/internal/bridge/scoped_store.go
+++ b/extras/scion-a2a-bridge/internal/bridge/scoped_store.go
@@ -32,7 +32,7 @@ type ScopedTaskStore struct {
 	inner taskstore.Store
 
 	mu        sync.RWMutex
-	ownership map[a2a.TaskID]string // taskID → "projectSlug:agentSlug"
+	ownership map[a2a.TaskID]string // taskID → "projectSlug:agentSlug[:userID]"
 }
 
 var _ taskstore.Store = (*ScopedTaskStore)(nil)
@@ -45,13 +45,22 @@ func NewScopedTaskStore(inner taskstore.Store) *ScopedTaskStore {
 	}
 }
 
-// ownerKey returns the ownership key from the route info in context.
+// ownerKey returns the ownership key derived from the request context.
+// When a CallerIdentity is present (per-user auth schemes like hubJWT/hubUAT),
+// the caller's UserID is incorporated into the key so that different users on
+// the same project/agent route get isolated task namespaces. For legacy auth
+// schemes (apiKey/bearer/none) where no CallerIdentity exists, the key is
+// based solely on the route (project + agent), preserving backward compatibility.
 func ownerKey(ctx context.Context) (string, bool) {
 	route, ok := RouteInfoFrom(ctx)
 	if !ok {
 		return "", false
 	}
-	return route.ProjectSlug + ":" + route.AgentSlug, true
+	key := route.ProjectSlug + ":" + route.AgentSlug
+	if caller := callerIdentityFromContext(ctx); caller != nil && caller.UserID != "" {
+		key += ":" + caller.UserID
+	}
+	return key, true
 }
 
 // Create stores the task and records its ownership based on the route info in context.
@@ -118,15 +127,21 @@ func (s *ScopedTaskStore) List(ctx context.Context, req *a2a.ListTasksRequest) (
 }
 
 // RouteKeyAuthenticator returns a taskstore.Authenticator that derives the
-// "user" identity from the RouteInfo in the request context. This ensures
-// the in-memory task store's built-in user-filtering on List matches tasks
-// to the correct project/agent pair.
+// "user" identity from the request context. When a CallerIdentity is present
+// (per-user auth schemes like hubJWT/hubUAT), the caller's UserID is included
+// in the identity key so the in-memory task store's built-in user-filtering on
+// List isolates tasks per caller. For legacy auth schemes (apiKey/bearer/none),
+// the identity is based solely on the route (project + agent pair).
 func RouteKeyAuthenticator() taskstore.Authenticator {
 	return func(ctx context.Context) (string, error) {
 		route, ok := RouteInfoFrom(ctx)
 		if !ok {
 			return "", fmt.Errorf("missing route info: %w", a2a.ErrUnauthenticated)
 		}
-		return route.ProjectSlug + ":" + route.AgentSlug, nil
+		key := route.ProjectSlug + ":" + route.AgentSlug
+		if caller := callerIdentityFromContext(ctx); caller != nil && caller.UserID != "" {
+			key += ":" + caller.UserID
+		}
+		return key, nil
 	}
 }

--- a/extras/scion-a2a-bridge/internal/bridge/scoped_store.go
+++ b/extras/scion-a2a-bridge/internal/bridge/scoped_store.go
@@ -55,33 +55,37 @@ func NewScopedTaskStore(inner taskstore.Store) *ScopedTaskStore {
 //
 // Both ownerKey() and RouteKeyAuthenticator() delegate here to ensure the key
 // format stays consistent across Create/Get/Update and List operations.
-func buildOwnerKey(ctx context.Context) (string, bool) {
+func buildOwnerKey(ctx context.Context) (string, bool, error) {
 	route, ok := RouteInfoFrom(ctx)
 	if !ok {
-		return "", false
+		return "", false, nil
 	}
 	key := route.ProjectSlug + ":" + route.AgentSlug
 	if caller := callerIdentityFromContext(ctx); caller != nil {
 		if caller.UserID != "" {
 			key += ":" + caller.UserID
 		} else {
-			slog.Warn("CallerIdentity present but UserID is empty; falling back to route-only key",
+			slog.Warn("CallerIdentity present but UserID is empty; rejecting request",
 				"project", route.ProjectSlug,
 				"agent", route.AgentSlug,
 			)
+			return "", true, fmt.Errorf("CallerIdentity present but UserID is empty: %w", a2a.ErrUnauthenticated)
 		}
 	}
-	return key, true
+	return key, true, nil
 }
 
 // ownerKey returns the ownership key derived from the request context.
-func ownerKey(ctx context.Context) (string, bool) {
+func ownerKey(ctx context.Context) (string, bool, error) {
 	return buildOwnerKey(ctx)
 }
 
 // Create stores the task and records its ownership based on the route info in context.
 func (s *ScopedTaskStore) Create(ctx context.Context, task *a2a.Task) (taskstore.TaskVersion, error) {
-	owner, ok := ownerKey(ctx)
+	owner, ok, err := ownerKey(ctx)
+	if err != nil {
+		return taskstore.TaskVersionMissing, fmt.Errorf("task creation rejected: %w", err)
+	}
 	if !ok {
 		return taskstore.TaskVersionMissing, fmt.Errorf("missing route info for task creation: %w", a2a.ErrInternalError)
 	}
@@ -100,7 +104,10 @@ func (s *ScopedTaskStore) Create(ctx context.Context, task *a2a.Task) (taskstore
 
 // Update verifies ownership before delegating to the inner store.
 func (s *ScopedTaskStore) Update(ctx context.Context, update *taskstore.UpdateRequest) (taskstore.TaskVersion, error) {
-	owner, ok := ownerKey(ctx)
+	owner, ok, err := ownerKey(ctx)
+	if err != nil {
+		return taskstore.TaskVersionMissing, fmt.Errorf("task update rejected: %w", err)
+	}
 	if !ok {
 		return taskstore.TaskVersionMissing, fmt.Errorf("missing route info for task update: %w", a2a.ErrInternalError)
 	}
@@ -118,7 +125,10 @@ func (s *ScopedTaskStore) Update(ctx context.Context, update *taskstore.UpdateRe
 
 // Get retrieves a task and verifies that the caller owns it.
 func (s *ScopedTaskStore) Get(ctx context.Context, taskID a2a.TaskID) (*taskstore.StoredTask, error) {
-	owner, ok := ownerKey(ctx)
+	owner, ok, err := ownerKey(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("task get rejected: %w", err)
+	}
 	if !ok {
 		return nil, fmt.Errorf("missing route info for task get: %w", a2a.ErrInternalError)
 	}
@@ -150,7 +160,10 @@ func (s *ScopedTaskStore) List(ctx context.Context, req *a2a.ListTasksRequest) (
 // the identity is based solely on the route (project + agent pair).
 func RouteKeyAuthenticator() taskstore.Authenticator {
 	return func(ctx context.Context) (string, error) {
-		key, ok := buildOwnerKey(ctx)
+		key, ok, err := buildOwnerKey(ctx)
+		if err != nil {
+			return "", err
+		}
 		if !ok {
 			return "", fmt.Errorf("missing route info: %w", a2a.ErrUnauthenticated)
 		}

--- a/extras/scion-a2a-bridge/internal/bridge/scoped_store.go
+++ b/extras/scion-a2a-bridge/internal/bridge/scoped_store.go
@@ -17,6 +17,7 @@ package bridge
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
@@ -45,22 +46,37 @@ func NewScopedTaskStore(inner taskstore.Store) *ScopedTaskStore {
 	}
 }
 
-// ownerKey returns the ownership key derived from the request context.
+// buildOwnerKey constructs the ownership key from the request context.
 // When a CallerIdentity is present (per-user auth schemes like hubJWT/hubUAT),
 // the caller's UserID is incorporated into the key so that different users on
 // the same project/agent route get isolated task namespaces. For legacy auth
 // schemes (apiKey/bearer/none) where no CallerIdentity exists, the key is
 // based solely on the route (project + agent), preserving backward compatibility.
-func ownerKey(ctx context.Context) (string, bool) {
+//
+// Both ownerKey() and RouteKeyAuthenticator() delegate here to ensure the key
+// format stays consistent across Create/Get/Update and List operations.
+func buildOwnerKey(ctx context.Context) (string, bool) {
 	route, ok := RouteInfoFrom(ctx)
 	if !ok {
 		return "", false
 	}
 	key := route.ProjectSlug + ":" + route.AgentSlug
-	if caller := callerIdentityFromContext(ctx); caller != nil && caller.UserID != "" {
-		key += ":" + caller.UserID
+	if caller := callerIdentityFromContext(ctx); caller != nil {
+		if caller.UserID != "" {
+			key += ":" + caller.UserID
+		} else {
+			slog.Warn("CallerIdentity present but UserID is empty; falling back to route-only key",
+				"project", route.ProjectSlug,
+				"agent", route.AgentSlug,
+			)
+		}
 	}
 	return key, true
+}
+
+// ownerKey returns the ownership key derived from the request context.
+func ownerKey(ctx context.Context) (string, bool) {
+	return buildOwnerKey(ctx)
 }
 
 // Create stores the task and records its ownership based on the route info in context.
@@ -134,13 +150,9 @@ func (s *ScopedTaskStore) List(ctx context.Context, req *a2a.ListTasksRequest) (
 // the identity is based solely on the route (project + agent pair).
 func RouteKeyAuthenticator() taskstore.Authenticator {
 	return func(ctx context.Context) (string, error) {
-		route, ok := RouteInfoFrom(ctx)
+		key, ok := buildOwnerKey(ctx)
 		if !ok {
 			return "", fmt.Errorf("missing route info: %w", a2a.ErrUnauthenticated)
-		}
-		key := route.ProjectSlug + ":" + route.AgentSlug
-		if caller := callerIdentityFromContext(ctx); caller != nil && caller.UserID != "" {
-			key += ":" + caller.UserID
 		}
 		return key, nil
 	}

--- a/extras/scion-a2a-bridge/internal/bridge/scoped_store_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/scoped_store_test.go
@@ -163,6 +163,57 @@ func TestScopedStoreGetRequiresRouteInfo(t *testing.T) {
 	}
 }
 
+// --- Empty UserID edge case (Optional-1) ---
+
+func TestScopedStoreEmptyUserIDFallback(t *testing.T) {
+	// When CallerIdentity is present but UserID is empty, the ownership key
+	// should fall back to route-only keying (project:agent). This documents
+	// current defense-in-depth behavior: a broken validator that produces an
+	// empty UserID does not silently create a separate namespace — instead it
+	// falls back to the shared route key (and a warning is logged).
+	store := newScopedStore(t)
+	ctxRouteOnly := ctxForRoute("proj-a", "agent-1")
+	ctxEmptyUser := ctxForRouteAndCaller("proj-a", "agent-1", "")
+
+	// Create a task with a route-only context (no CallerIdentity).
+	task := &a2a.Task{
+		ID:        "task-empty-uid",
+		ContextID: "ctx-1",
+		Status:    a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+	}
+	if _, err := store.Create(ctxRouteOnly, task); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// A context with CallerIdentity{UserID: ""} should resolve to the same
+	// route-only key and therefore be able to access the task.
+	stored, err := store.Get(ctxEmptyUser, "task-empty-uid")
+	if err != nil {
+		t.Fatalf("Get (empty UserID, same route): %v", err)
+	}
+	if stored.Task.ID != "task-empty-uid" {
+		t.Errorf("task ID = %q, want %q", stored.Task.ID, "task-empty-uid")
+	}
+
+	// Verify the reverse: a task created with empty UserID should also be
+	// visible to a route-only context.
+	task2 := &a2a.Task{
+		ID:        "task-empty-uid-2",
+		ContextID: "ctx-1",
+		Status:    a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+	}
+	if _, err := store.Create(ctxEmptyUser, task2); err != nil {
+		t.Fatalf("Create (empty UserID): %v", err)
+	}
+	stored2, err := store.Get(ctxRouteOnly, "task-empty-uid-2")
+	if err != nil {
+		t.Fatalf("Get (route-only for empty-UserID task): %v", err)
+	}
+	if stored2.Task.ID != "task-empty-uid-2" {
+		t.Errorf("task ID = %q, want %q", stored2.Task.ID, "task-empty-uid-2")
+	}
+}
+
 // --- Cross-user isolation tests (per-user auth: hubJWT/hubUAT) ---
 
 func TestScopedStoreCrossUserGetDenied(t *testing.T) {

--- a/extras/scion-a2a-bridge/internal/bridge/scoped_store_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/scoped_store_test.go
@@ -39,6 +39,13 @@ func ctxForRoute(project, agent string) context.Context {
 	})
 }
 
+// ctxForRouteAndCaller creates a context with both route info and a caller identity,
+// simulating a per-user auth request (hubJWT/hubUAT).
+func ctxForRouteAndCaller(project, agent, userID string) context.Context {
+	ctx := ctxForRoute(project, agent)
+	return withCallerIdentity(ctx, &CallerIdentity{UserID: userID})
+}
+
 func TestScopedStoreCreateAndGet(t *testing.T) {
 	store := newScopedStore(t)
 	ctx := ctxForRoute("proj-a", "agent-1")
@@ -153,5 +160,199 @@ func TestScopedStoreGetRequiresRouteInfo(t *testing.T) {
 	_, err := store.Get(context.Background(), "task-getnoroute")
 	if err == nil {
 		t.Fatal("expected error when route info is missing for Get")
+	}
+}
+
+// --- Cross-user isolation tests (per-user auth: hubJWT/hubUAT) ---
+
+func TestScopedStoreCrossUserGetDenied(t *testing.T) {
+	store := newScopedStore(t)
+	ctxAlice := ctxForRouteAndCaller("proj-a", "agent-1", "alice-id")
+	ctxBob := ctxForRouteAndCaller("proj-a", "agent-1", "bob-id")
+
+	task := &a2a.Task{
+		ID:        "task-alice",
+		ContextID: "ctx-1",
+		Status:    a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+	}
+	if _, err := store.Create(ctxAlice, task); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Alice can read her own task.
+	stored, err := store.Get(ctxAlice, "task-alice")
+	if err != nil {
+		t.Fatalf("Get (Alice, own task): %v", err)
+	}
+	if stored.Task.ID != "task-alice" {
+		t.Errorf("task ID = %q, want %q", stored.Task.ID, "task-alice")
+	}
+
+	// Bob on the same route must NOT see Alice's task.
+	_, err = store.Get(ctxBob, "task-alice")
+	if err == nil {
+		t.Fatal("expected error for cross-user Get on same route")
+	}
+	if !errors.Is(err, a2a.ErrTaskNotFound) {
+		t.Errorf("error = %v, want ErrTaskNotFound", err)
+	}
+}
+
+func TestScopedStoreCrossUserUpdateDenied(t *testing.T) {
+	store := newScopedStore(t)
+	ctxAlice := ctxForRouteAndCaller("proj-a", "agent-1", "alice-id")
+	ctxBob := ctxForRouteAndCaller("proj-a", "agent-1", "bob-id")
+
+	task := &a2a.Task{
+		ID:        "task-alice-upd",
+		ContextID: "ctx-1",
+		Status:    a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+	}
+	version, err := store.Create(ctxAlice, task)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Bob must not be able to update Alice's task.
+	updatedTask := &a2a.Task{
+		ID:        "task-alice-upd",
+		ContextID: "ctx-1",
+		Status:    a2a.TaskStatus{State: a2a.TaskStateFailed},
+	}
+	_, err = store.Update(ctxBob, &taskstore.UpdateRequest{
+		Task:        updatedTask,
+		PrevVersion: version,
+	})
+	if err == nil {
+		t.Fatal("expected error for cross-user Update on same route")
+	}
+	if !errors.Is(err, a2a.ErrTaskNotFound) {
+		t.Errorf("error = %v, want ErrTaskNotFound", err)
+	}
+}
+
+func TestScopedStoreCrossUserListIsolated(t *testing.T) {
+	store := newScopedStore(t)
+	ctxAlice := ctxForRouteAndCaller("proj-a", "agent-1", "alice-id")
+	ctxBob := ctxForRouteAndCaller("proj-a", "agent-1", "bob-id")
+
+	// Alice creates a task.
+	aliceTask := &a2a.Task{
+		ID:        "task-alice-list",
+		ContextID: "ctx-shared",
+		Status:    a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+	}
+	if _, err := store.Create(ctxAlice, aliceTask); err != nil {
+		t.Fatalf("Create (Alice): %v", err)
+	}
+
+	// Bob creates a task on the same route and context.
+	bobTask := &a2a.Task{
+		ID:        "task-bob-list",
+		ContextID: "ctx-shared",
+		Status:    a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+	}
+	if _, err := store.Create(ctxBob, bobTask); err != nil {
+		t.Fatalf("Create (Bob): %v", err)
+	}
+
+	// Alice's ListTasks should return only her task.
+	aliceResp, err := store.List(ctxAlice, &a2a.ListTasksRequest{ContextID: "ctx-shared"})
+	if err != nil {
+		t.Fatalf("List (Alice): %v", err)
+	}
+	if len(aliceResp.Tasks) != 1 || aliceResp.Tasks[0].ID != "task-alice-list" {
+		var ids []string
+		for _, tk := range aliceResp.Tasks {
+			ids = append(ids, string(tk.ID))
+		}
+		t.Errorf("Alice's List returned tasks %v, want [task-alice-list]", ids)
+	}
+
+	// Bob's ListTasks should return only his task.
+	bobResp, err := store.List(ctxBob, &a2a.ListTasksRequest{ContextID: "ctx-shared"})
+	if err != nil {
+		t.Fatalf("List (Bob): %v", err)
+	}
+	if len(bobResp.Tasks) != 1 || bobResp.Tasks[0].ID != "task-bob-list" {
+		var ids []string
+		for _, tk := range bobResp.Tasks {
+			ids = append(ids, string(tk.ID))
+		}
+		t.Errorf("Bob's List returned tasks %v, want [task-bob-list]", ids)
+	}
+}
+
+func TestScopedStorePerUserAuthOwnTasksWork(t *testing.T) {
+	store := newScopedStore(t)
+	ctxAlice := ctxForRouteAndCaller("proj-a", "agent-1", "alice-id")
+
+	task := &a2a.Task{
+		ID:        "task-alice-own",
+		ContextID: "ctx-1",
+		Status:    a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+	}
+	version, err := store.Create(ctxAlice, task)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Alice can Get her own task.
+	stored, err := store.Get(ctxAlice, "task-alice-own")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if stored.Task.ID != "task-alice-own" {
+		t.Errorf("task ID = %q, want %q", stored.Task.ID, "task-alice-own")
+	}
+
+	// Alice can Update her own task.
+	updatedTask := &a2a.Task{
+		ID:        "task-alice-own",
+		ContextID: "ctx-1",
+		Status:    a2a.TaskStatus{State: a2a.TaskStateCompleted},
+	}
+	_, err = store.Update(ctxAlice, &taskstore.UpdateRequest{
+		Task:        updatedTask,
+		PrevVersion: version,
+	})
+	if err != nil {
+		t.Fatalf("Update (own task): %v", err)
+	}
+}
+
+func TestScopedStoreNoCallerIdentityFallback(t *testing.T) {
+	// When no CallerIdentity is in context (legacy apiKey/bearer/none auth),
+	// the route-only keying should still work as before.
+	store := newScopedStore(t)
+	ctxA := ctxForRoute("proj-a", "agent-1") // No CallerIdentity
+	ctxB := ctxForRoute("proj-a", "agent-1") // Same route, also no CallerIdentity
+
+	task := &a2a.Task{
+		ID:        "task-legacy",
+		ContextID: "ctx-1",
+		Status:    a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+	}
+	if _, err := store.Create(ctxA, task); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Both contexts (same route, no caller identity) should see the task.
+	stored, err := store.Get(ctxB, "task-legacy")
+	if err != nil {
+		t.Fatalf("Get (same route, no caller): %v", err)
+	}
+	if stored.Task.ID != "task-legacy" {
+		t.Errorf("task ID = %q, want %q", stored.Task.ID, "task-legacy")
+	}
+
+	// But a different route still cannot see it.
+	ctxOther := ctxForRoute("proj-b", "agent-2")
+	_, err = store.Get(ctxOther, "task-legacy")
+	if err == nil {
+		t.Fatal("expected error for different-route Get")
+	}
+	if !errors.Is(err, a2a.ErrTaskNotFound) {
+		t.Errorf("error = %v, want ErrTaskNotFound", err)
 	}
 }

--- a/extras/scion-a2a-bridge/internal/bridge/scoped_store_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/scoped_store_test.go
@@ -163,55 +163,92 @@ func TestScopedStoreGetRequiresRouteInfo(t *testing.T) {
 	}
 }
 
-// --- Empty UserID edge case (Optional-1) ---
+// --- Empty UserID edge case: fail-closed ---
 
-func TestScopedStoreEmptyUserIDFallback(t *testing.T) {
-	// When CallerIdentity is present but UserID is empty, the ownership key
-	// should fall back to route-only keying (project:agent). This documents
-	// current defense-in-depth behavior: a broken validator that produces an
-	// empty UserID does not silently create a separate namespace — instead it
-	// falls back to the shared route key (and a warning is logged).
+func TestScopedStoreEmptyUserIDRejected(t *testing.T) {
+	// When CallerIdentity is present but UserID is empty, the request must be
+	// rejected (fail-closed). Falling back to route-only keying would silently
+	// restore the cross-user vulnerability that per-user scoping is meant to fix.
 	store := newScopedStore(t)
-	ctxRouteOnly := ctxForRoute("proj-a", "agent-1")
 	ctxEmptyUser := ctxForRouteAndCaller("proj-a", "agent-1", "")
 
-	// Create a task with a route-only context (no CallerIdentity).
-	task := &a2a.Task{
-		ID:        "task-empty-uid",
-		ContextID: "ctx-1",
-		Status:    a2a.TaskStatus{State: a2a.TaskStateSubmitted},
-	}
-	if _, err := store.Create(ctxRouteOnly, task); err != nil {
-		t.Fatalf("Create: %v", err)
-	}
+	t.Run("Create rejected", func(t *testing.T) {
+		task := &a2a.Task{
+			ID:        "task-empty-uid",
+			ContextID: "ctx-1",
+			Status:    a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+		}
+		_, err := store.Create(ctxEmptyUser, task)
+		if err == nil {
+			t.Fatal("expected error when CallerIdentity has empty UserID")
+		}
+		if !errors.Is(err, a2a.ErrUnauthenticated) {
+			t.Errorf("error = %v, want ErrUnauthenticated in chain", err)
+		}
+	})
 
-	// A context with CallerIdentity{UserID: ""} should resolve to the same
-	// route-only key and therefore be able to access the task.
-	stored, err := store.Get(ctxEmptyUser, "task-empty-uid")
-	if err != nil {
-		t.Fatalf("Get (empty UserID, same route): %v", err)
-	}
-	if stored.Task.ID != "task-empty-uid" {
-		t.Errorf("task ID = %q, want %q", stored.Task.ID, "task-empty-uid")
-	}
+	t.Run("Get rejected", func(t *testing.T) {
+		// First create a task with a valid context so there's something to Get.
+		ctxValid := ctxForRouteAndCaller("proj-a", "agent-1", "valid-user")
+		task := &a2a.Task{
+			ID:        "task-valid-for-get",
+			ContextID: "ctx-1",
+			Status:    a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+		}
+		if _, err := store.Create(ctxValid, task); err != nil {
+			t.Fatalf("Create (valid user): %v", err)
+		}
 
-	// Verify the reverse: a task created with empty UserID should also be
-	// visible to a route-only context.
-	task2 := &a2a.Task{
-		ID:        "task-empty-uid-2",
-		ContextID: "ctx-1",
-		Status:    a2a.TaskStatus{State: a2a.TaskStateSubmitted},
-	}
-	if _, err := store.Create(ctxEmptyUser, task2); err != nil {
-		t.Fatalf("Create (empty UserID): %v", err)
-	}
-	stored2, err := store.Get(ctxRouteOnly, "task-empty-uid-2")
-	if err != nil {
-		t.Fatalf("Get (route-only for empty-UserID task): %v", err)
-	}
-	if stored2.Task.ID != "task-empty-uid-2" {
-		t.Errorf("task ID = %q, want %q", stored2.Task.ID, "task-empty-uid-2")
-	}
+		// Getting with empty UserID must fail.
+		_, err := store.Get(ctxEmptyUser, "task-valid-for-get")
+		if err == nil {
+			t.Fatal("expected error when CallerIdentity has empty UserID")
+		}
+		if !errors.Is(err, a2a.ErrUnauthenticated) {
+			t.Errorf("error = %v, want ErrUnauthenticated in chain", err)
+		}
+	})
+
+	t.Run("Update rejected", func(t *testing.T) {
+		ctxValid := ctxForRouteAndCaller("proj-a", "agent-1", "valid-user")
+		task := &a2a.Task{
+			ID:        "task-valid-for-upd",
+			ContextID: "ctx-1",
+			Status:    a2a.TaskStatus{State: a2a.TaskStateSubmitted},
+		}
+		version, err := store.Create(ctxValid, task)
+		if err != nil {
+			t.Fatalf("Create (valid user): %v", err)
+		}
+
+		// Updating with empty UserID must fail.
+		updatedTask := &a2a.Task{
+			ID:        "task-valid-for-upd",
+			ContextID: "ctx-1",
+			Status:    a2a.TaskStatus{State: a2a.TaskStateFailed},
+		}
+		_, err = store.Update(ctxEmptyUser, &taskstore.UpdateRequest{
+			Task:        updatedTask,
+			PrevVersion: version,
+		})
+		if err == nil {
+			t.Fatal("expected error when CallerIdentity has empty UserID")
+		}
+		if !errors.Is(err, a2a.ErrUnauthenticated) {
+			t.Errorf("error = %v, want ErrUnauthenticated in chain", err)
+		}
+	})
+
+	t.Run("List rejected", func(t *testing.T) {
+		// List goes through RouteKeyAuthenticator which also calls buildOwnerKey.
+		_, err := store.List(ctxEmptyUser, &a2a.ListTasksRequest{ContextID: "ctx-1"})
+		if err == nil {
+			t.Fatal("expected error when CallerIdentity has empty UserID")
+		}
+		if !errors.Is(err, a2a.ErrUnauthenticated) {
+			t.Errorf("error = %v, want ErrUnauthenticated in chain", err)
+		}
+	})
 }
 
 // --- Cross-user isolation tests (per-user auth: hubJWT/hubUAT) ---


### PR DESCRIPTION
Fixes a cross-user task data leak where any authenticated user could read other users' tasks via GetTask/ListTasks under per-user auth schemes (hubJWT/hubUAT).

Root cause: ScopedTaskStore keyed ownership on project:agent route, not caller identity. Two users on the same agent endpoint were indistinguishable.

Fix: buildOwnerKey() helper incorporates CallerIdentity.UserID when present, falls back to route-only keying for legacy auth schemes. Includes empty-UserID log warning for defense-in-depth.

11 ScopedStore tests pass (5 original + 5 cross-user isolation + 1 empty-UserID edge case).

Ref: ptone/scion#846