### PR TITLE
feat: agent-side secret retrieval API (GET/LIST)

### DIFF
--- a/cmd/sciontool/commands/secret.go
+++ b/cmd/sciontool/commands/secret.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -175,7 +176,10 @@ Examples:
 			os.Exit(1)
 		}
 
-		os.Stdout.Write(decoded)
+		if _, err := os.Stdout.Write(decoded); err != nil {
+			log.Error("Failed to write secret value: %v", err)
+			os.Exit(1)
+		}
 	},
 }
 
@@ -210,12 +214,14 @@ Examples:
 			return
 		}
 
-		// Print header and table.
-		fmt.Printf("%-30s %-15s %s\n", "KEY", "TYPE", "TARGET")
-		fmt.Printf("%-30s %-15s %s\n", strings.Repeat("-", 30), strings.Repeat("-", 15), strings.Repeat("-", 20))
+		// Print header and table using tabwriter for aligned columns.
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "KEY\tTYPE\tTARGET")
+		fmt.Fprintln(w, "---\t----\t------")
 		for _, s := range resp.Secrets {
-			fmt.Printf("%-30s %-15s %s\n", s.Key, s.Type, s.Target)
+			fmt.Fprintf(w, "%s\t%s\t%s\n", s.Key, s.Type, s.Target)
 		}
+		w.Flush()
 	},
 }
 

--- a/cmd/sciontool/commands/secret.go
+++ b/cmd/sciontool/commands/secret.go
@@ -215,13 +215,16 @@ Examples:
 		}
 
 		// Print header and table using tabwriter for aligned columns.
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "KEY\tTYPE\tTARGET")
-		fmt.Fprintln(w, "---\t----\t------")
+		tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "KEY\tTYPE\tTARGET") //nolint:errcheck
+		fmt.Fprintln(tw, "---\t----\t------") //nolint:errcheck
 		for _, s := range resp.Secrets {
-			fmt.Fprintf(w, "%s\t%s\t%s\n", s.Key, s.Type, s.Target)
+			fmt.Fprintf(tw, "%s\t%s\t%s\n", s.Key, s.Type, s.Target) //nolint:errcheck
 		}
-		w.Flush()
+		if err := tw.Flush(); err != nil {
+			log.Error("Failed to flush output: %v", err)
+			os.Exit(1)
+		}
 	},
 }
 

--- a/cmd/sciontool/commands/secret.go
+++ b/cmd/sciontool/commands/secret.go
@@ -7,6 +7,7 @@ package commands
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,9 +136,94 @@ Examples:
 	},
 }
 
+var secretGetCmd = &cobra.Command{
+	Use:   "get KEY",
+	Short: "Retrieve a project-scoped secret via the Hub API",
+	Long: `Retrieve a project-scoped secret from the Hub from within an agent container.
+
+The decoded secret value is printed to stdout (suitable for piping).
+
+Examples:
+  # Retrieve a secret value
+  sciontool secret get MY_API_KEY
+
+  # Use in a script
+  export API_KEY=$(sciontool secret get MY_API_KEY)`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		key := args[0]
+
+		hubClient := hub.NewClient()
+		if hubClient == nil || !hubClient.IsConfigured() {
+			log.Error("Hub client not configured. Is SCION_HUB_ENDPOINT set?")
+			os.Exit(1)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		resp, err := hubClient.GetSecret(ctx, key)
+		if err != nil {
+			log.Error("%v", err)
+			os.Exit(1)
+		}
+
+		// Decode the base64 value and write raw bytes to stdout.
+		decoded, err := base64.StdEncoding.DecodeString(resp.Value)
+		if err != nil {
+			log.Error("Failed to decode secret value: %v", err)
+			os.Exit(1)
+		}
+
+		os.Stdout.Write(decoded)
+	},
+}
+
+var secretListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available project-scoped secrets via the Hub API",
+	Long: `List metadata for all project-scoped secrets from within an agent container.
+
+Only metadata (key, type, target) is returned — secret values are not included.
+
+Examples:
+  sciontool secret list`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		hubClient := hub.NewClient()
+		if hubClient == nil || !hubClient.IsConfigured() {
+			log.Error("Hub client not configured. Is SCION_HUB_ENDPOINT set?")
+			os.Exit(1)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		resp, err := hubClient.ListSecrets(ctx)
+		if err != nil {
+			log.Error("%v", err)
+			os.Exit(1)
+		}
+
+		if len(resp.Secrets) == 0 {
+			log.Info("No secrets found")
+			return
+		}
+
+		// Print header and table.
+		fmt.Printf("%-30s %-15s %s\n", "KEY", "TYPE", "TARGET")
+		fmt.Printf("%-30s %-15s %s\n", strings.Repeat("-", 30), strings.Repeat("-", 15), strings.Repeat("-", 20))
+		for _, s := range resp.Secrets {
+			fmt.Printf("%-30s %-15s %s\n", s.Key, s.Type, s.Target)
+		}
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(secretCmd)
 	secretCmd.AddCommand(secretSetCmd)
+	secretCmd.AddCommand(secretGetCmd)
+	secretCmd.AddCommand(secretListCmd)
 
 	secretSetCmd.Flags().StringVar(&secretType, "type", "", "Secret type: environment (default), variable, file")
 	secretSetCmd.Flags().StringVar(&secretTarget, "target", "", "Injection target path (defaults to key for env, required for file)")

--- a/pkg/hub/audit.go
+++ b/pkg/hub/audit.go
@@ -174,6 +174,20 @@ type LifecycleHookExecutionEvent struct {
 	Timestamp         time.Time                       `json:"timestamp"`
 }
 
+// ---------------------------------------------------------------------------
+// Agent Secret Read audit events
+// ---------------------------------------------------------------------------
+
+// AgentSecretReadEvent represents an auditable agent secret read event.
+type AgentSecretReadEvent struct {
+	AgentID    string    `json:"agentId"`
+	ProjectID  string    `json:"projectId"`
+	SecretKey  string    `json:"secretKey"`
+	Success    bool      `json:"success"`
+	FailReason string    `json:"failReason,omitempty"`
+	Timestamp  time.Time `json:"timestamp"`
+}
+
 // AuditLogger defines the interface for logging audit events.
 type AuditLogger interface {
 	// LogBrokerAuthEvent logs a broker authentication event.
@@ -186,6 +200,8 @@ type AuditLogger interface {
 	LogLifecycleHookEvent(ctx context.Context, event *LifecycleHookEvent) error
 	// LogLifecycleHookExecutionEvent logs a lifecycle-hook execution event (M5).
 	LogLifecycleHookExecutionEvent(ctx context.Context, event *LifecycleHookExecutionEvent) error
+	// LogAgentSecretReadEvent logs an agent secret read event.
+	LogAgentSecretReadEvent(ctx context.Context, event *AgentSecretReadEvent) error
 }
 
 // LogAuditLogger is a simple implementation that logs to the standard logger.
@@ -370,6 +386,47 @@ func (l *LogAuditLogger) LogLifecycleHookExecutionEvent(ctx context.Context, eve
 	l.logger().LogAttrs(ctx, level, "lifecycle hook execution event", attrs...)
 
 	return nil
+}
+
+// LogAgentSecretReadEvent logs an agent secret read event to the standard logger.
+func (l *LogAuditLogger) LogAgentSecretReadEvent(ctx context.Context, event *AgentSecretReadEvent) error {
+	level := slog.LevelInfo
+	if !event.Success {
+		level = slog.LevelWarn
+	}
+
+	attrs := []slog.Attr{
+		slog.String("event_type", "agent_secret_read"),
+		slog.String("agent_id", event.AgentID),
+		slog.String("project_id", event.ProjectID),
+		slog.String("secret_key", event.SecretKey),
+		slog.Bool("success", event.Success),
+	}
+	if event.FailReason != "" {
+		attrs = append(attrs, slog.String("fail_reason", event.FailReason))
+	}
+
+	l.logger().LogAttrs(ctx, level, "agent secret read event", attrs...)
+
+	return nil
+}
+
+// LogAgentSecretRead logs an agent secret read event through the AuditLogger interface.
+func LogAgentSecretRead(ctx context.Context, logger AuditLogger, agentID, projectID, secretKey string, success bool, failReason string) {
+	if logger == nil {
+		return
+	}
+
+	event := &AgentSecretReadEvent{
+		AgentID:    agentID,
+		ProjectID:  projectID,
+		SecretKey:  secretKey,
+		Success:    success,
+		FailReason: failReason,
+		Timestamp:  time.Now(),
+	}
+
+	_ = logger.LogAgentSecretReadEvent(ctx, event)
 }
 
 // AuditableBrokerAuthMiddleware creates middleware that logs authentication events.

--- a/pkg/hub/audit_gcp_test.go
+++ b/pkg/hub/audit_gcp_test.go
@@ -47,6 +47,10 @@ func (m *mockAuditLogger) LogLifecycleHookExecutionEvent(_ context.Context, _ *L
 	return nil
 }
 
+func (m *mockAuditLogger) LogAgentSecretReadEvent(_ context.Context, _ *AgentSecretReadEvent) error {
+	return nil
+}
+
 func TestLogGCPTokenGeneration_Success(t *testing.T) {
 	mock := &mockAuditLogger{}
 	ctx := context.Background()

--- a/pkg/hub/handlers_agent_secret_getlist_test.go
+++ b/pkg/hub/handlers_agent_secret_getlist_test.go
@@ -281,7 +281,7 @@ func TestAgentListSecrets_ReturnsMetadataNoValues(t *testing.T) {
 	for _, s := range secrets {
 		sm, ok := s.(map[string]interface{})
 		if !ok {
-			continue
+			t.Fatalf("expected secret entry to be a JSON object, got %T", s)
 		}
 		if _, exists := sm["value"]; exists {
 			t.Errorf("list response should not contain a 'value' field, got: %v", sm)

--- a/pkg/hub/handlers_agent_secret_getlist_test.go
+++ b/pkg/hub/handlers_agent_secret_getlist_test.go
@@ -1,0 +1,454 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+// Package hub — tests for agent secret GET and LIST operations:
+//
+//   GET  /api/v1/agents/{agentID}/secrets/{key}   — retrieve a single secret
+//   GET  /api/v1/agents/{agentID}/secrets          — list secret metadata
+
+package hub
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// setupAgentSecretGetTest creates a test server with a project, agent, and a
+// pre-existing secret for GET/LIST testing.
+func setupAgentSecretGetTest(t *testing.T) (*Server, store.Store, string, string, string) {
+	t.Helper()
+	srv, s := testServer(t)
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	ctx := context.Background()
+
+	projectID := tid("project-agent-get-secret")
+	project := &store.Project{
+		ID: projectID, Name: "Agent Get Secret Project", Slug: "agent-get-secret-project",
+		Created: time.Now(), Updated: time.Now(),
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	agentID := tid("agent-get-secret-1")
+	agent := &store.Agent{
+		ID: agentID, Slug: "get-secret-agent", Name: "Get Secret Agent",
+		ProjectID: projectID, Phase: string(state.PhaseRunning), StateVersion: 1,
+		Created: time.Now(), Updated: time.Now(),
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+
+	agentToken, err := srv.agentTokenService.GenerateAgentToken(agentID, projectID, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to generate agent token: %v", err)
+	}
+
+	return srv, s, agentID, projectID, agentToken
+}
+
+// seedSecret creates a secret in the backend for testing.
+func seedSecret(t *testing.T, backend secret.SecretBackend, key, value, secretType, target, projectID string) {
+	t.Helper()
+	ctx := context.Background()
+	if secretType == "" {
+		secretType = store.SecretTypeEnvironment
+	}
+	if target == "" {
+		target = key
+	}
+	input := &secret.SetSecretInput{
+		Name:       key,
+		Value:      value,
+		SecretType: secretType,
+		Target:     target,
+		Scope:      store.ScopeProject,
+		ScopeID:    projectID,
+		CreatedBy:  "test-user",
+		UpdatedBy:  "test-user",
+	}
+	_, _, err := backend.Set(ctx, input)
+	if err != nil {
+		t.Fatalf("failed to seed secret %q: %v", key, err)
+	}
+}
+
+// ============================================================================
+// Agent GET secret tests
+// ============================================================================
+
+func TestAgentGetSecret_Success(t *testing.T) {
+	srv, _, agentID, projectID, agentToken := setupAgentSecretGetTest(t)
+
+	// Seed a secret.
+	seedSecret(t, srv.secretBackend, "GET_KEY", "my-secret-value", "", "", projectID)
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet,
+		"/api/v1/agents/"+agentID+"/secrets/GET_KEY", nil, agentToken)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp AgentGetSecretResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Key != "GET_KEY" {
+		t.Errorf("expected key GET_KEY, got %q", resp.Key)
+	}
+	// Value should be base64-encoded.
+	decoded, err := base64.StdEncoding.DecodeString(resp.Value)
+	if err != nil {
+		t.Fatalf("failed to decode base64 value: %v", err)
+	}
+	if string(decoded) != "my-secret-value" {
+		t.Errorf("expected value %q, got %q", "my-secret-value", string(decoded))
+	}
+	if resp.Type != store.SecretTypeEnvironment {
+		t.Errorf("expected type %q, got %q", store.SecretTypeEnvironment, resp.Type)
+	}
+	if resp.Target != "GET_KEY" {
+		t.Errorf("expected target GET_KEY, got %q", resp.Target)
+	}
+}
+
+func TestAgentGetSecret_NotFound(t *testing.T) {
+	srv, _, agentID, _, agentToken := setupAgentSecretGetTest(t)
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet,
+		"/api/v1/agents/"+agentID+"/secrets/NONEXISTENT_KEY", nil, agentToken)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentGetSecret_AgentIDMismatch(t *testing.T) {
+	srv, _, _, _, agentToken := setupAgentSecretGetTest(t)
+
+	// Use a different agentID in the URL than what's in the token.
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet,
+		"/api/v1/agents/"+tid("wrong-agent-get")+"/secrets/SOME_KEY", nil, agentToken)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for agent ID mismatch, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentGetSecret_NoAuth(t *testing.T) {
+	srv, _ := testServer(t)
+	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, "test-hub-id"))
+
+	rec := doRequestNoAuth(t, srv, http.MethodGet,
+		"/api/v1/agents/some-agent/secrets/MY_KEY", nil)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentGetSecret_UserTokenRejected(t *testing.T) {
+	srv, _ := testServer(t)
+	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, "test-hub-id"))
+
+	// Using dev token (user auth) should be rejected — agent-only endpoint.
+	rec := doRequest(t, srv, http.MethodGet,
+		"/api/v1/agents/some-agent/secrets/MY_KEY", nil)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for user token, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentGetSecret_CrossProject(t *testing.T) {
+	srv, s, _, _, agentToken := setupAgentSecretGetTest(t)
+	ctx := context.Background()
+
+	// Create a different project and seed a secret in it.
+	otherProjectID := tid("project-other-get")
+	otherProject := &store.Project{
+		ID: otherProjectID, Name: "Other Project", Slug: "other-project-get",
+		Created: time.Now(), Updated: time.Now(),
+	}
+	if err := s.CreateProject(ctx, otherProject); err != nil {
+		t.Fatalf("failed to create other project: %v", err)
+	}
+
+	// Create a second agent + token in the second project.
+	otherAgentID := tid("agent-other-get")
+	otherAgent := &store.Agent{
+		ID: otherAgentID, Slug: "other-get-agent", Name: "Other Get Agent",
+		ProjectID: otherProjectID, Phase: string(state.PhaseRunning), StateVersion: 1,
+		Created: time.Now(), Updated: time.Now(),
+	}
+	if err := s.CreateAgent(ctx, otherAgent); err != nil {
+		t.Fatalf("failed to create other agent: %v", err)
+	}
+
+	// Seed a secret in the other project.
+	seedSecret(t, srv.secretBackend, "OTHER_KEY", "other-value", "", "", otherProjectID)
+
+	// The original agent's token should NOT be able to read a secret from
+	// a different project (URL has a different agentID).
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet,
+		"/api/v1/agents/"+otherAgentID+"/secrets/OTHER_KEY", nil, agentToken)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for cross-project access, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentGetSecret_FileType(t *testing.T) {
+	srv, _, agentID, projectID, agentToken := setupAgentSecretGetTest(t)
+
+	seedSecret(t, srv.secretBackend, "CERT_FILE", "cert-content", "file", "/etc/ssl/cert.pem", projectID)
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet,
+		"/api/v1/agents/"+agentID+"/secrets/CERT_FILE", nil, agentToken)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp AgentGetSecretResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Type != "file" {
+		t.Errorf("expected type file, got %q", resp.Type)
+	}
+	if resp.Target != "/etc/ssl/cert.pem" {
+		t.Errorf("expected target /etc/ssl/cert.pem, got %q", resp.Target)
+	}
+}
+
+// ============================================================================
+// Agent LIST secrets tests
+// ============================================================================
+
+func TestAgentListSecrets_ReturnsMetadataNoValues(t *testing.T) {
+	srv, _, agentID, projectID, agentToken := setupAgentSecretGetTest(t)
+
+	// Seed multiple secrets.
+	seedSecret(t, srv.secretBackend, "LIST_KEY_1", "secret-1", "environment", "", projectID)
+	seedSecret(t, srv.secretBackend, "LIST_KEY_2", "secret-2", "variable", "LIST_KEY_2", projectID)
+	seedSecret(t, srv.secretBackend, "LIST_KEY_3", "secret-3", "file", "/tmp/file.txt", projectID)
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet,
+		"/api/v1/agents/"+agentID+"/secrets", nil, agentToken)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Capture the body before the decoder consumes it.
+	bodyBytes := rec.Body.Bytes()
+
+	var resp AgentListSecretsResponse
+	if err := json.Unmarshal(bodyBytes, &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp.Secrets) != 3 {
+		t.Fatalf("expected 3 secrets, got %d", len(resp.Secrets))
+	}
+
+	// Verify no values are returned — check the raw JSON to ensure no
+	// "value" field is present in any secret entry.
+	var raw map[string]interface{}
+	if err := json.Unmarshal(bodyBytes, &raw); err != nil {
+		t.Fatalf("failed to re-parse body: %v", err)
+	}
+	secrets, ok := raw["secrets"].([]interface{})
+	if !ok {
+		t.Fatal("expected secrets array in response")
+	}
+	for _, s := range secrets {
+		sm, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if _, exists := sm["value"]; exists {
+			t.Errorf("list response should not contain a 'value' field, got: %v", sm)
+		}
+	}
+
+	// Verify metadata is present.
+	keyMap := make(map[string]AgentSecretMeta)
+	for _, s := range resp.Secrets {
+		keyMap[s.Key] = s
+	}
+	if s, ok := keyMap["LIST_KEY_1"]; !ok || s.Type != "environment" {
+		t.Errorf("expected LIST_KEY_1 with type environment, got %+v", keyMap["LIST_KEY_1"])
+	}
+	if s, ok := keyMap["LIST_KEY_2"]; !ok || s.Type != "variable" {
+		t.Errorf("expected LIST_KEY_2 with type variable, got %+v", keyMap["LIST_KEY_2"])
+	}
+	if s, ok := keyMap["LIST_KEY_3"]; !ok || s.Type != "file" || s.Target != "/tmp/file.txt" {
+		t.Errorf("expected LIST_KEY_3 with type file and target /tmp/file.txt, got %+v", keyMap["LIST_KEY_3"])
+	}
+}
+
+func TestAgentListSecrets_Empty(t *testing.T) {
+	srv, _, agentID, _, agentToken := setupAgentSecretGetTest(t)
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet,
+		"/api/v1/agents/"+agentID+"/secrets", nil, agentToken)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp AgentListSecretsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp.Secrets) != 0 {
+		t.Errorf("expected 0 secrets, got %d", len(resp.Secrets))
+	}
+}
+
+func TestAgentListSecrets_NoAuth(t *testing.T) {
+	srv, _ := testServer(t)
+	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, "test-hub-id"))
+
+	rec := doRequestNoAuth(t, srv, http.MethodGet,
+		"/api/v1/agents/some-agent/secrets", nil)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentListSecrets_AgentIDMismatch(t *testing.T) {
+	srv, _, _, _, agentToken := setupAgentSecretGetTest(t)
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet,
+		"/api/v1/agents/"+tid("wrong-agent-list")+"/secrets", nil, agentToken)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for agent ID mismatch, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentGetSecret_NoSecretBackend(t *testing.T) {
+	srv, s := testServer(t)
+	// Deliberately do NOT set a secret backend.
+	ctx := context.Background()
+
+	projectID := tid("project-no-backend-get")
+	project := &store.Project{
+		ID: projectID, Name: "No Backend Get Project", Slug: "no-backend-get-project",
+		Created: time.Now(), Updated: time.Now(),
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	agentID := tid("agent-no-backend-get")
+	agent := &store.Agent{
+		ID: agentID, Slug: "no-backend-get-agent", Name: "No Backend Get Agent",
+		ProjectID: projectID, Phase: string(state.PhaseRunning), StateVersion: 1,
+		Created: time.Now(), Updated: time.Now(),
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+
+	agentToken, err := srv.agentTokenService.GenerateAgentToken(agentID, projectID, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to generate agent token: %v", err)
+	}
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet,
+		"/api/v1/agents/"+agentID+"/secrets/MY_KEY", nil, agentToken)
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("expected 501 when secret backend is nil, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// ============================================================================
+// Existing PUT tests still pass (regression)
+// ============================================================================
+
+func TestAgentPutSecret_StillWorks(t *testing.T) {
+	srv, _, agentID, projectID, agentToken := setupAgentSecretGetTest(t)
+
+	body := AgentSetSecretRequest{
+		Value: base64.StdEncoding.EncodeToString([]byte("my-new-secret")),
+	}
+	rec := doRequestWithAgentToken(t, srv, http.MethodPut,
+		"/api/v1/agents/"+agentID+"/secrets/PUT_REG_KEY", body, agentToken)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp AgentSetSecretResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Key != "PUT_REG_KEY" {
+		t.Errorf("expected key PUT_REG_KEY, got %q", resp.Key)
+	}
+	if resp.Scope != "project" {
+		t.Errorf("expected scope project, got %q", resp.Scope)
+	}
+	if resp.ScopeID != projectID {
+		t.Errorf("expected scopeId %q, got %q", projectID, resp.ScopeID)
+	}
+
+	// Now GET the secret we just PUT to verify the round trip.
+	rec2 := doRequestWithAgentToken(t, srv, http.MethodGet,
+		"/api/v1/agents/"+agentID+"/secrets/PUT_REG_KEY", nil, agentToken)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("expected 200 on GET after PUT, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+
+	var getResp AgentGetSecretResponse
+	if err := json.NewDecoder(rec2.Body).Decode(&getResp); err != nil {
+		t.Fatalf("failed to decode GET response: %v", err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(getResp.Value)
+	if err != nil {
+		t.Fatalf("failed to decode base64 value: %v", err)
+	}
+	if string(decoded) != "my-new-secret" {
+		t.Errorf("GET after PUT: expected value %q, got %q", "my-new-secret", string(decoded))
+	}
+}
+
+func TestAgentPutSecret_MethodNotAllowed_POST(t *testing.T) {
+	srv, _, agentID, _, agentToken := setupAgentSecretGetTest(t)
+
+	body := AgentSetSecretRequest{
+		Value: base64.StdEncoding.EncodeToString([]byte("value")),
+	}
+	rec := doRequestWithAgentToken(t, srv, http.MethodPost,
+		"/api/v1/agents/"+agentID+"/secrets/MY_KEY", body, agentToken)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for POST, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAgentPutSecret_MethodNotAllowed_DELETE(t *testing.T) {
+	srv, _, agentID, _, agentToken := setupAgentSecretGetTest(t)
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodDelete,
+		"/api/v1/agents/"+agentID+"/secrets/MY_KEY", nil, agentToken)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for DELETE, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -964,23 +964,8 @@ func (s *Server) handleAgentSecrets(w http.ResponseWriter, r *http.Request, agen
 
 	ctx := r.Context()
 
-	// Agent-only: require agent identity from JWT.
-	agentIdent := GetAgentIdentityFromContext(ctx)
-	if agentIdent == nil {
-		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "This endpoint requires agent authentication", nil)
-		return
-	}
-
-	// The agentID in the URL path must match the JWT subject.
-	if agentIdent.ID() != agentID {
-		writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agent token does not match the agent ID in the URL", nil)
-		return
-	}
-
-	// Extract project ID from agent token claims.
-	projectID := agentIdent.ProjectID()
-	if projectID == "" {
-		writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agent token lacks project context", nil)
+	projectID, ok := s.validateAgentSecretAccess(w, r, agentID)
+	if !ok {
 		return
 	}
 
@@ -1105,39 +1090,55 @@ func (s *Server) handleAgentSecrets(w http.ResponseWriter, r *http.Request, agen
 	}
 }
 
-// agentGetSecret handles GET /api/v1/agents/{agentID}/secrets/{key}.
-// Returns the secret value (base64-encoded) along with type and target metadata.
-func (s *Server) agentGetSecret(w http.ResponseWriter, r *http.Request, agentID, key string) {
+// validateAgentSecretAccess checks that the request is from an authenticated agent
+// whose JWT subject matches the agentID in the URL, and extracts the project ID.
+// On failure it writes an HTTP error response and returns ("", false).
+func (s *Server) validateAgentSecretAccess(w http.ResponseWriter, r *http.Request, agentID string) (projectID string, ok bool) {
 	ctx := r.Context()
 
 	// Agent-only: require agent identity from JWT.
 	agentIdent := GetAgentIdentityFromContext(ctx)
 	if agentIdent == nil {
 		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "This endpoint requires agent authentication", nil)
-		return
+		return "", false
 	}
 
 	// The agentID in the URL path must match the JWT subject.
 	if agentIdent.ID() != agentID {
 		writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agent token does not match the agent ID in the URL", nil)
-		return
+		return "", false
 	}
 
 	// Extract project ID from agent token claims.
-	projectID := agentIdent.ProjectID()
+	projectID = agentIdent.ProjectID()
 	if projectID == "" {
 		writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agent token lacks project context", nil)
+		return "", false
+	}
+
+	return projectID, true
+}
+
+// agentGetSecret handles GET /api/v1/agents/{agentID}/secrets/{key}.
+// Returns the secret value (base64-encoded) along with type and target metadata.
+func (s *Server) agentGetSecret(w http.ResponseWriter, r *http.Request, agentID, key string) {
+	ctx := r.Context()
+
+	projectID, ok := s.validateAgentSecretAccess(w, r, agentID)
+	if !ok {
+		LogAgentSecretRead(ctx, s.auditLogger, agentID, "", key, false, "auth failed")
 		return
 	}
 
 	// Retrieve the secret including its value.
 	secretVal, err := s.secretBackend.Get(ctx, key, store.ScopeProject, projectID)
 	if err != nil {
+		LogAgentSecretRead(ctx, s.auditLogger, agentID, projectID, key, false, err.Error())
 		writeErrorFromErr(w, err, "")
 		return
 	}
 
-	// Audit log the read.
+	// Audit log the successful read.
 	LogAgentSecretRead(ctx, s.auditLogger, agentID, projectID, key, true, "")
 
 	writeJSON(w, http.StatusOK, AgentGetSecretResponse{
@@ -1153,23 +1154,8 @@ func (s *Server) agentGetSecret(w http.ResponseWriter, r *http.Request, agentID,
 func (s *Server) agentListSecrets(w http.ResponseWriter, r *http.Request, agentID string) {
 	ctx := r.Context()
 
-	// Agent-only: require agent identity from JWT.
-	agentIdent := GetAgentIdentityFromContext(ctx)
-	if agentIdent == nil {
-		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "This endpoint requires agent authentication", nil)
-		return
-	}
-
-	// The agentID in the URL path must match the JWT subject.
-	if agentIdent.ID() != agentID {
-		writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agent token does not match the agent ID in the URL", nil)
-		return
-	}
-
-	// Extract project ID from agent token claims.
-	projectID := agentIdent.ProjectID()
-	if projectID == "" {
-		writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agent token lacks project context", nil)
+	projectID, ok := s.validateAgentSecretAccess(w, r, agentID)
+	if !ok {
 		return
 	}
 

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -896,15 +896,36 @@ type AgentSetSecretResponse struct {
 	ScopeID string `json:"scopeId"`
 }
 
-// handleAgentSecrets handles PUT /api/v1/agents/{agentID}/secrets/{key}.
-// Only agents may call this endpoint. The secret is always scoped to the
+// AgentGetSecretResponse is returned when an agent retrieves a single secret.
+type AgentGetSecretResponse struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`  // base64-encoded secret value
+	Type   string `json:"type"`   // environment, variable, file
+	Target string `json:"target"` // injection target
+}
+
+// AgentListSecretsResponse is returned when an agent lists available secrets.
+type AgentListSecretsResponse struct {
+	Secrets []AgentSecretMeta `json:"secrets"`
+}
+
+// AgentSecretMeta is secret metadata returned in list responses (no value).
+type AgentSecretMeta struct {
+	Key    string `json:"key"`
+	Type   string `json:"type"`   // environment, variable, file
+	Target string `json:"target"` // injection target
+}
+
+// handleAgentSecrets handles agent secret operations:
+//
+//	GET  /api/v1/agents/{agentID}/secrets          — list secret metadata
+//	GET  /api/v1/agents/{agentID}/secrets/{key}    — retrieve a single secret value
+//	PUT  /api/v1/agents/{agentID}/secrets/{key}    — create/update a secret
+//
+// Only agents may call this endpoint. Secrets are always scoped to the
 // agent's project (derived from the JWT).
 func (s *Server) handleAgentSecrets(w http.ResponseWriter, r *http.Request, agentID, subPath string) {
 	key := strings.TrimPrefix(subPath, "/")
-	if key == "" {
-		BadRequest(w, "Secret key is required in the URL path")
-		return
-	}
 
 	if s.secretBackend == nil {
 		writeJSON(w, http.StatusNotImplemented, map[string]string{
@@ -913,7 +934,21 @@ func (s *Server) handleAgentSecrets(w http.ResponseWriter, r *http.Request, agen
 		return
 	}
 
-	if r.Method != http.MethodPut {
+	switch r.Method {
+	case http.MethodGet:
+		if key == "" {
+			s.agentListSecrets(w, r, agentID)
+		} else {
+			s.agentGetSecret(w, r, agentID, key)
+		}
+		return
+	case http.MethodPut:
+		if key == "" {
+			BadRequest(w, "Secret key is required in the URL path")
+			return
+		}
+		// Fall through to existing PUT logic below.
+	default:
 		MethodNotAllowed(w)
 		return
 	}
@@ -1068,6 +1103,97 @@ func (s *Server) handleAgentSecrets(w http.ResponseWriter, r *http.Request, agen
 	} else {
 		w.WriteHeader(http.StatusNoContent)
 	}
+}
+
+// agentGetSecret handles GET /api/v1/agents/{agentID}/secrets/{key}.
+// Returns the secret value (base64-encoded) along with type and target metadata.
+func (s *Server) agentGetSecret(w http.ResponseWriter, r *http.Request, agentID, key string) {
+	ctx := r.Context()
+
+	// Agent-only: require agent identity from JWT.
+	agentIdent := GetAgentIdentityFromContext(ctx)
+	if agentIdent == nil {
+		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "This endpoint requires agent authentication", nil)
+		return
+	}
+
+	// The agentID in the URL path must match the JWT subject.
+	if agentIdent.ID() != agentID {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agent token does not match the agent ID in the URL", nil)
+		return
+	}
+
+	// Extract project ID from agent token claims.
+	projectID := agentIdent.ProjectID()
+	if projectID == "" {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agent token lacks project context", nil)
+		return
+	}
+
+	// Retrieve the secret including its value.
+	secretVal, err := s.secretBackend.Get(ctx, key, store.ScopeProject, projectID)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Audit log the read.
+	LogAgentSecretRead(ctx, s.auditLogger, agentID, projectID, key, true, "")
+
+	writeJSON(w, http.StatusOK, AgentGetSecretResponse{
+		Key:    secretVal.Name,
+		Value:  base64.StdEncoding.EncodeToString([]byte(secretVal.Value)),
+		Type:   secretVal.SecretType,
+		Target: secretVal.Target,
+	})
+}
+
+// agentListSecrets handles GET /api/v1/agents/{agentID}/secrets (no key).
+// Returns metadata for all secrets in the agent's project (no values).
+func (s *Server) agentListSecrets(w http.ResponseWriter, r *http.Request, agentID string) {
+	ctx := r.Context()
+
+	// Agent-only: require agent identity from JWT.
+	agentIdent := GetAgentIdentityFromContext(ctx)
+	if agentIdent == nil {
+		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "This endpoint requires agent authentication", nil)
+		return
+	}
+
+	// The agentID in the URL path must match the JWT subject.
+	if agentIdent.ID() != agentID {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agent token does not match the agent ID in the URL", nil)
+		return
+	}
+
+	// Extract project ID from agent token claims.
+	projectID := agentIdent.ProjectID()
+	if projectID == "" {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden, "Agent token lacks project context", nil)
+		return
+	}
+
+	metas, err := s.secretBackend.List(ctx, secret.Filter{
+		Scope:   store.ScopeProject,
+		ScopeID: projectID,
+	})
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	secrets := make([]AgentSecretMeta, len(metas))
+	for i, m := range metas {
+		secrets[i] = AgentSecretMeta{
+			Key:    m.Name,
+			Type:   m.SecretType,
+			Target: m.Target,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, AgentListSecretsResponse{
+		Secrets: secrets,
+	})
 }
 
 func (s *Server) handleProjectEnvVars(w http.ResponseWriter, r *http.Request, projectID string) {

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -563,6 +563,105 @@ func (c *Client) SetSecret(ctx context.Context, key, value, secretType, target s
 	}
 }
 
+// GetSecretResponse is the response from the agent secret GET endpoint.
+type GetSecretResponse struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"` // base64-encoded
+	Type   string `json:"type"`
+	Target string `json:"target"`
+}
+
+// GetSecret retrieves a project-scoped secret via the Hub API.
+// Returns the secret key, value (base64-encoded), type and target.
+func (c *Client) GetSecret(ctx context.Context, key string) (*GetSecretResponse, error) {
+	if !c.IsConfigured() {
+		return nil, fmt.Errorf("hub client not configured (is SCION_HUB_ENDPOINT set?)")
+	}
+
+	endpoint := fmt.Sprintf("%s/api/v1/agents/%s/secrets/%s",
+		strings.TrimSuffix(c.hubURL, "/"), c.agentID, key)
+
+	c.tokenMu.RLock()
+	currentToken := c.token
+	c.tokenMu.RUnlock()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("X-Scion-Agent-Token", currentToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("hub returned error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result GetSecretResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &result, nil
+}
+
+// ListSecretsSecretMeta is secret metadata returned in list responses.
+type ListSecretsSecretMeta struct {
+	Key    string `json:"key"`
+	Type   string `json:"type"`
+	Target string `json:"target"`
+}
+
+// ListSecretsResponse is the response from the agent secret LIST endpoint.
+type ListSecretsResponse struct {
+	Secrets []ListSecretsSecretMeta `json:"secrets"`
+}
+
+// ListSecrets lists metadata for all project-scoped secrets via the Hub API.
+func (c *Client) ListSecrets(ctx context.Context) (*ListSecretsResponse, error) {
+	if !c.IsConfigured() {
+		return nil, fmt.Errorf("hub client not configured (is SCION_HUB_ENDPOINT set?)")
+	}
+
+	endpoint := fmt.Sprintf("%s/api/v1/agents/%s/secrets",
+		strings.TrimSuffix(c.hubURL, "/"), c.agentID)
+
+	c.tokenMu.RLock()
+	currentToken := c.token
+	c.tokenMu.RUnlock()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("X-Scion-Agent-Token", currentToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("hub returned error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result ListSecretsResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &result, nil
+}
+
 // RefreshTokenEntry represents a single token in the generalized refresh response.
 // Mirrors the hub's RefreshTokenEntry type.
 type RefreshTokenEntry struct {


### PR DESCRIPTION
## Summary

Adds GET and LIST capabilities to the agent secret endpoint, enabling agents to retrieve secrets at runtime via hub API calls. Complements existing PUT-only agent secret endpoint and pairs with chat secret management (#771).

Ref: GoogleCloudPlatform/scion#772 (if upstream), ptone/scion#772

### Changes

- GET /api/v1/agents/{agentID}/secrets/{key} — retrieve single secret (base64-encoded value)
- GET /api/v1/agents/{agentID}/secrets — list secret metadata (no values)
- JWT identity validation (agent ID must match token subject)
- Project-scoped access (agent can only read own project secrets)
- Audit logging for successful and failed reads
- Extracted validateAgentSecretAccess helper (deduplicates auth boilerplate across GET/LIST/PUT)
- sciontool secret get/list CLI commands for in-container use
- 15 tests covering auth, error, and success paths
