### PR TITLE
fix(store): resolve advisory lock key collision between cache eviction and telegram webhook

### DIFF
--- a/pkg/store/concurrency.go
+++ b/pkg/store/concurrency.go
@@ -70,7 +70,7 @@ const (
 
 	// LockTelegramWebhook serializes the Telegram setWebhook registration
 	// call so only one standalone instance registers the webhook URL at a time.
-	LockTelegramWebhook AdvisoryLockKey = 0x5C10000A
+	LockTelegramWebhook AdvisoryLockKey = 0x5C10000D
 
 	// LockHubSettingsSeed guards first-boot seeding of operational settings
 	// from settings.yaml into the hub_settings table (settings-db §3.9).


### PR DESCRIPTION
## Summary

LockGitHubResolutionCacheEviction and LockTelegramWebhook both used advisory lock key 0x5C10000A, making them indistinguishable to Postgres. Changed LockTelegramWebhook to 0x5C10000D (next available sequential key).

Ref: ptone/scion#856

## Test plan

- go build ./cmd/... passes
- go vet ./pkg/store/... clean
- go test ./pkg/store/... -short passes
- All 13 singleton lock keys verified unique