### PR TITLE
fix: remove dead subscribeForProject code and improve bootstrap log

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -432,7 +432,7 @@ func (b *DiscordBroker) Configure(config map[string]string) error {
 					b.log.Info("Requested bootstrap subscription for Discord Gateway")
 					return
 				}
-				b.log.Error("Bootstrap subscription timed out — host callbacks never became available")
+				b.log.Warn("Bootstrap subscription timed out — this is expected in standalone gRPC mode where the Hub drives subscriptions via Subscribe() RPC")
 				// Reset flag so a future Configure can retry bootstrap.
 				b.mu.Lock()
 				b.bootstrapDone = false
@@ -1650,38 +1650,6 @@ func (b *DiscordBroker) getProjectAgents(ctx context.Context, projectID string) 
 	}
 
 	return slugs
-}
-
-// --- Dynamic subscription management ---
-
-func (b *DiscordBroker) subscribeForProject(projectID string) {
-	pattern := projectcompat.ProjectPattern(projectID)
-
-	b.mu.RLock()
-	hc := b.hostCallbacks
-	b.mu.RUnlock()
-
-	if hc != nil {
-		if err := hc.RequestSubscription(pattern); err != nil {
-			b.log.Warn("Failed to request subscription via host callbacks",
-				"pattern", pattern, "error", err)
-		}
-	}
-}
-
-func (b *DiscordBroker) unsubscribeForProject(projectID string) {
-	pattern := projectcompat.ProjectPattern(projectID)
-
-	b.mu.RLock()
-	hc := b.hostCallbacks
-	b.mu.RUnlock()
-
-	if hc != nil {
-		if err := hc.CancelSubscription(pattern); err != nil {
-			b.log.Warn("Failed to cancel subscription via host callbacks",
-				"pattern", pattern, "error", err)
-		}
-	}
 }
 
 // --- Routing helpers ---

--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -2594,38 +2594,6 @@ func (b *TelegramBrokerV2) getProjectAgents(ctx context.Context, projectID strin
 	return agentSlugs(agents)
 }
 
-// --- Dynamic subscription management ---
-
-func (b *TelegramBrokerV2) subscribeForProject(projectID string) {
-	pattern := projectcompat.ProjectPattern(projectID)
-
-	b.mu.RLock()
-	hc := b.hostCallbacks
-	b.mu.RUnlock()
-
-	if hc != nil {
-		if err := hc.RequestSubscription(pattern); err != nil {
-			b.log.Warn("Failed to request subscription via host callbacks",
-				"pattern", pattern, "error", err)
-		}
-	}
-}
-
-func (b *TelegramBrokerV2) unsubscribeForProject(projectID string) {
-	pattern := projectcompat.ProjectPattern(projectID)
-
-	b.mu.RLock()
-	hc := b.hostCallbacks
-	b.mu.RUnlock()
-
-	if hc != nil {
-		if err := hc.CancelSubscription(pattern); err != nil {
-			b.log.Warn("Failed to cancel subscription via host callbacks",
-				"pattern", pattern, "error", err)
-		}
-	}
-}
-
 // --- Hub delivery (reuses the same pattern as v1) ---
 
 func (b *TelegramBrokerV2) deliverInbound(topic string, msg *messages.StructuredMessage) {


### PR DESCRIPTION
Delete subscribeForProject and unsubscribeForProject from both Discord and Telegram brokers — these functions have zero callers and are dead code. In standalone gRPC mode the Hub drives subscriptions via the Subscribe() RPC, so the plugin-initiated direction is unnecessary.

Also downgrade the Discord bootstrap subscription timeout from Error to Warn and clarify that the timeout is expected in standalone gRPC mode, reducing log noise for normal operation.

Closes #855

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
