### PR TITLE
feat(discord): add /scion secret command for managing project secrets

### DIFF
--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1174,6 +1174,17 @@ func (b *DiscordBroker) handleInteractionCreate(s *discordgo.Session, i *discord
 			go func() {
 				HandleModalSubmit(s, i, store, b.deliverInbound, b.log)
 			}()
+		} else if strings.HasPrefix(data.CustomID, "secret:") {
+			// Secret modal submission — defer then process async.
+			_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Flags: discordgo.MessageFlagsEphemeral,
+				},
+			})
+			go func() {
+				commands.HandleSecretModalSubmit(s, i)
+			}()
 		}
 
 	case discordgo.InteractionApplicationCommandAutocomplete:

--- a/extras/scion-discord/internal/discord/broker.go
+++ b/extras/scion-discord/internal/discord/broker.go
@@ -1175,6 +1175,9 @@ func (b *DiscordBroker) handleInteractionCreate(s *discordgo.Session, i *discord
 				HandleModalSubmit(s, i, store, b.deliverInbound, b.log)
 			}()
 		} else if strings.HasPrefix(data.CustomID, "secret:") {
+			if commands == nil {
+				return
+			}
 			// Secret modal submission — defer then process async.
 			_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,

--- a/extras/scion-discord/internal/discord/commands.go
+++ b/extras/scion-discord/internal/discord/commands.go
@@ -75,6 +75,19 @@ type HubClient interface {
 
 	// HubBaseURL returns the base URL of the hub (e.g. "https://hub.example.com").
 	HubBaseURL() string
+
+	// ListSecrets returns metadata for all secrets in the given scope.
+	ListSecrets(ctx context.Context, scope, scopeID string) ([]SecretInfo, error)
+
+	// GetSecret returns metadata for a single secret.
+	GetSecret(ctx context.Context, key, scope, scopeID string) (*SecretInfo, error)
+
+	// SetSecret creates or updates a secret value. onBehalfOf is a namespaced
+	// principal (e.g. "user:alice@example.com") sent as X-Scion-On-Behalf-Of.
+	SetSecret(ctx context.Context, key, value, scope, scopeID, onBehalfOf string) error
+
+	// DeleteSecret removes a secret. onBehalfOf is sent as X-Scion-On-Behalf-Of.
+	DeleteSecret(ctx context.Context, key, scope, scopeID, onBehalfOf string) error
 }
 
 // CommandHandler manages Discord slash command registration and dispatch.
@@ -308,6 +321,51 @@ func (h *CommandHandler) RegisterCommandsForGuild(guildID string) error {
 				},
 			},
 			{
+				Type:        discordgo.ApplicationCommandOptionSubCommandGroup,
+				Name:        "secret",
+				Description: "Manage project secrets",
+				Options: []*discordgo.ApplicationCommandOption{
+					{
+						Type:        discordgo.ApplicationCommandOptionSubCommand,
+						Name:        "list",
+						Description: "List secrets in the linked project",
+					},
+					{
+						Type:        discordgo.ApplicationCommandOptionSubCommand,
+						Name:        "set",
+						Description: "Set a secret value (entered via secure dialog)",
+						Options: []*discordgo.ApplicationCommandOption{{
+							Type:        discordgo.ApplicationCommandOptionString,
+							Name:        "key",
+							Description: "Secret key name",
+							Required:    true,
+						}},
+					},
+					{
+						Type:        discordgo.ApplicationCommandOptionSubCommand,
+						Name:        "get",
+						Description: "Show secret metadata (value is never shown)",
+						Options: []*discordgo.ApplicationCommandOption{{
+							Type:        discordgo.ApplicationCommandOptionString,
+							Name:        "key",
+							Description: "Secret key name",
+							Required:    true,
+						}},
+					},
+					{
+						Type:        discordgo.ApplicationCommandOptionSubCommand,
+						Name:        "delete",
+						Description: "Delete a secret",
+						Options: []*discordgo.ApplicationCommandOption{{
+							Type:        discordgo.ApplicationCommandOptionString,
+							Name:        "key",
+							Description: "Secret key name",
+							Required:    true,
+						}},
+					},
+				},
+			},
+			{
 				Type:        discordgo.ApplicationCommandOptionSubCommand,
 				Name:        "help",
 				Description: "Show available commands",
@@ -340,6 +398,7 @@ var ephemeralCommands = map[string]bool{
 	"terminal": true,
 	"thread":   true,
 	"send":     true,
+	"secret":   true,
 }
 
 // ephemeralFlag returns MessageFlagsEphemeral if the subcommand should be
@@ -368,6 +427,43 @@ func (h *CommandHandler) HandleSlashCommand(s *discordgo.Session, i *discordgo.I
 	// Commands that don't need async Hub API calls respond immediately.
 	if subcommand == "help" {
 		h.respondImmediate(s, i, helpText())
+		return
+	}
+
+	// Secret subcommand group: "set" opens a modal (must be first response,
+	// no defer); all other sub-subcommands use the standard deferred path.
+	if subcommand == "secret" {
+		subSub := ""
+		if len(data.Options[0].Options) > 0 {
+			subSub = data.Options[0].Options[0].Name
+		}
+		if subSub == "set" {
+			h.HandleSecretSet(s, i)
+			return
+		}
+		// Defer for list/get/delete.
+		err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		if err != nil {
+			h.log.Error("Failed to acknowledge secret command", "error", err)
+			return
+		}
+		go func() {
+			switch subSub {
+			case "list":
+				h.HandleSecretList(s, i)
+			case "get":
+				h.HandleSecretGet(s, i)
+			case "delete":
+				h.HandleSecretDelete(s, i)
+			default:
+				h.followup(s, i, fmt.Sprintf("Unknown secret operation: %s", subSub))
+			}
+		}()
 		return
 	}
 
@@ -548,6 +644,10 @@ func helpText() string {
 		"`/scion terminal <agent>` — Get the web terminal URL for an agent\n" +
 		"`/scion send <path>` — Send a file by path or search for files\n" +
 		"`/scion thread <title> [template]` — Create a thread with a new agent\n" +
+		"`/scion secret list` — List project secrets (metadata only)\n" +
+		"`/scion secret set <key>` — Set a secret (value entered via secure dialog)\n" +
+		"`/scion secret get <key>` — Show secret metadata\n" +
+		"`/scion secret delete <key>` — Delete a secret\n" +
 		"`/scion register` — Link your Discord account to Scion Hub\n" +
 		"`/scion unregister` — Unlink your Discord account\n" +
 		"`/scion settings` — Configure channel notification settings\n" +

--- a/extras/scion-discord/internal/discord/commands_secret.go
+++ b/extras/scion-discord/internal/discord/commands_secret.go
@@ -31,8 +31,8 @@ func validateSecretKey(key string) error {
 	if key == "" {
 		return fmt.Errorf("secret key cannot be empty")
 	}
-	if strings.ContainsAny(key, " \t\n\r=") {
-		return fmt.Errorf("secret key must not contain spaces, tabs, newlines, or '='")
+	if strings.ContainsAny(key, " \t\n\r=:") {
+		return fmt.Errorf("secret key must not contain spaces, tabs, newlines, '=' or ':'")
 	}
 	return nil
 }
@@ -166,15 +166,21 @@ func (h *CommandHandler) HandleSecretModalSubmit(s *discordgo.Session, i *discor
 		return
 	}
 	mapping, err := h.store.GetUserMapping(ctx, discordUserID)
-	if err != nil || mapping == nil {
+	if err != nil {
+		h.log.Error("Failed to look up user mapping", "error", err)
+		h.followup(s, i, "Something went wrong looking up your account. Please try again.")
+		return
+	}
+	if mapping == nil {
 		h.followup(s, i, "Please link your Discord account first with `/scion register`.")
 		return
 	}
 
-	onBehalfOf := ""
-	if mapping.ScionEmail != "" {
-		onBehalfOf = "user:" + mapping.ScionEmail
+	if mapping.ScionEmail == "" {
+		h.followup(s, i, "Your account has no email associated. Please re-register with `/scion register`.")
+		return
 	}
+	onBehalfOf := "user:" + mapping.ScionEmail
 
 	// Call hub API to set the secret.
 	err = h.hubClient.SetSecret(ctx, key, value, "project", projectID, onBehalfOf)
@@ -341,10 +347,11 @@ func (h *CommandHandler) HandleSecretDelete(s *discordgo.Session, i *discordgo.I
 		return
 	}
 
-	onBehalfOf := ""
-	if mapping.ScionEmail != "" {
-		onBehalfOf = "user:" + mapping.ScionEmail
+	if mapping.ScionEmail == "" {
+		h.followup(s, i, "Your account has no email associated. Please re-register with `/scion register`.")
+		return
 	}
+	onBehalfOf := "user:" + mapping.ScionEmail
 
 	err = h.hubClient.DeleteSecret(ctx, key, "project", link.ProjectID, onBehalfOf)
 	if err != nil {

--- a/extras/scion-discord/internal/discord/commands_secret.go
+++ b/extras/scion-discord/internal/discord/commands_secret.go
@@ -90,9 +90,10 @@ func (h *CommandHandler) HandleSecretSet(s *discordgo.Session, i *discordgo.Inte
 	}
 
 	// Modal title is limited to 45 chars by Discord.
+	// Use runes to avoid splitting multi-byte UTF-8 characters.
 	title := "Set Secret: " + key
-	if len(title) > 45 {
-		title = title[:45]
+	if runes := []rune(title); len(runes) > 45 {
+		title = string(runes[:45])
 	}
 
 	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
@@ -254,7 +255,13 @@ func (h *CommandHandler) HandleSecretList(s *discordgo.Session, i *discordgo.Int
 		sb.WriteString(line + "\n")
 	}
 
-	h.followup(s, i, sb.String())
+	// Discord messages are limited to 2000 characters. Truncate defensively.
+	output := sb.String()
+	if len(output) > 1900 {
+		output = output[:1900] + "\n... (truncated)"
+	}
+
+	h.followup(s, i, output)
 }
 
 // HandleSecretGet shows metadata for a single secret (never the value).

--- a/extras/scion-discord/internal/discord/commands_secret.go
+++ b/extras/scion-discord/internal/discord/commands_secret.go
@@ -1,0 +1,359 @@
+package discord
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// getSubSubcommandOption extracts a named option value from a sub-subcommand
+// interaction (i.e. options nested two levels deep under a subcommand group).
+func getSubSubcommandOption(i *discordgo.InteractionCreate, name string) string {
+	data := i.ApplicationCommandData()
+	if len(data.Options) == 0 || len(data.Options[0].Options) == 0 {
+		return ""
+	}
+	sub := data.Options[0].Options[0] // sub-subcommand
+	for _, opt := range sub.Options {
+		if opt.Name == name {
+			return opt.StringValue()
+		}
+	}
+	return ""
+}
+
+// validateSecretKey checks that a key is non-empty and contains no spaces,
+// newlines, or equals signs.
+func validateSecretKey(key string) error {
+	if key == "" {
+		return fmt.Errorf("secret key cannot be empty")
+	}
+	if strings.ContainsAny(key, " \t\n\r=") {
+		return fmt.Errorf("secret key must not contain spaces, tabs, newlines, or '='")
+	}
+	return nil
+}
+
+// HandleSecretSet opens a modal for the user to enter a secret value.
+// This MUST be the first interaction response (no defer) because Discord
+// requires InteractionResponseModal as the initial response.
+func (h *CommandHandler) HandleSecretSet(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Check user registration.
+	discordUserID := interactionUserID(i)
+	if discordUserID == "" {
+		h.respondModalError(s, i, "Could not identify your user.")
+		return
+	}
+	mapping, err := h.store.GetUserMapping(ctx, discordUserID)
+	if err != nil {
+		h.log.Error("Failed to check user mapping for secret set", "error", err)
+		h.respondModalError(s, i, "Something went wrong. Please try again.")
+		return
+	}
+	if mapping == nil {
+		h.respondModalError(s, i, "Please link your Discord account first with `/scion register`.")
+		return
+	}
+
+	// Resolve channel link for project context.
+	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
+	if err != nil {
+		h.log.Error("Failed to resolve channel link for secret set", "error", err)
+		h.respondModalError(s, i, "Something went wrong. Please try again.")
+		return
+	}
+	if link == nil {
+		h.respondModalError(s, i, "This channel is not linked to a project. Use `/scion setup` first.")
+		return
+	}
+
+	// Extract and validate key.
+	key := getSubSubcommandOption(i, "key")
+	if err := validateSecretKey(key); err != nil {
+		h.respondModalError(s, i, fmt.Sprintf("Invalid key: %s", err))
+		return
+	}
+
+	// Build the modal custom ID. Discord limits custom IDs to 100 chars.
+	// Format: "secret:set:<key>:<projectID>"
+	customID := fmt.Sprintf("secret:set:%s:%s", key, link.ProjectID)
+	if len(customID) > 100 {
+		// Key or project ID too long — truncate is not safe. Use ephemeral error.
+		h.respondModalError(s, i, "The secret key is too long for this operation. Please use a shorter key name.")
+		return
+	}
+
+	// Modal title is limited to 45 chars by Discord.
+	title := "Set Secret: " + key
+	if len(title) > 45 {
+		title = title[:45]
+	}
+
+	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseModal,
+		Data: &discordgo.InteractionResponseData{
+			CustomID: customID,
+			Title:    title,
+			Components: []discordgo.MessageComponent{
+				discordgo.ActionsRow{
+					Components: []discordgo.MessageComponent{
+						discordgo.TextInput{
+							CustomID:    "secret_value",
+							Label:       "Secret Value",
+							Style:       discordgo.TextInputParagraph,
+							Placeholder: "Enter the secret value...",
+							Required:    true,
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		h.log.Error("Failed to open secret set modal", "error", err, "key", key)
+	}
+}
+
+// respondModalError sends an immediate ephemeral message for cases where
+// the modal cannot be opened (e.g. validation failures before the modal).
+func (h *CommandHandler) respondModalError(s *discordgo.Session, i *discordgo.InteractionCreate, msg string) {
+	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: msg,
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	})
+	if err != nil {
+		h.log.Error("Failed to send modal error response", "error", err)
+	}
+}
+
+// HandleSecretModalSubmit processes the modal submission for secret set.
+// It is called after the broker defers the interaction response.
+func (h *CommandHandler) HandleSecretModalSubmit(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	data := i.ModalSubmitData()
+
+	// Parse customID: "secret:set:<key>:<projectID>"
+	parts := strings.SplitN(data.CustomID, ":", 4)
+	if len(parts) < 4 || parts[1] != "set" {
+		h.followup(s, i, "Invalid modal submission.")
+		return
+	}
+	key := parts[2]
+	projectID := parts[3]
+
+	// Extract the secret value from modal components.
+	value := extractModalTextValue(data.Components, "secret_value")
+	if value == "" {
+		h.followup(s, i, "Empty secret value — no action taken.")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Look up user mapping for on-behalf-of header.
+	discordUserID := interactionUserID(i)
+	if discordUserID == "" {
+		h.followup(s, i, "Could not identify your user.")
+		return
+	}
+	mapping, err := h.store.GetUserMapping(ctx, discordUserID)
+	if err != nil || mapping == nil {
+		h.followup(s, i, "Please link your Discord account first with `/scion register`.")
+		return
+	}
+
+	onBehalfOf := ""
+	if mapping.ScionEmail != "" {
+		onBehalfOf = "user:" + mapping.ScionEmail
+	}
+
+	// Call hub API to set the secret.
+	err = h.hubClient.SetSecret(ctx, key, value, "project", projectID, onBehalfOf)
+	if err != nil {
+		h.log.Error("Failed to set secret via hub", "error", err, "key", key, "project_id", projectID)
+		h.followup(s, i, fmt.Sprintf("Failed to set secret **%s**: %s", key, err))
+		return
+	}
+
+	h.followup(s, i, fmt.Sprintf("Secret **%s** has been set.", key))
+	h.log.Info("Secret set via Discord",
+		"key", key, "project_id", projectID, "discord_user", discordUserID)
+}
+
+// HandleSecretList lists all secrets in the linked project (metadata only).
+func (h *CommandHandler) HandleSecretList(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Check user registration.
+	discordUserID := interactionUserID(i)
+	if discordUserID == "" {
+		h.followup(s, i, "Could not identify your user.")
+		return
+	}
+	mapping, err := h.store.GetUserMapping(ctx, discordUserID)
+	if err != nil || mapping == nil {
+		h.followup(s, i, "Please link your Discord account first with `/scion register`.")
+		return
+	}
+
+	// Resolve channel link.
+	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
+	if err != nil {
+		h.log.Error("Failed to resolve channel link for secret list", "error", err)
+		h.followup(s, i, "Something went wrong. Please try again.")
+		return
+	}
+	if link == nil {
+		h.followup(s, i, "This channel is not linked to a project. Use `/scion setup` first.")
+		return
+	}
+
+	secrets, err := h.hubClient.ListSecrets(ctx, "project", link.ProjectID)
+	if err != nil {
+		h.log.Error("Failed to list secrets", "error", err, "project_id", link.ProjectID)
+		h.followup(s, i, "Failed to list secrets. Please try again later.")
+		return
+	}
+
+	if len(secrets) == 0 {
+		h.followup(s, i, fmt.Sprintf("No secrets found in project **%s**.", link.ProjectSlug))
+		return
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("**Secrets in %s** (%d):\n", link.ProjectSlug, len(secrets)))
+	for _, sec := range secrets {
+		line := fmt.Sprintf("- `%s`", sec.Key)
+		if sec.Type != "" {
+			line += fmt.Sprintf(" (type: %s)", sec.Type)
+		}
+		if sec.Description != "" {
+			line += fmt.Sprintf(" — %s", sec.Description)
+		}
+		sb.WriteString(line + "\n")
+	}
+
+	h.followup(s, i, sb.String())
+}
+
+// HandleSecretGet shows metadata for a single secret (never the value).
+func (h *CommandHandler) HandleSecretGet(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Check user registration.
+	discordUserID := interactionUserID(i)
+	if discordUserID == "" {
+		h.followup(s, i, "Could not identify your user.")
+		return
+	}
+	mapping, err := h.store.GetUserMapping(ctx, discordUserID)
+	if err != nil || mapping == nil {
+		h.followup(s, i, "Please link your Discord account first with `/scion register`.")
+		return
+	}
+
+	key := getSubSubcommandOption(i, "key")
+	if err := validateSecretKey(key); err != nil {
+		h.followup(s, i, fmt.Sprintf("Invalid key: %s", err))
+		return
+	}
+
+	// Resolve channel link.
+	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
+	if err != nil {
+		h.log.Error("Failed to resolve channel link for secret get", "error", err)
+		h.followup(s, i, "Something went wrong. Please try again.")
+		return
+	}
+	if link == nil {
+		h.followup(s, i, "This channel is not linked to a project. Use `/scion setup` first.")
+		return
+	}
+
+	info, err := h.hubClient.GetSecret(ctx, key, "project", link.ProjectID)
+	if err != nil {
+		h.log.Error("Failed to get secret", "error", err, "key", key, "project_id", link.ProjectID)
+		h.followup(s, i, fmt.Sprintf("Failed to get secret **%s**: %s", key, err))
+		return
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("**Secret: %s**\n", info.Key))
+	if info.Type != "" {
+		sb.WriteString(fmt.Sprintf("**Type:** %s\n", info.Type))
+	}
+	sb.WriteString(fmt.Sprintf("**Scope:** %s\n", info.Scope))
+	if info.Description != "" {
+		sb.WriteString(fmt.Sprintf("**Description:** %s\n", info.Description))
+	}
+	if info.Updated != "" {
+		sb.WriteString(fmt.Sprintf("**Last updated:** %s\n", info.Updated))
+	}
+	sb.WriteString(fmt.Sprintf("**Version:** %d\n", info.Version))
+	sb.WriteString("_(Secret value is never shown)_")
+
+	h.followup(s, i, sb.String())
+}
+
+// HandleSecretDelete deletes a secret from the linked project.
+func (h *CommandHandler) HandleSecretDelete(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Check user registration.
+	discordUserID := interactionUserID(i)
+	if discordUserID == "" {
+		h.followup(s, i, "Could not identify your user.")
+		return
+	}
+	mapping, err := h.store.GetUserMapping(ctx, discordUserID)
+	if err != nil || mapping == nil {
+		h.followup(s, i, "Please link your Discord account first with `/scion register`.")
+		return
+	}
+
+	key := getSubSubcommandOption(i, "key")
+	if err := validateSecretKey(key); err != nil {
+		h.followup(s, i, fmt.Sprintf("Invalid key: %s", err))
+		return
+	}
+
+	// Resolve channel link.
+	link, err := resolveChannelLink(ctx, s, h.store, i.ChannelID)
+	if err != nil {
+		h.log.Error("Failed to resolve channel link for secret delete", "error", err)
+		h.followup(s, i, "Something went wrong. Please try again.")
+		return
+	}
+	if link == nil {
+		h.followup(s, i, "This channel is not linked to a project. Use `/scion setup` first.")
+		return
+	}
+
+	onBehalfOf := ""
+	if mapping.ScionEmail != "" {
+		onBehalfOf = "user:" + mapping.ScionEmail
+	}
+
+	err = h.hubClient.DeleteSecret(ctx, key, "project", link.ProjectID, onBehalfOf)
+	if err != nil {
+		h.log.Error("Failed to delete secret", "error", err, "key", key, "project_id", link.ProjectID)
+		h.followup(s, i, fmt.Sprintf("Failed to delete secret **%s**: %s", key, err))
+		return
+	}
+
+	h.followup(s, i, fmt.Sprintf("Secret **%s** has been deleted.", key))
+	h.log.Info("Secret deleted via Discord",
+		"key", key, "project_id", link.ProjectID, "discord_user", discordUserID)
+}

--- a/extras/scion-discord/internal/discord/commands_secret.go
+++ b/extras/scion-discord/internal/discord/commands_secret.go
@@ -207,7 +207,12 @@ func (h *CommandHandler) HandleSecretList(s *discordgo.Session, i *discordgo.Int
 		return
 	}
 	mapping, err := h.store.GetUserMapping(ctx, discordUserID)
-	if err != nil || mapping == nil {
+	if err != nil {
+		h.log.Error("Failed to look up user mapping", "error", err)
+		h.followup(s, i, "Something went wrong looking up your account. Please try again.")
+		return
+	}
+	if mapping == nil {
 		h.followup(s, i, "Please link your Discord account first with `/scion register`.")
 		return
 	}
@@ -264,7 +269,12 @@ func (h *CommandHandler) HandleSecretGet(s *discordgo.Session, i *discordgo.Inte
 		return
 	}
 	mapping, err := h.store.GetUserMapping(ctx, discordUserID)
-	if err != nil || mapping == nil {
+	if err != nil {
+		h.log.Error("Failed to look up user mapping", "error", err)
+		h.followup(s, i, "Something went wrong looking up your account. Please try again.")
+		return
+	}
+	if mapping == nil {
 		h.followup(s, i, "Please link your Discord account first with `/scion register`.")
 		return
 	}
@@ -324,7 +334,12 @@ func (h *CommandHandler) HandleSecretDelete(s *discordgo.Session, i *discordgo.I
 		return
 	}
 	mapping, err := h.store.GetUserMapping(ctx, discordUserID)
-	if err != nil || mapping == nil {
+	if err != nil {
+		h.log.Error("Failed to look up user mapping", "error", err)
+		h.followup(s, i, "Something went wrong looking up your account. Please try again.")
+		return
+	}
+	if mapping == nil {
 		h.followup(s, i, "Please link your Discord account first with `/scion register`.")
 		return
 	}

--- a/extras/scion-discord/internal/discord/commands_secret_test.go
+++ b/extras/scion-discord/internal/discord/commands_secret_test.go
@@ -1,6 +1,7 @@
 package discord
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bwmarrin/discordgo"
@@ -38,6 +39,7 @@ func TestValidateSecretKey_Invalid(t *testing.T) {
 		{"newline", "has\nnewline"},
 		{"carriage_return", "has\rreturn"},
 		{"equals", "key=value"},
+		{"colon", "service:api_key"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -175,4 +177,27 @@ func TestHelpText_IncludesSecretCommands(t *testing.T) {
 	assert.Contains(t, text, "/scion secret set")
 	assert.Contains(t, text, "/scion secret get")
 	assert.Contains(t, text, "/scion secret delete")
+}
+
+// ---------------------------------------------------------------------------
+// Modal submit customID parsing
+// ---------------------------------------------------------------------------
+
+func TestSecretModalCustomID_ParsesCorrectly(t *testing.T) {
+	customID := "secret:set:mykey:proj-uuid-1234"
+	parts := strings.SplitN(customID, ":", 4)
+
+	assert.Len(t, parts, 4)
+	assert.Equal(t, "secret", parts[0])
+	assert.Equal(t, "set", parts[1])
+	assert.Equal(t, "mykey", parts[2])
+	assert.Equal(t, "proj-uuid-1234", parts[3])
+}
+
+func TestSecretModalCustomID_ColonInKeyRejected(t *testing.T) {
+	// After R1 fix, keys with colons are rejected before they
+	// reach the customID construction, preventing mis-parsing.
+	err := validateSecretKey("service:api_key")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "':'")
 }

--- a/extras/scion-discord/internal/discord/commands_secret_test.go
+++ b/extras/scion-discord/internal/discord/commands_secret_test.go
@@ -1,0 +1,178 @@
+package discord
+
+import (
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// validateSecretKey
+// ---------------------------------------------------------------------------
+
+func TestValidateSecretKey_Valid(t *testing.T) {
+	tests := []string{
+		"MY_API_KEY",
+		"simple",
+		"DB_HOST",
+		"a",
+		"key-with-dashes",
+		"key.with.dots",
+	}
+	for _, key := range tests {
+		t.Run(key, func(t *testing.T) {
+			assert.NoError(t, validateSecretKey(key))
+		})
+	}
+}
+
+func TestValidateSecretKey_Invalid(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{"empty", ""},
+		{"space", "has space"},
+		{"tab", "has\ttab"},
+		{"newline", "has\nnewline"},
+		{"carriage_return", "has\rreturn"},
+		{"equals", "key=value"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSecretKey(tt.key)
+			assert.Error(t, err)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getSubSubcommandOption
+// ---------------------------------------------------------------------------
+
+func TestGetSubSubcommandOption_ExtractsKey(t *testing.T) {
+	i := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionApplicationCommand,
+			Data: discordgo.ApplicationCommandInteractionData{
+				Name: "scion",
+				Options: []*discordgo.ApplicationCommandInteractionDataOption{
+					{
+						Name: "secret",
+						Type: discordgo.ApplicationCommandOptionSubCommandGroup,
+						Options: []*discordgo.ApplicationCommandInteractionDataOption{
+							{
+								Name: "set",
+								Type: discordgo.ApplicationCommandOptionSubCommand,
+								Options: []*discordgo.ApplicationCommandInteractionDataOption{
+									{
+										Name:  "key",
+										Type:  discordgo.ApplicationCommandOptionString,
+										Value: "MY_API_KEY",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := getSubSubcommandOption(i, "key")
+	assert.Equal(t, "MY_API_KEY", got)
+}
+
+func TestGetSubSubcommandOption_EmptyWhenNoOptions(t *testing.T) {
+	i := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionApplicationCommand,
+			Data: discordgo.ApplicationCommandInteractionData{
+				Name:    "scion",
+				Options: []*discordgo.ApplicationCommandInteractionDataOption{},
+			},
+		},
+	}
+
+	got := getSubSubcommandOption(i, "key")
+	assert.Empty(t, got)
+}
+
+func TestGetSubSubcommandOption_EmptyWhenNoSubSub(t *testing.T) {
+	i := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionApplicationCommand,
+			Data: discordgo.ApplicationCommandInteractionData{
+				Name: "scion",
+				Options: []*discordgo.ApplicationCommandInteractionDataOption{
+					{
+						Name:    "secret",
+						Type:    discordgo.ApplicationCommandOptionSubCommandGroup,
+						Options: []*discordgo.ApplicationCommandInteractionDataOption{},
+					},
+				},
+			},
+		},
+	}
+
+	got := getSubSubcommandOption(i, "key")
+	assert.Empty(t, got)
+}
+
+func TestGetSubSubcommandOption_WrongOptionName(t *testing.T) {
+	i := &discordgo.InteractionCreate{
+		Interaction: &discordgo.Interaction{
+			Type: discordgo.InteractionApplicationCommand,
+			Data: discordgo.ApplicationCommandInteractionData{
+				Name: "scion",
+				Options: []*discordgo.ApplicationCommandInteractionDataOption{
+					{
+						Name: "secret",
+						Type: discordgo.ApplicationCommandOptionSubCommandGroup,
+						Options: []*discordgo.ApplicationCommandInteractionDataOption{
+							{
+								Name: "get",
+								Type: discordgo.ApplicationCommandOptionSubCommand,
+								Options: []*discordgo.ApplicationCommandInteractionDataOption{
+									{
+										Name:  "key",
+										Type:  discordgo.ApplicationCommandOptionString,
+										Value: "DB_HOST",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := getSubSubcommandOption(i, "nonexistent")
+	assert.Empty(t, got)
+
+	got = getSubSubcommandOption(i, "key")
+	assert.Equal(t, "DB_HOST", got)
+}
+
+// ---------------------------------------------------------------------------
+// ephemeralCommands map includes "secret"
+// ---------------------------------------------------------------------------
+
+func TestEphemeralCommands_IncludesSecret(t *testing.T) {
+	assert.True(t, ephemeralCommands["secret"],
+		"secret commands should be in the ephemeral commands map")
+}
+
+// ---------------------------------------------------------------------------
+// helpText includes secret commands
+// ---------------------------------------------------------------------------
+
+func TestHelpText_IncludesSecretCommands(t *testing.T) {
+	text := helpText()
+	assert.Contains(t, text, "/scion secret list")
+	assert.Contains(t, text, "/scion secret set")
+	assert.Contains(t, text, "/scion secret get")
+	assert.Contains(t, text, "/scion secret delete")
+}

--- a/extras/scion-discord/internal/discord/hubclient.go
+++ b/extras/scion-discord/internal/discord/hubclient.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
@@ -392,6 +393,163 @@ func (c *httpHubClient) CreateAgent(ctx context.Context, projectID string, req C
 
 func (c *httpHubClient) HubBaseURL() string {
 	return c.hubURL
+}
+
+// --- Secrets API ---
+
+// SecretInfo holds metadata about a secret for display in Discord.
+// Values are never included.
+type SecretInfo struct {
+	Key         string `json:"key"`
+	Type        string `json:"type"`
+	Scope       string `json:"scope"`
+	ScopeID     string `json:"scopeId"`
+	Description string `json:"description,omitempty"`
+	Updated     string `json:"updated,omitempty"`
+	Version     int    `json:"version"`
+}
+
+// setSecretPayload is the JSON body sent to PUT /api/v1/secrets/{key}.
+type setSecretPayload struct {
+	Value    string `json:"value"`
+	Encoding string `json:"encoding"`
+	Scope    string `json:"scope"`
+	ScopeID  string `json:"scopeId"`
+}
+
+// hubListSecretsResponse mirrors the hub's list-secrets JSON envelope.
+type hubListSecretsResponse struct {
+	Secrets []SecretInfo `json:"secrets"`
+}
+
+func (c *httpHubClient) ListSecrets(ctx context.Context, scope, scopeID string) ([]SecretInfo, error) {
+	u := fmt.Sprintf("%s/api/v1/secrets?scope=%s&scopeId=%s",
+		c.hubURL, url.QueryEscape(scope), url.QueryEscape(scopeID))
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create list secrets request: %w", err)
+	}
+	if err := c.signRequest(req); err != nil {
+		return nil, fmt.Errorf("sign request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list secrets request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list secrets returned status %d", resp.StatusCode)
+	}
+
+	var result hubListSecretsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode list secrets response: %w", err)
+	}
+	return result.Secrets, nil
+}
+
+func (c *httpHubClient) GetSecret(ctx context.Context, key, scope, scopeID string) (*SecretInfo, error) {
+	u := fmt.Sprintf("%s/api/v1/secrets/%s?scope=%s&scopeId=%s",
+		c.hubURL, url.PathEscape(key), url.QueryEscape(scope), url.QueryEscape(scopeID))
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create get secret request: %w", err)
+	}
+	if err := c.signRequest(req); err != nil {
+		return nil, fmt.Errorf("sign request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get secret request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("secret %q not found", key)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("get secret returned status %d", resp.StatusCode)
+	}
+
+	var info SecretInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return nil, fmt.Errorf("decode get secret response: %w", err)
+	}
+	return &info, nil
+}
+
+func (c *httpHubClient) SetSecret(ctx context.Context, key, value, scope, scopeID, onBehalfOf string) error {
+	u := fmt.Sprintf("%s/api/v1/secrets/%s", c.hubURL, url.PathEscape(key))
+
+	payload := setSecretPayload{
+		Value:    value,
+		Encoding: "raw",
+		Scope:    scope,
+		ScopeID:  scopeID,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal set secret request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "PUT", u, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create set secret request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if onBehalfOf != "" {
+		httpReq.Header.Set("X-Scion-On-Behalf-Of", onBehalfOf)
+		httpReq.Header.Set("X-Scion-Signed-Headers", "x-scion-on-behalf-of")
+	}
+	if err := c.signRequest(httpReq); err != nil {
+		return fmt.Errorf("sign request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("set secret request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		he := parseHubError(resp)
+		return fmt.Errorf("set secret returned status %d: %s", resp.StatusCode, he.Message)
+	}
+	return nil
+}
+
+func (c *httpHubClient) DeleteSecret(ctx context.Context, key, scope, scopeID, onBehalfOf string) error {
+	u := fmt.Sprintf("%s/api/v1/secrets/%s?scope=%s&scopeId=%s",
+		c.hubURL, url.PathEscape(key), url.QueryEscape(scope), url.QueryEscape(scopeID))
+
+	httpReq, err := http.NewRequestWithContext(ctx, "DELETE", u, nil)
+	if err != nil {
+		return fmt.Errorf("create delete secret request: %w", err)
+	}
+	if onBehalfOf != "" {
+		httpReq.Header.Set("X-Scion-On-Behalf-Of", onBehalfOf)
+		httpReq.Header.Set("X-Scion-Signed-Headers", "x-scion-on-behalf-of")
+	}
+	if err := c.signRequest(httpReq); err != nil {
+		return fmt.Errorf("sign request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("delete secret request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		he := parseHubError(resp)
+		return fmt.Errorf("delete secret returned status %d: %s", resp.StatusCode, he.Message)
+	}
+	return nil
 }
 
 func (c *httpHubClient) signRequest(req *http.Request) error {

--- a/extras/scion-discord/internal/discord/hubclient.go
+++ b/extras/scion-discord/internal/discord/hubclient.go
@@ -441,7 +441,8 @@ func (c *httpHubClient) ListSecrets(ctx context.Context, scope, scopeID string) 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("list secrets returned status %d", resp.StatusCode)
+		he := parseHubError(resp)
+		return nil, fmt.Errorf("list secrets returned status %d: %s", resp.StatusCode, he.Message)
 	}
 
 	var result hubListSecretsResponse
@@ -473,7 +474,8 @@ func (c *httpHubClient) GetSecret(ctx context.Context, key, scope, scopeID strin
 		return nil, fmt.Errorf("secret %q not found", key)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("get secret returned status %d", resp.StatusCode)
+		he := parseHubError(resp)
+		return nil, fmt.Errorf("get secret returned status %d: %s", resp.StatusCode, he.Message)
 	}
 
 	var info SecretInfo

--- a/extras/scion-discord/internal/discord/hubclient_test.go
+++ b/extras/scion-discord/internal/discord/hubclient_test.go
@@ -137,3 +137,162 @@ func TestHTTPHubClient_PlainClient_WhenNoIAP(t *testing.T) {
 	assert.Len(t, projects, 1)
 	assert.Equal(t, "test", projects[0].Slug)
 }
+
+// ---------------------------------------------------------------------------
+// Secrets API methods
+// ---------------------------------------------------------------------------
+
+func TestHTTPHubClient_ListSecrets(t *testing.T) {
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/secrets", r.URL.Path)
+		assert.Equal(t, "project", r.URL.Query().Get("scope"))
+		assert.Equal(t, "proj-1", r.URL.Query().Get("scopeId"))
+
+		json.NewEncoder(w).Encode(hubListSecretsResponse{
+			Secrets: []SecretInfo{
+				{Key: "API_KEY", Type: "environment", Scope: "project"},
+				{Key: "DB_PASS", Type: "environment", Scope: "project", Description: "Database password"},
+			},
+		})
+	}))
+	defer hub.Close()
+
+	client := NewHTTPHubClient(hub.URL, "", "", nil)
+	secrets, err := client.ListSecrets(context.Background(), "project", "proj-1")
+	require.NoError(t, err)
+	assert.Len(t, secrets, 2)
+	assert.Equal(t, "API_KEY", secrets[0].Key)
+	assert.Equal(t, "DB_PASS", secrets[1].Key)
+	assert.Equal(t, "Database password", secrets[1].Description)
+}
+
+func TestHTTPHubClient_ListSecrets_Error(t *testing.T) {
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer hub.Close()
+
+	client := NewHTTPHubClient(hub.URL, "", "", nil)
+	_, err := client.ListSecrets(context.Background(), "project", "proj-1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status 500")
+}
+
+func TestHTTPHubClient_GetSecret(t *testing.T) {
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/v1/secrets/MY_KEY", r.URL.Path)
+		assert.Equal(t, "project", r.URL.Query().Get("scope"))
+
+		json.NewEncoder(w).Encode(SecretInfo{
+			Key:     "MY_KEY",
+			Type:    "environment",
+			Scope:   "project",
+			Version: 3,
+			Updated: "2026-01-01T00:00:00Z",
+		})
+	}))
+	defer hub.Close()
+
+	client := NewHTTPHubClient(hub.URL, "", "", nil)
+	info, err := client.GetSecret(context.Background(), "MY_KEY", "project", "proj-1")
+	require.NoError(t, err)
+	assert.Equal(t, "MY_KEY", info.Key)
+	assert.Equal(t, 3, info.Version)
+}
+
+func TestHTTPHubClient_GetSecret_NotFound(t *testing.T) {
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer hub.Close()
+
+	client := NewHTTPHubClient(hub.URL, "", "", nil)
+	_, err := client.GetSecret(context.Background(), "MISSING", "project", "proj-1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestHTTPHubClient_SetSecret(t *testing.T) {
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/api/v1/secrets/NEW_KEY", r.URL.Path)
+		assert.Equal(t, "user:alice@example.com", r.Header.Get("X-Scion-On-Behalf-Of"))
+		assert.Equal(t, "x-scion-on-behalf-of", r.Header.Get("X-Scion-Signed-Headers"))
+
+		var payload setSecretPayload
+		err := json.NewDecoder(r.Body).Decode(&payload)
+		require.NoError(t, err)
+		assert.Equal(t, "my-secret-value", payload.Value)
+		assert.Equal(t, "raw", payload.Encoding)
+		assert.Equal(t, "project", payload.Scope)
+		assert.Equal(t, "proj-1", payload.ScopeID)
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]interface{}{"created": true})
+	}))
+	defer hub.Close()
+
+	client := NewHTTPHubClient(hub.URL, "", "", nil)
+	err := client.SetSecret(context.Background(), "NEW_KEY", "my-secret-value", "project", "proj-1", "user:alice@example.com")
+	assert.NoError(t, err)
+}
+
+func TestHTTPHubClient_SetSecret_Error(t *testing.T) {
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{"error": "forbidden", "message": "no access"})
+	}))
+	defer hub.Close()
+
+	client := NewHTTPHubClient(hub.URL, "", "", nil)
+	err := client.SetSecret(context.Background(), "KEY", "val", "project", "p1", "user:bob@example.com")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status 403")
+}
+
+func TestHTTPHubClient_DeleteSecret(t *testing.T) {
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method)
+		assert.Equal(t, "/api/v1/secrets/OLD_KEY", r.URL.Path)
+		assert.Equal(t, "project", r.URL.Query().Get("scope"))
+		assert.Equal(t, "proj-1", r.URL.Query().Get("scopeId"))
+		assert.Equal(t, "user:alice@example.com", r.Header.Get("X-Scion-On-Behalf-Of"))
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer hub.Close()
+
+	client := NewHTTPHubClient(hub.URL, "", "", nil)
+	err := client.DeleteSecret(context.Background(), "OLD_KEY", "project", "proj-1", "user:alice@example.com")
+	assert.NoError(t, err)
+}
+
+func TestHTTPHubClient_DeleteSecret_Error(t *testing.T) {
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "not_found", "message": "secret not found"})
+	}))
+	defer hub.Close()
+
+	client := NewHTTPHubClient(hub.URL, "", "", nil)
+	err := client.DeleteSecret(context.Background(), "MISSING", "project", "proj-1", "user:alice@example.com")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status 404")
+}
+
+func TestHTTPHubClient_SetSecret_NoOnBehalfOf(t *testing.T) {
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// When onBehalfOf is empty, headers should not be set.
+		assert.Empty(t, r.Header.Get("X-Scion-On-Behalf-Of"))
+		assert.Empty(t, r.Header.Get("X-Scion-Signed-Headers"))
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"created": false})
+	}))
+	defer hub.Close()
+
+	client := NewHTTPHubClient(hub.URL, "", "", nil)
+	err := client.SetSecret(context.Background(), "KEY", "val", "project", "p1", "")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Adds /scion secret slash command with list, set (via modal), get, delete operations. Modal-based secure value input, ephemeral responses, HMAC-signed Hub API calls with X-Scion-On-Behalf-Of delegation. Closes #771