### PR TITLE
fix(web): allow clearing agent limit fields to null in admin settings

### DIFF
--- a/pkg/hub/admin_settings_test.go
+++ b/pkg/hub/admin_settings_test.go
@@ -231,6 +231,93 @@ func TestApplySettingsUpdates_AutoExposePortsNilRequest(t *testing.T) {
 	}
 }
 
+// TestApplySettingsUpdates_ClearFieldsToBlank is a regression test for
+// ptone/scion#860: clearing a field to blank in the admin UI should delete
+// the key from settings.yaml, not preserve the old value.
+//
+// Round-trip: set value → save → clear to blank → save → confirm deleted.
+func TestApplySettingsUpdates_ClearFieldsToBlank(t *testing.T) {
+	// Step 1: Start with existing settings containing the fields we'll clear.
+	raw := map[string]interface{}{
+		"schema_version":       "1",
+		"default_max_duration": "2h",
+		"default_max_turns":    200,
+		"default_max_model_calls": 500,
+		"default_model":        "gemini-2.0-flash",
+		"default_thinking_level": 3,
+	}
+
+	// Verify they're present.
+	for _, key := range []string{
+		"default_max_duration", "default_max_turns",
+		"default_max_model_calls", "default_model", "default_thinking_level",
+	} {
+		if _, ok := raw[key]; !ok {
+			t.Fatalf("precondition: expected %q to be present", key)
+		}
+	}
+
+	// Step 2: Send an update with empty/zero values to clear each field.
+	emptyStr := ""
+	zeroInt := 0
+	req := &ServerConfigUpdateRequest{
+		DefaultMaxDuration:   &emptyStr,
+		DefaultMaxTurns:      &zeroInt,
+		DefaultMaxModelCalls: &zeroInt,
+		DefaultModel:         &emptyStr,
+		DefaultThinkingLevel: &zeroInt,
+	}
+
+	applySettingsUpdates(raw, req)
+
+	// Step 3: Verify all fields are deleted from the raw map.
+	for _, key := range []string{
+		"default_max_duration", "default_max_turns",
+		"default_max_model_calls", "default_model", "default_thinking_level",
+	} {
+		if _, ok := raw[key]; ok {
+			t.Errorf("expected %q to be deleted after clearing to blank, but it still exists with value %v", key, raw[key])
+		}
+	}
+
+	// schema_version should still be present (not affected).
+	if _, ok := raw["schema_version"]; !ok {
+		t.Error("schema_version should be preserved")
+	}
+}
+
+// TestApplySettingsUpdates_OmittedFieldsPreserved verifies that when a field
+// is NOT included in the update request (nil pointer), the existing value is
+// preserved. This is the complement of TestApplySettingsUpdates_ClearFieldsToBlank.
+func TestApplySettingsUpdates_OmittedFieldsPreserved(t *testing.T) {
+	raw := map[string]interface{}{
+		"schema_version":       "1",
+		"default_max_duration": "2h",
+		"default_max_turns":    200,
+		"default_model":        "gemini-2.0-flash",
+	}
+
+	// Request with nil pointers — fields are omitted, not cleared.
+	req := &ServerConfigUpdateRequest{
+		DefaultMaxDuration: nil,
+		DefaultMaxTurns:    nil,
+		DefaultModel:       nil,
+	}
+
+	applySettingsUpdates(raw, req)
+
+	// All fields should be preserved.
+	if raw["default_max_duration"] != "2h" {
+		t.Errorf("expected default_max_duration to be preserved as '2h', got %v", raw["default_max_duration"])
+	}
+	if raw["default_max_turns"] != 200 {
+		t.Errorf("expected default_max_turns to be preserved as 200, got %v", raw["default_max_turns"])
+	}
+	if raw["default_model"] != "gemini-2.0-flash" {
+		t.Errorf("expected default_model to be preserved as 'gemini-2.0-flash', got %v", raw["default_model"])
+	}
+}
+
 func serverConfigForMaskTest() config.V1ServerConfig {
 	return config.V1ServerConfig{
 		Auth: &config.V1AuthConfig{

--- a/pkg/hub/admin_settings_test.go
+++ b/pkg/hub/admin_settings_test.go
@@ -239,12 +239,12 @@ func TestApplySettingsUpdates_AutoExposePortsNilRequest(t *testing.T) {
 func TestApplySettingsUpdates_ClearFieldsToBlank(t *testing.T) {
 	// Step 1: Start with existing settings containing the fields we'll clear.
 	raw := map[string]interface{}{
-		"schema_version":       "1",
-		"default_max_duration": "2h",
-		"default_max_turns":    200,
+		"schema_version":          "1",
+		"default_max_duration":    "2h",
+		"default_max_turns":       200,
 		"default_max_model_calls": 500,
-		"default_model":        "gemini-2.0-flash",
-		"default_thinking_level": 3,
+		"default_model":           "gemini-2.0-flash",
+		"default_thinking_level":  3,
 	}
 
 	// Verify they're present.

--- a/web/src/components/pages/admin-server-config.test.ts
+++ b/web/src/components/pages/admin-server-config.test.ts
@@ -606,4 +606,50 @@ describe('scion-page-admin-server-config', () => {
       expect(badgeTexts.some(t => t.includes('deployment configuration'))).toBe(true);
     });
   });
+
+  // ── Regression: clearing fields to blank (ptone/scion#860) ──
+
+  describe('Regression #860 — clearing agent limit fields to blank', () => {
+    it('file mode PUT includes zero/empty agent limit fields so backend can clear them', async () => {
+      // Start with agent limits set to non-zero values, then verify
+      // the PUT payload includes the zeroed values (not undefined).
+      const config = makeBaseConfig({
+        settings_tier: 'file',
+        default_max_turns: 100,
+        default_max_model_calls: 200,
+        default_max_duration: '2h',
+      });
+      let capturedPayload: Record<string, unknown> | null = null;
+
+      element = await createComponent(createFetchHandler(config, {
+        putHandler: (body) => {
+          capturedPayload = body;
+          return { status: 200, body: { reload: { applied: [] } } };
+        },
+      }));
+
+      // Simulate clearing the fields: set the internal state to zero/empty.
+      // In the real UI, the user would clear the input fields.
+      (element as any).defaultMaxTurns = 0;
+      (element as any).defaultMaxModelCalls = 0;
+      (element as any).defaultMaxDuration = '';
+      await (element as any).updateComplete;
+
+      // Trigger save.
+      const buttons = queryAll(element, 'sl-button[variant="primary"]');
+      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      expect(saveBtn).not.toBeNull();
+      (saveBtn as HTMLElement).click();
+      await new Promise(resolve => setTimeout(resolve, 300));
+      await (element as any).updateComplete;
+
+      expect(capturedPayload).not.toBeNull();
+
+      // The key assertion: zero/empty values MUST be present in the payload
+      // (not undefined), so the backend receives them and can delete the keys.
+      expect(capturedPayload!.default_max_turns).toBe(0);
+      expect(capturedPayload!.default_max_model_calls).toBe(0);
+      expect(capturedPayload!.default_max_duration).toBe('');
+    });
+  });
 });

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -1694,12 +1694,15 @@ export class ScionPageAdminServerConfig extends LitElement {
     if (ok('image_registry')) payload.image_registry = this.imageRegistry || undefined;
     if (ok('workspace_path')) payload.workspace_path = this.workspacePath || undefined;
 
-    // Default agent limits
-    if (ok('default_max_turns')) payload.default_max_turns = this.defaultMaxTurns || undefined;
+    // Default agent limits — send zero/empty values so the backend can clear
+    // the field (delete from settings.yaml). Using `|| undefined` here would
+    // convert 0/"" to undefined, omitting the key from JSON and preventing
+    // the user from resetting a limit to null. See ptone/scion#860.
+    if (ok('default_max_turns')) payload.default_max_turns = this.defaultMaxTurns;
     if (ok('default_max_model_calls'))
-      payload.default_max_model_calls = this.defaultMaxModelCalls || undefined;
+      payload.default_max_model_calls = this.defaultMaxModelCalls;
     if (ok('default_max_duration'))
-      payload.default_max_duration = this.defaultMaxDuration || undefined;
+      payload.default_max_duration = this.defaultMaxDuration;
     if (
       ok('default_resources') &&
       (this.defaultResCpuReq ||


### PR DESCRIPTION
## Summary

The admin settings UI could not clear agent limit fields (default_max_turns, default_max_model_calls, default_max_duration) to null. Clearing a field and saving would restore the previous value on reload.

Root cause: buildFilePayload() used value || undefined for these fields. JavaScript treats 0 and empty string as falsy, converting them to undefined, which JSON.stringify omits. The backend never received the field and preserved the old value.

Fix: Remove || undefined from the 3 agent limit fields so zero/empty values are serialized and sent to the backend, which already correctly deletes the key from settings.yaml.

Includes regression tests (backend: clear-to-blank round-trip + omitted-fields-preserved; frontend: PUT payload includes zero/empty values).

Ref: ptone/scion#860

## Test plan

- npm run build passes
- npx vitest run: 157/157 pass
- go build ./cmd/... passes
- go test ./pkg/hub/... -short passes
- Manual: set limits:duration, save, clear to blank, save, reload - confirms null