### PR TITLE
feat(oidc): add OIDC Identity Provider for agent identity tokens

### DIFF
--- a/cmd/sciontool/commands/identity_token.go
+++ b/cmd/sciontool/commands/identity_token.go
@@ -79,7 +79,7 @@ func runIdentityToken(cmd *cobra.Command, args []string) error {
 		}
 	default:
 		// Raw token output — no trailing newline for clean pipeline use.
-		fmt.Fprint(cmd.OutOrStdout(), resp.Token)
+		_, _ = fmt.Fprint(cmd.OutOrStdout(), resp.Token)
 	}
 
 	return nil

--- a/cmd/sciontool/commands/identity_token.go
+++ b/cmd/sciontool/commands/identity_token.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2026 The Scion Authors.
+*/
+
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
+)
+
+var (
+	identityTokenAudience string
+	identityTokenFormat   string
+)
+
+var identityTokenCmd = &cobra.Command{
+	Use:   "identity-token",
+	Short: "Request an OIDC identity token for external system authentication",
+	Long: `Requests a short-lived RS256-signed identity token from the Hub.
+The token can be used to authenticate to external systems that support
+OIDC/JWT verification (Vault, GCP WIF, AWS IRSA, A2A bridges, etc.).
+
+Examples:
+  # Get a raw token for pipeline use
+  sciontool identity-token --audience=https://vault.example.com
+
+  # Get structured JSON output
+  sciontool identity-token --audience=https://vault.example.com --format=json
+
+  # Use in a script
+  export TOKEN=$(sciontool identity-token --audience=https://vault.example.com)`,
+	RunE: runIdentityToken,
+}
+
+func init() {
+	rootCmd.AddCommand(identityTokenCmd)
+
+	identityTokenCmd.Flags().StringVar(&identityTokenAudience, "audience", "",
+		"Target audience for the token (required)")
+	identityTokenCmd.Flags().StringVar(&identityTokenFormat, "format", "token",
+		"Output format: \"token\" (raw JWT) or \"json\"")
+}
+
+func runIdentityToken(cmd *cobra.Command, args []string) error {
+	if identityTokenAudience == "" {
+		return fmt.Errorf("--audience is required")
+	}
+
+	if identityTokenFormat != "token" && identityTokenFormat != "json" {
+		return fmt.Errorf("--format must be \"token\" or \"json\", got %q", identityTokenFormat)
+	}
+
+	hubClient := hub.NewClient()
+	if hubClient == nil || !hubClient.IsConfigured() {
+		return fmt.Errorf("hub client not configured (is SCION_HUB_ENDPOINT set?)")
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+	defer cancel()
+
+	resp, err := hubClient.RequestIdentityToken(ctx, identityTokenAudience)
+	if err != nil {
+		return err
+	}
+
+	switch identityTokenFormat {
+	case "json":
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "")
+		if err := enc.Encode(resp); err != nil {
+			return fmt.Errorf("failed to encode response: %w", err)
+		}
+	default:
+		// Raw token output — no trailing newline for clean pipeline use.
+		fmt.Fprint(cmd.OutOrStdout(), resp.Token)
+	}
+
+	return nil
+}

--- a/cmd/sciontool/commands/identity_token_test.go
+++ b/cmd/sciontool/commands/identity_token_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2026 The Scion Authors.
+*/
+
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIdentityTokenCommand_MissingAudience(t *testing.T) {
+	scrubScionEnv(t)
+
+	// Reset flags to defaults before each test (cobra retains flag state).
+	identityTokenAudience = ""
+	identityTokenFormat = "token"
+
+	var stderr bytes.Buffer
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"identity-token"})
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--audience is required")
+}
+
+func TestIdentityTokenCommand_InvalidFormat(t *testing.T) {
+	scrubScionEnv(t)
+
+	identityTokenAudience = ""
+	identityTokenFormat = "token"
+
+	var stderr bytes.Buffer
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"identity-token", "--audience=test", "--format=xml"})
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--format must be")
+}
+
+func TestIdentityTokenCommand_DefaultFormat(t *testing.T) {
+	scrubScionEnv(t)
+	// Redirect token file reads so NewClient() uses the env var, not the real container token.
+	t.Cleanup(hub.SetTokenHome(t.TempDir()))
+
+	wantToken := "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZ2VudC0xMjMifQ.signature"
+	wantExpiry := time.Now().Add(15 * time.Minute).Truncate(time.Second).UTC()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/agent/identity-token", r.URL.Path)
+		assert.Equal(t, "test-token", r.Header.Get("X-Scion-Agent-Token"))
+
+		var body map[string]string
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "https://vault.example.com", body["audience"])
+
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]interface{}{
+			"token":      wantToken,
+			"expires_at": wantExpiry.Format(time.RFC3339),
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	}))
+	defer srv.Close()
+
+	// Point the hub client at our test server.
+	t.Setenv("SCION_HUB_ENDPOINT", srv.URL)
+	t.Setenv("SCION_AUTH_TOKEN", "test-token")
+	t.Setenv("SCION_AGENT_ID", "agent-123")
+
+	identityTokenAudience = ""
+	identityTokenFormat = "token"
+
+	var stdout bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetArgs([]string{"identity-token", "--audience=https://vault.example.com"})
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	// Default format should output raw JWT only — no trailing newline.
+	assert.Equal(t, wantToken, stdout.String())
+}
+
+func TestIdentityTokenCommand_JSONFormat(t *testing.T) {
+	scrubScionEnv(t)
+	t.Cleanup(hub.SetTokenHome(t.TempDir()))
+
+	wantToken := "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZ2VudC0xMjMifQ.signature"
+	wantExpiry := time.Now().Add(15 * time.Minute).Truncate(time.Second).UTC()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]interface{}{
+			"token":      wantToken,
+			"expires_at": wantExpiry.Format(time.RFC3339),
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	}))
+	defer srv.Close()
+
+	t.Setenv("SCION_HUB_ENDPOINT", srv.URL)
+	t.Setenv("SCION_AUTH_TOKEN", "test-token")
+	t.Setenv("SCION_AGENT_ID", "agent-123")
+
+	identityTokenAudience = ""
+	identityTokenFormat = "token"
+
+	var stdout bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetArgs([]string{"identity-token", "--audience=https://vault.example.com", "--format=json"})
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	// JSON format should output valid JSON with token and expires_at.
+	var result hub.IdentityTokenResponse
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	assert.Equal(t, wantToken, result.Token)
+	assert.True(t, result.ExpiresAt.Equal(wantExpiry),
+		"ExpiresAt mismatch: got %v, want %v", result.ExpiresAt, wantExpiry)
+}
+
+func TestIdentityTokenCommand_HubError(t *testing.T) {
+	scrubScionEnv(t)
+	t.Cleanup(hub.SetTokenHome(t.TempDir()))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"agent not authorized to request identity tokens"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("SCION_HUB_ENDPOINT", srv.URL)
+	t.Setenv("SCION_AUTH_TOKEN", "test-token")
+	t.Setenv("SCION_AGENT_ID", "agent-123")
+
+	identityTokenAudience = ""
+	identityTokenFormat = "token"
+
+	rootCmd.SetArgs([]string{"identity-token", "--audience=https://vault.example.com"})
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}
+
+func TestIdentityTokenCommand_NoHubConfigured(t *testing.T) {
+	scrubScionEnv(t)
+
+	identityTokenAudience = ""
+	identityTokenFormat = "token"
+
+	rootCmd.SetArgs([]string{"identity-token", "--audience=test"})
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hub client not configured")
+}

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1466,6 +1466,7 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 		// new host that changed the HubID). Operators enabling this must supply a
 		// session secret or pre-provision the signing keys.
 		RequireStableSigningKey: os.Getenv("SCION_REQUIRE_STABLE_SIGNING_KEY") == "true",
+		OIDCConfig:              cfg.OIDC,
 	}
 
 	// In hosted mode every replica must share the same session secret for

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -324,10 +324,6 @@ type OIDCProviderConfig struct {
 	Enabled bool `json:"enabled" yaml:"enabled" koanf:"enabled"`
 	// TokenLifetime is the validity duration of issued identity tokens. Default: 15m.
 	TokenLifetime time.Duration `json:"token_lifetime,omitempty" yaml:"token_lifetime,omitempty" koanf:"token_lifetime"`
-	// SigningKeySecret is an optional pre-provisioned PEM-encoded RSA private key
-	// for signing identity tokens. When empty, a key is generated and stored
-	// via the secret backend / store on first boot.
-	SigningKeySecret string `json:"signing_key_secret,omitempty" yaml:"signing_key_secret,omitempty" koanf:"signing_key_secret"`
 }
 
 // GlobalConfig holds the complete server configuration.

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -312,6 +312,24 @@ type OAuthConfig struct {
 	Device OAuthClientConfig `json:"device" yaml:"device" koanf:"device"`
 }
 
+// OIDCProviderConfig holds configuration for the OIDC Identity Provider feature.
+// When enabled, the Hub acts as a minimal OIDC IdP, issuing RS256-signed identity
+// tokens that agents can use to authenticate to external systems (Vault, GCP WIF, etc.).
+type OIDCProviderConfig struct {
+	// IssuerURL is the OIDC issuer URL (the "iss" claim in identity tokens).
+	// Must be a valid HTTPS URL in hosted mode (HTTP allowed in workstation mode).
+	// Defaults to the Hub endpoint if empty.
+	IssuerURL string `json:"issuer_url,omitempty" yaml:"issuer_url,omitempty" koanf:"issuer_url"`
+	// Enabled controls whether the OIDC IdP feature is active. Default: false.
+	Enabled bool `json:"enabled" yaml:"enabled" koanf:"enabled"`
+	// TokenLifetime is the validity duration of issued identity tokens. Default: 15m.
+	TokenLifetime time.Duration `json:"token_lifetime,omitempty" yaml:"token_lifetime,omitempty" koanf:"token_lifetime"`
+	// SigningKeySecret is an optional pre-provisioned PEM-encoded RSA private key
+	// for signing identity tokens. When empty, a key is generated and stored
+	// via the secret backend / store on first boot.
+	SigningKeySecret string `json:"signing_key_secret,omitempty" yaml:"signing_key_secret,omitempty" koanf:"signing_key_secret"`
+}
+
 // GlobalConfig holds the complete server configuration.
 // This is distinct from hub.ServerConfig which only holds HTTP server settings.
 type GlobalConfig struct {
@@ -362,6 +380,9 @@ type GlobalConfig struct {
 
 	// Scheduler settings
 	Scheduler SchedulerConfig `json:"scheduler" yaml:"scheduler" koanf:"scheduler"`
+
+	// OIDC Identity Provider settings
+	OIDC OIDCProviderConfig `json:"oidc,omitempty" yaml:"oidc,omitempty" koanf:"oidc"`
 
 	// SlowRequestThreshold is the duration after which an HTTP request is
 	// logged as slow. Default: 10s when unset/zero.

--- a/pkg/hub/agenttoken.go
+++ b/pkg/hub/agenttoken.go
@@ -57,6 +57,8 @@ const (
 	ScopeAgentTokenRefresh AgentTokenScope = "agent:token:refresh"
 	// ScopeAgentPortForward allows the agent to register ports and hold port-forward tunnels.
 	ScopeAgentPortForward AgentTokenScope = "agent:port:forward"
+	// ScopeIdentityToken grants the ability to request OIDC identity tokens.
+	ScopeIdentityToken AgentTokenScope = "agent:identity:token"
 	// ScopeGCPTokenPrefix is the prefix for GCP token scopes.
 	// Full scope format: "project:gcp:token:<sa-id>"
 	ScopeGCPTokenPrefix = "project:gcp:token:"

--- a/pkg/hub/auth.go
+++ b/pkg/hub/auth.go
@@ -381,6 +381,10 @@ func isUnauthenticatedEndpoint(path string) bool {
 		return true
 	case "/github-app/setup": // GitHub App post-installation callback (browser redirect)
 		return true
+	case "/.well-known/openid-configuration": // OIDC discovery document (public metadata)
+		return true
+	case "/.well-known/jwks.json": // OIDC JSON Web Key Set (public keys)
+		return true
 	}
 	return false
 }

--- a/pkg/hub/handlers_oidc.go
+++ b/pkg/hub/handlers_oidc.go
@@ -28,13 +28,13 @@ import (
 // oidcDiscoveryDocument represents the OpenID Connect Provider Metadata
 // returned by the /.well-known/openid-configuration endpoint.
 type oidcDiscoveryDocument struct {
-	Issuer                            string   `json:"issuer"`
-	JWKSURI                           string   `json:"jwks_uri"`
-	ResponseTypesSupported            []string `json:"response_types_supported"`
-	SubjectTypesSupported             []string `json:"subject_types_supported"`
-	IDTokenSigningAlgValuesSupported  []string `json:"id_token_signing_alg_values_supported"`
-	ClaimsSupported                   []string `json:"claims_supported"`
-	ScopesSupported                   []string `json:"scopes_supported"`
+	Issuer                           string   `json:"issuer"`
+	JWKSURI                          string   `json:"jwks_uri"`
+	ResponseTypesSupported           []string `json:"response_types_supported"`
+	SubjectTypesSupported            []string `json:"subject_types_supported"`
+	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+	ClaimsSupported                  []string `json:"claims_supported"`
+	ScopesSupported                  []string `json:"scopes_supported"`
 }
 
 // handleOIDCDiscovery serves the OIDC Provider Metadata at

--- a/pkg/hub/handlers_oidc.go
+++ b/pkg/hub/handlers_oidc.go
@@ -15,8 +15,14 @@
 package hub
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
+	"log/slog"
 	"net/http"
+	"time"
+
+	"github.com/go-jose/go-jose/v4/jwt"
 )
 
 // oidcDiscoveryDocument represents the OpenID Connect Provider Metadata
@@ -75,4 +81,133 @@ func (s *Server) handleJWKS(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(jwks); err != nil {
 		http.Error(w, "failed to encode JWKS", http.StatusInternalServerError)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Identity Token Endpoint — POST /api/v1/agent/identity-token
+// ---------------------------------------------------------------------------
+
+// identityTokenRequest is the request body for POST /api/v1/agent/identity-token.
+type identityTokenRequest struct {
+	Audience string `json:"audience"`
+}
+
+// identityTokenResponse is the response body for POST /api/v1/agent/identity-token.
+type identityTokenResponse struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// OIDCIdentityTokenClaims defines the claims in a Scion OIDC identity token.
+type OIDCIdentityTokenClaims struct {
+	jwt.Claims
+
+	ProjectID string   `json:"project_id"`
+	AgentName string   `json:"agent_name"`
+	Ancestry  []string `json:"ancestry"`
+	RootUser  string   `json:"root_user"`
+}
+
+// handleAgentIdentityToken handles POST /api/v1/agent/identity-token.
+// It mints an RS256-signed OIDC identity token for the calling agent.
+func (s *Server) handleAgentIdentityToken(w http.ResponseWriter, r *http.Request) {
+	// 1. Extract agent identity from context.
+	agent := GetAgentFromContext(r.Context())
+	if agent == nil {
+		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "agent authentication required", nil)
+		return
+	}
+
+	// 2. Rate limit (per-agent).
+	if s.oidcTokenRateLimiter != nil && !s.oidcTokenRateLimiter.Allow(agent.Subject) {
+		writeError(w, http.StatusTooManyRequests, ErrCodeRateLimited, "rate limit exceeded for identity token requests", nil)
+		return
+	}
+
+	// 3. Parse and validate request body.
+	var req identityTokenRequest
+	if err := readJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "invalid request body: "+err.Error(), nil)
+		return
+	}
+	if req.Audience == "" {
+		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "audience is required", nil)
+		return
+	}
+
+	// 4. Check scope: agent must have agent:identity:token scope.
+	if !agent.HasScope(ScopeIdentityToken) {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden, "agent not authorized to request identity tokens", nil)
+		return
+	}
+
+	// 5. Look up agent record from store.
+	agentRecord, err := s.store.GetAgent(r.Context(), agent.Subject)
+	if err != nil {
+		NotFound(w, "Agent")
+		return
+	}
+
+	// 6. Build claims.
+	now := time.Now()
+	expiresAt := now.Add(s.oidcTokenLifetime)
+
+	jti := make([]byte, 16)
+	if _, err := rand.Read(jti); err != nil {
+		writeError(w, http.StatusInternalServerError, ErrCodeRuntimeError, "failed to generate token ID", nil)
+		return
+	}
+
+	var rootUser string
+	if len(agent.Ancestry) > 0 {
+		rootUser = agent.Ancestry[0]
+	}
+
+	agentName := agentRecord.Slug
+	if agentName == "" {
+		agentName = agentRecord.Name
+	}
+
+	claims := OIDCIdentityTokenClaims{
+		Claims: jwt.Claims{
+			Issuer:    s.oidcIssuerURL,
+			Subject:   agent.Subject,
+			Audience:  jwt.Audience{req.Audience},
+			IssuedAt:  jwt.NewNumericDate(now),
+			Expiry:    jwt.NewNumericDate(expiresAt),
+			NotBefore: jwt.NewNumericDate(now),
+			ID:        base64.RawURLEncoding.EncodeToString(jti),
+		},
+		ProjectID: agent.ProjectID,
+		AgentName: agentName,
+		Ancestry:  agent.Ancestry,
+		RootUser:  rootUser,
+	}
+
+	// 7. Sign with RS256.
+	signer := s.oidcKeyManager.Signer()
+	token, err := jwt.Signed(signer).Claims(claims).Serialize()
+	if err != nil {
+		slog.Error("Failed to sign OIDC identity token",
+			"agent_id", agent.Subject,
+			"error", err,
+		)
+		writeError(w, http.StatusInternalServerError, ErrCodeRuntimeError, "failed to sign identity token", nil)
+		return
+	}
+
+	// 8. Audit log.
+	slog.Info("OIDC identity token issued",
+		"agent_id", agent.Subject,
+		"project_id", agent.ProjectID,
+		"audience", req.Audience,
+		"agent_name", agentName,
+		"expires_at", expiresAt.Format(time.RFC3339),
+	)
+
+	// 9. Return 200 with token and expiry.
+	writeJSON(w, http.StatusOK, identityTokenResponse{
+		Token:     token,
+		ExpiresAt: expiresAt,
+	})
 }

--- a/pkg/hub/handlers_oidc.go
+++ b/pkg/hub/handlers_oidc.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// oidcDiscoveryDocument represents the OpenID Connect Provider Metadata
+// returned by the /.well-known/openid-configuration endpoint.
+type oidcDiscoveryDocument struct {
+	Issuer                            string   `json:"issuer"`
+	JWKSURI                           string   `json:"jwks_uri"`
+	ResponseTypesSupported            []string `json:"response_types_supported"`
+	SubjectTypesSupported             []string `json:"subject_types_supported"`
+	IDTokenSigningAlgValuesSupported  []string `json:"id_token_signing_alg_values_supported"`
+	ClaimsSupported                   []string `json:"claims_supported"`
+	ScopesSupported                   []string `json:"scopes_supported"`
+}
+
+// handleOIDCDiscovery serves the OIDC Provider Metadata at
+// GET /.well-known/openid-configuration.
+func (s *Server) handleOIDCDiscovery(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	issuer := s.oidcIssuerURL
+
+	doc := oidcDiscoveryDocument{
+		Issuer:                           issuer,
+		JWKSURI:                          issuer + "/.well-known/jwks.json",
+		ResponseTypesSupported:           []string{"id_token"},
+		SubjectTypesSupported:            []string{"public"},
+		IDTokenSigningAlgValuesSupported: []string{"RS256"},
+		ClaimsSupported: []string{
+			"iss", "sub", "aud", "iat", "exp", "nbf", "jti",
+			"project_id", "agent_name", "ancestry", "root_user",
+		},
+		ScopesSupported: []string{"openid"},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	if err := json.NewEncoder(w).Encode(doc); err != nil {
+		http.Error(w, "failed to encode discovery document", http.StatusInternalServerError)
+	}
+}
+
+// handleJWKS serves the JSON Web Key Set at GET /.well-known/jwks.json.
+func (s *Server) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	jwks := s.oidcKeyManager.JWKS()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	if err := json.NewEncoder(w).Encode(jwks); err != nil {
+		http.Error(w, "failed to encode JWKS", http.StatusInternalServerError)
+	}
+}

--- a/pkg/hub/handlers_oidc_test.go
+++ b/pkg/hub/handlers_oidc_test.go
@@ -17,6 +17,7 @@
 package hub
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -25,8 +26,13 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,9 +58,17 @@ func testOIDCServer(t *testing.T) *Server {
 		Active:     true,
 	}
 
+	// Create the RS256 signer (needed by identity token endpoint).
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: privKey},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", kid),
+	)
+	require.NoError(t, err)
+
 	mgr := &OIDCKeyManager{
 		activeKey: signingKey,
 		allKeys:   []*OIDCSigningKey{signingKey},
+		signer:    signer,
 		issuerURL: testOIDCIssuerURL,
 	}
 
@@ -301,4 +315,312 @@ func TestOIDCEndpoints_DisabledWhenKeyManagerNil(t *testing.T) {
 				"%s should not return 200 when OIDC is disabled", tc.path)
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Identity Token Endpoint Tests
+// ---------------------------------------------------------------------------
+
+// testOIDCIdentityServer creates a Server with OIDC fully configured for
+// identity token tests: key manager, rate limiter, token lifetime, and a
+// test agent + project in the store.
+func testOIDCIdentityServer(t *testing.T) (*Server, store.Store, *AgentTokenClaims) {
+	t.Helper()
+	srv := testOIDCServer(t)
+
+	// Set up token lifetime and rate limiter.
+	srv.oidcTokenLifetime = 15 * time.Minute
+	srv.oidcTokenRateLimiter = NewGCPTokenRateLimiter(0.5, 30)
+
+	// Get the underlying store.
+	s := srv.store
+
+	// Create a project via the HTTP handler to get proper OwnerID etc.
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects", map[string]string{
+		"name": "test-oidc-project",
+	})
+	require.Equal(t, http.StatusCreated, rec.Code, "create project: %s", rec.Body.String())
+	var project store.Project
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&project))
+
+	// Create an agent in the store.
+	agentID := uuid.New().String()
+	agent := &store.Agent{
+		ID:        agentID,
+		Slug:      "test-agent",
+		Name:      "Test Agent",
+		ProjectID: project.ID,
+	}
+	err := s.CreateAgent(context.Background(), agent)
+	require.NoError(t, err)
+
+	// Build agent token claims with identity token scope.
+	rootUserID := uuid.New().String()
+	parentAgentID := uuid.New().String()
+	claims := &AgentTokenClaims{
+		Claims: jwt.Claims{
+			Subject: agentID,
+		},
+		ProjectID: project.ID,
+		Scopes:    []AgentTokenScope{ScopeAgentStatusUpdate, ScopeIdentityToken},
+		Ancestry:  []string{rootUserID, parentAgentID},
+	}
+
+	return srv, s, claims
+}
+
+// doIdentityTokenRequest is a helper that makes a request to the identity token endpoint.
+func doIdentityTokenRequest(t *testing.T, srv *Server, claims *AgentTokenClaims, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = json.Marshal(body)
+		require.NoError(t, err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agent/identity-token", bytes.NewReader(bodyBytes))
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	// Inject agent claims into the context.
+	if claims != nil {
+		ctx := context.WithValue(req.Context(), agentContextKey{}, claims)
+		req = req.WithContext(ctx)
+	}
+
+	w := httptest.NewRecorder()
+	srv.handleAgentIdentityToken(w, req)
+	return w
+}
+
+func TestHandleAgentIdentityToken(t *testing.T) {
+	tests := []struct {
+		name           string
+		claims         func(base *AgentTokenClaims) *AgentTokenClaims
+		body           interface{}
+		wantStatus     int
+		wantErrCode    string
+		checkToken     bool
+		checkAudience  string
+	}{
+		{
+			name: "valid request returns RS256-signed JWT with correct claims",
+			claims: func(base *AgentTokenClaims) *AgentTokenClaims {
+				return base
+			},
+			body:          identityTokenRequest{Audience: "https://api.example.com"},
+			wantStatus:    http.StatusOK,
+			checkToken:    true,
+			checkAudience: "https://api.example.com",
+		},
+		{
+			name: "missing scope returns 403",
+			claims: func(base *AgentTokenClaims) *AgentTokenClaims {
+				c := *base
+				c.Scopes = []AgentTokenScope{ScopeAgentStatusUpdate} // no ScopeIdentityToken
+				return &c
+			},
+			body:        identityTokenRequest{Audience: "https://api.example.com"},
+			wantStatus:  http.StatusForbidden,
+			wantErrCode: ErrCodeForbidden,
+		},
+		{
+			name: "missing audience returns 400",
+			claims: func(base *AgentTokenClaims) *AgentTokenClaims {
+				return base
+			},
+			body:        identityTokenRequest{Audience: ""},
+			wantStatus:  http.StatusBadRequest,
+			wantErrCode: ErrCodeInvalidRequest,
+		},
+		{
+			name: "empty body returns 400",
+			claims: func(base *AgentTokenClaims) *AgentTokenClaims {
+				return base
+			},
+			body:        map[string]string{},
+			wantStatus:  http.StatusBadRequest,
+			wantErrCode: ErrCodeInvalidRequest,
+		},
+		{
+			name:        "no agent context returns 401",
+			claims:      func(_ *AgentTokenClaims) *AgentTokenClaims { return nil },
+			body:        identityTokenRequest{Audience: "https://api.example.com"},
+			wantStatus:  http.StatusUnauthorized,
+			wantErrCode: ErrCodeUnauthorized,
+		},
+		{
+			name: "agent not found in store returns 404",
+			claims: func(base *AgentTokenClaims) *AgentTokenClaims {
+				c := *base
+				c.Subject = "nonexistent-agent-uuid"
+				return &c
+			},
+			body:       identityTokenRequest{Audience: "https://api.example.com"},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, _, baseClaims := testOIDCIdentityServer(t)
+
+			claims := tc.claims(baseClaims)
+			w := doIdentityTokenRequest(t, srv, claims, tc.body)
+
+			assert.Equal(t, tc.wantStatus, w.Code, "body: %s", w.Body.String())
+
+			if tc.wantErrCode != "" {
+				var errResp ErrorResponse
+				err := json.Unmarshal(w.Body.Bytes(), &errResp)
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantErrCode, errResp.Error.Code)
+			}
+
+			if tc.checkToken {
+				var resp identityTokenResponse
+				err := json.Unmarshal(w.Body.Bytes(), &resp)
+				require.NoError(t, err, "response should be valid JSON")
+				assert.NotEmpty(t, resp.Token, "token should not be empty")
+				assert.False(t, resp.ExpiresAt.IsZero(), "expires_at should be set")
+
+				// Parse the token and verify claims.
+				parsedToken, err := jwt.ParseSigned(resp.Token, []jose.SignatureAlgorithm{jose.RS256})
+				require.NoError(t, err, "token should be parseable as a signed JWT")
+
+				// Verify using the public key from the key manager.
+				jwks := srv.oidcKeyManager.JWKS()
+				require.NotEmpty(t, jwks.Keys, "JWKS should contain at least one key")
+
+				var tokenClaims OIDCIdentityTokenClaims
+				err = parsedToken.Claims(jwks.Keys[0].Key, &tokenClaims)
+				require.NoError(t, err, "token should be verifiable with JWKS public key")
+
+				// Verify iss
+				assert.Equal(t, testOIDCIssuerURL, tokenClaims.Issuer, "iss should match issuer URL")
+
+				// Verify aud
+				assert.Equal(t, jwt.Audience{tc.checkAudience}, tokenClaims.Audience, "aud should match requested audience")
+
+				// Verify sub
+				assert.Equal(t, claims.Subject, tokenClaims.Subject, "sub should be the agent UUID")
+
+				// Verify custom claims
+				assert.Equal(t, claims.ProjectID, tokenClaims.ProjectID, "project_id should match")
+				assert.Equal(t, "test-agent", tokenClaims.AgentName, "agent_name should be the agent slug")
+				assert.Equal(t, claims.Ancestry, tokenClaims.Ancestry, "ancestry should match")
+				assert.Equal(t, claims.Ancestry[0], tokenClaims.RootUser, "root_user should be ancestry[0]")
+
+				// Verify exp = now + token_lifetime (within 5 second tolerance)
+				expectedExpiry := time.Now().Add(15 * time.Minute)
+				tokenExpiry := tokenClaims.Expiry.Time()
+				assert.WithinDuration(t, expectedExpiry, tokenExpiry, 5*time.Second,
+					"exp should be approximately now + 15m")
+
+				// Verify jti is non-empty
+				assert.NotEmpty(t, tokenClaims.ID, "jti should be set")
+
+				// Verify kid header matches JWKS active key
+				headers := parsedToken.Headers
+				require.NotEmpty(t, headers)
+				assert.Equal(t, jwks.Keys[0].KeyID, headers[0].KeyID,
+					"kid header should match JWKS active key")
+			}
+		})
+	}
+}
+
+func TestHandleAgentIdentityToken_TokenVerifiableWithJWKS(t *testing.T) {
+	srv, _, claims := testOIDCIdentityServer(t)
+
+	w := doIdentityTokenRequest(t, srv, claims, identityTokenRequest{
+		Audience: "https://verify.example.com",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp identityTokenResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Get JWKS and verify the token is valid.
+	jwks := srv.oidcKeyManager.JWKS()
+	require.NotEmpty(t, jwks.Keys)
+
+	parsedToken, err := jwt.ParseSigned(resp.Token, []jose.SignatureAlgorithm{jose.RS256})
+	require.NoError(t, err)
+
+	var tokenClaims OIDCIdentityTokenClaims
+	err = parsedToken.Claims(jwks.Keys[0].Key, &tokenClaims)
+	require.NoError(t, err, "token MUST be verifiable with the JWKS public key")
+
+	// Validate standard claims.
+	expected := jwt.Expected{
+		Issuer:      testOIDCIssuerURL,
+		AnyAudience: jwt.Audience{"https://verify.example.com"},
+		Time:        time.Now(),
+	}
+	err = tokenClaims.Validate(expected)
+	assert.NoError(t, err, "standard claims should validate successfully")
+}
+
+func TestHandleAgentIdentityToken_EmptyAncestry(t *testing.T) {
+	srv, _, baseClaims := testOIDCIdentityServer(t)
+
+	// Test with empty ancestry — root_user should be empty.
+	claims := *baseClaims
+	claims.Ancestry = nil
+
+	w := doIdentityTokenRequest(t, srv, &claims, identityTokenRequest{
+		Audience: "https://api.example.com",
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp identityTokenResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	jwks := srv.oidcKeyManager.JWKS()
+	parsedToken, err := jwt.ParseSigned(resp.Token, []jose.SignatureAlgorithm{jose.RS256})
+	require.NoError(t, err)
+
+	var tokenClaims OIDCIdentityTokenClaims
+	err = parsedToken.Claims(jwks.Keys[0].Key, &tokenClaims)
+	require.NoError(t, err)
+
+	assert.Empty(t, tokenClaims.RootUser, "root_user should be empty when ancestry is nil")
+}
+
+func TestHandleAgentIdentityToken_RateLimiting(t *testing.T) {
+	srv, _, claims := testOIDCIdentityServer(t)
+
+	// Configure a tight rate limiter: burst of 2 only.
+	srv.oidcTokenRateLimiter = NewGCPTokenRateLimiter(0.01, 2) // very low rate, burst 2
+
+	body := identityTokenRequest{Audience: "https://api.example.com"}
+
+	// First 2 requests should succeed (burst).
+	for i := 0; i < 2; i++ {
+		w := doIdentityTokenRequest(t, srv, claims, body)
+		assert.Equal(t, http.StatusOK, w.Code, "request %d should succeed within burst", i+1)
+	}
+
+	// 3rd request should be rate limited.
+	w := doIdentityTokenRequest(t, srv, claims, body)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code, "request exceeding burst should be rate limited")
+}
+
+func TestHandleAgentIdentityToken_ForbiddenMessage(t *testing.T) {
+	srv, _, baseClaims := testOIDCIdentityServer(t)
+
+	claims := *baseClaims
+	claims.Scopes = []AgentTokenScope{ScopeAgentStatusUpdate} // no identity token scope
+
+	w := doIdentityTokenRequest(t, srv, &claims, identityTokenRequest{
+		Audience: "https://api.example.com",
+	})
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	var errResp ErrorResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &errResp))
+	assert.Contains(t, errResp.Error.Message, "agent not authorized to request identity tokens")
 }

--- a/pkg/hub/handlers_oidc_test.go
+++ b/pkg/hub/handlers_oidc_test.go
@@ -1,0 +1,304 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testOIDCIssuerURL = "https://scion.example.com"
+
+// testOIDCServer creates a Server with an OIDCKeyManager configured for testing.
+// The key manager is set after server creation, so routes are NOT registered
+// via the mux. Use this for direct handler tests.
+func testOIDCServer(t *testing.T) *Server {
+	t.Helper()
+	srv, _ := testServer(t)
+
+	// Generate a test RSA key pair.
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	kid := computeKeyID(&privKey.PublicKey)
+	signingKey := &OIDCSigningKey{
+		KeyID:      kid,
+		PrivateKey: privKey,
+		PublicKey:  &privKey.PublicKey,
+		Active:     true,
+	}
+
+	mgr := &OIDCKeyManager{
+		activeKey: signingKey,
+		allKeys:   []*OIDCSigningKey{signingKey},
+		issuerURL: testOIDCIssuerURL,
+	}
+
+	srv.oidcKeyManager = mgr
+	srv.oidcIssuerURL = testOIDCIssuerURL
+	return srv
+}
+
+// testOIDCServerWithRoutes creates a Server with OIDC enabled via config so
+// that routes are registered during New(). Use for mux-routing tests.
+func testOIDCServerWithRoutes(t *testing.T) *Server {
+	t.Helper()
+	s, err := newTestStore(":memory:")
+	if err != nil {
+		if strings.Contains(err.Error(), "sqlite driver not registered") {
+			t.Skip("Skipping test because sqlite driver is not registered (build with -tags sqlite to enable)")
+		}
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("failed to migrate test store: %v", err)
+	}
+
+	cfg := DefaultServerConfig()
+	cfg.DevAuthToken = testDevToken
+	cfg.OIDCConfig = config.OIDCProviderConfig{
+		Enabled:   true,
+		IssuerURL: testOIDCIssuerURL,
+	}
+
+	srv, err := New(cfg, s)
+	if err != nil {
+		t.Fatalf("New() with OIDC failed: %v", err)
+	}
+	srv.SetHubID("test-hub-id")
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+	return srv
+}
+
+func TestHandleOIDCDiscovery(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		oidcEnabled    bool
+		wantStatus     int
+		checkBody      bool
+		checkCacheCtrl string
+	}{
+		{
+			name:           "GET returns valid discovery document",
+			method:         http.MethodGet,
+			oidcEnabled:    true,
+			wantStatus:     http.StatusOK,
+			checkBody:      true,
+			checkCacheCtrl: "public, max-age=3600",
+		},
+		{
+			name:        "POST returns 405",
+			method:      http.MethodPost,
+			oidcEnabled: true,
+			wantStatus:  http.StatusMethodNotAllowed,
+		},
+		{
+			name:        "PUT returns 405",
+			method:      http.MethodPut,
+			oidcEnabled: true,
+			wantStatus:  http.StatusMethodNotAllowed,
+		},
+		{
+			name:        "DELETE returns 405",
+			method:      http.MethodDelete,
+			oidcEnabled: true,
+			wantStatus:  http.StatusMethodNotAllowed,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := testOIDCServer(t)
+
+			req := httptest.NewRequest(tc.method, "/.well-known/openid-configuration", nil)
+			w := httptest.NewRecorder()
+
+			srv.handleOIDCDiscovery(w, req)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+
+			if tc.checkBody {
+				assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+				assert.Equal(t, tc.checkCacheCtrl, w.Header().Get("Cache-Control"))
+
+				var doc oidcDiscoveryDocument
+				err := json.Unmarshal(w.Body.Bytes(), &doc)
+				require.NoError(t, err, "response should be valid JSON")
+
+				assert.Equal(t, testOIDCIssuerURL, doc.Issuer)
+				assert.Equal(t, testOIDCIssuerURL+"/.well-known/jwks.json", doc.JWKSURI)
+				assert.Equal(t, []string{"id_token"}, doc.ResponseTypesSupported)
+				assert.Equal(t, []string{"public"}, doc.SubjectTypesSupported)
+				assert.Equal(t, []string{"RS256"}, doc.IDTokenSigningAlgValuesSupported)
+				assert.Equal(t, []string{"openid"}, doc.ScopesSupported)
+
+				// Verify all required claims are present.
+				expectedClaims := []string{
+					"iss", "sub", "aud", "iat", "exp", "nbf", "jti",
+					"project_id", "agent_name", "ancestry", "root_user",
+				}
+				assert.Equal(t, expectedClaims, doc.ClaimsSupported)
+			}
+		})
+	}
+}
+
+func TestHandleJWKS(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		wantStatus     int
+		checkBody      bool
+		checkCacheCtrl string
+	}{
+		{
+			name:           "GET returns valid JWKS",
+			method:         http.MethodGet,
+			wantStatus:     http.StatusOK,
+			checkBody:      true,
+			checkCacheCtrl: "public, max-age=300",
+		},
+		{
+			name:       "POST returns 405",
+			method:     http.MethodPost,
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:       "PUT returns 405",
+			method:     http.MethodPut,
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:       "DELETE returns 405",
+			method:     http.MethodDelete,
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := testOIDCServer(t)
+
+			req := httptest.NewRequest(tc.method, "/.well-known/jwks.json", nil)
+			w := httptest.NewRecorder()
+
+			srv.handleJWKS(w, req)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+
+			if tc.checkBody {
+				assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+				assert.Equal(t, tc.checkCacheCtrl, w.Header().Get("Cache-Control"))
+
+				// Parse the JWKS response.
+				var jwks struct {
+					Keys []map[string]interface{} `json:"keys"`
+				}
+				err := json.Unmarshal(w.Body.Bytes(), &jwks)
+				require.NoError(t, err, "response should be valid JSON")
+
+				require.NotEmpty(t, jwks.Keys, "JWKS should contain at least one key")
+
+				key := jwks.Keys[0]
+
+				// Verify required JWK fields are present.
+				assert.Equal(t, "RSA", key["kty"], "key type should be RSA")
+				assert.NotEmpty(t, key["kid"], "kid should be present")
+				assert.Equal(t, "sig", key["use"], "use should be sig")
+				assert.Equal(t, "RS256", key["alg"], "alg should be RS256")
+				assert.NotEmpty(t, key["n"], "RSA modulus (n) should be present")
+				assert.NotEmpty(t, key["e"], "RSA exponent (e) should be present")
+
+				// Verify no private key material is exposed.
+				privateFields := []string{"d", "p", "q", "dp", "dq", "qi"}
+				for _, f := range privateFields {
+					assert.Nil(t, key[f], "private key field %q must not be present in JWKS", f)
+				}
+			}
+		})
+	}
+}
+
+func TestOIDCEndpoints_Unauthenticated(t *testing.T) {
+	srv := testOIDCServerWithRoutes(t)
+
+	// These requests do NOT include any auth headers.
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "discovery endpoint", path: "/.well-known/openid-configuration"},
+		{name: "JWKS endpoint", path: "/.well-known/jwks.json"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Verify isUnauthenticatedEndpoint returns true.
+			assert.True(t, isUnauthenticatedEndpoint(tc.path),
+				"%s should be unauthenticated", tc.path)
+
+			// Also verify the handler responds to unauthenticated requests.
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			w := httptest.NewRecorder()
+
+			// Route through the server mux to exercise registration.
+			srv.mux.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code,
+				"%s should return 200 without auth", tc.path)
+		})
+	}
+}
+
+func TestOIDCEndpoints_DisabledWhenKeyManagerNil(t *testing.T) {
+	// Create a server WITHOUT an OIDCKeyManager — routes should not be registered.
+	srv, _ := testServer(t)
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "discovery endpoint disabled", path: "/.well-known/openid-configuration"},
+		{name: "JWKS endpoint disabled", path: "/.well-known/jwks.json"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			w := httptest.NewRecorder()
+
+			srv.mux.ServeHTTP(w, req)
+
+			// When OIDC is disabled, these paths are not registered and the mux
+			// returns 404 (or the catch-all handler's status).
+			assert.NotEqual(t, http.StatusOK, w.Code,
+				"%s should not return 200 when OIDC is disabled", tc.path)
+		})
+	}
+}

--- a/pkg/hub/handlers_oidc_test.go
+++ b/pkg/hub/handlers_oidc_test.go
@@ -397,13 +397,13 @@ func doIdentityTokenRequest(t *testing.T, srv *Server, claims *AgentTokenClaims,
 
 func TestHandleAgentIdentityToken(t *testing.T) {
 	tests := []struct {
-		name           string
-		claims         func(base *AgentTokenClaims) *AgentTokenClaims
-		body           interface{}
-		wantStatus     int
-		wantErrCode    string
-		checkToken     bool
-		checkAudience  string
+		name          string
+		claims        func(base *AgentTokenClaims) *AgentTokenClaims
+		body          interface{}
+		wantStatus    int
+		wantErrCode   string
+		checkToken    bool
+		checkAudience string
 	}{
 		{
 			name: "valid request returns RS256-signed JWT with correct claims",

--- a/pkg/hub/oidckeys.go
+++ b/pkg/hub/oidckeys.go
@@ -55,11 +55,12 @@ const (
 
 // OIDCSigningKey holds an RSA key pair used for signing OIDC identity tokens.
 type OIDCSigningKey struct {
-	KeyID      string
-	PrivateKey *rsa.PrivateKey
-	PublicKey  *rsa.PublicKey
-	CreatedAt  time.Time
-	Active     bool
+	KeyID         string
+	PrivateKey    *rsa.PrivateKey
+	PublicKey     *rsa.PublicKey
+	CreatedAt     time.Time
+	DeactivatedAt time.Time // zero until rotated out
+	Active        bool
 }
 
 // OIDCKeyManager manages RSA key pairs for OIDC identity token signing.
@@ -135,6 +136,9 @@ func NewOIDCKeyManager(ctx context.Context, cfg OIDCKeyManagerConfig) (*OIDCKeyM
 	}
 
 	mgr.activeKey = signingKey
+	// Note: only the active key is loaded on startup. Previously rotated keys
+	// (serving JWKS overlap) are not restored. The overlap window does not
+	// survive hub restarts.
 	mgr.allKeys = []*OIDCSigningKey{signingKey}
 	mgr.signer = signer
 
@@ -200,36 +204,16 @@ func (m *OIDCKeyManager) RotateKey(ctx context.Context) error {
 		return fmt.Errorf("creating signer for rotated OIDC key: %w", err)
 	}
 
-	newKey := &OIDCSigningKey{
-		KeyID:      newKID,
-		PrivateKey: newPrivKey,
-		PublicKey:  &newPrivKey.PublicKey,
-		CreatedAt:  time.Now(),
-		Active:     true,
-	}
-
-	// 3. Swap keys under write lock.
-	m.mu.Lock()
-	oldKID := ""
-	if m.activeKey != nil {
-		oldKID = m.activeKey.KeyID
-		m.activeKey.Active = false
-	}
-	m.activeKey = newKey
-	m.allKeys = append([]*OIDCSigningKey{newKey}, m.allKeys...)
-	m.signer = newSigner
-	m.mu.Unlock()
-
-	// 4. Persist new key to backend/store (same pattern as initial key storage).
+	// 3. Persist new key to backend/store BEFORE in-memory swap.
 	pemData, err := encodePEMPrivateKey(newPrivKey)
 	if err != nil {
 		return fmt.Errorf("PEM-encoding rotated OIDC key: %w", err)
 	}
 	pemStr := string(pemData)
 
-	// Use a rotation-specific secret name to avoid overwriting the original key.
-	// The primary key name stays for the current active key that will be loaded on restart.
+	// Overwrite the stored key with the new active key so it is loaded on restart.
 	keyName := SecretKeyOIDCSigningKey
+	persisted := false
 	if m.backend != nil {
 		input := &secret.SetSecretInput{
 			Name:        keyName,
@@ -242,12 +226,44 @@ func (m *OIDCKeyManager) RotateKey(ctx context.Context) error {
 		if _, _, setErr := m.backend.Set(ctx, input); setErr != nil {
 			m.log.Warn("Failed to persist rotated OIDC key to secret backend",
 				"kid", newKID, "error", setErr)
+		} else {
+			persisted = true
 		}
 	}
-	if persistErr := m.backupKeyToStore(ctx, keyName, pemStr, m.hubID); persistErr != nil {
-		m.log.Warn("Failed to persist rotated OIDC key to store",
-			"kid", newKID, "error", persistErr)
+	if m.store != nil {
+		if persistErr := m.backupKeyToStore(ctx, keyName, pemStr, m.hubID); persistErr != nil {
+			m.log.Warn("Failed to persist rotated OIDC key to store",
+				"kid", newKID, "error", persistErr)
+		} else {
+			persisted = true
+		}
 	}
+
+	// If ALL persistence paths failed, do NOT swap in-memory — return an error.
+	if !persisted {
+		return fmt.Errorf("persisting rotated OIDC key: all persistence paths failed for kid %s", newKID)
+	}
+
+	// 4. Swap keys under write lock (only after successful persistence).
+	newKey := &OIDCSigningKey{
+		KeyID:      newKID,
+		PrivateKey: newPrivKey,
+		PublicKey:  &newPrivKey.PublicKey,
+		CreatedAt:  time.Now(),
+		Active:     true,
+	}
+
+	m.mu.Lock()
+	oldKID := ""
+	if m.activeKey != nil {
+		oldKID = m.activeKey.KeyID
+		m.activeKey.Active = false
+		m.activeKey.DeactivatedAt = time.Now()
+	}
+	m.activeKey = newKey
+	m.allKeys = append([]*OIDCSigningKey{newKey}, m.allKeys...)
+	m.signer = newSigner
+	m.mu.Unlock()
 
 	m.log.Info("OIDC signing key rotated",
 		"old_kid", oldKID,
@@ -271,14 +287,14 @@ func (m *OIDCKeyManager) CleanupExpiredKeys() {
 			kept = append(kept, k)
 			continue
 		}
-		age := now.Sub(k.CreatedAt)
+		age := now.Sub(k.DeactivatedAt)
 		if age < oidcKeyOverlapWindow {
 			kept = append(kept, k)
 			continue
 		}
 		m.log.Info("Removing expired OIDC key from JWKS",
 			"kid", k.KeyID,
-			"created_at", k.CreatedAt,
+			"deactivated_at", k.DeactivatedAt,
 			"age", age.Round(time.Second),
 		)
 	}

--- a/pkg/hub/oidckeys.go
+++ b/pkg/hub/oidckeys.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/secret"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/go-jose/go-jose/v4"
@@ -75,7 +74,6 @@ type OIDCKeyManagerConfig struct {
 	Backend                secret.SecretBackend
 	HubID                  string
 	IssuerURL              string
-	OIDCConfig             config.OIDCProviderConfig
 	RequireStableSigningKey bool
 	Log                    *slog.Logger
 }
@@ -148,7 +146,8 @@ func (m *OIDCKeyManager) Signer() jose.Signer {
 }
 
 // JWKS returns the public key set as a jose.JSONWebKeySet for the
-// /.well-known/jwks.json endpoint. Only active keys are included.
+// /.well-known/jwks.json endpoint. All keys (active and rotated) are
+// included to support key rotation overlap.
 // Thread-safe for concurrent reads.
 func (m *OIDCKeyManager) JWKS() jose.JSONWebKeySet {
 	m.mu.RLock()
@@ -226,10 +225,10 @@ func (m *OIDCKeyManager) loadOrCreateKey(ctx context.Context, cfg OIDCKeyManager
 	// 3. No existing key found — generate or fail
 	if cfg.RequireStableSigningKey {
 		return nil, fmt.Errorf("refusing to generate a new OIDC signing key: RequireStableSigningKey is set and no existing key was found; "+
-			"pre-provision the key via signing_key_secret config or the secret backend")
+			"pre-provision the key via the secret backend or store")
 	}
 
-	m.log.Info("No existing OIDC signing key found, generating new RSA-2048 key pair", "key", keyName)
+	m.log.Warn("Generated new OIDC signing key; all previously issued identity tokens are invalid", "key", keyName)
 	privKey, err := generateRSAKeyPair()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate OIDC RSA key pair: %w", err)

--- a/pkg/hub/oidckeys.go
+++ b/pkg/hub/oidckeys.go
@@ -228,11 +228,11 @@ func (m *OIDCKeyManager) loadOrCreateKey(ctx context.Context, cfg OIDCKeyManager
 			"pre-provision the key via the secret backend or store")
 	}
 
-	m.log.Warn("Generated new OIDC signing key; all previously issued identity tokens are invalid", "key", keyName)
 	privKey, err := generateRSAKeyPair()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate OIDC RSA key pair: %w", err)
 	}
+	m.log.Warn("Generated new OIDC signing key; all previously issued identity tokens are invalid", "key", keyName)
 
 	pemData, err := encodePEMPrivateKey(privKey)
 	if err != nil {

--- a/pkg/hub/oidckeys.go
+++ b/pkg/hub/oidckeys.go
@@ -42,6 +42,15 @@ const (
 
 	// oidcRSAKeyBits is the RSA key size for OIDC signing keys.
 	oidcRSAKeyBits = 2048
+
+	// oidcKeyOverlapWindow is the duration that rotated-out keys remain in the
+	// JWKS after rotation, allowing external systems to pick up the new key.
+	// 24 hours provides ample margin for all JWKS caching consumers.
+	oidcKeyOverlapWindow = 24 * time.Hour
+
+	// oidcCleanupInterval is how often the background cleanup loop checks for
+	// expired rotated keys.
+	oidcCleanupInterval = 1 * time.Hour
 )
 
 // OIDCSigningKey holds an RSA key pair used for signing OIDC identity tokens.
@@ -168,6 +177,130 @@ func (m *OIDCKeyManager) JWKS() jose.JSONWebKeySet {
 // IssuerURL returns the configured OIDC issuer URL.
 func (m *OIDCKeyManager) IssuerURL() string {
 	return m.issuerURL
+}
+
+// RotateKey generates a new RSA key pair, makes it the active signing key,
+// and retains the old key in the JWKS for the overlap window. The old key
+// will be removed by CleanupExpiredKeys after oidcKeyOverlapWindow (24h).
+func (m *OIDCKeyManager) RotateKey(ctx context.Context) error {
+	// 1. Generate new RSA-2048 key pair (outside the lock).
+	newPrivKey, err := generateRSAKeyPair()
+	if err != nil {
+		return fmt.Errorf("generating new OIDC signing key: %w", err)
+	}
+
+	newKID := computeKeyID(&newPrivKey.PublicKey)
+
+	// 2. Create new jose.Signer with the new key.
+	newSigner, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: newPrivKey},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", newKID),
+	)
+	if err != nil {
+		return fmt.Errorf("creating signer for rotated OIDC key: %w", err)
+	}
+
+	newKey := &OIDCSigningKey{
+		KeyID:      newKID,
+		PrivateKey: newPrivKey,
+		PublicKey:  &newPrivKey.PublicKey,
+		CreatedAt:  time.Now(),
+		Active:     true,
+	}
+
+	// 3. Swap keys under write lock.
+	m.mu.Lock()
+	oldKID := ""
+	if m.activeKey != nil {
+		oldKID = m.activeKey.KeyID
+		m.activeKey.Active = false
+	}
+	m.activeKey = newKey
+	m.allKeys = append([]*OIDCSigningKey{newKey}, m.allKeys...)
+	m.signer = newSigner
+	m.mu.Unlock()
+
+	// 4. Persist new key to backend/store (same pattern as initial key storage).
+	pemData, err := encodePEMPrivateKey(newPrivKey)
+	if err != nil {
+		return fmt.Errorf("PEM-encoding rotated OIDC key: %w", err)
+	}
+	pemStr := string(pemData)
+
+	// Use a rotation-specific secret name to avoid overwriting the original key.
+	// The primary key name stays for the current active key that will be loaded on restart.
+	keyName := SecretKeyOIDCSigningKey
+	if m.backend != nil {
+		input := &secret.SetSecretInput{
+			Name:        keyName,
+			Value:       pemStr,
+			SecretType:  store.SecretTypeInternal,
+			Scope:       store.ScopeHub,
+			ScopeID:     m.hubID,
+			Description: "OIDC identity token signing key (RSA-2048)",
+		}
+		if _, _, setErr := m.backend.Set(ctx, input); setErr != nil {
+			m.log.Warn("Failed to persist rotated OIDC key to secret backend",
+				"kid", newKID, "error", setErr)
+		}
+	}
+	if persistErr := m.backupKeyToStore(ctx, keyName, pemStr, m.hubID); persistErr != nil {
+		m.log.Warn("Failed to persist rotated OIDC key to store",
+			"kid", newKID, "error", persistErr)
+	}
+
+	m.log.Info("OIDC signing key rotated",
+		"old_kid", oldKID,
+		"new_kid", newKID,
+	)
+
+	return nil
+}
+
+// CleanupExpiredKeys removes inactive keys that have been rotated out
+// longer than the overlap window (24 hours). The active key is never
+// removed regardless of age.
+func (m *OIDCKeyManager) CleanupExpiredKeys() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	kept := make([]*OIDCSigningKey, 0, len(m.allKeys))
+	for _, k := range m.allKeys {
+		if k.Active {
+			kept = append(kept, k)
+			continue
+		}
+		age := now.Sub(k.CreatedAt)
+		if age < oidcKeyOverlapWindow {
+			kept = append(kept, k)
+			continue
+		}
+		m.log.Info("Removing expired OIDC key from JWKS",
+			"kid", k.KeyID,
+			"created_at", k.CreatedAt,
+			"age", age.Round(time.Second),
+		)
+	}
+	m.allKeys = kept
+}
+
+// StartCleanupLoop starts a background goroutine that periodically removes
+// expired rotated keys from the JWKS. Call this once after initialization.
+// The goroutine stops when ctx is canceled.
+func (m *OIDCKeyManager) StartCleanupLoop(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(oidcCleanupInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				m.CleanupExpiredKeys()
+			}
+		}
+	}()
 }
 
 // loadOrCreateKey attempts to load an existing OIDC signing key from the

--- a/pkg/hub/oidckeys.go
+++ b/pkg/hub/oidckeys.go
@@ -80,12 +80,12 @@ type OIDCKeyManager struct {
 
 // OIDCKeyManagerConfig holds the configuration needed to initialize an OIDCKeyManager.
 type OIDCKeyManagerConfig struct {
-	Store                  store.Store
-	Backend                secret.SecretBackend
-	HubID                  string
-	IssuerURL              string
+	Store                   store.Store
+	Backend                 secret.SecretBackend
+	HubID                   string
+	IssuerURL               string
 	RequireStableSigningKey bool
-	Log                    *slog.Logger
+	Log                     *slog.Logger
 }
 
 // NewOIDCKeyManager creates a new OIDCKeyManager, loading or generating
@@ -373,7 +373,7 @@ func (m *OIDCKeyManager) loadOrCreateKey(ctx context.Context, cfg OIDCKeyManager
 
 	// 3. No existing key found — generate or fail
 	if cfg.RequireStableSigningKey {
-		return nil, fmt.Errorf("refusing to generate a new OIDC signing key: RequireStableSigningKey is set and no existing key was found; "+
+		return nil, fmt.Errorf("refusing to generate a new OIDC signing key: RequireStableSigningKey is set and no existing key was found; " +
 			"pre-provision the key via the secret backend or store")
 	}
 

--- a/pkg/hub/oidckeys.go
+++ b/pkg/hub/oidckeys.go
@@ -1,0 +1,374 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/google/uuid"
+)
+
+const (
+	// SecretKeyOIDCSigningKey is the secret key name for the OIDC signing key.
+	SecretKeyOIDCSigningKey = "oidc_signing_key"
+
+	// oidcKIDPrefix is the prefix for OIDC key IDs.
+	oidcKIDPrefix = "scion-oidc-"
+
+	// oidcRSAKeyBits is the RSA key size for OIDC signing keys.
+	oidcRSAKeyBits = 2048
+)
+
+// OIDCSigningKey holds an RSA key pair used for signing OIDC identity tokens.
+type OIDCSigningKey struct {
+	KeyID      string
+	PrivateKey *rsa.PrivateKey
+	PublicKey  *rsa.PublicKey
+	CreatedAt  time.Time
+	Active     bool
+}
+
+// OIDCKeyManager manages RSA key pairs for OIDC identity token signing.
+// It loads or generates keys on initialization and provides thread-safe
+// access to the jose.Signer and JWKS for downstream consumers.
+type OIDCKeyManager struct {
+	mu        sync.RWMutex
+	activeKey *OIDCSigningKey
+	allKeys   []*OIDCSigningKey
+	signer    jose.Signer
+	store     store.Store
+	backend   secret.SecretBackend
+	hubID     string
+	issuerURL string
+	log       *slog.Logger
+}
+
+// OIDCKeyManagerConfig holds the configuration needed to initialize an OIDCKeyManager.
+type OIDCKeyManagerConfig struct {
+	Store                  store.Store
+	Backend                secret.SecretBackend
+	HubID                  string
+	IssuerURL              string
+	OIDCConfig             config.OIDCProviderConfig
+	RequireStableSigningKey bool
+	Log                    *slog.Logger
+}
+
+// NewOIDCKeyManager creates a new OIDCKeyManager, loading or generating
+// the RSA signing key pair. The initialization flow mirrors ensureSigningKey
+// in server.go but works with PEM-encoded RSA private keys instead of
+// base64-encoded symmetric keys.
+//
+// Resolution order:
+//  1. Secret backend (e.g. GCP Secret Manager)
+//  2. SQLite store fallback
+//  3. Generate new RSA-2048 key pair (or fail if RequireStableSigningKey)
+func NewOIDCKeyManager(ctx context.Context, cfg OIDCKeyManagerConfig) (*OIDCKeyManager, error) {
+	log := cfg.Log
+	if log == nil {
+		log = slog.Default()
+	}
+
+	mgr := &OIDCKeyManager{
+		store:     cfg.Store,
+		backend:   cfg.Backend,
+		hubID:     cfg.HubID,
+		issuerURL: cfg.IssuerURL,
+		log:       log,
+	}
+
+	privKey, err := mgr.loadOrCreateKey(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("OIDC key initialization: %w", err)
+	}
+
+	kid := computeKeyID(&privKey.PublicKey)
+
+	signingKey := &OIDCSigningKey{
+		KeyID:      kid,
+		PrivateKey: privKey,
+		PublicKey:  &privKey.PublicKey,
+		CreatedAt:  time.Now(),
+		Active:     true,
+	}
+
+	// Create the jose.Signer with RS256 and kid in the header.
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: privKey},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", kid),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OIDC RS256 signer: %w", err)
+	}
+
+	mgr.activeKey = signingKey
+	mgr.allKeys = []*OIDCSigningKey{signingKey}
+	mgr.signer = signer
+
+	log.Info("OIDC key manager initialized",
+		"kid", kid,
+		"issuer_url", cfg.IssuerURL,
+	)
+
+	return mgr, nil
+}
+
+// Signer returns the RS256 jose.Signer for signing identity tokens.
+// Thread-safe for concurrent reads.
+func (m *OIDCKeyManager) Signer() jose.Signer {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.signer
+}
+
+// JWKS returns the public key set as a jose.JSONWebKeySet for the
+// /.well-known/jwks.json endpoint. Only active keys are included.
+// Thread-safe for concurrent reads.
+func (m *OIDCKeyManager) JWKS() jose.JSONWebKeySet {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var keys []jose.JSONWebKey
+	for _, k := range m.allKeys {
+		keys = append(keys, jose.JSONWebKey{
+			Key:       k.PublicKey,
+			KeyID:     k.KeyID,
+			Algorithm: string(jose.RS256),
+			Use:       "sig",
+		})
+	}
+	return jose.JSONWebKeySet{Keys: keys}
+}
+
+// IssuerURL returns the configured OIDC issuer URL.
+func (m *OIDCKeyManager) IssuerURL() string {
+	return m.issuerURL
+}
+
+// loadOrCreateKey attempts to load an existing OIDC signing key from the
+// secret backend or store, falling back to generating a new key pair.
+func (m *OIDCKeyManager) loadOrCreateKey(ctx context.Context, cfg OIDCKeyManagerConfig) (*rsa.PrivateKey, error) {
+	keyName := SecretKeyOIDCSigningKey
+	hubID := cfg.HubID
+	hasBackend := cfg.Backend != nil
+
+	// 1. Try the secret backend (e.g. GCP Secret Manager)
+	if hasBackend {
+		sv, err := cfg.Backend.Get(ctx, keyName, store.ScopeHub, hubID)
+		if err == nil {
+			m.log.Info("Loading OIDC signing key from secret backend", "key", keyName)
+			privKey, parseErr := decodePEMPrivateKey([]byte(sv.Value))
+			if parseErr != nil {
+				return nil, fmt.Errorf("failed to decode OIDC signing key from secret backend: %w", parseErr)
+			}
+			// Backfill to SQLite as local backup
+			if persistErr := m.backupKeyToStore(ctx, keyName, sv.Value, hubID); persistErr != nil {
+				m.log.Warn("Failed to persist OIDC key backup to store after loading from backend",
+					"key", keyName, "error", persistErr)
+			}
+			return privKey, nil
+		}
+		if err != store.ErrNotFound {
+			m.log.Warn("Failed to load OIDC signing key from secret backend, trying store",
+				"key", keyName, "error", err)
+		}
+	}
+
+	// 2. Try the SQLite store
+	if cfg.Store != nil {
+		val, err := cfg.Store.GetSecretValue(ctx, keyName, store.ScopeHub, hubID)
+		if err == nil && val != "" {
+			m.log.Info("Loading OIDC signing key from store", "key", keyName)
+			privKey, parseErr := decodePEMPrivateKey([]byte(val))
+			if parseErr != nil {
+				return nil, fmt.Errorf("failed to decode OIDC signing key from store: %w", parseErr)
+			}
+			// Sync to secret backend for future loads
+			if hasBackend {
+				if syncErr := m.syncKeyToBackend(ctx, keyName, val, hubID); syncErr != nil {
+					m.log.Warn("Failed to sync OIDC signing key to secret backend",
+						"key", keyName, "error", syncErr)
+				}
+			}
+			return privKey, nil
+		}
+		if err != nil && err != store.ErrNotFound {
+			return nil, fmt.Errorf("failed to load OIDC signing key from store: %w", err)
+		}
+	}
+
+	// 3. No existing key found — generate or fail
+	if cfg.RequireStableSigningKey {
+		return nil, fmt.Errorf("refusing to generate a new OIDC signing key: RequireStableSigningKey is set and no existing key was found; "+
+			"pre-provision the key via signing_key_secret config or the secret backend")
+	}
+
+	m.log.Info("No existing OIDC signing key found, generating new RSA-2048 key pair", "key", keyName)
+	privKey, err := generateRSAKeyPair()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate OIDC RSA key pair: %w", err)
+	}
+
+	pemData, err := encodePEMPrivateKey(privKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to PEM-encode OIDC signing key: %w", err)
+	}
+	pemStr := string(pemData)
+
+	// Persist to secret backend first, then store as backup
+	if hasBackend {
+		input := &secret.SetSecretInput{
+			Name:        keyName,
+			Value:       pemStr,
+			SecretType:  store.SecretTypeInternal,
+			Scope:       store.ScopeHub,
+			ScopeID:     hubID,
+			Description: "OIDC identity token signing key (RSA-2048)",
+		}
+		if _, _, err := cfg.Backend.Set(ctx, input); err != nil {
+			_, isGCP := cfg.Backend.(*secret.GCPBackend)
+			if isGCP {
+				return nil, fmt.Errorf("failed to persist OIDC signing key to Secret Manager: %w", err)
+			}
+			m.log.Warn("Secret backend unavailable for OIDC signing key, falling back to store",
+				"key", keyName, "error", err)
+		} else {
+			m.log.Info("Persisted new OIDC signing key via secret backend", "key", keyName)
+		}
+	}
+
+	// Save to store as backup (or primary if no backend)
+	if persistErr := m.backupKeyToStore(ctx, keyName, pemStr, hubID); persistErr != nil {
+		m.log.Warn("Failed to persist OIDC signing key to store", "key", keyName, "error", persistErr)
+	} else {
+		m.log.Info("Persisted OIDC signing key to store", "key", keyName)
+	}
+
+	return privKey, nil
+}
+
+// backupKeyToStore saves the PEM-encoded key to SQLite as a local backup.
+func (m *OIDCKeyManager) backupKeyToStore(ctx context.Context, keyName, pemValue, hubID string) error {
+	if m.store == nil {
+		return nil
+	}
+	existing, err := m.store.GetSecret(ctx, keyName, store.ScopeHub, hubID)
+	if err == nil {
+		existing.EncryptedValue = pemValue
+		return m.store.UpdateSecret(ctx, existing)
+	}
+	if err != store.ErrNotFound {
+		return fmt.Errorf("checking existing OIDC key record: %w", err)
+	}
+	sec := &store.Secret{
+		ID:             oidcSigningKeySecretID(hubID),
+		Key:            keyName,
+		EncryptedValue: pemValue,
+		Scope:          store.ScopeHub,
+		ScopeID:        hubID,
+		SecretType:     store.SecretTypeInternal,
+		Description:    "OIDC identity token signing key (RSA-2048)",
+	}
+	_, err = m.store.UpsertSecret(ctx, sec)
+	return err
+}
+
+// syncKeyToBackend syncs a PEM-encoded key to the secret backend.
+func (m *OIDCKeyManager) syncKeyToBackend(ctx context.Context, keyName, pemValue, hubID string) error {
+	if m.backend == nil {
+		return nil
+	}
+	input := &secret.SetSecretInput{
+		Name:        keyName,
+		Value:       pemValue,
+		SecretType:  store.SecretTypeInternal,
+		Scope:       store.ScopeHub,
+		ScopeID:     hubID,
+		Description: "OIDC identity token signing key (RSA-2048)",
+	}
+	_, _, err := m.backend.Set(ctx, input)
+	return err
+}
+
+// oidcSigningKeySecretID returns a deterministic primary key for the OIDC
+// signing key record, scoped to the hub instance.
+func oidcSigningKeySecretID(hubID string) string {
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte("hub-oidc-signing-key:"+hubID)).String()
+}
+
+// generateRSAKeyPair generates a new RSA-2048 key pair.
+func generateRSAKeyPair() (*rsa.PrivateKey, error) {
+	return rsa.GenerateKey(rand.Reader, oidcRSAKeyBits)
+}
+
+// encodePEMPrivateKey encodes an RSA private key to PEM format using
+// PKCS#8 encoding (standard "PRIVATE KEY" block type).
+func encodePEMPrivateKey(key *rsa.PrivateKey) ([]byte, error) {
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal private key to PKCS#8: %w", err)
+	}
+	block := &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: der,
+	}
+	return pem.EncodeToMemory(block), nil
+}
+
+// decodePEMPrivateKey decodes a PEM-encoded private key, expecting PKCS#8 format.
+func decodePEMPrivateKey(data []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in key data")
+	}
+	if block.Type != "PRIVATE KEY" {
+		return nil, fmt.Errorf("unexpected PEM block type %q, expected PRIVATE KEY", block.Type)
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse PKCS#8 private key: %w", err)
+	}
+	rsaKey, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("parsed key is not RSA (got %T)", parsed)
+	}
+	return rsaKey, nil
+}
+
+// computeKeyID generates a deterministic key ID from an RSA public key.
+// Format: "scion-oidc-" + first 12 hex chars of SHA-256(DER-encoded public key).
+func computeKeyID(pub *rsa.PublicKey) string {
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		// This should never fail for a valid RSA public key.
+		panic(fmt.Sprintf("failed to marshal public key to DER: %v", err))
+	}
+	hash := sha256.Sum256(der)
+	return oidcKIDPrefix + hex.EncodeToString(hash[:6]) // 12 hex chars = 6 bytes
+}

--- a/pkg/hub/oidckeys_test.go
+++ b/pkg/hub/oidckeys_test.go
@@ -116,8 +116,8 @@ func TestGenerateRSAKeyPair(t *testing.T) {
 			assert.Equal(t, 2048, key.N.BitLen(), "RSA key should be 2048 bits")
 
 			// Verify public key is extractable
-			assert.NotNil(t, key.PublicKey.N)
-			assert.NotNil(t, key.PublicKey.E)
+			assert.NotNil(t, key.N)
+			assert.NotNil(t, key.E)
 
 			// Verify the key validates
 			err = key.Validate()
@@ -170,9 +170,9 @@ func TestPEMEncodingRoundTrip(t *testing.T) {
 					"Modulus should be preserved")
 			} else {
 				// Public key should match
-				assert.Equal(t, key.PublicKey.N.Bytes(), decoded.PublicKey.N.Bytes(),
+				assert.Equal(t, key.N.Bytes(), decoded.N.Bytes(),
 					"Public key modulus should be preserved")
-				assert.Equal(t, key.PublicKey.E, decoded.PublicKey.E,
+				assert.Equal(t, key.E, decoded.E,
 					"Public key exponent should be preserved")
 			}
 		})

--- a/pkg/hub/oidckeys_test.go
+++ b/pkg/hub/oidckeys_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"testing"
 	"time"
 
@@ -809,11 +810,11 @@ func TestOIDCKeyManager_CleanupExpiredKeys(t *testing.T) {
 		{
 			name: "removes old inactive keys",
 			setup: func() {
-				// Artificially age the inactive key past the overlap window.
+				// Artificially age the inactive key's deactivation time past the overlap window.
 				mgr.mu.Lock()
 				for _, k := range mgr.allKeys {
 					if !k.Active {
-						k.CreatedAt = time.Now().Add(-25 * time.Hour) // 25h ago
+						k.DeactivatedAt = time.Now().Add(-25 * time.Hour) // 25h ago
 					}
 				}
 				mgr.mu.Unlock()
@@ -950,7 +951,7 @@ func TestOIDCKeyManager_StartCleanupLoop(t *testing.T) {
 	mgr.mu.Lock()
 	for _, k := range mgr.allKeys {
 		if !k.Active {
-			k.CreatedAt = time.Now().Add(-25 * time.Hour)
+			k.DeactivatedAt = time.Now().Add(-25 * time.Hour)
 		}
 	}
 	mgr.mu.Unlock()
@@ -964,6 +965,77 @@ func TestOIDCKeyManager_StartCleanupLoop(t *testing.T) {
 	// without panicking.
 	mgr.StartCleanupLoop(ctx)
 	cancel()
+}
+
+func TestOIDCKeyManager_CleanupUsesDeactivationTime(t *testing.T) {
+	// Regression test for R1: CleanupExpiredKeys must use DeactivatedAt, not CreatedAt.
+	// A key created 48h ago but deactivated just now should NOT be cleaned up.
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+
+	mgr, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     "test-hub-deactivation-time",
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	// Artificially age the initial key's CreatedAt to 48 hours ago.
+	mgr.mu.Lock()
+	mgr.activeKey.CreatedAt = time.Now().Add(-48 * time.Hour)
+	mgr.mu.Unlock()
+
+	// Rotate — the old key is now inactive with DeactivatedAt = now.
+	err = mgr.RotateKey(ctx)
+	require.NoError(t, err)
+	require.Len(t, mgr.JWKS().Keys, 2, "Should have 2 keys after rotation")
+
+	// Run cleanup — old key should NOT be removed because DeactivatedAt is recent.
+	mgr.CleanupExpiredKeys()
+	jwks := mgr.JWKS()
+	assert.Len(t, jwks.Keys, 2,
+		"Old key created 48h ago but deactivated just now should still be in JWKS")
+}
+
+func TestOIDCKeyManager_RotateKey_PersistFailure(t *testing.T) {
+	// Regression test for R2: RotateKey should return an error and leave
+	// in-memory state unchanged when all persistence paths fail.
+	ctx := context.Background()
+	backend := newOIDCMockSecretBackend()
+
+	// Initialize with a backend (no store) so there is only one persistence path.
+	mgr, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Backend:   backend,
+		HubID:     "test-hub-persist-fail",
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	originalKID := mgr.JWKS().Keys[0].KeyID
+	originalSigner := mgr.Signer()
+
+	// Inject error on the backend — the only persistence path.
+	backend.setErr = fmt.Errorf("backend unavailable")
+
+	// Attempt rotation — should fail because all persistence paths fail.
+	err = mgr.RotateKey(ctx)
+	require.Error(t, err, "RotateKey should return an error when all persistence fails")
+	assert.Contains(t, err.Error(), "all persistence paths failed")
+
+	// Verify in-memory state is unchanged.
+	assert.Equal(t, originalKID, mgr.JWKS().Keys[0].KeyID,
+		"Active key should be unchanged after persist failure")
+	assert.Len(t, mgr.JWKS().Keys, 1,
+		"No new key should be added after persist failure")
+
+	currentSigner := mgr.Signer()
+	assert.Equal(t, originalSigner, currentSigner,
+		"Signer should be unchanged after persist failure")
+
+	// Verify the old key is still active.
+	mgr.mu.RLock()
+	assert.True(t, mgr.activeKey.Active, "Active key should still be marked active")
+	mgr.mu.RUnlock()
 }
 
 // createOIDCTestStore creates an in-memory SQLite store for OIDC tests.

--- a/pkg/hub/oidckeys_test.go
+++ b/pkg/hub/oidckeys_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/pem"
 	"testing"
 
-	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/secret"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/go-jose/go-jose/v4"
@@ -337,9 +336,6 @@ func TestOIDCKeyManager_JWKS(t *testing.T) {
 		Store:     s,
 		HubID:     "test-hub",
 		IssuerURL: "https://hub.example.com",
-		OIDCConfig: config.OIDCProviderConfig{
-			Enabled: true,
-		},
 	})
 	require.NoError(t, err)
 
@@ -423,9 +419,6 @@ func TestOIDCKeyManager_LoadFromStore(t *testing.T) {
 		Store:     s,
 		HubID:     hubID,
 		IssuerURL: "https://hub.example.com",
-		OIDCConfig: config.OIDCProviderConfig{
-			Enabled: true,
-		},
 	})
 	require.NoError(t, err)
 	kid1 := mgr1.JWKS().Keys[0].KeyID
@@ -435,9 +428,6 @@ func TestOIDCKeyManager_LoadFromStore(t *testing.T) {
 		Store:     s,
 		HubID:     hubID,
 		IssuerURL: "https://hub.example.com",
-		OIDCConfig: config.OIDCProviderConfig{
-			Enabled: true,
-		},
 	})
 	require.NoError(t, err)
 	kid2 := mgr2.JWKS().Keys[0].KeyID
@@ -470,9 +460,6 @@ func TestOIDCKeyManager_LoadFromBackend(t *testing.T) {
 		Backend:   backend,
 		HubID:     hubID,
 		IssuerURL: "https://hub.example.com",
-		OIDCConfig: config.OIDCProviderConfig{
-			Enabled: true,
-		},
 	})
 	require.NoError(t, err)
 	kid1 := mgr1.JWKS().Keys[0].KeyID
@@ -489,9 +476,6 @@ func TestOIDCKeyManager_LoadFromBackend(t *testing.T) {
 		Backend:   backend,
 		HubID:     hubID,
 		IssuerURL: "https://hub.example.com",
-		OIDCConfig: config.OIDCProviderConfig{
-			Enabled: true,
-		},
 	})
 	require.NoError(t, err)
 	kid2 := mgr2.JWKS().Keys[0].KeyID
@@ -525,9 +509,6 @@ func TestOIDCKeyManager_GenerateWhenNoKey(t *testing.T) {
 				Backend:   tc.backend,
 				HubID:     "test-hub-gen-" + tc.name,
 				IssuerURL: "https://hub.example.com",
-				OIDCConfig: config.OIDCProviderConfig{
-					Enabled: true,
-				},
 			})
 			require.NoError(t, err)
 			require.NotNil(t, mgr)
@@ -576,9 +557,6 @@ func TestOIDCKeyManager_RequireStableSigningKey(t *testing.T) {
 				HubID:                   "test-hub-require-stable-" + tc.name,
 				IssuerURL:               "https://hub.example.com",
 				RequireStableSigningKey: true,
-				OIDCConfig: config.OIDCProviderConfig{
-					Enabled: true,
-				},
 			})
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.wantErr)
@@ -596,9 +574,6 @@ func TestOIDCKeyManager_RequireStableSigningKey(t *testing.T) {
 			Backend:   be,
 			HubID:     hubID,
 			IssuerURL: "https://hub.example.com",
-			OIDCConfig: config.OIDCProviderConfig{
-				Enabled: true,
-			},
 		})
 		require.NoError(t, err)
 		kid1 := mgr1.JWKS().Keys[0].KeyID
@@ -610,9 +585,6 @@ func TestOIDCKeyManager_RequireStableSigningKey(t *testing.T) {
 			HubID:                   hubID,
 			IssuerURL:               "https://hub.example.com",
 			RequireStableSigningKey: true,
-			OIDCConfig: config.OIDCProviderConfig{
-				Enabled: true,
-			},
 		})
 		require.NoError(t, err)
 		kid2 := mgr2.JWKS().Keys[0].KeyID
@@ -638,9 +610,6 @@ func TestOIDCKeyManager_IssuerURL(t *testing.T) {
 				Store:     s,
 				HubID:     "test-hub-issuer-" + tc.name,
 				IssuerURL: tc.issuerURL,
-				OIDCConfig: config.OIDCProviderConfig{
-					Enabled: true,
-				},
 			})
 			require.NoError(t, err)
 			assert.Equal(t, tc.issuerURL, mgr.IssuerURL())

--- a/pkg/hub/oidckeys_test.go
+++ b/pkg/hub/oidckeys_test.go
@@ -1,0 +1,709 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock secret backend for OIDC tests ---
+
+// oidcMockSecretBackend implements secret.SecretBackend for tests.
+// It stores secrets in-memory and allows controlling Get/Set behavior.
+type oidcMockSecretBackend struct {
+	secrets map[string]*secret.SecretWithValue // keyed by "name/scope/scopeID"
+	setErr  error                              // if set, Set() returns this error
+	getErr  error                              // if set, Get() returns this error
+}
+
+func newOIDCMockSecretBackend() *oidcMockSecretBackend {
+	return &oidcMockSecretBackend{
+		secrets: make(map[string]*secret.SecretWithValue),
+	}
+}
+
+func (m *oidcMockSecretBackend) secretKey(name, scope, scopeID string) string {
+	return name + "/" + scope + "/" + scopeID
+}
+
+func (m *oidcMockSecretBackend) Get(_ context.Context, name, scope, scopeID string) (*secret.SecretWithValue, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	sv, ok := m.secrets[m.secretKey(name, scope, scopeID)]
+	if !ok {
+		return nil, store.ErrNotFound
+	}
+	return sv, nil
+}
+
+func (m *oidcMockSecretBackend) Set(_ context.Context, input *secret.SetSecretInput) (bool, *secret.SecretMeta, error) {
+	if m.setErr != nil {
+		return false, nil, m.setErr
+	}
+	key := m.secretKey(input.Name, input.Scope, input.ScopeID)
+	_, existed := m.secrets[key]
+	m.secrets[key] = &secret.SecretWithValue{
+		Value: input.Value,
+	}
+	return !existed, &secret.SecretMeta{}, nil
+}
+
+func (m *oidcMockSecretBackend) Delete(_ context.Context, name, scope, scopeID string) error {
+	delete(m.secrets, m.secretKey(name, scope, scopeID))
+	return nil
+}
+
+func (m *oidcMockSecretBackend) List(_ context.Context, _ secret.Filter) ([]secret.SecretMeta, error) {
+	return nil, nil
+}
+
+func (m *oidcMockSecretBackend) GetMeta(_ context.Context, _, _, _ string) (*secret.SecretMeta, error) {
+	return nil, nil
+}
+
+func (m *oidcMockSecretBackend) Resolve(_ context.Context, _, _, _ string, _ *secret.ResolveOpts) ([]secret.SecretWithValue, error) {
+	return nil, nil
+}
+
+func (m *oidcMockSecretBackend) HubID() string { return "test-hub" }
+
+// --- Tests ---
+
+func TestGenerateRSAKeyPair(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "generates valid RSA-2048 key"},
+		{name: "generates different key each call"},
+	}
+
+	var firstKey *rsa.PrivateKey
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			key, err := generateRSAKeyPair()
+			require.NoError(t, err)
+			require.NotNil(t, key)
+
+			// Verify key size is 2048 bits
+			assert.Equal(t, 2048, key.N.BitLen(), "RSA key should be 2048 bits")
+
+			// Verify public key is extractable
+			assert.NotNil(t, key.PublicKey.N)
+			assert.NotNil(t, key.PublicKey.E)
+
+			// Verify the key validates
+			err = key.Validate()
+			assert.NoError(t, err, "Generated RSA key should be valid")
+
+			if i == 0 {
+				firstKey = key
+			} else {
+				// Keys should be unique
+				assert.NotEqual(t, firstKey.D.Bytes(), key.D.Bytes(),
+					"Each call should generate a unique key")
+			}
+		})
+	}
+}
+
+func TestPEMEncodingRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "round-trip preserves private key"},
+		{name: "round-trip preserves public key"},
+	}
+
+	key, err := generateRSAKeyPair()
+	require.NoError(t, err)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Encode to PEM
+			pemData, err := encodePEMPrivateKey(key)
+			require.NoError(t, err)
+			require.NotEmpty(t, pemData)
+
+			// Verify PEM block type
+			block, _ := pem.Decode(pemData)
+			require.NotNil(t, block, "PEM decode should produce a block")
+			assert.Equal(t, "PRIVATE KEY", block.Type, "PEM block type should be PRIVATE KEY")
+
+			// Decode from PEM
+			decoded, err := decodePEMPrivateKey(pemData)
+			require.NoError(t, err)
+			require.NotNil(t, decoded)
+
+			if tc.name == "round-trip preserves private key" {
+				// Private key should match
+				assert.Equal(t, key.D.Bytes(), decoded.D.Bytes(),
+					"Private key exponent should be preserved")
+				assert.Equal(t, key.N.Bytes(), decoded.N.Bytes(),
+					"Modulus should be preserved")
+			} else {
+				// Public key should match
+				assert.Equal(t, key.PublicKey.N.Bytes(), decoded.PublicKey.N.Bytes(),
+					"Public key modulus should be preserved")
+				assert.Equal(t, key.PublicKey.E, decoded.PublicKey.E,
+					"Public key exponent should be preserved")
+			}
+		})
+	}
+}
+
+func TestDecodePEMPrivateKey_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		wantErr string
+	}{
+		{
+			name:    "no PEM block",
+			input:   []byte("not a PEM block"),
+			wantErr: "no PEM block found",
+		},
+		{
+			name: "wrong PEM block type",
+			input: pem.EncodeToMemory(&pem.Block{
+				Type:  "RSA PRIVATE KEY",
+				Bytes: []byte("dummy"),
+			}),
+			wantErr: "unexpected PEM block type",
+		},
+		{
+			name: "invalid DER data",
+			input: pem.EncodeToMemory(&pem.Block{
+				Type:  "PRIVATE KEY",
+				Bytes: []byte("invalid-der"),
+			}),
+			wantErr: "failed to parse PKCS#8 private key",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := decodePEMPrivateKey(tc.input)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestComputeKeyID(t *testing.T) {
+	key1, err := generateRSAKeyPair()
+	require.NoError(t, err)
+	key2, err := generateRSAKeyPair()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		pub        *rsa.PublicKey
+		wantPrefix string
+	}{
+		{
+			name:       "deterministic for same key",
+			pub:        &key1.PublicKey,
+			wantPrefix: oidcKIDPrefix,
+		},
+		{
+			name:       "unique across different keys",
+			pub:        &key2.PublicKey,
+			wantPrefix: oidcKIDPrefix,
+		},
+	}
+
+	var firstKID string
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			kid := computeKeyID(tc.pub)
+
+			// Should start with prefix
+			assert.Contains(t, kid, tc.wantPrefix, "kid should start with scion-oidc- prefix")
+
+			// Should be deterministic: calling again produces the same result
+			kid2 := computeKeyID(tc.pub)
+			assert.Equal(t, kid, kid2, "kid should be deterministic for the same key")
+
+			// Should have correct length: prefix (11) + 12 hex chars = 23
+			assert.Len(t, kid, len(oidcKIDPrefix)+12,
+				"kid should be prefix + 12 hex chars")
+
+			if i == 0 {
+				firstKID = kid
+			} else {
+				// Different keys should produce different KIDs
+				assert.NotEqual(t, firstKID, kid,
+					"Different keys should produce different KIDs")
+			}
+		})
+	}
+}
+
+func TestJoseSignerProducesValidRS256(t *testing.T) {
+	key, err := generateRSAKeyPair()
+	require.NoError(t, err)
+
+	kid := computeKeyID(&key.PublicKey)
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: key},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", kid),
+	)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name   string
+		claims map[string]interface{}
+	}{
+		{
+			name: "signs basic claims",
+			claims: map[string]interface{}{
+				"sub": "agent-123",
+				"iss": "https://hub.example.com",
+				"aud": "https://vault.example.com",
+			},
+		},
+		{
+			name: "signs claims with nested fields",
+			claims: map[string]interface{}{
+				"sub":        "agent-456",
+				"iss":        "https://hub.example.com",
+				"project_id": "proj-789",
+				"scopes":     []string{"identity"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Sign claims
+			token, err := jwt.Signed(signer).Claims(tc.claims).Serialize()
+			require.NoError(t, err)
+			assert.NotEmpty(t, token)
+
+			// Parse and verify with the public key
+			parsed, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256})
+			require.NoError(t, err)
+
+			var result map[string]interface{}
+			err = parsed.Claims(&key.PublicKey, &result)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.claims["sub"], result["sub"])
+			assert.Equal(t, tc.claims["iss"], result["iss"])
+
+			// Verify that verifying with a different key fails
+			wrongKey, err := generateRSAKeyPair()
+			require.NoError(t, err)
+			var wrongResult map[string]interface{}
+			err = parsed.Claims(&wrongKey.PublicKey, &wrongResult)
+			assert.Error(t, err, "Verification with wrong key should fail")
+		})
+	}
+}
+
+func TestOIDCKeyManager_JWKS(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+
+	mgr, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     "test-hub",
+		IssuerURL: "https://hub.example.com",
+		OIDCConfig: config.OIDCProviderConfig{
+			Enabled: true,
+		},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		check func(t *testing.T, jwks jose.JSONWebKeySet)
+	}{
+		{
+			name: "returns non-empty key set",
+			check: func(t *testing.T, jwks jose.JSONWebKeySet) {
+				assert.NotEmpty(t, jwks.Keys, "JWKS should contain at least one key")
+			},
+		},
+		{
+			name: "key has correct algorithm and use",
+			check: func(t *testing.T, jwks jose.JSONWebKeySet) {
+				require.Len(t, jwks.Keys, 1)
+				key := jwks.Keys[0]
+				assert.Equal(t, string(jose.RS256), key.Algorithm)
+				assert.Equal(t, "sig", key.Use)
+			},
+		},
+		{
+			name: "key has correct kid",
+			check: func(t *testing.T, jwks jose.JSONWebKeySet) {
+				require.Len(t, jwks.Keys, 1)
+				key := jwks.Keys[0]
+				assert.Contains(t, key.KeyID, oidcKIDPrefix)
+				assert.Len(t, key.KeyID, len(oidcKIDPrefix)+12)
+			},
+		},
+		{
+			name: "key is an RSA public key",
+			check: func(t *testing.T, jwks jose.JSONWebKeySet) {
+				require.Len(t, jwks.Keys, 1)
+				key := jwks.Keys[0]
+				_, ok := key.Key.(*rsa.PublicKey)
+				assert.True(t, ok, "JWKS key should be an RSA public key")
+			},
+		},
+		{
+			name: "JWKS key validates tokens from signer",
+			check: func(t *testing.T, jwks jose.JSONWebKeySet) {
+				require.Len(t, jwks.Keys, 1)
+
+				// Sign a token with the manager's signer
+				claims := map[string]interface{}{
+					"sub": "agent-test",
+					"iss": "https://hub.example.com",
+				}
+				token, err := jwt.Signed(mgr.Signer()).Claims(claims).Serialize()
+				require.NoError(t, err)
+
+				// Verify with the JWKS public key
+				parsed, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256})
+				require.NoError(t, err)
+
+				var result map[string]interface{}
+				err = parsed.Claims(jwks.Keys[0].Key, &result)
+				require.NoError(t, err)
+				assert.Equal(t, "agent-test", result["sub"])
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			jwks := mgr.JWKS()
+			tc.check(t, jwks)
+		})
+	}
+}
+
+func TestOIDCKeyManager_LoadFromStore(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+	hubID := "test-hub-store"
+
+	// First initialization: generates and stores a key
+	mgr1, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+		OIDCConfig: config.OIDCProviderConfig{
+			Enabled: true,
+		},
+	})
+	require.NoError(t, err)
+	kid1 := mgr1.JWKS().Keys[0].KeyID
+
+	// Second initialization with the same store: should load the same key
+	mgr2, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+		OIDCConfig: config.OIDCProviderConfig{
+			Enabled: true,
+		},
+	})
+	require.NoError(t, err)
+	kid2 := mgr2.JWKS().Keys[0].KeyID
+
+	assert.Equal(t, kid1, kid2, "Second initialization should load the same key from store")
+
+	// Verify cross-validation: token signed by mgr1 can be verified with mgr2's JWKS
+	claims := map[string]interface{}{"sub": "agent-cross"}
+	token, err := jwt.Signed(mgr1.Signer()).Claims(claims).Serialize()
+	require.NoError(t, err)
+
+	parsed, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256})
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	err = parsed.Claims(mgr2.JWKS().Keys[0].Key, &result)
+	require.NoError(t, err)
+	assert.Equal(t, "agent-cross", result["sub"])
+}
+
+func TestOIDCKeyManager_LoadFromBackend(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+	hubID := "test-hub-backend"
+	backend := newOIDCMockSecretBackend()
+
+	// First initialization with backend: generates and stores to both backend and store
+	mgr1, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		Backend:   backend,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+		OIDCConfig: config.OIDCProviderConfig{
+			Enabled: true,
+		},
+	})
+	require.NoError(t, err)
+	kid1 := mgr1.JWKS().Keys[0].KeyID
+
+	// Verify the key was stored in the backend
+	sv, err := backend.Get(ctx, SecretKeyOIDCSigningKey, store.ScopeHub, hubID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, sv.Value, "Key should be stored in backend")
+
+	// Create a new store (simulating fresh start) but same backend
+	s2 := createOIDCTestStore(t)
+	mgr2, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s2,
+		Backend:   backend,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+		OIDCConfig: config.OIDCProviderConfig{
+			Enabled: true,
+		},
+	})
+	require.NoError(t, err)
+	kid2 := mgr2.JWKS().Keys[0].KeyID
+
+	assert.Equal(t, kid1, kid2, "Should load the same key from backend")
+}
+
+func TestOIDCKeyManager_GenerateWhenNoKey(t *testing.T) {
+	s := createOIDCTestStore(t)
+	backend := newOIDCMockSecretBackend()
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		backend secret.SecretBackend
+	}{
+		{
+			name:    "generates key with no backend",
+			backend: nil,
+		},
+		{
+			name:    "generates key with empty backend",
+			backend: backend,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+				Store:     s,
+				Backend:   tc.backend,
+				HubID:     "test-hub-gen-" + tc.name,
+				IssuerURL: "https://hub.example.com",
+				OIDCConfig: config.OIDCProviderConfig{
+					Enabled: true,
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, mgr)
+
+			// Verify signer works
+			signer := mgr.Signer()
+			require.NotNil(t, signer)
+
+			// Verify JWKS is populated
+			jwks := mgr.JWKS()
+			require.Len(t, jwks.Keys, 1)
+
+			// Verify IssuerURL
+			assert.Equal(t, "https://hub.example.com", mgr.IssuerURL())
+		})
+	}
+}
+
+func TestOIDCKeyManager_RequireStableSigningKey(t *testing.T) {
+	s := createOIDCTestStore(t)
+	backend := newOIDCMockSecretBackend()
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		backend secret.SecretBackend
+		wantErr string
+	}{
+		{
+			name:    "fails with no backend and no existing key",
+			backend: nil,
+			wantErr: "RequireStableSigningKey is set",
+		},
+		{
+			name:    "fails with empty backend and no existing key",
+			backend: backend,
+			wantErr: "RequireStableSigningKey is set",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+				Store:                   s,
+				Backend:                 tc.backend,
+				HubID:                   "test-hub-require-stable-" + tc.name,
+				IssuerURL:               "https://hub.example.com",
+				RequireStableSigningKey: true,
+				OIDCConfig: config.OIDCProviderConfig{
+					Enabled: true,
+				},
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+
+	// Verify that RequireStableSigningKey succeeds when a key exists
+	t.Run("succeeds when key exists in backend", func(t *testing.T) {
+		hubID := "test-hub-require-stable-exists"
+		be := newOIDCMockSecretBackend()
+
+		// First: create a key normally
+		mgr1, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+			Store:     s,
+			Backend:   be,
+			HubID:     hubID,
+			IssuerURL: "https://hub.example.com",
+			OIDCConfig: config.OIDCProviderConfig{
+				Enabled: true,
+			},
+		})
+		require.NoError(t, err)
+		kid1 := mgr1.JWKS().Keys[0].KeyID
+
+		// Second: load with RequireStableSigningKey — should succeed
+		mgr2, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+			Store:                   s,
+			Backend:                 be,
+			HubID:                   hubID,
+			IssuerURL:               "https://hub.example.com",
+			RequireStableSigningKey: true,
+			OIDCConfig: config.OIDCProviderConfig{
+				Enabled: true,
+			},
+		})
+		require.NoError(t, err)
+		kid2 := mgr2.JWKS().Keys[0].KeyID
+		assert.Equal(t, kid1, kid2)
+	})
+}
+
+func TestOIDCKeyManager_IssuerURL(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		issuerURL string
+	}{
+		{name: "https URL", issuerURL: "https://hub.example.com"},
+		{name: "localhost URL", issuerURL: "http://localhost:9810"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+				Store:     s,
+				HubID:     "test-hub-issuer-" + tc.name,
+				IssuerURL: tc.issuerURL,
+				OIDCConfig: config.OIDCProviderConfig{
+					Enabled: true,
+				},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.issuerURL, mgr.IssuerURL())
+		})
+	}
+}
+
+func TestOIDCSigningKeySecretID(t *testing.T) {
+	tests := []struct {
+		name  string
+		hubID string
+	}{
+		{name: "deterministic", hubID: "hub-1"},
+		{name: "different hub IDs produce different IDs", hubID: "hub-2"},
+	}
+
+	var firstID string
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id := oidcSigningKeySecretID(tc.hubID)
+			assert.NotEmpty(t, id)
+
+			// Deterministic
+			id2 := oidcSigningKeySecretID(tc.hubID)
+			assert.Equal(t, id, id2, "Should be deterministic")
+
+			if i == 0 {
+				firstID = id
+			} else {
+				assert.NotEqual(t, firstID, id, "Different hub IDs should produce different secret IDs")
+			}
+		})
+	}
+}
+
+func TestEncodePEMPrivateKey_PKCS8Format(t *testing.T) {
+	key, err := generateRSAKeyPair()
+	require.NoError(t, err)
+
+	pemData, err := encodePEMPrivateKey(key)
+	require.NoError(t, err)
+
+	// Should be valid PKCS#8
+	block, _ := pem.Decode(pemData)
+	require.NotNil(t, block)
+
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	require.NoError(t, err)
+
+	rsaKey, ok := parsed.(*rsa.PrivateKey)
+	require.True(t, ok, "Parsed key should be RSA")
+	assert.Equal(t, key.D.Bytes(), rsaKey.D.Bytes())
+}
+
+// createOIDCTestStore creates an in-memory SQLite store for OIDC tests.
+func createOIDCTestStore(t *testing.T) store.Store {
+	t.Helper()
+	s, err := newTestStore(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("failed to migrate test store: %v", err)
+	}
+	return s
+}

--- a/pkg/hub/oidckeys_test.go
+++ b/pkg/hub/oidckeys_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/secret"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -662,6 +663,307 @@ func TestEncodePEMPrivateKey_PKCS8Format(t *testing.T) {
 	rsaKey, ok := parsed.(*rsa.PrivateKey)
 	require.True(t, ok, "Parsed key should be RSA")
 	assert.Equal(t, key.D.Bytes(), rsaKey.D.Bytes())
+}
+
+// --- Key Rotation and Cleanup Tests ---
+
+func TestOIDCKeyManager_RotateKey(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+
+	mgr, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     "test-hub-rotate",
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	originalKID := mgr.JWKS().Keys[0].KeyID
+	originalSigner := mgr.Signer()
+
+	// Sign a token with the original key before rotation.
+	preRotationClaims := map[string]interface{}{
+		"sub": "agent-pre-rotate",
+		"iss": "https://hub.example.com",
+	}
+	preRotationToken, err := jwt.Signed(originalSigner).Claims(preRotationClaims).Serialize()
+	require.NoError(t, err)
+
+	// Rotate.
+	err = mgr.RotateKey(ctx)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		check func(t *testing.T)
+	}{
+		{
+			name: "rotation produces new kid",
+			check: func(t *testing.T) {
+				jwks := mgr.JWKS()
+				require.NotEmpty(t, jwks.Keys)
+				// Active key (first in JWKS) should have a different kid.
+				newKID := jwks.Keys[0].KeyID
+				assert.NotEqual(t, originalKID, newKID,
+					"After rotation, active key should have a different kid")
+			},
+		},
+		{
+			name: "old key remains in JWKS",
+			check: func(t *testing.T) {
+				jwks := mgr.JWKS()
+				require.Len(t, jwks.Keys, 2, "JWKS should contain both old and new keys")
+				kids := []string{jwks.Keys[0].KeyID, jwks.Keys[1].KeyID}
+				assert.Contains(t, kids, originalKID, "Old key should still be in JWKS")
+			},
+		},
+		{
+			name: "signing uses new key",
+			check: func(t *testing.T) {
+				newClaims := map[string]interface{}{
+					"sub": "agent-post-rotate",
+					"iss": "https://hub.example.com",
+				}
+				token, signErr := jwt.Signed(mgr.Signer()).Claims(newClaims).Serialize()
+				require.NoError(t, signErr)
+
+				parsed, parseErr := jwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256})
+				require.NoError(t, parseErr)
+
+				// The token's kid header should match the new active key.
+				jwks := mgr.JWKS()
+				newKID := jwks.Keys[0].KeyID
+				assert.NotEqual(t, originalKID, newKID)
+
+				// Token should verify with the new key.
+				var result map[string]interface{}
+				verifyErr := parsed.Claims(jwks.Keys[0].Key, &result)
+				require.NoError(t, verifyErr)
+				assert.Equal(t, "agent-post-rotate", result["sub"])
+			},
+		},
+		{
+			name: "old tokens still verifiable via JWKS",
+			check: func(t *testing.T) {
+				parsed, parseErr := jwt.ParseSigned(preRotationToken, []jose.SignatureAlgorithm{jose.RS256})
+				require.NoError(t, parseErr)
+
+				// Find the old key in JWKS.
+				jwks := mgr.JWKS()
+				var oldKey interface{}
+				for _, k := range jwks.Keys {
+					if k.KeyID == originalKID {
+						oldKey = k.Key
+						break
+					}
+				}
+				require.NotNil(t, oldKey, "Old key must still be in JWKS")
+
+				var result map[string]interface{}
+				verifyErr := parsed.Claims(oldKey, &result)
+				require.NoError(t, verifyErr, "Token signed before rotation should still verify with old key from JWKS")
+				assert.Equal(t, "agent-pre-rotate", result["sub"])
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.check(t)
+		})
+	}
+}
+
+func TestOIDCKeyManager_CleanupExpiredKeys(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+
+	mgr, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     "test-hub-cleanup",
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	// Rotate to get a second key.
+	err = mgr.RotateKey(ctx)
+	require.NoError(t, err)
+	require.Len(t, mgr.JWKS().Keys, 2, "Should have 2 keys after rotation")
+
+	tests := []struct {
+		name  string
+		setup func()
+		check func(t *testing.T)
+	}{
+		{
+			name: "keeps recent inactive keys",
+			setup: func() {
+				// Inactive key is recent (created moments ago) — should be kept.
+			},
+			check: func(t *testing.T) {
+				mgr.CleanupExpiredKeys()
+				jwks := mgr.JWKS()
+				assert.Len(t, jwks.Keys, 2, "Recent inactive key should not be removed")
+			},
+		},
+		{
+			name: "removes old inactive keys",
+			setup: func() {
+				// Artificially age the inactive key past the overlap window.
+				mgr.mu.Lock()
+				for _, k := range mgr.allKeys {
+					if !k.Active {
+						k.CreatedAt = time.Now().Add(-25 * time.Hour) // 25h ago
+					}
+				}
+				mgr.mu.Unlock()
+			},
+			check: func(t *testing.T) {
+				mgr.CleanupExpiredKeys()
+				jwks := mgr.JWKS()
+				assert.Len(t, jwks.Keys, 1, "Old inactive key should be removed")
+				assert.True(t, jwks.Keys[0].KeyID != "", "Remaining key should have a kid")
+			},
+		},
+		{
+			name: "never removes active key regardless of age",
+			setup: func() {
+				// Age the active key past the overlap window.
+				mgr.mu.Lock()
+				for _, k := range mgr.allKeys {
+					if k.Active {
+						k.CreatedAt = time.Now().Add(-48 * time.Hour) // 48h ago
+					}
+				}
+				mgr.mu.Unlock()
+			},
+			check: func(t *testing.T) {
+				mgr.CleanupExpiredKeys()
+				jwks := mgr.JWKS()
+				assert.Len(t, jwks.Keys, 1, "Active key should never be removed")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup()
+			tc.check(t)
+		})
+	}
+}
+
+func TestOIDCKeyManager_RotateKey_MultipleRotations(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+
+	mgr, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     "test-hub-multi-rotate",
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	// Rotate three times.
+	kids := make([]string, 0, 4)
+	kids = append(kids, mgr.JWKS().Keys[0].KeyID)
+
+	for i := 0; i < 3; i++ {
+		err = mgr.RotateKey(ctx)
+		require.NoError(t, err)
+		jwks := mgr.JWKS()
+		kids = append(kids, jwks.Keys[0].KeyID)
+	}
+
+	t.Run("all kids are unique", func(t *testing.T) {
+		seen := make(map[string]bool)
+		for _, kid := range kids {
+			assert.False(t, seen[kid], "kid %s should be unique", kid)
+			seen[kid] = true
+		}
+	})
+
+	t.Run("JWKS contains all keys", func(t *testing.T) {
+		jwks := mgr.JWKS()
+		assert.Len(t, jwks.Keys, 4, "JWKS should contain original + 3 rotated keys")
+	})
+
+	t.Run("only one key is active", func(t *testing.T) {
+		mgr.mu.RLock()
+		defer mgr.mu.RUnlock()
+		activeCount := 0
+		for _, k := range mgr.allKeys {
+			if k.Active {
+				activeCount++
+			}
+		}
+		assert.Equal(t, 1, activeCount, "Exactly one key should be active")
+	})
+}
+
+func TestOIDCKeyManager_RotateKey_WithBackend(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+	backend := newOIDCMockSecretBackend()
+
+	mgr, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		Backend:   backend,
+		HubID:     "test-hub-rotate-backend",
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	err = mgr.RotateKey(ctx)
+	require.NoError(t, err)
+
+	// Verify the rotated key was persisted to the backend.
+	sv, err := backend.Get(ctx, SecretKeyOIDCSigningKey, store.ScopeHub, "test-hub-rotate-backend")
+	require.NoError(t, err)
+	assert.NotEmpty(t, sv.Value, "Rotated key should be persisted to backend")
+
+	// The persisted key should be the new active key.
+	privKey, err := decodePEMPrivateKey([]byte(sv.Value))
+	require.NoError(t, err)
+	newKID := computeKeyID(&privKey.PublicKey)
+	assert.Equal(t, mgr.JWKS().Keys[0].KeyID, newKID,
+		"Persisted key should match the new active key")
+}
+
+func TestOIDCKeyManager_StartCleanupLoop(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgr, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     "test-hub-cleanup-loop",
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	// Rotate and age the old key past the overlap window.
+	err = mgr.RotateKey(ctx)
+	require.NoError(t, err)
+	require.Len(t, mgr.JWKS().Keys, 2)
+
+	mgr.mu.Lock()
+	for _, k := range mgr.allKeys {
+		if !k.Active {
+			k.CreatedAt = time.Now().Add(-25 * time.Hour)
+		}
+	}
+	mgr.mu.Unlock()
+
+	// Manually call CleanupExpiredKeys to verify (we don't wait for the ticker
+	// since the 1-hour interval is too long for a unit test).
+	mgr.CleanupExpiredKeys()
+	assert.Len(t, mgr.JWKS().Keys, 1, "Expired key should be cleaned up")
+
+	// Verify the cleanup loop can be started and stopped via context cancellation
+	// without panicking.
+	mgr.StartCleanupLoop(ctx)
+	cancel()
 }
 
 // createOIDCTestStore creates an in-memory SQLite store for OIDC tests.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3143,6 +3143,12 @@ func (s *Server) registerRoutes() {
 	s.mux.Handle("/api/v1/system/registry", s.requireWorkstation(http.HandlerFunc(s.handleSystemRegistry)))
 	s.mux.Handle("/api/v1/system/workstation-settings", s.requireWorkstation(http.HandlerFunc(s.handleWorkstationSettings)))
 
+	// OIDC Identity Provider endpoints (unauthenticated — public metadata)
+	if s.oidcKeyManager != nil {
+		s.mux.HandleFunc("GET /.well-known/openid-configuration", s.handleOIDCDiscovery)
+		s.mux.HandleFunc("GET /.well-known/jwks.json", s.handleJWKS)
+	}
+
 	// Workstation-only filesystem endpoints
 	s.mux.Handle("/api/v1/system/fs/list", s.requireWorkstation(http.HandlerFunc(s.handleFSList)))
 	s.mux.Handle("/api/v1/system/fs/mkdir", s.requireWorkstation(http.HandlerFunc(s.handleFSMkdir)))

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -706,8 +706,10 @@ type Server struct {
 	transportMode     string
 
 	// OIDC identity provider (nil = OIDC IdP disabled)
-	oidcKeyManager *OIDCKeyManager
-	oidcIssuerURL  string
+	oidcKeyManager       *OIDCKeyManager
+	oidcIssuerURL        string
+	oidcTokenRateLimiter *GCPTokenRateLimiter // per-agent rate limiter for OIDC identity token requests
+	oidcTokenLifetime    time.Duration        // validity duration for OIDC identity tokens
 
 	// GCP token generator for agent identity (nil = GCP identity disabled)
 	gcpTokenGenerator GCPTokenGenerator
@@ -1008,6 +1010,7 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 		if oidcIssuerURL == "" {
 			return nil, fmt.Errorf("OIDC is enabled but no issuer URL configured (set oidc.issuer_url or hub.endpoint)")
 		}
+		oidcIssuerURL = strings.TrimRight(oidcIssuerURL, "/")
 
 		oidcMgr, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
 			Store:                   s,
@@ -1025,6 +1028,16 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 		} else {
 			srv.oidcKeyManager = oidcMgr
 			srv.oidcIssuerURL = oidcIssuerURL
+
+			// OIDC identity token lifetime: use config if set, else default 15m
+			srv.oidcTokenLifetime = 15 * time.Minute
+			if cfg.OIDCConfig.TokenLifetime > 0 {
+				srv.oidcTokenLifetime = cfg.OIDCConfig.TokenLifetime
+			}
+
+			// Per-agent rate limiter for OIDC identity token requests (0.5 req/sec avg, burst 30)
+			srv.oidcTokenRateLimiter = NewGCPTokenRateLimiter(0.5, 30)
+
 			slog.Info("OIDC Identity Provider enabled", "issuer_url", oidcIssuerURL)
 		}
 	}
@@ -2771,9 +2784,12 @@ func (s *Server) StartBackgroundServices(ctx context.Context) {
 		}
 	}
 
-	// Start rate limiter cleanup goroutine (exits when ctx is cancelled).
+	// Start rate limiter cleanup goroutines (exit when ctx is cancelled).
 	if s.gcpTokenRateLimiter != nil {
 		s.gcpTokenRateLimiter.StartCleanup(ctx)
+	}
+	if s.oidcTokenRateLimiter != nil {
+		s.oidcTokenRateLimiter.StartCleanup(ctx)
 	}
 
 	// Start notification dispatcher (uses the current event publisher).
@@ -3147,6 +3163,7 @@ func (s *Server) registerRoutes() {
 	if s.oidcKeyManager != nil {
 		s.mux.HandleFunc("GET /.well-known/openid-configuration", s.handleOIDCDiscovery)
 		s.mux.HandleFunc("GET /.well-known/jwks.json", s.handleJWKS)
+		s.mux.HandleFunc("POST /api/v1/agent/identity-token", s.handleAgentIdentityToken)
 	}
 
 	// Workstation-only filesystem endpoints

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1014,7 +1014,6 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 			Backend:                 srv.secretBackend,
 			HubID:                   srv.hubID,
 			IssuerURL:               oidcIssuerURL,
-			OIDCConfig:              cfg.OIDCConfig,
 			RequireStableSigningKey: cfg.RequireStableSigningKey,
 			Log:                     logging.Subsystem("hub.oidc"),
 		})

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2792,6 +2792,11 @@ func (s *Server) StartBackgroundServices(ctx context.Context) {
 		s.oidcTokenRateLimiter.StartCleanup(ctx)
 	}
 
+	// Start OIDC key cleanup loop to remove expired rotated keys from JWKS.
+	if s.oidcKeyManager != nil {
+		s.oidcKeyManager.StartCleanupLoop(ctx)
+	}
+
 	// Start notification dispatcher (uses the current event publisher).
 	// The dispatcher is resolved lazily so it works even if SetDispatcher
 	// is called after Start().

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/config/opsettings"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent"
 	"github.com/GoogleCloudPlatform/scion/pkg/eventbus"
@@ -231,6 +232,10 @@ type ServerConfig struct {
 	Workstation bool
 	// DevUserConfig holds optional identity overrides for the development user.
 	DevUserConfig DevUserConfig
+
+	// OIDCConfig holds configuration for the OIDC Identity Provider feature.
+	// When Enabled, the hub initializes an OIDCKeyManager and exposes OIDC endpoints.
+	OIDCConfig config.OIDCProviderConfig
 }
 
 // MaintenanceConfig holds configuration for routine maintenance operation executors.
@@ -700,6 +705,10 @@ type Server struct {
 	transportAudience string
 	transportMode     string
 
+	// OIDC identity provider (nil = OIDC IdP disabled)
+	oidcKeyManager *OIDCKeyManager
+	oidcIssuerURL  string
+
 	// GCP token generator for agent identity (nil = GCP identity disabled)
 	gcpTokenGenerator GCPTokenGenerator
 
@@ -988,6 +997,37 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 		slog.Info("Transport token minter configured",
 			"mode", cfg.TransportMode,
 			"audience", cfg.TransportAudience)
+	}
+
+	// Initialize OIDC Identity Provider key manager if enabled
+	if cfg.OIDCConfig.Enabled {
+		oidcIssuerURL := cfg.OIDCConfig.IssuerURL
+		if oidcIssuerURL == "" {
+			oidcIssuerURL = cfg.HubEndpoint
+		}
+		if oidcIssuerURL == "" {
+			return nil, fmt.Errorf("OIDC is enabled but no issuer URL configured (set oidc.issuer_url or hub.endpoint)")
+		}
+
+		oidcMgr, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+			Store:                   s,
+			Backend:                 srv.secretBackend,
+			HubID:                   srv.hubID,
+			IssuerURL:               oidcIssuerURL,
+			OIDCConfig:              cfg.OIDCConfig,
+			RequireStableSigningKey: cfg.RequireStableSigningKey,
+			Log:                     logging.Subsystem("hub.oidc"),
+		})
+		if err != nil {
+			if isGCPBackend || cfg.RequireStableSigningKey {
+				return nil, fmt.Errorf("OIDC key manager: %w", err)
+			}
+			slog.Warn("Failed to initialize OIDC key manager", "error", err)
+		} else {
+			srv.oidcKeyManager = oidcMgr
+			srv.oidcIssuerURL = oidcIssuerURL
+			slog.Info("OIDC Identity Provider enabled", "issuer_url", oidcIssuerURL)
+		}
 	}
 
 	// Initialize control channel manager

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -1689,6 +1689,58 @@ func (c *Client) FetchGCPIdentityToken(ctx context.Context, audience string) (st
 	return result.Token, nil
 }
 
+// IdentityTokenResponse is the Hub's response for an OIDC identity token request.
+type IdentityTokenResponse struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// RequestIdentityToken requests an OIDC identity token for the given audience.
+// The token is a short-lived RS256-signed JWT that can be used to authenticate
+// to external systems supporting OIDC/JWT verification (Vault, GCP WIF, AWS
+// IRSA, A2A bridges, etc.).
+func (c *Client) RequestIdentityToken(ctx context.Context, audience string) (*IdentityTokenResponse, error) {
+	if !c.IsConfigured() {
+		return nil, fmt.Errorf("hub client not configured")
+	}
+
+	endpoint := fmt.Sprintf("%s/api/v1/agent/identity-token",
+		strings.TrimSuffix(c.hubURL, "/"))
+
+	body, _ := json.Marshal(map[string]string{
+		"audience": audience,
+	})
+
+	c.tokenMu.RLock()
+	currentToken := c.token
+	c.tokenMu.RUnlock()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Scion-Agent-Token", currentToken)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("hub request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("hub returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result IdentityTokenResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
 // AgentSelf is the subset of Hub agent fields returned by GetSelf.
 // It covers the Tier 2 fields needed by `scion whoami --full`.
 type AgentSelf struct {

--- a/pkg/sciontool/hub/client_test.go
+++ b/pkg/sciontool/hub/client_test.go
@@ -1473,6 +1473,74 @@ func TestClient_SetSecret_NotConfigured(t *testing.T) {
 	assert.Contains(t, err.Error(), "not configured")
 }
 
+func TestClient_RequestIdentityToken(t *testing.T) {
+	t.Run("successful request", func(t *testing.T) {
+		wantToken := "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZ2VudC0xMjMifQ.sig"
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/api/v1/agent/identity-token", r.URL.Path)
+			assert.Equal(t, "test-token", r.Header.Get("X-Scion-Agent-Token"))
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			var body map[string]string
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "https://vault.example.com", body["audience"])
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"token":      wantToken,
+				"expires_at": "2030-01-01T00:15:00Z",
+			})
+		}))
+		defer server.Close()
+
+		client := NewClientWithConfig(server.URL, "test-token", "agent-123")
+		resp, err := client.RequestIdentityToken(context.Background(), "https://vault.example.com")
+
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, wantToken, resp.Token)
+		assert.Equal(t, time.Date(2030, 1, 1, 0, 15, 0, 0, time.UTC), resp.ExpiresAt)
+	})
+
+	t.Run("not configured", func(t *testing.T) {
+		client := &Client{}
+		_, err := client.RequestIdentityToken(context.Background(), "test")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not configured")
+	})
+
+	t.Run("server returns 403", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error":"agent not authorized to request identity tokens"}`))
+		}))
+		defer server.Close()
+
+		client := NewClientWithConfig(server.URL, "test-token", "agent-123")
+		_, err := client.RequestIdentityToken(context.Background(), "test")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "403")
+	})
+
+	t.Run("server returns 429", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":"rate limit exceeded"}`))
+		}))
+		defer server.Close()
+
+		client := NewClientWithConfig(server.URL, "test-token", "agent-123")
+		_, err := client.RequestIdentityToken(context.Background(), "test")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "429")
+	})
+}
+
 func TestClient_SetSecret_ServerError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Implement OIDC IdP support in the Scion Hub so agents can obtain RS256-signed identity tokens for external system authentication (Vault, GCP WIF, AWS IRSA, A2A bridges) via standard OIDC/JWT verification.

New endpoints: /.well-known/openid-configuration, /.well-known/jwks.json, POST /api/v1/agent/identity-token. New sciontool command: identity-token --audience. Key rotation with 24h overlap. Feature-gated via oidc.enabled config.

Ref: ptone/scion#399, ptone/scion#864