### PR TITLE
fix(cli): suppress local-only mode hints when running as hub-managed agent

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -365,7 +365,7 @@ func GetProjectID(hubCtx *HubContext) (string, error) {
 		if !config.IsHubManagedAgent() {
 			msg += ", or use --no-hub for local-only mode"
 		}
-		return "", fmt.Errorf("%s", msg)
+		return "", errors.New(msg)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -323,9 +323,14 @@ func PrintUsingHub(endpoint string) {
 }
 
 // wrapHubError wraps a Hub error with guidance to disable Hub integration.
+// When running inside a hub-managed agent, the local-only mode hint is
+// suppressed because disabling the Hub would break orchestration connectivity.
 func wrapHubError(err error) error {
 	if apiclient.IsUnauthorizedError(err) {
 		return fmt.Errorf("authentication failed, login to hub with 'scion hub auth login'")
+	}
+	if config.IsHubManagedAgent() {
+		return err
 	}
 	return fmt.Errorf("%w\n\nTo use local-only mode, run: scion hub disable", err)
 }
@@ -356,7 +361,11 @@ func GetProjectID(hubCtx *HubContext) (string, error) {
 	// Fall back to git remote lookup
 	gitRemote := util.GetGitRemote()
 	if gitRemote == "" {
-		return "", fmt.Errorf("no git origin remote found for this project.\n\nThe Hub uses the origin remote URL to identify projects.\nRun 'scion hub link' to link this project with the Hub, or use --no-hub for local-only mode")
+		msg := "no git origin remote found for this project.\n\nThe Hub uses the origin remote URL to identify projects.\nRun 'scion hub link' to link this project with the Hub"
+		if !config.IsHubManagedAgent() {
+			msg += ", or use --no-hub for local-only mode"
+		}
+		return "", fmt.Errorf("%s", msg)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/cmd/common_hubhint_test.go
+++ b/cmd/common_hubhint_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestWrapHubError_SuppressesLocalHintForAgents(t *testing.T) {
+	baseErr := errors.New("hub connection refused")
+
+	t.Run("standalone CLI includes local-only hint", func(t *testing.T) {
+		t.Setenv("SCION_AGENT_ID", "")
+		got := wrapHubError(baseErr)
+		if !strings.Contains(got.Error(), "local-only mode") {
+			t.Errorf("expected local-only mode hint for standalone CLI, got: %s", got)
+		}
+	})
+
+	t.Run("hub-managed agent omits local-only hint", func(t *testing.T) {
+		t.Setenv("SCION_AGENT_ID", "agent-uuid-123")
+		got := wrapHubError(baseErr)
+		if strings.Contains(got.Error(), "local-only mode") {
+			t.Errorf("expected no local-only mode hint for hub-managed agent, got: %s", got)
+		}
+		if !errors.Is(got, baseErr) {
+			t.Errorf("expected wrapped error to contain base error")
+		}
+	})
+}

--- a/pkg/config/hub_agent_detect.go
+++ b/pkg/config/hub_agent_detect.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "os"
+
+// IsHubManagedAgent reports whether the current process is running as a
+// hub-managed agent. The RuntimeBroker sets SCION_AGENT_ID when it starts
+// an agent inside hub infrastructure; its presence (and non-empty value)
+// is the canonical signal that the CLI is operating in an agent context
+// where local-only mode suggestions are inappropriate.
+func IsHubManagedAgent() bool {
+	return os.Getenv("SCION_AGENT_ID") != ""
+}

--- a/pkg/config/hub_agent_detect_test.go
+++ b/pkg/config/hub_agent_detect_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "testing"
+
+func TestIsHubManagedAgent(t *testing.T) {
+	t.Run("not set", func(t *testing.T) {
+		t.Setenv("SCION_AGENT_ID", "")
+		if IsHubManagedAgent() {
+			t.Error("IsHubManagedAgent() = true, want false when SCION_AGENT_ID is empty")
+		}
+	})
+
+	t.Run("set to non-empty value", func(t *testing.T) {
+		t.Setenv("SCION_AGENT_ID", "agent-uuid-123")
+		if !IsHubManagedAgent() {
+			t.Error("IsHubManagedAgent() = false, want true when SCION_AGENT_ID is set")
+		}
+	})
+}

--- a/pkg/hubsync/sync.go
+++ b/pkg/hubsync/sync.go
@@ -398,9 +398,12 @@ func EnsureHubReady(projectPath string, opts EnsureHubReadyOptions) (*HubContext
 			} else {
 				// No matching projects - ask for confirmation
 				if !ShowLinkPrompt(projectName, opts.AutoConfirm) {
-					return nil, fmt.Errorf("project must be linked to Hub to perform this operation\n\n" +
-						"Link this project: scion hub link\n" +
-						"Or use local-only mode: scion --no-hub <command>")
+					msg := "project must be linked to Hub to perform this operation\n\n" +
+						"Link this project: scion hub link"
+					if !config.IsHubManagedAgent() {
+						msg += "\nOr use local-only mode: scion --no-hub <command>"
+					}
+					return nil, fmt.Errorf("%s", msg)
 				}
 			}
 		}
@@ -487,9 +490,12 @@ func EnsureHubReady(projectPath string, opts EnsureHubReadyOptions) (*HubContext
 				return nil, wrapHubError(fmt.Errorf("failed to sync agents: %w", err))
 			}
 		} else {
-			return nil, fmt.Errorf("agents must be synchronized with Hub to perform this operation\n\n" +
-				"Sync agents: scion hub sync\n" +
-				"Or use local-only mode: scion --no-hub <command>")
+			msg := "agents must be synchronized with Hub to perform this operation\n\n" +
+				"Sync agents: scion hub sync"
+			if !config.IsHubManagedAgent() {
+				msg += "\nOr use local-only mode: scion --no-hub <command>"
+			}
+			return nil, fmt.Errorf("%s", msg)
 		}
 	} else {
 		// Already in sync — update the watermark and synced agents to keep current
@@ -1391,9 +1397,14 @@ func isLocalhostEndpoint(endpoint string) bool {
 }
 
 // wrapHubError wraps a Hub error with guidance to disable Hub integration.
+// When running inside a hub-managed agent, the local-only mode hint is
+// suppressed because disabling the Hub would break orchestration connectivity.
 func wrapHubError(err error) error {
 	if apiclient.IsUnauthorizedError(err) {
 		return fmt.Errorf("authentication failed, login to hub with 'scion hub auth login'")
+	}
+	if config.IsHubManagedAgent() {
+		return err
 	}
 	return fmt.Errorf("%w\n\nTo use local-only mode, use: scion --no-hub <command>", err)
 }

--- a/pkg/hubsync/sync.go
+++ b/pkg/hubsync/sync.go
@@ -403,7 +403,7 @@ func EnsureHubReady(projectPath string, opts EnsureHubReadyOptions) (*HubContext
 					if !config.IsHubManagedAgent() {
 						msg += "\nOr use local-only mode: scion --no-hub <command>"
 					}
-					return nil, fmt.Errorf("%s", msg)
+					return nil, errors.New(msg)
 				}
 			}
 		}
@@ -495,7 +495,7 @@ func EnsureHubReady(projectPath string, opts EnsureHubReadyOptions) (*HubContext
 			if !config.IsHubManagedAgent() {
 				msg += "\nOr use local-only mode: scion --no-hub <command>"
 			}
-			return nil, fmt.Errorf("%s", msg)
+			return nil, errors.New(msg)
 		}
 	} else {
 		// Already in sync — update the watermark and synced agents to keep current

--- a/pkg/hubsync/sync_test.go
+++ b/pkg/hubsync/sync_test.go
@@ -17,6 +17,7 @@ package hubsync
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -2358,4 +2359,28 @@ func TestAddRemoveSyncedAgent(t *testing.T) {
 			t.Fatal("agent-b should have been removed")
 		}
 	}
+}
+
+func TestWrapHubError_SuppressesLocalHintForAgents(t *testing.T) {
+	baseErr := errors.New("hub connection refused")
+
+	t.Run("standalone CLI includes local-only hint", func(t *testing.T) {
+		t.Setenv("SCION_AGENT_ID", "") // Ensure agent context is cleared.
+		got := wrapHubError(baseErr)
+		if !strings.Contains(got.Error(), "local-only mode") {
+			t.Errorf("expected local-only mode hint for standalone CLI, got: %s", got)
+		}
+	})
+
+	t.Run("hub-managed agent omits local-only hint", func(t *testing.T) {
+		t.Setenv("SCION_AGENT_ID", "agent-uuid-123")
+		got := wrapHubError(baseErr)
+		if strings.Contains(got.Error(), "local-only mode") {
+			t.Errorf("expected no local-only mode hint for hub-managed agent, got: %s", got)
+		}
+		// The original error should still be present.
+		if !errors.Is(got, baseErr) {
+			t.Errorf("expected wrapped error to contain base error")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

CLI error paths suggested "scion hub disable" or "--no-hub" as workarounds, but for agents running inside hub-managed infrastructure, disabling hub mode would break orchestration connectivity (messaging, status, task coordination).

Adds config.IsHubManagedAgent() helper (checks SCION_AGENT_ID env var set by RuntimeBroker) and suppresses local-only mode suggestions in 5 error paths across cmd/common.go and pkg/hubsync/sync.go.

Ref: ptone/scion#868

## Test plan

- go build ./cmd/... passes
- go test ./cmd/... -short passes
- go test ./pkg/config/... -short passes
- go test ./pkg/hubsync/... -short passes
- Unit tests verify hint suppression in both standalone and agent contexts