### PR TITLE
docs: nightly documentation update for Aug 7 changelog

### DIFF
--- a/docs-site/src/content/docs/hosted/user/external-channels.md
+++ b/docs-site/src/content/docs/hosted/user/external-channels.md
@@ -83,6 +83,7 @@ All bot interactions are handled via `/scion` slash commands:
 | `/scion logs <agent>` | Stream/view recent logs for an agent. |
 | `/scion default [agent]` | Set or clear the default agent for the channel or thread (so unaddressed text routes automatically). |
 | `/scion send <path>` | Send a file from your workspace by path or search for files. Supports container-to-host path translation. |
+| `/scion secret` | Subcommand group for managing project secrets (list, get, set, delete) directly from Discord (see below). |
 | `/scion thread <title> [template]` | Create a Discord thread and a Scion agent in one atomic step (see below). |
 | `/scion register` | Link your Discord account to your Scion Hub identity. |
 | `/scion unregister` | Unlink your Discord account from Scion Hub. |
@@ -106,6 +107,21 @@ The `/scion thread <title> [template]` command allows you to spin up a new conve
 
 - **Multi-Server (Multi-Guild) Support:** A single bot instance can serve multiple servers simultaneously. Admins can configure `guild_ids` for instant command registration on listed servers.
 - **Outage Protection:** Automatically deactivates channel links when the bot is removed from a server, while protecting active links against temporary Discord API outages.
+
+#### Managing Project Secrets via Discord (`/scion secret`)
+
+You can view and modify project-scoped secrets directly from a linked Discord channel or thread using the `/scion secret` subcommand group. To protect sensitive credentials, secret values are never typed or printed in public chat rooms; they are input securely via Discord pop-up modals, and all responses are ephemeral (visible only to you).
+
+##### Requirements
+*   **Channel Link**: The Discord channel or thread must be linked to a project (via `/scion setup`).
+*   **Account Association**: Your Discord account must be registered with your Scion Hub identity (via `/scion register`). Write operations use secure `X-Scion-On-Behalf-Of` delegation.
+
+##### Subcommands
+*   **`/scion secret list`**: Lists the keys, types, and injection targets of all secrets in the linked project. Secret values themselves are never shown.
+*   **`/scion secret set <key>`**: Initiates setting a secret. After specifying the key name, Discord displays an interactive pop-up modal. Enter your sensitive secret value securely inside this modal and submit. The value is securely sent to the Hub over an HMAC-signed API call and stored in your project scope.
+    *   *Key Restriction*: Secret keys must not contain spaces, tabs, newlines, or colons (`:`).
+*   **`/scion secret get <key>`**: Displays the metadata (key, type, target) of a specific secret to verify its existence. The secret value itself is never shown.
+*   **`/scion secret delete <key>`**: Permanently deletes a secret from the linked project.
 
 #### File Transfers & Attachments
 

--- a/docs-site/src/content/docs/hosted/user/external-channels.md
+++ b/docs-site/src/content/docs/hosted/user/external-channels.md
@@ -119,7 +119,7 @@ You can view and modify project-scoped secrets directly from a linked Discord ch
 ##### Subcommands
 *   **`/scion secret list`**: Lists the keys, types, and injection targets of all secrets in the linked project. Secret values themselves are never shown.
 *   **`/scion secret set <key>`**: Initiates setting a secret. After specifying the key name, Discord displays an interactive pop-up modal. Enter your sensitive secret value securely inside this modal and submit. The value is securely sent to the Hub over an HMAC-signed API call and stored in your project scope.
-    *   *Key Restriction*: Secret keys must not contain spaces, tabs, newlines, or colons (`:`).
+    *   *Key Restriction*: Secret keys must not contain spaces, tabs, newlines, carriage returns, equals signs (=), or colons (:).
 *   **`/scion secret get <key>`**: Displays the metadata (key, type, target) of a specific secret to verify its existence. The secret value itself is never shown.
 *   **`/scion secret delete <key>`**: Permanently deletes a secret from the linked project.
 

--- a/docs-site/src/content/docs/hosted/user/secrets.md
+++ b/docs-site/src/content/docs/hosted/user/secrets.md
@@ -66,7 +66,7 @@ scion hub env set --broker=my-gpu-node CUDA_VISIBLE_DEVICES=0
 
 ## Managing Secrets
 
-Secrets are write-only. Once set, their values cannot be retrieved via the CLI or API; they are only decrypted and injected into the agent container at runtime.
+Secrets are write-only from host-level CLI commands and the Web Dashboard. Once set, their values cannot be read back by users. However, authorized agents running inside their containers can securely retrieve project-scoped secrets at runtime via the Hub API or the `sciontool` utility.
 
 ### Setting Secrets
 Secrets can be set manually via the CLI or Web Dashboard, or gathered interactively during agent creation.
@@ -121,6 +121,55 @@ scion hub secret set \
 ```
 
 Once set, every agent that starts will have the credential file mounted at `~/.scion/telemetry-gcp-credentials.json` and GCP-native telemetry will be enabled automatically — no additional environment variable configuration required. See [Metrics & OpenTelemetry](/scion/hosted/single-node/metrics/#4-gcp-credentials-for-agent-containers-non-adc-environments) for the full setup guide.
+
+---
+
+### Agent Runtime Secret Retrieval
+
+While environment and file-based injection deliver secrets at agent startup, Scion also supports **dynamic runtime secret retrieval** from inside the agent container. This enables harnesses or scripts to request project-scoped secrets programmatically as-needed, reducing initial environment exposure.
+
+This runtime retrieval is accessible either via the `sciontool` helper utility or directly through the Hub API.
+
+#### Using `sciontool`
+From inside an agent container, use the `sciontool secret` command suite:
+
+*   **List Available Secrets**: Lists metadata (keys, types, and injection targets) for all secrets in the agent's project. Sensitive values are omitted.
+    ```bash
+    sciontool secret list
+    ```
+    *Output:*
+    ```text
+    KEY              TYPE         TARGET
+    ---              ----         ------
+    MY_API_KEY       environment  MY_API_KEY
+    CLAUDE_AUTH      file         ~/.claude/.credentials.json
+    ```
+
+*   **Retrieve a Secret Value**: Decodes and outputs the raw bytes of a specific secret to stdout (ideal for piping or scripting).
+    ```bash
+    sciontool secret get MY_API_KEY
+    ```
+    *Example script usage:*
+    ```bash
+    export API_KEY=$(sciontool secret get MY_API_KEY)
+    ```
+
+*   **Set a Project Secret**: You can also write/update secrets from inside the container to persist credentials discovered or generated at runtime:
+    ```bash
+    sciontool secret set NEW_TOKEN "secret-value"
+    ```
+
+#### Using the Hub API Directly
+Under the hood, `sciontool` interacts with the Hub's agent-specific secrets API:
+
+*   **`GET /api/v1/agents/{agentID}/secrets`**: Lists available secret metadata in the agent's project.
+*   **`GET /api/v1/agents/{agentID}/secrets/{key}`**: Retrieves a single secret's metadata and its base64-encoded value.
+*   **`PUT /api/v1/agents/{agentID}/secrets/{key}`**: Stores or updates a secret.
+
+#### Security & Audit Logging
+*   **Authentication**: API access is restricted to the running agent container. The agent must include its unique Hub-issued JWT (loaded from `SCION_HUB_TOKEN`) in the `Authorization: Bearer <token>` header of every request.
+*   **Authorization**: Agents are strictly bounded to their own project's secrets. They cannot access secrets in other projects, user-scoped secrets, or global Hub secrets unless explicitly shared via progeny policies (descendant access).
+*   **Audit Trail**: To ensure accountability, every runtime read and write operation is fully audited on the Hub. Successful and failed retrieval attempts log an audit event (`agent_secret_read`) identifying the calling agent, requested key, and status.
 
 ---
 

--- a/docs-site/src/content/docs/reference/admin-settings.md
+++ b/docs-site/src/content/docs/reference/admin-settings.md
@@ -164,7 +164,7 @@ To streamline management of complex environments, the **General** settings tab i
 
 1. **General Card**: Houses central Hub identity, registration endpoints, and core server configurations.
 2. **Agent Defaults Card** (with dedicated sub-tabs):
-   - Configures default resource constraints (`max_turns`, `max_duration`, limits).
+   - Configures default resource constraints (`max_turns`, `max_duration`, limits). These fields can be cleared to blank in the UI, which persists them as `null` in the Hub settings database instead of preserving their previous values, allowing administrators to remove default constraints entirely.
    - Introduces **Default Model** (`default_model`) and **Default Thinking Level** (`default_thinking_level`) fields directly into the agent default pipeline.
    - Houses the **Telemetry Toggle**, which has been moved to this card to keep telemetry configuration closely aligned with operational defaults.
 3. **Project Default Settings Card**: Configures platform-level default annotations and behaviors for newly created projects.


### PR DESCRIPTION
## Summary

Nightly documentation update covering the Aug 7 changelog.

- Documented agent runtime secret retrieval API and sciontool CLI commands
- Added Discord /scion secret slash commands to external-channels docs
- Updated admin settings reference for clearing agent limit fields

3 files changed, 67 insertions, 2 deletions.
