### PR TITLE
fix(cloudbuild): anchor .gcloudignore internal/ pattern to repo root

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -23,7 +23,7 @@ docs-site/
 examples/
 extras/
 hack/
-internal/
+/internal/
 reviews/
 scratch/
 /scripts/


### PR DESCRIPTION
Adds a leading / to the internal/ pattern in .gcloudignore, anchoring it to the repo root. Without the anchor, the pattern excluded all internal/ dirs anywhere in the tree, including extras/scion-a2a-bridge/internal/, breaking Cloud Build for extras modules.