### PR TITLE
feat(admin): add Restart Hub button to maintenance page

### DIFF
--- a/pkg/hub/admin_maintenance.go
+++ b/pkg/hub/admin_maintenance.go
@@ -703,11 +703,11 @@ func (s *Server) handleAdminRestart(w http.ResponseWriter, r *http.Request) {
 	if err := cmd.Start(); err != nil {
 		log.Error("Failed to initiate hub restart", "error", err, "user", user.Email())
 		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
-			"Failed to initiate restart: "+err.Error(), nil)
+			"Failed to initiate restart", nil)
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{
+	writeJSON(w, http.StatusOK, map[string]any{
 		"status":  "restarting",
 		"message": "Hub restart initiated",
 	})

--- a/pkg/hub/admin_maintenance.go
+++ b/pkg/hub/admin_maintenance.go
@@ -673,9 +673,9 @@ func (s *Server) handleCheckForUpdates(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleAdminRestart handles POST /api/v1/admin/maintenance/restart.
-// It initiates a graceful systemd restart of the hub service using the same
-// fire-and-forget pattern as the rebuild-server executor. The response is
-// sent before the restart takes effect so the client receives a 200.
+// It initiates a graceful systemd restart of the hub service. The
+// --no-block flag lets systemd schedule the restart asynchronously,
+// so the response is sent before the restart takes effect.
 func (s *Server) handleAdminRestart(w http.ResponseWriter, r *http.Request) {
 	user := GetUserIdentityFromContext(r.Context())
 	if user == nil || user.Role() != "admin" {

--- a/pkg/hub/admin_maintenance.go
+++ b/pkg/hub/admin_maintenance.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -669,4 +670,45 @@ func (s *Server) handleCheckForUpdates(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, result)
+}
+
+// handleAdminRestart handles POST /api/v1/admin/maintenance/restart.
+// It initiates a graceful systemd restart of the hub service using the same
+// fire-and-forget pattern as the rebuild-server executor. The response is
+// sent before the restart takes effect so the client receives a 200.
+func (s *Server) handleAdminRestart(w http.ResponseWriter, r *http.Request) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil || user.Role() != "admin" {
+		Forbidden(w)
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	serviceName := s.config.MaintenanceConfig.ServiceName
+	if serviceName == "" {
+		serviceName = "scion-hub"
+	}
+
+	log := s.maintenanceLog
+	log.Info("Hub restart requested via admin API", "user", user.Email(), "service", serviceName)
+
+	// Fire-and-forget: start the restart but don't wait for it.
+	// "systemctl restart" sends SIGTERM to this process, so cmd.Run()
+	// would never return. Using cmd.Start() lets us return success first.
+	cmd := exec.Command("sudo", "systemctl", "restart", serviceName)
+	if err := cmd.Start(); err != nil {
+		log.Error("Failed to initiate hub restart", "error", err, "user", user.Email())
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+			"Failed to initiate restart: "+err.Error(), nil)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"status":  "restarting",
+		"message": "Hub restart initiated",
+	})
 }

--- a/pkg/hub/admin_maintenance.go
+++ b/pkg/hub/admin_maintenance.go
@@ -696,11 +696,14 @@ func (s *Server) handleAdminRestart(w http.ResponseWriter, r *http.Request) {
 	log := s.maintenanceLog
 	log.Info("Hub restart requested via admin API", "user", user.Email(), "service", serviceName)
 
-	// Fire-and-forget: start the restart but don't wait for it.
-	// "systemctl restart" sends SIGTERM to this process, so cmd.Run()
-	// would never return. Using cmd.Start() lets us return success first.
-	cmd := exec.Command("sudo", "systemctl", "restart", serviceName)
-	if err := cmd.Start(); err != nil {
+	// Use --no-block so systemd schedules the restart asynchronously.
+	// Without it, "systemctl restart" waits for the service to fully
+	// stop and restart — but this process IS the service, creating a
+	// deadlock.  With --no-block, systemd returns immediately, cmd.Run()
+	// completes, and we can send the response before the process is
+	// killed.
+	cmd := exec.Command("sudo", "systemctl", "restart", "--no-block", serviceName)
+	if err := cmd.Run(); err != nil {
 		log.Error("Failed to initiate hub restart", "error", err, "user", user.Email())
 		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
 			"Failed to initiate restart", nil)

--- a/pkg/hub/admin_maintenance_test.go
+++ b/pkg/hub/admin_maintenance_test.go
@@ -607,6 +607,79 @@ func TestCheckForUpdates_NonAdmin(t *testing.T) {
 	}
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// handleAdminRestart tests
+// ────────────────────────────────────────────────────────────────────────────
+
+func TestHandleAdminRestart_Forbidden(t *testing.T) {
+	srv, _ := newTestServerWithStore(t)
+
+	// Non-admin user should receive 403.
+	member := NewAuthenticatedUser("u1", "member@example.com", "Member", "member", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/maintenance/restart", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), member))
+	rr := httptest.NewRecorder()
+	srv.handleAdminRestart(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Nil user (unauthenticated) should also receive 403.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/admin/maintenance/restart", nil)
+	rr2 := httptest.NewRecorder()
+	srv.handleAdminRestart(rr2, req2)
+
+	if rr2.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for nil user, got %d: %s", rr2.Code, rr2.Body.String())
+	}
+}
+
+func TestHandleAdminRestart_MethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServerWithStore(t)
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/maintenance/restart", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminRestart(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleAdminRestart_ExecFailure(t *testing.T) {
+	srv, _ := newTestServerWithStore(t)
+
+	// Clear PATH so that exec.Command("sudo", ...) fails at Start()
+	// because the binary cannot be found.
+	t.Setenv("PATH", t.TempDir())
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/maintenance/restart", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminRestart(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify the error message is generic and does not leak exec details (N1 fix).
+	var resp struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp.Error.Message != "Failed to initiate restart" {
+		t.Errorf("expected generic error message, got %q", resp.Error.Message)
+	}
+}
+
 func TestListMaintenanceOperations_HidesContainerBinariesByDefault(t *testing.T) {
 	srv, _ := newTestServerWithStore(t)
 	t.Setenv("SCION_DEV_BINARIES", "")

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3019,6 +3019,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/admin/maintenance/operations/", s.handleAdminMaintenanceOps)
 	s.mux.HandleFunc("/api/v1/admin/maintenance/migrations/", s.handleAdminMaintenanceMigrations)
 	s.mux.HandleFunc("/api/v1/admin/maintenance/check-updates", s.handleCheckForUpdates)
+	s.mux.HandleFunc("/api/v1/admin/maintenance/restart", s.handleAdminRestart)
 	s.mux.HandleFunc("/api/v1/admin/scheduler", s.handleAdminScheduler)
 	s.mux.HandleFunc("/api/v1/admin/allow-list", s.handleAdminAllowList)
 	s.mux.HandleFunc("/api/v1/admin/allow-list/", s.handleAdminAllowListByEmail)

--- a/web/src/components/pages/admin-maintenance.ts
+++ b/web/src/components/pages/admin-maintenance.ts
@@ -127,6 +127,14 @@ export class ScionPageAdminMaintenance extends LitElement {
   @state()
   private viewingRun: MaintenanceRun | null = null;
 
+  /** Whether the restart hub confirmation dialog is open. */
+  @state()
+  private restartDialogOpen = false;
+
+  /** Whether a restart request is in-flight. */
+  @state()
+  private restartLoading = false;
+
   /** Whether the bulk reset-auth request is in-flight. */
   @state()
   private resetAuthAllLoading = false;
@@ -925,6 +933,7 @@ export class ScionPageAdminMaintenance extends LitElement {
 
       ${this.renderRunDialog()}
       ${this.renderRunDetailDialog()}
+      ${this.renderRestartDialog()}
     `;
   }
 
@@ -969,6 +978,29 @@ export class ScionPageAdminMaintenance extends LitElement {
           One-off administrative actions across all agents.
         </p>
         <div class="card-list">
+          <div class="card">
+            <div class="card-header">
+              <sl-icon name="arrow-clockwise" class="pending"></sl-icon>
+              <span class="card-title">Restart Hub</span>
+              ${this.restartLoading
+                ? html`<sl-button size="small" disabled loading>Restarting...</sl-button>`
+                : html`
+                    <sl-button
+                      variant="warning"
+                      size="small"
+                      @click=${() => this.openRestartDialog()}
+                    >
+                      <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+                      Restart
+                    </sl-button>
+                  `}
+            </div>
+            <div class="card-description">
+              Restart the hub service via systemd. This will briefly drop all
+              active connections (including WebSockets) while the process restarts.
+              Use this after changing settings that require a restart to take effect.
+            </div>
+          </div>
           <div class="card">
             <div class="card-header">
               <sl-icon name="key" class="pending"></sl-icon>
@@ -1030,6 +1062,35 @@ export class ScionPageAdminMaintenance extends LitElement {
       showToast(err instanceof Error ? err.message : 'Failed to reset auth for all agents');
     } finally {
       this.resetAuthAllLoading = false;
+    }
+  }
+
+  private openRestartDialog(): void {
+    this.restartDialogOpen = true;
+  }
+
+  private closeRestartDialog(): void {
+    if (!this.restartLoading) {
+      this.restartDialogOpen = false;
+    }
+  }
+
+  private async handleRestartHub(): Promise<void> {
+    this.restartLoading = true;
+    try {
+      const response = await apiFetch('/api/v1/admin/maintenance/restart', {
+        method: 'POST',
+      });
+      if (!response.ok) {
+        const errMsg = await extractApiError(response, `HTTP ${response.status}`);
+        throw new Error(errMsg);
+      }
+      this.restartDialogOpen = false;
+      showToast('Hub is restarting... The page will reconnect shortly.', 'primary', { icon: 'info-circle', duration: 10000 });
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to restart hub');
+    } finally {
+      this.restartLoading = false;
     }
   }
 
@@ -1390,6 +1451,43 @@ export class ScionPageAdminMaintenance extends LitElement {
           variant="default"
           @click=${() => this.closeRunDetail()}
         >Close</sl-button>
+      </sl-dialog>
+    `;
+  }
+
+  private renderRestartDialog() {
+    if (!this.restartDialogOpen) return nothing;
+
+    return html`
+      <sl-dialog
+        label="Restart Hub"
+        open
+        @sl-request-close=${() => this.closeRestartDialog()}
+      >
+        <div class="dialog-body">
+          <p>
+            Are you sure you want to restart the hub service?
+          </p>
+          <p style="color: var(--sl-color-warning-700, #a16207); font-weight: 500;">
+            This will briefly disconnect all users and drop active WebSocket
+            connections. The hub will be back online within a few seconds.
+          </p>
+        </div>
+        <sl-button
+          slot="footer"
+          variant="default"
+          @click=${() => this.closeRestartDialog()}
+          ?disabled=${this.restartLoading}
+        >Cancel</sl-button>
+        <sl-button
+          slot="footer"
+          variant="warning"
+          ?loading=${this.restartLoading}
+          @click=${() => this.handleRestartHub()}
+        >
+          <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+          Restart Hub
+        </sl-button>
       </sl-dialog>
     `;
   }


### PR DESCRIPTION
Adds POST /api/v1/admin/maintenance/restart (fire-and-forget systemd restart, admin-gated) and a Restart Hub card with confirmation dialog in the admin maintenance page Quick Actions section. Ref: ptone/scion#866