### PR TITLE
feat(image-build): add thick base image variant using Cloud Workstations base

### DIFF
--- a/image-build/README.md
+++ b/image-build/README.md
@@ -14,6 +14,11 @@ core-base          System dependencies (Go, Node, Python)
   └── scion-base   Adds sciontool binary and scion user
         ├── harness images  Optional recipes from harnesses/<name>/
         └── hub             Scion hub server
+
+thick-prep         Patches Cloud Workstations base for scion compatibility (amd64 only)
+  └── scion-base   Same Dockerfile, different foundation
+        ├── harness images
+        └── hub
 ```
 
 `core-base/`, `scion-base/`, and `hub/` live under `image-build/`. Harness images
@@ -57,6 +62,8 @@ The orchestrator owns target sequencing, tag computation, and BASE_IMAGE threadi
 | `hub` | `scion-hub` | Hub server image. Uses existing `scion-base:<tag>`. |
 | `common` (default) | `scion-base` + catalog harnesses + hub | Skips `core-base`. Most common rebuild. |
 | `all` | Full DAG | Rebuilds everything from `core-base`. |
+| `thick-prep` | `thick-prep` | Prep layer for thick base. amd64 only. |
+| `thick` | `thick-prep` + `scion-base` + catalog harnesses + hub | Full thick rebuild using Cloud Workstations base instead of `core-base`. amd64 only. |
 
 ### Tagging
 
@@ -125,6 +132,8 @@ The `cloud-build` builder maps each `--target` to a static YAML file:
 | `scion-base` | `cloudbuild-scion-base.yaml` |
 | `harnesses` | `cloudbuild-harnesses.yaml` |
 | `hub` | `cloudbuild-hub.yaml` |
+| `thick-prep` | `cloudbuild-thick.yaml` |
+| `thick` | `cloudbuild-thick.yaml` |
 
 These YAMLs reference `$_TAG`, `$_SHORT_SHA`, `$_COMMIT_SHA`, and `$_REGISTRY` substitutions, all forwarded by the orchestrator.
 

--- a/image-build/README.md
+++ b/image-build/README.md
@@ -132,8 +132,13 @@ The `cloud-build` builder maps each `--target` to a static YAML file:
 | `scion-base` | `cloudbuild-scion-base.yaml` |
 | `harnesses` | `cloudbuild-harnesses.yaml` |
 | `hub` | `cloudbuild-hub.yaml` |
-| `thick-prep` | `cloudbuild-thick.yaml` |
+| `thick-prep` | `cloudbuild-thick.yaml` (builds the full thick chain — see note below) |
 | `thick` | `cloudbuild-thick.yaml` |
+
+**Note:** `--target thick-prep` with `--builder cloud-build` builds the full thick
+chain (thick-prep + scion-base + harnesses + hub), since both `thick-prep` and
+`thick` map to the same `cloudbuild-thick.yaml`. With per-image builders
+(`local-docker`, `local-podman`), `--target thick-prep` builds only thick-prep.
 
 These YAMLs reference `$_TAG`, `$_SHORT_SHA`, `$_COMMIT_SHA`, and `$_REGISTRY` substitutions, all forwarded by the orchestrator.
 

--- a/image-build/cloudbuild-thick.yaml
+++ b/image-build/cloudbuild-thick.yaml
@@ -1,0 +1,114 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Thick base full rebuild: thick-prep, scion-base, catalog harness images, and hub.
+# Uses the Google Cloud Workstations base image instead of core-base.
+# Architecture: amd64 only (the Cloud Workstations base has no arm64 variant).
+steps:
+  - name: 'gcr.io/cloud-builders/gcloud'
+    id: 'verify-registry'
+    entrypoint: 'bash'
+    args: ['image-build/scripts/verify-registry.sh', '$_REGISTRY']
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'setup-buildx'
+    args: ['buildx', 'create', '--name', 'mybuilder', '--use']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'bootstrap-buildx'
+    args: ['buildx', 'inspect', '--bootstrap']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  # Stage 1: Build thick-prep from Cloud Workstations base
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-thick-prep'
+    dir: 'image-build/thick-prep'
+    args: ['buildx', 'build', '--platform', 'linux/amd64', '-t', '$_REGISTRY/thick-prep:$_SHORT_SHA', '-t', '$_REGISTRY/thick-prep:$_TAG', '-f', 'Dockerfile', '--push', '.']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  # Stage 2: Build scion-base on top of thick-prep (replaces core-base)
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-scion-base'
+    args: ['buildx', 'build', '--platform', 'linux/amd64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/thick-prep:$_SHORT_SHA', '--build-arg', 'GIT_COMMIT=$_COMMIT_SHA', '-t', '$_REGISTRY/scion-base:$_SHORT_SHA', '-t', '$_REGISTRY/scion-base:$_TAG', '-f', 'image-build/scion-base/Dockerfile', '--pull', '--push', '.']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  # Stage 3: Build all harnesses and hub in parallel on top of thick scion-base
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-scion-antigravity'
+    dir: 'harnesses/antigravity'
+    args: ['buildx', 'build', '--platform', 'linux/amd64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_SHORT_SHA', '-t', '$_REGISTRY/scion-antigravity:$_SHORT_SHA', '-t', '$_REGISTRY/scion-antigravity:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-scion-claude'
+    dir: 'harnesses/claude'
+    args: ['buildx', 'build', '--platform', 'linux/amd64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_SHORT_SHA', '-t', '$_REGISTRY/scion-claude:$_SHORT_SHA', '-t', '$_REGISTRY/scion-claude:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-scion-codex'
+    dir: 'harnesses/codex'
+    args: ['buildx', 'build', '--platform', 'linux/amd64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_SHORT_SHA', '-t', '$_REGISTRY/scion-codex:$_SHORT_SHA', '-t', '$_REGISTRY/scion-codex:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-scion-copilot'
+    dir: 'harnesses/copilot'
+    args: ['buildx', 'build', '--platform', 'linux/amd64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_SHORT_SHA', '-t', '$_REGISTRY/scion-copilot:$_SHORT_SHA', '-t', '$_REGISTRY/scion-copilot:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-scion-gemini-cli'
+    dir: 'harnesses/gemini-cli'
+    args: ['buildx', 'build', '--platform', 'linux/amd64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_SHORT_SHA', '-t', '$_REGISTRY/scion-gemini-cli:$_SHORT_SHA', '-t', '$_REGISTRY/scion-gemini-cli:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-scion-hermes'
+    dir: 'harnesses/hermes'
+    args: ['buildx', 'build', '--platform', 'linux/amd64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_SHORT_SHA', '-t', '$_REGISTRY/scion-hermes:$_SHORT_SHA', '-t', '$_REGISTRY/scion-hermes:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-scion-opencode'
+    dir: 'harnesses/opencode'
+    args: ['buildx', 'build', '--platform', 'linux/amd64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_SHORT_SHA', '-t', '$_REGISTRY/scion-opencode:$_SHORT_SHA', '-t', '$_REGISTRY/scion-opencode:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-scion-hub'
+    dir: 'image-build/hub'
+    args: ['buildx', 'build', '--platform', 'linux/amd64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_SHORT_SHA', '-t', '$_REGISTRY/scion-hub:$_SHORT_SHA', '-t', '$_REGISTRY/scion-hub:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+substitutions:
+  _REGISTRY: 'us-central1-docker.pkg.dev/${PROJECT_ID}/public-docker'
+  _TAG: 'latest'
+options:
+  dynamicSubstitutions: true
+  machineType: 'E2_HIGHCPU_8'
+timeout: 14400s

--- a/image-build/cloudbuild-thick.yaml
+++ b/image-build/cloudbuild-thick.yaml
@@ -48,7 +48,7 @@ steps:
     env:
       - 'DOCKER_CLI_EXPERIMENTAL=enabled'
 
-  # Stage 3: Build all harnesses and hub in parallel on top of thick scion-base
+  # Stage 3: Build all harnesses and hub on top of thick scion-base
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-scion-antigravity'
     dir: 'harnesses/antigravity'

--- a/image-build/scripts/build-images.sh
+++ b/image-build/scripts/build-images.sh
@@ -143,6 +143,13 @@ if [[ -n "${PLATFORM}" ]]; then
   fi
 fi
 
+# Thick targets are amd64-only; reject early if arm64 is requested.
+if [[ "${THICK_BUILD}" == "true" && "${PLATFORMS}" == *"arm64"* ]]; then
+  echo "Error: --target ${TARGET} is amd64-only (Cloud Workstations base has no arm64 variant)." >&2
+  echo "Remove --platform or use --platform linux/amd64." >&2
+  exit 1
+fi
+
 # Multi-arch builds require --push (buildx can't load multi-arch images
 # into the local docker daemon). Auto-promote and warn, matching the prior
 # build-images.sh behavior.

--- a/image-build/scripts/build-images.sh
+++ b/image-build/scripts/build-images.sh
@@ -37,6 +37,7 @@ REGISTRY=""
 TARGET="common"
 TAG="latest"
 PLATFORM=""
+PLATFORM_EXPLICIT="false"
 PUSH="false"
 DRY_RUN="false"
 
@@ -94,7 +95,7 @@ while [[ $# -gt 0 ]]; do
     --registry) REGISTRY="$2"; shift 2 ;;
     --target)   TARGET="$2"; shift 2 ;;
     --tag)      TAG="$2"; shift 2 ;;
-    --platform) PLATFORM="$2"; shift 2 ;;
+    --platform) PLATFORM="$2"; PLATFORM_EXPLICIT="true"; shift 2 ;;
     --push)     PUSH="true"; shift ;;
     --dry-run)  DRY_RUN="true"; shift ;;
     -h|--help)  usage 0 ;;
@@ -106,7 +107,7 @@ REGISTRY="${REGISTRY%/}"
 
 # Set THICK_BUILD flag when building the thick target, so step descriptors
 # in targets.sh route scion-base to thick-prep instead of core-base.
-THICK_BUILD="false"
+THICK_BUILD="${THICK_BUILD:-false}"
 if [[ "${TARGET}" == "thick" || "${TARGET}" == "thick-prep" ]]; then
   THICK_BUILD="true"
 fi
@@ -143,11 +144,17 @@ if [[ -n "${PLATFORM}" ]]; then
   fi
 fi
 
-# Thick targets are amd64-only; reject early if arm64 is requested.
-if [[ "${THICK_BUILD}" == "true" && "${PLATFORMS}" == *"arm64"* ]]; then
-  echo "Error: --target ${TARGET} is amd64-only (Cloud Workstations base has no arm64 variant)." >&2
-  echo "Remove --platform or use --platform linux/amd64." >&2
-  exit 1
+# Thick targets are amd64-only. When the user explicitly requested arm64,
+# error out. When no --platform was given, default to linux/amd64 so that
+# builds on arm64 hosts (e.g. Apple Silicon) don't silently fail.
+if [[ "${THICK_BUILD}" == "true" ]]; then
+  if [[ "${PLATFORM_EXPLICIT}" == "true" && "${PLATFORMS}" == *"arm64"* ]]; then
+    echo "Error: --target ${TARGET} is amd64-only (Cloud Workstations base has no arm64 variant)." >&2
+    echo "Remove --platform or use --platform linux/amd64." >&2
+    exit 1
+  elif [[ "${PLATFORM_EXPLICIT}" != "true" ]]; then
+    PLATFORMS="linux/amd64"
+  fi
 fi
 
 # Multi-arch builds require --push (buildx can't load multi-arch images

--- a/image-build/scripts/build-images.sh
+++ b/image-build/scripts/build-images.sh
@@ -66,6 +66,10 @@ Options:
                           hub         - just scion-hub (uses existing scion-base:<tag>)
                           common      - scion-base + harnesses + hub (skip core-base)
                           all         - full rebuild including core-base
+                          thick-prep  - just the thick base prep layer (amd64 only)
+                          thick       - full thick rebuild: thick-prep + scion-base +
+                                        harnesses + hub (amd64 only, uses Cloud
+                                        Workstations base instead of core-base)
   --tag <tag>           Mutable image tag (default: latest). The :<short-sha> tag
                         is always added when run inside a git repo.
   --platform <plat>     Target platform(s) (default: builder's native arch)
@@ -99,6 +103,14 @@ while [[ $# -gt 0 ]]; do
 done
 
 REGISTRY="${REGISTRY%/}"
+
+# Set THICK_BUILD flag when building the thick target, so step descriptors
+# in targets.sh route scion-base to thick-prep instead of core-base.
+THICK_BUILD="false"
+if [[ "${TARGET}" == "thick" || "${TARGET}" == "thick-prep" ]]; then
+  THICK_BUILD="true"
+fi
+export THICK_BUILD
 
 # Validate builder against allow-list.
 builder_ok="false"

--- a/image-build/scripts/builders/cloud-build.sh
+++ b/image-build/scripts/builders/cloud-build.sh
@@ -48,6 +48,8 @@ cloud_build_config_for_target() {
     scion-base) file="cloudbuild-scion-base.yaml" ;;
     harnesses)  file="cloudbuild-harnesses.yaml" ;;
     hub)        file="cloudbuild-hub.yaml" ;;
+    thick-prep) file="cloudbuild-thick.yaml" ;;
+    thick)      file="cloudbuild-thick.yaml" ;;
     *)
       echo "cloud-build: no cloudbuild-*.yaml mapping for target '${target}'" >&2
       return 1

--- a/image-build/scripts/lib/targets.sh
+++ b/image-build/scripts/lib/targets.sh
@@ -52,6 +52,7 @@ emit_harness_steps() {
 # harnesses catalog.
 ALL_STEP_IDS=(
   core-base
+  thick-prep
   scion-base
 )
 while IFS= read -r harness_step; do
@@ -65,11 +66,13 @@ ALL_STEP_IDS+=(
 # validation.
 ALL_TARGETS=(
   core-base
+  thick-prep
   scion-base
   harnesses
   hub
   common
   all
+  thick
 )
 
 # resolve_targets <target>
@@ -100,6 +103,14 @@ resolve_targets() {
       emit_harness_steps
       printf '%s\n' scion-hub
       ;;
+    thick-prep)
+      echo thick-prep
+      ;;
+    thick)
+      printf '%s\n' thick-prep scion-base
+      emit_harness_steps
+      printf '%s\n' scion-hub
+      ;;
     *)
       return 1
       ;;
@@ -118,6 +129,7 @@ step_image_name() {
 step_dockerfile() {
   case "$1" in
     core-base)     echo "${IMAGE_BUILD_DIR}/core-base/Dockerfile" ;;
+    thick-prep)    echo "${IMAGE_BUILD_DIR}/thick-prep/Dockerfile" ;;
     scion-base)    echo "${IMAGE_BUILD_DIR}/scion-base/Dockerfile" ;;
     scion-hub)     echo "${IMAGE_BUILD_DIR}/hub/Dockerfile" ;;
     *)
@@ -138,6 +150,7 @@ step_dockerfile() {
 step_context_dir() {
   case "$1" in
     core-base)     echo "${IMAGE_BUILD_DIR}/core-base" ;;
+    thick-prep)    echo "${IMAGE_BUILD_DIR}/thick-prep" ;;
     scion-base)    echo "${REPO_ROOT}" ;;
     scion-hub)     echo "${IMAGE_BUILD_DIR}/hub" ;;
     *)
@@ -167,8 +180,15 @@ step_build_args() {
     core-base)
       # No build-args.
       ;;
+    thick-prep)
+      # No build-args — BASE_IMAGE default is in the Dockerfile ARG.
+      ;;
     scion-base)
-      echo "BASE_IMAGE=${prefix}core-base:${BASE_TAG}"
+      if [[ "${THICK_BUILD:-}" == "true" ]]; then
+        echo "BASE_IMAGE=${prefix}thick-prep:${BASE_TAG}"
+      else
+        echo "BASE_IMAGE=${prefix}core-base:${BASE_TAG}"
+      fi
       if [[ -n "${COMMIT_SHA:-}" ]]; then
         echo "GIT_COMMIT=${COMMIT_SHA}"
       fi
@@ -194,7 +214,14 @@ step_build_args() {
 step_parent() {
   case "$1" in
     core-base)     echo "" ;;
-    scion-base)    echo "core-base" ;;
+    thick-prep)    echo "" ;;
+    scion-base)
+      if [[ "${THICK_BUILD:-}" == "true" ]]; then
+        echo "thick-prep"
+      else
+        echo "core-base"
+      fi
+      ;;
     scion-hub)     echo "scion-base" ;;
     *)
       if is_harness_step "$1"; then

--- a/image-build/thick-prep/Dockerfile
+++ b/image-build/thick-prep/Dockerfile
@@ -33,7 +33,8 @@ USER root
 
 # Remove the ubuntu user (UID 1000) to avoid conflict with the scion user
 # that scion-base creates at the same UID.
-RUN userdel -r ubuntu 2>/dev/null || true
+RUN userdel -r ubuntu 2>/dev/null || true && \
+    groupdel ubuntu 2>/dev/null || true
 
 # Install packages that scion-base and harnesses expect but the thick base lacks.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/image-build/thick-prep/Dockerfile
+++ b/image-build/thick-prep/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Thick Base Prep Layer
+# Prepares the Google Cloud Workstations base image for use as a scion-base
+# foundation. Fixes compatibility issues between the Cloud Workstations image
+# and scion-base's expectations:
+#
+#   1. UID 1000 conflict  - Cloud Workstations ships an 'ubuntu' user at UID
+#      1000; scion-base creates 'scion' at the same UID.
+#   2. Missing packages   - zsh (required by useradd -s /bin/zsh), fzf (claude
+#      harness keybindings), gh and ripgrep (core scion tools).
+#   3. Missing directory  - /usr/local/share/npm-global (scion-base chowns it).
+#
+# Architecture: amd64 only (Cloud Workstations base has no arm64 variant).
+
+ARG BASE_IMAGE=us-central1-docker.pkg.dev/cloud-workstations-images/predefined/base:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Remove the ubuntu user (UID 1000) to avoid conflict with the scion user
+# that scion-base creates at the same UID.
+RUN userdel -r ubuntu 2>/dev/null || true
+
+# Install packages that scion-base and harnesses expect but the thick base lacks.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    zsh \
+    fzf \
+    gh \
+    ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create the npm-global directory that scion-base expects to chown.
+RUN mkdir -p /usr/local/share/npm-global


### PR DESCRIPTION
Add a thick build target using the Google Cloud Workstations base image as an alternative to core-base. Includes a thick-prep intermediate layer for compatibility, Cloud Build config, build script integration, and documentation. All 10 images (base, 7 harnesses, hub) built and verified. amd64 only.

Ref: ptone/scion#301