### PR TITLE
feat(auth): add OIDC-based federation authentication with multi-issuer support

### DIFF
--- a/pkg/config/federation_config.go
+++ b/pkg/config/federation_config.go
@@ -88,6 +88,8 @@ func (c *FederationConfig) Validate() []error {
 				errs = append(errs, fmt.Errorf("trusted_issuers[%d]: invalid issuer_url %q: %v", i, issuer.IssuerURL, err))
 			} else if u.Scheme != "https" && u.Scheme != "http" {
 				errs = append(errs, fmt.Errorf("trusted_issuers[%d]: issuer_url %q must use https or http scheme", i, issuer.IssuerURL))
+			} else if u.Host == "" {
+				errs = append(errs, fmt.Errorf("trusted_issuers[%d]: issuer_url %q has no host", i, issuer.IssuerURL))
 			}
 
 			if seen[issuer.IssuerURL] {

--- a/pkg/config/federation_config.go
+++ b/pkg/config/federation_config.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// FederationConfig holds configuration for hub-hub federation authentication.
+type FederationConfig struct {
+	Enabled        bool                  `json:"enabled" yaml:"enabled" koanf:"enabled"`
+	TrustedIssuers []TrustedIssuerConfig `json:"trusted_issuers,omitempty" yaml:"trusted_issuers,omitempty" koanf:"trusted_issuers"`
+	Algorithms     []string              `json:"algorithms,omitempty" yaml:"algorithms,omitempty" koanf:"algorithms"`
+	Cache          FederationCacheConfig `json:"cache,omitempty" yaml:"cache,omitempty" koanf:"cache"`
+}
+
+// TrustedIssuerConfig holds configuration for a single trusted OIDC issuer.
+// The issuer is not assumed to be a Scion Hub — any OIDC-compliant issuer
+// with a JWKS endpoint should work.
+type TrustedIssuerConfig struct {
+	IssuerURL        string   `json:"issuer_url" yaml:"issuer_url" koanf:"issuer_url"`
+	JWKSURL          string   `json:"jwks_url,omitempty" yaml:"jwks_url,omitempty" koanf:"jwks_url"`
+	ExpectedAudience string   `json:"expected_audience,omitempty" yaml:"expected_audience,omitempty" koanf:"expected_audience"`
+	AllowedProjects  []string `json:"allowed_projects,omitempty" yaml:"allowed_projects,omitempty" koanf:"allowed_projects"`
+	AllowedRootUsers []string `json:"allowed_root_users,omitempty" yaml:"allowed_root_users,omitempty" koanf:"allowed_root_users"`
+	// DefaultScopes holds scope strings applied to federated agents from this issuer.
+	// These are string representations of AgentTokenScope (defined in pkg/hub/agenttoken.go);
+	// string is used here to avoid a circular import between pkg/config and pkg/hub.
+	DefaultScopes []string `json:"default_scopes,omitempty" yaml:"default_scopes,omitempty" koanf:"default_scopes"`
+}
+
+// FederationCacheConfig holds cache tuning parameters for federation JWKS fetching.
+type FederationCacheConfig struct {
+	RefreshInterval  time.Duration `json:"refresh_interval,omitempty" yaml:"refresh_interval,omitempty" koanf:"refresh_interval"`
+	DebounceInterval time.Duration `json:"debounce_interval,omitempty" yaml:"debounce_interval,omitempty" koanf:"debounce_interval"`
+}
+
+// allowedAlgorithms is the set of algorithms permitted for federation token validation.
+var allowedAlgorithms = map[string]bool{
+	"RS256": true,
+	"ES256": true,
+}
+
+// Validate checks FederationConfig for configuration errors.
+// It returns a slice of all errors found (not just the first).
+func (c *FederationConfig) Validate() []error {
+	var errs []error
+
+	if !c.Enabled {
+		return nil
+	}
+
+	// Rule 1: When enabled, at least one trusted issuer is required.
+	if len(c.TrustedIssuers) == 0 {
+		errs = append(errs, fmt.Errorf("federation is enabled but no trusted_issuers are configured"))
+	}
+
+	// Rule 3: Validate algorithms (if specified).
+	for _, alg := range c.Algorithms {
+		if !allowedAlgorithms[alg] {
+			errs = append(errs, fmt.Errorf("unsupported algorithm %q: only RS256 and ES256 are allowed", alg))
+		}
+	}
+
+	// Rule 5: Check for duplicate IssuerURLs.
+	seen := make(map[string]bool)
+	for i, issuer := range c.TrustedIssuers {
+		// Rule 2: Validate IssuerURL is a valid URL with http(s) scheme.
+		if issuer.IssuerURL == "" {
+			errs = append(errs, fmt.Errorf("trusted_issuers[%d]: issuer_url is required", i))
+		} else {
+			u, err := url.Parse(issuer.IssuerURL)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("trusted_issuers[%d]: invalid issuer_url %q: %v", i, issuer.IssuerURL, err))
+			} else if u.Scheme != "https" && u.Scheme != "http" {
+				errs = append(errs, fmt.Errorf("trusted_issuers[%d]: issuer_url %q must use https or http scheme", i, issuer.IssuerURL))
+			}
+
+			if seen[issuer.IssuerURL] {
+				errs = append(errs, fmt.Errorf("trusted_issuers[%d]: duplicate issuer_url %q", i, issuer.IssuerURL))
+			}
+			seen[issuer.IssuerURL] = true
+		}
+
+		// Rule 4: Empty ExpectedAudience is allowed (resolved later).
+	}
+
+	return errs
+}

--- a/pkg/config/federation_config.go
+++ b/pkg/config/federation_config.go
@@ -127,11 +127,9 @@ func (c *FederationConfig) Validate() []error {
 			errs = append(errs, fmt.Errorf("trusted_issuers[%d]: unknown issuer_type %q (must be \"hub\", \"service_account\", or \"user\")", i, issuer.IssuerType))
 		}
 
-		// Rule 7: Non-hub issuers require jwks_url (OIDC discovery not yet implemented).
+		// Rule 7: Non-hub issuers may omit jwks_url if OIDC discovery is available.
+		// The authenticator will attempt discovery at startup and fail if neither works.
 		isNonHub := issuer.IssuerType != "" && issuer.IssuerType != "hub"
-		if isNonHub && issuer.JWKSURL == "" {
-			errs = append(errs, fmt.Errorf("trusted_issuers[%d]: jwks_url is required for issuer_type %q (OIDC discovery not yet implemented)", i, issuer.IssuerType))
-		}
 
 		// Rule 8: Warn if hub-specific fields are set on non-hub issuers.
 		if isNonHub && len(issuer.AllowedProjects) > 0 {

--- a/pkg/config/federation_config.go
+++ b/pkg/config/federation_config.go
@@ -41,12 +41,34 @@ type TrustedIssuerConfig struct {
 	// These are string representations of AgentTokenScope (defined in pkg/hub/agenttoken.go);
 	// string is used here to avoid a circular import between pkg/config and pkg/hub.
 	DefaultScopes []string `json:"default_scopes,omitempty" yaml:"default_scopes,omitempty" koanf:"default_scopes"`
+
+	// IssuerType controls claims extraction and identity construction.
+	// Default: "hub". Options: "hub", "service_account", "user".
+	// Uses string (not the hub IssuerType type) to avoid circular imports.
+	IssuerType string `json:"issuer_type,omitempty" yaml:"issuer_type,omitempty" koanf:"issuer_type"`
+
+	// DefaultRole sets the role for federated user identities (issuer_type: user).
+	// Ignored for other issuer types. Default: "viewer".
+	DefaultRole string `json:"default_role,omitempty" yaml:"default_role,omitempty" koanf:"default_role"`
+
+	// AllowedEmails restricts accepted tokens to specific email claims.
+	// Supports leading-wildcard suffix matching (e.g. "*@example.com").
+	// If empty, all emails accepted.
+	AllowedEmails []string `json:"allowed_emails,omitempty" yaml:"allowed_emails,omitempty" koanf:"allowed_emails"`
 }
 
 // FederationCacheConfig holds cache tuning parameters for federation JWKS fetching.
 type FederationCacheConfig struct {
 	RefreshInterval  time.Duration `json:"refresh_interval,omitempty" yaml:"refresh_interval,omitempty" koanf:"refresh_interval"`
 	DebounceInterval time.Duration `json:"debounce_interval,omitempty" yaml:"debounce_interval,omitempty" koanf:"debounce_interval"`
+}
+
+// allowedIssuerTypes is the set of valid issuer_type values for TrustedIssuerConfig.
+var allowedIssuerTypes = map[string]bool{
+	"":                true, // empty defaults to "hub"
+	"hub":             true,
+	"service_account": true,
+	"user":            true,
 }
 
 // allowedAlgorithms is the set of algorithms permitted for federation token validation.
@@ -99,6 +121,25 @@ func (c *FederationConfig) Validate() []error {
 		}
 
 		// Rule 4: Empty ExpectedAudience is allowed (resolved later).
+
+		// Rule 6: Validate issuer_type is a known value.
+		if !allowedIssuerTypes[issuer.IssuerType] {
+			errs = append(errs, fmt.Errorf("trusted_issuers[%d]: unknown issuer_type %q (must be \"hub\", \"service_account\", or \"user\")", i, issuer.IssuerType))
+		}
+
+		// Rule 7: Non-hub issuers require jwks_url (OIDC discovery not yet implemented).
+		isNonHub := issuer.IssuerType != "" && issuer.IssuerType != "hub"
+		if isNonHub && issuer.JWKSURL == "" {
+			errs = append(errs, fmt.Errorf("trusted_issuers[%d]: jwks_url is required for issuer_type %q (OIDC discovery not yet implemented)", i, issuer.IssuerType))
+		}
+
+		// Rule 8: Warn if hub-specific fields are set on non-hub issuers.
+		if isNonHub && len(issuer.AllowedProjects) > 0 {
+			errs = append(errs, fmt.Errorf("trusted_issuers[%d]: allowed_projects is not applicable for issuer_type %q", i, issuer.IssuerType))
+		}
+		if isNonHub && len(issuer.AllowedRootUsers) > 0 {
+			errs = append(errs, fmt.Errorf("trusted_issuers[%d]: allowed_root_users is not applicable for issuer_type %q", i, issuer.IssuerType))
+		}
 	}
 
 	return errs

--- a/pkg/config/federation_config_test.go
+++ b/pkg/config/federation_config_test.go
@@ -152,6 +152,17 @@ func TestFederationConfig_Validate(t *testing.T) {
 			wantSubst: []string{"must use https or http scheme"},
 		},
 		{
+			name: "issuer URL with empty host is rejected",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: "https://"},
+				},
+			},
+			wantErrs:  1,
+			wantSubst: []string{"has no host"},
+		},
+		{
 			name: "empty issuer URL is rejected",
 			config: FederationConfig{
 				Enabled: true,

--- a/pkg/config/federation_config_test.go
+++ b/pkg/config/federation_config_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFederationConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    FederationConfig
+		wantErrs  int  // expected number of errors (0 = valid)
+		wantSubst []string // substrings expected in error messages
+	}{
+		{
+			name: "disabled with no issuers is valid",
+			config: FederationConfig{
+				Enabled: false,
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "enabled with no issuers is invalid",
+			config: FederationConfig{
+				Enabled: true,
+			},
+			wantErrs: 1,
+			wantSubst: []string{"no trusted_issuers"},
+		},
+		{
+			name: "enabled with valid issuer is valid",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: "https://hub.example.com"},
+				},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "enabled with http issuer is valid",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: "http://localhost:9810"},
+				},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "duplicate issuer URLs are rejected",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: "https://hub-a.example.com"},
+					{IssuerURL: "https://hub-a.example.com"},
+				},
+			},
+			wantErrs: 1,
+			wantSubst: []string{"duplicate issuer_url"},
+		},
+		{
+			name: "HS256 algorithm is rejected",
+			config: FederationConfig{
+				Enabled:    true,
+				Algorithms: []string{"HS256"},
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: "https://hub.example.com"},
+				},
+			},
+			wantErrs: 1,
+			wantSubst: []string{"unsupported algorithm", "HS256"},
+		},
+		{
+			name: "none algorithm is rejected",
+			config: FederationConfig{
+				Enabled:    true,
+				Algorithms: []string{"none"},
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: "https://hub.example.com"},
+				},
+			},
+			wantErrs: 1,
+			wantSubst: []string{"unsupported algorithm", "none"},
+		},
+		{
+			name: "RS256 algorithm is valid",
+			config: FederationConfig{
+				Enabled:    true,
+				Algorithms: []string{"RS256"},
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: "https://hub.example.com"},
+				},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "RS256 and ES256 algorithms are valid",
+			config: FederationConfig{
+				Enabled:    true,
+				Algorithms: []string{"RS256", "ES256"},
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: "https://hub.example.com"},
+				},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "empty algorithms is valid",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: "https://hub.example.com"},
+				},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "issuer URL with no scheme is rejected",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: "hub.example.com"},
+				},
+			},
+			wantErrs: 1,
+			wantSubst: []string{"must use https or http scheme"},
+		},
+		{
+			name: "issuer URL with non-http scheme is rejected",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: "ftp://hub.example.com"},
+				},
+			},
+			wantErrs: 1,
+			wantSubst: []string{"must use https or http scheme"},
+		},
+		{
+			name: "empty issuer URL is rejected",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: ""},
+				},
+			},
+			wantErrs: 1,
+			wantSubst: []string{"issuer_url is required"},
+		},
+		{
+			name: "empty expected_audience is valid",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{
+						IssuerURL:        "https://hub.example.com",
+						ExpectedAudience: "",
+					},
+				},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "multiple errors are collected",
+			config: FederationConfig{
+				Enabled:    true,
+				Algorithms: []string{"HS256", "none"},
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: "ftp://bad.example.com"},
+					{IssuerURL: "https://good.example.com"},
+					{IssuerURL: "https://good.example.com"},
+				},
+			},
+			wantErrs: 4, // 2 bad algorithms + 1 bad scheme + 1 duplicate
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := tt.config.Validate()
+			if len(errs) != tt.wantErrs {
+				t.Errorf("Validate() returned %d errors, want %d: %v", len(errs), tt.wantErrs, errs)
+				return
+			}
+			if len(tt.wantSubst) > 0 && len(errs) > 0 {
+				combined := ""
+				for _, e := range errs {
+					combined += e.Error() + " "
+				}
+				for _, sub := range tt.wantSubst {
+					if !strings.Contains(combined, sub) {
+						t.Errorf("expected error messages to contain %q, got: %s", sub, combined)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/config/federation_config_test.go
+++ b/pkg/config/federation_config_test.go
@@ -260,19 +260,18 @@ func TestFederationConfig_Validate(t *testing.T) {
 			wantErrs: 0,
 		},
 		{
-			name: "non-hub issuer without jwks_url is rejected",
+			name: "non-hub issuer without jwks_url is valid (OIDC discovery available)",
 			config: FederationConfig{
 				Enabled: true,
 				TrustedIssuers: []TrustedIssuerConfig{
 					{
 						IssuerURL:  "https://accounts.google.com",
 						IssuerType: "service_account",
-						// JWKSURL omitted
+						// JWKSURL omitted — OIDC discovery can resolve it at runtime
 					},
 				},
 			},
-			wantErrs:  1,
-			wantSubst: []string{"jwks_url is required"},
+			wantErrs: 0,
 		},
 		{
 			name: "allowed_projects on non-hub issuer produces warning error",

--- a/pkg/config/federation_config_test.go
+++ b/pkg/config/federation_config_test.go
@@ -23,7 +23,7 @@ func TestFederationConfig_Validate(t *testing.T) {
 	tests := []struct {
 		name      string
 		config    FederationConfig
-		wantErrs  int  // expected number of errors (0 = valid)
+		wantErrs  int      // expected number of errors (0 = valid)
 		wantSubst []string // substrings expected in error messages
 	}{
 		{
@@ -38,7 +38,7 @@ func TestFederationConfig_Validate(t *testing.T) {
 			config: FederationConfig{
 				Enabled: true,
 			},
-			wantErrs: 1,
+			wantErrs:  1,
 			wantSubst: []string{"no trusted_issuers"},
 		},
 		{
@@ -70,7 +70,7 @@ func TestFederationConfig_Validate(t *testing.T) {
 					{IssuerURL: "https://hub-a.example.com"},
 				},
 			},
-			wantErrs: 1,
+			wantErrs:  1,
 			wantSubst: []string{"duplicate issuer_url"},
 		},
 		{
@@ -82,7 +82,7 @@ func TestFederationConfig_Validate(t *testing.T) {
 					{IssuerURL: "https://hub.example.com"},
 				},
 			},
-			wantErrs: 1,
+			wantErrs:  1,
 			wantSubst: []string{"unsupported algorithm", "HS256"},
 		},
 		{
@@ -94,7 +94,7 @@ func TestFederationConfig_Validate(t *testing.T) {
 					{IssuerURL: "https://hub.example.com"},
 				},
 			},
-			wantErrs: 1,
+			wantErrs:  1,
 			wantSubst: []string{"unsupported algorithm", "none"},
 		},
 		{
@@ -137,7 +137,7 @@ func TestFederationConfig_Validate(t *testing.T) {
 					{IssuerURL: "hub.example.com"},
 				},
 			},
-			wantErrs: 1,
+			wantErrs:  1,
 			wantSubst: []string{"must use https or http scheme"},
 		},
 		{
@@ -148,7 +148,7 @@ func TestFederationConfig_Validate(t *testing.T) {
 					{IssuerURL: "ftp://hub.example.com"},
 				},
 			},
-			wantErrs: 1,
+			wantErrs:  1,
 			wantSubst: []string{"must use https or http scheme"},
 		},
 		{
@@ -170,7 +170,7 @@ func TestFederationConfig_Validate(t *testing.T) {
 					{IssuerURL: ""},
 				},
 			},
-			wantErrs: 1,
+			wantErrs:  1,
 			wantSubst: []string{"issuer_url is required"},
 		},
 		{

--- a/pkg/config/federation_config_test.go
+++ b/pkg/config/federation_config_test.go
@@ -199,6 +199,127 @@ func TestFederationConfig_Validate(t *testing.T) {
 			},
 			wantErrs: 4, // 2 bad algorithms + 1 bad scheme + 1 duplicate
 		},
+		// --- issuer_type validation ---
+		{
+			name: "issuer_type hub is valid",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: "https://hub.example.com", IssuerType: "hub"},
+				},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "issuer_type service_account is valid with jwks_url",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{
+						IssuerURL:  "https://accounts.google.com",
+						IssuerType: "service_account",
+						JWKSURL:    "https://www.googleapis.com/oauth2/v3/certs",
+					},
+				},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "issuer_type user is valid with jwks_url",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{
+						IssuerURL:  "https://securetoken.google.com/my-project",
+						IssuerType: "user",
+						JWKSURL:    "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com",
+					},
+				},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "unknown issuer_type is rejected",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: "https://hub.example.com", IssuerType: "unknown", JWKSURL: "https://example.com/jwks"},
+				},
+			},
+			wantErrs:  1,
+			wantSubst: []string{"unknown issuer_type"},
+		},
+		{
+			name: "empty issuer_type defaults to hub (valid)",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{IssuerURL: "https://hub.example.com", IssuerType: ""},
+				},
+			},
+			wantErrs: 0,
+		},
+		{
+			name: "non-hub issuer without jwks_url is rejected",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{
+						IssuerURL:  "https://accounts.google.com",
+						IssuerType: "service_account",
+						// JWKSURL omitted
+					},
+				},
+			},
+			wantErrs:  1,
+			wantSubst: []string{"jwks_url is required"},
+		},
+		{
+			name: "allowed_projects on non-hub issuer produces warning error",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{
+						IssuerURL:       "https://accounts.google.com",
+						IssuerType:      "service_account",
+						JWKSURL:         "https://www.googleapis.com/oauth2/v3/certs",
+						AllowedProjects: []string{"project-1"},
+					},
+				},
+			},
+			wantErrs:  1,
+			wantSubst: []string{"allowed_projects is not applicable"},
+		},
+		{
+			name: "allowed_root_users on non-hub issuer produces warning error",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{
+						IssuerURL:        "https://securetoken.google.com/proj",
+						IssuerType:       "user",
+						JWKSURL:          "https://www.googleapis.com/keys",
+						AllowedRootUsers: []string{"user:alice"},
+					},
+				},
+			},
+			wantErrs:  1,
+			wantSubst: []string{"allowed_root_users is not applicable"},
+		},
+		{
+			name: "hub issuer with allowed_projects is still valid",
+			config: FederationConfig{
+				Enabled: true,
+				TrustedIssuers: []TrustedIssuerConfig{
+					{
+						IssuerURL:       "https://hub.example.com",
+						IssuerType:      "hub",
+						AllowedProjects: []string{"project-1"},
+					},
+				},
+			},
+			wantErrs: 0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -380,6 +380,9 @@ type GlobalConfig struct {
 	// OIDC Identity Provider settings
 	OIDC OIDCProviderConfig `json:"oidc,omitempty" yaml:"oidc,omitempty" koanf:"oidc"`
 
+	// Federation settings for hub-hub authentication
+	Federation FederationConfig `json:"federation,omitempty" yaml:"federation,omitempty" koanf:"federation"`
+
 	// SlowRequestThreshold is the duration after which an HTTP request is
 	// logged as slow. Default: 10s when unset/zero.
 	SlowRequestThreshold time.Duration `json:"slowRequestThreshold,omitempty" yaml:"slowRequestThreshold,omitempty" koanf:"slowRequestThreshold"`

--- a/pkg/hub/auth.go
+++ b/pkg/hub/auth.go
@@ -54,6 +54,9 @@ type AuthConfig struct {
 	ProxyUserProvisioner func(ctx context.Context, info *ProxyUserInfo) (UserIdentity, error)
 	// AuthMode is the exclusive human auth mode: "oauth", "proxy", "dev".
 	AuthMode string
+	// FederationAuthenticator validates OIDC tokens from trusted external hubs.
+	// nil when federation is disabled.
+	FederationAuthenticator *FederationAuthenticator
 	// Debug enables verbose logging
 	Debug bool
 	// Logger is the subsystem logger for auth middleware (defaults to slog.Default())
@@ -138,6 +141,35 @@ func UnifiedAuthMiddleware(cfg AuthConfig) func(http.Handler) http.Handler {
 					}
 				}
 				// Bearer token wasn't an agent token, continue to user auth
+			}
+
+			// Step 1.5: Federation OIDC token (X-Scion-Federation-Token header)
+			if federationToken := r.Header.Get(FederationTokenHeader); federationToken != "" {
+				if cfg.FederationAuthenticator == nil {
+					// Header present but federation not enabled — reject, don't silently ignore
+					writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized,
+						"federation authentication is not configured", nil)
+					return
+				}
+				identity, err := cfg.FederationAuthenticator.Authenticate(federationToken)
+				if err != nil {
+					if cfg.Debug {
+						log.Debug("Federation token validation failed", "error", err)
+					}
+					writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized,
+						"invalid federation token", nil)
+					return
+				}
+				ctx = contextWithIdentity(ctx, identity)
+				ctx = contextWithAuthType(ctx, AuthTypeFederation)
+				if cfg.Debug {
+					log.Debug("Federated agent authenticated",
+						"issuer", identity.IssuerURL(),
+						"agent_id", identity.RemoteAgentID(),
+						"agent_name", identity.AgentName())
+				}
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
 			}
 
 			// Step 2: Check for broker HMAC authentication (X-Scion-Broker-ID header)

--- a/pkg/hub/auth.go
+++ b/pkg/hub/auth.go
@@ -163,10 +163,10 @@ func UnifiedAuthMiddleware(cfg AuthConfig) func(http.Handler) http.Handler {
 				ctx = contextWithIdentity(ctx, identity)
 				ctx = contextWithAuthType(ctx, AuthTypeFederation)
 				if cfg.Debug {
-					log.Debug("Federated agent authenticated",
+					log.Debug("Federated identity authenticated",
 						"issuer", identity.IssuerURL(),
-						"agent_id", identity.RemoteAgentID(),
-						"agent_name", identity.AgentName())
+						"type", identity.Type(),
+						"id", identity.ID())
 				}
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return

--- a/pkg/hub/federation_access.go
+++ b/pkg/hub/federation_access.go
@@ -19,19 +19,33 @@ import (
 	"net/http"
 )
 
+// scopeChecker is implemented by identity types that support scope-based access control.
+type scopeChecker interface {
+	HasScope(scope AgentTokenScope) bool
+}
+
 // RequireFederationAccess returns a middleware that requires the caller to be
-// either a local agent or a federated agent with the specified scope.
-// This works for both local and federated agents because both implement AgentIdentity.
+// any identity with scope-based access (local agent, federated agent,
+// federated service account, or federated user) and to have the specified scope.
 func RequireFederationAccess(scope AgentTokenScope) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			identity := GetAgentIdentityFromContext(r.Context())
+			identity := GetIdentityFromContext(r.Context())
 			if identity == nil {
 				writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized,
-					"agent authentication required", nil)
+					"authentication required", nil)
 				return
 			}
-			if !identity.HasScope(scope) {
+
+			sc, ok := identity.(scopeChecker)
+			if !ok {
+				// Identity type does not support scope checking (e.g. UserIdentity from IAP).
+				writeError(w, http.StatusForbidden, ErrCodeForbidden,
+					fmt.Sprintf("identity type %q does not support scope-based access", identity.Type()), nil)
+				return
+			}
+
+			if !sc.HasScope(scope) {
 				writeError(w, http.StatusForbidden, ErrCodeForbidden,
 					fmt.Sprintf("missing required scope: %s", scope), nil)
 				return

--- a/pkg/hub/federation_access.go
+++ b/pkg/hub/federation_access.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// RequireFederationAccess returns a middleware that requires the caller to be
+// either a local agent or a federated agent with the specified scope.
+// This works for both local and federated agents because both implement AgentIdentity.
+func RequireFederationAccess(scope AgentTokenScope) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			identity := GetAgentIdentityFromContext(r.Context())
+			if identity == nil {
+				writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized,
+					"agent authentication required", nil)
+				return
+			}
+			if !identity.HasScope(scope) {
+				writeError(w, http.StatusForbidden, ErrCodeForbidden,
+					fmt.Sprintf("missing required scope: %s", scope), nil)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/hub/federation_access_test.go
+++ b/pkg/hub/federation_access_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-jose/go-jose/v4/jwt"
+)
+
+// okHandler is a simple handler that returns 200 for middleware pass-through tests.
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+}
+
+// TestRequireFederationAccess_LocalAgentWithScope verifies that a local agent
+// identity with the required scope passes through the middleware.
+func TestRequireFederationAccess_LocalAgentWithScope(t *testing.T) {
+	middleware := RequireFederationAccess(ScopeAgentStatusUpdate)
+
+	claims := &AgentTokenClaims{
+		Claims:    jwt.Claims{Subject: "local-agent-1"},
+		ProjectID: "project-1",
+		Scopes:    []AgentTokenScope{ScopeAgentStatusUpdate, ScopeAgentLogAppend},
+	}
+	identity := &agentIdentityWrapper{claims}
+
+	handler := middleware(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), identity))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestRequireFederationAccess_LocalAgentWithoutScope verifies that a local agent
+// identity without the required scope is rejected with 403.
+func TestRequireFederationAccess_LocalAgentWithoutScope(t *testing.T) {
+	middleware := RequireFederationAccess(ScopeProjectSecretRead)
+
+	claims := &AgentTokenClaims{
+		Claims:    jwt.Claims{Subject: "local-agent-1"},
+		ProjectID: "project-1",
+		Scopes:    []AgentTokenScope{ScopeAgentStatusUpdate},
+	}
+	identity := &agentIdentityWrapper{claims}
+
+	handler := middleware(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), identity))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "missing required scope") {
+		t.Errorf("expected 'missing required scope' in body, got: %s", rec.Body.String())
+	}
+}
+
+// TestRequireFederationAccess_FederatedAgentWithScope verifies that a federated
+// agent identity with the required scope passes through the middleware.
+func TestRequireFederationAccess_FederatedAgentWithScope(t *testing.T) {
+	middleware := RequireFederationAccess(ScopeAgentStatusUpdate)
+
+	identity := NewFederatedAgentIdentity(
+		"https://hub-a.example.com",
+		"agent-123",
+		"project-alpha",
+		"worker-1",
+		"user:alice",
+		[]string{"user:alice", "agent:root"},
+		[]AgentTokenScope{ScopeAgentStatusUpdate, ScopeAgentLogAppend},
+	)
+
+	handler := middleware(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), identity))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestRequireFederationAccess_FederatedAgentWithoutScope verifies that a federated
+// agent identity without the required scope is rejected with 403.
+func TestRequireFederationAccess_FederatedAgentWithoutScope(t *testing.T) {
+	middleware := RequireFederationAccess(ScopeProjectSecretRead)
+
+	identity := NewFederatedAgentIdentity(
+		"https://hub-a.example.com",
+		"agent-123",
+		"project-alpha",
+		"worker-1",
+		"user:alice",
+		[]string{"user:alice", "agent:root"},
+		[]AgentTokenScope{ScopeAgentStatusUpdate, ScopeAgentLogAppend},
+	)
+
+	handler := middleware(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), identity))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "missing required scope") {
+		t.Errorf("expected 'missing required scope' in body, got: %s", rec.Body.String())
+	}
+}
+
+// TestRequireFederationAccess_NoIdentity verifies that a request with no
+// identity on the context is rejected with 401.
+func TestRequireFederationAccess_NoIdentity(t *testing.T) {
+	middleware := RequireFederationAccess(ScopeAgentStatusUpdate)
+
+	handler := middleware(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	// No identity on context
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "agent authentication required") {
+		t.Errorf("expected 'agent authentication required' in body, got: %s", rec.Body.String())
+	}
+}
+
+// TestRequireFederationAccess_UserIdentity verifies that a user identity
+// (not an agent) on the context is rejected with 401, since
+// GetAgentIdentityFromContext returns nil for users.
+func TestRequireFederationAccess_UserIdentity(t *testing.T) {
+	middleware := RequireFederationAccess(ScopeAgentStatusUpdate)
+
+	user := NewAuthenticatedUser("user-1", "alice@example.com", "Alice", "admin", "web")
+
+	handler := middleware(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), user))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "agent authentication required") {
+		t.Errorf("expected 'agent authentication required' in body, got: %s", rec.Body.String())
+	}
+}
+
+// TestRequireFederationAccess_DefaultFederationScopes verifies that a federated
+// agent with DefaultFederationScopes has ScopeAgentStatusUpdate but not
+// ScopeProjectSecretRead.
+func TestRequireFederationAccess_DefaultFederationScopes(t *testing.T) {
+	identity := NewFederatedAgentIdentity(
+		"https://hub-a.example.com",
+		"agent-123",
+		"project-alpha",
+		"worker-1",
+		"user:alice",
+		[]string{"user:alice"},
+		DefaultFederationScopes,
+	)
+
+	// HasScope(ScopeAgentStatusUpdate) should return true
+	if !identity.HasScope(ScopeAgentStatusUpdate) {
+		t.Error("expected HasScope(ScopeAgentStatusUpdate) to return true with DefaultFederationScopes")
+	}
+
+	// HasScope(ScopeProjectSecretRead) should return false
+	if identity.HasScope(ScopeProjectSecretRead) {
+		t.Error("expected HasScope(ScopeProjectSecretRead) to return false with DefaultFederationScopes")
+	}
+
+	// Verify via middleware: ScopeAgentStatusUpdate -> 200
+	middleware := RequireFederationAccess(ScopeAgentStatusUpdate)
+	handler := middleware(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), identity))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200 for default scope, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify via middleware: ScopeProjectSecretRead -> 403
+	middleware2 := RequireFederationAccess(ScopeProjectSecretRead)
+	handler2 := middleware2(okHandler())
+
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req2 = req2.WithContext(contextWithIdentity(req2.Context(), identity))
+
+	rec2 := httptest.NewRecorder()
+	handler2.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403 for non-default scope, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+
+	// Verify error response contains the scope name
+	var errResp ErrorResponse
+	if err := json.Unmarshal(rec2.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+	if !strings.Contains(errResp.Error.Message, string(ScopeProjectSecretRead)) {
+		t.Errorf("expected scope name in error message, got: %s", errResp.Error.Message)
+	}
+}

--- a/pkg/hub/federation_access_test.go
+++ b/pkg/hub/federation_access_test.go
@@ -160,14 +160,14 @@ func TestRequireFederationAccess_NoIdentity(t *testing.T) {
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("expected status 401, got %d: %s", rec.Code, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "agent authentication required") {
-		t.Errorf("expected 'agent authentication required' in body, got: %s", rec.Body.String())
+	if !strings.Contains(rec.Body.String(), "authentication required") {
+		t.Errorf("expected 'authentication required' in body, got: %s", rec.Body.String())
 	}
 }
 
 // TestRequireFederationAccess_UserIdentity verifies that a user identity
-// (not an agent) on the context is rejected with 401, since
-// GetAgentIdentityFromContext returns nil for users.
+// (not an agent) on the context is rejected with 403, since
+// UserIdentity does not implement scopeChecker.
 func TestRequireFederationAccess_UserIdentity(t *testing.T) {
 	middleware := RequireFederationAccess(ScopeAgentStatusUpdate)
 
@@ -181,11 +181,91 @@ func TestRequireFederationAccess_UserIdentity(t *testing.T) {
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("expected status 401, got %d: %s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d: %s", rec.Code, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "agent authentication required") {
-		t.Errorf("expected 'agent authentication required' in body, got: %s", rec.Body.String())
+	if !strings.Contains(rec.Body.String(), "does not support scope-based access") {
+		t.Errorf("expected 'does not support scope-based access' in body, got: %s", rec.Body.String())
+	}
+}
+
+// TestRequireFederationAccess_FederatedServiceWithScope verifies that a federated
+// service identity with the required scope passes through the middleware.
+func TestRequireFederationAccess_FederatedServiceWithScope(t *testing.T) {
+	middleware := RequireFederationAccess(ScopeAgentStatusUpdate)
+
+	identity := NewFederatedServiceIdentity(
+		"https://accounts.google.com",
+		"123456789",
+		"my-sa@my-project.iam.gserviceaccount.com",
+		[]AgentTokenScope{ScopeAgentStatusUpdate, ScopeAgentLogAppend},
+	)
+
+	handler := middleware(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), identity))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestRequireFederationAccess_FederatedServiceWithoutScope verifies that a federated
+// service identity without the required scope is rejected with 403.
+func TestRequireFederationAccess_FederatedServiceWithoutScope(t *testing.T) {
+	middleware := RequireFederationAccess(ScopeProjectSecretRead)
+
+	identity := NewFederatedServiceIdentity(
+		"https://accounts.google.com",
+		"123456789",
+		"my-sa@my-project.iam.gserviceaccount.com",
+		[]AgentTokenScope{ScopeAgentStatusUpdate},
+	)
+
+	handler := middleware(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), identity))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "missing required scope") {
+		t.Errorf("expected 'missing required scope' in body, got: %s", rec.Body.String())
+	}
+}
+
+// TestRequireFederationAccess_FederatedUserWithScope verifies that a federated
+// user identity with the required scope passes through the middleware.
+func TestRequireFederationAccess_FederatedUserWithScope(t *testing.T) {
+	middleware := RequireFederationAccess(ScopeAgentStatusUpdate)
+
+	identity := NewFederatedUserIdentity(
+		"https://securetoken.google.com/my-project",
+		"abcdef123456",
+		"user@example.com",
+		"Test User",
+		"viewer",
+		[]AgentTokenScope{ScopeAgentStatusUpdate, ScopeAgentLogAppend},
+	)
+
+	handler := middleware(okHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), identity))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/pkg/hub/federation_auth.go
+++ b/pkg/hub/federation_auth.go
@@ -104,7 +104,8 @@ func NewFederationAuthenticator(cfg config.FederationConfig, oidcIssuerURL strin
 				issuerType = IssuerTypeHub
 			}
 			if issuerType != IssuerTypeHub {
-				discovered, err := discoverJWKSURL(issuer.IssuerURL, httpClient)
+				requireHTTPS := mode != "dev" && mode != "workstation"
+				discovered, err := discoverJWKSURL(issuer.IssuerURL, httpClient, requireHTTPS)
 				if err != nil {
 					return nil, fmt.Errorf("federation: issuer %q: jwks_url not configured and OIDC discovery failed: %w", issuer.IssuerURL, err)
 				}
@@ -341,8 +342,13 @@ func extractUserClaims(verified *jwt.Claims, raw map[string]interface{},
 
 // matchesAllowedEmails checks if an email matches any pattern in the allowed list.
 // Supports exact match and leading-wildcard suffix match (e.g. "*@example.com").
+// Note: a bare "*" pattern matches all emails (the suffix after "*" is empty,
+// and strings.HasSuffix always returns true for an empty suffix). Use an empty
+// AllowedEmails slice instead to express "accept all emails" in configuration.
 func matchesAllowedEmails(patterns []string, email string) bool {
+	email = strings.ToLower(email)
 	for _, pattern := range patterns {
+		pattern = strings.ToLower(pattern)
 		if strings.HasPrefix(pattern, "*") {
 			// Leading-wildcard: match suffix.
 			suffix := pattern[1:] // strip the *

--- a/pkg/hub/federation_auth.go
+++ b/pkg/hub/federation_auth.go
@@ -145,8 +145,8 @@ func NewFederationAuthenticator(cfg config.FederationConfig, oidcIssuerURL strin
 }
 
 // Authenticate validates a federation OIDC identity token and returns the
-// authenticated FederatedAgentIdentity on success.
-func (a *FederationAuthenticator) Authenticate(tokenString string) (*FederatedAgentIdentity, error) {
+// authenticated FederatedIdentity on success.
+func (a *FederationAuthenticator) Authenticate(tokenString string) (FederatedIdentity, error) {
 	// 1. Parse JWT with algorithm pinning — rejects wrong algorithms at parse time.
 	tok, err := jwt.ParseSigned(tokenString, a.algorithms)
 	if err != nil {
@@ -200,54 +200,147 @@ func (a *FederationAuthenticator) Authenticate(tokenString string) (*FederatedAg
 		return nil, fmt.Errorf("federation: claims validation failed: %w", err)
 	}
 
-	// 8. Validate federation-specific constraints.
-	// Sub (agent ID) must be non-empty.
-	if claims.Subject == "" {
-		return nil, fmt.Errorf("federation: empty sub claim")
+	// 8. Extract identity based on issuer type.
+	issuerType := IssuerType(entry.config.IssuerType)
+	if issuerType == "" {
+		issuerType = IssuerTypeHub
 	}
 
-	// If allowed_projects is non-empty, project_id must be in the list.
-	if len(entry.config.AllowedProjects) > 0 {
-		if !contains(entry.config.AllowedProjects, claims.ProjectID) {
-			return nil, fmt.Errorf("federation: project %q not in allowed_projects", claims.ProjectID)
-		}
-	}
-
-	// If allowed_root_users is non-empty, root_user must be in the list.
-	if len(entry.config.AllowedRootUsers) > 0 {
-		if !contains(entry.config.AllowedRootUsers, claims.RootUser) {
-			return nil, fmt.Errorf("federation: root_user %q not in allowed_root_users", claims.RootUser)
-		}
-	}
-
-	// 9. Build scopes.
+	// Build scopes.
 	scopes := DefaultFederationScopes
 	if len(entry.config.DefaultScopes) > 0 {
 		scopes = make([]AgentTokenScope, len(entry.config.DefaultScopes))
 		for i, s := range entry.config.DefaultScopes {
 			scopes[i] = AgentTokenScope(s)
 		}
+	} else if issuerType != IssuerTypeHub {
+		// Non-hub issuers default to empty scopes (zero-trust).
+		scopes = nil
 	}
 
-	// 10. Construct and return FederatedAgentIdentity.
-	identity := NewFederatedAgentIdentity(
-		claims.Issuer,
-		claims.Subject,
-		claims.ProjectID,
-		claims.AgentName,
-		claims.RootUser,
-		claims.Ancestry,
-		scopes,
-	)
+	var identity FederatedIdentity
+	switch issuerType {
+	case IssuerTypeHub:
+		identity, err = extractHubClaims(&claims, entry.config, scopes)
+	case IssuerTypeServiceAccount:
+		// For SA/user types, get raw claims map for email/name extraction.
+		var rawClaims map[string]interface{}
+		if err := tok.UnsafeClaimsWithoutVerification(&rawClaims); err != nil {
+			return nil, fmt.Errorf("federation: failed to extract raw claims: %w", err)
+		}
+		identity, err = extractServiceAccountClaims(&claims.Claims, rawClaims, entry.config, scopes)
+	case IssuerTypeUser:
+		var rawClaims map[string]interface{}
+		if err := tok.UnsafeClaimsWithoutVerification(&rawClaims); err != nil {
+			return nil, fmt.Errorf("federation: failed to extract raw claims: %w", err)
+		}
+		identity, err = extractUserClaims(&claims.Claims, rawClaims, entry.config, scopes)
+	default:
+		return nil, fmt.Errorf("federation: unknown issuer type %q", issuerType)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// 9. Apply issuer constraints based on type.
+	switch issuerType {
+	case IssuerTypeHub:
+		if len(entry.config.AllowedProjects) > 0 {
+			if !contains(entry.config.AllowedProjects, claims.ProjectID) {
+				return nil, fmt.Errorf("federation: project %q not in allowed_projects", claims.ProjectID)
+			}
+		}
+		if len(entry.config.AllowedRootUsers) > 0 {
+			if !contains(entry.config.AllowedRootUsers, claims.RootUser) {
+				return nil, fmt.Errorf("federation: root_user %q not in allowed_root_users", claims.RootUser)
+			}
+		}
+	case IssuerTypeServiceAccount, IssuerTypeUser:
+		if len(entry.config.AllowedEmails) > 0 {
+			var email string
+			if sid, ok := identity.(*FederatedServiceIdentity); ok {
+				email = sid.Email()
+			} else if uid, ok := identity.(*FederatedUserIdentity); ok {
+				email = uid.Email()
+			}
+			if !matchesAllowedEmails(entry.config.AllowedEmails, email) {
+				return nil, fmt.Errorf("federation: email %q not in allowed_emails", email)
+			}
+		}
+	}
 
 	a.log.Debug("federation token validated",
-		"issuer", claims.Issuer,
-		"subject", claims.Subject,
-		"project_id", claims.ProjectID,
-		"agent_name", claims.AgentName,
+		"issuer", identity.IssuerURL(),
+		"type", identity.Type(),
+		"id", identity.ID(),
 	)
 
 	return identity, nil
+}
+
+// extractHubClaims extracts Scion hub agent claims. This is the existing
+// extraction logic moved into a function.
+func extractHubClaims(claims *federationClaims, issuerCfg config.TrustedIssuerConfig,
+	scopes []AgentTokenScope) (FederatedIdentity, error) {
+	if claims.Subject == "" {
+		return nil, fmt.Errorf("federation: empty sub claim")
+	}
+	return NewFederatedAgentIdentity(
+		claims.Issuer, claims.Subject, claims.ProjectID,
+		claims.AgentName, claims.RootUser, claims.Ancestry, scopes,
+	), nil
+}
+
+// extractServiceAccountClaims extracts GCP service account claims.
+func extractServiceAccountClaims(verified *jwt.Claims, raw map[string]interface{},
+	issuerCfg config.TrustedIssuerConfig, scopes []AgentTokenScope) (FederatedIdentity, error) {
+	if verified.Subject == "" {
+		return nil, fmt.Errorf("federation: service account token missing sub claim")
+	}
+	email, _ := raw["email"].(string)
+	if email == "" {
+		return nil, fmt.Errorf("federation: service account token missing email claim")
+	}
+	return NewFederatedServiceIdentity(
+		verified.Issuer, verified.Subject, email, scopes,
+	), nil
+}
+
+// extractUserClaims extracts Firebase/Google user claims.
+func extractUserClaims(verified *jwt.Claims, raw map[string]interface{},
+	issuerCfg config.TrustedIssuerConfig, scopes []AgentTokenScope) (FederatedIdentity, error) {
+	if verified.Subject == "" {
+		return nil, fmt.Errorf("federation: user token missing sub claim")
+	}
+	email, _ := raw["email"].(string)
+	name, _ := raw["name"].(string)
+	role := issuerCfg.DefaultRole
+	if role == "" {
+		role = "viewer"
+	}
+	return NewFederatedUserIdentity(
+		verified.Issuer, verified.Subject, email, name, role, scopes,
+	), nil
+}
+
+// matchesAllowedEmails checks if an email matches any pattern in the allowed list.
+// Supports exact match and leading-wildcard suffix match (e.g. "*@example.com").
+func matchesAllowedEmails(patterns []string, email string) bool {
+	for _, pattern := range patterns {
+		if strings.HasPrefix(pattern, "*") {
+			// Leading-wildcard: match suffix.
+			suffix := pattern[1:] // strip the *
+			if strings.HasSuffix(email, suffix) {
+				return true
+			}
+		} else {
+			// Exact match.
+			if pattern == email {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // contains checks if a string is present in a slice.

--- a/pkg/hub/federation_auth.go
+++ b/pkg/hub/federation_auth.go
@@ -55,10 +55,13 @@ type issuerEntry struct {
 // Separate from OIDCIdentityTokenClaims (outbound) to maintain trust boundary separation.
 type federationClaims struct {
 	jwt.Claims
-	ProjectID string   `json:"project_id,omitempty"`
-	AgentName string   `json:"agent_name,omitempty"`
-	Ancestry  []string `json:"ancestry,omitempty"`
-	RootUser  string   `json:"root_user,omitempty"`
+	ProjectID     string   `json:"project_id,omitempty"`
+	AgentName     string   `json:"agent_name,omitempty"`
+	Ancestry      []string `json:"ancestry,omitempty"`
+	RootUser      string   `json:"root_user,omitempty"`
+	Email         string   `json:"email,omitempty"`
+	EmailVerified bool     `json:"email_verified,omitempty"`
+	Name          string   `json:"name,omitempty"`
 }
 
 // NewFederationAuthenticator creates a FederationAuthenticator from the given config.
@@ -82,9 +85,12 @@ func NewFederationAuthenticator(cfg config.FederationConfig, oidcIssuerURL strin
 	issuers := make(map[string]*issuerEntry, len(cfg.TrustedIssuers))
 
 	for _, issuer := range cfg.TrustedIssuers {
+		// Normalize issuer URL by trimming trailing slashes for consistent map lookup.
+		normalizedIssuer := strings.TrimRight(issuer.IssuerURL, "/")
+
 		// Fix 2: In hosted mode (not workstation, not dev), reject HTTP issuer URLs.
 		if mode != "workstation" && mode != "dev" {
-			u, err := url.Parse(issuer.IssuerURL)
+			u, err := url.Parse(normalizedIssuer)
 			if err != nil {
 				return nil, fmt.Errorf("invalid issuer_url %q: %v", issuer.IssuerURL, err)
 			}
@@ -137,7 +143,7 @@ func NewFederationAuthenticator(cfg config.FederationConfig, oidcIssuerURL strin
 			debounceInterval: cfg.Cache.DebounceInterval,
 		}
 
-		issuers[issuer.IssuerURL] = &issuerEntry{
+		issuers[normalizedIssuer] = &issuerEntry{
 			config: resolvedCfg,
 			cache:  cache,
 		}
@@ -185,8 +191,9 @@ func (a *FederationAuthenticator) Authenticate(tokenString string) (FederatedIde
 		return nil, fmt.Errorf("federation: failed to peek at claims: %w", err)
 	}
 
-	// 4. Look up issuer.
-	entry, ok := a.issuers[unverified.Issuer]
+	// 4. Look up issuer (normalize trailing slashes for consistent matching).
+	normalizedIssuer := strings.TrimRight(unverified.Issuer, "/")
+	entry, ok := a.issuers[normalizedIssuer]
 	if !ok {
 		return nil, fmt.Errorf("federation: untrusted issuer %q", unverified.Issuer)
 	}
@@ -207,8 +214,11 @@ func (a *FederationAuthenticator) Authenticate(tokenString string) (FederatedIde
 	expectedAud := entry.config.ExpectedAudience
 	now := time.Now()
 
+	// Normalize issuer for comparison (handles trailing slash differences).
+	claims.Issuer = strings.TrimRight(claims.Issuer, "/")
+
 	expected := jwt.Expected{
-		Issuer:      unverified.Issuer,
+		Issuer:      strings.TrimRight(entry.config.IssuerURL, "/"),
 		AnyAudience: jwt.Audience{expectedAud},
 		Time:        now,
 	}
@@ -240,18 +250,9 @@ func (a *FederationAuthenticator) Authenticate(tokenString string) (FederatedIde
 	case IssuerTypeHub:
 		identity, err = extractHubClaims(&claims, entry.config, scopes)
 	case IssuerTypeServiceAccount:
-		// For SA/user types, get raw claims map for email/name extraction.
-		var rawClaims map[string]interface{}
-		if err := tok.UnsafeClaimsWithoutVerification(&rawClaims); err != nil {
-			return nil, fmt.Errorf("federation: failed to extract raw claims: %w", err)
-		}
-		identity, err = extractServiceAccountClaims(&claims.Claims, rawClaims, entry.config, scopes)
+		identity, err = extractServiceAccountClaims(&claims, entry.config, scopes)
 	case IssuerTypeUser:
-		var rawClaims map[string]interface{}
-		if err := tok.UnsafeClaimsWithoutVerification(&rawClaims); err != nil {
-			return nil, fmt.Errorf("federation: failed to extract raw claims: %w", err)
-		}
-		identity, err = extractUserClaims(&claims.Claims, rawClaims, entry.config, scopes)
+		identity, err = extractUserClaims(&claims, entry.config, scopes)
 	default:
 		return nil, fmt.Errorf("federation: unknown issuer type %q", issuerType)
 	}
@@ -309,34 +310,31 @@ func extractHubClaims(claims *federationClaims, issuerCfg config.TrustedIssuerCo
 }
 
 // extractServiceAccountClaims extracts GCP service account claims.
-func extractServiceAccountClaims(verified *jwt.Claims, raw map[string]interface{},
+func extractServiceAccountClaims(claims *federationClaims,
 	issuerCfg config.TrustedIssuerConfig, scopes []AgentTokenScope) (FederatedIdentity, error) {
-	if verified.Subject == "" {
+	if claims.Subject == "" {
 		return nil, fmt.Errorf("federation: service account token missing sub claim")
 	}
-	email, _ := raw["email"].(string)
-	if email == "" {
+	if claims.Email == "" {
 		return nil, fmt.Errorf("federation: service account token missing email claim")
 	}
 	return NewFederatedServiceIdentity(
-		verified.Issuer, verified.Subject, email, scopes,
+		claims.Issuer, claims.Subject, claims.Email, scopes,
 	), nil
 }
 
 // extractUserClaims extracts Firebase/Google user claims.
-func extractUserClaims(verified *jwt.Claims, raw map[string]interface{},
+func extractUserClaims(claims *federationClaims,
 	issuerCfg config.TrustedIssuerConfig, scopes []AgentTokenScope) (FederatedIdentity, error) {
-	if verified.Subject == "" {
+	if claims.Subject == "" {
 		return nil, fmt.Errorf("federation: user token missing sub claim")
 	}
-	email, _ := raw["email"].(string)
-	name, _ := raw["name"].(string)
 	role := issuerCfg.DefaultRole
 	if role == "" {
 		role = "viewer"
 	}
 	return NewFederatedUserIdentity(
-		verified.Issuer, verified.Subject, email, name, role, scopes,
+		claims.Issuer, claims.Subject, claims.Email, claims.Name, role, scopes,
 	), nil
 }
 

--- a/pkg/hub/federation_auth.go
+++ b/pkg/hub/federation_auth.go
@@ -93,10 +93,26 @@ func NewFederationAuthenticator(cfg config.FederationConfig, oidcIssuerURL strin
 			}
 		}
 
-		// Resolve JWKS URL: derive from issuer URL if not explicitly set.
+		// Resolve JWKS URL with 3-tier resolution:
+		// 1. Explicit jwks_url config (always wins)
+		// 2. Non-hub: OIDC discovery ({iss}/.well-known/openid-configuration -> jwks_uri)
+		// 3. Hub: derive {iss}/.well-known/jwks.json (existing convention)
 		jwksURL := issuer.JWKSURL
 		if jwksURL == "" {
-			jwksURL = strings.TrimRight(issuer.IssuerURL, "/") + "/.well-known/jwks.json"
+			issuerType := IssuerType(issuer.IssuerType)
+			if issuerType == "" {
+				issuerType = IssuerTypeHub
+			}
+			if issuerType != IssuerTypeHub {
+				discovered, err := discoverJWKSURL(issuer.IssuerURL, httpClient)
+				if err != nil {
+					return nil, fmt.Errorf("federation: issuer %q: jwks_url not configured and OIDC discovery failed: %w", issuer.IssuerURL, err)
+				}
+				jwksURL = discovered
+			} else {
+				// Hub convention: derive from issuer URL
+				jwksURL = strings.TrimRight(issuer.IssuerURL, "/") + "/.well-known/jwks.json"
+			}
 		}
 
 		// Resolve expected audience: fall back to this hub's OIDC issuer URL.

--- a/pkg/hub/federation_auth.go
+++ b/pkg/hub/federation_auth.go
@@ -63,6 +63,8 @@ type federationClaims struct {
 
 // NewFederationAuthenticator creates a FederationAuthenticator from the given config.
 // oidcIssuerURL is this hub's own OIDC issuer URL, used as the default expected audience.
+// httpClient is used for JWKS endpoint fetches. The caller should configure
+// CheckRedirect to return http.ErrUseLastResponse to prevent open-redirect attacks.
 // mode is the server mode (e.g. "workstation", "dev", "hosted"); non-dev/workstation
 // modes reject HTTP issuer URLs for security.
 func NewFederationAuthenticator(cfg config.FederationConfig, oidcIssuerURL string,
@@ -238,7 +240,7 @@ func (a *FederationAuthenticator) Authenticate(tokenString string) (*FederatedAg
 		scopes,
 	)
 
-	a.log.Info("federation token validated",
+	a.log.Debug("federation token validated",
 		"issuer", claims.Issuer,
 		"subject", claims.Subject,
 		"project_id", claims.ProjectID,

--- a/pkg/hub/federation_auth.go
+++ b/pkg/hub/federation_auth.go
@@ -1,0 +1,259 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// FederationTokenHeader is the HTTP header carrying federation OIDC identity tokens.
+const FederationTokenHeader = "X-Scion-Federation-Token"
+
+// DefaultFederationScopes is the scope set granted to federated agents when
+// no per-issuer default_scopes are configured.
+var DefaultFederationScopes = []AgentTokenScope{
+	ScopeAgentStatusUpdate,
+	ScopeAgentLogAppend,
+}
+
+// FederationAuthenticator validates OIDC identity tokens from trusted external issuers.
+type FederationAuthenticator struct {
+	issuers    map[string]*issuerEntry
+	algorithms []jose.SignatureAlgorithm
+	log        *slog.Logger
+}
+
+// issuerEntry holds the configuration and JWKS cache for a single trusted issuer.
+type issuerEntry struct {
+	config config.TrustedIssuerConfig
+	cache  *jwksCache
+}
+
+// federationClaims is the claims shape for inbound federation OIDC identity tokens.
+// Separate from OIDCIdentityTokenClaims (outbound) to maintain trust boundary separation.
+type federationClaims struct {
+	jwt.Claims
+	ProjectID string   `json:"project_id,omitempty"`
+	AgentName string   `json:"agent_name,omitempty"`
+	Ancestry  []string `json:"ancestry,omitempty"`
+	RootUser  string   `json:"root_user,omitempty"`
+}
+
+// NewFederationAuthenticator creates a FederationAuthenticator from the given config.
+// oidcIssuerURL is this hub's own OIDC issuer URL, used as the default expected audience.
+// mode is the server mode (e.g. "workstation", "dev", "hosted"); non-dev/workstation
+// modes reject HTTP issuer URLs for security.
+func NewFederationAuthenticator(cfg config.FederationConfig, oidcIssuerURL string,
+	httpClient *http.Client, mode string, log *slog.Logger) (*FederationAuthenticator, error) {
+
+	// Validate config.
+	if errs := cfg.Validate(); len(errs) > 0 {
+		msgs := make([]string, len(errs))
+		for i, e := range errs {
+			msgs[i] = e.Error()
+		}
+		return nil, fmt.Errorf("federation config validation failed: %s", strings.Join(msgs, "; "))
+	}
+
+	issuers := make(map[string]*issuerEntry, len(cfg.TrustedIssuers))
+
+	for _, issuer := range cfg.TrustedIssuers {
+		// Fix 2: In hosted mode (not workstation, not dev), reject HTTP issuer URLs.
+		if mode != "workstation" && mode != "dev" {
+			u, err := url.Parse(issuer.IssuerURL)
+			if err != nil {
+				return nil, fmt.Errorf("invalid issuer_url %q: %v", issuer.IssuerURL, err)
+			}
+			if u.Scheme == "http" {
+				return nil, fmt.Errorf("issuer_url %q uses http, which is not allowed in %q mode (HTTPS required)", issuer.IssuerURL, mode)
+			}
+		}
+
+		// Resolve JWKS URL: derive from issuer URL if not explicitly set.
+		jwksURL := issuer.JWKSURL
+		if jwksURL == "" {
+			jwksURL = strings.TrimRight(issuer.IssuerURL, "/") + "/.well-known/jwks.json"
+		}
+
+		// Resolve expected audience: fall back to this hub's OIDC issuer URL.
+		expectedAud := issuer.ExpectedAudience
+		if expectedAud == "" {
+			expectedAud = oidcIssuerURL
+		}
+		if expectedAud == "" {
+			return nil, fmt.Errorf("issuer %q: expected_audience is empty and no oidcIssuerURL provided", issuer.IssuerURL)
+		}
+
+		// Store the resolved audience back into the config copy for later use.
+		resolvedCfg := issuer
+		resolvedCfg.ExpectedAudience = expectedAud
+
+		// Create a jwksCache with configurable intervals.
+		cache := &jwksCache{
+			url:              jwksURL,
+			client:           httpClient,
+			refreshInterval:  cfg.Cache.RefreshInterval,
+			debounceInterval: cfg.Cache.DebounceInterval,
+		}
+
+		issuers[issuer.IssuerURL] = &issuerEntry{
+			config: resolvedCfg,
+			cache:  cache,
+		}
+	}
+
+	// Build algorithms list: default to RS256 if none configured.
+	var algorithms []jose.SignatureAlgorithm
+	if len(cfg.Algorithms) == 0 {
+		algorithms = []jose.SignatureAlgorithm{jose.RS256}
+	} else {
+		algorithms = make([]jose.SignatureAlgorithm, len(cfg.Algorithms))
+		for i, alg := range cfg.Algorithms {
+			algorithms[i] = jose.SignatureAlgorithm(alg)
+		}
+	}
+
+	return &FederationAuthenticator{
+		issuers:    issuers,
+		algorithms: algorithms,
+		log:        log,
+	}, nil
+}
+
+// Authenticate validates a federation OIDC identity token and returns the
+// authenticated FederatedAgentIdentity on success.
+func (a *FederationAuthenticator) Authenticate(tokenString string) (*FederatedAgentIdentity, error) {
+	// 1. Parse JWT with algorithm pinning — rejects wrong algorithms at parse time.
+	tok, err := jwt.ParseSigned(tokenString, a.algorithms)
+	if err != nil {
+		return nil, fmt.Errorf("federation: failed to parse JWT: %w", err)
+	}
+
+	// 2. Extract kid from JWT header.
+	if len(tok.Headers) == 0 {
+		return nil, fmt.Errorf("federation: JWT has no headers")
+	}
+	kid := tok.Headers[0].KeyID
+	if kid == "" {
+		return nil, fmt.Errorf("federation: JWT has no kid")
+	}
+
+	// 3. Extract unverified issuer to look up the correct key set.
+	var unverified federationClaims
+	if err := tok.UnsafeClaimsWithoutVerification(&unverified); err != nil {
+		return nil, fmt.Errorf("federation: failed to peek at claims: %w", err)
+	}
+
+	// 4. Look up issuer.
+	entry, ok := a.issuers[unverified.Issuer]
+	if !ok {
+		return nil, fmt.Errorf("federation: untrusted issuer %q", unverified.Issuer)
+	}
+
+	// 5. Fetch public key via JWKS cache.
+	key, err := entry.cache.GetKey(kid)
+	if err != nil {
+		return nil, fmt.Errorf("federation: JWKS key lookup failed for kid %q: %w", kid, err)
+	}
+
+	// 6. Verify signature and extract verified claims.
+	var claims federationClaims
+	if err := tok.Claims(key, &claims); err != nil {
+		return nil, fmt.Errorf("federation: JWT signature verification failed: %w", err)
+	}
+
+	// 7. Validate standard claims (iss, aud, exp, nbf with clock skew).
+	expectedAud := entry.config.ExpectedAudience
+	now := time.Now()
+
+	expected := jwt.Expected{
+		Issuer:      unverified.Issuer,
+		AnyAudience: jwt.Audience{expectedAud},
+		Time:        now,
+	}
+	// Apply clock skew tolerance.
+	if err := claims.ValidateWithLeeway(expected, iapClockSkew); err != nil {
+		return nil, fmt.Errorf("federation: claims validation failed: %w", err)
+	}
+
+	// 8. Validate federation-specific constraints.
+	// Sub (agent ID) must be non-empty.
+	if claims.Subject == "" {
+		return nil, fmt.Errorf("federation: empty sub claim")
+	}
+
+	// If allowed_projects is non-empty, project_id must be in the list.
+	if len(entry.config.AllowedProjects) > 0 {
+		if !contains(entry.config.AllowedProjects, claims.ProjectID) {
+			return nil, fmt.Errorf("federation: project %q not in allowed_projects", claims.ProjectID)
+		}
+	}
+
+	// If allowed_root_users is non-empty, root_user must be in the list.
+	if len(entry.config.AllowedRootUsers) > 0 {
+		if !contains(entry.config.AllowedRootUsers, claims.RootUser) {
+			return nil, fmt.Errorf("federation: root_user %q not in allowed_root_users", claims.RootUser)
+		}
+	}
+
+	// 9. Build scopes.
+	scopes := DefaultFederationScopes
+	if len(entry.config.DefaultScopes) > 0 {
+		scopes = make([]AgentTokenScope, len(entry.config.DefaultScopes))
+		for i, s := range entry.config.DefaultScopes {
+			scopes[i] = AgentTokenScope(s)
+		}
+	}
+
+	// 10. Construct and return FederatedAgentIdentity.
+	identity := NewFederatedAgentIdentity(
+		claims.Issuer,
+		claims.Subject,
+		claims.ProjectID,
+		claims.AgentName,
+		claims.RootUser,
+		claims.Ancestry,
+		scopes,
+	)
+
+	a.log.Info("federation token validated",
+		"issuer", claims.Issuer,
+		"subject", claims.Subject,
+		"project_id", claims.ProjectID,
+		"agent_name", claims.AgentName,
+	)
+
+	return identity, nil
+}
+
+// contains checks if a string is present in a slice.
+func contains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/hub/federation_auth_integration_test.go
+++ b/pkg/hub/federation_auth_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -93,12 +94,6 @@ func setupFederationIntegration(t *testing.T) (
 	return privKey, auth, issuer, audience, kid
 }
 
-// signIntegrationToken creates a signed JWT for integration testing.
-func signIntegrationToken(t *testing.T, key *rsa.PrivateKey, kid string, claims federationClaims) string {
-	t.Helper()
-	return signFederationToken(t, key, kid, claims)
-}
-
 // TestFederationMiddleware_ValidToken verifies that a valid federation token
 // in X-Scion-Federation-Token results in 200 with correct identity on the context.
 func TestFederationMiddleware_ValidToken(t *testing.T) {
@@ -119,7 +114,7 @@ func TestFederationMiddleware_ValidToken(t *testing.T) {
 	claims.AgentName = "test-worker"
 	claims.RootUser = "user:integrator"
 	claims.Ancestry = []string{"user:integrator", "agent:root"}
-	token := signIntegrationToken(t, privKey, kid, claims)
+	token := signFederationToken(t, privKey, kid, claims)
 
 	var gotIdentity Identity
 	var gotAgentIdentity AgentIdentity
@@ -228,7 +223,7 @@ func TestFederationMiddleware_InvalidToken(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	if !containsStr(body, "invalid federation token") {
+	if !strings.Contains(body, "invalid federation token") {
 		t.Errorf("expected 'invalid federation token' in body, got: %s", body)
 	}
 }
@@ -262,7 +257,7 @@ func TestFederationMiddleware_NotConfigured(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	if !containsStr(body, "federation authentication is not configured") {
+	if !strings.Contains(body, "federation authentication is not configured") {
 		t.Errorf("expected 'federation authentication is not configured' in body, got: %s", body)
 	}
 }
@@ -300,7 +295,7 @@ func TestFederationMiddleware_NoHeader(t *testing.T) {
 
 	body := rec.Body.String()
 	// Should fall through to "missing authorization header" — not a federation error
-	if !containsStr(body, "missing authorization header") {
+	if !strings.Contains(body, "missing authorization header") {
 		t.Errorf("expected 'missing authorization header' in body (fall-through), got: %s", body)
 	}
 }
@@ -336,7 +331,7 @@ func TestFederationMiddleware_AgentTokenTakesPriority(t *testing.T) {
 	// Create a valid federation token too
 	claims := validFederationClaims(issuer, audience)
 	claims.Subject = "federated-agent-1"
-	fedToken := signIntegrationToken(t, privKey, kid, claims)
+	fedToken := signFederationToken(t, privKey, kid, claims)
 
 	var gotIdentity Identity
 	var gotAuthType string
@@ -396,7 +391,7 @@ func TestFederationMiddleware_ExpiredToken(t *testing.T) {
 	claims.Expiry = jwt.NewNumericDate(time.Now().Add(-10 * time.Minute))
 	claims.IssuedAt = jwt.NewNumericDate(time.Now().Add(-15 * time.Minute))
 	claims.NotBefore = jwt.NewNumericDate(time.Now().Add(-15 * time.Minute))
-	token := signIntegrationToken(t, privKey, kid, claims)
+	token := signFederationToken(t, privKey, kid, claims)
 
 	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("handler should not be called for expired token")
@@ -414,7 +409,7 @@ func TestFederationMiddleware_ExpiredToken(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	if !containsStr(body, "invalid federation token") {
+	if !strings.Contains(body, "invalid federation token") {
 		t.Errorf("expected 'invalid federation token' in body, got: %s", body)
 	}
 }

--- a/pkg/hub/federation_auth_integration_test.go
+++ b/pkg/hub/federation_auth_integration_test.go
@@ -1,0 +1,420 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
+)
+
+// setupFederationIntegration generates an RSA key pair and JWKS test server,
+// creates a FederationAuthenticator, and returns everything needed for
+// middleware integration tests.
+func setupFederationIntegration(t *testing.T) (
+	privKey *rsa.PrivateKey,
+	auth *FederationAuthenticator,
+	issuer string,
+	audience string,
+	kid string,
+) {
+	t.Helper()
+
+	kid = "integration-test-key"
+	audience = "https://hub-local.example.com"
+
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{
+				Key:       &privKey.PublicKey,
+				KeyID:     kid,
+				Algorithm: string(jose.RS256),
+				Use:       "sig",
+			},
+		},
+	}
+	jwksData, err := json.Marshal(jwks)
+	if err != nil {
+		t.Fatalf("failed to marshal JWKS: %v", err)
+	}
+
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksData)
+	}))
+	t.Cleanup(jwksSrv.Close)
+
+	issuer = "https://hub-remote.example.com"
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+			},
+		},
+	}
+	auth, err = NewFederationAuthenticator(cfg, audience,
+		&http.Client{Timeout: 5 * time.Second}, "dev", slog.Default())
+	if err != nil {
+		t.Fatalf("NewFederationAuthenticator failed: %v", err)
+	}
+
+	return privKey, auth, issuer, audience, kid
+}
+
+// signIntegrationToken creates a signed JWT for integration testing.
+func signIntegrationToken(t *testing.T, key *rsa.PrivateKey, kid string, claims federationClaims) string {
+	t.Helper()
+	return signFederationToken(t, key, kid, claims)
+}
+
+// TestFederationMiddleware_ValidToken verifies that a valid federation token
+// in X-Scion-Federation-Token results in 200 with correct identity on the context.
+func TestFederationMiddleware_ValidToken(t *testing.T) {
+	privKey, auth, issuer, audience, kid := setupFederationIntegration(t)
+
+	cfg := AuthConfig{
+		Mode:                    "production",
+		FederationAuthenticator: auth,
+		Debug:                   true,
+		Logger:                  slog.Default(),
+	}
+
+	middleware := UnifiedAuthMiddleware(cfg)
+
+	claims := validFederationClaims(issuer, audience)
+	claims.Subject = "agent-integration-1"
+	claims.ProjectID = "project-test"
+	claims.AgentName = "test-worker"
+	claims.RootUser = "user:integrator"
+	claims.Ancestry = []string{"user:integrator", "agent:root"}
+	token := signIntegrationToken(t, privKey, kid, claims)
+
+	var gotIdentity Identity
+	var gotAgentIdentity AgentIdentity
+	var gotUserIdentity UserIdentity
+	var gotAgent *AgentTokenClaims
+	var gotAuthType string
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotIdentity = GetIdentityFromContext(r.Context())
+		gotAgentIdentity = GetAgentIdentityFromContext(r.Context())
+		gotUserIdentity = GetUserIdentityFromContext(r.Context())
+		gotAgent = GetAgentFromContext(r.Context())
+		if at, ok := r.Context().Value(logging.AuthTypeKey{}).(string); ok {
+			gotAuthType = at
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req.Header.Set(FederationTokenHeader, token)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify identity is a *FederatedAgentIdentity
+	if gotIdentity == nil {
+		t.Fatal("expected identity in context, got nil")
+	}
+	fedIdentity, ok := gotIdentity.(*FederatedAgentIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedAgentIdentity, got %T", gotIdentity)
+	}
+
+	// Verify FederatedAgentIdentity fields
+	if fedIdentity.IssuerURL() != issuer {
+		t.Errorf("expected issuer %q, got %q", issuer, fedIdentity.IssuerURL())
+	}
+	if fedIdentity.RemoteAgentID() != "agent-integration-1" {
+		t.Errorf("expected agent ID 'agent-integration-1', got %q", fedIdentity.RemoteAgentID())
+	}
+	if fedIdentity.RemoteProjectID() != "project-test" {
+		t.Errorf("expected project 'project-test', got %q", fedIdentity.RemoteProjectID())
+	}
+	if fedIdentity.AgentName() != "test-worker" {
+		t.Errorf("expected agent name 'test-worker', got %q", fedIdentity.AgentName())
+	}
+	if fedIdentity.OriginUserID() != "user:integrator" {
+		t.Errorf("expected root user 'user:integrator', got %q", fedIdentity.OriginUserID())
+	}
+	if fedIdentity.Type() != "federated_agent" {
+		t.Errorf("expected type 'federated_agent', got %q", fedIdentity.Type())
+	}
+
+	// Verify GetAgentIdentityFromContext returns the FederatedAgentIdentity
+	if gotAgentIdentity == nil {
+		t.Fatal("expected agent identity from GetAgentIdentityFromContext, got nil")
+	}
+
+	// Verify GetUserIdentityFromContext returns nil (not a user)
+	if gotUserIdentity != nil {
+		t.Errorf("expected nil from GetUserIdentityFromContext, got %v", gotUserIdentity)
+	}
+
+	// Verify GetAgentFromContext returns nil (not a local agent token)
+	if gotAgent != nil {
+		t.Errorf("expected nil from GetAgentFromContext, got %v", gotAgent)
+	}
+
+	// Verify auth type is "federation"
+	if gotAuthType != AuthTypeFederation {
+		t.Errorf("expected auth type %q, got %q", AuthTypeFederation, gotAuthType)
+	}
+}
+
+// TestFederationMiddleware_InvalidToken verifies that an invalid federation token
+// results in 401 "invalid federation token".
+func TestFederationMiddleware_InvalidToken(t *testing.T) {
+	_, auth, _, _, _ := setupFederationIntegration(t)
+
+	cfg := AuthConfig{
+		Mode:                    "production",
+		FederationAuthenticator: auth,
+		Debug:                   true,
+		Logger:                  slog.Default(),
+	}
+
+	middleware := UnifiedAuthMiddleware(cfg)
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called for invalid token")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req.Header.Set(FederationTokenHeader, "invalid.token.here")
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !containsStr(body, "invalid federation token") {
+		t.Errorf("expected 'invalid federation token' in body, got: %s", body)
+	}
+}
+
+// TestFederationMiddleware_NotConfigured verifies that a federation header
+// present but federation not configured (nil authenticator) results in 401
+// "federation authentication is not configured".
+func TestFederationMiddleware_NotConfigured(t *testing.T) {
+	cfg := AuthConfig{
+		Mode:                    "production",
+		FederationAuthenticator: nil, // federation not enabled
+		Debug:                   true,
+		Logger:                  slog.Default(),
+	}
+
+	middleware := UnifiedAuthMiddleware(cfg)
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called when federation is not configured")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req.Header.Set(FederationTokenHeader, "some.federation.token")
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !containsStr(body, "federation authentication is not configured") {
+		t.Errorf("expected 'federation authentication is not configured' in body, got: %s", body)
+	}
+}
+
+// TestFederationMiddleware_NoHeader verifies that when no federation header is
+// present, the request falls through to subsequent auth steps (not rejected by
+// the federation check). With no other auth configured, it should get a
+// "missing authorization header" response — proving federation didn't intercept.
+func TestFederationMiddleware_NoHeader(t *testing.T) {
+	_, auth, _, _, _ := setupFederationIntegration(t)
+
+	cfg := AuthConfig{
+		Mode:                    "production",
+		FederationAuthenticator: auth,
+		Debug:                   true,
+		Logger:                  slog.Default(),
+	}
+
+	middleware := UnifiedAuthMiddleware(cfg)
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called without any auth")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// No federation header, no agent header, no bearer token
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+	// Should fall through to "missing authorization header" — not a federation error
+	if !containsStr(body, "missing authorization header") {
+		t.Errorf("expected 'missing authorization header' in body (fall-through), got: %s", body)
+	}
+}
+
+// TestFederationMiddleware_AgentTokenTakesPriority verifies that when both
+// X-Scion-Agent-Token (valid) and X-Scion-Federation-Token are present, the
+// agent token wins because step 1 runs before step 1.5.
+func TestFederationMiddleware_AgentTokenTakesPriority(t *testing.T) {
+	privKey, auth, issuer, audience, kid := setupFederationIntegration(t)
+
+	// Create an agent token service for the local agent token
+	agentTokenSvc, err := NewAgentTokenService(AgentTokenConfig{})
+	if err != nil {
+		t.Fatalf("failed to create agent token service: %v", err)
+	}
+
+	agentToken, err := agentTokenSvc.GenerateAgentToken(
+		"local-agent-1", "project-local", []AgentTokenScope{ScopeAgentStatusUpdate}, nil)
+	if err != nil {
+		t.Fatalf("failed to generate agent token: %v", err)
+	}
+
+	cfg := AuthConfig{
+		Mode:                    "production",
+		AgentTokenSvc:           agentTokenSvc,
+		FederationAuthenticator: auth,
+		Debug:                   true,
+		Logger:                  slog.Default(),
+	}
+
+	middleware := UnifiedAuthMiddleware(cfg)
+
+	// Create a valid federation token too
+	claims := validFederationClaims(issuer, audience)
+	claims.Subject = "federated-agent-1"
+	fedToken := signIntegrationToken(t, privKey, kid, claims)
+
+	var gotIdentity Identity
+	var gotAuthType string
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotIdentity = GetIdentityFromContext(r.Context())
+		if at, ok := r.Context().Value(logging.AuthTypeKey{}).(string); ok {
+			gotAuthType = at
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req.Header.Set("X-Scion-Agent-Token", agentToken)
+	req.Header.Set(FederationTokenHeader, fedToken)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if gotIdentity == nil {
+		t.Fatal("expected identity in context, got nil")
+	}
+
+	// The identity should be the local agent, not the federated agent
+	if gotIdentity.Type() != "agent" {
+		t.Errorf("expected identity type 'agent' (local), got %q", gotIdentity.Type())
+	}
+	if gotIdentity.ID() != "local-agent-1" {
+		t.Errorf("expected agent ID 'local-agent-1', got %q", gotIdentity.ID())
+	}
+
+	// Auth type should be "agent", not "federation"
+	if gotAuthType != AuthTypeAgent {
+		t.Errorf("expected auth type %q, got %q", AuthTypeAgent, gotAuthType)
+	}
+}
+
+// TestFederationMiddleware_ExpiredToken verifies that an expired but otherwise
+// valid federation token is rejected at the middleware level with 401.
+func TestFederationMiddleware_ExpiredToken(t *testing.T) {
+	privKey, auth, issuer, audience, kid := setupFederationIntegration(t)
+
+	cfg := AuthConfig{
+		Mode:                    "production",
+		FederationAuthenticator: auth,
+		Debug:                   true,
+		Logger:                  slog.Default(),
+	}
+
+	middleware := UnifiedAuthMiddleware(cfg)
+
+	claims := validFederationClaims(issuer, audience)
+	claims.Expiry = jwt.NewNumericDate(time.Now().Add(-10 * time.Minute))
+	claims.IssuedAt = jwt.NewNumericDate(time.Now().Add(-15 * time.Minute))
+	claims.NotBefore = jwt.NewNumericDate(time.Now().Add(-15 * time.Minute))
+	token := signIntegrationToken(t, privKey, kid, claims)
+
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called for expired token")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	req.Header.Set(FederationTokenHeader, token)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !containsStr(body, "invalid federation token") {
+		t.Errorf("expected 'invalid federation token' in body, got: %s", body)
+	}
+}

--- a/pkg/hub/federation_auth_test.go
+++ b/pkg/hub/federation_auth_test.go
@@ -1,0 +1,801 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// --- Test helpers ---
+
+// setupFederationTestServer generates an RSA key pair, starts a JWKS test server,
+// and returns the private key, server, and kid for signing tokens.
+func setupFederationTestServer(t *testing.T) (*rsa.PrivateKey, *httptest.Server, string) {
+	t.Helper()
+	kid := "test-fed-key-1"
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{
+				Key:       &privKey.PublicKey,
+				KeyID:     kid,
+				Algorithm: string(jose.RS256),
+				Use:       "sig",
+			},
+		},
+	}
+	jwksData, err := json.Marshal(jwks)
+	if err != nil {
+		t.Fatalf("failed to marshal JWKS: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksData)
+	}))
+	t.Cleanup(srv.Close)
+
+	return privKey, srv, kid
+}
+
+// signFederationToken creates a signed RS256 JWT for federation testing.
+func signFederationToken(t *testing.T, key *rsa.PrivateKey, kid string, claims federationClaims) string {
+	t.Helper()
+	signerKey := jose.SigningKey{Algorithm: jose.RS256, Key: key}
+	opts := (&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", kid)
+	signer, err := jose.NewSigner(signerKey, opts)
+	if err != nil {
+		t.Fatalf("failed to create signer: %v", err)
+	}
+	raw, err := jwt.Signed(signer).Claims(claims).Serialize()
+	if err != nil {
+		t.Fatalf("failed to sign JWT: %v", err)
+	}
+	return raw
+}
+
+// validFederationClaims returns a baseline valid claims set for testing.
+func validFederationClaims(issuer, audience string) federationClaims {
+	now := time.Now()
+	return federationClaims{
+		Claims: jwt.Claims{
+			Issuer:    issuer,
+			Subject:   "agent-123",
+			Audience:  jwt.Audience{audience},
+			IssuedAt:  jwt.NewNumericDate(now.Add(-1 * time.Minute)),
+			Expiry:    jwt.NewNumericDate(now.Add(5 * time.Minute)),
+			NotBefore: jwt.NewNumericDate(now.Add(-1 * time.Minute)),
+		},
+		ProjectID: "project-alpha",
+		AgentName: "worker-1",
+		Ancestry:  []string{"user:alice", "agent:root"},
+		RootUser:  "user:alice",
+	}
+}
+
+// newTestAuthenticator creates a FederationAuthenticator with a single trusted issuer
+// pointing at the given JWKS test server.
+func newTestAuthenticator(t *testing.T, issuerURL, jwksURL, expectedAudience string) *FederationAuthenticator {
+	t.Helper()
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuerURL,
+				JWKSURL:          jwksURL,
+				ExpectedAudience: expectedAudience,
+			},
+		},
+	}
+	auth, err := NewFederationAuthenticator(cfg, expectedAudience, &http.Client{Timeout: 5 * time.Second}, "dev", slog.Default())
+	if err != nil {
+		t.Fatalf("NewFederationAuthenticator failed: %v", err)
+	}
+	return auth
+}
+
+// --- Test cases ---
+
+// Test 1: Valid RS256 token from trusted issuer -> success
+func TestFederationAuth_ValidToken(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+
+	auth := newTestAuthenticator(t, issuer, jwksSrv.URL, audience)
+
+	claims := validFederationClaims(issuer, audience)
+	token := signFederationToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if identity == nil {
+		t.Fatal("expected identity, got nil")
+	}
+	if identity.RemoteAgentID() != "agent-123" {
+		t.Errorf("expected agent ID 'agent-123', got %q", identity.RemoteAgentID())
+	}
+	if identity.IssuerURL() != issuer {
+		t.Errorf("expected issuer %q, got %q", issuer, identity.IssuerURL())
+	}
+	if identity.RemoteProjectID() != "project-alpha" {
+		t.Errorf("expected project 'project-alpha', got %q", identity.RemoteProjectID())
+	}
+	if identity.AgentName() != "worker-1" {
+		t.Errorf("expected agent name 'worker-1', got %q", identity.AgentName())
+	}
+	if identity.OriginUserID() != "user:alice" {
+		t.Errorf("expected root user 'user:alice', got %q", identity.OriginUserID())
+	}
+	if identity.Type() != "federated_agent" {
+		t.Errorf("expected type 'federated_agent', got %q", identity.Type())
+	}
+}
+
+// Test 2: Token from untrusted issuer -> reject
+func TestFederationAuth_UntrustedIssuer(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	trustedIssuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+
+	auth := newTestAuthenticator(t, trustedIssuer, jwksSrv.URL, audience)
+
+	// Sign token with a different issuer
+	claims := validFederationClaims("https://evil.example.com", audience)
+	token := signFederationToken(t, privKey, kid, claims)
+
+	_, err := auth.Authenticate(token)
+	if err == nil {
+		t.Fatal("expected error for untrusted issuer, got nil")
+	}
+	if !containsStr(err.Error(), "untrusted issuer") {
+		t.Errorf("expected 'untrusted issuer' in error, got: %v", err)
+	}
+}
+
+// Test 3: Expired token -> reject
+func TestFederationAuth_ExpiredToken(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+
+	auth := newTestAuthenticator(t, issuer, jwksSrv.URL, audience)
+
+	claims := validFederationClaims(issuer, audience)
+	// Set expiry well in the past (beyond clock skew)
+	claims.Expiry = jwt.NewNumericDate(time.Now().Add(-5 * time.Minute))
+	claims.IssuedAt = jwt.NewNumericDate(time.Now().Add(-10 * time.Minute))
+	claims.NotBefore = jwt.NewNumericDate(time.Now().Add(-10 * time.Minute))
+	token := signFederationToken(t, privKey, kid, claims)
+
+	_, err := auth.Authenticate(token)
+	if err == nil {
+		t.Fatal("expected error for expired token, got nil")
+	}
+	if !containsStr(err.Error(), "claims validation failed") {
+		t.Errorf("expected 'claims validation failed' in error, got: %v", err)
+	}
+}
+
+// Test 4: Token with wrong audience -> reject
+func TestFederationAuth_WrongAudience(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+
+	auth := newTestAuthenticator(t, issuer, jwksSrv.URL, audience)
+
+	claims := validFederationClaims(issuer, "https://wrong-audience.example.com")
+	token := signFederationToken(t, privKey, kid, claims)
+
+	_, err := auth.Authenticate(token)
+	if err == nil {
+		t.Fatal("expected error for wrong audience, got nil")
+	}
+	if !containsStr(err.Error(), "claims validation failed") {
+		t.Errorf("expected 'claims validation failed' in error, got: %v", err)
+	}
+}
+
+// Test 5: Token with project not in allowed_projects -> reject
+func TestFederationAuth_ProjectNotAllowed(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				AllowedProjects:  []string{"project-beta", "project-gamma"},
+			},
+		},
+	}
+	auth, err := NewFederationAuthenticator(cfg, audience, &http.Client{Timeout: 5 * time.Second}, "dev", slog.Default())
+	if err != nil {
+		t.Fatalf("NewFederationAuthenticator failed: %v", err)
+	}
+
+	claims := validFederationClaims(issuer, audience)
+	claims.ProjectID = "project-alpha" // not in allowed list
+	token := signFederationToken(t, privKey, kid, claims)
+
+	_, err = auth.Authenticate(token)
+	if err == nil {
+		t.Fatal("expected error for disallowed project, got nil")
+	}
+	if !containsStr(err.Error(), "not in allowed_projects") {
+		t.Errorf("expected 'not in allowed_projects' in error, got: %v", err)
+	}
+}
+
+// Test 6: Token with root_user not in allowed_root_users -> reject
+func TestFederationAuth_RootUserNotAllowed(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				AllowedRootUsers: []string{"user:bob"},
+			},
+		},
+	}
+	auth, err := NewFederationAuthenticator(cfg, audience, &http.Client{Timeout: 5 * time.Second}, "dev", slog.Default())
+	if err != nil {
+		t.Fatalf("NewFederationAuthenticator failed: %v", err)
+	}
+
+	claims := validFederationClaims(issuer, audience)
+	claims.RootUser = "user:alice" // not in allowed list
+	token := signFederationToken(t, privKey, kid, claims)
+
+	_, err = auth.Authenticate(token)
+	if err == nil {
+		t.Fatal("expected error for disallowed root_user, got nil")
+	}
+	if !containsStr(err.Error(), "not in allowed_root_users") {
+		t.Errorf("expected 'not in allowed_root_users' in error, got: %v", err)
+	}
+}
+
+// Test 7: Token with alg: HS256 -> reject (algorithm pinning)
+func TestFederationAuth_HS256Rejected(t *testing.T) {
+	_, jwksSrv, _ := setupFederationTestServer(t)
+	issuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+
+	auth := newTestAuthenticator(t, issuer, jwksSrv.URL, audience)
+
+	// Create an HS256-signed token
+	symmetricKey := []byte("super-secret-key-for-testing-1234")
+	signerKey := jose.SigningKey{Algorithm: jose.HS256, Key: symmetricKey}
+	opts := (&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", "hmac-key")
+	signer, err := jose.NewSigner(signerKey, opts)
+	if err != nil {
+		t.Fatalf("failed to create HS256 signer: %v", err)
+	}
+
+	claims := validFederationClaims(issuer, audience)
+	token, err := jwt.Signed(signer).Claims(claims).Serialize()
+	if err != nil {
+		t.Fatalf("failed to sign HS256 JWT: %v", err)
+	}
+
+	_, err = auth.Authenticate(token)
+	if err == nil {
+		t.Fatal("expected error for HS256 token, got nil")
+	}
+	if !containsStr(err.Error(), "failed to parse JWT") {
+		t.Errorf("expected 'failed to parse JWT' in error, got: %v", err)
+	}
+}
+
+// Test 8: Unknown kid triggers JWKS refresh -> success after refresh
+func TestFederationAuth_UnknownKidTriggersRefresh(t *testing.T) {
+	kid1 := "key-1"
+	kid2 := "key-2"
+
+	privKey1, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key 1: %v", err)
+	}
+	privKey2, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key 2: %v", err)
+	}
+
+	// Start with only key 1 in JWKS
+	var currentJWKS atomic.Value
+	jwks1 := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{Key: &privKey1.PublicKey, KeyID: kid1, Algorithm: string(jose.RS256), Use: "sig"},
+		},
+	}
+	jwks1Data, _ := json.Marshal(jwks1)
+	currentJWKS.Store(jwks1Data)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(currentJWKS.Load().([]byte))
+	}))
+	t.Cleanup(srv.Close)
+
+	issuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+	auth := newTestAuthenticator(t, issuer, srv.URL, audience)
+
+	// First, authenticate with key 1 to populate cache
+	claims1 := validFederationClaims(issuer, audience)
+	token1 := signFederationToken(t, privKey1, kid1, claims1)
+	_, err = auth.Authenticate(token1)
+	if err != nil {
+		t.Fatalf("first auth failed: %v", err)
+	}
+
+	// Now add key 2 to the JWKS
+	jwks2 := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{Key: &privKey1.PublicKey, KeyID: kid1, Algorithm: string(jose.RS256), Use: "sig"},
+			{Key: &privKey2.PublicKey, KeyID: kid2, Algorithm: string(jose.RS256), Use: "sig"},
+		},
+	}
+	jwks2Data, _ := json.Marshal(jwks2)
+	currentJWKS.Store(jwks2Data)
+
+	// Reset debounce to allow a fresh fetch
+	entry := auth.issuers[issuer]
+	entry.cache.mu.Lock()
+	entry.cache.lastAttempted = time.Time{}
+	entry.cache.mu.Unlock()
+
+	// Authenticate with key 2 — should trigger refresh and succeed
+	claims2 := validFederationClaims(issuer, audience)
+	claims2.Subject = "agent-456"
+	token2 := signFederationToken(t, privKey2, kid2, claims2)
+	identity, err := auth.Authenticate(token2)
+	if err != nil {
+		t.Fatalf("second auth (new kid) failed: %v", err)
+	}
+	if identity.RemoteAgentID() != "agent-456" {
+		t.Errorf("expected agent ID 'agent-456', got %q", identity.RemoteAgentID())
+	}
+}
+
+// Test 9: JWKS endpoint down, cached keys -> serve from cache
+func TestFederationAuth_JWKSDownCachedKeys(t *testing.T) {
+	kid := "cached-key"
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{Key: &privKey.PublicKey, KeyID: kid, Algorithm: string(jose.RS256), Use: "sig"},
+		},
+	}
+	jwksData, _ := json.Marshal(jwks)
+
+	var serverUp atomic.Bool
+	serverUp.Store(true)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !serverUp.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksData)
+	}))
+	t.Cleanup(srv.Close)
+
+	issuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+	auth := newTestAuthenticator(t, issuer, srv.URL, audience)
+
+	// First auth to populate cache
+	claims := validFederationClaims(issuer, audience)
+	token := signFederationToken(t, privKey, kid, claims)
+	_, err = auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("initial auth failed: %v", err)
+	}
+
+	// Take JWKS server down
+	serverUp.Store(false)
+
+	// A new token with the same kid should still succeed from cache
+	// (proactive background refresh will fail silently)
+	claims2 := validFederationClaims(issuer, audience)
+	claims2.Subject = "agent-789"
+	token2 := signFederationToken(t, privKey, kid, claims2)
+	identity, err := auth.Authenticate(token2)
+	if err != nil {
+		t.Fatalf("auth with cached key during outage failed: %v", err)
+	}
+	if identity.RemoteAgentID() != "agent-789" {
+		t.Errorf("expected agent ID 'agent-789', got %q", identity.RemoteAgentID())
+	}
+}
+
+// Test 10: Empty sub claim -> reject
+func TestFederationAuth_EmptySubject(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+
+	auth := newTestAuthenticator(t, issuer, jwksSrv.URL, audience)
+
+	claims := validFederationClaims(issuer, audience)
+	claims.Subject = "" // empty sub
+	token := signFederationToken(t, privKey, kid, claims)
+
+	_, err := auth.Authenticate(token)
+	if err == nil {
+		t.Fatal("expected error for empty sub claim, got nil")
+	}
+	if !containsStr(err.Error(), "empty sub claim") {
+		t.Errorf("expected 'empty sub claim' in error, got: %v", err)
+	}
+}
+
+// Test 11: Valid token with default scopes (no per-issuer config) -> gets DefaultFederationScopes
+func TestFederationAuth_DefaultScopes(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+
+	auth := newTestAuthenticator(t, issuer, jwksSrv.URL, audience)
+
+	claims := validFederationClaims(issuer, audience)
+	token := signFederationToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	scopes := identity.Scopes()
+	if len(scopes) != len(DefaultFederationScopes) {
+		t.Fatalf("expected %d default scopes, got %d", len(DefaultFederationScopes), len(scopes))
+	}
+	for i, s := range DefaultFederationScopes {
+		if scopes[i] != s {
+			t.Errorf("scope[%d]: expected %q, got %q", i, s, scopes[i])
+		}
+	}
+}
+
+// Test 12: Valid token with per-issuer scopes -> gets configured scopes
+func TestFederationAuth_PerIssuerScopes(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				DefaultScopes:    []string{"agent:status:update", "agent:log:append", "project:secret:read"},
+			},
+		},
+	}
+	auth, err := NewFederationAuthenticator(cfg, audience, &http.Client{Timeout: 5 * time.Second}, "dev", slog.Default())
+	if err != nil {
+		t.Fatalf("NewFederationAuthenticator failed: %v", err)
+	}
+
+	claims := validFederationClaims(issuer, audience)
+	token := signFederationToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	scopes := identity.Scopes()
+	if len(scopes) != 3 {
+		t.Fatalf("expected 3 scopes, got %d: %v", len(scopes), scopes)
+	}
+	if !identity.HasScope(ScopeProjectSecretRead) {
+		t.Error("expected ScopeProjectSecretRead to be granted")
+	}
+}
+
+// Test 13: Multiple issuers -> each validates independently
+func TestFederationAuth_MultipleIssuers(t *testing.T) {
+	issuerA := "https://hub-a.example.com"
+	issuerB := "https://hub-b.example.com"
+	audience := "https://hub-c.example.com"
+
+	kidA := "key-a"
+	kidB := "key-b"
+
+	privKeyA, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key A: %v", err)
+	}
+	privKeyB, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key B: %v", err)
+	}
+
+	jwksA := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{Key: &privKeyA.PublicKey, KeyID: kidA, Algorithm: string(jose.RS256), Use: "sig"},
+		},
+	}
+	jwksAData, _ := json.Marshal(jwksA)
+	srvA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksAData)
+	}))
+	t.Cleanup(srvA.Close)
+
+	jwksB := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{Key: &privKeyB.PublicKey, KeyID: kidB, Algorithm: string(jose.RS256), Use: "sig"},
+		},
+	}
+	jwksBData, _ := json.Marshal(jwksB)
+	srvB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksBData)
+	}))
+	t.Cleanup(srvB.Close)
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuerA,
+				JWKSURL:          srvA.URL,
+				ExpectedAudience: audience,
+			},
+			{
+				IssuerURL:        issuerB,
+				JWKSURL:          srvB.URL,
+				ExpectedAudience: audience,
+			},
+		},
+	}
+	auth, err := NewFederationAuthenticator(cfg, audience, &http.Client{Timeout: 5 * time.Second}, "dev", slog.Default())
+	if err != nil {
+		t.Fatalf("NewFederationAuthenticator failed: %v", err)
+	}
+
+	// Token from issuer A
+	claimsA := validFederationClaims(issuerA, audience)
+	claimsA.Subject = "agent-from-a"
+	tokenA := signFederationToken(t, privKeyA, kidA, claimsA)
+	identityA, err := auth.Authenticate(tokenA)
+	if err != nil {
+		t.Fatalf("auth for issuer A failed: %v", err)
+	}
+	if identityA.IssuerURL() != issuerA {
+		t.Errorf("expected issuer %q, got %q", issuerA, identityA.IssuerURL())
+	}
+
+	// Token from issuer B
+	claimsB := validFederationClaims(issuerB, audience)
+	claimsB.Subject = "agent-from-b"
+	tokenB := signFederationToken(t, privKeyB, kidB, claimsB)
+	identityB, err := auth.Authenticate(tokenB)
+	if err != nil {
+		t.Fatalf("auth for issuer B failed: %v", err)
+	}
+	if identityB.IssuerURL() != issuerB {
+		t.Errorf("expected issuer %q, got %q", issuerB, identityB.IssuerURL())
+	}
+
+	// Cross-signing: token signed by A's key but claiming issuer B -> should fail
+	claimsCross := validFederationClaims(issuerB, audience)
+	tokenCross := signFederationToken(t, privKeyA, kidA, claimsCross)
+	_, err = auth.Authenticate(tokenCross)
+	if err == nil {
+		t.Fatal("expected error for cross-signed token, got nil")
+	}
+}
+
+// Test 14: NewFederationAuthenticator with HTTP issuer in hosted mode -> error
+func TestFederationAuth_HTTPIssuerHostedMode(t *testing.T) {
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        "http://insecure-hub.example.com",
+				ExpectedAudience: "https://hub-b.example.com",
+			},
+		},
+	}
+
+	// "hosted" mode (not workstation or dev) should reject HTTP
+	_, err := NewFederationAuthenticator(cfg, "https://hub-b.example.com",
+		&http.Client{Timeout: 5 * time.Second}, "hosted", slog.Default())
+	if err == nil {
+		t.Fatal("expected error for HTTP issuer in hosted mode, got nil")
+	}
+	if !containsStr(err.Error(), "not allowed") {
+		t.Errorf("expected 'not allowed' in error, got: %v", err)
+	}
+
+	// "workstation" mode should allow HTTP
+	_, err = NewFederationAuthenticator(cfg, "https://hub-b.example.com",
+		&http.Client{Timeout: 5 * time.Second}, "workstation", slog.Default())
+	if err != nil {
+		t.Errorf("expected HTTP issuer allowed in workstation mode, got error: %v", err)
+	}
+
+	// "dev" mode should allow HTTP
+	_, err = NewFederationAuthenticator(cfg, "https://hub-b.example.com",
+		&http.Client{Timeout: 5 * time.Second}, "dev", slog.Default())
+	if err != nil {
+		t.Errorf("expected HTTP issuer allowed in dev mode, got error: %v", err)
+	}
+}
+
+// --- Additional edge case tests ---
+
+// Test: JWKS URL is derived from issuer URL when not explicitly set
+func TestFederationAuth_DerivedJWKSURL(t *testing.T) {
+	kid := "derived-key"
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{Key: &privKey.PublicKey, KeyID: kid, Algorithm: string(jose.RS256), Use: "sig"},
+		},
+	}
+	jwksData, _ := json.Marshal(jwks)
+
+	// Start server that serves JWKS at /.well-known/jwks.json
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksData)
+	}))
+	t.Cleanup(srv.Close)
+
+	audience := "https://hub-b.example.com"
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        srv.URL,        // JWKS will be derived as srv.URL + /.well-known/jwks.json
+				JWKSURL:          srv.URL,         // for test simplicity, point directly at server
+				ExpectedAudience: audience,
+			},
+		},
+	}
+	auth, err := NewFederationAuthenticator(cfg, audience, &http.Client{Timeout: 5 * time.Second}, "dev", slog.Default())
+	if err != nil {
+		t.Fatalf("NewFederationAuthenticator failed: %v", err)
+	}
+
+	claims := validFederationClaims(srv.URL, audience)
+	token := signFederationToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if identity == nil {
+		t.Fatal("expected identity, got nil")
+	}
+}
+
+// Test: NewFederationAuthenticator fails when audience cannot be resolved
+func TestFederationAuth_NoAudienceError(t *testing.T) {
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        "https://hub-a.example.com",
+				ExpectedAudience: "", // empty
+			},
+		},
+	}
+
+	// Both config audience and oidcIssuerURL are empty
+	_, err := NewFederationAuthenticator(cfg, "", &http.Client{}, "dev", slog.Default())
+	if err == nil {
+		t.Fatal("expected error when audience cannot be resolved, got nil")
+	}
+	if !containsStr(err.Error(), "expected_audience is empty") {
+		t.Errorf("expected 'expected_audience is empty' in error, got: %v", err)
+	}
+}
+
+// Test: Token with project in allowed_projects -> success
+func TestFederationAuth_ProjectAllowed(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				AllowedProjects:  []string{"project-alpha", "project-beta"},
+			},
+		},
+	}
+	auth, err := NewFederationAuthenticator(cfg, audience, &http.Client{Timeout: 5 * time.Second}, "dev", slog.Default())
+	if err != nil {
+		t.Fatalf("NewFederationAuthenticator failed: %v", err)
+	}
+
+	claims := validFederationClaims(issuer, audience)
+	claims.ProjectID = "project-alpha" // in allowed list
+	token := signFederationToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if identity.RemoteProjectID() != "project-alpha" {
+		t.Errorf("expected project 'project-alpha', got %q", identity.RemoteProjectID())
+	}
+}
+
+// containsStr checks if a string contains a substring.
+func containsStr(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 || findSubstring(s, sub))
+}
+
+func findSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/hub/federation_auth_test.go
+++ b/pkg/hub/federation_auth_test.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -179,7 +180,7 @@ func TestFederationAuth_UntrustedIssuer(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for untrusted issuer, got nil")
 	}
-	if !containsStr(err.Error(), "untrusted issuer") {
+	if !strings.Contains(err.Error(), "untrusted issuer") {
 		t.Errorf("expected 'untrusted issuer' in error, got: %v", err)
 	}
 }
@@ -203,7 +204,7 @@ func TestFederationAuth_ExpiredToken(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for expired token, got nil")
 	}
-	if !containsStr(err.Error(), "claims validation failed") {
+	if !strings.Contains(err.Error(), "claims validation failed") {
 		t.Errorf("expected 'claims validation failed' in error, got: %v", err)
 	}
 }
@@ -223,7 +224,7 @@ func TestFederationAuth_WrongAudience(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for wrong audience, got nil")
 	}
-	if !containsStr(err.Error(), "claims validation failed") {
+	if !strings.Contains(err.Error(), "claims validation failed") {
 		t.Errorf("expected 'claims validation failed' in error, got: %v", err)
 	}
 }
@@ -258,7 +259,7 @@ func TestFederationAuth_ProjectNotAllowed(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for disallowed project, got nil")
 	}
-	if !containsStr(err.Error(), "not in allowed_projects") {
+	if !strings.Contains(err.Error(), "not in allowed_projects") {
 		t.Errorf("expected 'not in allowed_projects' in error, got: %v", err)
 	}
 }
@@ -293,7 +294,7 @@ func TestFederationAuth_RootUserNotAllowed(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for disallowed root_user, got nil")
 	}
-	if !containsStr(err.Error(), "not in allowed_root_users") {
+	if !strings.Contains(err.Error(), "not in allowed_root_users") {
 		t.Errorf("expected 'not in allowed_root_users' in error, got: %v", err)
 	}
 }
@@ -325,7 +326,7 @@ func TestFederationAuth_HS256Rejected(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for HS256 token, got nil")
 	}
-	if !containsStr(err.Error(), "failed to parse JWT") {
+	if !strings.Contains(err.Error(), "failed to parse JWT") {
 		t.Errorf("expected 'failed to parse JWT' in error, got: %v", err)
 	}
 }
@@ -483,7 +484,7 @@ func TestFederationAuth_JWKSDownNoCachedKeys(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when JWKS is down with no cached keys, got nil")
 	}
-	if !containsStr(err.Error(), "JWKS key lookup failed") {
+	if !strings.Contains(err.Error(), "JWKS key lookup failed") {
 		t.Errorf("expected 'JWKS key lookup failed' in error, got: %v", err)
 	}
 }
@@ -504,7 +505,7 @@ func TestFederationAuth_EmptySubject(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty sub claim, got nil")
 	}
-	if !containsStr(err.Error(), "empty sub claim") {
+	if !strings.Contains(err.Error(), "empty sub claim") {
 		t.Errorf("expected 'empty sub claim' in error, got: %v", err)
 	}
 }
@@ -688,7 +689,7 @@ func TestFederationAuth_HTTPIssuerHostedMode(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for HTTP issuer in hosted mode, got nil")
 	}
-	if !containsStr(err.Error(), "not allowed") {
+	if !strings.Contains(err.Error(), "not allowed") {
 		t.Errorf("expected 'not allowed' in error, got: %v", err)
 	}
 
@@ -779,7 +780,7 @@ func TestFederationAuth_NoAudienceError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when audience cannot be resolved, got nil")
 	}
-	if !containsStr(err.Error(), "expected_audience is empty") {
+	if !strings.Contains(err.Error(), "expected_audience is empty") {
 		t.Errorf("expected 'expected_audience is empty' in error, got: %v", err)
 	}
 }
@@ -819,16 +820,3 @@ func TestFederationAuth_ProjectAllowed(t *testing.T) {
 	}
 }
 
-// containsStr checks if a string contains a substring.
-func containsStr(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(sub) == 0 || findSubstring(s, sub))
-}
-
-func findSubstring(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/hub/federation_auth_test.go
+++ b/pkg/hub/federation_auth_test.go
@@ -124,6 +124,32 @@ func newTestAuthenticator(t *testing.T, issuerURL, jwksURL, expectedAudience str
 	return auth
 }
 
+// signGenericToken creates a signed RS256 JWT with arbitrary claims for non-hub token testing.
+func signGenericToken(t *testing.T, key *rsa.PrivateKey, kid string, claims interface{}) string {
+	t.Helper()
+	signerKey := jose.SigningKey{Algorithm: jose.RS256, Key: key}
+	opts := (&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", kid)
+	signer, err := jose.NewSigner(signerKey, opts)
+	if err != nil {
+		t.Fatalf("failed to create signer: %v", err)
+	}
+	raw, err := jwt.Signed(signer).Claims(claims).Serialize()
+	if err != nil {
+		t.Fatalf("failed to sign JWT: %v", err)
+	}
+	return raw
+}
+
+// newTestAuthenticatorWithConfig creates a FederationAuthenticator from a full config.
+func newTestAuthenticatorWithConfig(t *testing.T, cfg config.FederationConfig, expectedAudience string) *FederationAuthenticator {
+	t.Helper()
+	auth, err := NewFederationAuthenticator(cfg, expectedAudience, &http.Client{Timeout: 5 * time.Second}, "dev", slog.Default())
+	if err != nil {
+		t.Fatalf("NewFederationAuthenticator failed: %v", err)
+	}
+	return auth
+}
+
 // --- Test cases ---
 
 // Test 1: Valid RS256 token from trusted issuer -> success
@@ -144,20 +170,24 @@ func TestFederationAuth_ValidToken(t *testing.T) {
 	if identity == nil {
 		t.Fatal("expected identity, got nil")
 	}
-	if identity.RemoteAgentID() != "agent-123" {
-		t.Errorf("expected agent ID 'agent-123', got %q", identity.RemoteAgentID())
+	agentID, ok := identity.(*FederatedAgentIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedAgentIdentity, got %T", identity)
+	}
+	if agentID.RemoteAgentID() != "agent-123" {
+		t.Errorf("expected agent ID 'agent-123', got %q", agentID.RemoteAgentID())
 	}
 	if identity.IssuerURL() != issuer {
 		t.Errorf("expected issuer %q, got %q", issuer, identity.IssuerURL())
 	}
-	if identity.RemoteProjectID() != "project-alpha" {
-		t.Errorf("expected project 'project-alpha', got %q", identity.RemoteProjectID())
+	if agentID.RemoteProjectID() != "project-alpha" {
+		t.Errorf("expected project 'project-alpha', got %q", agentID.RemoteProjectID())
 	}
-	if identity.AgentName() != "worker-1" {
-		t.Errorf("expected agent name 'worker-1', got %q", identity.AgentName())
+	if agentID.AgentName() != "worker-1" {
+		t.Errorf("expected agent name 'worker-1', got %q", agentID.AgentName())
 	}
-	if identity.OriginUserID() != "user:alice" {
-		t.Errorf("expected root user 'user:alice', got %q", identity.OriginUserID())
+	if agentID.OriginUserID() != "user:alice" {
+		t.Errorf("expected root user 'user:alice', got %q", agentID.OriginUserID())
 	}
 	if identity.Type() != "federated_agent" {
 		t.Errorf("expected type 'federated_agent', got %q", identity.Type())
@@ -397,8 +427,12 @@ func TestFederationAuth_UnknownKidTriggersRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second auth (new kid) failed: %v", err)
 	}
-	if identity.RemoteAgentID() != "agent-456" {
-		t.Errorf("expected agent ID 'agent-456', got %q", identity.RemoteAgentID())
+	agentID, ok := identity.(*FederatedAgentIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedAgentIdentity, got %T", identity)
+	}
+	if agentID.RemoteAgentID() != "agent-456" {
+		t.Errorf("expected agent ID 'agent-456', got %q", agentID.RemoteAgentID())
 	}
 }
 
@@ -454,8 +488,12 @@ func TestFederationAuth_JWKSDownCachedKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("auth with cached key during outage failed: %v", err)
 	}
-	if identity.RemoteAgentID() != "agent-789" {
-		t.Errorf("expected agent ID 'agent-789', got %q", identity.RemoteAgentID())
+	agentID, ok := identity.(*FederatedAgentIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedAgentIdentity, got %T", identity)
+	}
+	if agentID.RemoteAgentID() != "agent-789" {
+		t.Errorf("expected agent ID 'agent-789', got %q", agentID.RemoteAgentID())
 	}
 }
 
@@ -526,7 +564,11 @@ func TestFederationAuth_DefaultScopes(t *testing.T) {
 		t.Fatalf("expected success, got error: %v", err)
 	}
 
-	scopes := identity.Scopes()
+	agentID, ok := identity.(*FederatedAgentIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedAgentIdentity, got %T", identity)
+	}
+	scopes := agentID.Scopes()
 	if len(scopes) != len(DefaultFederationScopes) {
 		t.Fatalf("expected %d default scopes, got %d", len(DefaultFederationScopes), len(scopes))
 	}
@@ -567,11 +609,15 @@ func TestFederationAuth_PerIssuerScopes(t *testing.T) {
 		t.Fatalf("expected success, got error: %v", err)
 	}
 
-	scopes := identity.Scopes()
+	agentID, ok := identity.(*FederatedAgentIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedAgentIdentity, got %T", identity)
+	}
+	scopes := agentID.Scopes()
 	if len(scopes) != 3 {
 		t.Fatalf("expected 3 scopes, got %d: %v", len(scopes), scopes)
 	}
-	if !identity.HasScope(ScopeProjectSecretRead) {
+	if !agentID.HasScope(ScopeProjectSecretRead) {
 		t.Error("expected ScopeProjectSecretRead to be granted")
 	}
 }
@@ -815,7 +861,568 @@ func TestFederationAuth_ProjectAllowed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected success, got error: %v", err)
 	}
-	if identity.RemoteProjectID() != "project-alpha" {
-		t.Errorf("expected project 'project-alpha', got %q", identity.RemoteProjectID())
+	agentID, ok := identity.(*FederatedAgentIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedAgentIdentity, got %T", identity)
+	}
+	if agentID.RemoteProjectID() != "project-alpha" {
+		t.Errorf("expected project 'project-alpha', got %q", agentID.RemoteProjectID())
+	}
+}
+
+// --- Service Account tests ---
+
+// SA Test 1: Valid SA token (iss=accounts.google.com, has email+sub) -> FederatedServiceIdentity
+func TestFederationAuth_ServiceAccount_ValidToken(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://accounts.google.com"
+	audience := "https://hub-b.example.com"
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				IssuerType:       "service_account",
+			},
+		},
+	}
+	auth := newTestAuthenticatorWithConfig(t, cfg, audience)
+
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":            issuer,
+		"sub":            "123456789",
+		"aud":            audience,
+		"iat":            now.Add(-1 * time.Minute).Unix(),
+		"exp":            now.Add(5 * time.Minute).Unix(),
+		"nbf":            now.Add(-1 * time.Minute).Unix(),
+		"email":          "my-sa@my-project.iam.gserviceaccount.com",
+		"email_verified": true,
+	}
+	token := signGenericToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	sid, ok := identity.(*FederatedServiceIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedServiceIdentity, got %T", identity)
+	}
+	if sid.Email() != "my-sa@my-project.iam.gserviceaccount.com" {
+		t.Errorf("expected email 'my-sa@my-project.iam.gserviceaccount.com', got %q", sid.Email())
+	}
+	if sid.Subject() != "123456789" {
+		t.Errorf("expected subject '123456789', got %q", sid.Subject())
+	}
+	if sid.IssuerURL() != issuer {
+		t.Errorf("expected issuer %q, got %q", issuer, sid.IssuerURL())
+	}
+	if sid.Type() != "federated_service" {
+		t.Errorf("expected type 'federated_service', got %q", sid.Type())
+	}
+}
+
+// SA Test 2: SA token missing email -> reject
+func TestFederationAuth_ServiceAccount_MissingEmail(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://accounts.google.com"
+	audience := "https://hub-b.example.com"
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				IssuerType:       "service_account",
+			},
+		},
+	}
+	auth := newTestAuthenticatorWithConfig(t, cfg, audience)
+
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss": issuer,
+		"sub": "123456789",
+		"aud": audience,
+		"iat": now.Add(-1 * time.Minute).Unix(),
+		"exp": now.Add(5 * time.Minute).Unix(),
+		"nbf": now.Add(-1 * time.Minute).Unix(),
+		// no email claim
+	}
+	token := signGenericToken(t, privKey, kid, claims)
+
+	_, err := auth.Authenticate(token)
+	if err == nil {
+		t.Fatal("expected error for missing email, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing email claim") {
+		t.Errorf("expected 'missing email claim' in error, got: %v", err)
+	}
+}
+
+// SA Test 3: SA token with email not in allowed_emails -> reject
+func TestFederationAuth_ServiceAccount_EmailNotAllowed(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://accounts.google.com"
+	audience := "https://hub-b.example.com"
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				IssuerType:       "service_account",
+				AllowedEmails:    []string{"allowed-sa@my-project.iam.gserviceaccount.com"},
+			},
+		},
+	}
+	auth := newTestAuthenticatorWithConfig(t, cfg, audience)
+
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":   issuer,
+		"sub":   "123456789",
+		"aud":   audience,
+		"iat":   now.Add(-1 * time.Minute).Unix(),
+		"exp":   now.Add(5 * time.Minute).Unix(),
+		"nbf":   now.Add(-1 * time.Minute).Unix(),
+		"email": "disallowed-sa@other-project.iam.gserviceaccount.com",
+	}
+	token := signGenericToken(t, privKey, kid, claims)
+
+	_, err := auth.Authenticate(token)
+	if err == nil {
+		t.Fatal("expected error for disallowed email, got nil")
+	}
+	if !strings.Contains(err.Error(), "not in allowed_emails") {
+		t.Errorf("expected 'not in allowed_emails' in error, got: %v", err)
+	}
+}
+
+// SA Test 4: SA token with email matching wildcard pattern -> success
+func TestFederationAuth_ServiceAccount_WildcardEmailMatch(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://accounts.google.com"
+	audience := "https://hub-b.example.com"
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				IssuerType:       "service_account",
+				AllowedEmails:    []string{"*@my-project.iam.gserviceaccount.com"},
+			},
+		},
+	}
+	auth := newTestAuthenticatorWithConfig(t, cfg, audience)
+
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":   issuer,
+		"sub":   "123456789",
+		"aud":   audience,
+		"iat":   now.Add(-1 * time.Minute).Unix(),
+		"exp":   now.Add(5 * time.Minute).Unix(),
+		"nbf":   now.Add(-1 * time.Minute).Unix(),
+		"email": "deploy-bot@my-project.iam.gserviceaccount.com",
+	}
+	token := signGenericToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	sid, ok := identity.(*FederatedServiceIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedServiceIdentity, got %T", identity)
+	}
+	if sid.Email() != "deploy-bot@my-project.iam.gserviceaccount.com" {
+		t.Errorf("expected email 'deploy-bot@my-project.iam.gserviceaccount.com', got %q", sid.Email())
+	}
+}
+
+// SA Test 5: SA token default scopes are empty (zero-trust)
+func TestFederationAuth_ServiceAccount_DefaultScopesEmpty(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://accounts.google.com"
+	audience := "https://hub-b.example.com"
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				IssuerType:       "service_account",
+			},
+		},
+	}
+	auth := newTestAuthenticatorWithConfig(t, cfg, audience)
+
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":   issuer,
+		"sub":   "123456789",
+		"aud":   audience,
+		"iat":   now.Add(-1 * time.Minute).Unix(),
+		"exp":   now.Add(5 * time.Minute).Unix(),
+		"nbf":   now.Add(-1 * time.Minute).Unix(),
+		"email": "my-sa@my-project.iam.gserviceaccount.com",
+	}
+	token := signGenericToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	sid, ok := identity.(*FederatedServiceIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedServiceIdentity, got %T", identity)
+	}
+	scopes := sid.Scopes()
+	if len(scopes) != 0 {
+		t.Errorf("expected empty scopes for SA (zero-trust), got %v", scopes)
+	}
+}
+
+// --- User tests ---
+
+// User Test 6: Valid user token (Firebase-shaped, has email+sub+name) -> FederatedUserIdentity
+func TestFederationAuth_User_ValidToken(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://securetoken.google.com/my-firebase-project"
+	audience := "my-firebase-project"
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				IssuerType:       "user",
+			},
+		},
+	}
+	auth := newTestAuthenticatorWithConfig(t, cfg, audience)
+
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":            issuer,
+		"sub":            "abcdef123456",
+		"aud":            audience,
+		"iat":            now.Add(-1 * time.Minute).Unix(),
+		"exp":            now.Add(5 * time.Minute).Unix(),
+		"nbf":            now.Add(-1 * time.Minute).Unix(),
+		"email":          "user@example.com",
+		"email_verified": true,
+		"name":           "Test User",
+	}
+	token := signGenericToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	uid, ok := identity.(*FederatedUserIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedUserIdentity, got %T", identity)
+	}
+	if uid.Email() != "user@example.com" {
+		t.Errorf("expected email 'user@example.com', got %q", uid.Email())
+	}
+	if uid.DisplayName() != "Test User" {
+		t.Errorf("expected display name 'Test User', got %q", uid.DisplayName())
+	}
+	if uid.Subject() != "abcdef123456" {
+		t.Errorf("expected subject 'abcdef123456', got %q", uid.Subject())
+	}
+	if uid.IssuerURL() != issuer {
+		t.Errorf("expected issuer %q, got %q", issuer, uid.IssuerURL())
+	}
+	if uid.Type() != "federated_user" {
+		t.Errorf("expected type 'federated_user', got %q", uid.Type())
+	}
+}
+
+// User Test 7: User token with default role -> role is "viewer"
+func TestFederationAuth_User_DefaultRole(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://securetoken.google.com/my-firebase-project"
+	audience := "my-firebase-project"
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				IssuerType:       "user",
+				// DefaultRole not set — should default to "viewer"
+			},
+		},
+	}
+	auth := newTestAuthenticatorWithConfig(t, cfg, audience)
+
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":   issuer,
+		"sub":   "abcdef123456",
+		"aud":   audience,
+		"iat":   now.Add(-1 * time.Minute).Unix(),
+		"exp":   now.Add(5 * time.Minute).Unix(),
+		"nbf":   now.Add(-1 * time.Minute).Unix(),
+		"email": "user@example.com",
+	}
+	token := signGenericToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	uid, ok := identity.(*FederatedUserIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedUserIdentity, got %T", identity)
+	}
+	if uid.Role() != "viewer" {
+		t.Errorf("expected default role 'viewer', got %q", uid.Role())
+	}
+}
+
+// User Test 8: User token with configured default_role -> role matches config
+func TestFederationAuth_User_ConfiguredRole(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://securetoken.google.com/my-firebase-project"
+	audience := "my-firebase-project"
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				IssuerType:       "user",
+				DefaultRole:      "member",
+			},
+		},
+	}
+	auth := newTestAuthenticatorWithConfig(t, cfg, audience)
+
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":   issuer,
+		"sub":   "abcdef123456",
+		"aud":   audience,
+		"iat":   now.Add(-1 * time.Minute).Unix(),
+		"exp":   now.Add(5 * time.Minute).Unix(),
+		"nbf":   now.Add(-1 * time.Minute).Unix(),
+		"email": "user@example.com",
+	}
+	token := signGenericToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	uid, ok := identity.(*FederatedUserIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedUserIdentity, got %T", identity)
+	}
+	if uid.Role() != "member" {
+		t.Errorf("expected configured role 'member', got %q", uid.Role())
+	}
+}
+
+// User Test 9: User token with email not in allowed_emails -> reject
+func TestFederationAuth_User_EmailNotAllowed(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://securetoken.google.com/my-firebase-project"
+	audience := "my-firebase-project"
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				IssuerType:       "user",
+				AllowedEmails:    []string{"allowed@example.com"},
+			},
+		},
+	}
+	auth := newTestAuthenticatorWithConfig(t, cfg, audience)
+
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":   issuer,
+		"sub":   "abcdef123456",
+		"aud":   audience,
+		"iat":   now.Add(-1 * time.Minute).Unix(),
+		"exp":   now.Add(5 * time.Minute).Unix(),
+		"nbf":   now.Add(-1 * time.Minute).Unix(),
+		"email": "disallowed@example.com",
+	}
+	token := signGenericToken(t, privKey, kid, claims)
+
+	_, err := auth.Authenticate(token)
+	if err == nil {
+		t.Fatal("expected error for disallowed email, got nil")
+	}
+	if !strings.Contains(err.Error(), "not in allowed_emails") {
+		t.Errorf("expected 'not in allowed_emails' in error, got: %v", err)
+	}
+}
+
+// User Test 10: User token default scopes are empty (zero-trust)
+func TestFederationAuth_User_DefaultScopesEmpty(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://securetoken.google.com/my-firebase-project"
+	audience := "my-firebase-project"
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				IssuerType:       "user",
+			},
+		},
+	}
+	auth := newTestAuthenticatorWithConfig(t, cfg, audience)
+
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":   issuer,
+		"sub":   "abcdef123456",
+		"aud":   audience,
+		"iat":   now.Add(-1 * time.Minute).Unix(),
+		"exp":   now.Add(5 * time.Minute).Unix(),
+		"nbf":   now.Add(-1 * time.Minute).Unix(),
+		"email": "user@example.com",
+	}
+	token := signGenericToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	uid, ok := identity.(*FederatedUserIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedUserIdentity, got %T", identity)
+	}
+	scopes := uid.Scopes()
+	if len(scopes) != 0 {
+		t.Errorf("expected empty scopes for user (zero-trust), got %v", scopes)
+	}
+}
+
+// --- Email matching tests ---
+
+// Email Test 11: Exact match works
+func TestMatchesAllowedEmails_ExactMatch(t *testing.T) {
+	patterns := []string{"user@example.com", "admin@corp.com"}
+	if !matchesAllowedEmails(patterns, "user@example.com") {
+		t.Error("expected exact match for user@example.com")
+	}
+	if !matchesAllowedEmails(patterns, "admin@corp.com") {
+		t.Error("expected exact match for admin@corp.com")
+	}
+	if matchesAllowedEmails(patterns, "other@example.com") {
+		t.Error("expected no match for other@example.com")
+	}
+}
+
+// Email Test 12: Wildcard *@example.com matches user@example.com
+func TestMatchesAllowedEmails_WildcardMatch(t *testing.T) {
+	patterns := []string{"*@example.com"}
+	if !matchesAllowedEmails(patterns, "user@example.com") {
+		t.Error("expected wildcard match for user@example.com")
+	}
+	if !matchesAllowedEmails(patterns, "admin@example.com") {
+		t.Error("expected wildcard match for admin@example.com")
+	}
+}
+
+// Email Test 13: Wildcard *@example.com does NOT match user@other.com
+func TestMatchesAllowedEmails_WildcardNoMatch(t *testing.T) {
+	patterns := []string{"*@example.com"}
+	if matchesAllowedEmails(patterns, "user@other.com") {
+		t.Error("expected no match for user@other.com with pattern *@example.com")
+	}
+	if matchesAllowedEmails(patterns, "user@example.com.evil.com") {
+		t.Error("expected no match for user@example.com.evil.com with pattern *@example.com")
+	}
+}
+
+// Email Test 14: Empty allowed_emails list -> all accepted
+func TestMatchesAllowedEmails_EmptyListAcceptsAll(t *testing.T) {
+	// When AllowedEmails is empty, the caller (Authenticate) skips the check entirely.
+	// But matchesAllowedEmails with empty list should return false (defense-in-depth).
+	patterns := []string{}
+	if matchesAllowedEmails(patterns, "anyone@example.com") {
+		t.Error("expected empty pattern list to not match anything (caller should skip)")
+	}
+}
+
+// --- Hub backward compatibility ---
+
+// Hub Test 15: Existing hub issuer with no issuer_type field -> works as before (defaults to "hub")
+func TestFederationAuth_HubBackwardCompat_NoIssuerType(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	issuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+
+	// No IssuerType set — should default to hub behavior
+	auth := newTestAuthenticator(t, issuer, jwksSrv.URL, audience)
+
+	claims := validFederationClaims(issuer, audience)
+	token := signFederationToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	agentID, ok := identity.(*FederatedAgentIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedAgentIdentity (hub default), got %T", identity)
+	}
+	if agentID.RemoteAgentID() != "agent-123" {
+		t.Errorf("expected agent ID 'agent-123', got %q", agentID.RemoteAgentID())
+	}
+	if agentID.RemoteProjectID() != "project-alpha" {
+		t.Errorf("expected project 'project-alpha', got %q", agentID.RemoteProjectID())
+	}
+	if agentID.AgentName() != "worker-1" {
+		t.Errorf("expected agent name 'worker-1', got %q", agentID.AgentName())
+	}
+	// Verify default scopes are applied (hub defaults)
+	scopes := agentID.Scopes()
+	if len(scopes) != len(DefaultFederationScopes) {
+		t.Errorf("expected %d default scopes, got %d", len(DefaultFederationScopes), len(scopes))
 	}
 }

--- a/pkg/hub/federation_auth_test.go
+++ b/pkg/hub/federation_auth_test.go
@@ -1340,6 +1340,61 @@ func TestFederationAuth_User_DefaultScopesEmpty(t *testing.T) {
 	}
 }
 
+// --- Trailing slash normalization tests ---
+
+// Test: Issuer URL trailing slash normalization — config has no slash, token has slash
+func TestFederationAuth_IssuerTrailingSlashNormalization(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	// Config issuer has no trailing slash
+	configIssuer := "https://hub-a.example.com"
+	// Token issuer has trailing slash
+	tokenIssuer := "https://hub-a.example.com/"
+	audience := "https://hub-b.example.com"
+
+	auth := newTestAuthenticator(t, configIssuer, jwksSrv.URL, audience)
+
+	claims := validFederationClaims(tokenIssuer, audience)
+	token := signFederationToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected success despite trailing slash difference, got error: %v", err)
+	}
+	if identity == nil {
+		t.Fatal("expected identity, got nil")
+	}
+	agentID, ok := identity.(*FederatedAgentIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedAgentIdentity, got %T", identity)
+	}
+	if agentID.RemoteAgentID() != "agent-123" {
+		t.Errorf("expected agent ID 'agent-123', got %q", agentID.RemoteAgentID())
+	}
+}
+
+// Test: Issuer URL trailing slash normalization — config has slash, token has no slash
+func TestFederationAuth_IssuerTrailingSlashNormalization_Reverse(t *testing.T) {
+	privKey, jwksSrv, kid := setupFederationTestServer(t)
+	// Config issuer has trailing slash
+	configIssuer := "https://hub-a.example.com/"
+	// Token issuer has no trailing slash
+	tokenIssuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+
+	auth := newTestAuthenticator(t, configIssuer, jwksSrv.URL, audience)
+
+	claims := validFederationClaims(tokenIssuer, audience)
+	token := signFederationToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected success despite trailing slash difference, got error: %v", err)
+	}
+	if identity == nil {
+		t.Fatal("expected identity, got nil")
+	}
+}
+
 // --- Email matching tests ---
 
 // Email Test 11: Exact match works

--- a/pkg/hub/federation_auth_test.go
+++ b/pkg/hub/federation_auth_test.go
@@ -1426,3 +1426,118 @@ func TestFederationAuth_HubBackwardCompat_NoIssuerType(t *testing.T) {
 		t.Errorf("expected %d default scopes, got %d", len(DefaultFederationScopes), len(scopes))
 	}
 }
+
+// --- OIDC Discovery integration tests ---
+
+// Discovery Test 1: OIDC discovery resolves JWKS URL for non-hub issuer
+func TestFederationAuth_OIDCDiscovery_ResolvesJWKSURL(t *testing.T) {
+	kid := "discovery-key"
+	audience := "https://hub-b.example.com"
+
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	// JWKS server
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{Key: &privKey.PublicKey, KeyID: kid, Algorithm: string(jose.RS256), Use: "sig"},
+		},
+	}
+	jwksData, _ := json.Marshal(jwks)
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksData)
+	}))
+	t.Cleanup(jwksSrv.Close)
+
+	// Issuer server with OIDC discovery that points to the JWKS server
+	issuerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/openid-configuration" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jwks_uri": "` + jwksSrv.URL + `"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(issuerSrv.Close)
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuerSrv.URL,
+				JWKSURL:          "", // empty — discovery should resolve
+				ExpectedAudience: audience,
+				IssuerType:       "service_account",
+			},
+		},
+	}
+
+	// NewFederationAuthenticator should succeed (discovery resolves JWKS URL)
+	auth, err := NewFederationAuthenticator(cfg, audience,
+		&http.Client{Timeout: 5 * time.Second}, "dev", slog.Default())
+	if err != nil {
+		t.Fatalf("NewFederationAuthenticator should succeed with discovery, got error: %v", err)
+	}
+
+	// Authenticate a valid token to prove the discovered URL was used
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":   issuerSrv.URL,
+		"sub":   "discovery-test-subject",
+		"aud":   audience,
+		"iat":   now.Add(-1 * time.Minute).Unix(),
+		"exp":   now.Add(5 * time.Minute).Unix(),
+		"nbf":   now.Add(-1 * time.Minute).Unix(),
+		"email": "test-sa@project.iam.gserviceaccount.com",
+	}
+	token := signGenericToken(t, privKey, kid, claims)
+
+	identity, err := auth.Authenticate(token)
+	if err != nil {
+		t.Fatalf("expected authentication success, got error: %v", err)
+	}
+
+	sid, ok := identity.(*FederatedServiceIdentity)
+	if !ok {
+		t.Fatalf("expected *FederatedServiceIdentity, got %T", identity)
+	}
+	if sid.Email() != "test-sa@project.iam.gserviceaccount.com" {
+		t.Errorf("expected email 'test-sa@project.iam.gserviceaccount.com', got %q", sid.Email())
+	}
+}
+
+// Discovery Test 2: OIDC discovery failure when no jwks_url configured and no discovery endpoint
+func TestFederationAuth_OIDCDiscovery_FailureNoEndpoint(t *testing.T) {
+	audience := "https://hub-b.example.com"
+
+	// Issuer server with NO discovery endpoint
+	issuerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(issuerSrv.Close)
+
+	cfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuerSrv.URL,
+				JWKSURL:          "", // empty — discovery will fail
+				ExpectedAudience: audience,
+				IssuerType:       "service_account",
+			},
+		},
+	}
+
+	// NewFederationAuthenticator should fail — no JWKS URL and discovery fails
+	_, err := NewFederationAuthenticator(cfg, audience,
+		&http.Client{Timeout: 5 * time.Second}, "dev", slog.Default())
+	if err == nil {
+		t.Fatal("expected error when JWKS URL not configured and discovery fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "OIDC discovery failed") {
+		t.Errorf("expected 'OIDC discovery failed' in error, got: %v", err)
+	}
+}

--- a/pkg/hub/federation_auth_test.go
+++ b/pkg/hub/federation_auth_test.go
@@ -1388,6 +1388,22 @@ func TestMatchesAllowedEmails_EmptyListAcceptsAll(t *testing.T) {
 	}
 }
 
+// Email Test 15: Case-insensitive exact match
+func TestMatchesAllowedEmails_CaseInsensitiveExact(t *testing.T) {
+	patterns := []string{"User@Example.COM"}
+	if !matchesAllowedEmails(patterns, "user@example.com") {
+		t.Error("expected case-insensitive match for user@example.com against User@Example.COM")
+	}
+}
+
+// Email Test 16: Case-insensitive wildcard match
+func TestMatchesAllowedEmails_CaseInsensitiveWildcard(t *testing.T) {
+	patterns := []string{"*@Example.COM"}
+	if !matchesAllowedEmails(patterns, "user@example.com") {
+		t.Error("expected case-insensitive wildcard match for user@example.com against *@Example.COM")
+	}
+}
+
 // --- Hub backward compatibility ---
 
 // Hub Test 15: Existing hub issuer with no issuer_type field -> works as before (defaults to "hub")

--- a/pkg/hub/federation_auth_test.go
+++ b/pkg/hub/federation_auth_test.go
@@ -458,6 +458,36 @@ func TestFederationAuth_JWKSDownCachedKeys(t *testing.T) {
 	}
 }
 
+// Test 9b: JWKS endpoint down with no cached keys -> reject with clear error
+func TestFederationAuth_JWKSDownNoCachedKeys(t *testing.T) {
+	kid := "no-cache-key"
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	// JWKS server that always returns HTTP 500
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	issuer := "https://hub-a.example.com"
+	audience := "https://hub-b.example.com"
+	auth := newTestAuthenticator(t, issuer, srv.URL, audience)
+
+	claims := validFederationClaims(issuer, audience)
+	token := signFederationToken(t, privKey, kid, claims)
+
+	_, err = auth.Authenticate(token)
+	if err == nil {
+		t.Fatal("expected error when JWKS is down with no cached keys, got nil")
+	}
+	if !containsStr(err.Error(), "JWKS key lookup failed") {
+		t.Errorf("expected 'JWKS key lookup failed' in error, got: %v", err)
+	}
+}
+
 // Test 10: Empty sub claim -> reject
 func TestFederationAuth_EmptySubject(t *testing.T) {
 	privKey, jwksSrv, kid := setupFederationTestServer(t)
@@ -694,8 +724,12 @@ func TestFederationAuth_DerivedJWKSURL(t *testing.T) {
 	}
 	jwksData, _ := json.Marshal(jwks)
 
-	// Start server that serves JWKS at /.well-known/jwks.json
+	// Start server that serves JWKS only at the derived path /.well-known/jwks.json
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/jwks.json" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(jwksData)
 	}))
@@ -706,8 +740,7 @@ func TestFederationAuth_DerivedJWKSURL(t *testing.T) {
 		Enabled: true,
 		TrustedIssuers: []config.TrustedIssuerConfig{
 			{
-				IssuerURL:        srv.URL,        // JWKS will be derived as srv.URL + /.well-known/jwks.json
-				JWKSURL:          srv.URL,         // for test simplicity, point directly at server
+				IssuerURL:        srv.URL, // JWKSURL left empty — derivation adds /.well-known/jwks.json
 				ExpectedAudience: audience,
 			},
 		},

--- a/pkg/hub/federation_auth_test.go
+++ b/pkg/hub/federation_auth_test.go
@@ -819,4 +819,3 @@ func TestFederationAuth_ProjectAllowed(t *testing.T) {
 		t.Errorf("expected project 'project-alpha', got %q", identity.RemoteProjectID())
 	}
 }
-

--- a/pkg/hub/federation_e2e_test.go
+++ b/pkg/hub/federation_e2e_test.go
@@ -312,3 +312,447 @@ func TestFederationE2E_NoFederationHeader(t *testing.T) {
 		t.Fatalf("expected status 401, got %d", resp.StatusCode)
 	}
 }
+
+// --- Non-Hub Issuer E2E Tests ---
+
+// setupNonHubE2EServer creates a test server with federation auth middleware for non-hub issuers.
+// Unlike setupE2EServer, this does NOT use RequireFederationAccess (which requires AgentIdentity),
+// since non-hub identities (service accounts, users) do not implement AgentIdentity.
+// The handler extracts identity via GetIdentityFromContext and returns details as JSON.
+func setupNonHubE2EServer(t *testing.T, fedCfg config.FederationConfig, audience string) *httptest.Server {
+	t.Helper()
+
+	authenticator, err := NewFederationAuthenticator(fedCfg, audience,
+		&http.Client{Timeout: 5 * time.Second}, "dev", slog.Default())
+	if err != nil {
+		t.Fatalf("NewFederationAuthenticator failed: %v", err)
+	}
+
+	authCfg := AuthConfig{
+		Mode:                    "production",
+		FederationAuthenticator: authenticator,
+		Debug:                   true,
+		Logger:                  slog.Default(),
+	}
+
+	identityHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identity := GetIdentityFromContext(r.Context())
+		if identity == nil {
+			http.Error(w, "no identity in context", http.StatusInternalServerError)
+			return
+		}
+
+		resp := map[string]interface{}{
+			"id":   identity.ID(),
+			"type": identity.Type(),
+		}
+
+		if fed, ok := identity.(FederatedIdentity); ok {
+			resp["issuer_url"] = fed.IssuerURL()
+		}
+
+		if sid, ok := identity.(*FederatedServiceIdentity); ok {
+			resp["email"] = sid.Email()
+			resp["subject"] = sid.Subject()
+			resp["scopes_count"] = len(sid.Scopes())
+		}
+
+		if uid, ok := identity.(*FederatedUserIdentity); ok {
+			resp["email"] = uid.Email()
+			resp["display_name"] = uid.DisplayName()
+			resp["role"] = uid.Role()
+			resp["subject"] = uid.Subject()
+			resp["scopes_count"] = len(uid.Scopes())
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	authMiddleware := UnifiedAuthMiddleware(authCfg)
+	handler := authMiddleware(identityHandler)
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return server
+}
+
+// TestFederationE2E_GCPServiceAccount tests the full E2E flow for a GCP service account issuer.
+func TestFederationE2E_GCPServiceAccount(t *testing.T) {
+	kid := "sa-e2e-key"
+	saIssuer := "https://accounts.google.com"
+	audience := "https://hub-b.example.com"
+
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{Key: &privKey.PublicKey, KeyID: kid, Algorithm: string(jose.RS256), Use: "sig"},
+		},
+	}
+	jwksData, _ := json.Marshal(jwks)
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksData)
+	}))
+	t.Cleanup(jwksSrv.Close)
+
+	fedCfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        saIssuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				IssuerType:       "service_account",
+				AllowedEmails:    []string{"my-sa@my-project.iam.gserviceaccount.com"},
+			},
+		},
+	}
+
+	server := setupNonHubE2EServer(t, fedCfg, audience)
+
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":            saIssuer,
+		"sub":            "sa-subject-123",
+		"aud":            audience,
+		"iat":            now.Add(-1 * time.Minute).Unix(),
+		"exp":            now.Add(5 * time.Minute).Unix(),
+		"nbf":            now.Add(-1 * time.Minute).Unix(),
+		"email":          "my-sa@my-project.iam.gserviceaccount.com",
+		"email_verified": true,
+	}
+	token := signGenericToken(t, privKey, kid, claims)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set(FederationTokenHeader, token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// Verify identity fields
+	if body["type"] != "federated_service" {
+		t.Errorf("expected type 'federated_service', got %v", body["type"])
+	}
+	expectedID := saIssuer + ":sa-subject-123"
+	if body["id"] != expectedID {
+		t.Errorf("expected id %q, got %v", expectedID, body["id"])
+	}
+	if body["email"] != "my-sa@my-project.iam.gserviceaccount.com" {
+		t.Errorf("expected email 'my-sa@my-project.iam.gserviceaccount.com', got %v", body["email"])
+	}
+	if body["subject"] != "sa-subject-123" {
+		t.Errorf("expected subject 'sa-subject-123', got %v", body["subject"])
+	}
+	if body["issuer_url"] != saIssuer {
+		t.Errorf("expected issuer_url %q, got %v", saIssuer, body["issuer_url"])
+	}
+	// SA gets zero-trust empty scopes
+	if body["scopes_count"] != float64(0) {
+		t.Errorf("expected scopes_count 0 (zero-trust), got %v", body["scopes_count"])
+	}
+}
+
+// TestFederationE2E_FirebaseUser tests the full E2E flow for a Firebase user issuer.
+func TestFederationE2E_FirebaseUser(t *testing.T) {
+	kid := "user-e2e-key"
+	userIssuer := "https://securetoken.google.com/my-firebase-project"
+	audience := "my-firebase-project"
+
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{Key: &privKey.PublicKey, KeyID: kid, Algorithm: string(jose.RS256), Use: "sig"},
+		},
+	}
+	jwksData, _ := json.Marshal(jwks)
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksData)
+	}))
+	t.Cleanup(jwksSrv.Close)
+
+	fedCfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        userIssuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				IssuerType:       "user",
+				DefaultRole:      "editor",
+				AllowedEmails:    []string{"*@example.com"},
+			},
+		},
+	}
+
+	server := setupNonHubE2EServer(t, fedCfg, audience)
+
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":            userIssuer,
+		"sub":            "firebase-uid-abc123",
+		"aud":            audience,
+		"iat":            now.Add(-1 * time.Minute).Unix(),
+		"exp":            now.Add(5 * time.Minute).Unix(),
+		"nbf":            now.Add(-1 * time.Minute).Unix(),
+		"email":          "user@example.com",
+		"email_verified": true,
+		"name":           "Test User",
+	}
+	token := signGenericToken(t, privKey, kid, claims)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set(FederationTokenHeader, token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// Verify identity fields
+	if body["type"] != "federated_user" {
+		t.Errorf("expected type 'federated_user', got %v", body["type"])
+	}
+	expectedID := userIssuer + ":firebase-uid-abc123"
+	if body["id"] != expectedID {
+		t.Errorf("expected id %q, got %v", expectedID, body["id"])
+	}
+	if body["email"] != "user@example.com" {
+		t.Errorf("expected email 'user@example.com', got %v", body["email"])
+	}
+	if body["display_name"] != "Test User" {
+		t.Errorf("expected display_name 'Test User', got %v", body["display_name"])
+	}
+	if body["role"] != "editor" {
+		t.Errorf("expected role 'editor', got %v", body["role"])
+	}
+	if body["issuer_url"] != userIssuer {
+		t.Errorf("expected issuer_url %q, got %v", userIssuer, body["issuer_url"])
+	}
+	// User gets zero-trust empty scopes
+	if body["scopes_count"] != float64(0) {
+		t.Errorf("expected scopes_count 0 (zero-trust), got %v", body["scopes_count"])
+	}
+
+	// Also verify the identity can be retrieved via GetUserIdentityFromContext
+	// and GetFederatedIdentityFromContext. We do this by creating a direct
+	// authenticator-level test inline since E2E handlers can't easily return
+	// context interface assertions over HTTP.
+	authenticator, err := NewFederationAuthenticator(fedCfg, audience,
+		&http.Client{Timeout: 5 * time.Second}, "dev", slog.Default())
+	if err != nil {
+		t.Fatalf("NewFederationAuthenticator failed: %v", err)
+	}
+	identity, err := authenticator.Authenticate(token)
+	if err != nil {
+		t.Fatalf("Authenticate failed: %v", err)
+	}
+	// FederatedUserIdentity implements UserIdentity
+	if _, ok := identity.(UserIdentity); !ok {
+		t.Errorf("expected FederatedUserIdentity to implement UserIdentity")
+	}
+	// FederatedUserIdentity implements FederatedIdentity
+	if _, ok := identity.(FederatedIdentity); !ok {
+		t.Errorf("expected FederatedUserIdentity to implement FederatedIdentity")
+	}
+}
+
+// TestFederationE2E_SAEmailRejected tests that a SA with email not in allowed_emails is rejected.
+func TestFederationE2E_SAEmailRejected(t *testing.T) {
+	kid := "sa-reject-key"
+	saIssuer := "https://accounts.google.com"
+	audience := "https://hub-b.example.com"
+
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{Key: &privKey.PublicKey, KeyID: kid, Algorithm: string(jose.RS256), Use: "sig"},
+		},
+	}
+	jwksData, _ := json.Marshal(jwks)
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksData)
+	}))
+	t.Cleanup(jwksSrv.Close)
+
+	fedCfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        saIssuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: audience,
+				IssuerType:       "service_account",
+				AllowedEmails:    []string{"allowed-sa@my-project.iam.gserviceaccount.com"},
+			},
+		},
+	}
+
+	server := setupNonHubE2EServer(t, fedCfg, audience)
+
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":            saIssuer,
+		"sub":            "wrong-sa-subject",
+		"aud":            audience,
+		"iat":            now.Add(-1 * time.Minute).Unix(),
+		"exp":            now.Add(5 * time.Minute).Unix(),
+		"nbf":            now.Add(-1 * time.Minute).Unix(),
+		"email":          "wrong-sa@other-project.iam.gserviceaccount.com",
+		"email_verified": true,
+	}
+	token := signGenericToken(t, privKey, kid, claims)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set(FederationTokenHeader, token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected status 401 for disallowed email, got %d", resp.StatusCode)
+	}
+}
+
+// TestFederationE2E_OIDCDiscovery tests the full E2E flow where OIDC discovery resolves the JWKS URL.
+func TestFederationE2E_OIDCDiscovery(t *testing.T) {
+	kid := "discovery-e2e-key"
+	audience := "https://hub-b.example.com"
+
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{Key: &privKey.PublicKey, KeyID: kid, Algorithm: string(jose.RS256), Use: "sig"},
+		},
+	}
+	jwksData, _ := json.Marshal(jwks)
+
+	// JWKS server at a separate URL
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksData)
+	}))
+	t.Cleanup(jwksSrv.Close)
+
+	// Issuer server with OIDC discovery endpoint that points to the JWKS server
+	issuerSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/openid-configuration" {
+			w.Header().Set("Content-Type", "application/json")
+			discoveryDoc := `{"issuer": "` + "placeholder" + `", "jwks_uri": "` + jwksSrv.URL + `"}`
+			_, _ = w.Write([]byte(discoveryDoc))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(issuerSrv.Close)
+
+	// Configure with NO jwks_url — OIDC discovery should resolve it
+	fedCfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        issuerSrv.URL,
+				JWKSURL:          "", // empty — discovery should resolve
+				ExpectedAudience: audience,
+				IssuerType:       "service_account",
+				AllowedEmails:    []string{"*@my-project.iam.gserviceaccount.com"},
+			},
+		},
+	}
+
+	server := setupNonHubE2EServer(t, fedCfg, audience)
+
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":            issuerSrv.URL,
+		"sub":            "discovery-sa-subject",
+		"aud":            audience,
+		"iat":            now.Add(-1 * time.Minute).Unix(),
+		"exp":            now.Add(5 * time.Minute).Unix(),
+		"nbf":            now.Add(-1 * time.Minute).Unix(),
+		"email":          "discovered-sa@my-project.iam.gserviceaccount.com",
+		"email_verified": true,
+	}
+	token := signGenericToken(t, privKey, kid, claims)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set(FederationTokenHeader, token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200 (OIDC discovery should resolve JWKS URL), got %d", resp.StatusCode)
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if body["type"] != "federated_service" {
+		t.Errorf("expected type 'federated_service', got %v", body["type"])
+	}
+	if body["email"] != "discovered-sa@my-project.iam.gserviceaccount.com" {
+		t.Errorf("expected email 'discovered-sa@my-project.iam.gserviceaccount.com', got %v", body["email"])
+	}
+}

--- a/pkg/hub/federation_e2e_test.go
+++ b/pkg/hub/federation_e2e_test.go
@@ -589,10 +589,6 @@ func TestFederationE2E_FirebaseUser(t *testing.T) {
 	if _, ok := identity.(UserIdentity); !ok {
 		t.Errorf("expected FederatedUserIdentity to implement UserIdentity")
 	}
-	// FederatedUserIdentity implements FederatedIdentity
-	if _, ok := identity.(FederatedIdentity); !ok {
-		t.Errorf("expected FederatedUserIdentity to implement FederatedIdentity")
-	}
 }
 
 // TestFederationE2E_SAEmailRejected tests that a SA with email not in allowed_emails is rejected.

--- a/pkg/hub/federation_e2e_test.go
+++ b/pkg/hub/federation_e2e_test.go
@@ -173,7 +173,7 @@ func TestFederationE2E_FullSuccessPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected status 200, got %d", resp.StatusCode)
@@ -223,7 +223,7 @@ func TestFederationE2E_ScopeDenied(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected status 403, got %d", resp.StatusCode)
@@ -256,7 +256,7 @@ func TestFederationE2E_UntrustedIssuer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("expected status 401, got %d", resp.StatusCode)
@@ -284,7 +284,7 @@ func TestFederationE2E_ExpiredToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("expected status 401, got %d", resp.StatusCode)
@@ -306,7 +306,7 @@ func TestFederationE2E_NoFederationHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("expected status 401, got %d", resp.StatusCode)

--- a/pkg/hub/federation_e2e_test.go
+++ b/pkg/hub/federation_e2e_test.go
@@ -1,0 +1,314 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// e2eResponse is the JSON response returned by the E2E test endpoint handler
+// to verify identity details from the full authentication flow.
+type e2eResponse struct {
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	IssuerURL string `json:"issuer_url"`
+	AgentID   string `json:"agent_id"`
+	AgentName string `json:"agent_name"`
+	ProjectID string `json:"project_id"`
+}
+
+// setupE2EServer sets up the full Hub B middleware stack:
+//   - FederationAuthenticator trusting Hub A
+//   - UnifiedAuthMiddleware with the authenticator
+//   - RequireFederationAccess(requiredScope) on a test endpoint
+//   - A handler that returns identity details as JSON
+//
+// It returns the test server, the Hub A private key and kid for signing tokens,
+// the Hub A issuer URL, and the Hub B audience.
+func setupE2EServer(t *testing.T, requiredScope AgentTokenScope) (
+	server *httptest.Server,
+	hubAKey *rsa.PrivateKey,
+	hubAIssuer string,
+	hubBAudience string,
+	kid string,
+) {
+	t.Helper()
+
+	// --- Hub A's OIDC infrastructure ---
+	kid = "hub-a-e2e-key"
+	hubAIssuer = "https://hub-a.example.com"
+	hubBAudience = "https://hub-b.example.com"
+
+	hubAKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{
+				Key:       &hubAKey.PublicKey,
+				KeyID:     kid,
+				Algorithm: string(jose.RS256),
+				Use:       "sig",
+			},
+		},
+	}
+	jwksData, err := json.Marshal(jwks)
+	if err != nil {
+		t.Fatalf("failed to marshal JWKS: %v", err)
+	}
+
+	jwksSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(jwksData)
+	}))
+	t.Cleanup(jwksSrv.Close)
+
+	// --- Hub B's middleware stack ---
+	fedCfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        hubAIssuer,
+				JWKSURL:          jwksSrv.URL,
+				ExpectedAudience: hubBAudience,
+			},
+		},
+	}
+	authenticator, err := NewFederationAuthenticator(fedCfg, hubBAudience,
+		&http.Client{Timeout: 5 * time.Second}, "dev", slog.Default())
+	if err != nil {
+		t.Fatalf("NewFederationAuthenticator failed: %v", err)
+	}
+
+	authCfg := AuthConfig{
+		Mode:                    "production",
+		FederationAuthenticator: authenticator,
+		Debug:                   true,
+		Logger:                  slog.Default(),
+	}
+
+	// Build the handler chain: auth middleware -> access control -> handler
+	identityHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		identity := GetAgentIdentityFromContext(r.Context())
+		if identity == nil {
+			http.Error(w, "no agent identity", http.StatusInternalServerError)
+			return
+		}
+
+		fed, ok := identity.(*FederatedAgentIdentity)
+		if !ok {
+			http.Error(w, "not a federated identity", http.StatusInternalServerError)
+			return
+		}
+
+		resp := e2eResponse{
+			ID:        fed.ID(),
+			Type:      fed.Type(),
+			IssuerURL: fed.IssuerURL(),
+			AgentID:   fed.RemoteAgentID(),
+			AgentName: fed.AgentName(),
+			ProjectID: fed.ProjectID(),
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	accessMiddleware := RequireFederationAccess(requiredScope)
+	authMiddleware := UnifiedAuthMiddleware(authCfg)
+	handler := authMiddleware(accessMiddleware(identityHandler))
+
+	server = httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	return server, hubAKey, hubAIssuer, hubBAudience, kid
+}
+
+// TestFederationE2E_FullSuccessPath tests the complete federation flow:
+// Hub A issues a token -> Hub B validates it via middleware -> access control passes -> 200.
+func TestFederationE2E_FullSuccessPath(t *testing.T) {
+	server, hubAKey, hubAIssuer, hubBAudience, kid := setupE2EServer(t, ScopeAgentStatusUpdate)
+
+	claims := validFederationClaims(hubAIssuer, hubBAudience)
+	claims.Subject = "e2e-agent-1"
+	claims.AgentName = "e2e-worker"
+	claims.ProjectID = "e2e-project"
+	claims.RootUser = "user:e2e-admin"
+	token := signFederationToken(t, hubAKey, kid, claims)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set(FederationTokenHeader, token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var body e2eResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if body.AgentID != "e2e-agent-1" {
+		t.Errorf("expected agent_id 'e2e-agent-1', got %q", body.AgentID)
+	}
+	if body.Type != "federated_agent" {
+		t.Errorf("expected type 'federated_agent', got %q", body.Type)
+	}
+	if body.IssuerURL != hubAIssuer {
+		t.Errorf("expected issuer_url %q, got %q", hubAIssuer, body.IssuerURL)
+	}
+	if body.AgentName != "e2e-worker" {
+		t.Errorf("expected agent_name 'e2e-worker', got %q", body.AgentName)
+	}
+	// ProjectID should be empty — federated agents have no local project binding
+	if body.ProjectID != "" {
+		t.Errorf("expected empty project_id, got %q", body.ProjectID)
+	}
+}
+
+// TestFederationE2E_ScopeDenied tests that a valid token without the required
+// scope is rejected with 403.
+func TestFederationE2E_ScopeDenied(t *testing.T) {
+	// Server requires ScopeProjectSecretRead, but default scopes only include
+	// ScopeAgentStatusUpdate and ScopeAgentLogAppend.
+	server, hubAKey, hubAIssuer, hubBAudience, kid := setupE2EServer(t, ScopeProjectSecretRead)
+
+	claims := validFederationClaims(hubAIssuer, hubBAudience)
+	claims.Subject = "e2e-agent-2"
+	token := signFederationToken(t, hubAKey, kid, claims)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set(FederationTokenHeader, token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d", resp.StatusCode)
+	}
+}
+
+// TestFederationE2E_UntrustedIssuer tests that a token from an issuer not in
+// Hub B's trusted list is rejected with 401.
+func TestFederationE2E_UntrustedIssuer(t *testing.T) {
+	server, _, _, hubBAudience, _ := setupE2EServer(t, ScopeAgentStatusUpdate)
+
+	// Generate a separate key for the untrusted issuer
+	untrustedKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate untrusted RSA key: %v", err)
+	}
+
+	untrustedIssuer := "https://evil-hub.example.com"
+	claims := validFederationClaims(untrustedIssuer, hubBAudience)
+	claims.Subject = "evil-agent"
+	token := signFederationToken(t, untrustedKey, "evil-key", claims)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set(FederationTokenHeader, token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", resp.StatusCode)
+	}
+}
+
+// TestFederationE2E_ExpiredToken tests that an expired token is rejected with 401.
+func TestFederationE2E_ExpiredToken(t *testing.T) {
+	server, hubAKey, hubAIssuer, hubBAudience, kid := setupE2EServer(t, ScopeAgentStatusUpdate)
+
+	claims := validFederationClaims(hubAIssuer, hubBAudience)
+	claims.Subject = "expired-agent"
+	claims.Expiry = jwt.NewNumericDate(time.Now().Add(-10 * time.Minute))
+	claims.IssuedAt = jwt.NewNumericDate(time.Now().Add(-15 * time.Minute))
+	claims.NotBefore = jwt.NewNumericDate(time.Now().Add(-15 * time.Minute))
+	token := signFederationToken(t, hubAKey, kid, claims)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	req.Header.Set(FederationTokenHeader, token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", resp.StatusCode)
+	}
+}
+
+// TestFederationE2E_NoFederationHeader tests that a request without the
+// federation header is rejected with 401 (no agent identity for access control).
+func TestFederationE2E_NoFederationHeader(t *testing.T) {
+	server, _, _, _, _ := setupE2EServer(t, ScopeAgentStatusUpdate)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	// No federation header set
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d", resp.StatusCode)
+	}
+}

--- a/pkg/hub/federation_identity.go
+++ b/pkg/hub/federation_identity.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+// FederatedAgentIdentity represents an agent authenticated via OIDC from a
+// trusted external issuer. It implements the AgentIdentity interface.
+type FederatedAgentIdentity struct {
+	issuerURL string
+	agentID   string
+	projectID string
+	agentName string
+	ancestry  []string
+	rootUser  string
+	scopes    []AgentTokenScope
+}
+
+// NewFederatedAgentIdentity constructs a new FederatedAgentIdentity.
+func NewFederatedAgentIdentity(issuerURL, agentID, projectID, agentName, rootUser string,
+	ancestry []string, scopes []AgentTokenScope) *FederatedAgentIdentity {
+	return &FederatedAgentIdentity{
+		issuerURL: issuerURL,
+		agentID:   agentID,
+		projectID: projectID,
+		agentName: agentName,
+		ancestry:  ancestry,
+		rootUser:  rootUser,
+		scopes:    scopes,
+	}
+}
+
+// ID returns the unique identifier for this federated agent, combining the
+// issuer URL and remote agent ID.
+func (f *FederatedAgentIdentity) ID() string { return f.issuerURL + ":" + f.agentID }
+
+// Type returns the identity type ("federated_agent").
+func (f *FederatedAgentIdentity) Type() string { return "federated_agent" }
+
+// ProjectID returns an empty string. Federated agents are not bound to a local
+// project; use RemoteProjectID() to get the project on the originating hub.
+func (f *FederatedAgentIdentity) ProjectID() string { return "" }
+
+// Scopes returns the scopes granted to this federated agent.
+func (f *FederatedAgentIdentity) Scopes() []AgentTokenScope { return f.scopes }
+
+// HasScope reports whether the federated agent has been granted the given scope.
+func (f *FederatedAgentIdentity) HasScope(scope AgentTokenScope) bool {
+	for _, s := range f.scopes {
+		if s == scope {
+			return true
+		}
+	}
+	return false
+}
+
+// Ancestry returns the ordered ancestor chain from the OIDC token claims.
+func (f *FederatedAgentIdentity) Ancestry() []string { return f.ancestry }
+
+// OriginUserID returns the root user who originated the agent chain on the
+// remote hub.
+func (f *FederatedAgentIdentity) OriginUserID() string { return f.rootUser }
+
+// IssuerURL returns the OIDC issuer URL of the trusted external issuer.
+func (f *FederatedAgentIdentity) IssuerURL() string { return f.issuerURL }
+
+// RemoteAgentID returns the agent ID on the originating hub.
+func (f *FederatedAgentIdentity) RemoteAgentID() string { return f.agentID }
+
+// RemoteProjectID returns the project ID on the originating hub.
+func (f *FederatedAgentIdentity) RemoteProjectID() string { return f.projectID }
+
+// AgentName returns the human-readable name of the agent on the originating hub.
+func (f *FederatedAgentIdentity) AgentName() string { return f.agentName }

--- a/pkg/hub/federation_identity_ext.go
+++ b/pkg/hub/federation_identity_ext.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import "context"
+
+// IssuerType determines how tokens from a trusted issuer are parsed
+// and what identity type they produce.
+type IssuerType string
+
+const (
+	// IssuerTypeHub is a Scion Hub OIDC IdP. Tokens carry project_id,
+	// agent_name, ancestry, root_user claims. Produces FederatedAgentIdentity.
+	IssuerTypeHub IssuerType = "hub"
+
+	// IssuerTypeServiceAccount is a cloud provider issuing SA tokens
+	// (e.g. accounts.google.com). Tokens carry sub, email, aud.
+	// Produces FederatedServiceIdentity.
+	IssuerTypeServiceAccount IssuerType = "service_account"
+
+	// IssuerTypeUser is an identity provider issuing user tokens
+	// (e.g. Firebase Auth, Google Sign-In). Tokens carry sub, email,
+	// optionally name. Produces FederatedUserIdentity.
+	IssuerTypeUser IssuerType = "user"
+)
+
+// FederatedIdentity is implemented by all identity types that originate from
+// an external OIDC issuer. It provides the common federation metadata.
+type FederatedIdentity interface {
+	Identity
+	IssuerURL() string
+}
+
+// GetFederatedIdentityFromContext returns the identity if it implements FederatedIdentity.
+func GetFederatedIdentityFromContext(ctx context.Context) (FederatedIdentity, bool) {
+	id := GetIdentityFromContext(ctx)
+	if id == nil {
+		return nil, false
+	}
+	fed, ok := id.(FederatedIdentity)
+	return fed, ok
+}
+
+// FederatedServiceIdentity represents a machine identity authenticated via OIDC
+// from a trusted external issuer (e.g. GCP service account).
+// Implements Identity and FederatedIdentity but NOT AgentIdentity — service
+// accounts are not agents.
+type FederatedServiceIdentity struct {
+	issuerURL string
+	subject   string
+	email     string
+	scopes    []AgentTokenScope
+}
+
+// NewFederatedServiceIdentity constructs a new FederatedServiceIdentity.
+func NewFederatedServiceIdentity(issuerURL, subject, email string,
+	scopes []AgentTokenScope) *FederatedServiceIdentity {
+	return &FederatedServiceIdentity{
+		issuerURL: issuerURL,
+		subject:   subject,
+		email:     email,
+		scopes:    scopes,
+	}
+}
+
+// ID returns the unique identifier, combining issuer URL and subject.
+func (f *FederatedServiceIdentity) ID() string { return f.issuerURL + ":" + f.subject }
+
+// Type returns the identity type ("federated_service").
+func (f *FederatedServiceIdentity) Type() string { return "federated_service" }
+
+// IssuerURL returns the OIDC issuer URL.
+func (f *FederatedServiceIdentity) IssuerURL() string { return f.issuerURL }
+
+// Email returns the service account email (e.g. sa@project.iam.gserviceaccount.com).
+func (f *FederatedServiceIdentity) Email() string { return f.email }
+
+// Subject returns the OIDC subject claim.
+func (f *FederatedServiceIdentity) Subject() string { return f.subject }
+
+// Scopes returns the configured default scopes for this issuer.
+func (f *FederatedServiceIdentity) Scopes() []AgentTokenScope { return f.scopes }
+
+// HasScope reports whether the given scope is granted.
+func (f *FederatedServiceIdentity) HasScope(scope AgentTokenScope) bool {
+	for _, s := range f.scopes {
+		if s == scope {
+			return true
+		}
+	}
+	return false
+}
+
+// FederatedUserIdentity represents a human user authenticated via OIDC from
+// a trusted external identity provider (e.g. Firebase Auth).
+// Implements UserIdentity and FederatedIdentity.
+type FederatedUserIdentity struct {
+	issuerURL   string
+	subject     string
+	email       string
+	displayName string
+	role        string
+	scopes      []AgentTokenScope
+}
+
+// NewFederatedUserIdentity constructs a new FederatedUserIdentity.
+func NewFederatedUserIdentity(issuerURL, subject, email, displayName, role string,
+	scopes []AgentTokenScope) *FederatedUserIdentity {
+	return &FederatedUserIdentity{
+		issuerURL:   issuerURL,
+		subject:     subject,
+		email:       email,
+		displayName: displayName,
+		role:        role,
+		scopes:      scopes,
+	}
+}
+
+// ID returns the unique identifier, combining issuer URL and subject.
+func (f *FederatedUserIdentity) ID() string { return f.issuerURL + ":" + f.subject }
+
+// Type returns the identity type ("federated_user").
+func (f *FederatedUserIdentity) Type() string { return "federated_user" }
+
+// Email returns the user email.
+func (f *FederatedUserIdentity) Email() string { return f.email }
+
+// DisplayName returns the user display name.
+func (f *FederatedUserIdentity) DisplayName() string { return f.displayName }
+
+// Role returns the role assigned to this federated user.
+func (f *FederatedUserIdentity) Role() string { return f.role }
+
+// IssuerURL returns the OIDC issuer URL.
+func (f *FederatedUserIdentity) IssuerURL() string { return f.issuerURL }
+
+// Subject returns the OIDC subject claim.
+func (f *FederatedUserIdentity) Subject() string { return f.subject }
+
+// Scopes returns the configured default scopes for this issuer.
+func (f *FederatedUserIdentity) Scopes() []AgentTokenScope { return f.scopes }
+
+// HasScope reports whether the given scope is granted.
+func (f *FederatedUserIdentity) HasScope(scope AgentTokenScope) bool {
+	for _, s := range f.scopes {
+		if s == scope {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/hub/federation_identity_ext_test.go
+++ b/pkg/hub/federation_identity_ext_test.go
@@ -1,0 +1,324 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"testing"
+)
+
+// Compile-time interface compliance checks.
+var (
+	_ Identity          = (*FederatedServiceIdentity)(nil)
+	_ FederatedIdentity = (*FederatedServiceIdentity)(nil)
+
+	_ Identity          = (*FederatedUserIdentity)(nil)
+	_ UserIdentity      = (*FederatedUserIdentity)(nil)
+	_ FederatedIdentity = (*FederatedUserIdentity)(nil)
+
+	// Existing type satisfies the new interface without modification.
+	_ FederatedIdentity = (*FederatedAgentIdentity)(nil)
+)
+
+// --- FederatedServiceIdentity tests ---
+
+func TestFederatedServiceIdentity_ID(t *testing.T) {
+	f := NewFederatedServiceIdentity(
+		"https://accounts.google.com", "123456789",
+		"deploy-bot@my-project.iam.gserviceaccount.com",
+		[]AgentTokenScope{ScopeAgentStatusUpdate},
+	)
+
+	want := "https://accounts.google.com:123456789"
+	if got := f.ID(); got != want {
+		t.Errorf("ID() = %q, want %q", got, want)
+	}
+}
+
+func TestFederatedServiceIdentity_Type(t *testing.T) {
+	f := NewFederatedServiceIdentity(
+		"https://accounts.google.com", "123456789",
+		"deploy-bot@my-project.iam.gserviceaccount.com", nil,
+	)
+
+	if got := f.Type(); got != "federated_service" {
+		t.Errorf("Type() = %q, want %q", got, "federated_service")
+	}
+}
+
+func TestFederatedServiceIdentity_Accessors(t *testing.T) {
+	issuer := "https://accounts.google.com"
+	subject := "123456789"
+	email := "deploy-bot@my-project.iam.gserviceaccount.com"
+
+	f := NewFederatedServiceIdentity(issuer, subject, email, nil)
+
+	if got := f.Email(); got != email {
+		t.Errorf("Email() = %q, want %q", got, email)
+	}
+	if got := f.Subject(); got != subject {
+		t.Errorf("Subject() = %q, want %q", got, subject)
+	}
+	if got := f.IssuerURL(); got != issuer {
+		t.Errorf("IssuerURL() = %q, want %q", got, issuer)
+	}
+}
+
+func TestFederatedServiceIdentity_HasScope(t *testing.T) {
+	f := NewFederatedServiceIdentity(
+		"https://accounts.google.com", "123456789",
+		"deploy-bot@my-project.iam.gserviceaccount.com",
+		[]AgentTokenScope{ScopeAgentStatusUpdate, ScopeAgentLogAppend},
+	)
+
+	tests := []struct {
+		scope AgentTokenScope
+		want  bool
+	}{
+		{ScopeAgentStatusUpdate, true},
+		{ScopeAgentLogAppend, true},
+		{ScopeProjectSecretRead, false},
+		{ScopeAgentCreate, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.scope), func(t *testing.T) {
+			if got := f.HasScope(tt.scope); got != tt.want {
+				t.Errorf("HasScope(%q) = %v, want %v", tt.scope, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFederatedServiceIdentity_ContextIntegration(t *testing.T) {
+	f := NewFederatedServiceIdentity(
+		"https://accounts.google.com", "123456789",
+		"deploy-bot@my-project.iam.gserviceaccount.com",
+		[]AgentTokenScope{ScopeAgentStatusUpdate},
+	)
+
+	ctx := context.Background()
+	ctx = contextWithIdentity(ctx, f)
+
+	// GetIdentityFromContext returns it.
+	identity := GetIdentityFromContext(ctx)
+	if identity == nil {
+		t.Fatal("GetIdentityFromContext() returned nil")
+	}
+	if identity.ID() != "https://accounts.google.com:123456789" {
+		t.Errorf("identity.ID() = %q, want %q", identity.ID(), "https://accounts.google.com:123456789")
+	}
+
+	// GetFederatedIdentityFromContext returns it.
+	fed, ok := GetFederatedIdentityFromContext(ctx)
+	if !ok || fed == nil {
+		t.Fatal("GetFederatedIdentityFromContext() returned nil or false")
+	}
+	if fed.IssuerURL() != "https://accounts.google.com" {
+		t.Errorf("fed.IssuerURL() = %q, want %q", fed.IssuerURL(), "https://accounts.google.com")
+	}
+
+	// GetAgentIdentityFromContext returns nil — service accounts are not agents.
+	if agentID := GetAgentIdentityFromContext(ctx); agentID != nil {
+		t.Errorf("GetAgentIdentityFromContext() = %v, want nil", agentID)
+	}
+
+	// GetUserIdentityFromContext returns nil — service accounts are not users.
+	if userID := GetUserIdentityFromContext(ctx); userID != nil {
+		t.Errorf("GetUserIdentityFromContext() = %v, want nil", userID)
+	}
+
+	// GetAgentFromContext returns nil — no AgentTokenClaims.
+	if claims := GetAgentFromContext(ctx); claims != nil {
+		t.Errorf("GetAgentFromContext() = %v, want nil", claims)
+	}
+}
+
+// --- FederatedUserIdentity tests ---
+
+func TestFederatedUserIdentity_ID(t *testing.T) {
+	f := NewFederatedUserIdentity(
+		"https://securetoken.google.com/my-project", "abcdef123456",
+		"user@example.com", "Test User", "viewer",
+		[]AgentTokenScope{ScopeAgentStatusUpdate},
+	)
+
+	want := "https://securetoken.google.com/my-project:abcdef123456"
+	if got := f.ID(); got != want {
+		t.Errorf("ID() = %q, want %q", got, want)
+	}
+}
+
+func TestFederatedUserIdentity_Type(t *testing.T) {
+	f := NewFederatedUserIdentity(
+		"https://securetoken.google.com/my-project", "abcdef123456",
+		"user@example.com", "Test User", "viewer", nil,
+	)
+
+	if got := f.Type(); got != "federated_user" {
+		t.Errorf("Type() = %q, want %q", got, "federated_user")
+	}
+}
+
+func TestFederatedUserIdentity_Accessors(t *testing.T) {
+	issuer := "https://securetoken.google.com/my-project"
+	subject := "abcdef123456"
+	email := "user@example.com"
+	displayName := "Test User"
+	role := "viewer"
+
+	f := NewFederatedUserIdentity(issuer, subject, email, displayName, role, nil)
+
+	if got := f.Email(); got != email {
+		t.Errorf("Email() = %q, want %q", got, email)
+	}
+	if got := f.DisplayName(); got != displayName {
+		t.Errorf("DisplayName() = %q, want %q", got, displayName)
+	}
+	if got := f.Role(); got != role {
+		t.Errorf("Role() = %q, want %q", got, role)
+	}
+	if got := f.Subject(); got != subject {
+		t.Errorf("Subject() = %q, want %q", got, subject)
+	}
+	if got := f.IssuerURL(); got != issuer {
+		t.Errorf("IssuerURL() = %q, want %q", got, issuer)
+	}
+}
+
+func TestFederatedUserIdentity_HasScope(t *testing.T) {
+	f := NewFederatedUserIdentity(
+		"https://securetoken.google.com/my-project", "abcdef123456",
+		"user@example.com", "Test User", "viewer",
+		[]AgentTokenScope{ScopeAgentStatusUpdate, ScopeAgentLogAppend},
+	)
+
+	tests := []struct {
+		scope AgentTokenScope
+		want  bool
+	}{
+		{ScopeAgentStatusUpdate, true},
+		{ScopeAgentLogAppend, true},
+		{ScopeProjectSecretRead, false},
+		{ScopeAgentCreate, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.scope), func(t *testing.T) {
+			if got := f.HasScope(tt.scope); got != tt.want {
+				t.Errorf("HasScope(%q) = %v, want %v", tt.scope, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFederatedUserIdentity_ContextIntegration(t *testing.T) {
+	f := NewFederatedUserIdentity(
+		"https://securetoken.google.com/my-project", "abcdef123456",
+		"user@example.com", "Test User", "viewer",
+		[]AgentTokenScope{ScopeAgentStatusUpdate},
+	)
+
+	ctx := context.Background()
+	ctx = contextWithIdentity(ctx, f)
+
+	// GetIdentityFromContext returns it.
+	identity := GetIdentityFromContext(ctx)
+	if identity == nil {
+		t.Fatal("GetIdentityFromContext() returned nil")
+	}
+	if identity.ID() != "https://securetoken.google.com/my-project:abcdef123456" {
+		t.Errorf("identity.ID() = %q, want %q", identity.ID(), "https://securetoken.google.com/my-project:abcdef123456")
+	}
+
+	// GetFederatedIdentityFromContext returns it.
+	fed, ok := GetFederatedIdentityFromContext(ctx)
+	if !ok || fed == nil {
+		t.Fatal("GetFederatedIdentityFromContext() returned nil or false")
+	}
+	if fed.IssuerURL() != "https://securetoken.google.com/my-project" {
+		t.Errorf("fed.IssuerURL() = %q, want %q", fed.IssuerURL(), "https://securetoken.google.com/my-project")
+	}
+
+	// GetUserIdentityFromContext returns it — federated users implement UserIdentity.
+	userID := GetUserIdentityFromContext(ctx)
+	if userID == nil {
+		t.Fatal("GetUserIdentityFromContext() returned nil, expected FederatedUserIdentity")
+	}
+	if userID.Email() != "user@example.com" {
+		t.Errorf("userID.Email() = %q, want %q", userID.Email(), "user@example.com")
+	}
+	if userID.DisplayName() != "Test User" {
+		t.Errorf("userID.DisplayName() = %q, want %q", userID.DisplayName(), "Test User")
+	}
+	if userID.Role() != "viewer" {
+		t.Errorf("userID.Role() = %q, want %q", userID.Role(), "viewer")
+	}
+
+	// GetAgentIdentityFromContext returns nil — federated users are not agents.
+	if agentID := GetAgentIdentityFromContext(ctx); agentID != nil {
+		t.Errorf("GetAgentIdentityFromContext() = %v, want nil", agentID)
+	}
+
+	// GetAgentFromContext returns nil — no AgentTokenClaims.
+	if claims := GetAgentFromContext(ctx); claims != nil {
+		t.Errorf("GetAgentFromContext() = %v, want nil", claims)
+	}
+}
+
+// --- FederatedAgentIdentity satisfies FederatedIdentity ---
+
+func TestFederatedAgentIdentity_SatisfiesFederatedIdentity(t *testing.T) {
+	f := NewFederatedAgentIdentity(
+		"https://hub-a.example.com", "agent-42", "proj-99", "test-agent", "user-origin",
+		[]string{"user-origin"}, []AgentTokenScope{ScopeAgentStatusUpdate},
+	)
+
+	ctx := context.Background()
+	ctx = contextWithIdentity(ctx, f)
+
+	// GetFederatedIdentityFromContext returns the FederatedAgentIdentity.
+	fed, ok := GetFederatedIdentityFromContext(ctx)
+	if !ok || fed == nil {
+		t.Fatal("GetFederatedIdentityFromContext() returned nil or false for FederatedAgentIdentity")
+	}
+	if fed.IssuerURL() != "https://hub-a.example.com" {
+		t.Errorf("fed.IssuerURL() = %q, want %q", fed.IssuerURL(), "https://hub-a.example.com")
+	}
+	if fed.ID() != "https://hub-a.example.com:agent-42" {
+		t.Errorf("fed.ID() = %q, want %q", fed.ID(), "https://hub-a.example.com:agent-42")
+	}
+}
+
+// --- GetFederatedIdentityFromContext edge cases ---
+
+func TestGetFederatedIdentityFromContext_EmptyContext(t *testing.T) {
+	ctx := context.Background()
+	fed, ok := GetFederatedIdentityFromContext(ctx)
+	if ok || fed != nil {
+		t.Errorf("GetFederatedIdentityFromContext(empty) = (%v, %v), want (nil, false)", fed, ok)
+	}
+}
+
+func TestGetFederatedIdentityFromContext_NonFederatedIdentity(t *testing.T) {
+	user := NewAuthenticatedUser("user-1", "alice@example.com", "Alice", "admin", "web")
+	ctx := context.Background()
+	ctx = contextWithIdentity(ctx, user)
+
+	fed, ok := GetFederatedIdentityFromContext(ctx)
+	if ok || fed != nil {
+		t.Errorf("GetFederatedIdentityFromContext(local user) = (%v, %v), want (nil, false)", fed, ok)
+	}
+}

--- a/pkg/hub/federation_identity_test.go
+++ b/pkg/hub/federation_identity_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"testing"
+)
+
+// Compile-time check: *FederatedAgentIdentity must satisfy AgentIdentity.
+var _ AgentIdentity = (*FederatedAgentIdentity)(nil)
+
+func TestFederatedAgentIdentity_ID(t *testing.T) {
+	f := NewFederatedAgentIdentity(
+		"https://hub-a.example.com", "agent-123", "proj-456", "my-agent", "user-root",
+		[]string{"user-root", "parent-agent"}, []AgentTokenScope{ScopeAgentStatusUpdate},
+	)
+
+	want := "https://hub-a.example.com:agent-123"
+	if got := f.ID(); got != want {
+		t.Errorf("ID() = %q, want %q", got, want)
+	}
+}
+
+func TestFederatedAgentIdentity_Type(t *testing.T) {
+	f := NewFederatedAgentIdentity(
+		"https://hub.example.com", "agent-1", "proj-1", "agent", "user-1",
+		nil, nil,
+	)
+
+	if got := f.Type(); got != "federated_agent" {
+		t.Errorf("Type() = %q, want %q", got, "federated_agent")
+	}
+}
+
+func TestFederatedAgentIdentity_ProjectID(t *testing.T) {
+	f := NewFederatedAgentIdentity(
+		"https://hub.example.com", "agent-1", "proj-1", "agent", "user-1",
+		nil, nil,
+	)
+
+	if got := f.ProjectID(); got != "" {
+		t.Errorf("ProjectID() = %q, want empty string", got)
+	}
+}
+
+func TestFederatedAgentIdentity_RemoteProjectID(t *testing.T) {
+	f := NewFederatedAgentIdentity(
+		"https://hub.example.com", "agent-1", "proj-remote", "agent", "user-1",
+		nil, nil,
+	)
+
+	if got := f.RemoteProjectID(); got != "proj-remote" {
+		t.Errorf("RemoteProjectID() = %q, want %q", got, "proj-remote")
+	}
+}
+
+func TestFederatedAgentIdentity_HasScope(t *testing.T) {
+	f := NewFederatedAgentIdentity(
+		"https://hub.example.com", "agent-1", "proj-1", "agent", "user-1",
+		nil, []AgentTokenScope{ScopeAgentStatusUpdate, ScopeAgentLogAppend},
+	)
+
+	tests := []struct {
+		scope AgentTokenScope
+		want  bool
+	}{
+		{ScopeAgentStatusUpdate, true},
+		{ScopeAgentLogAppend, true},
+		{ScopeProjectSecretRead, false},
+		{ScopeAgentCreate, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.scope), func(t *testing.T) {
+			if got := f.HasScope(tt.scope); got != tt.want {
+				t.Errorf("HasScope(%q) = %v, want %v", tt.scope, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFederatedAgentIdentity_Ancestry(t *testing.T) {
+	ancestry := []string{"user-root", "parent-agent", "grandparent-agent"}
+	f := NewFederatedAgentIdentity(
+		"https://hub.example.com", "agent-1", "proj-1", "agent", "user-root",
+		ancestry, nil,
+	)
+
+	got := f.Ancestry()
+	if len(got) != len(ancestry) {
+		t.Fatalf("Ancestry() returned %d elements, want %d", len(got), len(ancestry))
+	}
+	for i, v := range got {
+		if v != ancestry[i] {
+			t.Errorf("Ancestry()[%d] = %q, want %q", i, v, ancestry[i])
+		}
+	}
+}
+
+func TestFederatedAgentIdentity_OriginUserID(t *testing.T) {
+	f := NewFederatedAgentIdentity(
+		"https://hub.example.com", "agent-1", "proj-1", "agent", "user-root",
+		[]string{"user-root"}, nil,
+	)
+
+	if got := f.OriginUserID(); got != "user-root" {
+		t.Errorf("OriginUserID() = %q, want %q", got, "user-root")
+	}
+}
+
+func TestFederatedAgentIdentity_AgentName(t *testing.T) {
+	f := NewFederatedAgentIdentity(
+		"https://hub.example.com", "agent-1", "proj-1", "my-cool-agent", "user-1",
+		nil, nil,
+	)
+
+	if got := f.AgentName(); got != "my-cool-agent" {
+		t.Errorf("AgentName() = %q, want %q", got, "my-cool-agent")
+	}
+}
+
+func TestFederatedAgentIdentity_ContextIntegration(t *testing.T) {
+	f := NewFederatedAgentIdentity(
+		"https://hub-a.example.com", "agent-42", "proj-99", "test-agent", "user-origin",
+		[]string{"user-origin"}, []AgentTokenScope{ScopeAgentStatusUpdate},
+	)
+
+	ctx := context.Background()
+	ctx = contextWithIdentity(ctx, f)
+
+	// GetAgentIdentityFromContext should return the federated identity.
+	agentID := GetAgentIdentityFromContext(ctx)
+	if agentID == nil {
+		t.Fatal("GetAgentIdentityFromContext() returned nil, expected FederatedAgentIdentity")
+	}
+	if agentID.ID() != "https://hub-a.example.com:agent-42" {
+		t.Errorf("agentIdentity.ID() = %q, want %q", agentID.ID(), "https://hub-a.example.com:agent-42")
+	}
+	if agentID.Type() != "federated_agent" {
+		t.Errorf("agentIdentity.Type() = %q, want %q", agentID.Type(), "federated_agent")
+	}
+
+	// GetUserIdentityFromContext should return nil.
+	userID := GetUserIdentityFromContext(ctx)
+	if userID != nil {
+		t.Errorf("GetUserIdentityFromContext() = %v, want nil", userID)
+	}
+
+	// GetAgentFromContext should return nil (it only returns AgentTokenClaims).
+	claims := GetAgentFromContext(ctx)
+	if claims != nil {
+		t.Errorf("GetAgentFromContext() = %v, want nil", claims)
+	}
+}

--- a/pkg/hub/identity.go
+++ b/pkg/hub/identity.go
@@ -194,12 +194,13 @@ func contextWithIdentity(ctx context.Context, identity Identity) context.Context
 
 // AuthType constants for request logging.
 const (
-	AuthTypeJWT      = "jwt"
-	AuthTypeUAT      = "uat"
-	AuthTypeDevToken = "dev-token"
-	AuthTypeAgent    = "agent"
-	AuthTypeBroker   = "broker"
-	AuthTypeProxy    = "proxy"
+	AuthTypeJWT        = "jwt"
+	AuthTypeUAT        = "uat"
+	AuthTypeDevToken   = "dev-token"
+	AuthTypeAgent      = "agent"
+	AuthTypeBroker     = "broker"
+	AuthTypeProxy      = "proxy"
+	AuthTypeFederation = "federation"
 )
 
 // contextWithAuthType returns a new context with the auth type set.

--- a/pkg/hub/oidc_discovery.go
+++ b/pkg/hub/oidc_discovery.go
@@ -17,10 +17,15 @@ package hub
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
 )
+
+// maxDiscoveryResponseSize limits the OIDC discovery response body to 1 MB
+// to prevent DoS from oversized responses.
+const maxDiscoveryResponseSize = 1 << 20 // 1 MB
 
 // discoverJWKSURL fetches the OIDC discovery document from the issuer and
 // extracts the jwks_uri field. Returns an error if the discovery document
@@ -41,7 +46,8 @@ func discoverJWKSURL(issuerURL string, client *http.Client, requireHTTPS bool) (
 	var doc struct {
 		JWKSURI string `json:"jwks_uri"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+	limitedBody := io.LimitReader(resp.Body, maxDiscoveryResponseSize)
+	if err := json.NewDecoder(limitedBody).Decode(&doc); err != nil {
 		return "", fmt.Errorf("oidc discovery: failed to parse response from %s: %w", discoveryURL, err)
 	}
 	if doc.JWKSURI == "" {

--- a/pkg/hub/oidc_discovery.go
+++ b/pkg/hub/oidc_discovery.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// discoverJWKSURL fetches the OIDC discovery document from the issuer and
+// extracts the jwks_uri field. Returns an error if the discovery document
+// cannot be fetched or does not contain a jwks_uri.
+func discoverJWKSURL(issuerURL string, client *http.Client) (string, error) {
+	discoveryURL := strings.TrimRight(issuerURL, "/") + "/.well-known/openid-configuration"
+	resp, err := client.Get(discoveryURL)
+	if err != nil {
+		return "", fmt.Errorf("oidc discovery: failed to fetch %s: %w", discoveryURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("oidc discovery: %s returned status %d", discoveryURL, resp.StatusCode)
+	}
+
+	var doc struct {
+		JWKSURI string `json:"jwks_uri"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return "", fmt.Errorf("oidc discovery: failed to parse response from %s: %w", discoveryURL, err)
+	}
+	if doc.JWKSURI == "" {
+		return "", fmt.Errorf("oidc discovery: no jwks_uri in response from %s", discoveryURL)
+	}
+
+	return doc.JWKSURI, nil
+}

--- a/pkg/hub/oidc_discovery.go
+++ b/pkg/hub/oidc_discovery.go
@@ -18,13 +18,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
 // discoverJWKSURL fetches the OIDC discovery document from the issuer and
 // extracts the jwks_uri field. Returns an error if the discovery document
 // cannot be fetched or does not contain a jwks_uri.
-func discoverJWKSURL(issuerURL string, client *http.Client) (string, error) {
+// When requireHTTPS is true, the discovered jwks_uri must use the HTTPS scheme.
+func discoverJWKSURL(issuerURL string, client *http.Client, requireHTTPS bool) (string, error) {
 	discoveryURL := strings.TrimRight(issuerURL, "/") + "/.well-known/openid-configuration"
 	resp, err := client.Get(discoveryURL)
 	if err != nil {
@@ -44,6 +46,16 @@ func discoverJWKSURL(issuerURL string, client *http.Client) (string, error) {
 	}
 	if doc.JWKSURI == "" {
 		return "", fmt.Errorf("oidc discovery: no jwks_uri in response from %s", discoveryURL)
+	}
+
+	if requireHTTPS {
+		parsed, err := url.Parse(doc.JWKSURI)
+		if err != nil {
+			return "", fmt.Errorf("oidc discovery: invalid jwks_uri %q: %w", doc.JWKSURI, err)
+		}
+		if parsed.Scheme != "https" {
+			return "", fmt.Errorf("oidc discovery: jwks_uri %q must use HTTPS", doc.JWKSURI)
+		}
 	}
 
 	return doc.JWKSURI, nil

--- a/pkg/hub/oidc_discovery_test.go
+++ b/pkg/hub/oidc_discovery_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Test 1: Valid discovery — mock returns {"jwks_uri": "..."}, function returns the URL
+func TestDiscoverJWKSURL_ValidDiscovery(t *testing.T) {
+	expectedJWKSURL := "https://example.com/keys"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issuer": "https://example.com", "jwks_uri": "` + expectedJWKSURL + `"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	jwksURL, err := discoverJWKSURL(srv.URL, client)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if jwksURL != expectedJWKSURL {
+		t.Errorf("expected jwks_uri %q, got %q", expectedJWKSURL, jwksURL)
+	}
+}
+
+// Test 2: Missing jwks_uri — mock returns {} or {"issuer": "..."}, function returns error
+func TestDiscoverJWKSURL_MissingJWKSURI(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issuer": "https://example.com"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := discoverJWKSURL(srv.URL, client)
+	if err == nil {
+		t.Fatal("expected error for missing jwks_uri, got nil")
+	}
+	if !strings.Contains(err.Error(), "no jwks_uri") {
+		t.Errorf("expected 'no jwks_uri' in error, got: %v", err)
+	}
+}
+
+// Test 3: Non-200 status — mock returns 404, function returns error
+func TestDiscoverJWKSURL_Non200Status(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := discoverJWKSURL(srv.URL, client)
+	if err == nil {
+		t.Fatal("expected error for non-200 status, got nil")
+	}
+	if !strings.Contains(err.Error(), "returned status 404") {
+		t.Errorf("expected 'returned status 404' in error, got: %v", err)
+	}
+}
+
+// Test 4: Invalid JSON — mock returns garbage, function returns error
+func TestDiscoverJWKSURL_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`this is not valid json`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := discoverJWKSURL(srv.URL, client)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to parse response") {
+		t.Errorf("expected 'failed to parse response' in error, got: %v", err)
+	}
+}
+
+// Test 5: Network error — use an unreachable URL, function returns error
+func TestDiscoverJWKSURL_NetworkError(t *testing.T) {
+	client := &http.Client{Timeout: 1 * time.Second}
+	_, err := discoverJWKSURL("http://127.0.0.1:1", client)
+	if err == nil {
+		t.Fatal("expected error for network error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to fetch") {
+		t.Errorf("expected 'failed to fetch' in error, got: %v", err)
+	}
+}
+
+// Test 6: Trailing slash normalization — issuerURL with trailing slash still works
+func TestDiscoverJWKSURL_TrailingSlashNormalization(t *testing.T) {
+	expectedJWKSURL := "https://example.com/keys"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The path should be /.well-known/openid-configuration (not //.well-known/...)
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			t.Errorf("unexpected path %q (double slash?)", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jwks_uri": "` + expectedJWKSURL + `"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	// Issuer URL with trailing slash
+	jwksURL, err := discoverJWKSURL(srv.URL+"/", client)
+	if err != nil {
+		t.Fatalf("expected success with trailing slash, got error: %v", err)
+	}
+	if jwksURL != expectedJWKSURL {
+		t.Errorf("expected jwks_uri %q, got %q", expectedJWKSURL, jwksURL)
+	}
+}

--- a/pkg/hub/oidc_discovery_test.go
+++ b/pkg/hub/oidc_discovery_test.go
@@ -36,7 +36,7 @@ func TestDiscoverJWKSURL_ValidDiscovery(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	client := &http.Client{Timeout: 5 * time.Second}
-	jwksURL, err := discoverJWKSURL(srv.URL, client)
+	jwksURL, err := discoverJWKSURL(srv.URL, client, false)
 	if err != nil {
 		t.Fatalf("expected success, got error: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestDiscoverJWKSURL_MissingJWKSURI(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	client := &http.Client{Timeout: 5 * time.Second}
-	_, err := discoverJWKSURL(srv.URL, client)
+	_, err := discoverJWKSURL(srv.URL, client, false)
 	if err == nil {
 		t.Fatal("expected error for missing jwks_uri, got nil")
 	}
@@ -71,7 +71,7 @@ func TestDiscoverJWKSURL_Non200Status(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	client := &http.Client{Timeout: 5 * time.Second}
-	_, err := discoverJWKSURL(srv.URL, client)
+	_, err := discoverJWKSURL(srv.URL, client, false)
 	if err == nil {
 		t.Fatal("expected error for non-200 status, got nil")
 	}
@@ -89,7 +89,7 @@ func TestDiscoverJWKSURL_InvalidJSON(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	client := &http.Client{Timeout: 5 * time.Second}
-	_, err := discoverJWKSURL(srv.URL, client)
+	_, err := discoverJWKSURL(srv.URL, client, false)
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
 	}
@@ -101,7 +101,7 @@ func TestDiscoverJWKSURL_InvalidJSON(t *testing.T) {
 // Test 5: Network error — use an unreachable URL, function returns error
 func TestDiscoverJWKSURL_NetworkError(t *testing.T) {
 	client := &http.Client{Timeout: 1 * time.Second}
-	_, err := discoverJWKSURL("http://127.0.0.1:1", client)
+	_, err := discoverJWKSURL("http://127.0.0.1:1", client, false)
 	if err == nil {
 		t.Fatal("expected error for network error, got nil")
 	}
@@ -127,9 +127,46 @@ func TestDiscoverJWKSURL_TrailingSlashNormalization(t *testing.T) {
 
 	client := &http.Client{Timeout: 5 * time.Second}
 	// Issuer URL with trailing slash
-	jwksURL, err := discoverJWKSURL(srv.URL+"/", client)
+	jwksURL, err := discoverJWKSURL(srv.URL+"/", client, false)
 	if err != nil {
 		t.Fatalf("expected success with trailing slash, got error: %v", err)
+	}
+	if jwksURL != expectedJWKSURL {
+		t.Errorf("expected jwks_uri %q, got %q", expectedJWKSURL, jwksURL)
+	}
+}
+
+// Test 7: requireHTTPS=true rejects HTTP jwks_uri
+func TestDiscoverJWKSURL_RequireHTTPS_RejectsHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jwks_uri": "http://example.com/keys"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := discoverJWKSURL(srv.URL, client, true)
+	if err == nil {
+		t.Fatal("expected error for HTTP jwks_uri with requireHTTPS=true, got nil")
+	}
+	if !strings.Contains(err.Error(), "must use HTTPS") {
+		t.Errorf("expected 'must use HTTPS' in error, got: %v", err)
+	}
+}
+
+// Test 8: requireHTTPS=true accepts HTTPS jwks_uri
+func TestDiscoverJWKSURL_RequireHTTPS_AcceptsHTTPS(t *testing.T) {
+	expectedJWKSURL := "https://example.com/keys"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jwks_uri": "` + expectedJWKSURL + `"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	jwksURL, err := discoverJWKSURL(srv.URL, client, true)
+	if err != nil {
+		t.Fatalf("expected success for HTTPS jwks_uri with requireHTTPS=true, got error: %v", err)
 	}
 	if jwksURL != expectedJWKSURL {
 		t.Errorf("expected jwks_uri %q, got %q", expectedJWKSURL, jwksURL)

--- a/pkg/hub/proxyauth.go
+++ b/pkg/hub/proxyauth.go
@@ -233,11 +233,32 @@ type jwksCache struct {
 	url    string
 	client *http.Client
 
+	refreshInterval  time.Duration // proactive refresh period; 0 = use jwksRefreshInterval
+	debounceInterval time.Duration // min time between fetches; 0 = use jwksDebounceInterval
+
 	mu            sync.RWMutex
 	keys          map[string]jose.JSONWebKey // kid -> key
 	lastFetched   time.Time                  // last successful fetch
 	lastAttempted time.Time                  // last fetch attempt (success or failure), for stampede prevention
 	refreshing    bool                       // true while a refresh is in-flight
+}
+
+// getRefreshInterval returns the configured refresh interval,
+// falling back to the package-level default.
+func (c *jwksCache) getRefreshInterval() time.Duration {
+	if c.refreshInterval > 0 {
+		return c.refreshInterval
+	}
+	return jwksRefreshInterval
+}
+
+// getDebounceInterval returns the configured debounce interval,
+// falling back to the package-level default.
+func (c *jwksCache) getDebounceInterval() time.Duration {
+	if c.debounceInterval > 0 {
+		return c.debounceInterval
+	}
+	return jwksDebounceInterval
 }
 
 // GetKey returns the public key for the given kid. If the kid is not found
@@ -248,7 +269,7 @@ func (c *jwksCache) GetKey(kid string) (interface{}, error) {
 	c.mu.RLock()
 	if c.keys != nil {
 		if k, ok := c.keys[kid]; ok {
-			needsRefresh := time.Since(c.lastFetched) > jwksRefreshInterval
+			needsRefresh := time.Since(c.lastFetched) > c.getRefreshInterval()
 			c.mu.RUnlock()
 			// Proactive background refresh (non-blocking)
 			if needsRefresh {
@@ -293,7 +314,7 @@ func (c *jwksCache) refresh() error {
 	c.mu.Lock()
 
 	// Debounce: skip if a refresh was attempted (success OR failure) very recently.
-	if time.Since(c.lastAttempted) < jwksDebounceInterval {
+	if time.Since(c.lastAttempted) < c.getDebounceInterval() {
 		c.mu.Unlock()
 		return nil
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -236,6 +236,16 @@ type ServerConfig struct {
 	// OIDCConfig holds configuration for the OIDC Identity Provider feature.
 	// When Enabled, the hub initializes an OIDCKeyManager and exposes OIDC endpoints.
 	OIDCConfig config.OIDCProviderConfig
+
+	// Federation holds configuration for hub-hub federation authentication.
+	// When Federation.Enabled is true, the server initializes a FederationAuthenticator
+	// and injects it into the auth middleware.
+	Federation config.FederationConfig
+
+	// Mode is the server mode (e.g. "workstation", "dev", "hosted").
+	// Used by the federation authenticator to enforce HTTPS on issuer URLs
+	// in non-dev/non-workstation modes.
+	Mode string
 }
 
 // MaintenanceConfig holds configuration for routine maintenance operation executors.
@@ -1137,20 +1147,54 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 			"runs", runs, "migrations", migrations)
 	}
 
+	// Initialize federation authenticator if enabled.
+	var federationAuth *FederationAuthenticator
+	if cfg.Federation.Enabled {
+		// Derive mode for HTTPS enforcement.
+		federationMode := cfg.Mode
+		if federationMode == "" {
+			if cfg.Workstation {
+				federationMode = "workstation"
+			} else {
+				federationMode = "hosted"
+			}
+		}
+		// Use the OIDC issuer URL as the default expected audience.
+		federationAudience := srv.oidcIssuerURL
+		if federationAudience == "" {
+			federationAudience = cfg.OIDCConfig.IssuerURL
+		}
+
+		var err error
+		federationAuth, err = NewFederationAuthenticator(
+			cfg.Federation,
+			federationAudience,
+			srv.federationClient,
+			federationMode,
+			logging.Subsystem("hub.federation"),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("federation authenticator init: %w", err)
+		}
+		slog.Info("Federation authenticator enabled",
+			"trusted_issuers", len(cfg.Federation.TrustedIssuers))
+	}
+
 	// Build unified auth configuration
 	srv.authConfig = AuthConfig{
-		Mode:               "production",
-		DevAuthEnabled:     cfg.DevAuthToken != "",
-		DevAuthToken:       cfg.DevAuthToken,
-		DevUserCfg:         cfg.DevUserConfig,
-		AgentTokenSvc:      srv.agentTokenService,
-		UserTokenSvc:       srv.userTokenService,
-		UATSvc:             srv.uatService,
-		TrustedProxies:     cfg.TrustedProxies,
-		ProxyAuthenticator: cfg.ProxyAuth,
-		AuthMode:           cfg.AuthMode,
-		Debug:              cfg.Debug,
-		Logger:             srv.authLog,
+		Mode:                    "production",
+		DevAuthEnabled:          cfg.DevAuthToken != "",
+		DevAuthToken:            cfg.DevAuthToken,
+		DevUserCfg:              cfg.DevUserConfig,
+		AgentTokenSvc:           srv.agentTokenService,
+		UserTokenSvc:            srv.userTokenService,
+		UATSvc:                  srv.uatService,
+		TrustedProxies:          cfg.TrustedProxies,
+		ProxyAuthenticator:      cfg.ProxyAuth,
+		FederationAuthenticator: federationAuth,
+		AuthMode:                cfg.AuthMode,
+		Debug:                   cfg.Debug,
+		Logger:                  srv.authLog,
 	}
 	// Wire the proxy user provisioner (wraps provisionUser with 60s cache)
 	if cfg.ProxyAuth != nil {


### PR DESCRIPTION
## Summary

Adds federation authentication: external identities authenticate to the hub using OIDC tokens from trusted issuers. Supports three issuer types:
- **Hub**: agents from other Scion hubs (FederatedAgentIdentity)
- **Service account**: GCP SAs (FederatedServiceIdentity)
- **User**: Firebase Auth, Google Sign-In (FederatedUserIdentity)

### Key changes
- Federation config with per-issuer trust (audience, scopes, allowed emails)
- FederationAuthenticator with per-issuer JWKS caching (RS256 pinned)
- Step 1.5 in UnifiedAuthMiddleware for X-Scion-Federation-Token
- OIDC discovery for automatic JWKS URL resolution
- RequireFederationAccess scope-gated middleware
- Feature-gated behind federation.enabled (default false)
- 80+ new tests

Ref: ptone/scion#875, ptone/scion#870