### PR TITLE
feat: tiered agent authorization roles and sub-agent scope inheritance

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -78,6 +78,7 @@ var (
 	labelFlags            []string
 	modelFlag             string
 	thinkingLevelFlag     int = -1
+	agentRoleFlag         string
 )
 
 func parseLabels(raw []string) (map[string]string, error) {
@@ -755,6 +756,16 @@ func startAgentViaHub(hubCtx *HubContext, agentName, task string, resume bool, i
 		return err
 	}
 
+	// Validate --role flag if provided
+	if agentRoleFlag != "" {
+		switch agentRoleFlag {
+		case "none", "readonly", "baseline", "full":
+			// valid
+		default:
+			return fmt.Errorf("invalid --role value %q: must be one of none, readonly, baseline, full", agentRoleFlag)
+		}
+	}
+
 	// Build create request (Hub creates and starts in one operation)
 	req := &hubclient.CreateAgentRequest{
 		Name:            agentName,
@@ -773,6 +784,7 @@ func startAgentViaHub(hubCtx *HubContext, agentName, task string, resume bool, i
 		Attach:          attach,
 		GatherEnv:       true, // Enable env-gather flow
 		Notify:          !startNoNotify,
+		AgentRole:       agentRoleFlag,
 	}
 
 	// Thread inline config from --config flag into the Hub request.

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -63,4 +63,7 @@ func init() {
 
 	// Inline config flag
 	resumeCmd.Flags().StringVar(&inlineConfigPath, "config", "", "Path to inline agent config file (YAML/JSON), or '-' for stdin")
+
+	// Agent role flag
+	resumeCmd.Flags().StringVar(&agentRoleFlag, "role", "", "Agent role for Hub API access: none, readonly, baseline, full (default: project ceiling)")
 }

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -65,5 +65,8 @@ func init() {
 	resumeCmd.Flags().StringVar(&inlineConfigPath, "config", "", "Path to inline agent config file (YAML/JSON), or '-' for stdin")
 
 	// Agent role flag
-	resumeCmd.Flags().StringVar(&agentRoleFlag, "role", "", "Agent role for Hub API access: none, readonly, baseline, full (default: project ceiling)")
+	resumeCmd.Flags().StringVar(&agentRoleFlag, "role", "",
+		"Agent role for Hub API access: none, readonly, baseline, full\n"+
+			"Members can grant up to baseline; admins up to full.\n"+
+			"Capped by project max_agent_role setting. Default: project ceiling.")
 }

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -64,9 +64,4 @@ func init() {
 	// Inline config flag
 	resumeCmd.Flags().StringVar(&inlineConfigPath, "config", "", "Path to inline agent config file (YAML/JSON), or '-' for stdin")
 
-	// Agent role flag
-	resumeCmd.Flags().StringVar(&agentRoleFlag, "role", "",
-		"Agent role for Hub API access: none, readonly, baseline, full\n"+
-			"Members can grant up to baseline; admins up to full.\n"+
-			"Capped by project max_agent_role setting. Default: project ceiling.")
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -88,5 +88,4 @@ func init() {
 
 	// Agent role flag
 	startCmd.Flags().StringVar(&agentRoleFlag, "role", "", "Agent role for Hub API access: none, readonly, baseline, full (default: project ceiling)")
-
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -86,4 +86,7 @@ func init() {
 	// Label flags
 	startCmd.Flags().StringArrayVar(&labelFlags, "label", nil, "Label in key=value format (repeatable)")
 
+	// Agent role flag
+	startCmd.Flags().StringVar(&agentRoleFlag, "role", "", "Agent role for Hub API access: none, readonly, baseline, full (default: project ceiling)")
+
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -87,5 +87,8 @@ func init() {
 	startCmd.Flags().StringArrayVar(&labelFlags, "label", nil, "Label in key=value format (repeatable)")
 
 	// Agent role flag
-	startCmd.Flags().StringVar(&agentRoleFlag, "role", "", "Agent role for Hub API access: none, readonly, baseline, full (default: project ceiling)")
+	startCmd.Flags().StringVar(&agentRoleFlag, "role", "",
+		"Agent role for Hub API access: none, readonly, baseline, full\n"+
+			"Members can grant up to baseline; admins up to full.\n"+
+			"Capped by project max_agent_role setting. Default: project ceiling.")
 }

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/hubsync"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 // templatesCmd represents the templates command
@@ -763,6 +764,9 @@ func runTemplateSync(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to read template config: %w", err)
 	}
 
+	// Warn if template uses deprecated hubAccess.scopes
+	warnDeprecatedHubAccessScopes(tpl.Name, tpl.Path)
+
 	return syncTemplateToHub(hubCtx, hubName, tpl.Path, destScope, harnessType)
 }
 
@@ -796,6 +800,9 @@ func syncAllTemplatesToHub(hubCtx *HubContext, scope string) error {
 			failed++
 			continue
 		}
+
+		// Warn if template uses deprecated hubAccess.scopes
+		warnDeprecatedHubAccessScopes(tpl.Name, tpl.Path)
 
 		err = syncTemplateToHub(hubCtx, tpl.Name, tpl.Path, scope, harnessType)
 		if err != nil {
@@ -1384,6 +1391,44 @@ func runTemplateStatus(cmd *cobra.Command, args []string) error {
 	_ = w.Flush()
 
 	return nil
+}
+
+// warnDeprecatedHubAccessScopes checks a local template's config file for
+// deprecated hubAccess.scopes and emits a warning to stderr. Agent authorization
+// is now controlled by the --role flag; hubAccess.scopes are ignored at dispatch.
+func warnDeprecatedHubAccessScopes(name, templatePath string) {
+	configPath := config.GetScionAgentConfigPath(templatePath)
+	if configPath == "" {
+		return
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return
+	}
+
+	// Parse into a struct that only captures hubAccess.scopes, ignoring all
+	// other fields. This works regardless of the Go ScionConfig struct shape.
+	var raw struct {
+		HubAccess *struct {
+			Scopes []string `json:"scopes" yaml:"scopes"`
+		} `json:"hubAccess" yaml:"hubAccess"`
+	}
+	ext := filepath.Ext(configPath)
+	if ext == ".yaml" || ext == ".yml" {
+		if yamlErr := yaml.Unmarshal(data, &raw); yamlErr != nil {
+			return
+		}
+	} else {
+		if jsonErr := json.Unmarshal(data, &raw); jsonErr != nil {
+			return
+		}
+	}
+	if raw.HubAccess != nil && len(raw.HubAccess.Scopes) > 0 {
+		fmt.Fprintf(os.Stderr, "Warning: template %q uses deprecated hubAccess.scopes; "+
+			"agent authorization is now controlled by the --role flag. "+
+			"hubAccess.scopes will be ignored at dispatch.\n", name)
+	}
 }
 
 func init() {

--- a/cmd/templates_test.go
+++ b/cmd/templates_test.go
@@ -440,3 +440,113 @@ func TestRunTemplateStatus_NoHub(t *testing.T) {
 	err := runTemplateStatus(nil, nil)
 	require.Error(t, err)
 }
+
+func TestWarnDeprecatedHubAccessScopes_JSON_WithScopes(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "scion-agent.json")
+	require.NoError(t, os.WriteFile(configPath, []byte(`{
+		"harness": "claude",
+		"hubAccess": {
+			"scopes": ["project:read", "agent:create"]
+		}
+	}`), 0644))
+
+	// Capture stderr
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	warnDeprecatedHubAccessScopes("test-template", dir)
+
+	_ = w.Close()
+	os.Stderr = oldStderr
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	assert.Contains(t, output, "deprecated hubAccess.scopes",
+		"should warn about deprecated hubAccess.scopes")
+	assert.Contains(t, output, "test-template",
+		"warning should include template name")
+}
+
+func TestWarnDeprecatedHubAccessScopes_JSON_WithoutScopes(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "scion-agent.json")
+	require.NoError(t, os.WriteFile(configPath, []byte(`{
+		"harness": "claude"
+	}`), 0644))
+
+	// Capture stderr
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	warnDeprecatedHubAccessScopes("test-template", dir)
+
+	_ = w.Close()
+	os.Stderr = oldStderr
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	assert.Empty(t, output,
+		"should not warn when hubAccess.scopes is absent")
+}
+
+func TestWarnDeprecatedHubAccessScopes_YAML_WithScopes(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "scion-agent.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+harness: claude
+hubAccess:
+  scopes:
+    - project:read
+    - agent:create
+`), 0644))
+
+	// Capture stderr
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	warnDeprecatedHubAccessScopes("yaml-template", dir)
+
+	_ = w.Close()
+	os.Stderr = oldStderr
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	assert.Contains(t, output, "deprecated hubAccess.scopes",
+		"should warn about deprecated hubAccess.scopes in YAML")
+	assert.Contains(t, output, "yaml-template",
+		"warning should include template name")
+}
+
+func TestWarnDeprecatedHubAccessScopes_EmptyScopes(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "scion-agent.json")
+	require.NoError(t, os.WriteFile(configPath, []byte(`{
+		"harness": "claude",
+		"hubAccess": {
+			"scopes": []
+		}
+	}`), 0644))
+
+	// Capture stderr
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	warnDeprecatedHubAccessScopes("empty-scopes", dir)
+
+	_ = w.Close()
+	os.Stderr = oldStderr
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	assert.Empty(t, output,
+		"should not warn when hubAccess.scopes is empty array")
+}

--- a/pkg/config/opsettings/registry.go
+++ b/pkg/config/opsettings/registry.go
@@ -291,6 +291,7 @@ func compileSchemas() {
 				"default_resources":       getSchemaProperty(root, "default_resources"),
 				"default_model":           map[string]interface{}{"type": "string"},
 				"default_thinking_level":  map[string]interface{}{"type": "integer"},
+				"default_max_agent_role":  getSchemaProperty(root, "default_max_agent_role"),
 			},
 			"additionalProperties": false,
 		},

--- a/pkg/config/opsettings/sections.go
+++ b/pkg/config/opsettings/sections.go
@@ -65,6 +65,7 @@ type AgentDefaultsSettings struct {
 	DefaultResources     *api.ResourceSpec `json:"default_resources,omitempty"`
 	DefaultModel         string            `json:"default_model,omitempty"`
 	DefaultThinkingLevel *int              `json:"default_thinking_level,omitempty"`
+	DefaultMaxAgentRole  string            `json:"default_max_agent_role,omitempty"`
 }
 
 // EndpointsSettings holds Layer-1 endpoint configuration.

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -232,6 +232,13 @@
       "description": "Default thinking/reasoning level for new agents (1-100). 0 is reserved as the clear sentinel.",
       "x-scope": "any",
       "x-since": "1"
+    },
+    "default_max_agent_role": {
+      "type": "string",
+      "enum": ["none", "readonly", "baseline", "full"],
+      "description": "Default maximum agent role for new projects. Caps the role agents can receive.",
+      "x-scope": "any",
+      "x-since": "1"
     }
   },
   "additionalProperties": false,

--- a/pkg/hub/agentrole.go
+++ b/pkg/hub/agentrole.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+// AgentRole represents a named authorization tier for agents.
+// Each role maps to a fixed bundle of JWT scopes.
+type AgentRole string
+
+const (
+	AgentRoleNone     AgentRole = "none"
+	AgentRoleReadOnly AgentRole = "readonly"
+	AgentRoleBaseline AgentRole = "baseline"
+	AgentRoleFull     AgentRole = "full"
+)
+
+// ValidAgentRole returns true if r is one of the four stock roles.
+func ValidAgentRole(r AgentRole) bool {
+	switch r {
+	case AgentRoleNone, AgentRoleReadOnly, AgentRoleBaseline, AgentRoleFull:
+		return true
+	}
+	return false
+}
+
+// ScopesForRole returns the JWT scopes granted by a named agent role.
+// Returns nil for AgentRoleNone (caller should set NoAuth=true instead).
+// GCP token scopes and identity token scopes are NOT included here —
+// they are appended dynamically at dispatch time based on agent config.
+func ScopesForRole(role AgentRole) []AgentTokenScope {
+	switch role {
+	case AgentRoleNone:
+		return nil
+	case AgentRoleReadOnly:
+		return []AgentTokenScope{ScopeProjectRead}
+	case AgentRoleBaseline:
+		return []AgentTokenScope{
+			ScopeProjectRead,
+			ScopeAgentStatusUpdate,
+			ScopeAgentTokenRefresh,
+			ScopeAgentNotify,
+			ScopeAgentPortForward,
+		}
+	case AgentRoleFull:
+		return []AgentTokenScope{
+			ScopeProjectRead,
+			ScopeAgentStatusUpdate,
+			ScopeAgentTokenRefresh,
+			ScopeAgentNotify,
+			ScopeAgentPortForward,
+			ScopeAgentCreate,
+			ScopeAgentLifecycle,
+			ScopeProjectSecretRead,
+		}
+	default:
+		return ScopesForRole(AgentRoleBaseline)
+	}
+}
+
+// roleOrdinal returns the numeric ordering for role comparison.
+// none(0) < readonly(1) < baseline(2) < full(3).
+func roleOrdinal(r AgentRole) int {
+	switch r {
+	case AgentRoleNone:
+		return 0
+	case AgentRoleReadOnly:
+		return 1
+	case AgentRoleBaseline:
+		return 2
+	case AgentRoleFull:
+		return 3
+	default:
+		return 2 // default to baseline
+	}
+}
+
+// CompareRoles returns negative if a < b, 0 if equal, positive if a > b.
+func CompareRoles(a, b AgentRole) int {
+	return roleOrdinal(a) - roleOrdinal(b)
+}
+
+// minRole returns the least-privileged role from the given set.
+func minRole(roles ...AgentRole) AgentRole {
+	if len(roles) == 0 {
+		return AgentRoleBaseline
+	}
+	min := roles[0]
+	for _, r := range roles[1:] {
+		if roleOrdinal(r) < roleOrdinal(min) {
+			min = r
+		}
+	}
+	return min
+}
+
+// ResolveEffectiveRole computes the effective agent role using the two-gate
+// authority lattice: min(requested, userCeiling, projectMax).
+//
+// userHubRole is the hub-level user role string ("admin" or "member").
+// If empty, defaults to "member" ceiling (baseline).
+func ResolveEffectiveRole(requested AgentRole, userHubRole string, projectMax AgentRole) AgentRole {
+	userCeiling := AgentRoleBaseline
+	if userHubRole == "admin" {
+		userCeiling = AgentRoleFull
+	}
+	return minRole(requested, userCeiling, projectMax)
+}

--- a/pkg/hub/agentrole_integration_test.go
+++ b/pkg/hub/agentrole_integration_test.go
@@ -183,20 +183,19 @@ func TestCreateAgent_RoleNone_SetsNoAuth(t *testing.T) {
 	}
 }
 
-func TestCreateAgent_RoleFull_CappedByMemberCeiling(t *testing.T) {
-	srv, s, user, project := setupAgentRoleTest(t)
+func TestCreateAgent_RoleFull_RejectedByMemberCeiling(t *testing.T) {
+	srv, _, user, project := setupAgentRoleTest(t)
 
-	_ = doAgentRoleRequest(t, srv, user, CreateAgentRequest{
+	rec := doAgentRoleRequest(t, srv, user, CreateAgentRequest{
 		Name:      "test-full-capped",
 		ProjectID: project.ID,
 		AgentRole: "full",
 	})
 
-	if role, ok := getStoredAgentRole(t, s, project.ID, "test-full-capped"); ok {
-		// Member user ceiling is baseline, so full should be capped.
-		assert.Equal(t, "baseline", role,
-			"member user requesting full should be capped to baseline")
-	}
+	// Member user ceiling is baseline; explicitly requesting full is fail-loud 403.
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"member user requesting full should be forbidden; got: %s", rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "user ceiling")
 }
 
 func TestCreateAgent_AdminGetsFull(t *testing.T) {
@@ -315,7 +314,7 @@ func TestCreateSubAgent_LegacyParent(t *testing.T) {
 	}
 }
 
-func TestCreateSubAgent_NoEscalationNotEnforced(t *testing.T) {
+func TestCreateSubAgent_NoEscalationEnforced(t *testing.T) {
 	srv, s, _, project := setupAgentRoleTest(t)
 	ctx := context.Background()
 
@@ -332,29 +331,25 @@ func TestCreateSubAgent_NoEscalationNotEnforced(t *testing.T) {
 	}
 	require.NoError(t, s.CreateAgent(ctx, baselineParent))
 
-	// Baseline parent requests role=full for child. In F2P1, this should
-	// still be allowed (no-escalation enforcement is F2P2).
+	// Baseline parent requests role=full for child — should be rejected with 403 (F2P2).
 	rec := doAgentCallerRequest(t, srv, baselineParent.ID, project.ID, CreateAgentRequest{
 		Name:      "child-escalated",
 		ProjectID: project.ID,
 		AgentRole: "full",
 	})
 
-	// Should NOT get a 403 — enforcement is not in place yet.
-	assert.NotEqual(t, http.StatusForbidden, rec.Code,
-		"baseline parent requesting full child should NOT be forbidden in F2P1")
+	// Should get a 403 — no-escalation enforcement is in place.
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"baseline parent requesting full child should be forbidden")
+	assert.Contains(t, rec.Body.String(), "parent agent role")
 
-	// The child should get full (capped only by projectMax=baseline, so baseline).
-	// NOTE: projectMax defaults to baseline, so the effective role is baseline
-	// even though full was requested. This is projectMax capping, not parentRole capping.
-	if role, ok := getStoredAgentRole(t, s, project.ID, "child-escalated"); ok {
-		assert.Equal(t, "baseline", role,
-			"role should be capped by projectMax (baseline), not by parentRole in F2P1")
-	}
+	// Agent should NOT have been created.
+	_, err := s.GetAgentBySlug(ctx, project.ID, "child-escalated")
+	assert.Error(t, err, "escalated sub-agent should not be persisted")
 }
 
 func TestCreateAgent_ProjectMaxCapsRole(t *testing.T) {
-	srv, s, _, _ := setupAgentRoleTest(t)
+	srv, st, _, _ := setupAgentRoleTest(t)
 	ctx := context.Background()
 
 	// Create a project with max-agent-role=readonly.
@@ -368,7 +363,7 @@ func TestCreateAgent_ProjectMaxCapsRole(t *testing.T) {
 		Created: time.Now(),
 		Updated: time.Now(),
 	}
-	require.NoError(t, s.CreateProject(ctx, project))
+	require.NoError(t, st.CreateProject(ctx, project))
 	srv.createProjectMembersGroupAndPolicy(ctx, project)
 
 	admin := &store.User{
@@ -379,17 +374,256 @@ func TestCreateAgent_ProjectMaxCapsRole(t *testing.T) {
 		Status:      "active",
 		Created:     time.Now(),
 	}
-	require.NoError(t, s.CreateUser(ctx, admin))
-	ensureHubMembership(ctx, s, admin.ID)
+	require.NoError(t, st.CreateUser(ctx, admin))
+	ensureHubMembership(ctx, st, admin.ID)
 
-	_ = doAgentRoleRequest(t, srv, admin, CreateAgentRequest{
+	rec := doAgentRoleRequest(t, srv, admin, CreateAgentRequest{
 		Name:      "test-admin-capped",
 		ProjectID: project.ID,
 		AgentRole: "full",
 	})
 
-	if role, ok := getStoredAgentRole(t, s, project.ID, "test-admin-capped"); ok {
-		assert.Equal(t, "readonly", role,
-			"admin requesting full in readonly-max project should get readonly")
+	// Admin requesting full in a readonly-max project should be fail-loud 403.
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"admin requesting full in readonly-max project should be forbidden; got: %s", rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "project maximum")
+}
+
+// ---------- F2P2 No-Escalation Integration Tests ----------
+
+// setupFullMaxProject creates a project with max-agent-role=full so that
+// projectMax does not interfere with parent-ceiling tests.
+func setupFullMaxProject(t *testing.T) (*Server, store.Store, *store.Project) {
+	t.Helper()
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	user := &store.User{
+		ID:          tid("user-f2p2-setup"),
+		Email:       "f2p2setup@test.com",
+		DisplayName: "F2P2 Setup",
+		Role:        store.UserRoleMember,
+		Status:      "active",
+		Created:     time.Now(),
 	}
+	require.NoError(t, s.CreateUser(ctx, user))
+	ensureHubMembership(ctx, s, user.ID)
+
+	project := &store.Project{
+		ID:        tid("project-f2p2"),
+		Name:      "f2p2-project",
+		Slug:      "f2p2-project",
+		OwnerID:   user.ID,
+		CreatedBy: user.ID,
+		Annotations: map[string]string{
+			"scion.dev/max-agent-role": "full",
+		},
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+	srv.createProjectMembersGroupAndPolicy(ctx, project)
+
+	return srv, s, project
+}
+
+func TestCreateSubAgent_BaselineParent_RequestsFull_403(t *testing.T) {
+	srv, s, project := setupFullMaxProject(t)
+	ctx := context.Background()
+
+	parent := &store.Agent{
+		ID:        tid("f2p2-parent-baseline"),
+		Slug:      "f2p2-parent-baseline",
+		Name:      "f2p2-parent-baseline",
+		ProjectID: project.ID,
+		Phase:     "running",
+		AppliedConfig: &store.AgentAppliedConfig{
+			AgentRole: "baseline",
+		},
+	}
+	require.NoError(t, s.CreateAgent(ctx, parent))
+
+	rec := doAgentCallerRequest(t, srv, parent.ID, project.ID, CreateAgentRequest{
+		Name:      "child-over-request",
+		ProjectID: project.ID,
+		AgentRole: "full",
+	})
+
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"baseline parent requesting full sub-agent should get 403; got: %s", rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "parent agent role")
+}
+
+func TestCreateSubAgent_FullParent_RequestsBaseline_OK(t *testing.T) {
+	srv, s, project := setupFullMaxProject(t)
+	ctx := context.Background()
+
+	parent := &store.Agent{
+		ID:        tid("f2p2-parent-full-bl"),
+		Slug:      "f2p2-parent-full-bl",
+		Name:      "f2p2-parent-full-bl",
+		ProjectID: project.ID,
+		Phase:     "running",
+		AppliedConfig: &store.AgentAppliedConfig{
+			AgentRole: "full",
+		},
+	}
+	require.NoError(t, s.CreateAgent(ctx, parent))
+
+	rec := doAgentCallerRequest(t, srv, parent.ID, project.ID, CreateAgentRequest{
+		Name:      "child-baseline-ok",
+		ProjectID: project.ID,
+		AgentRole: "baseline",
+	})
+
+	// Should succeed (not 403)
+	assert.NotEqual(t, http.StatusForbidden, rec.Code,
+		"full parent requesting baseline sub-agent should not be forbidden")
+
+	if role, ok := getStoredAgentRole(t, s, project.ID, "child-baseline-ok"); ok {
+		assert.Equal(t, "baseline", role,
+			"child should get the explicitly requested baseline role")
+	}
+}
+
+func TestCreateSubAgent_FullParent_RequestsFull_OK(t *testing.T) {
+	srv, s, project := setupFullMaxProject(t)
+	ctx := context.Background()
+
+	parent := &store.Agent{
+		ID:        tid("f2p2-parent-full-f"),
+		Slug:      "f2p2-parent-full-f",
+		Name:      "f2p2-parent-full-f",
+		ProjectID: project.ID,
+		Phase:     "running",
+		AppliedConfig: &store.AgentAppliedConfig{
+			AgentRole: "full",
+		},
+	}
+	require.NoError(t, s.CreateAgent(ctx, parent))
+
+	rec := doAgentCallerRequest(t, srv, parent.ID, project.ID, CreateAgentRequest{
+		Name:      "child-full-ok",
+		ProjectID: project.ID,
+		AgentRole: "full",
+	})
+
+	// Should succeed (not 403)
+	assert.NotEqual(t, http.StatusForbidden, rec.Code,
+		"full parent requesting full sub-agent should not be forbidden")
+
+	if role, ok := getStoredAgentRole(t, s, project.ID, "child-full-ok"); ok {
+		assert.Equal(t, "full", role,
+			"child of full parent in full-max project should get full")
+	}
+}
+
+func TestCreateSubAgent_BaselineParent_DefaultsToBaseline(t *testing.T) {
+	srv, s, project := setupFullMaxProject(t)
+	ctx := context.Background()
+
+	parent := &store.Agent{
+		ID:        tid("f2p2-parent-bl-def"),
+		Slug:      "f2p2-parent-bl-def",
+		Name:      "f2p2-parent-bl-def",
+		ProjectID: project.ID,
+		Phase:     "running",
+		AppliedConfig: &store.AgentAppliedConfig{
+			AgentRole: "baseline",
+		},
+	}
+	require.NoError(t, s.CreateAgent(ctx, parent))
+
+	// No explicit agentRole — should inherit parent's baseline.
+	rec := doAgentCallerRequest(t, srv, parent.ID, project.ID, CreateAgentRequest{
+		Name:      "child-default-bl",
+		ProjectID: project.ID,
+	})
+
+	assert.NotEqual(t, http.StatusForbidden, rec.Code,
+		"baseline parent with no explicit role should not be forbidden")
+
+	if role, ok := getStoredAgentRole(t, s, project.ID, "child-default-bl"); ok {
+		assert.Equal(t, "baseline", role,
+			"child with no explicit role should inherit parent's baseline")
+	}
+}
+
+func TestCreateSubAgent_MultiHop(t *testing.T) {
+	srv, s, project := setupFullMaxProject(t)
+	ctx := context.Background()
+
+	// Full grandparent creates a baseline child.
+	// We verify the grandparent→child request is allowed (not 403), then
+	// create the child directly in the store to test the child→grandchild hop
+	// (the HTTP path cannot persist agents without a broker).
+	grandparent := &store.Agent{
+		ID:        tid("f2p2-grandparent"),
+		Slug:      "f2p2-grandparent",
+		Name:      "f2p2-grandparent",
+		ProjectID: project.ID,
+		Phase:     "running",
+		AppliedConfig: &store.AgentAppliedConfig{
+			AgentRole: "full",
+		},
+	}
+	require.NoError(t, s.CreateAgent(ctx, grandparent))
+
+	rec := doAgentCallerRequest(t, srv, grandparent.ID, project.ID, CreateAgentRequest{
+		Name:      "mh-child-baseline",
+		ProjectID: project.ID,
+		AgentRole: "baseline",
+	})
+	assert.NotEqual(t, http.StatusForbidden, rec.Code,
+		"full grandparent creating baseline child should not be forbidden")
+
+	// Create the baseline child directly in store for the second hop test.
+	child := &store.Agent{
+		ID:        tid("f2p2-mh-child"),
+		Slug:      "mh-child-baseline",
+		Name:      "mh-child-baseline",
+		ProjectID: project.ID,
+		Phase:     "running",
+		AppliedConfig: &store.AgentAppliedConfig{
+			AgentRole: "baseline",
+		},
+	}
+	require.NoError(t, s.CreateAgent(ctx, child))
+
+	// Baseline child tries to create a full grandchild — should be 403.
+	rec2 := doAgentCallerRequest(t, srv, child.ID, project.ID, CreateAgentRequest{
+		Name:      "mh-grandchild-full",
+		ProjectID: project.ID,
+		AgentRole: "full",
+	})
+	assert.Equal(t, http.StatusForbidden, rec2.Code,
+		"baseline child should not be able to create full grandchild; got: %s", rec2.Body.String())
+	assert.Contains(t, rec2.Body.String(), "parent agent role")
+}
+
+func TestCreateSubAgent_LegacyParent_CapsAtBaseline(t *testing.T) {
+	srv, s, project := setupFullMaxProject(t)
+	ctx := context.Background()
+
+	// Legacy agent: AppliedConfig exists but has no AgentRole set.
+	legacy := &store.Agent{
+		ID:            tid("f2p2-legacy-parent"),
+		Slug:          "f2p2-legacy-parent",
+		Name:          "f2p2-legacy-parent",
+		ProjectID:     project.ID,
+		Phase:         "running",
+		AppliedConfig: &store.AgentAppliedConfig{},
+	}
+	require.NoError(t, s.CreateAgent(ctx, legacy))
+
+	// Legacy parent requesting full should be rejected — defaults to baseline ceiling.
+	rec := doAgentCallerRequest(t, srv, legacy.ID, project.ID, CreateAgentRequest{
+		Name:      "child-legacy-full",
+		ProjectID: project.ID,
+		AgentRole: "full",
+	})
+
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"legacy parent (no stored role → baseline) should not create full sub-agent; got: %s", rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "parent agent role")
 }

--- a/pkg/hub/agentrole_integration_test.go
+++ b/pkg/hub/agentrole_integration_test.go
@@ -1,0 +1,268 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupAgentRoleTest creates a server with a member user and project.
+// The user is the project creator and is in the hub-members group.
+func setupAgentRoleTest(t *testing.T) (*Server, store.Store, *store.User, *store.Project) {
+	t.Helper()
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	user := &store.User{
+		ID:          tid("user-role-test"),
+		Email:       "roletest@test.com",
+		DisplayName: "Role Tester",
+		Role:        store.UserRoleMember,
+		Status:      "active",
+		Created:     time.Now(),
+	}
+	require.NoError(t, s.CreateUser(ctx, user))
+	ensureHubMembership(ctx, s, user.ID)
+
+	project := &store.Project{
+		ID:        tid("project-role-test"),
+		Name:      "role-test-project",
+		Slug:      "role-test-project",
+		OwnerID:   user.ID,
+		CreatedBy: user.ID,
+		Created:   time.Now(),
+		Updated:   time.Now(),
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+	srv.createProjectMembersGroupAndPolicy(ctx, project)
+
+	return srv, s, user, project
+}
+
+func doAgentRoleRequest(t *testing.T, srv *Server, user *store.User, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	token, _, _, err := srv.userTokenService.GenerateTokenPair(
+		user.ID, user.Email, user.DisplayName, user.Role, ClientTypeWeb,
+	)
+	require.NoError(t, err)
+
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+// getStoredAgentRole retrieves the stored role for a created agent by slug.
+// Returns ("", false) if the agent was not persisted (e.g., request failed downstream).
+func getStoredAgentRole(t *testing.T, s store.Store, projectID, slug string) (string, bool) {
+	t.Helper()
+	agent, err := s.GetAgentBySlug(context.Background(), projectID, slug)
+	if err != nil {
+		return "", false
+	}
+	if agent.AppliedConfig == nil {
+		return "", false
+	}
+	return agent.AppliedConfig.AgentRole, true
+}
+
+func TestCreateAgent_InvalidAgentRole_Returns400(t *testing.T) {
+	srv, _, user, project := setupAgentRoleTest(t)
+
+	rec := doAgentRoleRequest(t, srv, user, CreateAgentRequest{
+		Name:      "test-invalid-role",
+		ProjectID: project.ID,
+		AgentRole: "superadmin",
+	})
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code,
+		"invalid agentRole should return 400; got: %s", rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "invalid agentRole")
+}
+
+func TestCreateAgent_NoAgentRole_GetsBaseline(t *testing.T) {
+	srv, s, user, project := setupAgentRoleTest(t)
+
+	rec := doAgentRoleRequest(t, srv, user, CreateAgentRequest{
+		Name:      "test-no-role",
+		ProjectID: project.ID,
+	})
+
+	// Should not fail with an agentRole validation error.
+	if rec.Code == http.StatusBadRequest {
+		assert.NotContains(t, rec.Body.String(), "invalid agentRole",
+			"empty agentRole should not trigger validation error")
+	}
+
+	// If the agent was persisted, verify default role.
+	if role, ok := getStoredAgentRole(t, s, project.ID, "test-no-role"); ok {
+		assert.Equal(t, "baseline", role,
+			"default role should be baseline for member user")
+	}
+}
+
+func TestCreateAgent_ValidAgentRoles_AcceptedByValidation(t *testing.T) {
+	srv, _, user, project := setupAgentRoleTest(t)
+
+	validRoles := []string{"none", "readonly", "baseline", "full"}
+	for _, role := range validRoles {
+		t.Run("role="+role, func(t *testing.T) {
+			rec := doAgentRoleRequest(t, srv, user, CreateAgentRequest{
+				Name:      "test-role-" + role,
+				ProjectID: project.ID,
+				AgentRole: role,
+			})
+			// Valid role values should not trigger an agentRole validation error.
+			if rec.Code == http.StatusBadRequest {
+				assert.NotContains(t, rec.Body.String(), "invalid agentRole",
+					"valid role %q should not trigger agentRole validation error", role)
+			}
+		})
+	}
+}
+
+func TestCreateAgent_RoleReadonly_StoresReadonly(t *testing.T) {
+	srv, s, user, project := setupAgentRoleTest(t)
+
+	_ = doAgentRoleRequest(t, srv, user, CreateAgentRequest{
+		Name:      "test-readonly",
+		ProjectID: project.ID,
+		AgentRole: "readonly",
+	})
+
+	if role, ok := getStoredAgentRole(t, s, project.ID, "test-readonly"); ok {
+		assert.Equal(t, "readonly", role,
+			"readonly role should be stored as-is (readonly < member baseline ceiling)")
+	}
+}
+
+func TestCreateAgent_RoleNone_SetsNoAuth(t *testing.T) {
+	srv, s, user, project := setupAgentRoleTest(t)
+
+	_ = doAgentRoleRequest(t, srv, user, CreateAgentRequest{
+		Name:      "test-none-role",
+		ProjectID: project.ID,
+		AgentRole: "none",
+	})
+
+	agent, err := s.GetAgentBySlug(context.Background(), project.ID, "test-none-role")
+	if err == nil && agent.AppliedConfig != nil {
+		assert.Equal(t, "none", agent.AppliedConfig.AgentRole)
+		assert.True(t, agent.AppliedConfig.NoAuth,
+			"role=none should set NoAuth=true")
+	}
+}
+
+func TestCreateAgent_RoleFull_CappedByMemberCeiling(t *testing.T) {
+	srv, s, user, project := setupAgentRoleTest(t)
+
+	_ = doAgentRoleRequest(t, srv, user, CreateAgentRequest{
+		Name:      "test-full-capped",
+		ProjectID: project.ID,
+		AgentRole: "full",
+	})
+
+	if role, ok := getStoredAgentRole(t, s, project.ID, "test-full-capped"); ok {
+		// Member user ceiling is baseline, so full should be capped.
+		assert.Equal(t, "baseline", role,
+			"member user requesting full should be capped to baseline")
+	}
+}
+
+func TestCreateAgent_AdminGetsFull(t *testing.T) {
+	srv, s, _, project := setupAgentRoleTest(t)
+	ctx := context.Background()
+
+	admin := &store.User{
+		ID:          tid("user-admin-role"),
+		Email:       "admin-role@test.com",
+		DisplayName: "Admin Role Tester",
+		Role:        store.UserRoleAdmin,
+		Status:      "active",
+		Created:     time.Now(),
+	}
+	require.NoError(t, s.CreateUser(ctx, admin))
+	ensureHubMembership(ctx, s, admin.ID)
+
+	_ = doAgentRoleRequest(t, srv, admin, CreateAgentRequest{
+		Name:      "test-admin-full",
+		ProjectID: project.ID,
+		AgentRole: "full",
+	})
+
+	if role, ok := getStoredAgentRole(t, s, project.ID, "test-admin-full"); ok {
+		assert.Equal(t, "full", role,
+			"admin user requesting full should get full")
+	}
+}
+
+func TestCreateAgent_ProjectMaxCapsRole(t *testing.T) {
+	srv, s, _, _ := setupAgentRoleTest(t)
+	ctx := context.Background()
+
+	// Create a project with max-agent-role=readonly.
+	project := &store.Project{
+		ID:   tid("project-readonly-max"),
+		Name: "readonly-max-project",
+		Slug: "readonly-max-project",
+		Annotations: map[string]string{
+			"scion.dev/max-agent-role": "readonly",
+		},
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+	srv.createProjectMembersGroupAndPolicy(ctx, project)
+
+	admin := &store.User{
+		ID:          tid("user-admin-cap"),
+		Email:       "admin-cap@test.com",
+		DisplayName: "Admin Cap Tester",
+		Role:        store.UserRoleAdmin,
+		Status:      "active",
+		Created:     time.Now(),
+	}
+	require.NoError(t, s.CreateUser(ctx, admin))
+	ensureHubMembership(ctx, s, admin.ID)
+
+	_ = doAgentRoleRequest(t, srv, admin, CreateAgentRequest{
+		Name:      "test-admin-capped",
+		ProjectID: project.ID,
+		AgentRole: "full",
+	})
+
+	if role, ok := getStoredAgentRole(t, s, project.ID, "test-admin-capped"); ok {
+		assert.Equal(t, "readonly", role,
+			"admin requesting full in readonly-max project should get readonly")
+	}
+}

--- a/pkg/hub/agentrole_integration_test.go
+++ b/pkg/hub/agentrole_integration_test.go
@@ -226,6 +226,133 @@ func TestCreateAgent_AdminGetsFull(t *testing.T) {
 	}
 }
 
+// doAgentCallerRequest creates a sub-agent request authenticated as an agent.
+// It generates an agent token for the given parentAgentID and projectID with the
+// ScopeAgentCreate scope, then performs a POST /api/v1/agents with the given body.
+func doAgentCallerRequest(t *testing.T, srv *Server, parentAgentID, projectID string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+
+	token, err := srv.GenerateAgentToken(parentAgentID, projectID, nil, AgentRoleFull, nil)
+	require.NoError(t, err)
+
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Scion-Agent-Token", token)
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+func TestCreateSubAgent_ParentRoleLogged(t *testing.T) {
+	srv, s, _, project := setupAgentRoleTest(t)
+	ctx := context.Background()
+
+	// Create a parent agent with role=full stored in its AppliedConfig.
+	parentAgent := &store.Agent{
+		ID:        tid("parent-full-role"),
+		Slug:      "parent-full",
+		Name:      "parent-full",
+		ProjectID: project.ID,
+		Phase:     "running",
+		AppliedConfig: &store.AgentAppliedConfig{
+			AgentRole: "full",
+		},
+	}
+	require.NoError(t, s.CreateAgent(ctx, parentAgent))
+
+	// Agent creates a sub-agent without specifying a role.
+	rec := doAgentCallerRequest(t, srv, parentAgent.ID, project.ID, CreateAgentRequest{
+		Name:      "child-inherit-full",
+		ProjectID: project.ID,
+	})
+
+	// The request should succeed (or at least not fail with authz error).
+	// It may fail downstream at dispatch, but the agent record should be created.
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("sub-agent creation should not be forbidden: %s", rec.Body.String())
+	}
+
+	// Verify the child agent was created and inherited the parent's role.
+	if role, ok := getStoredAgentRole(t, s, project.ID, "child-inherit-full"); ok {
+		assert.Equal(t, "full", role,
+			"child should inherit parent's full role when no role is requested")
+	}
+}
+
+func TestCreateSubAgent_LegacyParent(t *testing.T) {
+	srv, s, _, project := setupAgentRoleTest(t)
+	ctx := context.Background()
+
+	// Create a legacy parent agent with no AgentRole set in AppliedConfig.
+	legacyParent := &store.Agent{
+		ID:            tid("parent-legacy"),
+		Slug:          "parent-legacy",
+		Name:          "parent-legacy",
+		ProjectID:     project.ID,
+		Phase:         "running",
+		AppliedConfig: &store.AgentAppliedConfig{},
+	}
+	require.NoError(t, s.CreateAgent(ctx, legacyParent))
+
+	// Agent creates a sub-agent without specifying a role.
+	rec := doAgentCallerRequest(t, srv, legacyParent.ID, project.ID, CreateAgentRequest{
+		Name:      "child-legacy-parent",
+		ProjectID: project.ID,
+	})
+
+	if rec.Code == http.StatusForbidden {
+		t.Fatalf("sub-agent creation should not be forbidden: %s", rec.Body.String())
+	}
+
+	// Legacy parent defaults to baseline, so child should get baseline.
+	if role, ok := getStoredAgentRole(t, s, project.ID, "child-legacy-parent"); ok {
+		assert.Equal(t, "baseline", role,
+			"child of legacy parent (no stored role) should get baseline")
+	}
+}
+
+func TestCreateSubAgent_NoEscalationNotEnforced(t *testing.T) {
+	srv, s, _, project := setupAgentRoleTest(t)
+	ctx := context.Background()
+
+	// Create a parent agent with role=baseline.
+	baselineParent := &store.Agent{
+		ID:        tid("parent-baseline-esc"),
+		Slug:      "parent-baseline-esc",
+		Name:      "parent-baseline-esc",
+		ProjectID: project.ID,
+		Phase:     "running",
+		AppliedConfig: &store.AgentAppliedConfig{
+			AgentRole: "baseline",
+		},
+	}
+	require.NoError(t, s.CreateAgent(ctx, baselineParent))
+
+	// Baseline parent requests role=full for child. In F2P1, this should
+	// still be allowed (no-escalation enforcement is F2P2).
+	rec := doAgentCallerRequest(t, srv, baselineParent.ID, project.ID, CreateAgentRequest{
+		Name:      "child-escalated",
+		ProjectID: project.ID,
+		AgentRole: "full",
+	})
+
+	// Should NOT get a 403 — enforcement is not in place yet.
+	assert.NotEqual(t, http.StatusForbidden, rec.Code,
+		"baseline parent requesting full child should NOT be forbidden in F2P1")
+
+	// The child should get full (capped only by projectMax=baseline, so baseline).
+	// NOTE: projectMax defaults to baseline, so the effective role is baseline
+	// even though full was requested. This is projectMax capping, not parentRole capping.
+	if role, ok := getStoredAgentRole(t, s, project.ID, "child-escalated"); ok {
+		assert.Equal(t, "baseline", role,
+			"role should be capped by projectMax (baseline), not by parentRole in F2P1")
+	}
+}
+
 func TestCreateAgent_ProjectMaxCapsRole(t *testing.T) {
 	srv, s, _, _ := setupAgentRoleTest(t)
 	ctx := context.Background()

--- a/pkg/hub/agentrole_integration_test.go
+++ b/pkg/hub/agentrole_integration_test.go
@@ -601,6 +601,68 @@ func TestCreateSubAgent_MultiHop(t *testing.T) {
 	assert.Contains(t, rec2.Body.String(), "parent agent role")
 }
 
+func TestGetAgent_IncludesAgentRole(t *testing.T) {
+	srv, s, user, project := setupAgentRoleTest(t)
+	ctx := context.Background()
+
+	// Create an agent with role=baseline stored in AppliedConfig.
+	agent := &store.Agent{
+		ID:        tid("agent-get-role"),
+		Slug:      "agent-get-role",
+		Name:      "agent-get-role",
+		ProjectID: project.ID,
+		Phase:     "running",
+		AppliedConfig: &store.AgentAppliedConfig{
+			AgentRole: "baseline",
+		},
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	// GET the agent via the API.
+	rec := doRequestAsUser(t, srv, user, http.MethodGet, "/api/v1/agents/"+agent.ID, nil)
+	require.Equal(t, http.StatusOK, rec.Code,
+		"GET agent should succeed; got: %s", rec.Body.String())
+
+	// Parse the response and verify agentRole is present in appliedConfig.
+	var resp AgentWithCapabilities
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.AppliedConfig,
+		"response should include appliedConfig")
+	assert.Equal(t, "baseline", resp.AppliedConfig.AgentRole,
+		"GET response should include agentRole in appliedConfig")
+}
+
+func TestGetAgent_IncludesAgentRoleFull(t *testing.T) {
+	srv, s, user, project := setupAgentRoleTest(t)
+	ctx := context.Background()
+
+	// Create an agent with role=full stored in AppliedConfig.
+	agent := &store.Agent{
+		ID:        tid("agent-get-role-full"),
+		Slug:      "agent-get-role-full",
+		Name:      "agent-get-role-full",
+		ProjectID: project.ID,
+		Phase:     "running",
+		AppliedConfig: &store.AgentAppliedConfig{
+			AgentRole: "full",
+		},
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	// GET the agent via the API.
+	rec := doRequestAsUser(t, srv, user, http.MethodGet, "/api/v1/agents/"+agent.ID, nil)
+	require.Equal(t, http.StatusOK, rec.Code,
+		"GET agent should succeed; got: %s", rec.Body.String())
+
+	// Parse the response and verify agentRole=full is present.
+	var resp AgentWithCapabilities
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.AppliedConfig,
+		"response should include appliedConfig")
+	assert.Equal(t, "full", resp.AppliedConfig.AgentRole,
+		"GET response should include agentRole=full in appliedConfig")
+}
+
 func TestCreateSubAgent_LegacyParent_CapsAtBaseline(t *testing.T) {
 	srv, s, project := setupFullMaxProject(t)
 	ctx := context.Background()

--- a/pkg/hub/agentrole_integration_test.go
+++ b/pkg/hub/agentrole_integration_test.go
@@ -358,7 +358,7 @@ func TestCreateAgent_ProjectMaxCapsRole(t *testing.T) {
 		Name: "readonly-max-project",
 		Slug: "readonly-max-project",
 		Annotations: map[string]string{
-			"scion.dev/max-agent-role": "readonly",
+			projectSettingMaxAgentRole: "readonly",
 		},
 		Created: time.Now(),
 		Updated: time.Now(),
@@ -688,4 +688,73 @@ func TestCreateSubAgent_LegacyParent_CapsAtBaseline(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, rec.Code,
 		"legacy parent (no stored role → baseline) should not create full sub-agent; got: %s", rec.Body.String())
 	assert.Contains(t, rec.Body.String(), "parent agent role")
+}
+
+func TestCreateAgent_ProjectMaxBaseline_CapsFullToBaseline(t *testing.T) {
+	srv, s, _, _ := setupAgentRoleTest(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:   tid("project-baseline-max"),
+		Name: "baseline-max-project",
+		Slug: "baseline-max-project",
+		Annotations: map[string]string{
+			projectSettingMaxAgentRole: "baseline",
+		},
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+	srv.createProjectMembersGroupAndPolicy(ctx, project)
+
+	admin := &store.User{
+		ID:          tid("user-admin-base-cap"),
+		Email:       "admin-base-cap@test.com",
+		DisplayName: "Admin Baseline Cap",
+		Role:        store.UserRoleAdmin,
+		Status:      "active",
+		Created:     time.Now(),
+	}
+	require.NoError(t, s.CreateUser(ctx, admin))
+	ensureHubMembership(ctx, s, admin.ID)
+
+	_ = doAgentRoleRequest(t, srv, admin, CreateAgentRequest{
+		Name:      "test-full-in-baseline-max",
+		ProjectID: project.ID,
+		AgentRole: "full",
+	})
+
+	if role, ok := getStoredAgentRole(t, s, project.ID, "test-full-in-baseline-max"); ok {
+		assert.Equal(t, "baseline", role,
+			"admin requesting full in baseline-max project should be capped to baseline")
+	}
+}
+
+func TestCreateAgent_ProjectMaxReadonly_MemberGetsReadonly(t *testing.T) {
+	srv, s, user, _ := setupAgentRoleTest(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:   tid("project-readonly-member"),
+		Name: "readonly-member-project",
+		Slug: "readonly-member-project",
+		Annotations: map[string]string{
+			projectSettingMaxAgentRole: "readonly",
+		},
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+	srv.createProjectMembersGroupAndPolicy(ctx, project)
+
+	// Member user requesting no specific role — should default to project max (readonly)
+	_ = doAgentRoleRequest(t, srv, user, CreateAgentRequest{
+		Name:      "test-member-readonly-proj",
+		ProjectID: project.ID,
+	})
+
+	if role, ok := getStoredAgentRole(t, s, project.ID, "test-member-readonly-proj"); ok {
+		assert.Equal(t, "readonly", role,
+			"member in readonly-max project should get readonly")
+	}
 }

--- a/pkg/hub/agentrole_integration_test.go
+++ b/pkg/hub/agentrole_integration_test.go
@@ -348,6 +348,139 @@ func TestCreateSubAgent_NoEscalationEnforced(t *testing.T) {
 	assert.Error(t, err, "escalated sub-agent should not be persisted")
 }
 
+// TestTemplateHubAccessScopes_StoredButIgnoredForToken verifies that
+// hubAccess.scopes from a template are stored on the agent's AppliedConfig for
+// backward-compatibility visibility, but are NOT used for JWT token generation.
+// Token scopes are derived solely from the agent role (Phase 2 change).
+func TestTemplateHubAccessScopes_StoredButIgnoredForToken(t *testing.T) {
+	// Use a non-dev-auth server so the role is not auto-upgraded to full.
+	s, err := newTestStore(":memory:")
+	require.NoError(t, err)
+	require.NoError(t, s.Migrate(context.Background()))
+
+	cfg := DefaultServerConfig()
+	cfg.AgentTokenConfig = AgentTokenConfig{
+		SigningKey:    make([]byte, 32),
+		TokenDuration: time.Hour,
+	}
+	// Deliberately NOT setting DevAuthToken so role-based scopes are enforced.
+
+	srv, err := New(cfg, s)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	ctx := context.Background()
+
+	// Create a project
+	project := &store.Project{
+		ID:      tid("project-tmpl-scopes"),
+		Name:    "tmpl-scopes-project",
+		Slug:    "tmpl-scopes-project",
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	// Create a template with legacy hubAccess.scopes that include elevated permissions
+	tmpl := &store.Template{
+		ID:      tid("tmpl-hub-scopes"),
+		Name:    "hub-scopes-template",
+		Slug:    "hub-scopes-template",
+		Scope:   "project",
+		ScopeID: project.ID,
+		Status:  store.TemplateStatusActive,
+		Config: &store.TemplateConfig{
+			HubAccess: &store.HubAccessConfig{
+				Scopes: []string{"project:read", "agent:create", "agent:lifecycle", "secret:read"},
+			},
+		},
+	}
+	require.NoError(t, s.CreateTemplate(ctx, tmpl))
+
+	// Simulate what populateAgentConfig does: build an agent with a baseline role
+	// and populate it from the template.
+	agent := &store.Agent{
+		ID:        tid("agent-scopes-test"),
+		Name:      "scopes-test-agent",
+		Slug:      "scopes-test-agent",
+		ProjectID: project.ID,
+		AppliedConfig: &store.AgentAppliedConfig{
+			AgentRole: string(AgentRoleBaseline),
+		},
+	}
+
+	// Call populateAgentConfig to simulate the real code path
+	srv.populateAgentConfig(ctx, agent, project, tmpl)
+
+	// Verify the template scopes are stored on AppliedConfig for visibility
+	require.NotNil(t, agent.AppliedConfig, "AppliedConfig should be set")
+	assert.Equal(t, []string{"project:read", "agent:create", "agent:lifecycle", "secret:read"},
+		agent.AppliedConfig.HubAccessScopes,
+		"template hubAccess.scopes should be preserved on AppliedConfig for visibility")
+	assert.Equal(t, tmpl.ID, agent.AppliedConfig.TemplateID,
+		"template ID should be set on AppliedConfig")
+
+	// Verify agentRoleAndScopes does NOT read HubAccessScopes
+	role, additionalScopes := agentRoleAndScopes(agent)
+	assert.Equal(t, AgentRoleBaseline, role,
+		"role should come from AgentRole field, not template scopes")
+	assert.Empty(t, additionalScopes,
+		"agentRoleAndScopes should not produce additional scopes from HubAccessScopes")
+
+	// Generate a token and verify scopes match the baseline role, not template scopes
+	token, err := srv.GenerateAgentToken(agent.ID, agent.ProjectID, agent.Ancestry, role, additionalScopes)
+	require.NoError(t, err)
+
+	claims, err := srv.agentTokenService.ValidateAgentToken(token)
+	require.NoError(t, err)
+
+	// Baseline role grants: project:read, agent:status-update, agent:token-refresh,
+	// agent:notify, agent:port-forward
+	assert.True(t, claims.HasScope(ScopeProjectRead), "baseline should have project:read")
+	assert.True(t, claims.HasScope(ScopeAgentStatusUpdate), "baseline should have agent:status-update")
+	assert.True(t, claims.HasScope(ScopeAgentTokenRefresh), "baseline should have agent:token-refresh")
+
+	// These scopes were in the template's hubAccess but must NOT leak into the token
+	assert.False(t, claims.HasScope(ScopeAgentCreate),
+		"agent:create from template scopes should NOT appear in baseline token")
+	assert.False(t, claims.HasScope(ScopeAgentLifecycle),
+		"agent:lifecycle from template scopes should NOT appear in baseline token")
+	assert.False(t, claims.HasScope(ScopeProjectSecretRead),
+		"secret:read from template scopes should NOT appear in baseline token")
+}
+
+// TestTemplateHubAccessScopes_EmptyDoesNotWarn verifies that a template with
+// an empty hubAccess.scopes array does not trigger the deprecation warning.
+func TestTemplateHubAccessScopes_EmptyDoesNotWarn(t *testing.T) {
+	// An agent whose template config has hubAccess with empty scopes should
+	// not modify HubAccessScopes and should behave identically to a template
+	// without any hubAccess block.
+	agent := &store.Agent{
+		ID:   tid("agent-empty-scopes"),
+		Name: "empty-scopes-agent",
+		AppliedConfig: &store.AgentAppliedConfig{
+			AgentRole: string(AgentRoleBaseline),
+		},
+	}
+
+	tmpl := &store.Template{
+		ID:   tid("tmpl-empty-scopes"),
+		Name: "empty-scopes-template",
+		Slug: "empty-scopes-template",
+		Config: &store.TemplateConfig{
+			HubAccess: &store.HubAccessConfig{
+				Scopes: []string{},
+			},
+		},
+	}
+
+	srv, _ := testServer(t)
+	srv.populateAgentConfig(context.Background(), agent, nil, tmpl)
+
+	assert.Empty(t, agent.AppliedConfig.HubAccessScopes,
+		"empty scopes array should not populate HubAccessScopes")
+}
+
 func TestCreateAgent_ProjectMaxCapsRole(t *testing.T) {
 	srv, st, _, _ := setupAgentRoleTest(t)
 	ctx := context.Background()

--- a/pkg/hub/agentrole_integration_test.go
+++ b/pkg/hub/agentrole_integration_test.go
@@ -891,3 +891,182 @@ func TestCreateAgent_ProjectMaxReadonly_MemberGetsReadonly(t *testing.T) {
 			"member in readonly-max project should get readonly")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Phase 7 — Read endpoint enforcement (ScopeProjectRead)
+// ---------------------------------------------------------------------------
+
+// doAgentReadRequest makes a GET request to the given path using an agent token
+// with the specified scopes.
+func doAgentReadRequest(t *testing.T, srv *Server, agentID, projectID, path string, scopes []AgentTokenScope) *httptest.ResponseRecorder {
+	t.Helper()
+	tokenSvc := srv.GetAgentTokenService()
+	require.NotNil(t, tokenSvc)
+
+	token, err := tokenSvc.GenerateAgentToken(agentID, projectID, scopes, nil)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("X-Scion-Agent-Token", token)
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+// setupReadScopeTest creates a server, user, project, and agent for read scope tests.
+func setupReadScopeTest(t *testing.T) (*Server, store.Store, *store.Agent, *store.Project) {
+	t.Helper()
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	user := &store.User{
+		ID:          tid("user-read-scope"),
+		Email:       "readscope@test.com",
+		DisplayName: "Read Scope Tester",
+		Role:        store.UserRoleMember,
+		Status:      "active",
+		Created:     time.Now(),
+	}
+	require.NoError(t, s.CreateUser(ctx, user))
+	ensureHubMembership(ctx, s, user.ID)
+
+	project := &store.Project{
+		ID:        tid("project-read-scope"),
+		Name:      "read-scope-project",
+		Slug:      "read-scope-project",
+		OwnerID:   user.ID,
+		CreatedBy: user.ID,
+		Created:   time.Now(),
+		Updated:   time.Now(),
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+	srv.createProjectMembersGroupAndPolicy(ctx, project)
+
+	agent := &store.Agent{
+		ID:        tid("agent-read-scope"),
+		Slug:      "read-scope-agent",
+		Name:      "Read Scope Agent",
+		ProjectID: project.ID,
+		Phase:     "running",
+		Created:   time.Now(),
+		Updated:   time.Now(),
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	return srv, s, agent, project
+}
+
+func TestReadEndpoint_BaselineAgent_Allowed(t *testing.T) {
+	srv, _, agent, project := setupReadScopeTest(t)
+
+	// Baseline scopes include ScopeProjectRead.
+	scopes := ScopesForRole(AgentRoleBaseline)
+
+	endpoints := []string{
+		"/api/v1/agents?projectId=" + project.ID,
+		"/api/v1/agents/" + agent.ID,
+		"/api/v1/templates",
+		"/api/v1/skills",
+		"/api/v1/harness-configs",
+		"/api/v1/projects",
+		"/api/v1/projects/" + project.ID,
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep, func(t *testing.T) {
+			rec := doAgentReadRequest(t, srv, agent.ID, project.ID, ep, scopes)
+			assert.NotEqual(t, http.StatusForbidden, rec.Code,
+				"baseline agent should not be forbidden on %s; got %d: %s",
+				ep, rec.Code, rec.Body.String())
+		})
+	}
+}
+
+func TestReadEndpoint_ReadonlyAgent_Allowed(t *testing.T) {
+	srv, _, agent, project := setupReadScopeTest(t)
+
+	// Readonly scopes include ScopeProjectRead.
+	scopes := ScopesForRole(AgentRoleReadOnly)
+
+	endpoints := []string{
+		"/api/v1/agents?projectId=" + project.ID,
+		"/api/v1/agents/" + agent.ID,
+		"/api/v1/templates",
+		"/api/v1/skills",
+		"/api/v1/harness-configs",
+		"/api/v1/projects",
+		"/api/v1/projects/" + project.ID,
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep, func(t *testing.T) {
+			rec := doAgentReadRequest(t, srv, agent.ID, project.ID, ep, scopes)
+			assert.NotEqual(t, http.StatusForbidden, rec.Code,
+				"readonly agent should not be forbidden on %s; got %d: %s",
+				ep, rec.Code, rec.Body.String())
+		})
+	}
+}
+
+func TestReadEndpoint_NoReadScope_Blocked(t *testing.T) {
+	srv, _, agent, project := setupReadScopeTest(t)
+
+	// Simulate a legacy agent or misconfigured token: valid JWT but no ScopeProjectRead.
+	scopes := []AgentTokenScope{ScopeAgentStatusUpdate}
+
+	endpoints := []string{
+		"/api/v1/agents?projectId=" + project.ID,
+		"/api/v1/agents/" + agent.ID,
+		"/api/v1/templates",
+		"/api/v1/skills",
+		"/api/v1/harness-configs",
+		"/api/v1/projects",
+		"/api/v1/projects/" + project.ID,
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep, func(t *testing.T) {
+			rec := doAgentReadRequest(t, srv, agent.ID, project.ID, ep, scopes)
+			assert.Equal(t, http.StatusForbidden, rec.Code,
+				"agent without ScopeProjectRead should be forbidden on %s; got %d: %s",
+				ep, rec.Code, rec.Body.String())
+			assert.Contains(t, rec.Body.String(), "project:read",
+				"error should mention the missing scope")
+		})
+	}
+}
+
+func TestReadEndpoint_UserCaller_NotAffected(t *testing.T) {
+	srv, _, _, project := setupReadScopeTest(t)
+
+	// User callers should not be affected by the agent scope check.
+	token, _, _, err := srv.userTokenService.GenerateTokenPair(
+		tid("user-read-scope"), "readscope@test.com", "Read Scope Tester",
+		store.UserRoleMember, ClientTypeWeb,
+	)
+	require.NoError(t, err)
+
+	endpoints := []string{
+		"/api/v1/agents?projectId=" + project.ID,
+		"/api/v1/templates",
+		"/api/v1/skills",
+		"/api/v1/harness-configs",
+		"/api/v1/projects",
+		"/api/v1/projects/" + project.ID,
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, ep, nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			rec := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(rec, req)
+
+			assert.NotEqual(t, http.StatusForbidden, rec.Code,
+				"user caller should not be forbidden on %s; got %d: %s",
+				ep, rec.Code, rec.Body.String())
+		})
+	}
+}

--- a/pkg/hub/agentrole_integration_test.go
+++ b/pkg/hub/agentrole_integration_test.go
@@ -1037,6 +1037,50 @@ func TestReadEndpoint_NoReadScope_Blocked(t *testing.T) {
 	}
 }
 
+func TestReadEndpoint_ProjectScopedAgents_NoReadScope_Blocked(t *testing.T) {
+	srv, _, agent, project := setupReadScopeTest(t)
+
+	// Agent with valid JWT but no ScopeProjectRead should be blocked on project-scoped routes.
+	scopes := []AgentTokenScope{ScopeAgentStatusUpdate}
+
+	endpoints := []string{
+		"/api/v1/projects/" + project.ID + "/agents",
+		"/api/v1/projects/" + project.ID + "/agents/" + agent.ID,
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep, func(t *testing.T) {
+			rec := doAgentReadRequest(t, srv, agent.ID, project.ID, ep, scopes)
+			assert.Equal(t, http.StatusForbidden, rec.Code,
+				"agent without ScopeProjectRead should be forbidden on %s; got %d: %s",
+				ep, rec.Code, rec.Body.String())
+			assert.Contains(t, rec.Body.String(), "project:read",
+				"error should mention the missing scope")
+		})
+	}
+}
+
+func TestReadEndpoint_ProjectScopedAgents_WithReadScope_Allowed(t *testing.T) {
+	srv, _, agent, project := setupReadScopeTest(t)
+
+	// Baseline scopes include ScopeProjectRead — should be allowed.
+	scopes := ScopesForRole(AgentRoleBaseline)
+
+	endpoints := []string{
+		"/api/v1/projects/" + project.ID + "/agents",
+		"/api/v1/projects/" + project.ID + "/agents/" + agent.ID,
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep, func(t *testing.T) {
+			rec := doAgentReadRequest(t, srv, agent.ID, project.ID, ep, scopes)
+			assert.NotEqual(t, http.StatusForbidden, rec.Code,
+				"baseline agent should not be forbidden on %s; got %d: %s",
+				ep, rec.Code, rec.Body.String())
+		})
+	}
+}
+
 func TestReadEndpoint_UserCaller_NotAffected(t *testing.T) {
 	srv, _, _, project := setupReadScopeTest(t)
 

--- a/pkg/hub/agentrole_test.go
+++ b/pkg/hub/agentrole_test.go
@@ -181,3 +181,35 @@ func TestResolveEffectiveRole_InvalidRequestedRole(t *testing.T) {
 	// so readonly wins — project cap takes effect.
 	assert.Equal(t, AgentRoleReadOnly, ResolveEffectiveRole(AgentRole("superuser"), "admin", AgentRoleReadOnly))
 }
+
+func TestResolveEffectiveRole_ProjectMaxReadonly_AdminRequestsFull(t *testing.T) {
+	// When project max is "readonly" and an admin requests full, effective is readonly.
+	assert.Equal(t, AgentRoleReadOnly, ResolveEffectiveRole(AgentRoleFull, "admin", AgentRoleReadOnly))
+}
+
+func TestResolveEffectiveRole_ProjectMaxNone(t *testing.T) {
+	// When project max is "none", any request resolves to none.
+	assert.Equal(t, AgentRoleNone, ResolveEffectiveRole(AgentRoleFull, "admin", AgentRoleNone))
+	assert.Equal(t, AgentRoleNone, ResolveEffectiveRole(AgentRoleBaseline, "member", AgentRoleNone))
+	assert.Equal(t, AgentRoleNone, ResolveEffectiveRole(AgentRoleReadOnly, "admin", AgentRoleNone))
+}
+
+func TestResolveEffectiveRole_ProjectMaxFull_MemberCapped(t *testing.T) {
+	// When project max is full but user is member, member ceiling (baseline) applies.
+	assert.Equal(t, AgentRoleBaseline, ResolveEffectiveRole(AgentRoleFull, "member", AgentRoleFull))
+}
+
+func TestScopesForRole_RoleNoneMapToNoAuth(t *testing.T) {
+	// role=none produces nil scopes — caller should set NoAuth=true
+	scopes := ScopesForRole(AgentRoleNone)
+	assert.Nil(t, scopes)
+}
+
+func TestScopesForRole_RoleReadOnlyHasOnlyRead(t *testing.T) {
+	scopes := ScopesForRole(AgentRoleReadOnly)
+	require.Len(t, scopes, 1)
+	assert.Equal(t, ScopeProjectRead, scopes[0])
+	// Must NOT have elevated scopes
+	assert.NotContains(t, scopes, ScopeAgentCreate)
+	assert.NotContains(t, scopes, ScopeAgentStatusUpdate)
+}

--- a/pkg/hub/agentrole_test.go
+++ b/pkg/hub/agentrole_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScopesForRole_None(t *testing.T) {
+	scopes := ScopesForRole(AgentRoleNone)
+	assert.Nil(t, scopes)
+}
+
+func TestScopesForRole_ReadOnly(t *testing.T) {
+	scopes := ScopesForRole(AgentRoleReadOnly)
+	require.Len(t, scopes, 1)
+	assert.Equal(t, ScopeProjectRead, scopes[0])
+}
+
+func TestScopesForRole_Baseline(t *testing.T) {
+	scopes := ScopesForRole(AgentRoleBaseline)
+	require.Len(t, scopes, 5)
+
+	// Must include these scopes
+	assert.Contains(t, scopes, ScopeProjectRead)
+	assert.Contains(t, scopes, ScopeAgentStatusUpdate)
+	assert.Contains(t, scopes, ScopeAgentTokenRefresh)
+	assert.Contains(t, scopes, ScopeAgentNotify)
+	assert.Contains(t, scopes, ScopeAgentPortForward)
+
+	// Must NOT include elevated scopes
+	assert.NotContains(t, scopes, ScopeAgentCreate)
+	assert.NotContains(t, scopes, ScopeAgentLifecycle)
+	assert.NotContains(t, scopes, ScopeProjectSecretRead)
+}
+
+func TestScopesForRole_Full(t *testing.T) {
+	scopes := ScopesForRole(AgentRoleFull)
+	require.Len(t, scopes, 8)
+
+	// Must include everything in baseline
+	assert.Contains(t, scopes, ScopeProjectRead)
+	assert.Contains(t, scopes, ScopeAgentStatusUpdate)
+	assert.Contains(t, scopes, ScopeAgentTokenRefresh)
+	assert.Contains(t, scopes, ScopeAgentNotify)
+	assert.Contains(t, scopes, ScopeAgentPortForward)
+
+	// Plus elevated scopes
+	assert.Contains(t, scopes, ScopeAgentCreate)
+	assert.Contains(t, scopes, ScopeAgentLifecycle)
+	assert.Contains(t, scopes, ScopeProjectSecretRead)
+}
+
+func TestScopesForRole_InvalidDefault(t *testing.T) {
+	// Unknown role strings should fall back to baseline scopes
+	scopes := ScopesForRole(AgentRole("unknown-role"))
+	baselineScopes := ScopesForRole(AgentRoleBaseline)
+	assert.Equal(t, baselineScopes, scopes)
+}
+
+func TestValidAgentRole(t *testing.T) {
+	// All four stock roles are valid
+	assert.True(t, ValidAgentRole(AgentRoleNone))
+	assert.True(t, ValidAgentRole(AgentRoleReadOnly))
+	assert.True(t, ValidAgentRole(AgentRoleBaseline))
+	assert.True(t, ValidAgentRole(AgentRoleFull))
+
+	// Random strings are invalid
+	assert.False(t, ValidAgentRole(AgentRole("")))
+	assert.False(t, ValidAgentRole(AgentRole("admin")))
+	assert.False(t, ValidAgentRole(AgentRole("superuser")))
+	assert.False(t, ValidAgentRole(AgentRole("unknown")))
+}
+
+func TestCompareRoles(t *testing.T) {
+	// none < readonly < baseline < full
+	assert.Less(t, CompareRoles(AgentRoleNone, AgentRoleReadOnly), 0)
+	assert.Less(t, CompareRoles(AgentRoleReadOnly, AgentRoleBaseline), 0)
+	assert.Less(t, CompareRoles(AgentRoleBaseline, AgentRoleFull), 0)
+	assert.Less(t, CompareRoles(AgentRoleNone, AgentRoleFull), 0)
+
+	// Equal returns 0
+	assert.Equal(t, 0, CompareRoles(AgentRoleNone, AgentRoleNone))
+	assert.Equal(t, 0, CompareRoles(AgentRoleBaseline, AgentRoleBaseline))
+	assert.Equal(t, 0, CompareRoles(AgentRoleFull, AgentRoleFull))
+
+	// Reverse comparisons are positive
+	assert.Greater(t, CompareRoles(AgentRoleFull, AgentRoleNone), 0)
+	assert.Greater(t, CompareRoles(AgentRoleBaseline, AgentRoleReadOnly), 0)
+}
+
+func TestMinRole(t *testing.T) {
+	// Empty returns baseline
+	assert.Equal(t, AgentRoleBaseline, minRole())
+
+	// Single role returns itself
+	assert.Equal(t, AgentRoleNone, minRole(AgentRoleNone))
+	assert.Equal(t, AgentRoleFull, minRole(AgentRoleFull))
+
+	// Two roles
+	assert.Equal(t, AgentRoleReadOnly, minRole(AgentRoleFull, AgentRoleReadOnly))
+	assert.Equal(t, AgentRoleNone, minRole(AgentRoleBaseline, AgentRoleNone))
+
+	// Three roles
+	assert.Equal(t, AgentRoleNone, minRole(AgentRoleFull, AgentRoleBaseline, AgentRoleNone))
+	assert.Equal(t, AgentRoleReadOnly, minRole(AgentRoleFull, AgentRoleReadOnly, AgentRoleBaseline))
+}
+
+func TestResolveEffectiveRole_MemberUser(t *testing.T) {
+	// Member user requesting full gets capped at baseline
+	assert.Equal(t, AgentRoleBaseline, ResolveEffectiveRole(AgentRoleFull, "member", AgentRoleFull))
+
+	// Member user requesting baseline gets baseline
+	assert.Equal(t, AgentRoleBaseline, ResolveEffectiveRole(AgentRoleBaseline, "member", AgentRoleFull))
+
+	// Member user requesting readonly gets readonly
+	assert.Equal(t, AgentRoleReadOnly, ResolveEffectiveRole(AgentRoleReadOnly, "member", AgentRoleFull))
+}
+
+func TestResolveEffectiveRole_AdminUser(t *testing.T) {
+	// Admin requesting full in full-project gets full
+	assert.Equal(t, AgentRoleFull, ResolveEffectiveRole(AgentRoleFull, "admin", AgentRoleFull))
+
+	// Admin in baseline-project gets baseline (project cap takes effect)
+	assert.Equal(t, AgentRoleBaseline, ResolveEffectiveRole(AgentRoleFull, "admin", AgentRoleBaseline))
+}
+
+func TestResolveEffectiveRole_EmptyUserRole(t *testing.T) {
+	// Empty user role defaults to member ceiling (baseline)
+	assert.Equal(t, AgentRoleBaseline, ResolveEffectiveRole(AgentRoleFull, "", AgentRoleFull))
+	assert.Equal(t, AgentRoleReadOnly, ResolveEffectiveRole(AgentRoleReadOnly, "", AgentRoleFull))
+}
+
+func TestResolveEffectiveRole_LatticeMin(t *testing.T) {
+	// Three-way min: admin + full request + readonly project = readonly
+	assert.Equal(t, AgentRoleReadOnly, ResolveEffectiveRole(AgentRoleFull, "admin", AgentRoleReadOnly))
+
+	// Three-way min: member + readonly request + full project = readonly
+	assert.Equal(t, AgentRoleReadOnly, ResolveEffectiveRole(AgentRoleReadOnly, "member", AgentRoleFull))
+
+	// Three-way min: admin + none request + full project = none
+	assert.Equal(t, AgentRoleNone, ResolveEffectiveRole(AgentRoleNone, "admin", AgentRoleFull))
+
+	// Three-way min: member + full request + none project = none
+	assert.Equal(t, AgentRoleNone, ResolveEffectiveRole(AgentRoleFull, "member", AgentRoleNone))
+}

--- a/pkg/hub/agentrole_test.go
+++ b/pkg/hub/agentrole_test.go
@@ -159,3 +159,25 @@ func TestResolveEffectiveRole_LatticeMin(t *testing.T) {
 	// Three-way min: member + full request + none project = none
 	assert.Equal(t, AgentRoleNone, ResolveEffectiveRole(AgentRoleFull, "member", AgentRoleNone))
 }
+
+func TestResolveEffectiveRole_InvalidRequestedRole(t *testing.T) {
+	// An unknown/invalid requested role gets baseline-level ordinal (2) via the
+	// default case in roleOrdinal. minRole preserves the original role value, so
+	// the returned AgentRole string is the invalid one — but ScopesForRole will
+	// map it to baseline scopes via its own default case.
+
+	// Admin + invalid request + full project: invalid ordinal (2) < full (3),
+	// so the invalid role is returned. Its scopes resolve to baseline.
+	resolved := ResolveEffectiveRole(AgentRole("superuser"), "admin", AgentRoleFull)
+	assert.Equal(t, AgentRole("superuser"), resolved)
+	assert.Equal(t, ScopesForRole(AgentRoleBaseline), ScopesForRole(resolved))
+
+	// Member + invalid request + full project: member ceiling is baseline (2),
+	// invalid is also ordinal 2; the first encountered (invalid) wins the tie.
+	resolved = ResolveEffectiveRole(AgentRole("superuser"), "member", AgentRoleFull)
+	assert.Equal(t, ScopesForRole(AgentRoleBaseline), ScopesForRole(resolved))
+
+	// Admin + invalid request + readonly project: readonly (1) < invalid (2),
+	// so readonly wins — project cap takes effect.
+	assert.Equal(t, AgentRoleReadOnly, ResolveEffectiveRole(AgentRole("superuser"), "admin", AgentRoleReadOnly))
+}

--- a/pkg/hub/agenttoken.go
+++ b/pkg/hub/agenttoken.go
@@ -370,3 +370,24 @@ func RequireAgentSelfAccess(pathPrefix string) func(http.Handler) http.Handler {
 		})
 	}
 }
+
+// checkAgentReadScope verifies that agent callers have ScopeProjectRead.
+// Returns true if the request should proceed, false if a 403 was written.
+// User callers are not affected — the check only applies when the caller
+// is an agent (i.e., GetAgentIdentityFromContext returns non-nil).
+//
+// Backward compatibility note: legacy agents created before the role system
+// may not have ScopeProjectRead in their JWT. They must refresh their token,
+// which will mint scopes based on their effective role (defaulting to baseline,
+// which includes ScopeProjectRead). Token refresh is automatic and frequent,
+// so active legacy agents will have already refreshed.
+func checkAgentReadScope(w http.ResponseWriter, r *http.Request) bool {
+	if agentIdent := GetAgentIdentityFromContext(r.Context()); agentIdent != nil {
+		if !agentIdent.HasScope(ScopeProjectRead) {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden,
+				"Missing required scope: project:read", nil)
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/hub/agenttoken.go
+++ b/pkg/hub/agenttoken.go
@@ -59,6 +59,9 @@ const (
 	ScopeAgentPortForward AgentTokenScope = "agent:port:forward"
 	// ScopeIdentityToken grants the ability to request OIDC identity tokens.
 	ScopeIdentityToken AgentTokenScope = "agent:identity:token"
+	// ScopeProjectRead grants read access to project resources (agents, templates, project info).
+	// Enforcement is deferred to a later phase; defining the scope now allows role bundles to include it.
+	ScopeProjectRead AgentTokenScope = "project:read"
 	// ScopeGCPTokenPrefix is the prefix for GCP token scopes.
 	// Full scope format: "project:gcp:token:<sa-id>"
 	ScopeGCPTokenPrefix = "project:gcp:token:"

--- a/pkg/hub/agenttoken.go
+++ b/pkg/hub/agenttoken.go
@@ -59,8 +59,8 @@ const (
 	ScopeAgentPortForward AgentTokenScope = "agent:port:forward"
 	// ScopeIdentityToken grants the ability to request OIDC identity tokens.
 	ScopeIdentityToken AgentTokenScope = "agent:identity:token"
-	// ScopeProjectRead grants read access to project resources (agents, templates, project info).
-	// Enforcement is deferred to a later phase; defining the scope now allows role bundles to include it.
+	// ScopeProjectRead grants read access to project resources (agents, templates,
+	// skills, harness configs, projects). Enforced by checkAgentReadScope().
 	ScopeProjectRead AgentTokenScope = "project:read"
 	// ScopeGCPTokenPrefix is the prefix for GCP token scopes.
 	// Full scope format: "project:gcp:token:<sa-id>"

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -79,7 +79,7 @@ func (s *Server) getHarnessConfigFromTemplate(template *store.Template, fallback
 // buildAppliedConfig constructs an AgentAppliedConfig from a CreateAgentRequest.
 // When req.Config is a ScionConfig, its fields are extracted into the applied config
 // and the full ScionConfig is preserved as InlineConfig for threading to the broker.
-func (s *Server) buildAppliedConfig(req CreateAgentRequest, harnessConfig string, creatorName string) *store.AgentAppliedConfig {
+func (s *Server) buildAppliedConfig(req CreateAgentRequest, harnessConfig string, creatorName string, effectiveRole AgentRole) *store.AgentAppliedConfig {
 	ac := &store.AgentAppliedConfig{
 		Profile:       req.Profile,
 		HarnessConfig: harnessConfig,
@@ -89,6 +89,7 @@ func (s *Server) buildAppliedConfig(req CreateAgentRequest, harnessConfig string
 		Branch:        req.Branch,
 		Workspace:     req.Workspace,
 		CreatorName:   creatorName,
+		AgentRole:     string(effectiveRole),
 	}
 
 	ac.NoAuth = req.NoAuth

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -174,7 +174,16 @@ func (s *Server) populateAgentConfig(ctx context.Context, agent *store.Agent, pr
 		agent.AppliedConfig.TemplateID = resolvedTemplate.ID
 		agent.AppliedConfig.TemplateHash = resolvedTemplate.ContentHash
 		if resolvedTemplate.Config != nil && resolvedTemplate.Config.HubAccess != nil {
+			// Still store the scopes on AppliedConfig for backward-compat visibility,
+			// but they are no longer used for token generation (replaced by AgentRole).
 			agent.AppliedConfig.HubAccessScopes = resolvedTemplate.Config.HubAccess.Scopes
+			if len(resolvedTemplate.Config.HubAccess.Scopes) > 0 {
+				slog.Warn("Template uses deprecated hubAccess.scopes; agent role determines scopes instead",
+					"template", resolvedTemplate.Slug,
+					"scopes", resolvedTemplate.Config.HubAccess.Scopes,
+					"agent_role", agent.AppliedConfig.AgentRole,
+				)
+			}
 		}
 
 		// Merge template-level config values as defaults into AppliedConfig.

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -702,7 +702,9 @@ func TestAgentGetAgent_ProjectIsolation(t *testing.T) {
 	tokenSvc := srv.GetAgentTokenService()
 	require.NotNil(t, tokenSvc)
 
-	token, err := tokenSvc.GenerateAgentToken(agent1.ID, project1.ID, []AgentTokenScope{ScopeAgentStatusUpdate}, nil)
+	// Token includes ScopeProjectRead (required for read endpoints) and
+	// ScopeAgentStatusUpdate (standard baseline scope).
+	token, err := tokenSvc.GenerateAgentToken(agent1.ID, project1.ID, []AgentTokenScope{ScopeAgentStatusUpdate, ScopeProjectRead}, nil)
 	require.NoError(t, err)
 
 	t.Run("Agent can GET details of agents in same project", func(t *testing.T) {

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -423,6 +423,106 @@ func (s *Server) createAgentInProject(
 		return
 	}
 
+	// Resolve effective agent role using the authority lattice.
+	// Computed early (before broker resolution) so that fail-loud 403 on
+	// role over-requests fires before resource-intensive operations.
+	var effectiveRole AgentRole
+	requestedRole := AgentRole(req.AgentRole)
+
+	// Read project max agent role from annotations (default: baseline)
+	projectMax := AgentRoleBaseline
+	if project != nil && project.Annotations != nil {
+		if maxStr := project.Annotations["scion.dev/max-agent-role"]; maxStr != "" {
+			if ValidAgentRole(AgentRole(maxStr)) {
+				projectMax = AgentRole(maxStr)
+			}
+		}
+	}
+
+	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+		// Agent caller: read parent agent's stored role for no-escalation ceiling.
+		parentRole := AgentRoleBaseline
+		creatorAgent, err := s.store.GetAgent(ctx, agentIdent.ID())
+		if err != nil {
+			slog.Warn("Failed to read parent agent for role ceiling",
+				"parent_agent_id", agentIdent.ID(), "error", err)
+			// Fall through with baseline default — safe because it is the most restrictive
+			// non-zero role, so the ceiling is conservative.
+		} else if creatorAgent.AppliedConfig != nil && creatorAgent.AppliedConfig.AgentRole != "" {
+			parentRole = AgentRole(creatorAgent.AppliedConfig.AgentRole)
+		}
+
+		// Validate stored parentRole to guard against corrupted data.
+		if !ValidAgentRole(parentRole) {
+			slog.Warn("Parent agent has invalid stored role, defaulting to baseline",
+				"parent_agent_id", agentIdent.ID(), "stored_role", parentRole)
+			parentRole = AgentRoleBaseline
+		}
+
+		// Log the parent role for audit trail
+		slog.Info("Agent creating sub-agent",
+			"parent_agent_id", agentIdent.ID(),
+			"parent_role", parentRole,
+			"requested_role", requestedRole,
+			"project_max", projectMax,
+		)
+
+		if requestedRole == "" {
+			requestedRole = parentRole // default: inherit parent's role
+		}
+
+		// Enforce no-escalation: sub-agent role cannot exceed parent's role.
+		// Fail-loud so template misconfiguration is visible (a template requesting
+		// "full" for a sub-agent under a "baseline" parent is almost certainly wrong).
+		if req.AgentRole != "" && CompareRoles(AgentRole(req.AgentRole), parentRole) > 0 {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden,
+				fmt.Sprintf("Cannot grant sub-agent role %q: parent agent role is %q",
+					req.AgentRole, parentRole), nil)
+			return
+		}
+
+		effectiveRole = minRole(requestedRole, parentRole, projectMax)
+	} else if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+		// User caller: ceiling based on hub role
+		userHubRole := userIdent.Role()
+		userCeiling := AgentRoleBaseline
+		if userHubRole == "admin" {
+			userCeiling = AgentRoleFull
+		}
+
+		if requestedRole == "" {
+			requestedRole = projectMax
+		}
+
+		// Fail-loud: reject explicit over-request against user ceiling or project max.
+		if req.AgentRole != "" && CompareRoles(AgentRole(req.AgentRole), userCeiling) > 0 {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden,
+				fmt.Sprintf("Cannot grant agent role %q: user ceiling is %q",
+					req.AgentRole, userCeiling), nil)
+			return
+		}
+		if req.AgentRole != "" && CompareRoles(AgentRole(req.AgentRole), projectMax) > 0 {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden,
+				fmt.Sprintf("Cannot grant agent role %q: project maximum is %q",
+					req.AgentRole, projectMax), nil)
+			return
+		}
+
+		// Use minRole directly instead of ResolveEffectiveRole to avoid recomputing ceiling.
+		effectiveRole = minRole(requestedRole, userCeiling, projectMax)
+	} else {
+		// No identity (should not happen in practice) - default to baseline
+		if requestedRole == "" {
+			requestedRole = AgentRoleBaseline
+		}
+		effectiveRole = requestedRole
+	}
+
+	// Map role=none to NoAuth behavior
+	if effectiveRole == AgentRoleNone {
+		req.NoAuth = true
+	}
+
 	// Resolve the runtime broker
 	runtimeBrokerID, err := s.resolveRuntimeBroker(ctx, w, req.RuntimeBrokerID, project)
 	if err != nil {
@@ -685,63 +785,6 @@ func (s *Server) createAgentInProject(
 			BadRequest(w, "thinking_level must be between 0 and 100")
 			return
 		}
-	}
-
-	// Resolve effective agent role using the authority lattice.
-	var effectiveRole AgentRole
-	requestedRole := AgentRole(req.AgentRole)
-
-	// Read project max agent role from annotations (default: baseline)
-	projectMax := AgentRoleBaseline
-	if project != nil && project.Annotations != nil {
-		if maxStr := project.Annotations["scion.dev/max-agent-role"]; maxStr != "" {
-			if ValidAgentRole(AgentRole(maxStr)) {
-				projectMax = AgentRole(maxStr)
-			}
-		}
-	}
-
-	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
-		// Agent caller: read parent agent's stored role for no-escalation ceiling (F2P1).
-		parentRole := AgentRoleBaseline // default for legacy agents without stored role
-		if creatorAgent, err := s.store.GetAgent(ctx, agentIdent.ID()); err == nil {
-			if creatorAgent.AppliedConfig != nil && creatorAgent.AppliedConfig.AgentRole != "" {
-				parentRole = AgentRole(creatorAgent.AppliedConfig.AgentRole)
-			}
-		}
-
-		// Log the parent role for audit trail
-		slog.Info("Agent creating sub-agent",
-			"parent_agent_id", agentIdent.ID(),
-			"parent_role", parentRole,
-			"requested_role", requestedRole,
-			"project_max", projectMax,
-		)
-
-		if requestedRole == "" {
-			requestedRole = parentRole // default: inherit parent's role
-		}
-		// NOTE: parentRole is NOT yet used as a ceiling in minRole.
-		// Flow 2 Phase 2 will add: effectiveRole = minRole(requestedRole, parentRole, projectMax)
-		effectiveRole = minRole(requestedRole, projectMax)
-	} else if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-		// User caller: ceiling based on hub role
-		userHubRole := userIdent.Role()
-		if requestedRole == "" {
-			requestedRole = projectMax
-		}
-		effectiveRole = ResolveEffectiveRole(requestedRole, userHubRole, projectMax)
-	} else {
-		// No identity (should not happen in practice) - default to baseline
-		if requestedRole == "" {
-			requestedRole = AgentRoleBaseline
-		}
-		effectiveRole = requestedRole
-	}
-
-	// Map role=none to NoAuth behavior
-	if effectiveRole == AgentRoleNone {
-		req.NoAuth = true
 	}
 
 	agent.AppliedConfig = s.buildAppliedConfig(req, harnessConfig, creatorName, effectiveRole)

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -702,14 +702,27 @@ func (s *Server) createAgentInProject(
 	}
 
 	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
-		// Agent caller: ceiling is the parent agent's own role.
-		// TODO(F2P1): read the parent's effective role from its stored AgentRole
-		// and pass it as an additional ceiling to minRole, so a baseline parent
-		// cannot escalate a child to full. Until then, only projectMax caps.
-		// Default requested role to project max if not specified
-		if requestedRole == "" {
-			requestedRole = projectMax
+		// Agent caller: read parent agent's stored role for no-escalation ceiling (F2P1).
+		parentRole := AgentRoleBaseline // default for legacy agents without stored role
+		if creatorAgent, err := s.store.GetAgent(ctx, agentIdent.ID()); err == nil {
+			if creatorAgent.AppliedConfig != nil && creatorAgent.AppliedConfig.AgentRole != "" {
+				parentRole = AgentRole(creatorAgent.AppliedConfig.AgentRole)
+			}
 		}
+
+		// Log the parent role for audit trail
+		slog.Info("Agent creating sub-agent",
+			"parent_agent_id", agentIdent.ID(),
+			"parent_role", parentRole,
+			"requested_role", requestedRole,
+			"project_max", projectMax,
+		)
+
+		if requestedRole == "" {
+			requestedRole = parentRole // default: inherit parent's role
+		}
+		// NOTE: parentRole is NOT yet used as a ceiling in minRole.
+		// Flow 2 Phase 2 will add: effectiveRole = minRole(requestedRole, parentRole, projectMax)
 		effectiveRole = minRole(requestedRole, projectMax)
 	} else if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
 		// User caller: ceiling based on hub role

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -427,6 +427,7 @@ func (s *Server) createAgentInProject(
 	// Computed early (before broker resolution) so that fail-loud 403 on
 	// role over-requests fires before resource-intensive operations.
 	var effectiveRole AgentRole
+	var parentRole AgentRole // empty for user-created agents; set in agent-caller branch
 	requestedRole := AgentRole(req.AgentRole)
 
 	// Read project max agent role from annotations (default: baseline)
@@ -441,7 +442,7 @@ func (s *Server) createAgentInProject(
 
 	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
 		// Agent caller: read parent agent's stored role for no-escalation ceiling.
-		parentRole := AgentRoleBaseline
+		parentRole = AgentRoleBaseline
 		creatorAgent, err := s.store.GetAgent(ctx, agentIdent.ID())
 		if err != nil {
 			slog.Warn("Failed to read parent agent for role ceiling",
@@ -975,8 +976,12 @@ func (s *Server) createAgentInProject(
 
 	// Managed agent path: bypass broker dispatch entirely and handle directly.
 	if req.Profile == ManagedAgentsProfile {
+		logAttrs := []any{"agent_id", agent.ID, "agent", agent.Name, "elapsed", time.Since(hubCreateStart).String()}
+		if parentRole != "" {
+			logAttrs = append(logAttrs, "parent_agent_role", string(parentRole))
+		}
 		s.agentLifecycleLog.Info("Hub: managed agent create (hub-direct)",
-			"agent_id", agent.ID, "agent", agent.Name, "elapsed", time.Since(hubCreateStart).String())
+			logAttrs...)
 
 		task := ""
 		if agent.AppliedConfig != nil {
@@ -1011,8 +1016,12 @@ func (s *Server) createAgentInProject(
 	// Dispatch to runtime broker if available.
 	// Unless provision-only is requested, do a full create+start via DispatchAgentCreate.
 	// Otherwise provision only — set up dirs, worktree, templates without launching the container.
+	preDispatchAttrs := []any{"agent_id", agent.ID, "agent", agent.Name, "elapsed", time.Since(hubCreateStart).String()}
+	if parentRole != "" {
+		preDispatchAttrs = append(preDispatchAttrs, "parent_agent_role", string(parentRole))
+	}
 	s.agentLifecycleLog.Info("Hub: pre-dispatch setup complete",
-		"agent_id", agent.ID, "agent", agent.Name, "elapsed", time.Since(hubCreateStart).String())
+		preDispatchAttrs...)
 	var warnings []string
 	if dispatcher := s.GetDispatcher(); dispatcher != nil {
 		if !req.ProvisionOnly {
@@ -1106,8 +1115,12 @@ func (s *Server) createAgentInProject(
 		}
 	}
 
+	dispatchAttrs := []any{"agent_id", agent.ID, "agent", agent.Name, "totalElapsed", time.Since(hubCreateStart).String()}
+	if parentRole != "" {
+		dispatchAttrs = append(dispatchAttrs, "parent_agent_role", string(parentRole))
+	}
 	s.agentLifecycleLog.Info("Hub: dispatch complete",
-		"agent_id", agent.ID, "agent", agent.Name, "totalElapsed", time.Since(hubCreateStart).String())
+		dispatchAttrs...)
 
 	// Re-read the agent from the database before publishing the "created" event.
 	// A concurrent status update (e.g. sciontool reporting a clone error) may have

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -702,7 +702,10 @@ func (s *Server) createAgentInProject(
 	}
 
 	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
-		// Agent caller: ceiling is parent's role (Phase F2P1 will read this; for now use full)
+		// Agent caller: ceiling is the parent agent's own role.
+		// TODO(F2P1): read the parent's effective role from its stored AgentRole
+		// and pass it as an additional ceiling to minRole, so a baseline parent
+		// cannot escalate a child to full. Until then, only projectMax caps.
 		// Default requested role to project max if not specified
 		if requestedRole == "" {
 			requestedRole = projectMax

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -108,6 +108,10 @@ type CreateAgentRequest struct {
 	// NoAuth indicates the agent should start with zero injected credentials.
 	// When true, the Hub skips secret resolution and the broker skips credential injection.
 	NoAuth bool `json:"noAuth,omitempty"`
+	// AgentRole specifies the requested authorization role for the agent.
+	// Valid values: "none", "readonly", "baseline", "full".
+	// When omitted, defaults to the effective ceiling (project max intersected with caller ceiling).
+	AgentRole string `json:"agentRole,omitempty"`
 	// GCPIdentity specifies the GCP identity assignment for the agent.
 	// Controls metadata server behavior and optional service account binding.
 	GCPIdentity *GCPIdentityAssignment `json:"gcp_identity,omitempty"`
@@ -319,6 +323,11 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 			ValidationError(w, "metadata_mode must be 'block', 'passthrough', or 'assign'", nil)
 			return
 		}
+	}
+
+	if req.AgentRole != "" && !ValidAgentRole(AgentRole(req.AgentRole)) {
+		ValidationError(w, fmt.Sprintf("invalid agentRole %q: must be one of none, readonly, baseline, full", req.AgentRole), nil)
+		return
 	}
 
 	if err := labels.Validate(req.Labels); err != nil {
@@ -678,7 +687,48 @@ func (s *Server) createAgentInProject(
 		}
 	}
 
-	agent.AppliedConfig = s.buildAppliedConfig(req, harnessConfig, creatorName)
+	// Resolve effective agent role using the authority lattice.
+	var effectiveRole AgentRole
+	requestedRole := AgentRole(req.AgentRole)
+
+	// Read project max agent role from annotations (default: baseline)
+	projectMax := AgentRoleBaseline
+	if project != nil && project.Annotations != nil {
+		if maxStr := project.Annotations["scion.dev/max-agent-role"]; maxStr != "" {
+			if ValidAgentRole(AgentRole(maxStr)) {
+				projectMax = AgentRole(maxStr)
+			}
+		}
+	}
+
+	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+		// Agent caller: ceiling is parent's role (Phase F2P1 will read this; for now use full)
+		// Default requested role to project max if not specified
+		if requestedRole == "" {
+			requestedRole = projectMax
+		}
+		effectiveRole = minRole(requestedRole, projectMax)
+	} else if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+		// User caller: ceiling based on hub role
+		userHubRole := userIdent.Role()
+		if requestedRole == "" {
+			requestedRole = projectMax
+		}
+		effectiveRole = ResolveEffectiveRole(requestedRole, userHubRole, projectMax)
+	} else {
+		// No identity (should not happen in practice) - default to baseline
+		if requestedRole == "" {
+			requestedRole = AgentRoleBaseline
+		}
+		effectiveRole = requestedRole
+	}
+
+	// Map role=none to NoAuth behavior
+	if effectiveRole == AgentRoleNone {
+		req.NoAuth = true
+	}
+
+	agent.AppliedConfig = s.buildAppliedConfig(req, harnessConfig, creatorName, effectiveRole)
 
 	// Populate GCP identity in applied config.
 	// Default to "block" mode when no GCP identity is specified, so agents

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -433,7 +433,7 @@ func (s *Server) createAgentInProject(
 	// Read project max agent role from annotations (default: baseline)
 	projectMax := AgentRoleBaseline
 	if project != nil && project.Annotations != nil {
-		if maxStr := project.Annotations["scion.dev/max-agent-role"]; maxStr != "" {
+		if maxStr, ok := project.Annotations[projectSettingMaxAgentRole]; ok && maxStr != "" {
 			if ValidAgentRole(AgentRole(maxStr)) {
 				projectMax = AgentRole(maxStr)
 			}

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -170,6 +170,10 @@ func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 	query := r.URL.Query()
 
@@ -1703,6 +1707,10 @@ func (s *Server) handleAgentByID(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getAgent(w http.ResponseWriter, r *http.Request, id string) {
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 	agent, err := s.store.GetAgent(ctx, id)
 	if err != nil {

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -1183,6 +1183,10 @@ func (s *Server) agentListSecrets(w http.ResponseWriter, r *http.Request, agentI
 }
 
 func (s *Server) handleProjectEnvVars(w http.ResponseWriter, r *http.Request, projectID string) {
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 
 	// Verify project exists
@@ -1277,6 +1281,10 @@ func (s *Server) handleProjectEnvVars(w http.ResponseWriter, r *http.Request, pr
 }
 
 func (s *Server) handleProjectEnvVarByKey(w http.ResponseWriter, r *http.Request, projectID, key string) {
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 
 	// Verify project exists

--- a/pkg/hub/handlers_envsecret_authz_test.go
+++ b/pkg/hub/handlers_envsecret_authz_test.go
@@ -346,7 +346,8 @@ func TestEnvVar_ProjectScope_AgentReadOwnProject(t *testing.T) {
 		t.Fatalf("failed to create agent: %v", err)
 	}
 
-	agentToken, err := srv.agentTokenService.GenerateAgentToken(agent.ID, project.ID, nil, nil)
+	agentToken, err := srv.agentTokenService.GenerateAgentToken(agent.ID, project.ID,
+		[]AgentTokenScope{ScopeAgentStatusUpdate, ScopeProjectRead}, nil)
 	if err != nil {
 		t.Fatalf("failed to generate agent token: %v", err)
 	}
@@ -386,12 +387,13 @@ func TestEnvVar_ProjectScope_AgentOtherProjectDenied(t *testing.T) {
 		t.Fatalf("failed to create agent: %v", err)
 	}
 
-	agentToken, err := srv.agentTokenService.GenerateAgentToken(agent.ID, project1.ID, nil, nil)
+	agentToken, err := srv.agentTokenService.GenerateAgentToken(agent.ID, project1.ID,
+		[]AgentTokenScope{ScopeAgentStatusUpdate, ScopeProjectRead}, nil)
 	if err != nil {
 		t.Fatalf("failed to generate agent token: %v", err)
 	}
 
-	// Agent should NOT be able to read other project env vars
+	// Agent should NOT be able to read other project env vars (project isolation)
 	rec := doRequestWithAgentToken(t, srv, http.MethodGet, "/api/v1/projects/"+project2.ID+"/env", nil, agentToken)
 	if rec.Code != http.StatusForbidden {
 		t.Errorf("expected 403 for agent reading other project, got %d: %s", rec.Code, rec.Body.String())
@@ -419,12 +421,13 @@ func TestEnvVar_ProjectScope_AgentWriteDenied(t *testing.T) {
 		t.Fatalf("failed to create agent: %v", err)
 	}
 
-	agentToken, err := srv.agentTokenService.GenerateAgentToken(agent.ID, project.ID, nil, nil)
+	agentToken, err := srv.agentTokenService.GenerateAgentToken(agent.ID, project.ID,
+		[]AgentTokenScope{ScopeAgentStatusUpdate, ScopeProjectRead}, nil)
 	if err != nil {
 		t.Fatalf("failed to generate agent token: %v", err)
 	}
 
-	// Agent should NOT be able to write project env vars
+	// Agent should NOT be able to write project env vars (write is always denied for agents)
 	body := SetEnvVarRequest{Value: "agent-val"}
 	rec := doRequestWithAgentToken(t, srv, http.MethodPut, "/api/v1/projects/"+project.ID+"/env/AGENT_VAR", body, agentToken)
 	if rec.Code != http.StatusForbidden {

--- a/pkg/hub/handlers_logs.go
+++ b/pkg/hub/handlers_logs.go
@@ -36,6 +36,10 @@ func (s *Server) handleAgentLogs(w http.ResponseWriter, r *http.Request, agentID
 		return
 	}
 
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 
 	agent, err := s.store.GetAgent(ctx, agentID)
@@ -88,6 +92,10 @@ func (s *Server) handleAgentLogs(w http.ResponseWriter, r *http.Request, agentID
 func (s *Server) handleAgentCloudLogs(w http.ResponseWriter, r *http.Request, agentID string) {
 	if r.Method != http.MethodGet {
 		MethodNotAllowed(w)
+		return
+	}
+
+	if !checkAgentReadScope(w, r) {
 		return
 	}
 
@@ -269,6 +277,10 @@ func (s *Server) handleAgentCloudLogsStream(w http.ResponseWriter, r *http.Reque
 func (s *Server) handleAgentMessageLogs(w http.ResponseWriter, r *http.Request, agentID string) {
 	if r.Method != http.MethodGet {
 		MethodNotAllowed(w)
+		return
+	}
+
+	if !checkAgentReadScope(w, r) {
 		return
 	}
 

--- a/pkg/hub/handlers_logs.go
+++ b/pkg/hub/handlers_logs.go
@@ -178,6 +178,10 @@ func (s *Server) handleAgentCloudLogsStream(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	if s.logQueryService == nil {
 		writeError(w, http.StatusNotImplemented, "not_implemented",
 			"Cloud Logging is not configured", nil)
@@ -356,6 +360,10 @@ func (s *Server) handleAgentMessageLogsStream(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	if s.logQueryService == nil {
 		writeError(w, http.StatusNotImplemented, "not_implemented",
 			"Cloud Logging is not configured", nil)
@@ -446,6 +454,10 @@ func (s *Server) handleProjectMessageLogs(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	if s.logQueryService == nil {
 		writeError(w, http.StatusNotImplemented, "not_implemented",
 			"Cloud Logging is not configured", nil)
@@ -513,6 +525,10 @@ func (s *Server) handleProjectMessageLogs(w http.ResponseWriter, r *http.Request
 func (s *Server) handleProjectMessageLogsStream(w http.ResponseWriter, r *http.Request, projectID string) {
 	if r.Method != http.MethodGet {
 		MethodNotAllowed(w)
+		return
+	}
+
+	if !checkAgentReadScope(w, r) {
 		return
 	}
 

--- a/pkg/hub/handlers_messages.go
+++ b/pkg/hub/handlers_messages.go
@@ -159,6 +159,10 @@ func (s *Server) handleAgentMessages(w http.ResponseWriter, r *http.Request, age
 		return
 	}
 
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 	ctx, span := tracer.Start(ctx, "hub.message.list")
 	defer span.End()

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -356,6 +356,16 @@ func (s *Server) createProject(w http.ResponseWriter, r *http.Request) {
 		project.SharedDirs = s.defaultProjectSharedDirs()
 	}
 
+	// Apply hub-level default max agent role to new projects.
+	if defaults := s.hubAgentDefaults(); defaults.DefaultMaxAgentRole != "" {
+		if project.Annotations == nil {
+			project.Annotations = make(map[string]string)
+		}
+		if _, exists := project.Annotations[projectSettingMaxAgentRole]; !exists {
+			project.Annotations[projectSettingMaxAgentRole] = defaults.DefaultMaxAgentRole
+		}
+	}
+
 	if err := s.store.CreateProject(ctx, project); err != nil {
 		writeErrorFromErr(w, err, "")
 		return
@@ -1063,6 +1073,16 @@ func (s *Server) handleProjectRegister(w http.ResponseWriter, r *http.Request) {
 		// Apply default shared dirs from hub settings (new projects only).
 		if len(project.SharedDirs) == 0 {
 			project.SharedDirs = s.defaultProjectSharedDirs()
+		}
+
+		// Apply hub-level default max agent role to new projects.
+		if defaults := s.hubAgentDefaults(); defaults.DefaultMaxAgentRole != "" {
+			if project.Annotations == nil {
+				project.Annotations = make(map[string]string)
+			}
+			if _, exists := project.Annotations[projectSettingMaxAgentRole]; !exists {
+				project.Annotations[projectSettingMaxAgentRole] = defaults.DefaultMaxAgentRole
+			}
 		}
 
 		if err := s.store.CreateProject(ctx, project); err != nil {

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -1724,6 +1724,10 @@ func (s *Server) handleProjectAgents(w http.ResponseWriter, r *http.Request, pro
 
 // listProjectAgents lists agents within a specific project
 func (s *Server) listProjectAgents(w http.ResponseWriter, r *http.Request, projectID string) {
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 	query := r.URL.Query()
 
@@ -1846,6 +1850,10 @@ func (s *Server) createProjectAgent(w http.ResponseWriter, r *http.Request, proj
 
 // getProjectAgent gets an agent by ID within a specific project
 func (s *Server) getProjectAgent(w http.ResponseWriter, r *http.Request, projectID, agentID string) {
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 
 	// Try to get by slug first (more common case)

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -129,6 +129,10 @@ func (s *Server) handleProjects(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listProjects(w http.ResponseWriter, r *http.Request) {
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 	query := r.URL.Query()
 
@@ -2129,6 +2133,10 @@ func (s *Server) handleProjectByID(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getProject(w http.ResponseWriter, r *http.Request, id string) {
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 	project, err := s.store.GetProject(ctx, id)
 	if err != nil {

--- a/pkg/hub/handlers_scheduled_events.go
+++ b/pkg/hub/handlers_scheduled_events.go
@@ -67,6 +67,10 @@ func (s *Server) handleScheduledEvents(w http.ResponseWriter, r *http.Request, p
 		return
 	}
 
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	// For agent identities, enforce project isolation
 	if agentIdentity := GetAgentIdentityFromContext(r.Context()); agentIdentity != nil {
 		if agentIdentity.ProjectID() != projectID {

--- a/pkg/hub/handlers_schedules.go
+++ b/pkg/hub/handlers_schedules.go
@@ -71,6 +71,10 @@ func (s *Server) handleSchedules(w http.ResponseWriter, r *http.Request, project
 		return
 	}
 
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	// For agent identities, enforce project isolation
 	if agentIdentity := GetAgentIdentityFromContext(r.Context()); agentIdentity != nil {
 		if agentIdentity.ProjectID() != projectID {

--- a/pkg/hub/handlers_session_metrics.go
+++ b/pkg/hub/handlers_session_metrics.go
@@ -220,12 +220,16 @@ func (s *Server) authorizeSessionMetricsAccess(w http.ResponseWriter, r *http.Re
 //
 // GET /api/v1/agents/{id}/metrics/summary
 func (s *Server) handleAgentMetricsSummary(w http.ResponseWriter, r *http.Request, agentID string) {
-	ctx := r.Context()
-
 	if r.Method != http.MethodGet {
 		MethodNotAllowed(w)
 		return
 	}
+
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
+	ctx := r.Context()
 
 	// Verify the agent exists and the caller can view it.
 	agent, err := s.store.GetAgent(ctx, agentID)

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -148,6 +148,10 @@ func (s *Server) handleHarnessConfigs(w http.ResponseWriter, r *http.Request) {
 
 // listHarnessConfigs lists harness configs with filtering.
 func (s *Server) listHarnessConfigs(w http.ResponseWriter, r *http.Request) {
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 	query := r.URL.Query()
 
@@ -362,6 +366,10 @@ func (s *Server) handleHarnessConfigCRUD(w http.ResponseWriter, r *http.Request,
 }
 
 func (s *Server) getHarnessConfig(w http.ResponseWriter, r *http.Request, id string) {
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 	hc, err := s.store.GetHarnessConfig(ctx, id)
 	if err != nil {

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -201,6 +201,26 @@ func (d *HTTPAgentDispatcher) SetTokenGenerator(gen AgentTokenGenerator) {
 	d.tokenGenerator = gen
 }
 
+// agentRoleAndScopes extracts the effective role and config-based additional
+// scopes (e.g. GCP token) from the agent record. Used by all dispatch call
+// sites to keep role/scope computation in a single place.
+func agentRoleAndScopes(agent *store.Agent) (AgentRole, []AgentTokenScope) {
+	// Default to baseline for backward compat with pre-role agents.
+	role := AgentRoleBaseline
+	if agent.AppliedConfig != nil && agent.AppliedConfig.AgentRole != "" {
+		role = AgentRole(agent.AppliedConfig.AgentRole)
+	}
+
+	var additionalScopes []AgentTokenScope
+	if agent.AppliedConfig != nil {
+		// GCP token scope is config-based, not role-based.
+		if gcpID := agent.AppliedConfig.GCPIdentity; gcpID != nil && gcpID.MetadataMode == store.GCPMetadataModeAssign && gcpID.ServiceAccountID != "" {
+			additionalScopes = append(additionalScopes, GCPTokenScopeForSA(gcpID.ServiceAccountID))
+		}
+	}
+	return role, additionalScopes
+}
+
 // SetHubEndpoint sets the Hub endpoint URL that agents will use to call back.
 func (d *HTTPAgentDispatcher) SetHubEndpoint(endpoint string) {
 	d.hubEndpoint = endpoint
@@ -419,20 +439,7 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 
 	// Generate agent token if token generator is available
 	if d.tokenGenerator != nil {
-		// Determine agent role (default to baseline for backward compat with pre-role agents)
-		agentRole := AgentRoleBaseline
-		if agent.AppliedConfig != nil && agent.AppliedConfig.AgentRole != "" {
-			agentRole = AgentRole(agent.AppliedConfig.AgentRole)
-		}
-
-		// Compute additional scopes beyond the role (GCP token, etc.)
-		var additionalScopes []AgentTokenScope
-		if agent.AppliedConfig != nil {
-			// GCP token scope is config-based, not role-based
-			if gcpID := agent.AppliedConfig.GCPIdentity; gcpID != nil && gcpID.MetadataMode == store.GCPMetadataModeAssign && gcpID.ServiceAccountID != "" {
-				additionalScopes = append(additionalScopes, GCPTokenScopeForSA(gcpID.ServiceAccountID))
-			}
-		}
+		agentRole, additionalScopes := agentRoleAndScopes(agent)
 		token, err := d.tokenGenerator.GenerateAgentToken(agent.ID, agent.ProjectID, agent.Ancestry, agentRole, additionalScopes)
 		if err != nil {
 			if d.debug {
@@ -1819,17 +1826,7 @@ func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *sto
 
 	// Generate a fresh agent token for Hub authentication
 	if d.tokenGenerator != nil {
-		agentRole := AgentRoleBaseline
-		if agent.AppliedConfig != nil && agent.AppliedConfig.AgentRole != "" {
-			agentRole = AgentRole(agent.AppliedConfig.AgentRole)
-		}
-
-		var additionalScopes []AgentTokenScope
-		if agent.AppliedConfig != nil {
-			if gcpID := agent.AppliedConfig.GCPIdentity; gcpID != nil && gcpID.MetadataMode == store.GCPMetadataModeAssign && gcpID.ServiceAccountID != "" {
-				additionalScopes = append(additionalScopes, GCPTokenScopeForSA(gcpID.ServiceAccountID))
-			}
-		}
+		agentRole, additionalScopes := agentRoleAndScopes(agent)
 		token, err := d.tokenGenerator.GenerateAgentToken(agent.ID, agent.ProjectID, agent.Ancestry, agentRole, additionalScopes)
 		if err != nil {
 			if d.debug {
@@ -2075,17 +2072,7 @@ func (d *HTTPAgentDispatcher) DispatchAgentRestart(ctx context.Context, agent *s
 	}
 
 	if d.tokenGenerator != nil {
-		agentRole := AgentRoleBaseline
-		if agent.AppliedConfig != nil && agent.AppliedConfig.AgentRole != "" {
-			agentRole = AgentRole(agent.AppliedConfig.AgentRole)
-		}
-
-		var additionalScopes []AgentTokenScope
-		if agent.AppliedConfig != nil {
-			if gcpID := agent.AppliedConfig.GCPIdentity; gcpID != nil && gcpID.MetadataMode == store.GCPMetadataModeAssign && gcpID.ServiceAccountID != "" {
-				additionalScopes = append(additionalScopes, GCPTokenScopeForSA(gcpID.ServiceAccountID))
-			}
-		}
+		agentRole, additionalScopes := agentRoleAndScopes(agent)
 		token, err := d.tokenGenerator.GenerateAgentToken(agent.ID, agent.ProjectID, agent.Ancestry, agentRole, additionalScopes)
 		if err != nil {
 			if d.debug {
@@ -2171,17 +2158,7 @@ func (d *HTTPAgentDispatcher) DispatchAgentResetAuth(ctx context.Context, agent 
 
 	var token string
 	if d.tokenGenerator != nil {
-		agentRole := AgentRoleBaseline
-		if agent.AppliedConfig != nil && agent.AppliedConfig.AgentRole != "" {
-			agentRole = AgentRole(agent.AppliedConfig.AgentRole)
-		}
-
-		var additionalScopes []AgentTokenScope
-		if agent.AppliedConfig != nil {
-			if gcpID := agent.AppliedConfig.GCPIdentity; gcpID != nil && gcpID.MetadataMode == store.GCPMetadataModeAssign && gcpID.ServiceAccountID != "" {
-				additionalScopes = append(additionalScopes, GCPTokenScopeForSA(gcpID.ServiceAccountID))
-			}
-		}
+		agentRole, additionalScopes := agentRoleAndScopes(agent)
 		token, err = d.tokenGenerator.GenerateAgentToken(agent.ID, agent.ProjectID, agent.Ancestry, agentRole, additionalScopes)
 		if err != nil {
 			return fmt.Errorf("DispatchAgentResetAuth: failed to generate agent token: %w", err)

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -119,7 +119,7 @@ func (d *HTTPAgentDispatcher) GetClient() RuntimeBrokerClient {
 
 // AgentTokenGenerator generates JWT tokens for agents.
 type AgentTokenGenerator interface {
-	GenerateAgentToken(agentID, projectID string, ancestry []string, additionalScopes ...AgentTokenScope) (string, error)
+	GenerateAgentToken(agentID, projectID string, ancestry []string, role AgentRole, additionalScopes []AgentTokenScope) (string, error)
 }
 
 // GitHubAppTokenMinter mints GitHub App installation tokens for projects.
@@ -419,18 +419,21 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 
 	// Generate agent token if token generator is available
 	if d.tokenGenerator != nil {
-		// Convert hub access scopes from AppliedConfig to AgentTokenScope
+		// Determine agent role (default to baseline for backward compat with pre-role agents)
+		agentRole := AgentRoleBaseline
+		if agent.AppliedConfig != nil && agent.AppliedConfig.AgentRole != "" {
+			agentRole = AgentRole(agent.AppliedConfig.AgentRole)
+		}
+
+		// Compute additional scopes beyond the role (GCP token, etc.)
 		var additionalScopes []AgentTokenScope
 		if agent.AppliedConfig != nil {
-			for _, s := range agent.AppliedConfig.HubAccessScopes {
-				additionalScopes = append(additionalScopes, AgentTokenScope(s))
-			}
-			// Inject GCP token scope when the agent has an assigned service account
+			// GCP token scope is config-based, not role-based
 			if gcpID := agent.AppliedConfig.GCPIdentity; gcpID != nil && gcpID.MetadataMode == store.GCPMetadataModeAssign && gcpID.ServiceAccountID != "" {
 				additionalScopes = append(additionalScopes, GCPTokenScopeForSA(gcpID.ServiceAccountID))
 			}
 		}
-		token, err := d.tokenGenerator.GenerateAgentToken(agent.ID, agent.ProjectID, agent.Ancestry, additionalScopes...)
+		token, err := d.tokenGenerator.GenerateAgentToken(agent.ID, agent.ProjectID, agent.Ancestry, agentRole, additionalScopes)
 		if err != nil {
 			if d.debug {
 				d.log.Warn("Failed to generate agent token", "error", err)
@@ -1816,17 +1819,18 @@ func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *sto
 
 	// Generate a fresh agent token for Hub authentication
 	if d.tokenGenerator != nil {
+		agentRole := AgentRoleBaseline
+		if agent.AppliedConfig != nil && agent.AppliedConfig.AgentRole != "" {
+			agentRole = AgentRole(agent.AppliedConfig.AgentRole)
+		}
+
 		var additionalScopes []AgentTokenScope
 		if agent.AppliedConfig != nil {
-			for _, s := range agent.AppliedConfig.HubAccessScopes {
-				additionalScopes = append(additionalScopes, AgentTokenScope(s))
-			}
-			// Inject GCP token scope when the agent has an assigned service account
 			if gcpID := agent.AppliedConfig.GCPIdentity; gcpID != nil && gcpID.MetadataMode == store.GCPMetadataModeAssign && gcpID.ServiceAccountID != "" {
 				additionalScopes = append(additionalScopes, GCPTokenScopeForSA(gcpID.ServiceAccountID))
 			}
 		}
-		token, err := d.tokenGenerator.GenerateAgentToken(agent.ID, agent.ProjectID, agent.Ancestry, additionalScopes...)
+		token, err := d.tokenGenerator.GenerateAgentToken(agent.ID, agent.ProjectID, agent.Ancestry, agentRole, additionalScopes)
 		if err != nil {
 			if d.debug {
 				d.log.Warn("DispatchAgentStart: failed to generate agent token", "error", err)
@@ -2071,16 +2075,18 @@ func (d *HTTPAgentDispatcher) DispatchAgentRestart(ctx context.Context, agent *s
 	}
 
 	if d.tokenGenerator != nil {
+		agentRole := AgentRoleBaseline
+		if agent.AppliedConfig != nil && agent.AppliedConfig.AgentRole != "" {
+			agentRole = AgentRole(agent.AppliedConfig.AgentRole)
+		}
+
 		var additionalScopes []AgentTokenScope
 		if agent.AppliedConfig != nil {
-			for _, s := range agent.AppliedConfig.HubAccessScopes {
-				additionalScopes = append(additionalScopes, AgentTokenScope(s))
-			}
 			if gcpID := agent.AppliedConfig.GCPIdentity; gcpID != nil && gcpID.MetadataMode == store.GCPMetadataModeAssign && gcpID.ServiceAccountID != "" {
 				additionalScopes = append(additionalScopes, GCPTokenScopeForSA(gcpID.ServiceAccountID))
 			}
 		}
-		token, err := d.tokenGenerator.GenerateAgentToken(agent.ID, agent.ProjectID, agent.Ancestry, additionalScopes...)
+		token, err := d.tokenGenerator.GenerateAgentToken(agent.ID, agent.ProjectID, agent.Ancestry, agentRole, additionalScopes)
 		if err != nil {
 			if d.debug {
 				d.log.Warn("DispatchAgentRestart: failed to generate agent token", "error", err)
@@ -2165,16 +2171,18 @@ func (d *HTTPAgentDispatcher) DispatchAgentResetAuth(ctx context.Context, agent 
 
 	var token string
 	if d.tokenGenerator != nil {
+		agentRole := AgentRoleBaseline
+		if agent.AppliedConfig != nil && agent.AppliedConfig.AgentRole != "" {
+			agentRole = AgentRole(agent.AppliedConfig.AgentRole)
+		}
+
 		var additionalScopes []AgentTokenScope
 		if agent.AppliedConfig != nil {
-			for _, s := range agent.AppliedConfig.HubAccessScopes {
-				additionalScopes = append(additionalScopes, AgentTokenScope(s))
-			}
 			if gcpID := agent.AppliedConfig.GCPIdentity; gcpID != nil && gcpID.MetadataMode == store.GCPMetadataModeAssign && gcpID.ServiceAccountID != "" {
 				additionalScopes = append(additionalScopes, GCPTokenScopeForSA(gcpID.ServiceAccountID))
 			}
 		}
-		token, err = d.tokenGenerator.GenerateAgentToken(agent.ID, agent.ProjectID, agent.Ancestry, additionalScopes...)
+		token, err = d.tokenGenerator.GenerateAgentToken(agent.ID, agent.ProjectID, agent.Ancestry, agentRole, additionalScopes)
 		if err != nil {
 			return fmt.Errorf("DispatchAgentResetAuth: failed to generate agent token: %w", err)
 		}

--- a/pkg/hub/hub_agent_defaults.go
+++ b/pkg/hub/hub_agent_defaults.go
@@ -63,7 +63,8 @@ func agentDefaultsEqual(a, b opsettings.AgentDefaultsSettings) bool {
 		a.DefaultMaxTurns != b.DefaultMaxTurns ||
 		a.DefaultMaxModelCalls != b.DefaultMaxModelCalls ||
 		a.DefaultMaxDuration != b.DefaultMaxDuration ||
-		a.DefaultModel != b.DefaultModel {
+		a.DefaultModel != b.DefaultModel ||
+		a.DefaultMaxAgentRole != b.DefaultMaxAgentRole {
 		return false
 	}
 	if !intPtrEqual(a.DefaultThinkingLevel, b.DefaultThinkingLevel) {

--- a/pkg/hub/project_clone_test.go
+++ b/pkg/hub/project_clone_test.go
@@ -755,3 +755,30 @@ func TestProjectClone_StorageFilesCopied(t *testing.T) {
 	}
 	assert.True(t, found, "storage files should exist under clone's project ID")
 }
+
+func TestProjectClone_CopiesMaxAgentRole(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	src := &store.Project{
+		ID:        api.NewUUID(),
+		Name:      "Source With MaxRole",
+		Slug:      "source-maxrole",
+		OwnerID:   DevUserID,
+		CreatedBy: DevUserID,
+		Annotations: map[string]string{
+			projectSettingMaxAgentRole: "readonly",
+		},
+	}
+	require.NoError(t, s.CreateProject(ctx, src))
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+src.ID+"/clone",
+		map[string]string{"name": "Cloned MaxRole"})
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var clone store.Project
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&clone))
+
+	assert.Equal(t, "readonly", clone.Annotations[projectSettingMaxAgentRole],
+		"clone should copy max_agent_role annotation from source")
+}

--- a/pkg/hub/project_settings_handlers.go
+++ b/pkg/hub/project_settings_handlers.go
@@ -52,6 +52,9 @@ const (
 	projectSettingDefaultResourcesCPULim = "scion.io/default-resources-cpu-limit"
 	projectSettingDefaultResourcesMemLim = "scion.io/default-resources-memory-limit"
 	projectSettingDefaultResourcesDisk   = "scion.io/default-resources-disk"
+
+	// Agent authorization
+	projectSettingMaxAgentRole = "scion.io/max-agent-role"
 )
 
 // projectSettingKeys is the authoritative list of scion.io/* annotation keys
@@ -137,6 +140,9 @@ var projectSettingKeys = []string{
 	projectSettingDefaultResourcesCPULim,
 	projectSettingDefaultResourcesMemLim,
 	projectSettingDefaultResourcesDisk,
+
+	// Agent authorization
+	projectSettingMaxAgentRole,
 }
 
 // handleProjectSettings handles GET/PUT on /api/v1/projects/{projectId}/settings.
@@ -202,6 +208,11 @@ func (s *Server) handleProjectSettings(w http.ResponseWriter, r *http.Request, p
 				BadRequest(w, "thinking_level must be between 0 and 100")
 				return
 			}
+		}
+
+		if req.MaxAgentRole != "" && !ValidAgentRole(AgentRole(req.MaxAgentRole)) {
+			BadRequest(w, "maxAgentRole must be one of none, readonly, baseline, full")
+			return
 		}
 
 		applyProjectSettingsToAnnotations(project, &req)
@@ -271,6 +282,9 @@ func projectSettingsFromAnnotations(project *store.Project) *hubclient.ProjectSe
 		settings.DefaultResources = res
 	}
 
+	// Agent authorization
+	settings.MaxAgentRole = project.Annotations[projectSettingMaxAgentRole]
+
 	return settings
 }
 
@@ -333,6 +347,9 @@ func applyProjectSettingsToAnnotations(project *store.Project, settings *hubclie
 	setOrDeleteInt(project.Annotations, projectSettingDefaultMaxTurns, settings.DefaultMaxTurns)
 	setOrDeleteInt(project.Annotations, projectSettingDefaultMaxModelCalls, settings.DefaultMaxModelCalls)
 	setOrDelete(project.Annotations, projectSettingDefaultMaxDuration, settings.DefaultMaxDuration)
+
+	// Agent authorization
+	setOrDelete(project.Annotations, projectSettingMaxAgentRole, settings.MaxAgentRole)
 
 	// Default resources (flat keys)
 	if settings.DefaultResources != nil {

--- a/pkg/hub/project_settings_handlers_test.go
+++ b/pkg/hub/project_settings_handlers_test.go
@@ -520,6 +520,62 @@ func TestProjectSettings_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
+func TestProjectSettings_MaxAgentRole_PutAndGet(t *testing.T) {
+	srv, s := testServer(t)
+	project := createTestProjectForSettings(t, s)
+
+	putBody := hubclient.ProjectSettings{
+		MaxAgentRole: "readonly",
+	}
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/projects/"+project.ID+"/settings", putBody)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var putResp hubclient.ProjectSettings
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&putResp))
+	assert.Equal(t, "readonly", putResp.MaxAgentRole)
+
+	// GET should return persisted value
+	rec = doRequest(t, srv, http.MethodGet, "/api/v1/projects/"+project.ID+"/settings", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var getResp hubclient.ProjectSettings
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&getResp))
+	assert.Equal(t, "readonly", getResp.MaxAgentRole)
+}
+
+func TestProjectSettings_MaxAgentRole_InvalidReturns400(t *testing.T) {
+	srv, s := testServer(t)
+	project := createTestProjectForSettings(t, s)
+
+	putBody := hubclient.ProjectSettings{
+		MaxAgentRole: "superadmin",
+	}
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/projects/"+project.ID+"/settings", putBody)
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "maxAgentRole")
+}
+
+func TestProjectSettings_MaxAgentRole_ClearValue(t *testing.T) {
+	srv, s := testServer(t)
+	project := createTestProjectForSettings(t, s)
+
+	// Set it first
+	putBody := hubclient.ProjectSettings{MaxAgentRole: "readonly"}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/projects/"+project.ID+"/settings", putBody)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Clear it
+	putBody = hubclient.ProjectSettings{MaxAgentRole: ""}
+	rec = doRequest(t, srv, http.MethodPut, "/api/v1/projects/"+project.ID+"/settings", putBody)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var getResp hubclient.ProjectSettings
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&getResp))
+	assert.Empty(t, getResp.MaxAgentRole)
+}
+
 func createTestProjectForSettings(t *testing.T, s store.Store) *store.Project {
 	t.Helper()
 	project := &store.Project{

--- a/pkg/hub/project_settings_registry_test.go
+++ b/pkg/hub/project_settings_registry_test.go
@@ -38,7 +38,7 @@ const projectSettingsSourceFile = "project_settings_handlers.go"
 // .design/project-templates.md §3.1. It is asserted separately from the drift
 // guard so that adding or removing a setting shows up as a deliberate edit in
 // the diff rather than passing silently.
-const expectedProjectSettingCount = 17
+const expectedProjectSettingCount = 18
 
 // isProjectSettingConstName reports whether an identifier names a project
 // settings annotation key constant.

--- a/pkg/hub/project_settings_resolved.go
+++ b/pkg/hub/project_settings_resolved.go
@@ -309,6 +309,13 @@ var resolvedSettingDescriptors = map[string]resolvedSettingDescriptor{
 		path:              []string{"default_resources", "disk"},
 		absentWhenMissing: false,
 	},
+
+	// Agent authorization
+	projectSettingMaxAgentRole: {
+		source:            hubSourceAgentDefaults,
+		path:              []string{"default_max_agent_role"},
+		absentWhenMissing: false, // string, "" dropped by omitempty
+	},
 }
 
 // handleProjectSettingsResolved serves GET

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2118,7 +2118,8 @@ func (s *Server) CreateAuthenticatedDispatcher() *HTTPAgentDispatcher {
 
 // GenerateAgentToken generates a JWT for an agent.
 // This is a convenience method that delegates to the token service.
-// Additional scopes are merged with the default scopes (status update, token refresh, and notify).
+// Base scopes are determined by the agent's role (baseline, or full in dev-auth mode).
+// Additional scopes are merged with the role-based defaults, deduplicated.
 func (s *Server) GenerateAgentToken(agentID, projectID string, ancestry []string, additionalScopes ...AgentTokenScope) (string, error) {
 	s.mu.RLock()
 	tokenService := s.agentTokenService

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2128,13 +2128,12 @@ func (s *Server) GenerateAgentToken(agentID, projectID string, ancestry []string
 		return "", fmt.Errorf("agent token service not initialized")
 	}
 
-	scopes := []AgentTokenScope{ScopeAgentStatusUpdate, ScopeAgentTokenRefresh, ScopeAgentNotify, ScopeAgentPortForward}
-
-	// In dev-auth mode, auto-grant agent creation and lifecycle scopes
-	// so agents can create sub-agents without explicit template configuration.
+	// Default role is baseline; dev-auth mode grants full to match current behavior.
+	role := AgentRoleBaseline
 	if s.config.DevAuthToken != "" {
-		scopes = append(scopes, ScopeAgentCreate, ScopeAgentLifecycle)
+		role = AgentRoleFull
 	}
+	scopes := ScopesForRole(role)
 
 	// Merge additional scopes, deduplicating
 	seen := make(map[AgentTokenScope]bool, len(scopes))

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2118,9 +2118,11 @@ func (s *Server) CreateAuthenticatedDispatcher() *HTTPAgentDispatcher {
 
 // GenerateAgentToken generates a JWT for an agent.
 // This is a convenience method that delegates to the token service.
-// Base scopes are determined by the agent's role (baseline, or full in dev-auth mode).
+// Base scopes are determined by the passed role.
+// Dev-auth mode overrides to full if the role would be more restrictive,
+// preserving dev-mode behavior where all agents get full access.
 // Additional scopes are merged with the role-based defaults, deduplicated.
-func (s *Server) GenerateAgentToken(agentID, projectID string, ancestry []string, additionalScopes ...AgentTokenScope) (string, error) {
+func (s *Server) GenerateAgentToken(agentID, projectID string, ancestry []string, role AgentRole, additionalScopes []AgentTokenScope) (string, error) {
 	s.mu.RLock()
 	tokenService := s.agentTokenService
 	s.mu.RUnlock()
@@ -2129,12 +2131,14 @@ func (s *Server) GenerateAgentToken(agentID, projectID string, ancestry []string
 		return "", fmt.Errorf("agent token service not initialized")
 	}
 
-	// Default role is baseline; dev-auth mode grants full to match current behavior.
-	role := AgentRoleBaseline
-	if s.config.DevAuthToken != "" {
-		role = AgentRoleFull
+	// Use the specified role for base scopes.
+	// Dev-auth mode overrides to full if the role would be more restrictive,
+	// preserving dev-mode behavior where all agents get full access.
+	effectiveRole := role
+	if s.config.DevAuthToken != "" && CompareRoles(role, AgentRoleFull) < 0 {
+		effectiveRole = AgentRoleFull
 	}
-	scopes := ScopesForRole(role)
+	scopes := ScopesForRole(effectiveRole)
 
 	// Merge additional scopes, deduplicating
 	seen := make(map[AgentTokenScope]bool, len(scopes))

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -678,8 +678,8 @@ func TestServer_GenerateAgentToken_DevAuthAutoGrantsScopes(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
 
-	// Generate token without any additional scopes
-	token, err := srv.GenerateAgentToken(tid("agent-1"), tid("project-1"), nil)
+	// Generate token without any additional scopes — role=baseline, dev-auth upgrades to full
+	token, err := srv.GenerateAgentToken(tid("agent-1"), tid("project-1"), nil, AgentRoleBaseline, nil)
 	if err != nil {
 		t.Fatalf("GenerateAgentToken failed: %v", err)
 	}
@@ -727,8 +727,8 @@ func TestServer_GenerateAgentToken_DevAuthDeduplicatesScopes(t *testing.T) {
 	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
 
 	// Generate token with explicit scopes that overlap with auto-granted ones
-	token, err := srv.GenerateAgentToken(tid("agent-1"), tid("project-1"), nil,
-		ScopeAgentCreate, ScopeAgentLifecycle, ScopeProjectSecretRead)
+	token, err := srv.GenerateAgentToken(tid("agent-1"), tid("project-1"), nil, AgentRoleBaseline,
+		[]AgentTokenScope{ScopeAgentCreate, ScopeAgentLifecycle, ScopeProjectSecretRead})
 	if err != nil {
 		t.Fatalf("GenerateAgentToken failed: %v", err)
 	}
@@ -777,7 +777,7 @@ func TestServer_GenerateAgentToken_NoDevAuthDoesNotAutoGrant(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
 
-	token, err := srv.GenerateAgentToken(tid("agent-1"), tid("project-1"), nil)
+	token, err := srv.GenerateAgentToken(tid("agent-1"), tid("project-1"), nil, AgentRoleBaseline, nil)
 	if err != nil {
 		t.Fatalf("GenerateAgentToken failed: %v", err)
 	}
@@ -798,6 +798,185 @@ func TestServer_GenerateAgentToken_NoDevAuthDoesNotAutoGrant(t *testing.T) {
 	}
 	if claims.HasScope(ScopeAgentLifecycle) {
 		t.Error("expected ScopeAgentLifecycle NOT to be auto-granted without dev-auth")
+	}
+}
+
+func TestServer_GenerateAgentToken_RoleBaseline(t *testing.T) {
+	s, err := newTestStore(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("failed to migrate test store: %v", err)
+	}
+
+	cfg := DefaultServerConfig()
+	cfg.AgentTokenConfig = AgentTokenConfig{
+		SigningKey:    make([]byte, 32),
+		TokenDuration: time.Hour,
+	}
+
+	srv, err := New(cfg, s)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	token, err := srv.GenerateAgentToken(tid("agent-1"), tid("project-1"), nil, AgentRoleBaseline, nil)
+	if err != nil {
+		t.Fatalf("GenerateAgentToken failed: %v", err)
+	}
+
+	claims, err := srv.agentTokenService.ValidateAgentToken(token)
+	if err != nil {
+		t.Fatalf("ValidateAgentToken failed: %v", err)
+	}
+
+	if !claims.HasScope(ScopeProjectRead) {
+		t.Error("expected ScopeProjectRead for baseline role")
+	}
+	if !claims.HasScope(ScopeAgentStatusUpdate) {
+		t.Error("expected ScopeAgentStatusUpdate for baseline role")
+	}
+	if !claims.HasScope(ScopeAgentTokenRefresh) {
+		t.Error("expected ScopeAgentTokenRefresh for baseline role")
+	}
+	if claims.HasScope(ScopeAgentCreate) {
+		t.Error("expected ScopeAgentCreate NOT to be present for baseline role")
+	}
+	if claims.HasScope(ScopeAgentLifecycle) {
+		t.Error("expected ScopeAgentLifecycle NOT to be present for baseline role")
+	}
+}
+
+func TestServer_GenerateAgentToken_RoleFull(t *testing.T) {
+	s, err := newTestStore(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("failed to migrate test store: %v", err)
+	}
+
+	cfg := DefaultServerConfig()
+	cfg.AgentTokenConfig = AgentTokenConfig{
+		SigningKey:    make([]byte, 32),
+		TokenDuration: time.Hour,
+	}
+
+	srv, err := New(cfg, s)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	token, err := srv.GenerateAgentToken(tid("agent-1"), tid("project-1"), nil, AgentRoleFull, nil)
+	if err != nil {
+		t.Fatalf("GenerateAgentToken failed: %v", err)
+	}
+
+	claims, err := srv.agentTokenService.ValidateAgentToken(token)
+	if err != nil {
+		t.Fatalf("ValidateAgentToken failed: %v", err)
+	}
+
+	if !claims.HasScope(ScopeProjectRead) {
+		t.Error("expected ScopeProjectRead for full role")
+	}
+	if !claims.HasScope(ScopeAgentCreate) {
+		t.Error("expected ScopeAgentCreate for full role")
+	}
+	if !claims.HasScope(ScopeAgentLifecycle) {
+		t.Error("expected ScopeAgentLifecycle for full role")
+	}
+	if !claims.HasScope(ScopeProjectSecretRead) {
+		t.Error("expected ScopeProjectSecretRead for full role")
+	}
+}
+
+func TestServer_GenerateAgentToken_RoleReadOnly(t *testing.T) {
+	s, err := newTestStore(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("failed to migrate test store: %v", err)
+	}
+
+	cfg := DefaultServerConfig()
+	cfg.AgentTokenConfig = AgentTokenConfig{
+		SigningKey:    make([]byte, 32),
+		TokenDuration: time.Hour,
+	}
+
+	srv, err := New(cfg, s)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	token, err := srv.GenerateAgentToken(tid("agent-1"), tid("project-1"), nil, AgentRoleReadOnly, nil)
+	if err != nil {
+		t.Fatalf("GenerateAgentToken failed: %v", err)
+	}
+
+	claims, err := srv.agentTokenService.ValidateAgentToken(token)
+	if err != nil {
+		t.Fatalf("ValidateAgentToken failed: %v", err)
+	}
+
+	if !claims.HasScope(ScopeProjectRead) {
+		t.Error("expected ScopeProjectRead for readonly role")
+	}
+	if claims.HasScope(ScopeAgentStatusUpdate) {
+		t.Error("expected ScopeAgentStatusUpdate NOT to be present for readonly role")
+	}
+	if claims.HasScope(ScopeAgentCreate) {
+		t.Error("expected ScopeAgentCreate NOT to be present for readonly role")
+	}
+}
+
+func TestServer_GenerateAgentToken_DevAuthUpgradesRole(t *testing.T) {
+	s, err := newTestStore(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatalf("failed to migrate test store: %v", err)
+	}
+
+	cfg := DefaultServerConfig()
+	cfg.DevAuthToken = "test-dev-token"
+	cfg.AgentTokenConfig = AgentTokenConfig{
+		SigningKey:    make([]byte, 32),
+		TokenDuration: time.Hour,
+	}
+
+	srv, err := New(cfg, s)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	// Even with readonly role, dev-auth mode should upgrade to full
+	token, err := srv.GenerateAgentToken(tid("agent-1"), tid("project-1"), nil, AgentRoleReadOnly, nil)
+	if err != nil {
+		t.Fatalf("GenerateAgentToken failed: %v", err)
+	}
+
+	claims, err := srv.agentTokenService.ValidateAgentToken(token)
+	if err != nil {
+		t.Fatalf("ValidateAgentToken failed: %v", err)
+	}
+
+	if !claims.HasScope(ScopeAgentCreate) {
+		t.Error("expected ScopeAgentCreate to be present — dev-auth should upgrade to full")
+	}
+	if !claims.HasScope(ScopeAgentLifecycle) {
+		t.Error("expected ScopeAgentLifecycle to be present — dev-auth should upgrade to full")
+	}
+	if !claims.HasScope(ScopeProjectSecretRead) {
+		t.Error("expected ScopeProjectSecretRead to be present — dev-auth should upgrade to full")
 	}
 }
 

--- a/pkg/hub/skill_handlers.go
+++ b/pkg/hub/skill_handlers.go
@@ -215,6 +215,10 @@ func (s *Server) handleSkillCRUD(w http.ResponseWriter, r *http.Request, id stri
 
 // listSkills lists skills with filtering.
 func (s *Server) listSkills(w http.ResponseWriter, r *http.Request) {
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 	query := r.URL.Query()
 
@@ -414,6 +418,10 @@ func (s *Server) createSkill(w http.ResponseWriter, r *http.Request) {
 
 // getSkill retrieves a skill with capabilities.
 func (s *Server) getSkill(w http.ResponseWriter, r *http.Request, id string) {
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 	skill, err := s.store.GetSkill(ctx, id)
 	if err != nil {

--- a/pkg/hub/template_handlers.go
+++ b/pkg/hub/template_handlers.go
@@ -165,6 +165,10 @@ func (s *Server) handleTemplatesV2(w http.ResponseWriter, r *http.Request) {
 
 // listTemplatesV2 lists templates with extended filtering.
 func (s *Server) listTemplatesV2(w http.ResponseWriter, r *http.Request) {
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 	query := r.URL.Query()
 
@@ -386,6 +390,10 @@ func (s *Server) handleTemplateCRUD(w http.ResponseWriter, r *http.Request, id s
 
 // getTemplateV2 retrieves a template with full metadata.
 func (s *Server) getTemplateV2(w http.ResponseWriter, r *http.Request, id string) {
+	if !checkAgentReadScope(w, r) {
+		return
+	}
+
 	ctx := r.Context()
 	template, err := s.store.GetTemplate(ctx, id)
 	if err != nil {

--- a/pkg/hubclient/agents.go
+++ b/pkg/hubclient/agents.go
@@ -186,6 +186,9 @@ type CreateAgentRequest struct {
 	// Notify subscribes the creating agent/user to status notifications
 	// (COMPLETED, WAITING_FOR_INPUT, LIMITS_EXCEEDED) for the new agent.
 	Notify bool `json:"notify,omitempty"`
+
+	// AgentRole specifies the requested authorization role.
+	AgentRole string `json:"agentRole,omitempty"`
 }
 
 // MarshalJSON implements custom marshaling to support legacy groveId field.

--- a/pkg/hubclient/types.go
+++ b/pkg/hubclient/types.go
@@ -221,6 +221,9 @@ type ProjectSettings struct {
 	// Default GCP identity for new agents
 	DefaultGCPIdentityMode             string `json:"defaultGCPIdentityMode,omitempty"`             // "block", "passthrough", or "assign"
 	DefaultGCPIdentityServiceAccountID string `json:"defaultGCPIdentityServiceAccountID,omitempty"` // Required when mode is "assign"
+
+	// Agent authorization
+	MaxAgentRole string `json:"maxAgentRole,omitempty"`
 }
 
 // ResolvedHubDefault reports whether a hub-level default exists for a project

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -169,6 +169,10 @@ type AgentAppliedConfig struct {
 	// Hub access scopes granted to the agent (from template HubAccess config)
 	HubAccessScopes []string `json:"hubAccessScopes,omitempty"`
 
+	// AgentRole is the effective authorization role resolved at creation time.
+	// Determines which JWT scopes the agent receives. Immutable after creation.
+	AgentRole string `json:"agentRole,omitempty"`
+
 	// WorkspaceStoragePath is the GCS storage path for bootstrapped workspaces.
 	// Set during workspace bootstrap for non-git projects.
 	WorkspaceStoragePath string `json:"workspaceStoragePath,omitempty"`

--- a/web/src/components/pages/agent-configure.ts
+++ b/web/src/components/pages/agent-configure.ts
@@ -942,6 +942,16 @@ export class ScionPageAgentConfigure extends LitElement {
           `
         : nothing}
 
+      ${this.agent?.agentRole
+        ? html`
+            <div class="form-field">
+              <label>Agent Role</label>
+              <sl-input .value=${this.agent.agentRole} readonly></sl-input>
+              <div class="hint">Authorization role set at creation time. Determines hub API access level.</div>
+            </div>
+          `
+        : nothing}
+
       <div class="form-field">
         <label for="gcp-mode">GCP Identity</label>
         <sl-select

--- a/web/src/components/pages/agent-configure.ts
+++ b/web/src/components/pages/agent-configure.ts
@@ -942,11 +942,11 @@ export class ScionPageAgentConfigure extends LitElement {
           `
         : nothing}
 
-      ${this.agent?.agentRole
+      ${this.agent?.appliedConfig?.agentRole
         ? html`
             <div class="form-field">
               <label>Agent Role</label>
-              <sl-input .value=${this.agent.agentRole} readonly></sl-input>
+              <sl-input .value=${this.agent.appliedConfig.agentRole} readonly></sl-input>
               <div class="hint">Authorization role set at creation time. Determines hub API access level.</div>
             </div>
           `

--- a/web/src/components/pages/agent-configure.ts
+++ b/web/src/components/pages/agent-configure.ts
@@ -65,6 +65,7 @@ interface AppliedConfig {
   inlineConfig?: ScionConfigPayload & {
     harness_config?: string;
   };
+  agentRole?: string;
 }
 
 interface AgentWithConfig extends Omit<Agent, 'appliedConfig'> {

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -99,6 +99,9 @@ export class ScionPageAgentCreate extends LitElement {
   private branch = '';
 
   @state()
+  private agentRole = '';
+
+  @state()
   private task = '';
 
   @state()
@@ -518,6 +521,9 @@ export class ScionPageAgentCreate extends LitElement {
       if (this.task.trim()) {
         body.task = this.task.trim();
       }
+      if (this.agentRole) {
+        body.agentRole = this.agentRole;
+      }
 
       const builtLabels = this.buildLabels();
       if (builtLabels) {
@@ -654,6 +660,9 @@ export class ScionPageAgentCreate extends LitElement {
       }
       if (this.task.trim()) {
         body.task = this.task.trim();
+      }
+      if (this.agentRole) {
+        body.agentRole = this.agentRole;
       }
 
       const builtLabels = this.buildLabels();
@@ -1224,6 +1233,25 @@ private selectBrokerForProject(): void {
               <sl-option value="none">No Authentication</sl-option>
             </sl-select>
             <div class="hint">Override the authentication method for the harness.</div>
+          </div>
+
+          <div class="form-field">
+            <label for="agent-role">Agent Role</label>
+            <sl-select
+              id="agent-role"
+              placeholder="Select a role..."
+              .value=${this.agentRole}
+              @sl-change=${(e: Event) => {
+                this.agentRole = (e.target as HTMLElement & { value: string }).value;
+              }}
+            >
+              <sl-option value="">Default (determined by project settings)</sl-option>
+              <sl-option value="none">None (no hub access)</sl-option>
+              <sl-option value="readonly">Read-only</sl-option>
+              <sl-option value="baseline">Baseline (standard)</sl-option>
+              <sl-option value="full">Full (requires admin)</sl-option>
+            </sl-select>
+            <div class="hint">Authorization role for hub API access. Determines which operations the agent can perform.</div>
           </div>
 
           <div class="form-field">

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -65,6 +65,7 @@ interface ProjectSettings {
   defaultGCPIdentityServiceAccountID?: string | undefined;
   defaultModel?: string | undefined;
   defaultThinkingLevel?: number | null | undefined;
+  maxAgentRole?: string | undefined;
 }
 
 interface ResolvedHubSetting {
@@ -203,6 +204,10 @@ export class ScionPageProjectSettings extends LitElement {
 
   @state()
   private configDefaultGCPIdentitySAID = '';
+
+  // Agent authorization
+  @state()
+  private configMaxAgentRole = '';
 
   @state()
   private defaultModelSelection: '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other' = '';
@@ -1018,6 +1023,7 @@ export class ScionPageProjectSettings extends LitElement {
       this.configDefaultResDisk = res?.disk || '';
       this.configDefaultGCPIdentityMode = this.settings.defaultGCPIdentityMode || '';
       this.configDefaultGCPIdentitySAID = this.settings.defaultGCPIdentityServiceAccountID || '';
+      this.configMaxAgentRole = this.settings.maxAgentRole || '';
       if (this.settings.defaultModel) {
         const dm = normalizeModelAlias(this.settings.defaultModel);
         if (['small', 'medium', 'large', 'extra-large'].includes(dm)) {
@@ -1192,6 +1198,7 @@ export class ScionPageProjectSettings extends LitElement {
           this.configDefaultGCPIdentityMode === 'assign'
             ? this.configDefaultGCPIdentitySAID || undefined
             : undefined,
+        maxAgentRole: this.configMaxAgentRole || undefined,
       };
 
       const response = await apiFetch(`/api/v1/projects/${this.projectId}/settings`, {
@@ -1786,6 +1793,27 @@ export class ScionPageProjectSettings extends LitElement {
                 </sl-select>
                 <span class="field-help"
                   >Automatically detect and expose listening TCP ports in agent containers. "Use hub default" inherits the server-level setting.</span
+                >
+              </div>
+
+              <div class="config-field ${this.isHubDefault('scion.io/max-agent-role') ? 'hub-inherited' : ''}">
+                <label>Maximum Agent Role ${this.renderHubIndicator('scion.io/max-agent-role')}</label>
+                <sl-select
+                  placeholder=${this.hubSelectLabel('scion.io/max-agent-role', 'Baseline (default)')}
+                  clearable
+                  value=${this.configMaxAgentRole}
+                  ?disabled=${!canEdit}
+                  @sl-change=${(e: Event) => {
+                    this.configMaxAgentRole = (e.target as HTMLSelectElement).value;
+                  }}
+                >
+                  <sl-option value="none">None — No hub access</sl-option>
+                  <sl-option value="readonly">Read-only — Read-only access</sl-option>
+                  <sl-option value="baseline">Baseline — Standard access</sl-option>
+                  <sl-option value="full">Full — Full access (admin only)</sl-option>
+                </sl-select>
+                <span class="field-help"
+                  >Caps the maximum role agents in this project can receive.</span
                 >
               </div>
 

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -402,6 +402,7 @@ export interface AgentAppliedConfig {
   templateHash?: string;
   inlineConfig?: AgentInlineConfig;
   gcpIdentity?: GCPIdentityConfig;
+  agentRole?: string;
 }
 
 /**
@@ -445,10 +446,6 @@ export interface Agent {
   visibility?: string;
   createdBy?: string;
   appliedConfig?: AgentAppliedConfig;
-
-  // Authorization role resolved at creation time. Immutable after creation.
-  // Values: "none", "readonly", "baseline", "full".
-  agentRole?: string;
 
   // Ordered ancestor chain [root, ..., parent]; last entry is the direct
   // parent (user or spawning agent). Drives the lineage graph view.

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -446,6 +446,10 @@ export interface Agent {
   createdBy?: string;
   appliedConfig?: AgentAppliedConfig;
 
+  // Authorization role resolved at creation time. Immutable after creation.
+  // Values: "none", "readonly", "baseline", "full".
+  agentRole?: string;
+
   // Ordered ancestor chain [root, ..., parent]; last entry is the direct
   // parent (user or spawning agent). Drives the lineage graph view.
   ancestry?: string[];


### PR DESCRIPTION
Introduces named agent roles (none/readonly/baseline/full) with a two-gate authority lattice and sub-agent no-escalation enforcement.

Flow 1: User-to-Agent role grants with --role CLI flag, project max_agent_role setting, global hub default, UI integration, read endpoint enforcement, and template hubAccess.scopes deprecation.

Flow 2: Sub-agent scope inheritance ceiling - parent agents cannot grant children higher roles than their own, with fail-loud 403 on violation.

Ref: ptone/scion#482