### PR TITLE
feat: federation admin UI — runtime management via opsettings

### DIFF
--- a/pkg/config/opsettings/koanf.go
+++ b/pkg/config/opsettings/koanf.go
@@ -108,6 +108,13 @@ var koanfPathToJSONField = map[string]map[string]string{
 	"auto_expose_ports": {
 		"auto_expose_ports.enabled": "enabled",
 	},
+	"federation": {
+		"server.federation.enabled":           "enabled",
+		"server.federation.trusted_issuers":   "trusted_issuers",
+		"server.federation.algorithms":        "algorithms",
+		"server.federation.refresh_interval":  "refresh_interval",
+		"server.federation.debounce_interval": "debounce_interval",
+	},
 }
 
 // jsonFieldToKoanfPaths maps section name → json field → koanf path for the
@@ -137,6 +144,13 @@ var jsonFieldToKoanfPaths = map[string]map[string]string{
 	},
 	"auto_expose_ports": {
 		"enabled": "auto_expose_ports.enabled",
+	},
+	"federation": {
+		"enabled":           "server.federation.enabled",
+		"trusted_issuers":   "server.federation.trusted_issuers",
+		"algorithms":        "server.federation.algorithms",
+		"refresh_interval":  "server.federation.refresh_interval",
+		"debounce_interval": "server.federation.debounce_interval",
 	},
 }
 

--- a/pkg/config/opsettings/opsettings_test.go
+++ b/pkg/config/opsettings/opsettings_test.go
@@ -228,6 +228,7 @@ func TestValidateInvalidDoc(t *testing.T) {
 		{"federation", `{"trusted_issuers":[{"issuer_url":""}]}`, "empty issuer_url (minLength)"},
 		{"federation", `{"algorithms":["INVALID"]}`, "invalid algorithm enum"},
 		{"federation", `{"trusted_issuers":[{"issuer_type":"unknown"}]}`, "invalid issuer_type enum"},
+		{"federation", `{"unknown_field": true}`, "additional property"},
 	}
 	for _, tt := range tests {
 		errs := Validate(tt.section, json.RawMessage(tt.doc))

--- a/pkg/config/opsettings/opsettings_test.go
+++ b/pkg/config/opsettings/opsettings_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/confmap"
 	"github.com/knadh/koanf/providers/file"
@@ -31,7 +32,7 @@ import (
 func TestRegistryHasAllSections(t *testing.T) {
 	expected := []string{"access", "lifecycle", "maintenance", "telemetry",
 		"agent_defaults", "endpoints", "github_app", "notifications",
-		"project_defaults", "auto_expose_ports"}
+		"project_defaults", "auto_expose_ports", "federation"}
 	for _, name := range expected {
 		if SectionByName(name) == nil {
 			t.Errorf("section %q not found in registry", name)
@@ -114,6 +115,11 @@ func TestOwningSection(t *testing.T) {
 		{"server.github_app.webhooks_enabled", "github_app"},
 		{"server.notification_channels", "notifications"},
 		{"auto_expose_ports.enabled", "auto_expose_ports"},
+		{"server.federation.enabled", "federation"},
+		{"server.federation.trusted_issuers", "federation"},
+		{"server.federation.algorithms", "federation"},
+		{"server.federation.refresh_interval", "federation"},
+		{"server.federation.debounce_interval", "federation"},
 	}
 	for _, tt := range tests {
 		got := OwningSection(tt.key)
@@ -194,6 +200,9 @@ func TestValidateValidDoc(t *testing.T) {
 		{"project_defaults", `{}`},
 		{"auto_expose_ports", `{"enabled":true}`},
 		{"auto_expose_ports", `{}`},
+		{"federation", `{"enabled":true,"trusted_issuers":[{"issuer_url":"https://hub.example.com","issuer_type":"hub"}],"algorithms":["RS256"]}`},
+		{"federation", `{"enabled":false}`},
+		{"federation", `{}`},
 	}
 	for _, tt := range tests {
 		errs := Validate(tt.section, json.RawMessage(tt.doc))
@@ -216,6 +225,9 @@ func TestValidateInvalidDoc(t *testing.T) {
 		{"github_app", `{"app_id":"not-a-number"}`, "wrong type for int64"},
 		{"project_defaults", `{"default_scratchpad":"yes"}`, "wrong type for boolean"},
 		{"project_defaults", `{"unknown_field":true}`, "additional property"},
+		{"federation", `{"trusted_issuers":[{"issuer_url":""}]}`, "empty issuer_url (minLength)"},
+		{"federation", `{"algorithms":["INVALID"]}`, "invalid algorithm enum"},
+		{"federation", `{"trusted_issuers":[{"issuer_type":"unknown"}]}`, "invalid issuer_type enum"},
 	}
 	for _, tt := range tests {
 		errs := Validate(tt.section, json.RawMessage(tt.doc))
@@ -236,6 +248,64 @@ func TestValidateInvalidJSON(t *testing.T) {
 	errs := Validate("access", json.RawMessage(`{invalid`))
 	if len(errs) == 0 {
 		t.Error("expected error for invalid JSON")
+	}
+}
+
+// --- FederationSettings section document tests ---
+
+func TestFederationSettingsRoundTrip(t *testing.T) {
+	enabled := true
+	original := &FederationSettings{
+		Enabled: &enabled,
+		TrustedIssuers: []config.V1TrustedIssuerConfig{
+			{
+				IssuerURL:        "https://hub-a.example.com",
+				JWKSURL:          "https://hub-a.example.com/.well-known/jwks.json",
+				ExpectedAudience: "https://hub-b.example.com",
+				AllowedProjects:  []string{"proj1"},
+				AllowedRootUsers: []string{"admin@example.com"},
+				DefaultScopes:    []string{"agent:status:update"},
+				IssuerType:       "hub",
+			},
+		},
+		Algorithms:       []string{"RS256"},
+		RefreshInterval:  "1h",
+		DebounceInterval: "5s",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var restored FederationSettings
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if *restored.Enabled != true {
+		t.Errorf("Enabled: got %v, want true", *restored.Enabled)
+	}
+	if len(restored.TrustedIssuers) != 1 {
+		t.Fatalf("TrustedIssuers: got %d, want 1", len(restored.TrustedIssuers))
+	}
+	if restored.TrustedIssuers[0].IssuerURL != "https://hub-a.example.com" {
+		t.Errorf("IssuerURL: got %q, want %q", restored.TrustedIssuers[0].IssuerURL, "https://hub-a.example.com")
+	}
+	if restored.TrustedIssuers[0].IssuerType != "hub" {
+		t.Errorf("IssuerType: got %q, want %q", restored.TrustedIssuers[0].IssuerType, "hub")
+	}
+	if restored.RefreshInterval != "1h" {
+		t.Errorf("RefreshInterval: got %q, want %q", restored.RefreshInterval, "1h")
+	}
+	if restored.DebounceInterval != "5s" {
+		t.Errorf("DebounceInterval: got %q, want %q", restored.DebounceInterval, "5s")
+	}
+
+	// Validate the JSON against the section schema
+	errs := Validate("federation", json.RawMessage(data))
+	if len(errs) > 0 {
+		t.Errorf("section doc should validate against schema, got: %v", errs)
 	}
 }
 

--- a/pkg/config/opsettings/registry.go
+++ b/pkg/config/opsettings/registry.go
@@ -126,6 +126,17 @@ func init() {
 			KoanfPaths: nil,
 			New:        func() any { return &ProjectDefaultsSettings{} },
 		},
+		{
+			Name: "federation",
+			KoanfPaths: []string{
+				"server.federation.enabled",
+				"server.federation.trusted_issuers",
+				"server.federation.algorithms",
+				"server.federation.refresh_interval",
+				"server.federation.debounce_interval",
+			},
+			New: func() interface{} { return &FederationSettings{} },
+		},
 	}
 
 	ensureIndexes()
@@ -326,6 +337,38 @@ func compileSchemas() {
 				"default_scratchpad": map[string]interface{}{"type": "boolean"},
 			},
 			"additionalProperties": false,
+		},
+		// federation schema is hand-written — federation config has no $defs
+		// in settings-v1.schema.json because it is a new Layer-1 section.
+		"federation": {
+			"type": "object",
+			"properties": map[string]interface{}{
+				"enabled": map[string]interface{}{"type": "boolean"},
+				"trusted_issuers": map[string]interface{}{
+					"type": "array",
+					"items": map[string]interface{}{
+						"type":     "object",
+						"required": []string{"issuer_url"},
+						"properties": map[string]interface{}{
+							"issuer_url":         map[string]interface{}{"type": "string", "minLength": 1},
+							"jwks_url":           map[string]interface{}{"type": "string"},
+							"expected_audience":  map[string]interface{}{"type": "string"},
+							"allowed_projects":   map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}},
+							"allowed_root_users": map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}},
+							"default_scopes":     map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}},
+							"issuer_type":        map[string]interface{}{"type": "string", "enum": []string{"hub", "service_account", "user"}},
+							"default_role":       map[string]interface{}{"type": "string"},
+							"allowed_emails":     map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}},
+						},
+					},
+				},
+				"algorithms": map[string]interface{}{
+					"type":  "array",
+					"items": map[string]interface{}{"type": "string", "enum": []string{"RS256", "ES256"}},
+				},
+				"refresh_interval":  map[string]interface{}{"type": "string"},
+				"debounce_interval": map[string]interface{}{"type": "string"},
+			},
 		},
 	}
 

--- a/pkg/config/opsettings/registry.go
+++ b/pkg/config/opsettings/registry.go
@@ -360,6 +360,7 @@ func compileSchemas() {
 							"default_role":       map[string]interface{}{"type": "string"},
 							"allowed_emails":     map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}},
 						},
+						"additionalProperties": false,
 					},
 				},
 				"algorithms": map[string]interface{}{

--- a/pkg/config/opsettings/registry.go
+++ b/pkg/config/opsettings/registry.go
@@ -135,7 +135,7 @@ func init() {
 				"server.federation.refresh_interval",
 				"server.federation.debounce_interval",
 			},
-			New: func() interface{} { return &FederationSettings{} },
+			New: func() any { return &FederationSettings{} },
 		},
 	}
 
@@ -369,6 +369,7 @@ func compileSchemas() {
 				"refresh_interval":  map[string]interface{}{"type": "string"},
 				"debounce_interval": map[string]interface{}{"type": "string"},
 			},
+			"additionalProperties": false,
 		},
 	}
 

--- a/pkg/config/opsettings/sections.go
+++ b/pkg/config/opsettings/sections.go
@@ -90,6 +90,15 @@ type NotificationsSettings struct {
 	NotificationChannels []config.V1NotificationChannelConfig `json:"notification_channels,omitempty"`
 }
 
+// FederationSettings is the opsettings section struct for federation config.
+type FederationSettings struct {
+	Enabled          *bool                              `json:"enabled,omitempty"`
+	TrustedIssuers   []config.V1TrustedIssuerConfig     `json:"trusted_issuers,omitempty"`
+	Algorithms       []string                           `json:"algorithms,omitempty"`
+	RefreshInterval  string                             `json:"refresh_interval,omitempty"`
+	DebounceInterval string                             `json:"debounce_interval,omitempty"`
+}
+
 // ProjectDefaultsSettings holds Layer-1 project creation defaults.
 type ProjectDefaultsSettings struct {
 	// DefaultScratchpad controls whether new projects automatically get a

--- a/pkg/config/opsettings/sections.go
+++ b/pkg/config/opsettings/sections.go
@@ -92,11 +92,11 @@ type NotificationsSettings struct {
 
 // FederationSettings is the opsettings section struct for federation config.
 type FederationSettings struct {
-	Enabled          *bool                              `json:"enabled,omitempty"`
-	TrustedIssuers   []config.V1TrustedIssuerConfig     `json:"trusted_issuers,omitempty"`
-	Algorithms       []string                           `json:"algorithms,omitempty"`
-	RefreshInterval  string                             `json:"refresh_interval,omitempty"`
-	DebounceInterval string                             `json:"debounce_interval,omitempty"`
+	Enabled          *bool                          `json:"enabled,omitempty"`
+	TrustedIssuers   []config.V1TrustedIssuerConfig `json:"trusted_issuers,omitempty"`
+	Algorithms       []string                       `json:"algorithms,omitempty"`
+	RefreshInterval  string                         `json:"refresh_interval,omitempty"`
+	DebounceInterval string                         `json:"debounce_interval,omitempty"`
 }
 
 // ProjectDefaultsSettings holds Layer-1 project creation defaults.

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -1592,18 +1592,7 @@ func ConvertV1ServerToGlobalConfig(v1 *V1ServerConfig) *GlobalConfig {
 			gc.Federation.Enabled = *v1.Federation.Enabled
 		}
 		for _, vi := range v1.Federation.TrustedIssuers {
-			ti := TrustedIssuerConfig{
-				IssuerURL:        vi.IssuerURL,
-				JWKSURL:          vi.JWKSURL,
-				ExpectedAudience: vi.ExpectedAudience,
-				AllowedProjects:  vi.AllowedProjects,
-				AllowedRootUsers: vi.AllowedRootUsers,
-				DefaultScopes:    vi.DefaultScopes,
-				IssuerType:       vi.IssuerType,
-				DefaultRole:      vi.DefaultRole,
-				AllowedEmails:    vi.AllowedEmails,
-			}
-			gc.Federation.TrustedIssuers = append(gc.Federation.TrustedIssuers, ti)
+			gc.Federation.TrustedIssuers = append(gc.Federation.TrustedIssuers, TrustedIssuerConfig(vi))
 		}
 		gc.Federation.Algorithms = v1.Federation.Algorithms
 		if v1.Federation.RefreshInterval != "" {
@@ -1796,18 +1785,7 @@ func ConvertGlobalToV1ServerConfig(gc *GlobalConfig) *V1ServerConfig {
 			v1.Federation.DebounceInterval = gc.Federation.Cache.DebounceInterval.String()
 		}
 		for _, ti := range gc.Federation.TrustedIssuers {
-			vi := V1TrustedIssuerConfig{
-				IssuerURL:        ti.IssuerURL,
-				JWKSURL:          ti.JWKSURL,
-				ExpectedAudience: ti.ExpectedAudience,
-				AllowedProjects:  ti.AllowedProjects,
-				AllowedRootUsers: ti.AllowedRootUsers,
-				DefaultScopes:    ti.DefaultScopes,
-				IssuerType:       ti.IssuerType,
-				DefaultRole:      ti.DefaultRole,
-				AllowedEmails:    ti.AllowedEmails,
-			}
-			v1.Federation.TrustedIssuers = append(v1.Federation.TrustedIssuers, vi)
+			v1.Federation.TrustedIssuers = append(v1.Federation.TrustedIssuers, V1TrustedIssuerConfig(ti))
 		}
 	}
 

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -1607,10 +1607,14 @@ func ConvertV1ServerToGlobalConfig(v1 *V1ServerConfig) *GlobalConfig {
 		}
 		gc.Federation.Algorithms = v1.Federation.Algorithms
 		if v1.Federation.RefreshInterval != "" {
-			gc.Federation.Cache.RefreshInterval, _ = time.ParseDuration(v1.Federation.RefreshInterval)
+			if d, err := time.ParseDuration(v1.Federation.RefreshInterval); err == nil {
+				gc.Federation.Cache.RefreshInterval = d
+			}
 		}
 		if v1.Federation.DebounceInterval != "" {
-			gc.Federation.Cache.DebounceInterval, _ = time.ParseDuration(v1.Federation.DebounceInterval)
+			if d, err := time.ParseDuration(v1.Federation.DebounceInterval); err == nil {
+				gc.Federation.Cache.DebounceInterval = d
+			}
 		}
 	}
 

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -341,6 +341,9 @@ type V1ServerConfig struct {
 
 	// Scheduler configures the Hub background task scheduler.
 	Scheduler *V1SchedulerConfig `json:"scheduler,omitempty" yaml:"scheduler,omitempty" koanf:"scheduler"`
+
+	// Federation configures hub-hub federation authentication.
+	Federation *V1FederationConfig `json:"federation,omitempty" yaml:"federation,omitempty" koanf:"federation"`
 }
 
 // V1GitHubAppConfig holds the GitHub App configuration in settings.yaml format.
@@ -368,6 +371,28 @@ type V1SchedulerConfig struct {
 	// pool saturation) is active out-of-the-box. Set to 0 for unlimited
 	// (pre-fix behavior), or a higher value for larger deployments.
 	MaxConcurrency *int `json:"max_concurrency,omitempty" yaml:"max_concurrency,omitempty" koanf:"max_concurrency"`
+}
+
+// V1FederationConfig is the admin API wire format for federation settings.
+type V1FederationConfig struct {
+	Enabled          *bool                   `json:"enabled,omitempty" yaml:"enabled,omitempty" koanf:"enabled"`
+	TrustedIssuers   []V1TrustedIssuerConfig `json:"trusted_issuers,omitempty" yaml:"trusted_issuers,omitempty" koanf:"trusted_issuers"`
+	Algorithms       []string                `json:"algorithms,omitempty" yaml:"algorithms,omitempty" koanf:"algorithms"`
+	RefreshInterval  string                  `json:"refresh_interval,omitempty" yaml:"refresh_interval,omitempty" koanf:"refresh_interval"`
+	DebounceInterval string                  `json:"debounce_interval,omitempty" yaml:"debounce_interval,omitempty" koanf:"debounce_interval"`
+}
+
+// V1TrustedIssuerConfig is the admin API wire format for a single trusted issuer.
+type V1TrustedIssuerConfig struct {
+	IssuerURL        string   `json:"issuer_url" yaml:"issuer_url" koanf:"issuer_url"`
+	JWKSURL          string   `json:"jwks_url,omitempty" yaml:"jwks_url,omitempty" koanf:"jwks_url"`
+	ExpectedAudience string   `json:"expected_audience,omitempty" yaml:"expected_audience,omitempty" koanf:"expected_audience"`
+	AllowedProjects  []string `json:"allowed_projects,omitempty" yaml:"allowed_projects,omitempty" koanf:"allowed_projects"`
+	AllowedRootUsers []string `json:"allowed_root_users,omitempty" yaml:"allowed_root_users,omitempty" koanf:"allowed_root_users"`
+	DefaultScopes    []string `json:"default_scopes,omitempty" yaml:"default_scopes,omitempty" koanf:"default_scopes"`
+	IssuerType       string   `json:"issuer_type,omitempty" yaml:"issuer_type,omitempty" koanf:"issuer_type"`
+	DefaultRole      string   `json:"default_role,omitempty" yaml:"default_role,omitempty" koanf:"default_role"`
+	AllowedEmails    []string `json:"allowed_emails,omitempty" yaml:"allowed_emails,omitempty" koanf:"allowed_emails"`
 }
 
 // V1NotificationChannelConfig holds configuration for an external notification channel.
@@ -1561,6 +1586,34 @@ func ConvertV1ServerToGlobalConfig(v1 *V1ServerConfig) *GlobalConfig {
 		gc.Scheduler.MaxConcurrency = v1.Scheduler.MaxConcurrency // both are *int; nil propagates
 	}
 
+	// Federation
+	if v1.Federation != nil {
+		if v1.Federation.Enabled != nil {
+			gc.Federation.Enabled = *v1.Federation.Enabled
+		}
+		for _, vi := range v1.Federation.TrustedIssuers {
+			ti := TrustedIssuerConfig{
+				IssuerURL:        vi.IssuerURL,
+				JWKSURL:          vi.JWKSURL,
+				ExpectedAudience: vi.ExpectedAudience,
+				AllowedProjects:  vi.AllowedProjects,
+				AllowedRootUsers: vi.AllowedRootUsers,
+				DefaultScopes:    vi.DefaultScopes,
+				IssuerType:       vi.IssuerType,
+				DefaultRole:      vi.DefaultRole,
+				AllowedEmails:    vi.AllowedEmails,
+			}
+			gc.Federation.TrustedIssuers = append(gc.Federation.TrustedIssuers, ti)
+		}
+		gc.Federation.Algorithms = v1.Federation.Algorithms
+		if v1.Federation.RefreshInterval != "" {
+			gc.Federation.Cache.RefreshInterval, _ = time.ParseDuration(v1.Federation.RefreshInterval)
+		}
+		if v1.Federation.DebounceInterval != "" {
+			gc.Federation.Cache.DebounceInterval, _ = time.ParseDuration(v1.Federation.DebounceInterval)
+		}
+	}
+
 	return &gc
 }
 
@@ -1723,6 +1776,34 @@ func ConvertGlobalToV1ServerConfig(gc *GlobalConfig) *V1ServerConfig {
 		v1.Scheduler = &V1SchedulerConfig{
 			IntervalSeconds: gc.Scheduler.IntervalSeconds,
 			MaxConcurrency:  gc.Scheduler.MaxConcurrency,
+		}
+	}
+
+	// Federation
+	if gc.Federation.Enabled || len(gc.Federation.TrustedIssuers) > 0 {
+		v1.Federation = &V1FederationConfig{
+			Enabled:    &gc.Federation.Enabled,
+			Algorithms: gc.Federation.Algorithms,
+		}
+		if gc.Federation.Cache.RefreshInterval > 0 {
+			v1.Federation.RefreshInterval = gc.Federation.Cache.RefreshInterval.String()
+		}
+		if gc.Federation.Cache.DebounceInterval > 0 {
+			v1.Federation.DebounceInterval = gc.Federation.Cache.DebounceInterval.String()
+		}
+		for _, ti := range gc.Federation.TrustedIssuers {
+			vi := V1TrustedIssuerConfig{
+				IssuerURL:        ti.IssuerURL,
+				JWKSURL:          ti.JWKSURL,
+				ExpectedAudience: ti.ExpectedAudience,
+				AllowedProjects:  ti.AllowedProjects,
+				AllowedRootUsers: ti.AllowedRootUsers,
+				DefaultScopes:    ti.DefaultScopes,
+				IssuerType:       ti.IssuerType,
+				DefaultRole:      ti.DefaultRole,
+				AllowedEmails:    ti.AllowedEmails,
+			}
+			v1.Federation.TrustedIssuers = append(v1.Federation.TrustedIssuers, vi)
 		}
 	}
 

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -4215,6 +4215,124 @@ func TestConvertV1ServerToGlobalConfig_StalledThresholdInvalidIgnored(t *testing
 	assert.Equal(t, time.Duration(0), gc.Hub.StalledThreshold)
 }
 
+// --- Federation conversion tests ---
+
+func TestConvertV1FederationConfig_RoundTrip(t *testing.T) {
+	enabled := true
+	v1 := &V1ServerConfig{
+		Federation: &V1FederationConfig{
+			Enabled: &enabled,
+			TrustedIssuers: []V1TrustedIssuerConfig{
+				{
+					IssuerURL:        "https://hub-a.example.com",
+					JWKSURL:          "https://hub-a.example.com/.well-known/jwks.json",
+					ExpectedAudience: "https://hub-b.example.com",
+					AllowedProjects:  []string{"proj1", "proj2"},
+					AllowedRootUsers: []string{"user@example.com"},
+					DefaultScopes:    []string{"agent:status:update", "agent:message:send"},
+					IssuerType:       "hub",
+					DefaultRole:      "",
+					AllowedEmails:    nil,
+				},
+				{
+					IssuerURL:        "https://accounts.google.com",
+					JWKSURL:          "",
+					ExpectedAudience: "https://hub-b.example.com",
+					AllowedProjects:  nil,
+					AllowedRootUsers: nil,
+					DefaultScopes:    []string{"agent:status:update"},
+					IssuerType:       "service_account",
+					DefaultRole:      "",
+					AllowedEmails:    []string{"sa@proj.iam.gserviceaccount.com"},
+				},
+			},
+			Algorithms:       []string{"RS256", "ES256"},
+			RefreshInterval:  "1h",
+			DebounceInterval: "5s",
+		},
+	}
+
+	// V1 -> GlobalConfig
+	gc := ConvertV1ServerToGlobalConfig(v1)
+	assert.True(t, gc.Federation.Enabled)
+	require.Len(t, gc.Federation.TrustedIssuers, 2)
+
+	ti0 := gc.Federation.TrustedIssuers[0]
+	assert.Equal(t, "https://hub-a.example.com", ti0.IssuerURL)
+	assert.Equal(t, "https://hub-a.example.com/.well-known/jwks.json", ti0.JWKSURL)
+	assert.Equal(t, "https://hub-b.example.com", ti0.ExpectedAudience)
+	assert.Equal(t, []string{"proj1", "proj2"}, ti0.AllowedProjects)
+	assert.Equal(t, []string{"user@example.com"}, ti0.AllowedRootUsers)
+	assert.Equal(t, []string{"agent:status:update", "agent:message:send"}, ti0.DefaultScopes)
+	assert.Equal(t, "hub", ti0.IssuerType)
+
+	ti1 := gc.Federation.TrustedIssuers[1]
+	assert.Equal(t, "https://accounts.google.com", ti1.IssuerURL)
+	assert.Equal(t, "service_account", ti1.IssuerType)
+	assert.Equal(t, []string{"sa@proj.iam.gserviceaccount.com"}, ti1.AllowedEmails)
+
+	assert.Equal(t, []string{"RS256", "ES256"}, gc.Federation.Algorithms)
+	assert.Equal(t, time.Hour, gc.Federation.Cache.RefreshInterval)
+	assert.Equal(t, 5*time.Second, gc.Federation.Cache.DebounceInterval)
+
+	// GlobalConfig -> V1 (round-trip back)
+	v1Back := ConvertGlobalToV1ServerConfig(gc)
+	require.NotNil(t, v1Back.Federation)
+	assert.Equal(t, &enabled, v1Back.Federation.Enabled)
+	assert.Equal(t, []string{"RS256", "ES256"}, v1Back.Federation.Algorithms)
+	assert.Equal(t, "1h0m0s", v1Back.Federation.RefreshInterval)
+	assert.Equal(t, "5s", v1Back.Federation.DebounceInterval)
+
+	require.Len(t, v1Back.Federation.TrustedIssuers, 2)
+	vi0 := v1Back.Federation.TrustedIssuers[0]
+	assert.Equal(t, "https://hub-a.example.com", vi0.IssuerURL)
+	assert.Equal(t, "https://hub-a.example.com/.well-known/jwks.json", vi0.JWKSURL)
+	assert.Equal(t, "https://hub-b.example.com", vi0.ExpectedAudience)
+	assert.Equal(t, []string{"proj1", "proj2"}, vi0.AllowedProjects)
+	assert.Equal(t, []string{"user@example.com"}, vi0.AllowedRootUsers)
+	assert.Equal(t, []string{"agent:status:update", "agent:message:send"}, vi0.DefaultScopes)
+	assert.Equal(t, "hub", vi0.IssuerType)
+
+	vi1 := v1Back.Federation.TrustedIssuers[1]
+	assert.Equal(t, "https://accounts.google.com", vi1.IssuerURL)
+	assert.Equal(t, "service_account", vi1.IssuerType)
+	assert.Equal(t, []string{"sa@proj.iam.gserviceaccount.com"}, vi1.AllowedEmails)
+}
+
+func TestConvertV1FederationConfig_NilFederation(t *testing.T) {
+	v1 := &V1ServerConfig{}
+	gc := ConvertV1ServerToGlobalConfig(v1)
+	assert.False(t, gc.Federation.Enabled)
+	assert.Empty(t, gc.Federation.TrustedIssuers)
+}
+
+func TestConvertGlobalToV1_FederationDisabledNoIssuers(t *testing.T) {
+	gc := DefaultGlobalConfig()
+	gc.Federation.Enabled = false
+	gc.Federation.TrustedIssuers = nil
+	v1 := ConvertGlobalToV1ServerConfig(&gc)
+	// When federation is disabled with no issuers, Federation should be nil in V1
+	assert.Nil(t, v1.Federation)
+}
+
+func TestConvertV1FederationConfig_EnabledNilDereference(t *testing.T) {
+	// Test that nil Enabled is handled safely (defaults to false)
+	v1 := &V1ServerConfig{
+		Federation: &V1FederationConfig{
+			Enabled: nil,
+			TrustedIssuers: []V1TrustedIssuerConfig{
+				{
+					IssuerURL: "https://hub-a.example.com",
+				},
+			},
+		},
+	}
+	gc := ConvertV1ServerToGlobalConfig(v1)
+	assert.False(t, gc.Federation.Enabled)
+	require.Len(t, gc.Federation.TrustedIssuers, 1)
+	assert.Equal(t, "https://hub-a.example.com", gc.Federation.TrustedIssuers[0].IssuerURL)
+}
+
 // --- Helper ---
 
 func boolPtr(b bool) *bool {

--- a/pkg/hub/admin_settings.go
+++ b/pkg/hub/admin_settings.go
@@ -70,6 +70,9 @@ type ServerConfigResponse struct {
 	// AutoExposePorts controls whether ports are automatically exposed in agent containers.
 	AutoExposePorts *config.AutoExposePortsSettings `json:"auto_expose_ports,omitempty"`
 
+	// Federation holds the federation authentication config for the admin API.
+	Federation *config.V1FederationConfig `json:"federation,omitempty"`
+
 	// EnvOverrides lists koanf keys overridden by SCION_SERVER_* env vars
 	// on this node. Present in both file-mode and DB-mode responses so the
 	// admin UI can show env-pinned fields regardless of settings tier.
@@ -105,6 +108,9 @@ type ServerConfigUpdateRequest struct {
 
 	// AutoExposePorts controls whether ports are automatically exposed in agent containers.
 	AutoExposePorts *config.AutoExposePortsSettings `json:"auto_expose_ports,omitempty"`
+
+	// Federation holds the federation authentication config update.
+	Federation *config.V1FederationConfig `json:"federation,omitempty"`
 }
 
 // handleAdminServerConfig handles GET/PUT /api/v1/admin/server-config.
@@ -260,6 +266,11 @@ func (s *Server) handleGetServerConfig(w http.ResponseWriter) {
 		DefaultThinkingLevel: vs.DefaultThinkingLevel,
 		AutoInjectGcloudADC:  vs.AutoInjectGcloudADC,
 		AutoExposePorts:      vs.AutoExposePorts,
+	}
+
+	// Populate top-level federation field from the server config.
+	if vs.Server != nil && vs.Server.Federation != nil {
+		resp.Federation = vs.Server.Federation
 	}
 
 	// Env overrides — detect SCION_SERVER_* env vars so the admin UI can
@@ -485,6 +496,14 @@ func applySettingsUpdates(raw map[string]interface{}, req *ServerConfigUpdateReq
 		} else {
 			delete(raw, "auto_expose_ports")
 		}
+	}
+	if req.Federation != nil {
+		serverMap, ok := raw["server"].(map[string]interface{})
+		if !ok {
+			serverMap = make(map[string]interface{})
+			raw["server"] = serverMap
+		}
+		serverMap["federation"] = marshalToMap(req.Federation)
 	}
 }
 

--- a/pkg/hub/admin_settings_db.go
+++ b/pkg/hub/admin_settings_db.go
@@ -506,6 +506,24 @@ func (s *Server) handlePutServerConfigDB(w http.ResponseWriter, r *http.Request,
 	if doc, ok := sectionDocs["federation"]; ok {
 		var fedSettings opsettings.FederationSettings
 		if err := json.Unmarshal(doc, &fedSettings); err == nil {
+			// Validate duration strings before conversion (which silently
+			// falls back to zero for invalid values). Invalid durations like
+			// "1hour" would fail at time.ParseDuration during ApplySnapshot.
+			if fedSettings.RefreshInterval != "" {
+				if _, err := time.ParseDuration(fedSettings.RefreshInterval); err != nil {
+					writeError(w, http.StatusUnprocessableEntity, ErrCodeValidationError,
+						fmt.Sprintf("invalid refresh_interval %q: %v", fedSettings.RefreshInterval, err), nil)
+					return
+				}
+			}
+			if fedSettings.DebounceInterval != "" {
+				if _, err := time.ParseDuration(fedSettings.DebounceInterval); err != nil {
+					writeError(w, http.StatusUnprocessableEntity, ErrCodeValidationError,
+						fmt.Sprintf("invalid debounce_interval %q: %v", fedSettings.DebounceInterval, err), nil)
+					return
+				}
+			}
+
 			fedCfg := convertFederationSettingsToConfig(fedSettings)
 			if errs := fedCfg.Validate(); len(errs) > 0 {
 				var errMsgs []string

--- a/pkg/hub/admin_settings_db.go
+++ b/pkg/hub/admin_settings_db.go
@@ -1123,18 +1123,7 @@ func convertFederationSettingsToConfig(fs opsettings.FederationSettings) config.
 		fc.Enabled = *fs.Enabled
 	}
 	for _, vi := range fs.TrustedIssuers {
-		ti := config.TrustedIssuerConfig{
-			IssuerURL:        vi.IssuerURL,
-			JWKSURL:          vi.JWKSURL,
-			ExpectedAudience: vi.ExpectedAudience,
-			AllowedProjects:  vi.AllowedProjects,
-			AllowedRootUsers: vi.AllowedRootUsers,
-			DefaultScopes:    vi.DefaultScopes,
-			IssuerType:       vi.IssuerType,
-			DefaultRole:      vi.DefaultRole,
-			AllowedEmails:    vi.AllowedEmails,
-		}
-		fc.TrustedIssuers = append(fc.TrustedIssuers, ti)
+		fc.TrustedIssuers = append(fc.TrustedIssuers, config.TrustedIssuerConfig(vi))
 	}
 	if fs.RefreshInterval != "" {
 		if d, err := time.ParseDuration(fs.RefreshInterval); err == nil {

--- a/pkg/hub/admin_settings_db.go
+++ b/pkg/hub/admin_settings_db.go
@@ -843,6 +843,19 @@ func extractKoanfKeysFromRequest(req *ServerConfigUpdateRequest) []string {
 		}
 	}
 
+	// Federation keys — emit all 5 koanf paths when the federation field
+	// is present. The section doc builder handles per-field presence;
+	// ClassifyKeys only needs at least one key to activate the section.
+	if req.Federation != nil {
+		keys = append(keys,
+			"server.federation.enabled",
+			"server.federation.trusted_issuers",
+			"server.federation.algorithms",
+			"server.federation.refresh_interval",
+			"server.federation.debounce_interval",
+		)
+	}
+
 	return keys
 }
 
@@ -1121,11 +1134,17 @@ func convertFederationSettingsToConfig(fs opsettings.FederationSettings) config.
 	if fs.RefreshInterval != "" {
 		if d, err := time.ParseDuration(fs.RefreshInterval); err == nil {
 			fc.Cache.RefreshInterval = d
+		} else {
+			slog.Warn("convertFederationSettingsToConfig: invalid refresh_interval duration, using zero",
+				"value", fs.RefreshInterval, "error", err)
 		}
 	}
 	if fs.DebounceInterval != "" {
 		if d, err := time.ParseDuration(fs.DebounceInterval); err == nil {
 			fc.Cache.DebounceInterval = d
+		} else {
+			slog.Warn("convertFederationSettingsToConfig: invalid debounce_interval duration, using zero",
+				"value", fs.DebounceInterval, "error", err)
 		}
 	}
 	return fc

--- a/pkg/hub/admin_settings_db.go
+++ b/pkg/hub/admin_settings_db.go
@@ -248,6 +248,13 @@ func applySnapshotToResponse(resp *ServerConfigResponse, snap Layer1Snapshot) {
 			Enabled: snap.AutoExposePortsEnabled,
 		}
 	}
+
+	// Federation — populate from snapshot's FederationConfig.
+	if snap.FederationConfig != nil {
+		gc := &config.GlobalConfig{Federation: *snap.FederationConfig}
+		v1Server := config.ConvertGlobalToV1ServerConfig(gc)
+		resp.Federation = v1Server.Federation
+	}
 }
 
 // buildSectionMetadata reads the OperationalSettings cache to determine
@@ -493,6 +500,25 @@ func (s *Server) handlePutServerConfigDB(w http.ResponseWriter, r *http.Request,
 		slog.Error("PUT server-config: failed to build section documents", "error", err)
 		writeError(w, http.StatusInternalServerError, ErrCodeInternalError, "Failed to build section documents", nil)
 		return
+	}
+
+	// Validate federation semantics (beyond JSON schema).
+	if doc, ok := sectionDocs["federation"]; ok {
+		var fedSettings opsettings.FederationSettings
+		if err := json.Unmarshal(doc, &fedSettings); err == nil {
+			fedCfg := convertFederationSettingsToConfig(fedSettings)
+			if errs := fedCfg.Validate(); len(errs) > 0 {
+				var errMsgs []string
+				for _, e := range errs {
+					errMsgs = append(errMsgs, e.Error())
+				}
+				writeError(w, http.StatusUnprocessableEntity, ErrCodeValidationError,
+					"federation config validation failed", map[string]interface{}{
+						"errors": errMsgs,
+					})
+				return
+			}
+		}
 	}
 
 	// Validate ALL sections before writing ANY (atomic: all-or-nothing).
@@ -1051,11 +1077,58 @@ func buildSingleSectionDoc(req *ServerConfigUpdateRequest, secName string, fp *f
 		}
 		doc = d
 
+	case "federation":
+		fedSettings := opsettings.FederationSettings{}
+		if req.Federation != nil {
+			fedSettings.Enabled = req.Federation.Enabled
+			fedSettings.TrustedIssuers = req.Federation.TrustedIssuers
+			fedSettings.Algorithms = req.Federation.Algorithms
+			fedSettings.RefreshInterval = req.Federation.RefreshInterval
+			fedSettings.DebounceInterval = req.Federation.DebounceInterval
+		}
+		doc = &fedSettings
+
 	default:
 		return nil, nil
 	}
 
 	return json.Marshal(doc)
+}
+
+// convertFederationSettingsToConfig maps FederationSettings to config.FederationConfig
+// for semantic validation.
+func convertFederationSettingsToConfig(fs opsettings.FederationSettings) config.FederationConfig {
+	fc := config.FederationConfig{
+		Algorithms: fs.Algorithms,
+	}
+	if fs.Enabled != nil {
+		fc.Enabled = *fs.Enabled
+	}
+	for _, vi := range fs.TrustedIssuers {
+		ti := config.TrustedIssuerConfig{
+			IssuerURL:        vi.IssuerURL,
+			JWKSURL:          vi.JWKSURL,
+			ExpectedAudience: vi.ExpectedAudience,
+			AllowedProjects:  vi.AllowedProjects,
+			AllowedRootUsers: vi.AllowedRootUsers,
+			DefaultScopes:    vi.DefaultScopes,
+			IssuerType:       vi.IssuerType,
+			DefaultRole:      vi.DefaultRole,
+			AllowedEmails:    vi.AllowedEmails,
+		}
+		fc.TrustedIssuers = append(fc.TrustedIssuers, ti)
+	}
+	if fs.RefreshInterval != "" {
+		if d, err := time.ParseDuration(fs.RefreshInterval); err == nil {
+			fc.Cache.RefreshInterval = d
+		}
+	}
+	if fs.DebounceInterval != "" {
+		if d, err := time.ParseDuration(fs.DebounceInterval); err == nil {
+			fc.Cache.DebounceInterval = d
+		}
+	}
+	return fc
 }
 
 // mapKeys returns the keys of a map as a sorted slice.

--- a/pkg/hub/admin_settings_db.go
+++ b/pkg/hub/admin_settings_db.go
@@ -518,6 +518,11 @@ func (s *Server) handlePutServerConfigDB(w http.ResponseWriter, r *http.Request,
 					})
 				return
 			}
+		} else {
+			slog.Warn("PUT server-config: failed to deserialize federation section for validation",
+				"error", err,
+				"user", updatedBy,
+			)
 		}
 	}
 

--- a/pkg/hub/auth.go
+++ b/pkg/hub/auth.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
@@ -54,9 +55,11 @@ type AuthConfig struct {
 	ProxyUserProvisioner func(ctx context.Context, info *ProxyUserInfo) (UserIdentity, error)
 	// AuthMode is the exclusive human auth mode: "oauth", "proxy", "dev".
 	AuthMode string
-	// FederationAuthenticator validates OIDC tokens from trusted external hubs.
-	// nil when federation is disabled.
-	FederationAuthenticator *FederationAuthenticator
+	// FederationAuth points to the server's atomic.Pointer for the
+	// FederationAuthenticator. nil when federation was never configured.
+	// The middleware loads from this pointer on each request to see
+	// hot-reloaded authenticators.
+	FederationAuth *atomic.Pointer[FederationAuthenticator]
 	// Debug enables verbose logging
 	Debug bool
 	// Logger is the subsystem logger for auth middleware (defaults to slog.Default())
@@ -145,13 +148,17 @@ func UnifiedAuthMiddleware(cfg AuthConfig) func(http.Handler) http.Handler {
 
 			// Step 1.5: Federation OIDC token (X-Scion-Federation-Token header)
 			if federationToken := r.Header.Get(FederationTokenHeader); federationToken != "" {
-				if cfg.FederationAuthenticator == nil {
+				var fedAuth *FederationAuthenticator
+				if cfg.FederationAuth != nil {
+					fedAuth = cfg.FederationAuth.Load()
+				}
+				if fedAuth == nil {
 					// Header present but federation not enabled — reject, don't silently ignore
 					writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized,
 						"federation authentication is not configured", nil)
 					return
 				}
-				identity, err := cfg.FederationAuthenticator.Authenticate(federationToken)
+				identity, err := fedAuth.Authenticate(federationToken)
 				if err != nil {
 					if cfg.Debug {
 						log.Debug("Federation token validation failed", "error", err)

--- a/pkg/hub/federation_auth_integration_test.go
+++ b/pkg/hub/federation_auth_integration_test.go
@@ -101,10 +101,14 @@ func TestFederationMiddleware_ValidToken(t *testing.T) {
 	privKey, auth, issuer, audience, kid := setupFederationIntegration(t)
 
 	cfg := AuthConfig{
-		Mode:                    "production",
-		FederationAuth: func() *atomic.Pointer[FederationAuthenticator] { p := &atomic.Pointer[FederationAuthenticator]{}; p.Store(auth); return p }(),
-		Debug:                   true,
-		Logger:                  slog.Default(),
+		Mode: "production",
+		FederationAuth: func() *atomic.Pointer[FederationAuthenticator] {
+			p := &atomic.Pointer[FederationAuthenticator]{}
+			p.Store(auth)
+			return p
+		}(),
+		Debug:  true,
+		Logger: slog.Default(),
 	}
 
 	middleware := UnifiedAuthMiddleware(cfg)
@@ -200,10 +204,14 @@ func TestFederationMiddleware_InvalidToken(t *testing.T) {
 	_, auth, _, _, _ := setupFederationIntegration(t)
 
 	cfg := AuthConfig{
-		Mode:                    "production",
-		FederationAuth: func() *atomic.Pointer[FederationAuthenticator] { p := &atomic.Pointer[FederationAuthenticator]{}; p.Store(auth); return p }(),
-		Debug:                   true,
-		Logger:                  slog.Default(),
+		Mode: "production",
+		FederationAuth: func() *atomic.Pointer[FederationAuthenticator] {
+			p := &atomic.Pointer[FederationAuthenticator]{}
+			p.Store(auth)
+			return p
+		}(),
+		Debug:  true,
+		Logger: slog.Default(),
 	}
 
 	middleware := UnifiedAuthMiddleware(cfg)
@@ -234,10 +242,10 @@ func TestFederationMiddleware_InvalidToken(t *testing.T) {
 // "federation authentication is not configured".
 func TestFederationMiddleware_NotConfigured(t *testing.T) {
 	cfg := AuthConfig{
-		Mode:                    "production",
+		Mode:           "production",
 		FederationAuth: nil, // federation not enabled
-		Debug:                   true,
-		Logger:                  slog.Default(),
+		Debug:          true,
+		Logger:         slog.Default(),
 	}
 
 	middleware := UnifiedAuthMiddleware(cfg)
@@ -271,10 +279,14 @@ func TestFederationMiddleware_NoHeader(t *testing.T) {
 	_, auth, _, _, _ := setupFederationIntegration(t)
 
 	cfg := AuthConfig{
-		Mode:                    "production",
-		FederationAuth: func() *atomic.Pointer[FederationAuthenticator] { p := &atomic.Pointer[FederationAuthenticator]{}; p.Store(auth); return p }(),
-		Debug:                   true,
-		Logger:                  slog.Default(),
+		Mode: "production",
+		FederationAuth: func() *atomic.Pointer[FederationAuthenticator] {
+			p := &atomic.Pointer[FederationAuthenticator]{}
+			p.Store(auth)
+			return p
+		}(),
+		Debug:  true,
+		Logger: slog.Default(),
 	}
 
 	middleware := UnifiedAuthMiddleware(cfg)
@@ -320,11 +332,15 @@ func TestFederationMiddleware_AgentTokenTakesPriority(t *testing.T) {
 	}
 
 	cfg := AuthConfig{
-		Mode:                    "production",
-		AgentTokenSvc:           agentTokenSvc,
-		FederationAuth: func() *atomic.Pointer[FederationAuthenticator] { p := &atomic.Pointer[FederationAuthenticator]{}; p.Store(auth); return p }(),
-		Debug:                   true,
-		Logger:                  slog.Default(),
+		Mode:          "production",
+		AgentTokenSvc: agentTokenSvc,
+		FederationAuth: func() *atomic.Pointer[FederationAuthenticator] {
+			p := &atomic.Pointer[FederationAuthenticator]{}
+			p.Store(auth)
+			return p
+		}(),
+		Debug:  true,
+		Logger: slog.Default(),
 	}
 
 	middleware := UnifiedAuthMiddleware(cfg)
@@ -380,10 +396,14 @@ func TestFederationMiddleware_ExpiredToken(t *testing.T) {
 	privKey, auth, issuer, audience, kid := setupFederationIntegration(t)
 
 	cfg := AuthConfig{
-		Mode:                    "production",
-		FederationAuth: func() *atomic.Pointer[FederationAuthenticator] { p := &atomic.Pointer[FederationAuthenticator]{}; p.Store(auth); return p }(),
-		Debug:                   true,
-		Logger:                  slog.Default(),
+		Mode: "production",
+		FederationAuth: func() *atomic.Pointer[FederationAuthenticator] {
+			p := &atomic.Pointer[FederationAuthenticator]{}
+			p.Store(auth)
+			return p
+		}(),
+		Debug:  true,
+		Logger: slog.Default(),
 	}
 
 	middleware := UnifiedAuthMiddleware(cfg)

--- a/pkg/hub/federation_auth_integration_test.go
+++ b/pkg/hub/federation_auth_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -101,7 +102,7 @@ func TestFederationMiddleware_ValidToken(t *testing.T) {
 
 	cfg := AuthConfig{
 		Mode:                    "production",
-		FederationAuthenticator: auth,
+		FederationAuth: func() *atomic.Pointer[FederationAuthenticator] { p := &atomic.Pointer[FederationAuthenticator]{}; p.Store(auth); return p }(),
 		Debug:                   true,
 		Logger:                  slog.Default(),
 	}
@@ -200,7 +201,7 @@ func TestFederationMiddleware_InvalidToken(t *testing.T) {
 
 	cfg := AuthConfig{
 		Mode:                    "production",
-		FederationAuthenticator: auth,
+		FederationAuth: func() *atomic.Pointer[FederationAuthenticator] { p := &atomic.Pointer[FederationAuthenticator]{}; p.Store(auth); return p }(),
 		Debug:                   true,
 		Logger:                  slog.Default(),
 	}
@@ -234,7 +235,7 @@ func TestFederationMiddleware_InvalidToken(t *testing.T) {
 func TestFederationMiddleware_NotConfigured(t *testing.T) {
 	cfg := AuthConfig{
 		Mode:                    "production",
-		FederationAuthenticator: nil, // federation not enabled
+		FederationAuth: nil, // federation not enabled
 		Debug:                   true,
 		Logger:                  slog.Default(),
 	}
@@ -271,7 +272,7 @@ func TestFederationMiddleware_NoHeader(t *testing.T) {
 
 	cfg := AuthConfig{
 		Mode:                    "production",
-		FederationAuthenticator: auth,
+		FederationAuth: func() *atomic.Pointer[FederationAuthenticator] { p := &atomic.Pointer[FederationAuthenticator]{}; p.Store(auth); return p }(),
 		Debug:                   true,
 		Logger:                  slog.Default(),
 	}
@@ -321,7 +322,7 @@ func TestFederationMiddleware_AgentTokenTakesPriority(t *testing.T) {
 	cfg := AuthConfig{
 		Mode:                    "production",
 		AgentTokenSvc:           agentTokenSvc,
-		FederationAuthenticator: auth,
+		FederationAuth: func() *atomic.Pointer[FederationAuthenticator] { p := &atomic.Pointer[FederationAuthenticator]{}; p.Store(auth); return p }(),
 		Debug:                   true,
 		Logger:                  slog.Default(),
 	}
@@ -380,7 +381,7 @@ func TestFederationMiddleware_ExpiredToken(t *testing.T) {
 
 	cfg := AuthConfig{
 		Mode:                    "production",
-		FederationAuthenticator: auth,
+		FederationAuth: func() *atomic.Pointer[FederationAuthenticator] { p := &atomic.Pointer[FederationAuthenticator]{}; p.Store(auth); return p }(),
 		Debug:                   true,
 		Logger:                  slog.Default(),
 	}

--- a/pkg/hub/federation_e2e_test.go
+++ b/pkg/hub/federation_e2e_test.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,6 +30,15 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 )
+
+// newFedAuthPointer creates an atomic.Pointer pre-loaded with the given authenticator.
+func newFedAuthPointer(auth *FederationAuthenticator) *atomic.Pointer[FederationAuthenticator] {
+	p := &atomic.Pointer[FederationAuthenticator]{}
+	if auth != nil {
+		p.Store(auth)
+	}
+	return p
+}
 
 // e2eResponse is the JSON response returned by the E2E test endpoint handler
 // to verify identity details from the full authentication flow.
@@ -108,7 +118,7 @@ func setupE2EServer(t *testing.T, requiredScope AgentTokenScope) (
 
 	authCfg := AuthConfig{
 		Mode:                    "production",
-		FederationAuthenticator: authenticator,
+		FederationAuth: newFedAuthPointer(authenticator),
 		Debug:                   true,
 		Logger:                  slog.Default(),
 	}
@@ -330,7 +340,7 @@ func setupNonHubE2EServer(t *testing.T, fedCfg config.FederationConfig, audience
 
 	authCfg := AuthConfig{
 		Mode:                    "production",
-		FederationAuthenticator: authenticator,
+		FederationAuth: newFedAuthPointer(authenticator),
 		Debug:                   true,
 		Logger:                  slog.Default(),
 	}

--- a/pkg/hub/federation_e2e_test.go
+++ b/pkg/hub/federation_e2e_test.go
@@ -117,10 +117,10 @@ func setupE2EServer(t *testing.T, requiredScope AgentTokenScope) (
 	}
 
 	authCfg := AuthConfig{
-		Mode:                    "production",
+		Mode:           "production",
 		FederationAuth: newFedAuthPointer(authenticator),
-		Debug:                   true,
-		Logger:                  slog.Default(),
+		Debug:          true,
+		Logger:         slog.Default(),
 	}
 
 	// Build the handler chain: auth middleware -> access control -> handler
@@ -339,10 +339,10 @@ func setupNonHubE2EServer(t *testing.T, fedCfg config.FederationConfig, audience
 	}
 
 	authCfg := AuthConfig{
-		Mode:                    "production",
+		Mode:           "production",
 		FederationAuth: newFedAuthPointer(authenticator),
-		Debug:                   true,
-		Logger:                  slog.Default(),
+		Debug:          true,
+		Logger:         slog.Default(),
 	}
 
 	identityHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/hub/federation_hotreload_test.go
+++ b/pkg/hub/federation_hotreload_test.go
@@ -1,0 +1,493 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/config/opsettings"
+)
+
+// --- Deliverable 10a: Hot-reload via ApplySnapshot ---
+
+func TestApplySnapshot_FederationHotReload(t *testing.T) {
+	// Create a minimal Server with the fields ApplySnapshot needs.
+	srv := &Server{}
+	srv.config.Mode = "dev"
+	srv.config.Workstation = true
+	srv.config.OIDCConfig.IssuerURL = "https://hub.example.com"
+	srv.federationClient = &http.Client{Timeout: 5 * time.Second}
+
+	// Create a JWKS test server for the trusted issuer.
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"keys":[]}`))
+	}))
+	defer jwksServer.Close()
+
+	// Build a snapshot with federation config.
+	fedCfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        jwksServer.URL,
+				JWKSURL:          jwksServer.URL,
+				ExpectedAudience: "https://hub.example.com",
+			},
+		},
+	}
+	snap := Layer1Snapshot{
+		FederationConfig: &fedCfg,
+	}
+
+	// Initially, no authenticator is loaded.
+	if srv.federationAuth.Load() != nil {
+		t.Fatal("expected nil federationAuth before ApplySnapshot")
+	}
+
+	// Apply the snapshot — should hot-reload the authenticator.
+	result := ApplySnapshot(srv, snap)
+
+	// Verify the authenticator was stored.
+	newAuth := srv.federationAuth.Load()
+	if newAuth == nil {
+		t.Fatal("expected non-nil federationAuth after ApplySnapshot")
+	}
+
+	// Check that "federation" is in the applied list.
+	applied, ok := result["applied"].([]string)
+	if !ok {
+		t.Fatalf("expected applied to be []string, got %T", result["applied"])
+	}
+	found := false
+	for _, a := range applied {
+		if a == "federation" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'federation' in applied list, got %v", applied)
+	}
+}
+
+func TestApplySnapshot_FederationValidationFailure(t *testing.T) {
+	// Create a minimal Server.
+	srv := &Server{}
+	srv.config.Mode = "dev"
+	srv.config.Workstation = true
+
+	// Store an initial authenticator to verify it's kept on failure.
+	initialAuth := &FederationAuthenticator{}
+	srv.federationAuth.Store(initialAuth)
+
+	// Build a snapshot with invalid federation config (enabled but no issuers).
+	fedCfg := config.FederationConfig{
+		Enabled:        true,
+		TrustedIssuers: nil, // validation requires at least one issuer when enabled
+	}
+	snap := Layer1Snapshot{
+		FederationConfig: &fedCfg,
+	}
+
+	// Apply — should fail validation, keep old authenticator.
+	ApplySnapshot(srv, snap)
+
+	// Verify old authenticator is preserved.
+	currentAuth := srv.federationAuth.Load()
+	if currentAuth != initialAuth {
+		t.Error("expected old authenticator to be preserved after validation failure")
+	}
+}
+
+func TestApplySnapshot_FederationNilKeepsExisting(t *testing.T) {
+	// Create a minimal Server with an existing authenticator.
+	srv := &Server{}
+	initialAuth := &FederationAuthenticator{}
+	srv.federationAuth.Store(initialAuth)
+
+	// Apply snapshot without federation config.
+	snap := Layer1Snapshot{
+		FederationConfig: nil,
+	}
+	ApplySnapshot(srv, snap)
+
+	// Verify the existing authenticator is preserved (no-op on nil).
+	currentAuth := srv.federationAuth.Load()
+	if currentAuth != initialAuth {
+		t.Error("expected existing authenticator to be preserved when FederationConfig is nil")
+	}
+}
+
+// --- Deliverable 10b: Concurrent access ---
+
+func TestFederationAuth_ConcurrentAccess(t *testing.T) {
+	var fedAuth atomic.Pointer[FederationAuthenticator]
+
+	// Initial value.
+	auth1 := &FederationAuthenticator{}
+	fedAuth.Store(auth1)
+
+	const numReaders = 10
+	const numIterations = 1000
+
+	var wg sync.WaitGroup
+
+	// Readers: load from the atomic pointer concurrently.
+	for i := 0; i < numReaders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < numIterations; j++ {
+				loaded := fedAuth.Load()
+				if loaded == nil {
+					// nil is acceptable if a store of nil happened;
+					// in this test we only store non-nil, so this would be a bug.
+					t.Error("loaded nil from atomic pointer")
+					return
+				}
+			}
+		}()
+	}
+
+	// Writer: swap the authenticator concurrently.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < numIterations; j++ {
+			newAuth := &FederationAuthenticator{}
+			fedAuth.Store(newAuth)
+		}
+	}()
+
+	wg.Wait()
+}
+
+// --- Deliverable 10c: buildSingleSectionDoc federation case ---
+
+func TestBuildSingleSectionDoc_Federation(t *testing.T) {
+	enabled := true
+	req := &ServerConfigUpdateRequest{
+		Federation: &config.V1FederationConfig{
+			Enabled: &enabled,
+			TrustedIssuers: []config.V1TrustedIssuerConfig{
+				{
+					IssuerURL:        "https://hub-a.example.com",
+					ExpectedAudience: "https://hub-b.example.com",
+					IssuerType:       "hub",
+				},
+			},
+			Algorithms:      []string{"RS256"},
+			RefreshInterval: "1h",
+		},
+	}
+
+	fp := newFieldPresenceFromJSON(t, `{
+		"federation": {
+			"enabled": true,
+			"trusted_issuers": [{"issuer_url": "https://hub-a.example.com"}],
+			"algorithms": ["RS256"],
+			"refresh_interval": "1h"
+		}
+	}`)
+
+	doc, err := buildSingleSectionDoc(req, "federation", fp)
+	if err != nil {
+		t.Fatalf("buildSingleSectionDoc failed: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("expected non-nil doc for federation section")
+	}
+
+	// Unmarshal and verify fields.
+	var fedSettings opsettings.FederationSettings
+	if err := json.Unmarshal(doc, &fedSettings); err != nil {
+		t.Fatalf("failed to unmarshal federation doc: %v", err)
+	}
+
+	if fedSettings.Enabled == nil || !*fedSettings.Enabled {
+		t.Error("expected enabled to be true")
+	}
+	if len(fedSettings.TrustedIssuers) != 1 {
+		t.Errorf("expected 1 trusted issuer, got %d", len(fedSettings.TrustedIssuers))
+	}
+	if fedSettings.TrustedIssuers[0].IssuerURL != "https://hub-a.example.com" {
+		t.Errorf("expected issuer_url 'https://hub-a.example.com', got %q", fedSettings.TrustedIssuers[0].IssuerURL)
+	}
+	if len(fedSettings.Algorithms) != 1 || fedSettings.Algorithms[0] != "RS256" {
+		t.Errorf("expected algorithms [RS256], got %v", fedSettings.Algorithms)
+	}
+	if fedSettings.RefreshInterval != "1h" {
+		t.Errorf("expected refresh_interval '1h', got %q", fedSettings.RefreshInterval)
+	}
+}
+
+func TestBuildSingleSectionDoc_Federation_Nil(t *testing.T) {
+	req := &ServerConfigUpdateRequest{
+		Federation: nil,
+	}
+	fp := newFieldPresenceFromJSON(t, `{}`)
+
+	doc, err := buildSingleSectionDoc(req, "federation", fp)
+	if err != nil {
+		t.Fatalf("buildSingleSectionDoc failed: %v", err)
+	}
+
+	// When Federation is nil, we still get a doc (empty FederationSettings).
+	if doc == nil {
+		t.Fatal("expected non-nil doc for federation section even with nil federation field")
+	}
+	var fedSettings opsettings.FederationSettings
+	if err := json.Unmarshal(doc, &fedSettings); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if fedSettings.Enabled != nil {
+		t.Error("expected nil enabled when federation request field is nil")
+	}
+}
+
+// --- Deliverable 10d: Validation rejection ---
+
+func TestConvertFederationSettingsToConfig(t *testing.T) {
+	enabled := true
+	fs := opsettings.FederationSettings{
+		Enabled: &enabled,
+		TrustedIssuers: []config.V1TrustedIssuerConfig{
+			{
+				IssuerURL:        "https://hub-a.example.com",
+				ExpectedAudience: "https://hub-b.example.com",
+				IssuerType:       "hub",
+				AllowedProjects:  []string{"proj1"},
+				AllowedRootUsers: []string{"user@example.com"},
+				DefaultScopes:    []string{"agent:status:update"},
+			},
+		},
+		Algorithms:       []string{"RS256", "ES256"},
+		RefreshInterval:  "1h",
+		DebounceInterval: "5s",
+	}
+
+	fc := convertFederationSettingsToConfig(fs)
+
+	if !fc.Enabled {
+		t.Error("expected Enabled true")
+	}
+	if len(fc.TrustedIssuers) != 1 {
+		t.Fatalf("expected 1 issuer, got %d", len(fc.TrustedIssuers))
+	}
+	ti := fc.TrustedIssuers[0]
+	if ti.IssuerURL != "https://hub-a.example.com" {
+		t.Errorf("expected IssuerURL 'https://hub-a.example.com', got %q", ti.IssuerURL)
+	}
+	if ti.IssuerType != "hub" {
+		t.Errorf("expected IssuerType 'hub', got %q", ti.IssuerType)
+	}
+	if len(ti.AllowedProjects) != 1 || ti.AllowedProjects[0] != "proj1" {
+		t.Errorf("unexpected AllowedProjects: %v", ti.AllowedProjects)
+	}
+	if len(fc.Algorithms) != 2 {
+		t.Errorf("expected 2 algorithms, got %d", len(fc.Algorithms))
+	}
+	if fc.Cache.RefreshInterval != 1*time.Hour {
+		t.Errorf("expected RefreshInterval 1h, got %v", fc.Cache.RefreshInterval)
+	}
+	if fc.Cache.DebounceInterval != 5*time.Second {
+		t.Errorf("expected DebounceInterval 5s, got %v", fc.Cache.DebounceInterval)
+	}
+}
+
+func TestConvertFederationSettingsToConfig_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		fs   opsettings.FederationSettings
+		want string // substring expected in one of the validation errors
+	}{
+		{
+			name: "enabled with no issuers",
+			fs: opsettings.FederationSettings{
+				Enabled: boolPtr(true),
+			},
+			want: "no trusted_issuers",
+		},
+		{
+			name: "missing issuer_url",
+			fs: opsettings.FederationSettings{
+				Enabled: boolPtr(true),
+				TrustedIssuers: []config.V1TrustedIssuerConfig{
+					{IssuerURL: ""},
+				},
+			},
+			want: "issuer_url is required",
+		},
+		{
+			name: "invalid algorithm",
+			fs: opsettings.FederationSettings{
+				Enabled: boolPtr(true),
+				TrustedIssuers: []config.V1TrustedIssuerConfig{
+					{IssuerURL: "https://hub.example.com"},
+				},
+				Algorithms: []string{"HS256"},
+			},
+			want: "unsupported algorithm",
+		},
+		{
+			name: "duplicate issuers",
+			fs: opsettings.FederationSettings{
+				Enabled: boolPtr(true),
+				TrustedIssuers: []config.V1TrustedIssuerConfig{
+					{IssuerURL: "https://hub.example.com"},
+					{IssuerURL: "https://hub.example.com"},
+				},
+			},
+			want: "duplicate issuer_url",
+		},
+		{
+			name: "hub-only fields on service_account issuer",
+			fs: opsettings.FederationSettings{
+				Enabled: boolPtr(true),
+				TrustedIssuers: []config.V1TrustedIssuerConfig{
+					{
+						IssuerURL:       "https://accounts.google.com",
+						IssuerType:      "service_account",
+						AllowedProjects: []string{"proj1"},
+					},
+				},
+			},
+			want: "allowed_projects is not applicable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fc := convertFederationSettingsToConfig(tt.fs)
+			errs := fc.Validate()
+			if len(errs) == 0 {
+				t.Fatal("expected validation errors, got none")
+			}
+			found := false
+			for _, e := range errs {
+				if contains([]string{e.Error()}, "") || len(e.Error()) > 0 {
+					if containsSubstring(e.Error(), tt.want) {
+						found = true
+						break
+					}
+				}
+			}
+			if !found {
+				t.Errorf("expected error containing %q, got %v", tt.want, errs)
+			}
+		})
+	}
+}
+
+// --- Deliverable 10e: Middleware loads from atomic pointer ---
+
+func TestMiddleware_LoadsFromAtomicPointer(t *testing.T) {
+	// Start with no authenticator (nil pointer value).
+	var fedAuth atomic.Pointer[FederationAuthenticator]
+
+	cfg := AuthConfig{
+		Mode:           "production",
+		FederationAuth: &fedAuth,
+		Debug:          true,
+		Logger:         slog.Default(),
+	}
+
+	middleware := UnifiedAuthMiddleware(cfg)
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// With nil authenticator, sending a federation token should get 401.
+	req := httptest.NewRequest("GET", "/api/v1/agents", nil)
+	req.Header.Set("X-Scion-Federation-Token", "some-token")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 when authenticator is nil, got %d", rr.Code)
+	}
+
+	var body map[string]interface{}
+	json.Unmarshal(rr.Body.Bytes(), &body)
+	errData, _ := body["error"].(map[string]interface{})
+	if msg, ok := errData["message"].(string); ok {
+		if msg != "federation authentication is not configured" {
+			t.Errorf("unexpected error message: %s", msg)
+		}
+	}
+}
+
+func TestMiddleware_NilFederationAuthField(t *testing.T) {
+	// When FederationAuth field itself is nil (not just the pointer value).
+	cfg := AuthConfig{
+		Mode:           "production",
+		FederationAuth: nil,
+		Debug:          true,
+		Logger:         slog.Default(),
+	}
+
+	middleware := UnifiedAuthMiddleware(cfg)
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Sending a federation token should get 401.
+	req := httptest.NewRequest("GET", "/api/v1/agents", nil)
+	req.Header.Set("X-Scion-Federation-Token", "some-token")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 when FederationAuth is nil, got %d", rr.Code)
+	}
+}
+
+// --- Helpers ---
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (substr == "" || findSubstring(s, substr))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// newFieldPresenceFromJSON creates a fieldPresence from raw JSON for testing.
+func newFieldPresenceFromJSON(t *testing.T, rawJSON string) *fieldPresence {
+	t.Helper()
+	fp, err := parseFieldPresence([]byte(rawJSON))
+	if err != nil {
+		t.Fatalf("failed to parse field presence JSON: %v", err)
+	}
+	return fp
+}

--- a/pkg/hub/federation_hotreload_test.go
+++ b/pkg/hub/federation_hotreload_test.go
@@ -19,6 +19,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -386,11 +388,9 @@ func TestConvertFederationSettingsToConfig_ValidationErrors(t *testing.T) {
 			}
 			found := false
 			for _, e := range errs {
-				if contains([]string{e.Error()}, "") || len(e.Error()) > 0 {
-					if containsSubstring(e.Error(), tt.want) {
-						found = true
-						break
-					}
+				if strings.Contains(e.Error(), tt.want) {
+					found = true
+					break
 				}
 			}
 			if !found {
@@ -463,23 +463,131 @@ func TestMiddleware_NilFederationAuthField(t *testing.T) {
 	}
 }
 
+// --- Deliverable R1-fix: DB-mode PUT round-trip integration test ---
+
+// TestExtractKoanfKeys_FederationRoundTrip verifies the full DB-mode path:
+// PUT request with federation config → extractKoanfKeysFromRequest →
+// ClassifyKeys → buildSectionDocsFromRequest → federation section doc produced.
+// This is the gap that masked R1: federation config was silently dropped
+// because extractKoanfKeysFromRequest emitted no federation koanf keys.
+func TestExtractKoanfKeys_FederationRoundTrip(t *testing.T) {
+	enabled := true
+	req := &ServerConfigUpdateRequest{
+		Federation: &config.V1FederationConfig{
+			Enabled: &enabled,
+			TrustedIssuers: []config.V1TrustedIssuerConfig{
+				{
+					IssuerURL:        "https://hub-a.example.com",
+					ExpectedAudience: "https://hub-b.example.com",
+					IssuerType:       "hub",
+				},
+			},
+			Algorithms:      []string{"RS256"},
+			RefreshInterval: "1h",
+		},
+	}
+
+	// Step 1: Extract koanf keys — this was the bug (no federation keys emitted).
+	keys := extractKoanfKeysFromRequest(req)
+
+	// Verify at least one server.federation.* key is present.
+	hasFedKey := false
+	for _, k := range keys {
+		if strings.HasPrefix(k, "server.federation.") {
+			hasFedKey = true
+			break
+		}
+	}
+	if !hasFedKey {
+		t.Fatalf("extractKoanfKeysFromRequest emitted no server.federation.* keys; got %v", keys)
+	}
+
+	// Step 2: Classify keys — federation keys should land in layer1BySec["federation"].
+	layer1BySec, layer0Keys, _ := opsettings.ClassifyKeys(keys)
+
+	if len(layer0Keys) > 0 {
+		t.Errorf("unexpected Layer-0 keys: %v", layer0Keys)
+	}
+
+	fedKeys, ok := layer1BySec["federation"]
+	if !ok || len(fedKeys) == 0 {
+		t.Fatalf("ClassifyKeys did not produce a 'federation' entry; layer1BySec = %v", layer1BySec)
+	}
+
+	// Step 3: Build section docs — the federation section doc should be produced.
+	rawBody := []byte(`{
+		"federation": {
+			"enabled": true,
+			"trusted_issuers": [{"issuer_url": "https://hub-a.example.com", "expected_audience": "https://hub-b.example.com", "issuer_type": "hub"}],
+			"algorithms": ["RS256"],
+			"refresh_interval": "1h"
+		}
+	}`)
+	sectionDocs, err := buildSectionDocsFromRequest(req, layer1BySec, rawBody)
+	if err != nil {
+		t.Fatalf("buildSectionDocsFromRequest failed: %v", err)
+	}
+
+	fedDoc, ok := sectionDocs["federation"]
+	if !ok {
+		t.Fatalf("federation section doc not produced; sectionDocs keys = %v", mapKeys2(sectionDocs))
+	}
+
+	// Step 4: Verify the section doc contents — federation config is NOT silently dropped.
+	var fedSettings opsettings.FederationSettings
+	if err := json.Unmarshal(fedDoc, &fedSettings); err != nil {
+		t.Fatalf("failed to unmarshal federation section doc: %v", err)
+	}
+
+	if fedSettings.Enabled == nil || !*fedSettings.Enabled {
+		t.Error("expected federation enabled=true in section doc")
+	}
+	if len(fedSettings.TrustedIssuers) != 1 {
+		t.Errorf("expected 1 trusted issuer in section doc, got %d", len(fedSettings.TrustedIssuers))
+	}
+	if len(fedSettings.Algorithms) != 1 || fedSettings.Algorithms[0] != "RS256" {
+		t.Errorf("expected algorithms [RS256] in section doc, got %v", fedSettings.Algorithms)
+	}
+	if fedSettings.RefreshInterval != "1h" {
+		t.Errorf("expected refresh_interval '1h' in section doc, got %q", fedSettings.RefreshInterval)
+	}
+
+	// Step 5: Validate the section doc via convertFederationSettingsToConfig → Validate().
+	fedCfg := convertFederationSettingsToConfig(fedSettings)
+	if errs := fedCfg.Validate(); len(errs) > 0 {
+		t.Errorf("unexpected validation errors for federation section doc: %v", errs)
+	}
+}
+
+// TestExtractKoanfKeys_FederationNil verifies that when Federation is nil,
+// no server.federation.* keys are emitted and no federation section doc is produced.
+func TestExtractKoanfKeys_FederationNil(t *testing.T) {
+	req := &ServerConfigUpdateRequest{
+		Federation: nil,
+	}
+
+	keys := extractKoanfKeysFromRequest(req)
+	for _, k := range keys {
+		if strings.HasPrefix(k, "server.federation.") {
+			t.Errorf("unexpected federation key %q when Federation is nil", k)
+		}
+	}
+}
+
+// mapKeys2 is a test helper that returns sorted keys from a map[string]json.RawMessage.
+func mapKeys2(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 // --- Helpers ---
 
 func boolPtr(b bool) *bool {
 	return &b
-}
-
-func containsSubstring(s, substr string) bool {
-	return len(s) >= len(substr) && (substr == "" || findSubstring(s, substr))
-}
-
-func findSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }
 
 // newFieldPresenceFromJSON creates a fieldPresence from raw JSON for testing.

--- a/pkg/hub/federation_hotreload_test.go
+++ b/pkg/hub/federation_hotreload_test.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -144,11 +143,9 @@ func TestApplySnapshot_FederationNilKeepsExisting(t *testing.T) {
 // --- Deliverable 10b: Concurrent access ---
 
 func TestFederationAuth_ConcurrentAccess(t *testing.T) {
-	var fedAuth atomic.Pointer[FederationAuthenticator]
-
 	// Initial value.
 	auth1 := &FederationAuthenticator{}
-	fedAuth.Store(auth1)
+	fedAuth := newFedAuthPointer(auth1)
 
 	const numReaders = 10
 	const numIterations = 1000
@@ -404,11 +401,11 @@ func TestConvertFederationSettingsToConfig_ValidationErrors(t *testing.T) {
 
 func TestMiddleware_LoadsFromAtomicPointer(t *testing.T) {
 	// Start with no authenticator (nil pointer value).
-	var fedAuth atomic.Pointer[FederationAuthenticator]
+	fedAuth := newFedAuthPointer(nil)
 
 	cfg := AuthConfig{
 		Mode:           "production",
-		FederationAuth: &fedAuth,
+		FederationAuth: fedAuth,
 		Debug:          true,
 		Logger:         slog.Default(),
 	}

--- a/pkg/hub/federation_hotreload_test.go
+++ b/pkg/hub/federation_hotreload_test.go
@@ -121,22 +121,84 @@ func TestApplySnapshot_FederationValidationFailure(t *testing.T) {
 	}
 }
 
-func TestApplySnapshot_FederationNilKeepsExisting(t *testing.T) {
+func TestApplySnapshot_FederationNilClearsAuthenticator(t *testing.T) {
 	// Create a minimal Server with an existing authenticator.
 	srv := &Server{}
 	initialAuth := &FederationAuthenticator{}
 	srv.federationAuth.Store(initialAuth)
 
-	// Apply snapshot without federation config.
+	// Apply snapshot without federation config — should clear the authenticator.
 	snap := Layer1Snapshot{
 		FederationConfig: nil,
 	}
 	ApplySnapshot(srv, snap)
 
-	// Verify the existing authenticator is preserved (no-op on nil).
+	// Verify the authenticator is cleared (nil) so the middleware returns 401.
 	currentAuth := srv.federationAuth.Load()
-	if currentAuth != initialAuth {
-		t.Error("expected existing authenticator to be preserved when FederationConfig is nil")
+	if currentAuth != nil {
+		t.Error("expected authenticator to be cleared (nil) when FederationConfig is nil")
+	}
+}
+
+func TestApplySnapshot_FederationDisabledClearsAuthenticator(t *testing.T) {
+	// Create a minimal Server with an existing authenticator.
+	srv := &Server{}
+	srv.config.Mode = "dev"
+	srv.config.Workstation = true
+	srv.config.OIDCConfig.IssuerURL = "https://hub.example.com"
+	srv.federationClient = &http.Client{Timeout: 5 * time.Second}
+
+	// Start with federation enabled.
+	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"keys":[]}`))
+	}))
+	defer jwksServer.Close()
+
+	enabledCfg := config.FederationConfig{
+		Enabled: true,
+		TrustedIssuers: []config.TrustedIssuerConfig{
+			{
+				IssuerURL:        jwksServer.URL,
+				JWKSURL:          jwksServer.URL,
+				ExpectedAudience: "https://hub.example.com",
+			},
+		},
+	}
+	enableSnap := Layer1Snapshot{FederationConfig: &enabledCfg}
+	ApplySnapshot(srv, enableSnap)
+
+	// Verify federation is active.
+	if srv.federationAuth.Load() == nil {
+		t.Fatal("expected non-nil authenticator after enabling federation")
+	}
+
+	// Now disable federation via Enabled=false.
+	disabledCfg := config.FederationConfig{
+		Enabled: false,
+	}
+	disableSnap := Layer1Snapshot{FederationConfig: &disabledCfg}
+	result := ApplySnapshot(srv, disableSnap)
+
+	// Verify the authenticator is cleared.
+	if srv.federationAuth.Load() != nil {
+		t.Error("expected authenticator to be cleared (nil) when federation is disabled")
+	}
+
+	// Check "federation" is in the applied list.
+	applied, ok := result["applied"].([]string)
+	if !ok {
+		t.Fatalf("expected applied to be []string, got %T", result["applied"])
+	}
+	found := false
+	for _, a := range applied {
+		if a == "federation" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'federation' in applied list when disabling, got %v", applied)
 	}
 }
 
@@ -579,6 +641,50 @@ func mapKeys2(m map[string]json.RawMessage) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// --- Deliverable: Duration string validation ---
+
+func TestConvertFederationSettingsToConfig_InvalidDurations(t *testing.T) {
+	// convertFederationSettingsToConfig silently falls back to zero for invalid
+	// durations. The admin API must reject these before they reach ApplySnapshot.
+	tests := []struct {
+		name  string
+		ri    string // RefreshInterval
+		di    string // DebounceInterval
+		valid bool
+	}{
+		{"valid durations", "1h", "5s", true},
+		{"valid duration with minutes", "30m", "500ms", true},
+		{"empty durations (optional)", "", "", true},
+		{"invalid refresh_interval", "1hour", "5s", false},
+		{"invalid debounce_interval", "5s", "five_seconds", false},
+		{"both invalid", "1hour", "five_seconds", false},
+		{"number without unit", "30", "5", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var validationErrors []string
+			if tt.ri != "" {
+				if _, err := time.ParseDuration(tt.ri); err != nil {
+					validationErrors = append(validationErrors, err.Error())
+				}
+			}
+			if tt.di != "" {
+				if _, err := time.ParseDuration(tt.di); err != nil {
+					validationErrors = append(validationErrors, err.Error())
+				}
+			}
+
+			if tt.valid && len(validationErrors) > 0 {
+				t.Errorf("expected valid, got errors: %v", validationErrors)
+			}
+			if !tt.valid && len(validationErrors) == 0 {
+				t.Error("expected validation errors for invalid durations, got none")
+			}
+		})
+	}
 }
 
 // --- Helpers ---

--- a/pkg/hub/federation_hotreload_test.go
+++ b/pkg/hub/federation_hotreload_test.go
@@ -42,7 +42,7 @@ func TestApplySnapshot_FederationHotReload(t *testing.T) {
 	// Create a JWKS test server for the trusted issuer.
 	jwksServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"keys":[]}`))
+		_, _ = w.Write([]byte(`{"keys":[]}`))
 	}))
 	defer jwksServer.Close()
 
@@ -426,7 +426,7 @@ func TestMiddleware_LoadsFromAtomicPointer(t *testing.T) {
 	}
 
 	var body map[string]interface{}
-	json.Unmarshal(rr.Body.Bytes(), &body)
+	_ = json.Unmarshal(rr.Body.Bytes(), &body)
 	errData, _ := body["error"].(map[string]interface{})
 	if msg, ok := errData["message"].(string); ok {
 		if msg != "federation authentication is not configured" {

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -857,7 +857,17 @@ func ApplySnapshot(s *Server, snap Layer1Snapshot) map[string]interface{} {
 
 	// Federation (outside mutex — atomic.Pointer swap is lock-free,
 	// and NewFederationAuthenticator may do network I/O)
-	if snap.FederationConfig != nil {
+	//
+	// When federation is disabled (nil config or Enabled=false), clear the
+	// authenticator so the middleware returns 401. This ensures disabling
+	// federation at runtime actually takes effect.
+	if snap.FederationConfig == nil || !snap.FederationConfig.Enabled {
+		s.federationAuth.Store(nil)
+		if snap.FederationConfig != nil {
+			slog.Info("Federation disabled via config, authenticator cleared")
+		}
+		applied = append(applied, "federation")
+	} else {
 		if errs := snap.FederationConfig.Validate(); len(errs) > 0 {
 			slog.Error("Federation config validation failed during apply, keeping old config",
 				"errors", fmt.Sprintf("%v", errs))

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -644,8 +644,12 @@ func buildSnapshotFromKoanf(k *koanf.Koanf) Layer1Snapshot {
 		}
 		// TrustedIssuers: unmarshal from the koanf slice
 		if raw := k.Get("server.federation.trusted_issuers"); raw != nil {
-			data, _ := json.Marshal(raw)
-			json.Unmarshal(data, &fedCfg.TrustedIssuers)
+			data, err := json.Marshal(raw)
+			if err != nil {
+				slog.Warn("federation: failed to marshal trusted_issuers from koanf", "error", err)
+			} else if err := json.Unmarshal(data, &fedCfg.TrustedIssuers); err != nil {
+				slog.Warn("federation: failed to unmarshal trusted_issuers", "error", err)
+			}
 		}
 		if algs := k.Strings("server.federation.algorithms"); len(algs) > 0 {
 			fedCfg.Algorithms = algs

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -27,8 +27,8 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/config/opsettings"
 	"github.com/GoogleCloudPlatform/scion/pkg/secret"
-	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
 	"github.com/knadh/koanf/v2"
 )
 

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/config/opsettings"
 	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/knadh/koanf/v2"
 )
@@ -853,6 +854,47 @@ func ApplySnapshot(s *Server, snap Layer1Snapshot) map[string]interface{} {
 	// must never touch MaintenanceState (restoring pre-refactor behavior).
 	// In postgres mode, the caller uses ApplyMaintenanceFromSnapshot
 	// separately, which respects env > DB precedence (§3.4/§3.8).
+
+	// Federation (outside mutex — atomic.Pointer swap is lock-free,
+	// and NewFederationAuthenticator may do network I/O)
+	if snap.FederationConfig != nil {
+		if errs := snap.FederationConfig.Validate(); len(errs) > 0 {
+			slog.Error("Federation config validation failed during apply, keeping old config",
+				"errors", fmt.Sprintf("%v", errs))
+		} else {
+			// Derive federation mode using the same pattern as New().
+			federationMode := s.config.Mode
+			if federationMode == "" {
+				if s.config.Workstation {
+					federationMode = "workstation"
+				} else {
+					federationMode = "hosted"
+				}
+			}
+			// Use the OIDC issuer URL as the default expected audience.
+			federationAudience := s.oidcIssuerURL
+			if federationAudience == "" {
+				federationAudience = s.config.OIDCConfig.IssuerURL
+			}
+			newAuth, err := NewFederationAuthenticator(
+				*snap.FederationConfig,
+				federationAudience,
+				s.federationClient,
+				federationMode,
+				logging.Subsystem("hub.federation"),
+			)
+			if err != nil {
+				slog.Error("Federation authenticator rebuild failed, keeping old config",
+					"error", err)
+			} else {
+				s.federationAuth.Store(newAuth)
+				slog.Info("Federation authenticator hot-reloaded",
+					"trusted_issuers", len(snap.FederationConfig.TrustedIssuers),
+					"enabled", snap.FederationConfig.Enabled)
+				applied = append(applied, "federation")
+			}
+		}
+	}
 
 	// Settings that require restart
 	needsRestart := []string{

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -114,6 +114,9 @@ type Layer1Snapshot struct {
 	// Notifications
 	NotificationChannels []config.V1NotificationChannelConfig
 
+	// Federation
+	FederationConfig *config.FederationConfig // nil when federation section not present
+
 	// EnvOverrides lists Layer-1 koanf keys that are overridden by env vars
 	// on this node — used for drift warnings.
 	EnvOverrides []string
@@ -634,6 +637,28 @@ func buildSnapshotFromKoanf(k *koanf.Koanf) Layer1Snapshot {
 		}
 	}
 
+	// Federation
+	if k.Exists("server.federation.enabled") || k.Exists("server.federation.trusted_issuers") {
+		fedCfg := config.FederationConfig{
+			Enabled: k.Bool("server.federation.enabled"),
+		}
+		// TrustedIssuers: unmarshal from the koanf slice
+		if raw := k.Get("server.federation.trusted_issuers"); raw != nil {
+			data, _ := json.Marshal(raw)
+			json.Unmarshal(data, &fedCfg.TrustedIssuers)
+		}
+		if algs := k.Strings("server.federation.algorithms"); len(algs) > 0 {
+			fedCfg.Algorithms = algs
+		}
+		if ri := k.String("server.federation.refresh_interval"); ri != "" {
+			fedCfg.Cache.RefreshInterval, _ = time.ParseDuration(ri)
+		}
+		if di := k.String("server.federation.debounce_interval"); di != "" {
+			fedCfg.Cache.DebounceInterval, _ = time.ParseDuration(di)
+		}
+		snap.FederationConfig = &fedCfg
+	}
+
 	return snap
 }
 
@@ -668,6 +693,11 @@ func BuildLayer1SnapshotFromFile(gc *config.GlobalConfig) Layer1Snapshot {
 	snap.GitHubWebhooksEnabled = gc.GitHubApp.WebhooksEnabled
 	snap.GitHubInstallationURL = gc.GitHubApp.InstallationURL
 	snap.GitHubPrivateKeyPath = gc.GitHubApp.PrivateKeyPath
+
+	// Federation — read from GlobalConfig
+	if gc.Federation.Enabled || len(gc.Federation.TrustedIssuers) > 0 {
+		snap.FederationConfig = &gc.Federation
+	}
 
 	return snap
 }

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -655,10 +655,14 @@ func buildSnapshotFromKoanf(k *koanf.Koanf) Layer1Snapshot {
 			fedCfg.Algorithms = algs
 		}
 		if ri := k.String("server.federation.refresh_interval"); ri != "" {
-			fedCfg.Cache.RefreshInterval, _ = time.ParseDuration(ri)
+			if d, err := time.ParseDuration(ri); err == nil {
+				fedCfg.Cache.RefreshInterval = d
+			}
 		}
 		if di := k.String("server.federation.debounce_interval"); di != "" {
-			fedCfg.Cache.DebounceInterval, _ = time.ParseDuration(di)
+			if d, err := time.ParseDuration(di); err == nil {
+				fedCfg.Cache.DebounceInterval = d
+			}
 		}
 		snap.FederationConfig = &fedCfg
 	}

--- a/pkg/hub/operational_settings_test.go
+++ b/pkg/hub/operational_settings_test.go
@@ -865,3 +865,90 @@ func TestSnapshot_MixedSource_DBAndFile(t *testing.T) {
 		t.Errorf("SoftDeleteRetention: want '30d' (from file), got %q", snap.SoftDeleteRetention)
 	}
 }
+
+func TestSnapshot_FederationFromDB(t *testing.T) {
+	fakeStore := newFakeHubSettingStore()
+	fakeStore.seed("federation", json.RawMessage(`{
+		"enabled": true,
+		"trusted_issuers": [
+			{
+				"issuer_url": "https://hub-a.example.com",
+				"jwks_url": "https://hub-a.example.com/.well-known/jwks.json",
+				"expected_audience": "https://hub-b.example.com",
+				"allowed_projects": ["proj1"],
+				"issuer_type": "hub",
+				"default_scopes": ["agent:status:update"]
+			}
+		],
+		"algorithms": ["RS256"],
+		"refresh_interval": "1h",
+		"debounce_interval": "5s"
+	}`))
+
+	ops := NewOperationalSettings(fakeStore, emptyKoanf(), emptyKoanf())
+	_, _ = ops.Refresh(context.Background())
+
+	snap := ops.Snapshot()
+	if snap.FederationConfig == nil {
+		t.Fatal("want non-nil FederationConfig")
+	}
+	if !snap.FederationConfig.Enabled {
+		t.Error("want Enabled true")
+	}
+	if len(snap.FederationConfig.TrustedIssuers) != 1 {
+		t.Fatalf("want 1 issuer, got %d", len(snap.FederationConfig.TrustedIssuers))
+	}
+	iss := snap.FederationConfig.TrustedIssuers[0]
+	if iss.IssuerURL != "https://hub-a.example.com" {
+		t.Errorf("IssuerURL: want https://hub-a.example.com, got %s", iss.IssuerURL)
+	}
+	if iss.IssuerType != "hub" {
+		t.Errorf("IssuerType: want hub, got %s", iss.IssuerType)
+	}
+	if len(iss.AllowedProjects) != 1 || iss.AllowedProjects[0] != "proj1" {
+		t.Errorf("AllowedProjects: want [proj1], got %v", iss.AllowedProjects)
+	}
+	if len(snap.FederationConfig.Algorithms) != 1 || snap.FederationConfig.Algorithms[0] != "RS256" {
+		t.Errorf("Algorithms: want [RS256], got %v", snap.FederationConfig.Algorithms)
+	}
+	if snap.FederationConfig.Cache.RefreshInterval.String() != "1h0m0s" {
+		t.Errorf("RefreshInterval: want 1h0m0s, got %s", snap.FederationConfig.Cache.RefreshInterval)
+	}
+	if snap.FederationConfig.Cache.DebounceInterval.String() != "5s" {
+		t.Errorf("DebounceInterval: want 5s, got %s", snap.FederationConfig.Cache.DebounceInterval)
+	}
+}
+
+func TestBuildLayer1SnapshotFromFile_Federation(t *testing.T) {
+	gc := &config.GlobalConfig{
+		Federation: config.FederationConfig{
+			Enabled: true,
+			TrustedIssuers: []config.TrustedIssuerConfig{
+				{
+					IssuerURL:  "https://hub-a.example.com",
+					IssuerType: "hub",
+				},
+			},
+			Algorithms: []string{"RS256"},
+		},
+	}
+
+	snap := BuildLayer1SnapshotFromFile(gc)
+	if snap.FederationConfig == nil {
+		t.Fatal("want non-nil FederationConfig")
+	}
+	if !snap.FederationConfig.Enabled {
+		t.Error("want Enabled true")
+	}
+	if len(snap.FederationConfig.TrustedIssuers) != 1 {
+		t.Fatalf("want 1 issuer, got %d", len(snap.FederationConfig.TrustedIssuers))
+	}
+}
+
+func TestBuildLayer1SnapshotFromFile_NoFederation(t *testing.T) {
+	gc := &config.GlobalConfig{}
+	snap := BuildLayer1SnapshotFromFile(gc)
+	if snap.FederationConfig != nil {
+		t.Error("want nil FederationConfig when federation is disabled and no issuers")
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -782,6 +782,10 @@ type Server struct {
 	// Shared HTTP client for federation proxy calls (no redirect following).
 	federationClient *http.Client
 
+	// federationAuth holds the current FederationAuthenticator.
+	// Swapped atomically by ApplySnapshot; read by the auth middleware.
+	federationAuth atomic.Pointer[FederationAuthenticator]
+
 	imageBuildActive atomic.Bool
 	imagePullActive  atomic.Bool
 
@@ -1148,7 +1152,6 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 	}
 
 	// Initialize federation authenticator if enabled.
-	var federationAuth *FederationAuthenticator
 	if cfg.Federation.Enabled {
 		// Derive mode for HTTPS enforcement.
 		federationMode := cfg.Mode
@@ -1165,8 +1168,7 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 			federationAudience = cfg.OIDCConfig.IssuerURL
 		}
 
-		var err error
-		federationAuth, err = NewFederationAuthenticator(
+		fa, err := NewFederationAuthenticator(
 			cfg.Federation,
 			federationAudience,
 			srv.federationClient,
@@ -1176,6 +1178,7 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 		if err != nil {
 			return nil, fmt.Errorf("federation authenticator init: %w", err)
 		}
+		srv.federationAuth.Store(fa)
 		slog.Info("Federation authenticator enabled",
 			"trusted_issuers", len(cfg.Federation.TrustedIssuers))
 	}
@@ -1191,7 +1194,7 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 		UATSvc:                  srv.uatService,
 		TrustedProxies:          cfg.TrustedProxies,
 		ProxyAuthenticator:      cfg.ProxyAuth,
-		FederationAuthenticator: federationAuth,
+		FederationAuth: &srv.federationAuth,
 		AuthMode:                cfg.AuthMode,
 		Debug:                   cfg.Debug,
 		Logger:                  srv.authLog,

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1185,19 +1185,19 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 
 	// Build unified auth configuration
 	srv.authConfig = AuthConfig{
-		Mode:                    "production",
-		DevAuthEnabled:          cfg.DevAuthToken != "",
-		DevAuthToken:            cfg.DevAuthToken,
-		DevUserCfg:              cfg.DevUserConfig,
-		AgentTokenSvc:           srv.agentTokenService,
-		UserTokenSvc:            srv.userTokenService,
-		UATSvc:                  srv.uatService,
-		TrustedProxies:          cfg.TrustedProxies,
-		ProxyAuthenticator:      cfg.ProxyAuth,
-		FederationAuth: &srv.federationAuth,
-		AuthMode:                cfg.AuthMode,
-		Debug:                   cfg.Debug,
-		Logger:                  srv.authLog,
+		Mode:               "production",
+		DevAuthEnabled:     cfg.DevAuthToken != "",
+		DevAuthToken:       cfg.DevAuthToken,
+		DevUserCfg:         cfg.DevUserConfig,
+		AgentTokenSvc:      srv.agentTokenService,
+		UserTokenSvc:       srv.userTokenService,
+		UATSvc:             srv.uatService,
+		TrustedProxies:     cfg.TrustedProxies,
+		ProxyAuthenticator: cfg.ProxyAuth,
+		FederationAuth:     &srv.federationAuth,
+		AuthMode:           cfg.AuthMode,
+		Debug:              cfg.Debug,
+		Logger:             srv.authLog,
 	}
 	// Wire the proxy user provisioner (wraps provisionUser with 60s cache)
 	if cfg.ProxyAuth != nil {

--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -153,6 +153,7 @@ const ROUTES: RouteConfig[] = [
   { pattern: /^\/admin\/integrations$/, tag: 'scion-page-admin-integrations', load: () => import('../components/pages/admin-integrations.js') },
   { pattern: /^\/admin\/integrations\/[^/]+$/, tag: 'scion-page-admin-integrations', load: () => import('../components/pages/admin-integrations.js') },
   { pattern: /^\/admin\/server-config$/, tag: 'scion-page-admin-server-config', load: () => import('../components/pages/admin-server-config.js') },
+  { pattern: /^\/admin\/federation$/, tag: 'scion-page-admin-federation', load: () => import('../components/pages/admin-federation.js') },
   { pattern: /^\/settings$/, tag: 'scion-page-settings', load: () => import('../components/pages/settings.js') },
   { pattern: /^\/settings\/templates\/[^/]+$/, tag: 'scion-page-template-detail', load: () => import('../components/pages/template-detail.js') },
   { pattern: /^\/settings\/harness-configs\/[^/]+$/, tag: 'scion-page-harness-config-detail', load: () => import('../components/pages/harness-config-detail.js') },
@@ -192,7 +193,7 @@ const PROFILE_ROUTES = new Set(['scion-page-profile-env-vars', 'scion-page-profi
 /**
  * Routes that require admin role. Non-admin users are redirected to dashboard.
  */
-const ADMIN_ROUTES = new Set(['scion-page-settings', 'scion-page-admin-scheduler', 'scion-page-admin-maintenance', 'scion-page-admin-users', 'scion-page-admin-groups', 'scion-page-admin-group-detail', 'scion-page-admin-server-config', 'scion-page-admin-integrations', 'scion-page-admin-skill-registries', 'scion-page-admin-skill-registry-detail', 'scion-page-diagnostics', 'scion-page-health-dashboard']);
+const ADMIN_ROUTES = new Set(['scion-page-settings', 'scion-page-admin-scheduler', 'scion-page-admin-maintenance', 'scion-page-admin-users', 'scion-page-admin-groups', 'scion-page-admin-group-detail', 'scion-page-admin-server-config', 'scion-page-admin-federation', 'scion-page-admin-integrations', 'scion-page-admin-skill-registries', 'scion-page-admin-skill-registry-detail', 'scion-page-diagnostics', 'scion-page-health-dashboard']);
 
 /**
  * Initialize the client-side application

--- a/web/src/components/app-shell.ts
+++ b/web/src/components/app-shell.ts
@@ -49,6 +49,7 @@ const PAGE_TITLES: Record<string, string> = {
   '/admin/users': 'Users',
   '/admin/groups': 'Groups',
   '/admin/server-config': 'Server Config',
+  '/admin/federation': 'Federation',
   '/admin/integrations': 'Integrations',
   '/metrics': 'Metrics',
   '/admin/skill-registries': 'Skill Registries',

--- a/web/src/components/pages/admin-federation.ts
+++ b/web/src/components/pages/admin-federation.ts
@@ -68,6 +68,12 @@ export class ScionPageAdminFederation extends LitElement {
   @state() private deleteDialogOpen = false;
   @state() private deletingIndex = -1;
 
+  // URL validation state
+  @state() private issuerUrlError: string | null = null;
+
+  // Timer cleanup
+  private successMessageTimer: ReturnType<typeof setTimeout> | null = null;
+
   static override styles = css`
     :host {
       display: block;
@@ -312,6 +318,22 @@ export class ScionPageAdminFederation extends LitElement {
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+
+    .form-field.mb-1 {
+      margin-bottom: 1rem;
+    }
+
+    .cache-section {
+      margin-top: 1rem;
+    }
+
+    .cache-section-label {
+      font-size: 0.8125rem;
+      font-weight: 500;
+      color: var(--scion-text, #1e293b);
+      display: block;
+      margin-bottom: 0.5rem;
+    }
   `;
 
   // --- Lifecycle ---
@@ -319,6 +341,14 @@ export class ScionPageAdminFederation extends LitElement {
   override connectedCallback(): void {
     super.connectedCallback();
     void this.loadData();
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this.successMessageTimer !== null) {
+      clearTimeout(this.successMessageTimer);
+      this.successMessageTimer = null;
+    }
   }
 
   // --- Data ---
@@ -367,14 +397,19 @@ export class ScionPageAdminFederation extends LitElement {
       });
       if (!res.ok) {
         this.error = await extractApiError(res, 'Failed to save federation config');
+        // Reload server state so local data matches after failed save
+        await this.loadData();
         return;
       }
       this.successMessage = 'Federation config saved successfully';
-      setTimeout(() => {
+      this.successMessageTimer = setTimeout(() => {
         this.successMessage = null;
+        this.successMessageTimer = null;
       }, 3000);
     } catch {
       this.error = 'Failed to connect to server';
+      // Reload server state so local data matches after failed save
+      await this.loadData();
     } finally {
       this.saving = false;
     }
@@ -413,12 +448,20 @@ export class ScionPageAdminFederation extends LitElement {
     this.dialogOpen = false;
     this.editingIssuer = null;
     this.editingIndex = -1;
+    this.issuerUrlError = null;
   }
 
   private handleSaveIssuer(): void {
     if (!this.editingIssuer || !this.editingIssuer.issuer_url.trim()) {
       return;
     }
+
+    const url = this.editingIssuer.issuer_url.trim();
+    if (!url.startsWith('https://') && !url.startsWith('http://')) {
+      this.issuerUrlError = 'Issuer URL must start with https:// or http://';
+      return;
+    }
+    this.issuerUrlError = null;
 
     // Build clean issuer config — strip empty optional fields
     const issuer: TrustedIssuerConfig = {
@@ -536,11 +579,11 @@ export class ScionPageAdminFederation extends LitElement {
   private renderGlobalSettings() {
     return html`
       <div class="section">
-        <h3 class="section-title" style="margin: 0 0 1rem 0; padding-bottom: 0.75rem; border-bottom: 1px solid var(--scion-border, #e2e8f0);">
-          Global Settings
-        </h3>
+        <div class="section-header">
+          <h3 class="section-title">Global Settings</h3>
+        </div>
 
-        <div class="form-field" style="margin-bottom: 1rem;">
+        <div class="form-field mb-1">
           <sl-switch
             ?checked=${this.enabled}
             @sl-change=${(e: Event) => {
@@ -572,8 +615,8 @@ export class ScionPageAdminFederation extends LitElement {
           </div>
         </div>
 
-        <div style="margin-top: 1rem;">
-          <label style="font-size: 0.8125rem; font-weight: 500; color: var(--scion-text, #1e293b); display: block; margin-bottom: 0.5rem;">
+        <div class="cache-section">
+          <label class="cache-section-label">
             JWKS Cache
           </label>
           <div class="cache-row">
@@ -694,14 +737,20 @@ export class ScionPageAdminFederation extends LitElement {
                     required
                     placeholder="https://hub-a.example.com"
                     .value=${this.editingIssuer.issuer_url}
+                    @sl-input=${() => {
+                      this.issuerUrlError = null;
+                    }}
                     @sl-change=${(e: Event) => {
                       this.editingIssuer = {
                         ...this.editingIssuer!,
                         issuer_url: (e.target as HTMLInputElement).value,
                       };
+                      this.issuerUrlError = null;
                     }}
                   ></sl-input>
-                  <span class="hint">The OIDC issuer URL of the trusted external hub or service.</span>
+                  ${this.issuerUrlError
+                    ? html`<span class="hint" style="color: var(--scion-error-text, #991b1b);">${this.issuerUrlError}</span>`
+                    : html`<span class="hint">The OIDC issuer URL of the trusted external hub or service.</span>`}
                 </div>
 
                 <div class="form-field">

--- a/web/src/components/pages/admin-federation.ts
+++ b/web/src/components/pages/admin-federation.ts
@@ -1,0 +1,940 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Federation Admin Page
+ *
+ * Manages federation authentication configuration: global settings
+ * (enable/disable, algorithms, cache intervals) and trusted issuers
+ * (add/edit/delete via dialog). Saves atomically via PUT to the
+ * admin server-config API.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+
+import { apiFetch, extractApiError } from '../../client/api.js';
+
+// ── Type definitions matching the Go API response ──
+
+interface TrustedIssuerConfig {
+  issuer_url: string;
+  jwks_url?: string;
+  expected_audience?: string;
+  allowed_projects?: string[];
+  allowed_root_users?: string[];
+  default_scopes?: string[];
+  issuer_type?: string;
+  default_role?: string;
+  allowed_emails?: string[];
+}
+
+@customElement('scion-page-admin-federation')
+export class ScionPageAdminFederation extends LitElement {
+  // --- State ---
+  @state() private loading = true;
+  @state() private error: string | null = null;
+  @state() private successMessage: string | null = null;
+  @state() private saving = false;
+
+  // Global federation settings
+  @state() private enabled = false;
+  @state() private algorithms: string[] = ['RS256'];
+  @state() private refreshInterval = '1h';
+  @state() private debounceInterval = '5s';
+
+  // Trusted issuers list
+  @state() private issuers: TrustedIssuerConfig[] = [];
+
+  // Add/Edit dialog state
+  @state() private dialogOpen = false;
+  @state() private editingIssuer: TrustedIssuerConfig | null = null;
+  @state() private editingIndex = -1; // -1 = new, >= 0 = editing existing
+
+  // Delete confirmation dialog state
+  @state() private deleteDialogOpen = false;
+  @state() private deletingIndex = -1;
+
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 0.5rem;
+    }
+
+    .header-left {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .header sl-icon {
+      color: var(--scion-primary, #3b82f6);
+      font-size: 1.5rem;
+    }
+
+    .header h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--scion-text, #1e293b);
+      margin: 0;
+    }
+
+    .header-description {
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.875rem;
+      margin: 0 0 1.5rem 0;
+    }
+
+    .section {
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius-lg, 0.75rem);
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .section-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin: 0 0 1rem 0;
+      padding-bottom: 0.75rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+    }
+
+    .section-title {
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+      margin: 0;
+    }
+
+    .form-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
+
+    @media (max-width: 768px) {
+      .form-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .form-field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .form-field.full-width {
+      grid-column: 1 / -1;
+    }
+
+    .form-field label {
+      font-size: 0.8125rem;
+      font-weight: 500;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .form-field .hint {
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .loading-container {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 4rem;
+    }
+
+    .status-message {
+      font-size: 0.875rem;
+      padding: 0.75rem 1rem;
+      border-radius: var(--scion-radius, 0.5rem);
+      margin-bottom: 1rem;
+    }
+
+    .status-message.success {
+      background: var(--scion-success-bg, #dcfce7);
+      color: var(--scion-success-text, #166534);
+      border: 1px solid var(--scion-success-border, #86efac);
+    }
+
+    .status-message.error {
+      background: var(--scion-error-bg, #fef2f2);
+      color: var(--scion-error-text, #991b1b);
+      border: 1px solid var(--scion-error-border, #fca5a5);
+    }
+
+    sl-input::part(base),
+    sl-select::part(combobox) {
+      font-size: 0.875rem;
+      border-color: var(--scion-border, #e2e8f0);
+      background: var(--scion-surface, #ffffff);
+    }
+
+    sl-input::part(input) {
+      color: var(--scion-text, #1e293b);
+    }
+
+    sl-switch {
+      --sl-color-primary-600: var(--scion-primary, #3b82f6);
+    }
+
+    /* Issuer table */
+    .issuer-table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    .issuer-table th {
+      text-align: left;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--scion-text-muted, #64748b);
+      text-transform: uppercase;
+      letter-spacing: 0.025em;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+    }
+
+    .issuer-table td {
+      padding: 0.75rem 1rem;
+      font-size: 0.875rem;
+      color: var(--scion-text, #1e293b);
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+    }
+
+    .issuer-table tr:last-child td {
+      border-bottom: none;
+    }
+
+    .issuer-actions {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 2rem;
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.875rem;
+    }
+
+    .empty-state sl-icon {
+      font-size: 2rem;
+      margin-bottom: 0.75rem;
+      display: block;
+    }
+
+    /* Dialog form */
+    .dialog-form {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .dialog-form .form-field label {
+      font-size: 0.8125rem;
+      font-weight: 500;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .dialog-form .form-field .hint {
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .dialog-footer {
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.5rem;
+      margin-top: 0.5rem;
+    }
+
+    .cache-row {
+      display: flex;
+      gap: 1rem;
+      align-items: flex-end;
+    }
+
+    .cache-row .form-field {
+      flex: 1;
+    }
+
+    @media (max-width: 640px) {
+      .cache-row {
+        flex-direction: column;
+      }
+    }
+
+    .conditional-section {
+      padding: 0.75rem;
+      margin-top: 0.25rem;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius, 0.5rem);
+      background: var(--scion-bg, #f8fafc);
+    }
+
+    .conditional-section-title {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--scion-text-muted, #64748b);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.75rem;
+    }
+
+    .issuer-url-cell {
+      max-width: 20rem;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  `;
+
+  // --- Lifecycle ---
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    void this.loadData();
+  }
+
+  // --- Data ---
+
+  private async loadData(): Promise<void> {
+    this.loading = true;
+    this.error = null;
+    try {
+      const res = await apiFetch('/api/v1/admin/server-config');
+      if (!res.ok) {
+        this.error = await extractApiError(res, 'Failed to load federation config');
+        return;
+      }
+      const data = await res.json();
+      if (data.federation) {
+        this.enabled = data.federation.enabled ?? false;
+        this.algorithms = data.federation.algorithms ?? ['RS256'];
+        this.refreshInterval = data.federation.refresh_interval ?? '1h';
+        this.debounceInterval = data.federation.debounce_interval ?? '5s';
+        this.issuers = data.federation.trusted_issuers ?? [];
+      }
+    } catch {
+      this.error = 'Failed to connect to server';
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private async save(): Promise<void> {
+    this.saving = true;
+    this.error = null;
+    this.successMessage = null;
+    try {
+      const res = await apiFetch('/api/v1/admin/server-config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          federation: {
+            enabled: this.enabled,
+            trusted_issuers: this.issuers,
+            algorithms: this.algorithms,
+            refresh_interval: this.refreshInterval,
+            debounce_interval: this.debounceInterval,
+          },
+        }),
+      });
+      if (!res.ok) {
+        this.error = await extractApiError(res, 'Failed to save federation config');
+        return;
+      }
+      this.successMessage = 'Federation config saved successfully';
+      setTimeout(() => {
+        this.successMessage = null;
+      }, 3000);
+    } catch {
+      this.error = 'Failed to connect to server';
+    } finally {
+      this.saving = false;
+    }
+  }
+
+  // --- Issuer CRUD ---
+
+  private openAddDialog(): void {
+    this.editingIssuer = {
+      issuer_url: '',
+      issuer_type: 'hub',
+    };
+    this.editingIndex = -1;
+    this.dialogOpen = true;
+  }
+
+  private openEditDialog(index: number): void {
+    const issuer = this.issuers[index];
+    // Deep-copy to avoid mutating the original during editing
+    this.editingIssuer = {
+      issuer_url: issuer.issuer_url,
+      jwks_url: issuer.jwks_url ?? '',
+      expected_audience: issuer.expected_audience ?? '',
+      allowed_projects: issuer.allowed_projects ? [...issuer.allowed_projects] : [],
+      allowed_root_users: issuer.allowed_root_users ? [...issuer.allowed_root_users] : [],
+      default_scopes: issuer.default_scopes ? [...issuer.default_scopes] : [],
+      issuer_type: issuer.issuer_type ?? 'hub',
+      default_role: issuer.default_role ?? '',
+      allowed_emails: issuer.allowed_emails ? [...issuer.allowed_emails] : [],
+    };
+    this.editingIndex = index;
+    this.dialogOpen = true;
+  }
+
+  private handleDialogClose(): void {
+    this.dialogOpen = false;
+    this.editingIssuer = null;
+    this.editingIndex = -1;
+  }
+
+  private handleSaveIssuer(): void {
+    if (!this.editingIssuer || !this.editingIssuer.issuer_url.trim()) {
+      return;
+    }
+
+    // Build clean issuer config — strip empty optional fields
+    const issuer: TrustedIssuerConfig = {
+      issuer_url: this.editingIssuer.issuer_url.trim(),
+    };
+
+    if (this.editingIssuer.issuer_type) {
+      issuer.issuer_type = this.editingIssuer.issuer_type;
+    }
+    if (this.editingIssuer.jwks_url?.trim()) {
+      issuer.jwks_url = this.editingIssuer.jwks_url.trim();
+    }
+    if (this.editingIssuer.expected_audience?.trim()) {
+      issuer.expected_audience = this.editingIssuer.expected_audience.trim();
+    }
+    if (this.editingIssuer.allowed_projects && this.editingIssuer.allowed_projects.length > 0) {
+      issuer.allowed_projects = this.editingIssuer.allowed_projects;
+    }
+    if (this.editingIssuer.allowed_root_users && this.editingIssuer.allowed_root_users.length > 0) {
+      issuer.allowed_root_users = this.editingIssuer.allowed_root_users;
+    }
+    if (this.editingIssuer.default_scopes && this.editingIssuer.default_scopes.length > 0) {
+      issuer.default_scopes = this.editingIssuer.default_scopes;
+    }
+    if (this.editingIssuer.default_role?.trim()) {
+      issuer.default_role = this.editingIssuer.default_role.trim();
+    }
+    if (this.editingIssuer.allowed_emails && this.editingIssuer.allowed_emails.length > 0) {
+      issuer.allowed_emails = this.editingIssuer.allowed_emails;
+    }
+
+    const updated = [...this.issuers];
+    if (this.editingIndex >= 0) {
+      updated[this.editingIndex] = issuer;
+    } else {
+      updated.push(issuer);
+    }
+    this.issuers = updated;
+
+    this.handleDialogClose();
+    void this.save();
+  }
+
+  private openDeleteDialog(index: number): void {
+    this.deletingIndex = index;
+    this.deleteDialogOpen = true;
+  }
+
+  private handleDeleteDialogClose(): void {
+    this.deleteDialogOpen = false;
+    this.deletingIndex = -1;
+  }
+
+  private confirmDeleteIssuer(): void {
+    if (this.deletingIndex < 0 || this.deletingIndex >= this.issuers.length) {
+      return;
+    }
+    const updated = this.issuers.filter((_, i) => i !== this.deletingIndex);
+    this.issuers = updated;
+    this.handleDeleteDialogClose();
+    void this.save();
+  }
+
+  // --- Helpers for comma-separated array fields ---
+
+  private arrayToCommaString(arr?: string[]): string {
+    return (arr ?? []).join(', ');
+  }
+
+  private commaStringToArray(value: string): string[] {
+    return value
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s !== '');
+  }
+
+  // --- Render ---
+
+  override render() {
+    return html`
+      ${this.error ? html`<div class="status-message error">${this.error}</div>` : nothing}
+      ${this.successMessage
+        ? html`<div class="status-message success">${this.successMessage}</div>`
+        : nothing}
+      ${this.loading
+        ? html`<div class="loading-container"><sl-spinner></sl-spinner></div>`
+        : this.renderContent()}
+    `;
+  }
+
+  private renderContent() {
+    return html`
+      <div class="header">
+        <div class="header-left">
+          <sl-icon name="globe"></sl-icon>
+          <h1>Federation Authentication</h1>
+        </div>
+        <sl-button variant="primary" ?loading=${this.saving} @click=${() => { void this.save(); }}>
+          Save
+        </sl-button>
+      </div>
+      <p class="header-description">
+        Manage trusted external OIDC issuers for cross-hub federation authentication.
+      </p>
+
+      ${this.renderGlobalSettings()}
+      ${this.renderIssuersSection()}
+      ${this.renderAddEditDialog()}
+      ${this.renderDeleteDialog()}
+    `;
+  }
+
+  // --- Global Settings Section ---
+
+  private renderGlobalSettings() {
+    return html`
+      <div class="section">
+        <h3 class="section-title" style="margin: 0 0 1rem 0; padding-bottom: 0.75rem; border-bottom: 1px solid var(--scion-border, #e2e8f0);">
+          Global Settings
+        </h3>
+
+        <div class="form-field" style="margin-bottom: 1rem;">
+          <sl-switch
+            ?checked=${this.enabled}
+            @sl-change=${(e: Event) => {
+              this.enabled = (e.target as HTMLInputElement).checked;
+            }}
+          >
+            Enabled
+          </sl-switch>
+          <span class="hint">Enable or disable federation authentication globally.</span>
+        </div>
+
+        <div class="form-grid">
+          <div class="form-field">
+            <label>Algorithms</label>
+            <sl-select
+              multiple
+              .value=${this.algorithms.join(' ')}
+              @sl-change=${(e: Event) => {
+                const value = (e.target as HTMLSelectElement).value;
+                this.algorithms = Array.isArray(value)
+                  ? value as string[]
+                  : (value as string).split(' ').filter(Boolean);
+              }}
+            >
+              <sl-option value="RS256">RS256</sl-option>
+              <sl-option value="ES256">ES256</sl-option>
+            </sl-select>
+            <span class="hint">Allowed JWT signing algorithms.</span>
+          </div>
+        </div>
+
+        <div style="margin-top: 1rem;">
+          <label style="font-size: 0.8125rem; font-weight: 500; color: var(--scion-text, #1e293b); display: block; margin-bottom: 0.5rem;">
+            JWKS Cache
+          </label>
+          <div class="cache-row">
+            <div class="form-field">
+              <label>Refresh Interval</label>
+              <sl-input
+                .value=${this.refreshInterval}
+                placeholder="1h"
+                @sl-change=${(e: Event) => {
+                  this.refreshInterval = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>
+              <span class="hint">How often to refresh JWKS keys (e.g. 1h, 30m).</span>
+            </div>
+            <div class="form-field">
+              <label>Debounce Interval</label>
+              <sl-input
+                .value=${this.debounceInterval}
+                placeholder="5s"
+                @sl-change=${(e: Event) => {
+                  this.debounceInterval = (e.target as HTMLInputElement).value;
+                }}
+              ></sl-input>
+              <span class="hint">Minimum delay between JWKS fetches (e.g. 5s).</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  // --- Trusted Issuers Section ---
+
+  private renderIssuersSection() {
+    return html`
+      <div class="section">
+        <div class="section-header">
+          <h3 class="section-title">Trusted Issuers</h3>
+          <sl-button size="small" variant="primary" @click=${() => this.openAddDialog()}>
+            <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+            Add Issuer
+          </sl-button>
+        </div>
+
+        ${this.issuers.length === 0
+          ? html`
+              <div class="empty-state">
+                <sl-icon name="shield-lock"></sl-icon>
+                <p>No trusted issuers configured.</p>
+                <p style="font-size: 0.8125rem">
+                  Add a trusted OIDC issuer to enable federation authentication from external hubs or services.
+                </p>
+              </div>
+            `
+          : html`
+              <table class="issuer-table">
+                <thead>
+                  <tr>
+                    <th>Issuer URL</th>
+                    <th>Type</th>
+                    <th>Audience</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${this.issuers.map((issuer, index) => html`
+                    <tr>
+                      <td class="issuer-url-cell" title=${issuer.issuer_url}>${issuer.issuer_url}</td>
+                      <td>${issuer.issuer_type ?? 'hub'}</td>
+                      <td>${issuer.expected_audience
+                        ? html`<span title=${issuer.expected_audience}>${this.truncate(issuer.expected_audience, 30)}</span>`
+                        : html`<span style="color: var(--scion-text-muted, #64748b);">—</span>`}
+                      </td>
+                      <td>
+                        <div class="issuer-actions">
+                          <sl-button size="small" variant="default" @click=${() => this.openEditDialog(index)}>
+                            Edit
+                          </sl-button>
+                          <sl-button size="small" variant="danger" outline @click=${() => this.openDeleteDialog(index)}>
+                            Delete
+                          </sl-button>
+                        </div>
+                      </td>
+                    </tr>
+                  `)}
+                </tbody>
+              </table>
+            `}
+      </div>
+    `;
+  }
+
+  // --- Add/Edit Issuer Dialog ---
+
+  private renderAddEditDialog() {
+    const title = this.editingIndex >= 0 ? 'Edit Trusted Issuer' : 'Add Trusted Issuer';
+    const issuerType = this.editingIssuer?.issuer_type ?? 'hub';
+
+    return html`
+      <sl-dialog
+        label=${title}
+        ?open=${this.dialogOpen}
+        @sl-request-close=${() => this.handleDialogClose()}
+        style="--width: 32rem;"
+      >
+        ${this.dialogOpen && this.editingIssuer
+          ? html`
+              <div class="dialog-form">
+                <sl-alert variant="warning" open>
+                  <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+                  Adding a trusted issuer grants authentication capability to agents from that
+                  issuer. Only add issuers you control or explicitly trust.
+                </sl-alert>
+
+                <div class="form-field">
+                  <label>Issuer URL *</label>
+                  <sl-input
+                    required
+                    placeholder="https://hub-a.example.com"
+                    .value=${this.editingIssuer.issuer_url}
+                    @sl-change=${(e: Event) => {
+                      this.editingIssuer = {
+                        ...this.editingIssuer!,
+                        issuer_url: (e.target as HTMLInputElement).value,
+                      };
+                    }}
+                  ></sl-input>
+                  <span class="hint">The OIDC issuer URL of the trusted external hub or service.</span>
+                </div>
+
+                <div class="form-field">
+                  <label>Issuer Type</label>
+                  <sl-select
+                    .value=${issuerType}
+                    @sl-change=${(e: Event) => {
+                      this.editingIssuer = {
+                        ...this.editingIssuer!,
+                        issuer_type: (e.target as HTMLSelectElement).value as string,
+                      };
+                    }}
+                  >
+                    <sl-option value="hub">Hub</sl-option>
+                    <sl-option value="service_account">Service Account</sl-option>
+                    <sl-option value="user">User</sl-option>
+                  </sl-select>
+                  <span class="hint">The type of entities this issuer authenticates.</span>
+                </div>
+
+                <div class="form-field">
+                  <label>JWKS URL</label>
+                  <sl-input
+                    placeholder=${issuerType === 'hub'
+                      ? 'Derived from issuer URL if empty'
+                      : 'https://example.com/.well-known/jwks.json'}
+                    .value=${this.editingIssuer.jwks_url ?? ''}
+                    @sl-change=${(e: Event) => {
+                      this.editingIssuer = {
+                        ...this.editingIssuer!,
+                        jwks_url: (e.target as HTMLInputElement).value,
+                      };
+                    }}
+                  ></sl-input>
+                  <span class="hint">
+                    ${issuerType === 'hub'
+                      ? 'Optional. Derived from issuer URL if left empty.'
+                      : 'URL to fetch the JSON Web Key Set from.'}
+                  </span>
+                </div>
+
+                <div class="form-field">
+                  <label>Expected Audience</label>
+                  <sl-input
+                    placeholder="https://this-hub.example.com"
+                    .value=${this.editingIssuer.expected_audience ?? ''}
+                    @sl-change=${(e: Event) => {
+                      this.editingIssuer = {
+                        ...this.editingIssuer!,
+                        expected_audience: (e.target as HTMLInputElement).value,
+                      };
+                    }}
+                  ></sl-input>
+                  <span class="hint">Expected audience claim in JWT tokens. Usually this hub's URL.</span>
+                </div>
+
+                ${issuerType === 'hub' ? this.renderHubFields() : nothing}
+                ${issuerType === 'service_account' || issuerType === 'user'
+                  ? this.renderEmailFields()
+                  : nothing}
+                ${issuerType === 'user' ? this.renderUserFields() : nothing}
+
+                <div class="form-field">
+                  <label>Default Scopes</label>
+                  <sl-input
+                    placeholder="agent:status:update, agent:logs:read"
+                    .value=${this.arrayToCommaString(this.editingIssuer.default_scopes)}
+                    @sl-change=${(e: Event) => {
+                      this.editingIssuer = {
+                        ...this.editingIssuer!,
+                        default_scopes: this.commaStringToArray(
+                          (e.target as HTMLInputElement).value,
+                        ),
+                      };
+                    }}
+                  ></sl-input>
+                  <span class="hint">Comma-separated list of default token scopes.</span>
+                </div>
+              </div>
+
+              <div slot="footer" class="dialog-footer">
+                <sl-button variant="default" @click=${() => this.handleDialogClose()}>
+                  Cancel
+                </sl-button>
+                <sl-button
+                  variant="primary"
+                  @click=${() => this.handleSaveIssuer()}
+                  ?disabled=${!this.editingIssuer?.issuer_url?.trim()}
+                >
+                  Save Issuer
+                </sl-button>
+              </div>
+            `
+          : nothing}
+      </sl-dialog>
+    `;
+  }
+
+  private renderHubFields() {
+    return html`
+      <div class="conditional-section">
+        <div class="conditional-section-title">Hub Options</div>
+        <div class="form-field" style="margin-bottom: 0.75rem;">
+          <label>Allowed Projects</label>
+          <sl-input
+            placeholder="project-a, project-b"
+            .value=${this.arrayToCommaString(this.editingIssuer?.allowed_projects)}
+            @sl-change=${(e: Event) => {
+              this.editingIssuer = {
+                ...this.editingIssuer!,
+                allowed_projects: this.commaStringToArray(
+                  (e.target as HTMLInputElement).value,
+                ),
+              };
+            }}
+          ></sl-input>
+          <span class="hint">Comma-separated project slugs allowed from this hub.</span>
+        </div>
+        <div class="form-field">
+          <label>Allowed Root Users</label>
+          <sl-input
+            placeholder="user@example.com"
+            .value=${this.arrayToCommaString(this.editingIssuer?.allowed_root_users)}
+            @sl-change=${(e: Event) => {
+              this.editingIssuer = {
+                ...this.editingIssuer!,
+                allowed_root_users: this.commaStringToArray(
+                  (e.target as HTMLInputElement).value,
+                ),
+              };
+            }}
+          ></sl-input>
+          <span class="hint">Comma-separated emails of root users allowed from this hub.</span>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderEmailFields() {
+    return html`
+      <div class="conditional-section">
+        <div class="conditional-section-title">
+          ${this.editingIssuer?.issuer_type === 'service_account'
+            ? 'Service Account Options'
+            : 'User Options'}
+        </div>
+        <div class="form-field">
+          <label>Allowed Emails</label>
+          <sl-input
+            placeholder="*@corp.com, admin@example.com"
+            .value=${this.arrayToCommaString(this.editingIssuer?.allowed_emails)}
+            @sl-change=${(e: Event) => {
+              this.editingIssuer = {
+                ...this.editingIssuer!,
+                allowed_emails: this.commaStringToArray(
+                  (e.target as HTMLInputElement).value,
+                ),
+              };
+            }}
+          ></sl-input>
+          <span class="hint">Comma-separated email patterns. Use * for wildcards (e.g. *@corp.com).</span>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderUserFields() {
+    return html`
+      <div class="form-field" style="margin-top: 0.5rem;">
+        <label>Default Role</label>
+        <sl-select
+          .value=${this.editingIssuer?.default_role ?? ''}
+          placeholder="Select a default role"
+          @sl-change=${(e: Event) => {
+            this.editingIssuer = {
+              ...this.editingIssuer!,
+              default_role: (e.target as HTMLSelectElement).value as string,
+            };
+          }}
+        >
+          <sl-option value="admin">Admin</sl-option>
+          <sl-option value="member">Member</sl-option>
+          <sl-option value="viewer">Viewer</sl-option>
+        </sl-select>
+        <span class="hint">Default role assigned to users authenticating via this issuer.</span>
+      </div>
+    `;
+  }
+
+  // --- Delete Confirmation Dialog ---
+
+  private renderDeleteDialog() {
+    const issuer = this.deletingIndex >= 0 && this.deletingIndex < this.issuers.length
+      ? this.issuers[this.deletingIndex]
+      : null;
+
+    return html`
+      <sl-dialog
+        label="Delete Trusted Issuer"
+        ?open=${this.deleteDialogOpen}
+        @sl-request-close=${() => this.handleDeleteDialogClose()}
+        style="--width: 28rem;"
+      >
+        ${issuer
+          ? html`
+              <p style="font-size: 0.875rem; color: var(--scion-text, #1e293b); margin: 0;">
+                Are you sure you want to remove the trusted issuer
+                <strong>${issuer.issuer_url}</strong>?
+                This will revoke federation trust for agents from this issuer.
+              </p>
+              <div slot="footer" class="dialog-footer">
+                <sl-button variant="default" @click=${() => this.handleDeleteDialogClose()}>
+                  Cancel
+                </sl-button>
+                <sl-button variant="danger" @click=${() => this.confirmDeleteIssuer()}>
+                  Delete Issuer
+                </sl-button>
+              </div>
+            `
+          : nothing}
+      </sl-dialog>
+    `;
+  }
+
+  // --- Utility ---
+
+  private truncate(text: string, maxLen: number): string {
+    return text.length > maxLen ? text.substring(0, maxLen) + '...' : text;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-page-admin-federation': ScionPageAdminFederation;
+  }
+}

--- a/web/src/components/pages/admin-federation.ts
+++ b/web/src/components/pages/admin-federation.ts
@@ -353,8 +353,10 @@ export class ScionPageAdminFederation extends LitElement {
 
   // --- Data ---
 
-  private async loadData(): Promise<void> {
-    this.loading = true;
+  private async loadData(showSpinner = true): Promise<void> {
+    if (showSpinner) {
+      this.loading = true;
+    }
     this.error = null;
     try {
       const res = await apiFetch('/api/v1/admin/server-config');
@@ -405,21 +407,20 @@ export class ScionPageAdminFederation extends LitElement {
       });
       if (!res.ok) {
         this.error = await extractApiError(res, 'Failed to save federation config');
-        // Reload server state so local data matches after failed save
-        await this.loadData();
         return;
       }
       // Reload server state so server-side normalization is reflected
-      await this.loadData();
+      await this.loadData(false);
       this.successMessage = 'Federation config saved successfully';
+      if (this.successMessageTimer !== null) {
+        clearTimeout(this.successMessageTimer);
+      }
       this.successMessageTimer = setTimeout(() => {
         this.successMessage = null;
         this.successMessageTimer = null;
       }, 3000);
     } catch {
       this.error = 'Failed to connect to server';
-      // Reload server state so local data matches after failed save
-      await this.loadData();
     } finally {
       this.saving = false;
     }

--- a/web/src/components/pages/admin-federation.ts
+++ b/web/src/components/pages/admin-federation.ts
@@ -362,7 +362,15 @@ export class ScionPageAdminFederation extends LitElement {
         this.error = await extractApiError(res, 'Failed to load federation config');
         return;
       }
-      const data = await res.json();
+      const data = (await res.json()) as {
+        federation?: {
+          enabled?: boolean;
+          algorithms?: string[];
+          refresh_interval?: string;
+          debounce_interval?: string;
+          trusted_issuers?: TrustedIssuerConfig[];
+        };
+      };
       if (data.federation) {
         this.enabled = data.federation.enabled ?? false;
         this.algorithms = data.federation.algorithms ?? ['RS256'];
@@ -401,6 +409,8 @@ export class ScionPageAdminFederation extends LitElement {
         await this.loadData();
         return;
       }
+      // Reload server state so server-side normalization is reflected
+      await this.loadData();
       this.successMessage = 'Federation config saved successfully';
       this.successMessageTimer = setTimeout(() => {
         this.successMessage = null;
@@ -605,7 +615,7 @@ export class ScionPageAdminFederation extends LitElement {
                 const value = (e.target as HTMLSelectElement).value;
                 this.algorithms = Array.isArray(value)
                   ? value as string[]
-                  : (value as string).split(' ').filter(Boolean);
+                  : value.split(' ').filter(Boolean);
               }}
             >
               <sl-option value="RS256">RS256</sl-option>
@@ -760,7 +770,7 @@ export class ScionPageAdminFederation extends LitElement {
                     @sl-change=${(e: Event) => {
                       this.editingIssuer = {
                         ...this.editingIssuer!,
-                        issuer_type: (e.target as HTMLSelectElement).value as string,
+                        issuer_type: (e.target as HTMLSelectElement).value,
                       };
                     }}
                   >
@@ -927,7 +937,7 @@ export class ScionPageAdminFederation extends LitElement {
           @sl-change=${(e: Event) => {
             this.editingIssuer = {
               ...this.editingIssuer!,
-              default_role: (e.target as HTMLSelectElement).value as string,
+              default_role: (e.target as HTMLSelectElement).value,
             };
           }}
         >

--- a/web/src/components/shared/nav.ts
+++ b/web/src/components/shared/nav.ts
@@ -64,6 +64,7 @@ const ADMIN_SECTION: NavSection = {
   items: [
     { path: '/settings', label: 'Hub Resources', icon: 'gear' },
     { path: '/admin/server-config', label: 'Server Config', icon: 'sliders' },
+    { path: '/admin/federation', label: 'Federation', icon: 'globe' },
     { path: '/admin/integrations', label: 'Integrations', icon: 'plug' },
     { path: '/admin/scheduler', label: 'Scheduler', icon: 'clock' },
     { path: '/admin/users', label: 'Users', icon: 'people' },


### PR DESCRIPTION
## Summary

Add runtime management of federation config via the admin UI, following the opsettings pattern. Federation auth (#1088) is merged; this makes it configurable at runtime without server restarts.

- V1 config types, opsettings section registration, conversion functions
- atomic.Pointer hot-reload of FederationAuthenticator (lock-free auth path)
- Admin API integration (DB + file modes) with semantic validation
- New /admin/federation page with issuer CRUD, conditional fields, security warning

19 files changed, +2266 lines.

Refs ptone/scion#891