### PR TITLE
docs: nightly documentation update for Aug 8 changelog

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -224,6 +224,11 @@ _See also_: A2A Protocol, Hub
 
 ## Users & Access
 
+**Agent Authorization Role**:
+A named authority tier (one of `none`, `readonly`, `baseline`, or `full`) assigned to an agent that governs the API scopes granted in its Hub-issued JWT. Resolves via a two-gate authority lattice matching requested role, user ceiling, and project maximums.
+_Avoid_: raw template scopes, agent scopes
+_See also_: User Access Token (UAT)
+
 **Group**:
 A named collection of Hub users (and nested groups) used by the Hub permissions system to assign access. This is the primary meaning of "group" in Scion.
 _Avoid_: team, org, role

--- a/docs-site/src/content/docs/glossary.md
+++ b/docs-site/src/content/docs/glossary.md
@@ -254,3 +254,14 @@ The in-container OTLP receiver and forwarding pipeline (`pkg/sciontool/telemetry
 
 ### Session metrics
 Database-backed summaries and aggregations computed on agent session-end (aggregated by `sciontool` and delivered as a `MetricsPayload` in the StatusUpdate protocol) and stored in the Hub's `agent_session_metrics` SQL table. They provide an IDOR-safe structural view of token usage (input, output, cached, reasoning), tool execution counts, session duration, and model usage, queried via dedicated summary API endpoints and displayed in the Web Dashboard. Contrast with raw OpenTelemetry time-series metrics.
+
+## Users & Access
+
+### Agent Authorization Role
+A named authority tier (one of `none`, `readonly`, `baseline`, or `full`) assigned to an agent that governs the API scopes granted in its Hub-issued JWT. Resolves via a two-gate authority lattice matching requested role, user ceiling, and project maximums.
+
+### Group
+A named collection of Hub users (and nested groups) used by the Hub permissions system to assign access. This is the primary meaning of "group" in Scion.
+
+### User Access Token (UAT)
+A scoped, revocable bearer token (prefixed with `scion_pat_`) linked to a user account and used for non-interactive Hub authentication (e.g., CLI, CI/CD pipelines, desktop app integration). Every UAT is scoped to a single project and carries a specific list of action permissions (scopes).

--- a/docs-site/src/content/docs/hosted/ha/permissions.md
+++ b/docs-site/src/content/docs/hosted/ha/permissions.md
@@ -71,7 +71,11 @@ A policy defines the rules for access:
 
 ## Roles
 
-To simplify management, Scion provides built-in roles that bundle common permissions:
+To simplify management, Scion separates roles into **User Roles** (for human operators) and **Agent Roles** (for running agents).
+
+### User Roles
+
+These built-in roles bundle common permissions for human users:
 
 | Role | Description |
 |------|-------------|
@@ -80,6 +84,37 @@ To simplify management, Scion provides built-in roles that bundle common permiss
 | `project:admin` | Full control over a specific project and its agents. |
 | `project:developer` | Can create and manage agents within a project. |
 | `project:viewer` | Read-only access to project status and logs. |
+
+### Tiered Agent Authorization Roles
+
+Scion implements a dedicated, tiered authorization model for **agents**. This ensures that running agents only possess the specific permissions they need to interact with the Hub API.
+
+Agents are assigned one of four named roles, each mapping to a fixed set of JWT scopes:
+
+| Agent Role | Granted Scopes | Description |
+| :--- | :--- | :--- |
+| `none` | *None* | No access to the Hub API (runs with no authorization claims). |
+| `readonly` | `project:read` | Can view and query project state, but cannot report status, register port forwards, or manage other agents. |
+| `baseline` | `project:read`<br>`agent:status:update`<br>`agent:token:refresh`<br>`project:agent:notify`<br>`agent:port:forward` | Standard execution permissions. Allows the agent to report progress, refresh its token, register reverse-proxied port forwards, and send notifications. |
+| `full` | *All baseline scopes* +<br>`project:agent:create`<br>`project:agent:lifecycle`<br>`project:secret:read` | Complete agent control. Allows spawning child (sub) agents, managing their lifecycles, and reading project-scoped secrets from the secret backend. |
+
+#### Two-Gate Authority Lattice
+The effective role granted to an agent at creation is resolved by a **two-gate authority lattice**:
+
+$$\text{effectiveRole} = \min(\text{requestedRole}, \text{userCeiling}, \text{projectMax})$$
+
+1. **Requested Role**: The role requested during agent dispatch (e.g., using the `--role` flag in the CLI). If not specified, defaults to `baseline`.
+2. **User Ceiling**: Capped by the user's own system permissions. A standard `hub:member` has an agent role ceiling of `baseline`. Only a `hub:admin` has a ceiling of `full`.
+3. **Project Max**: Set by the project's `max_agent_role` setting, which defaults to the global Hub configuration (`default_max_agent_role` under `agent_defaults`).
+
+#### Sub-Agent No-Escalation Enforcement
+To prevent security bypasses via sub-agent creation, Scion enforces strict no-escalation rules:
+- When a parent agent spawns a child (sub-agent), the parent agent acts as the requester.
+- A parent agent **cannot** grant a child agent a higher role than its own.
+- Any attempt by an agent to spawn a child with elevated permissions will result in a loud, immediate `403 Forbidden` API rejection.
+
+#### Deprecation of Raw Template Scopes
+With the introduction of tiered agent roles, the raw template field `hubAccess.scopes` has been **deprecated**. Agent permissions must be configured via the named roles.
 
 ## Implementation Status
 

--- a/docs-site/src/content/docs/hosted/single-node/auth.md
+++ b/docs-site/src/content/docs/hosted/single-node/auth.md
@@ -101,6 +101,80 @@ auth:
 - **Case insensitive**: `Example.COM` matches `example.com`.
 - **Exact match**: Subdomains must be listed explicitly.
 
+## OIDC Identity Provider (IdP)
+
+When enabled, the Scion Hub can act as a minimal OpenID Connect (OIDC) Identity Provider. This allows running agents inside containers to request short-lived, cryptographically signed OIDC tokens to prove their identity to external systems.
+
+### Configuration
+Enable the OIDC IdP feature in `settings.yaml`:
+
+```yaml
+server:
+  oidc:
+    enabled: true
+    # IssuerURL defaults to the Hub's public endpoint if empty.
+    # Must be valid HTTPS in hosted mode (HTTP allowed in workstation mode).
+    issuer_url: "https://hub.scion.dev"
+    token_lifetime: "15m"
+```
+
+### Endpoints
+When active, the Hub exposes standard OIDC discovery and key endpoints:
+- `/.well-known/openid-configuration`: Returns OIDC discovery metadata.
+- `/.well-known/jwks.json`: Publishes the public keys (JWKS) used to verify token signatures.
+- `POST /api/v1/agent/identity-token`: Endpoint for agents to request tokens.
+
+### Token Issuance and Rotation
+- **Token Signing**: Tokens are RS256-signed using keys generated and managed by the Hub's secrets backend.
+- **Key Rotation**: The Hub rotates signing keys every 24 hours automatically, maintaining a key overlap period to ensure seamless token verification during transitions.
+- **Audience Scope**: Tokens are minted targeting specific external audiences.
+
+### In-Agent Retrieval
+From inside any authorized agent container, retrieve an OIDC identity token using `sciontool`:
+
+```bash
+sciontool identity-token --audience="https://vault.example.com"
+```
+
+Use this token to authenticate agents to external services like HashiCorp Vault, AWS IAM Roles for Service Accounts (IRSA), or GCP Workload Identity Federation (WIF).
+
+---
+
+## OIDC-Based Federation
+
+Scion supports inbound OIDC-based federation authentication. This allows external identities (such as other Scion Hubs, Google Cloud Service Accounts, or Firebase/Google users) to authenticate against the Hub API using OIDC ID tokens from trusted issuers.
+
+### Configuration
+Federation is feature-gated and configured under the `server.federation` block in `settings.yaml`:
+
+```yaml
+server:
+  federation:
+    enabled: true
+    trusted_issuers:
+      - issuer_url: "https://hub.other-org.com"
+        # Optional: Explicit JWKS URL (retrieved via discovery if omitted)
+        jwks_url: "https://hub.other-org.com/.well-known/jwks.json"
+        expected_audience: "https://hub.scion.dev"
+        # Optional restriction lists
+        allowed_projects: ["project-uuid-1", "project-uuid-2"]
+        allowed_root_users: ["user@other-org.com"]
+        # Default scopes/roles for identities from this issuer
+        default_scopes: ["project:read", "agent:status:update"]
+        issuer_type: "hub" # hub, service_account, or user
+```
+
+### How It Works
+- **Multi-Issuer Support**: The federation authenticator handles multiple external trust domains simultaneously.
+- **JWKS Caching**: Public verification keys are cached locally with RS256-signature pinning and automatic refresh to eliminate per-request latency.
+- **Federation Access Middleware**: Requests carrying external OIDC tokens pass through the `RequireFederationAccess` scope-gated middleware, validating token authenticity, issuer rules, and matching scopes.
+- **Identity Types**:
+  - `hub`: Identifies requests originating from federated partner Hubs.
+  - `service_account`: Authenticates automated workloads via GCP Service Accounts.
+  - `user`: Maps OIDC tokens to standard user identities, with configurable `default_role` (defaults to `viewer`) and domain restrictions using wildcards (e.g. `allowed_emails: ["*@example.com"]`).
+
+---
+
 ## Development Authentication (Dev Auth)
 
 To minimize friction during local setup, Scion includes a "Dev Auth" mode. When enabled, the Hub auto-generates a token and creates a "Development User" identity.

--- a/docs-site/src/content/docs/hosted/single-node/hub-server.md
+++ b/docs-site/src/content/docs/hosted/single-node/hub-server.md
@@ -145,6 +145,7 @@ Administrators can trigger critical infrastructure operations directly from the 
 - **Rebuild Server (`rebuild-server`)**: Initiates a fire-and-forget server rebuild and restart sequence. It uses staging paths and sudoers implementation to ensure reliable updates even while the server is running.
 - **Rebuild Web (`rebuild-web`)**: Recompiles the web frontend assets.
 - **Pull Images (`pull-images`)**: Triggers the Docker/Podman executor to pull the latest agent container images.
+- **Restart Hub**: Initiates a fire-and-forget server restart (`POST /api/v1/admin/maintenance/restart`) via systemd, restricted to administrators. A modal confirmation dialog prevents accidental triggers of restarts.
 
 ### Operation Execution & History
 

--- a/docs-site/src/content/docs/hosted/user/a2a-bridge.md
+++ b/docs-site/src/content/docs/hosted/user/a2a-bridge.md
@@ -41,6 +41,18 @@ The `scion-a2a-bridge` process runs two concurrent RPC servers:
 1. **A2A HTTP Server (Default: Port 8443)**: Serves external A2A clients. Handles agent discovery requests (`/.well-known/agent-card.json`), JSON-RPC message exchanges, operational health checks (`/healthz`, `/readyz`), and Prometheus metrics (`/metrics`).
 2. **Broker Plugin RPC Server (Default: Port 9090)**: A `go-plugin` RPC interface. The Scion Hub connects to this port to push real-time agent-emitted messages, events, and status changes back to the bridge.
 
+### High Availability (HA) & Cloud Run Deployment
+
+To support robust, load-balanced hosted environments, the A2A Bridge includes advanced production capabilities:
+
+#### Leaderless HA Architecture
+The A2A Bridge supports High Availability (HA) natively through a **leaderless architecture**. Every replica is completely identical, interchangeable, and stateless. There is no leader election, coordination overhead, or instance-identity requirement. Behind a load balancer, any replica can handle any incoming A2A request or receive broker plugin events, enabling seamless horizontal scaling.
+
+#### Single-Port h2c Multiplexing (Cloud Run)
+Google Cloud Run enforces a strict single-port limitation for incoming traffic. To run both the A2A HTTP server and the Broker Plugin RPC gRPC server on a single container port, the bridge implements **h2c port multiplexing**:
+- **Auto-Detection**: The bridge automatically detects when it is running on Cloud Run by checking for the presence of the `K_SERVICE` environment variable.
+- **Traffic Routing**: When detected, the bridge binds to the designated `$PORT` and multiplexes incoming HTTP/1.1 (standard A2A protocol JSON-RPC, health checks, and metrics) and HTTP/2 (gRPC broker traffic) over that single port. This eliminates the need for separate external ports or complex sidecar routing proxies.
+
 ### Interaction Modes
 The bridge supports three distinct A2A communication mechanics:
 * **Synchronous Blocking (SendMessage)**: The client POSTs a message and holds the HTTP connection open (up to `timeouts.send_message`, default 120s) until the agent produces its final response.

--- a/docs-site/src/content/docs/hosted/user/a2a-bridge.md
+++ b/docs-site/src/content/docs/hosted/user/a2a-bridge.md
@@ -46,7 +46,9 @@ The `scion-a2a-bridge` process runs two concurrent RPC servers:
 To support robust, load-balanced hosted environments, the A2A Bridge includes advanced production capabilities:
 
 #### Leaderless HA Architecture
-The A2A Bridge supports High Availability (HA) natively through a **leaderless architecture**. Every replica is completely identical, interchangeable, and stateless. There is no leader election, coordination overhead, or instance-identity requirement. Behind a load balancer, any replica can handle any incoming A2A request or receive broker plugin events, enabling seamless horizontal scaling.
+The A2A Bridge supports High Availability (HA) natively through a **leaderless architecture**. Every replica is identical and interchangeable — there is no leader election, coordination overhead, or instance-identity requirement. Behind a load balancer, any replica can handle any incoming A2A request or receive broker plugin events, enabling seamless horizontal scaling.
+
+HA mode requires **standalone mode** (`--standalone` flag or `A2A_STANDALONE=true`) with a shared **PostgreSQL** backend (`DATABASE_URL`). This replaces the default local SQLite store so that all replicas share webhook subscriptions, task state, and admin configuration. Without a shared database, per-replica local state (SQLite) would drift across replicas and be lost on restart — making SQLite unsuitable for multi-replica or ephemeral deployments like Cloud Run.
 
 #### Single-Port h2c Multiplexing (Cloud Run)
 Google Cloud Run enforces a strict single-port limitation for incoming traffic. To run both the A2A HTTP server and the Broker Plugin RPC gRPC server on a single container port, the bridge implements **h2c port multiplexing**:
@@ -57,7 +59,7 @@ Google Cloud Run enforces a strict single-port limitation for incoming traffic. 
 The bridge supports three distinct A2A communication mechanics:
 * **Synchronous Blocking (SendMessage)**: The client POSTs a message and holds the HTTP connection open (up to `timeouts.send_message`, default 120s) until the agent produces its final response.
 * **Server-Sent Events (SSE) Streaming (SendStreamingMessage)**: The client opens an SSE connection (`message/stream`) to receive real-time, token-by-token streaming updates as the agent executes.
-* **Asynchronous Webhooks (Push Notifications)**: Clients register a callback URL (`tasks/pushNotification/set`). The bridge stores this subscription in its SQLite database and POSTs state-change alerts (running, completed, input-required, error) to the webhook as they occur.
+* **Asynchronous Webhooks (Push Notifications)**: Clients register a callback URL (`tasks/pushNotification/set`). The bridge stores this subscription in its state database (SQLite in default mode, PostgreSQL in standalone/HA mode) and POSTs state-change alerts (running, completed, input-required, error) to the webhook as they occur.
 
 ---
 

--- a/docs-site/src/content/docs/hosted/user/secrets.md
+++ b/docs-site/src/content/docs/hosted/user/secrets.md
@@ -79,6 +79,21 @@ scion hub secret set ANTHROPIC_API_KEY sk-ant-api01-...
 scion hub secret set --project DB_PASSWORD my-secure-password
 ```
 
+#### Streamlined Project Secrets via `scion secret`
+
+While `scion hub secret` manages secrets at any scope (user, project, broker, hub), you can use the streamlined, top-level `scion secret` command group on your host to manage project-scoped secrets directly within your current project context:
+
+```bash
+# Set a project-scoped secret (inferred from current directory context)
+scion secret set ANTHROPIC_API_KEY sk-ant-api01-...
+
+# List all project secrets (metadata only)
+scion secret list
+
+# Get metadata for a specific project secret
+scion secret get ANTHROPIC_API_KEY
+```
+
 :::tip[Graceful Raw vs. Base64 Fallback]
 To prevent silent integration failures (such as when the web UI sends raw plaintext but the underlying REST endpoint accepts base64), all four of Scion's secret-write API handlers (Hub, User, Project, and Broker scopes) feature a **graceful fallback mechanism**.
 

--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -226,6 +226,20 @@ Manages per-user Hub settings.
         - Flags: `--as <alias>` (alias under which to mount the skill), `--optional` (continue provisioning if resolution fails), `--from-directory <url>` (discover and batch-add all skills from a GitHub repository directory).
     - `remove <id|uri>` (aliases `rm`, `delete`): Remove an auto-injected skill entry from your personal list by its ID or full URI.
 
+### `scion secret`
+
+Manages project-scoped secrets from the host or within an agent container. This command mirrors the `sciontool secret` commands used in agent containers, using the `hubclient` Secrets service to operate on the active project.
+
+Unlike `scion hub secret` (which supports managing secrets at any scope: user, hub, project, or broker), `scion secret` is streamlined for project-level secrets within your current project context.
+
+- `scion secret set KEY VALUE`: Store a project-scoped secret in the Hub.
+    - If `VALUE` starts with `@`, the remainder is treated as a file path. The file contents are read and base64-encoded, and `--type` defaults to `file`.
+    - Flags:
+        - `--type <string>`: Secret type: `environment` (default), `variable`, or `file`.
+        - `--target <string>`: Injection target path (defaults to key for env, required for file-type secrets).
+- `scion secret get KEY`: Retrieve the metadata of a project-scoped secret. Secret values are never returned to protect security.
+- `scion secret list`: List metadata (key, type, version, updated time) for all project-scoped secrets. Secret values are never returned.
+
 ### `scion clean`
 
 Removes the scion project configuration from the current project or global location.

--- a/docs-site/src/content/docs/reference/security.md
+++ b/docs-site/src/content/docs/reference/security.md
@@ -32,11 +32,11 @@ For both Web and CLI access, Scion relies on standard OAuth 2.0 providers (Googl
 Agents running inside containers must report status back to the Hub without possessing user-level credentials.
 
 - **Hub-Issued JWT**: During provisioning, the Hub generates a short-lived JWT scoped specifically to that agent instance.
-- **Claims**: The token includes the `agent_id` (sub) and `project_id`.
-- **Scopes**: Standardized scopes include:
-    - `agent:status:update`: Allows reporting progress and heartbeats.
-    - `agent:log:append`: Allows streaming logs back to the Hub.
-    - `project:secret:read`: Allows the agent to retrieve project-scoped secrets.
+- **Claims**: The token includes the `agent_id` (sub), `project_id`, and `scopes`.
+- **Role-Based Scopes**: Instead of raw template scopes (which are deprecated), an agent's scopes are governed by its assigned **Tiered Agent Role** (`none`, `readonly`, `baseline`, or `full`):
+    - `project:read` (Readonly): Allows reading project state (agents, templates, etc.).
+    - `agent:status:update`, `agent:token:refresh`, `project:agent:notify`, `agent:port:forward` (Baseline): Standard operational scopes allowing the agent to report progress, refresh its token, and hold port tunnels.
+    - `project:agent:create`, `project:agent:lifecycle`, `project:secret:read` (Full): Complete programmatic control allowing the agent to spawn sub-agents, manage their phases, and retrieve project secrets dynamically.
 - **Transmission**: The token is injected into the container via the `SCION_HUB_TOKEN` environment variable and is used by `sciontool` for all API calls.
 
 ### 1.4 Runtime Broker Authentication (HMAC)
@@ -69,15 +69,16 @@ In production mode, Scion mandates the use of TLS for all network traffic.
 
 Scion supports restricting authentication to specific email domains via the `SCION_AUTHORIZED_DOMAINS` configuration. This provides a first-line defense, ensuring only authorized organization members can access the Hub.
 
-### 3.2 Permissions System (Future Plans)
+### 3.2 Permissions and Policy Model
 
-A comprehensive, hierarchical RBAC (Role-Based Access Control) system is currently in the design phase. For a detailed technical specification of the policy language and agent identity claims, see the [Policy & Permissions Reference](/scion/reference/permissions-policy/).
+Scion implements a robust, hierarchical RBAC (Role-Based Access Control) and policy system. For a detailed technical specification of the policy language and agent identity claims, see the [Policy & Permissions Reference](/scion/reference/permissions-policy/) and [Permissions & Policy Guide](/scion/hosted/ha/permissions/).
 
 - **Principal-Based**: Permissions are granted to **Users** and **Groups**.
 - **Hierarchical Groups**: Groups can contain other groups, allowing for complex team structures.
 - **Resource Scopes**: Policies are attached to scopes (Hub, Project, or specific Resource) and follow a containment hierarchy.
 - **Override Model**: Lower-level policies (e.g., at the Agent level) override higher-level ones (e.g., at the Project level), allowing for granular delegation of authority.
 - **Actions**: Standardized CRUD actions (`create`, `read`, `update`, `delete`, `list`) plus resource-specific actions (`start`, `stop`, `attach`, `message`).
+- **Lattice-Based Agent Authorization**: Agents are assigned tiered roles (`none`, `readonly`, `baseline`, `full`) that restrict their JWT scopes via a two-gate authority lattice.
 
 ## 4. Secret Management
 

--- a/docs-site/src/content/docs/reference/server-config.md
+++ b/docs-site/src/content/docs/reference/server-config.md
@@ -208,6 +208,42 @@ Controls the background task scheduler in the Hub. This regulates the tick inter
 Configuring a modest concurrency limit (such as the default `2`) is highly recommended for small or single-node database instances to prevent sudden spikes in database connection usage.
 :::
 
+### OIDC Identity Provider (`server.oidc`)
+
+Configuration for the Hub's built-in OIDC Identity Provider feature.
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `enabled` | bool | `false` | Enable the OIDC Identity Provider endpoints. |
+| `issuer_url` | string | | The public issuer URL of this Hub. If empty, the hub public URL is used. |
+| `token_lifetime` | duration | `"15m"` | Validity duration for minted OIDC identity tokens (e.g. `"15m"`, `"1h"`). |
+
+### OIDC Federation (`server.federation`)
+
+Configuration for inbound OIDC-based federation authentication.
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `enabled` | bool | `false` | Enable OIDC federation authentication. |
+| `trusted_issuers` | list of objects | `[]` | List of trusted OIDC issuers (see below). |
+| `algorithms` | list of strings | `["RS256"]` | Supported cryptographic signing algorithms. |
+| `cache.refresh_interval` | duration | `"1h"` | How often to refresh cached issuer public keys (JWKS). |
+| `cache.debounce_interval` | duration | `"1s"` | Min interval between JWKS reload attempts to prevent DDOS. |
+
+#### Trusted Issuer Settings (`server.federation.trusted_issuers[]`)
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `issuer_url` | string | | **MANDATORY.** The exact OIDC issuer URL (matching token `iss` claim). |
+| `jwks_url` | string | | The URL to fetch signing public keys. Discovered via OIDC discovery if empty. |
+| `expected_audience` | string | | The expected audience `aud` claim in tokens. |
+| `allowed_projects` | list of strings | | If set, restricts tokens to specific project UUIDs. |
+| `allowed_root_users` | list of strings | | If set, restricts tokens to specific root user emails. |
+| `default_scopes` | list of strings | | Default JWT scopes granted to federated agents. |
+| `issuer_type` | string | `"hub"` | Type of issuer: `"hub"`, `"service_account"`, or `"user"`. |
+| `default_role` | string | `"viewer"` | Default role for federated users (`issuer_type: user`). |
+| `allowed_emails` | list of strings | | Restrict user tokens to specific email claims (supports wildcards e.g. `*@example.com`). |
+
 ## Environment Variables
 
 :::tip[Database Mode]
@@ -445,7 +481,7 @@ Settings that can be changed at runtime and are shared across all replicas. Stor
 | `lifecycle` | `auto_suspend_stalled`, `soft_delete_retention`, `soft_delete_retain_files` |
 | `maintenance` | `admin_mode`, `maintenance_message` (durable + cluster-wide) |
 | `telemetry` | Full `telemetry.*` subtree (enabled, cloud, hub, local, filter, resource) |
-| `agent_defaults` | `default_template`, `default_harness_config`, `default_max_turns`, `default_max_model_calls`, `default_max_duration`, `default_resources`, `default_model`, `default_thinking_level` |
+| `agent_defaults` | `default_template`, `default_harness_config`, `default_max_turns`, `default_max_model_calls`, `default_max_duration`, `default_resources`, `default_model`, `default_thinking_level`, `default_max_agent_role` |
 | `endpoints` | `hub.public_url`, `image_registry` |
 | `github_app` | `app_id`, `api_base_url`, `webhooks_enabled`, `installation_url`, `private_key_path` |
 | `notifications` | `notification_channels[]` |


### PR DESCRIPTION
## Summary

Nightly documentation update covering the Aug 8 changelog.

- Documented tiered agent authorization roles with sub-agent scope inheritance (permissions, security reference, glossary)
- Documented OIDC Identity Provider and inbound OIDC federation authentication
- Documented A2A bridge HA architecture and Cloud Run h2c port multiplexing
- Added top-level scion secret CLI commands to CLI reference and secrets guide
- Documented Restart Hub maintenance operation
- Updated server-config reference with OIDC, federation, and default_max_agent_role settings

10 files changed, 213 insertions, 9 deletions.
