### PR TITLE
fix: wire OIDC federation config end-to-end

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1467,6 +1467,7 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 		// session secret or pre-provision the signing keys.
 		RequireStableSigningKey: os.Getenv("SCION_REQUIRE_STABLE_SIGNING_KEY") == "true",
 		OIDCConfig:              cfg.OIDC,
+		Federation:              cfg.Federation,
 	}
 
 	// In hosted mode every replica must share the same session secret for

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -346,6 +346,9 @@ type V1ServerConfig struct {
 	// Scheduler configures the Hub background task scheduler.
 	Scheduler *V1SchedulerConfig `json:"scheduler,omitempty" yaml:"scheduler,omitempty" koanf:"scheduler"`
 
+	// OIDC configures the OIDC Identity Provider feature.
+	OIDC *OIDCProviderConfig `json:"oidc,omitempty" yaml:"oidc,omitempty" koanf:"oidc"`
+
 	// Federation configures hub-hub federation authentication.
 	Federation *V1FederationConfig `json:"federation,omitempty" yaml:"federation,omitempty" koanf:"federation"`
 }
@@ -1590,6 +1593,11 @@ func ConvertV1ServerToGlobalConfig(v1 *V1ServerConfig) *GlobalConfig {
 		gc.Scheduler.MaxConcurrency = v1.Scheduler.MaxConcurrency // both are *int; nil propagates
 	}
 
+	// OIDC Identity Provider
+	if v1.OIDC != nil {
+		gc.OIDC = *v1.OIDC
+	}
+
 	// Federation
 	if v1.Federation != nil {
 		if v1.Federation.Enabled != nil {
@@ -1774,6 +1782,12 @@ func ConvertGlobalToV1ServerConfig(gc *GlobalConfig) *V1ServerConfig {
 			IntervalSeconds: gc.Scheduler.IntervalSeconds,
 			MaxConcurrency:  gc.Scheduler.MaxConcurrency,
 		}
+	}
+
+	// OIDC Identity Provider config
+	if gc.OIDC.Enabled || gc.OIDC.IssuerURL != "" {
+		oidc := gc.OIDC
+		v1.OIDC = &oidc
 	}
 
 	// Federation

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -587,6 +587,10 @@ func (ws *WebServer) MountHubAPI(hubHandler http.Handler, hubShutdown func(conte
 	// longest-prefix matching, so /api/v1/ takes priority over /
 	// (the SPA catch-all).
 	ws.mux.Handle("/api/v1/", ws.sessionToBearerMiddleware(hubHandler))
+	// Forward OIDC discovery endpoints so they are reachable in combo mode
+	// (hub + web on the same port). Without this, the SPA catch-all "/"
+	// intercepts /.well-known/ requests and returns HTML instead of JSON.
+	ws.mux.Handle("/.well-known/", hubHandler)
 }
 
 // sessionToBearerMiddleware bridges cookie-based web sessions to the
@@ -1192,6 +1196,9 @@ func isPublicRoute(path string) bool {
 	case strings.HasPrefix(path, "/api/v1/"):
 		// Hub API routes have their own auth (UnifiedAuth middleware).
 		// Let them pass through the Web session auth layer untouched.
+		return true
+	case strings.HasPrefix(path, "/.well-known/"):
+		// OIDC discovery endpoints must be publicly accessible (unauthenticated).
 		return true
 	case path == "/login":
 		return true


### PR DESCRIPTION
Fixes 3 bugs found during deployed Cloud Run e2e testing that prevented OIDC federation auth from working: federation config wasn't wired into hub.ServerConfig, V1ServerConfig was missing oidc/federation fields (silently dropped from settings.yaml), and /.well-known/ OIDC discovery endpoints were unreachable in combo mode (SPA catch-all intercepted them). Verified end-to-end against a real deployed hub + bridge after this fix: RS256 token issuance, bridge decode, hub JWKS fetch, signature validation, and correct scope enforcement all confirmed working.