### PR TITLE
fix: resolve harness config reimport git+https:// round-trip bug

### DIFF
--- a/pkg/config/remote_templates.go
+++ b/pkg/config/remote_templates.go
@@ -76,7 +76,9 @@ func NormalizeTemplateSourceURL(raw string) string {
 	s := strings.TrimSpace(raw)
 
 	// Handle git+https:// and git+http:// scheme prefixes.
-	s = strings.TrimPrefix(s, "git+")
+	if strings.HasPrefix(s, "git+https://") || strings.HasPrefix(s, "git+http://") {
+		s = strings.TrimPrefix(s, "git+")
+	}
 
 	// Add https:// scheme if missing (not rclone and not already http/https)
 	if !strings.HasPrefix(s, ":") && !strings.HasPrefix(s, "http://") && !strings.HasPrefix(s, "https://") {

--- a/pkg/config/remote_templates.go
+++ b/pkg/config/remote_templates.go
@@ -75,6 +75,9 @@ func remoteCacheDir() (string, error) {
 func NormalizeTemplateSourceURL(raw string) string {
 	s := strings.TrimSpace(raw)
 
+	// Handle git+https:// and git+http:// scheme prefixes.
+	s = strings.TrimPrefix(s, "git+")
+
 	// Add https:// scheme if missing (not rclone and not already http/https)
 	if !strings.HasPrefix(s, ":") && !strings.HasPrefix(s, "http://") && !strings.HasPrefix(s, "https://") {
 		s = "https://" + s

--- a/pkg/config/remote_templates_test.go
+++ b/pkg/config/remote_templates_test.go
@@ -298,12 +298,59 @@ func TestNormalizeTemplateSourceURL(t *testing.T) {
 			input:    "github.com/org/repo/.scion/templates/mytmpl",
 			expected: "https://github.com/org/repo/.scion/templates/mytmpl",
 		},
+		{
+			name:     "git+https:// prefix is stripped",
+			input:    "git+https://github.com/org/repo/tree/main/path",
+			expected: "https://github.com/org/repo/tree/main/path",
+		},
+		{
+			name:     "git+http:// prefix is stripped and kept as http",
+			input:    "git+http://example.com/template.tgz",
+			expected: "http://example.com/template.tgz",
+		},
+		{
+			name:     "git+https:// harness config URL normalizes correctly",
+			input:    "git+https://github.com/GoogleCloudPlatform/scion/harnesses/claude",
+			expected: "https://github.com/GoogleCloudPlatform/scion/harnesses/claude",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := NormalizeTemplateSourceURL(tt.input)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNormalizeAndDetect_GitPlusHTTPS(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantType RemoteTemplateType
+	}{
+		{
+			name:     "git+https github harness URL detected as GitHub",
+			input:    "git+https://github.com/GoogleCloudPlatform/scion/harnesses/claude",
+			wantType: RemoteTypeGitHub,
+		},
+		{
+			name:     "git+https github repo URL detected as GitHub",
+			input:    "git+https://github.com/org/repo/tree/main/templates",
+			wantType: RemoteTypeGitHub,
+		},
+		{
+			name:     "git+http github URL detected as GitHub after normalize",
+			input:    "git+http://github.com/org/repo/tree/main/templates",
+			wantType: RemoteTypeGitHub,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalized := NormalizeTemplateSourceURL(tt.input)
+			got := DetectRemoteType(normalized)
+			assert.Equal(t, tt.wantType, got, "normalized URL: %s", normalized)
 		})
 	}
 }

--- a/pkg/hub/resource_source.go
+++ b/pkg/hub/resource_source.go
@@ -80,9 +80,12 @@ type BootstrapResult struct {
 }
 
 // IsBuiltinManaged returns true if sourceURL identifies a resource managed by
-// the built-in bundled catalog.
+// the built-in bundled catalog.  It recognises both the current https:// prefix
+// and the legacy git+https:// prefix for backward compatibility with existing
+// hub databases.
 func IsBuiltinManaged(sourceURL string) bool {
 	return strings.HasPrefix(sourceURL, "builtin://scion/") ||
+		strings.HasPrefix(sourceURL, "https://github.com/GoogleCloudPlatform/scion/harnesses/") ||
 		strings.HasPrefix(sourceURL, "git+https://github.com/GoogleCloudPlatform/scion/harnesses/")
 }
 

--- a/pkg/hub/resource_source_test.go
+++ b/pkg/hub/resource_source_test.go
@@ -115,6 +115,7 @@ func TestIsBuiltinManaged(t *testing.T) {
 	}{
 		{"builtin://scion/dev/template/default", true},
 		{"builtin://scion/v1.0.0/harness-config/claude", true},
+		{"https://github.com/GoogleCloudPlatform/scion/harnesses/claude", true},
 		{"git+https://github.com/GoogleCloudPlatform/scion/harnesses/claude", true},
 		{"https://github.com/example/templates", false},
 		{"", false},

--- a/resources/catalog.go
+++ b/resources/catalog.go
@@ -47,7 +47,7 @@ func sourceURL(kind storage.ResourceKind, name string) string {
 }
 
 func harnessConfigSourceURL(name string) string {
-	return fmt.Sprintf("git+https://github.com/GoogleCloudPlatform/scion/harnesses/%s", name)
+	return fmt.Sprintf("https://github.com/GoogleCloudPlatform/scion/harnesses/%s", name)
 }
 
 // BuiltinTemplates returns the bundled template resources.

--- a/resources/catalog_test.go
+++ b/resources/catalog_test.go
@@ -107,7 +107,7 @@ func TestBuiltinResources(t *testing.T) {
 }
 
 func TestSourceURLFormat(t *testing.T) {
-	const harnessPrefix = "git+https://github.com/GoogleCloudPlatform/scion/harnesses/"
+	const harnessPrefix = "https://github.com/GoogleCloudPlatform/scion/harnesses/"
 	const builtinPrefix = "builtin://scion/"
 
 	for _, r := range BuiltinResources() {
@@ -160,8 +160,8 @@ func TestMandatoryBoilerplateFS(t *testing.T) {
 func assertSourceURL(t *testing.T, r BundledResource) {
 	t.Helper()
 	if r.Kind == storage.ResourceKindHarnessConfig {
-		if !strings.HasPrefix(r.SourceURL, "git+https://github.com/GoogleCloudPlatform/scion/harnesses/") {
-			t.Errorf("%s %q SourceURL = %q, want git+https://... prefix", r.Kind, r.Name, r.SourceURL)
+		if !strings.HasPrefix(r.SourceURL, "https://github.com/GoogleCloudPlatform/scion/harnesses/") {
+			t.Errorf("%s %q SourceURL = %q, want https://... prefix", r.Kind, r.Name, r.SourceURL)
 		}
 	} else if !strings.HasPrefix(r.SourceURL, "builtin://scion/") {
 		t.Errorf("%s %q SourceURL = %q, want builtin://scion/... prefix", r.Kind, r.Name, r.SourceURL)


### PR DESCRIPTION
Fixes harness config reimport, which was completely broken for all 7 built-in harness configs on every hub. resources/catalog.go now generates plain https:// URLs instead of git+https:// (the git+ prefix wasn't recognized by the normalization pipeline); NormalizeTemplateSourceURL and IsBuiltinManaged both updated to still handle legacy git+https:// URLs already stored in existing hub databases. Ref: ptone/scion#897