### PR TITLE
fix: add GatherEnv two-pass to DispatchAgentProvision for auth env resolution

### DIFF
--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -944,6 +944,9 @@ func (d *HTTPAgentDispatcher) DispatchAgentCreate(ctx context.Context, agent *st
 }
 
 // DispatchAgentProvision provisions an agent on the runtime broker without starting it.
+// It uses the same GatherEnv two-pass mechanism as DispatchAgentCreateWithGather so
+// that as_needed env vars (e.g. GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_REGION) are
+// resolved before auth provisioning runs on the broker.
 func (d *HTTPAgentDispatcher) DispatchAgentProvision(ctx context.Context, agent *store.Agent) error {
 	if err := requireRuntimeBrokerAssigned(agent); err != nil {
 		return err
@@ -959,10 +962,70 @@ func (d *HTTPAgentDispatcher) DispatchAgentProvision(ctx context.Context, agent 
 		return err
 	}
 	req.ProvisionOnly = true
+	req.GatherEnv = true
+
+	// Track which scope provided each key
+	req.EnvSources = d.buildEnvSources(ctx, agent, req.ResolvedEnv)
+
+	// First pass: use CreateAgentWithGather so the broker can report which
+	// env vars are still needed (returned as a 202 with env requirements).
+	resp, envReqs, err := d.client.CreateAgentWithGather(ctx, agent.RuntimeBrokerID, endpoint, req)
+	if isHashMismatchError(err) {
+		if repairErr := d.repairHashMismatch(ctx, agent, err); repairErr == nil {
+			resp, envReqs, err = d.client.CreateAgentWithGather(ctx, agent.RuntimeBrokerID, endpoint, req)
+		}
+	}
+	if errors.Is(err, ErrLifecycleDeferred) {
+		envReqs, err = d.deferredCreateWithGather(ctx, agent)
+		if err != nil {
+			return err
+		}
+		// Fall through to the second-pass as_needed resolution below.
+	} else if err != nil {
+		return err
+	} else if resp != nil {
+		d.applyBrokerResponse(agent, resp)
+	}
+
+	// Second pass: if the broker reported needed keys, check whether any can
+	// be satisfied by as_needed env vars or secrets — mirroring the pattern in
+	// DispatchAgentCreateWithGather. We inline this instead of calling
+	// DispatchFinalizeEnv because the finalize path does not set ProvisionOnly.
+	if envReqs != nil && len(envReqs.Needs) > 0 {
+		asNeededEnv := d.resolveAsNeededForKeys(ctx, agent, envReqs.Needs, envReqs.Alternatives)
+		if len(asNeededEnv) > 0 {
+			if req.ResolvedEnv == nil {
+				req.ResolvedEnv = make(map[string]string)
+			}
+			for k, v := range asNeededEnv {
+				req.ResolvedEnv[k] = v
+			}
+			req.EnvSources = d.buildEnvSources(ctx, agent, req.ResolvedEnv)
+
+			// Replay the provision request with the resolved env.
+			resp2, envReqs2, err2 := d.client.CreateAgentWithGather(ctx, agent.RuntimeBrokerID, endpoint, req)
+			if isHashMismatchError(err2) {
+				if repairErr := d.repairHashMismatch(ctx, agent, err2); repairErr == nil {
+					resp2, envReqs2, err2 = d.client.CreateAgentWithGather(ctx, agent.RuntimeBrokerID, endpoint, req)
+				}
+			}
+			if err2 != nil {
+				return err2
+			}
+			if envReqs2 != nil && len(envReqs2.Needs) > 0 {
+				d.log.Warn("DispatchAgentProvision: env vars still missing after second pass",
+					"agent", agent.Name, "needs", envReqs2.Needs)
+			}
+			if resp2 != nil {
+				d.applyBrokerResponse(agent, resp2)
+			}
+		}
+	}
 
 	// Merge resolved storage env vars back into AppliedConfig so they are
 	// visible in the advanced config form. Exclude internal SCION_* vars
-	// and dev tokens which are injected at start time.
+	// and dev tokens which are injected at start time. This runs after both
+	// passes so that as_needed vars resolved in the second pass are included.
 	if agent.AppliedConfig != nil && len(req.ResolvedEnv) > 0 {
 		if agent.AppliedConfig.Env == nil {
 			agent.AppliedConfig.Env = make(map[string]string)
@@ -977,17 +1040,6 @@ func (d *HTTPAgentDispatcher) DispatchAgentProvision(ctx context.Context, agent 
 		}
 	}
 
-	resp, err := d.client.CreateAgent(ctx, agent.RuntimeBrokerID, endpoint, req)
-	if isHashMismatchError(err) {
-		if repairErr := d.repairHashMismatch(ctx, agent, err); repairErr == nil {
-			resp, err = d.client.CreateAgent(ctx, agent.RuntimeBrokerID, endpoint, req)
-		}
-	}
-	if err != nil {
-		return err
-	}
-
-	d.applyBrokerResponse(agent, resp)
 	return nil
 }
 

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -976,11 +976,10 @@ func (d *HTTPAgentDispatcher) DispatchAgentProvision(ctx context.Context, agent 
 		}
 	}
 	if errors.Is(err, ErrLifecycleDeferred) {
-		envReqs, err = d.deferredCreateWithGather(ctx, agent)
-		if err != nil {
-			return err
-		}
-		// Fall through to the second-pass as_needed resolution below.
+		// deferredCreateWithGather dispatches via DispatchAgentCreateWithGather which
+		// does not set ProvisionOnly — fall back to returning the error rather than
+		// accidentally triggering a full create on the remote node.
+		return fmt.Errorf("provision not supported for cross-node broker: %w", err)
 	} else if err != nil {
 		return err
 	} else if resp != nil {

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -900,6 +900,164 @@ func TestHTTPAgentDispatcher_DispatchAgentProvision_PassesTaskThrough(t *testing
 	}
 }
 
+// setupProvisionEnvTest creates a broker, project, project provider, and
+// as_needed env vars in the test store, then returns an agent wired to them.
+// This mirrors setupFinalizeEnvTest but uses unique IDs for the provision path.
+func setupProvisionEnvTest(t *testing.T, ctx context.Context, memStore store.Store, asNeededVars []store.EnvVar) *store.Agent {
+	t.Helper()
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("broker-provision"),
+		Name:     "provision-broker",
+		Slug:     "provision-broker",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	project := &store.Project{
+		ID:   tid("project-provision"),
+		Name: "provision-project",
+		Slug: "provision-project",
+	}
+	if err := memStore.CreateProject(ctx, project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	provider := &store.ProjectProvider{
+		ProjectID:  tid("project-provision"),
+		BrokerID:   tid("broker-provision"),
+		BrokerName: "provision-broker",
+		LocalPath:  "/home/user/project/.scion",
+		Status:     store.BrokerStatusOnline,
+	}
+	if err := memStore.AddProjectProvider(ctx, provider); err != nil {
+		t.Fatalf("failed to add project provider: %v", err)
+	}
+
+	for i, v := range asNeededVars {
+		v.Scope = "project"
+		v.ScopeID = tid("project-provision")
+		v.InjectionMode = store.InjectionModeAsNeeded
+		if v.ID == "" {
+			v.ID = tid("ev-provision-" + string(rune('0'+i)))
+		}
+		asNeededVars[i] = v
+		if err := memStore.CreateEnvVar(ctx, &asNeededVars[i]); err != nil {
+			t.Fatalf("failed to create env var %q: %v", v.Key, err)
+		}
+	}
+
+	return &store.Agent{
+		ID:              tid("agent-provision-env"),
+		Name:            "provision-env-agent",
+		Slug:            "provision-env-agent",
+		ProjectID:       tid("project-provision"),
+		OwnerID:         "owner-1",
+		RuntimeBrokerID: tid("broker-provision"),
+		AppliedConfig:   &store.AgentAppliedConfig{},
+	}
+}
+
+func TestHTTPAgentDispatcher_DispatchAgentProvision_TwoPassSuccess(t *testing.T) {
+	// Scenario: first pass returns envReqs with needs (API_KEY), the
+	// as_needed store has the key, second pass fires with merged env and succeeds.
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	agent := setupProvisionEnvTest(t, ctx, memStore, []store.EnvVar{
+		{Key: "API_KEY", Value: "resolved-api-key"},
+	})
+
+	callCount := 0
+	mockClient := &mockRuntimeBrokerClient{
+		createWithGatherFunc: func(_ context.Context, _, _ string, req *RemoteCreateAgentRequest) (*RemoteAgentResponse, *RemoteEnvRequirementsResponse, error) {
+			callCount++
+			if callCount == 1 {
+				// First pass: broker says API_KEY is still needed.
+				// Verify ProvisionOnly and GatherEnv are set.
+				if !req.ProvisionOnly {
+					t.Error("first pass: expected ProvisionOnly to be true")
+				}
+				if !req.GatherEnv {
+					t.Error("first pass: expected GatherEnv to be true")
+				}
+				return nil, &RemoteEnvRequirementsResponse{
+					AgentID: req.ID,
+					Needs:   []string{"API_KEY"},
+				}, nil
+			}
+			// Second pass: verify API_KEY was merged into ResolvedEnv.
+			if v, ok := req.ResolvedEnv["API_KEY"]; !ok || v != "resolved-api-key" {
+				t.Errorf("second pass: expected API_KEY='resolved-api-key', got %q (ok=%v)", v, ok)
+			}
+			// Verify ProvisionOnly and GatherEnv are still set on second pass.
+			if !req.ProvisionOnly {
+				t.Error("second pass: expected ProvisionOnly to be true")
+			}
+			if !req.GatherEnv {
+				t.Error("second pass: expected GatherEnv to be true")
+			}
+			return &RemoteAgentResponse{
+				Agent: &RemoteAgentInfo{
+					ID:    req.ID,
+					Slug:  req.Slug,
+					Name:  req.Name,
+					Phase: string(state.PhaseRunning),
+				},
+				Created: true,
+			}, nil, nil
+		},
+	}
+
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+
+	err := dispatcher.DispatchAgentProvision(ctx, agent)
+	if err != nil {
+		t.Fatalf("DispatchAgentProvision returned unexpected error: %v", err)
+	}
+
+	if callCount != 2 {
+		t.Errorf("expected 2 CreateAgentWithGather calls, got %d", callCount)
+	}
+}
+
+func TestHTTPAgentDispatcher_DispatchAgentProvision_TwoPassNoResolution(t *testing.T) {
+	// Scenario: first pass returns envReqs with needs, but no as_needed vars
+	// match. No second pass should occur and no error should be returned.
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	// No as_needed vars in the store.
+	agent := setupProvisionEnvTest(t, ctx, memStore, nil)
+
+	callCount := 0
+	mockClient := &mockRuntimeBrokerClient{
+		createWithGatherFunc: func(_ context.Context, _, _ string, req *RemoteCreateAgentRequest) (*RemoteAgentResponse, *RemoteEnvRequirementsResponse, error) {
+			callCount++
+			// First pass: broker says MISSING_VAR is needed but no store entry exists.
+			return nil, &RemoteEnvRequirementsResponse{
+				AgentID: req.ID,
+				Needs:   []string{"MISSING_VAR"},
+			}, nil
+		},
+	}
+
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+
+	err := dispatcher.DispatchAgentProvision(ctx, agent)
+	if err != nil {
+		t.Fatalf("DispatchAgentProvision returned unexpected error: %v", err)
+	}
+
+	// Only one call — no second pass because resolution returned nothing.
+	if callCount != 1 {
+		t.Errorf("expected 1 CreateAgentWithGather call, got %d", callCount)
+	}
+}
+
 func TestHTTPAgentDispatcher_DispatchAgentCreate_WithWorkspace(t *testing.T) {
 	ctx := context.Background()
 	memStore := createTestStore(t)


### PR DESCRIPTION
The create & edit UI flow uses DispatchAgentProvision, which only did single-pass env resolution without GatherEnv, so as_needed keys like GOOGLE_CLOUD_PROJECT/GOOGLE_CLOUD_REGION were never resolved and auth provisioning failed with no valid auth method found. Adds the same GatherEnv two-pass mechanism DispatchAgentCreateWithGather already uses: CreateAgentWithGather reports needed env keys, resolveAsNeededForKeys resolves them, then the provision request is replayed with fully resolved env. Ref: ptone/scion#899