### PR TITLE
security(hub): gate agent DELETE with lifecycle scope + project isola…

### DIFF
--- a/pkg/hub/handlers_agent_delete_authz_test.go
+++ b/pkg/hub/handlers_agent_delete_authz_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+)
+
+// deleteReqWithAgent builds a DELETE request carrying agentIdent in its context
+// (no user identity), so performAgentDelete's agent-caller branch is exercised.
+func deleteReqWithAgent(agentIdent Identity) *http.Request {
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/agents/victim", nil)
+	return req.WithContext(contextWithIdentity(req.Context(), agentIdent))
+}
+
+// TestPerformAgentDelete_AgentCallerScopeAndProjectGate verifies an agent
+// caller must hold ScopeAgentLifecycle and target an agent in its own project.
+func TestPerformAgentDelete_AgentCallerScopeAndProjectGate(t *testing.T) {
+	srv, _, _, project := setupAgentRoleTest(t)
+	victim := &store.Agent{ID: tid("victim"), ProjectID: project.ID}
+
+	t.Run("missing lifecycle scope is 403", func(t *testing.T) {
+		agentIdent := &agentIdentityWrapper{&AgentTokenClaims{
+			ProjectID: project.ID,
+			Scopes:    []AgentTokenScope{ScopeProjectRead}, // readonly/baseline: no lifecycle
+		}}
+		rec := httptest.NewRecorder()
+		srv.performAgentDelete(rec, deleteReqWithAgent(agentIdent), victim)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.Contains(t, rec.Body.String(), "project:agent:lifecycle")
+	})
+
+	t.Run("lifecycle scope but foreign project is 403", func(t *testing.T) {
+		agentIdent := &agentIdentityWrapper{&AgentTokenClaims{
+			ProjectID: tid("some-other-project"),
+			Scopes:    []AgentTokenScope{ScopeAgentLifecycle},
+		}}
+		rec := httptest.NewRecorder()
+		srv.performAgentDelete(rec, deleteReqWithAgent(agentIdent), victim)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.Contains(t, rec.Body.String(), "within their own project")
+	})
+
+	t.Run("no identity at all is 403 (fail closed)", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/agents/victim", nil)
+		rec := httptest.NewRecorder()
+		srv.performAgentDelete(rec, req, victim)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("lifecycle scope in the same project passes the gate", func(t *testing.T) {
+		// Already-soft-deleted: 204 right after the gate (idempotency), so an
+		// authorized agent clears the gate without a live broker.
+		deleted := &store.Agent{ID: tid("victim"), ProjectID: project.ID, DeletedAt: time.Now()}
+		agentIdent := &agentIdentityWrapper{&AgentTokenClaims{
+			ProjectID: project.ID,
+			Scopes:    []AgentTokenScope{ScopeAgentLifecycle},
+		}}
+		rec := httptest.NewRecorder()
+		srv.performAgentDelete(rec, deleteReqWithAgent(agentIdent), deleted)
+		assert.Equal(t, http.StatusNoContent, rec.Code)
+		assert.NotContains(t, rec.Body.String(), "project:agent:lifecycle")
+	})
+}

--- a/pkg/hub/handlers_agent_delete_authz_test.go
+++ b/pkg/hub/handlers_agent_delete_authz_test.go
@@ -68,6 +68,23 @@ func TestPerformAgentDelete_AgentCallerScopeAndProjectGate(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, rec.Code)
 	})
 
+	t.Run("empty project id on either side never authorizes", func(t *testing.T) {
+		// Two empty strings compare equal, so an empty project id must be
+		// rejected outright rather than allowed to match.
+		lifecycleAgent := func(pid string) Identity {
+			return &agentIdentityWrapper{&AgentTokenClaims{ProjectID: pid, Scopes: []AgentTokenScope{ScopeAgentLifecycle}}}
+		}
+		// Empty token project id against an empty-project target.
+		rec := httptest.NewRecorder()
+		srv.performAgentDelete(rec, deleteReqWithAgent(lifecycleAgent("")), &store.Agent{ID: tid("victim"), ProjectID: ""})
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		assert.Contains(t, rec.Body.String(), "within their own project")
+		// Empty token project id against a real-project target.
+		rec = httptest.NewRecorder()
+		srv.performAgentDelete(rec, deleteReqWithAgent(lifecycleAgent("")), victim)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
 	t.Run("lifecycle scope in the same project passes the gate", func(t *testing.T) {
 		// Already-soft-deleted: 204 right after the gate (idempotency), so an
 		// authorized agent clears the gate without a live broker.

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -1946,24 +1946,22 @@ func (s *Server) performAgentDelete(w http.ResponseWriter, r *http.Request, agen
 	// Authorize by caller kind: users by delete policy, agents by lifecycle
 	// scope + same-project isolation (as in handleAgentAction). Fail closed
 	// for a caller that is neither — a user-only check would silently skip
-	// agent callers, since GetUserIdentityFromContext returns nil for them.
-	userIdent := GetUserIdentityFromContext(ctx)
-	agentIdent := GetAgentIdentityFromContext(ctx)
-	switch {
-	case userIdent != nil:
-		decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionDelete)
+	// agent callers, which do not satisfy the UserIdentity interface.
+	switch ident := GetIdentityFromContext(ctx).(type) {
+	case UserIdentity:
+		decision := s.authzService.CheckAccess(ctx, ident, agentResource(agent), ActionDelete)
 		if !decision.Allowed {
 			writeError(w, http.StatusForbidden, ErrCodeForbidden,
 				"Only the agent's creator can delete it", nil)
 			return
 		}
-	case agentIdent != nil:
-		if !agentIdent.HasScope(ScopeAgentLifecycle) {
+	case AgentIdentity:
+		if !ident.HasScope(ScopeAgentLifecycle) {
 			writeError(w, http.StatusForbidden, ErrCodeForbidden,
 				"Missing required scope: project:agent:lifecycle", nil)
 			return
 		}
-		if agent.ProjectID != agentIdent.ProjectID() {
+		if agent.ProjectID != ident.ProjectID() {
 			writeError(w, http.StatusForbidden, ErrCodeForbidden,
 				"Agents can only manage agents within their own project", nil)
 			return

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -1943,14 +1943,35 @@ func (s *Server) performAgentDelete(w http.ResponseWriter, r *http.Request, agen
 		attribute.String("scion.agent.id", agent.ID),
 	)
 
-	// Enforce policy-based authorization: only the agent's creator (owner) or admins can delete
-	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+	// Authorize by caller kind: users by delete policy, agents by lifecycle
+	// scope + same-project isolation (as in handleAgentAction). Fail closed
+	// for a caller that is neither — a user-only check would silently skip
+	// agent callers, since GetUserIdentityFromContext returns nil for them.
+	userIdent := GetUserIdentityFromContext(ctx)
+	agentIdent := GetAgentIdentityFromContext(ctx)
+	switch {
+	case userIdent != nil:
 		decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionDelete)
 		if !decision.Allowed {
 			writeError(w, http.StatusForbidden, ErrCodeForbidden,
 				"Only the agent's creator can delete it", nil)
 			return
 		}
+	case agentIdent != nil:
+		if !agentIdent.HasScope(ScopeAgentLifecycle) {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden,
+				"Missing required scope: project:agent:lifecycle", nil)
+			return
+		}
+		if agent.ProjectID != agentIdent.ProjectID() {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden,
+				"Agents can only manage agents within their own project", nil)
+			return
+		}
+	default:
+		writeError(w, http.StatusForbidden, ErrCodeForbidden,
+			"This action requires user or agent authentication", nil)
+		return
 	}
 
 	query := r.URL.Query()

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -1961,7 +1961,10 @@ func (s *Server) performAgentDelete(w http.ResponseWriter, r *http.Request, agen
 				"Missing required scope: project:agent:lifecycle", nil)
 			return
 		}
-		if agent.ProjectID != ident.ProjectID() {
+		// An empty project ID on either side must never authorize: two empty
+		// strings compare equal, so a malformed token or corrupted record would
+		// otherwise slip past the isolation gate.
+		if agent.ProjectID == "" || ident.ProjectID() == "" || agent.ProjectID != ident.ProjectID() {
 			writeError(w, http.StatusForbidden, ErrCodeForbidden,
 				"Agents can only manage agents within their own project", nil)
 			return


### PR DESCRIPTION
## Summary

`performAgentDelete` authorized only **user** callers. It used the idiom

```go
if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
    decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionDelete)
    ...
}
```

An agent identity does not satisfy GetUserIdentityFromContext — it returns
nil for agent-authenticated callers — so this check was silently skipped for
every agent JWT. DELETE was therefore the one agent-CRUD verb with no scope or
project gate: create (ScopeAgentCreate), start/stop
(ScopeAgentLifecycle), token-refresh (ScopeAgentTokenRefresh) and read
(checkAgentReadScope) all gate agent callers, but delete did not.

Impact: any valid agent JWT — from any project — could delete any agent
hub-wide, including across project boundaries.


### Fix

Gate deletion exactly like the interactive lifecycle actions in
handleAgentAction:

- user callers keep the existing creator/admin policy check;
- agent callers must carry ScopeAgentLifecycle and target an agent in
their own project (agent.ProjectID == agentIdent.ProjectID());
- a caller that is neither now fails closed with 403.

Both delete routes — DELETE /api/v1/agents/{id} and
DELETE /api/v1/projects/{projectId}/agents/{agentId} — funnel through
performAgentDelete, so the single gate covers both.

This complements the policy-handler hardening in #990, closing the remaining
agent-CRUD handler that used the same skip-for-agents idiom.

### Test

TestPerformAgentDelete_AgentCallerScopeAndProjectGate:
- agent without ScopeAgentLifecycle → 403 (missing scope)
- agent with the scope but a foreign project → 403 (project isolation)
- no identity → 403 (fail closed)
- agent with the scope in the same project → clears the gate (204 on an
already-soft-deleted target, proving authorization without a live broker)
