### PR TITLE
docs: nightly documentation update for Aug 9 changelog

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -96,6 +96,7 @@ export default defineConfig({
 							label: 'Release Notes',
 							items: [
 								{ label: 'Overview', slug: 'release-notes' },
+								{ label: 'Aug 3 -- 9', slug: 'release-notes/2026-08-03' },
 								{ label: 'Jul 27 -- Aug 2', slug: 'release-notes/2026-07-27' },
 								{ label: 'Jul 19 -- 25', slug: 'release-notes/2026-07-19' },
 								{ label: 'Jul 12 -- 19', slug: 'release-notes/2026-07-12' },

--- a/docs-site/src/content/docs/hosted/ha/permissions.md
+++ b/docs-site/src/content/docs/hosted/ha/permissions.md
@@ -103,9 +103,16 @@ The effective role granted to an agent at creation is resolved by a **two-gate a
 
 $$\text{effectiveRole} = \min(\text{requestedRole}, \text{userCeiling}, \text{projectMax})$$
 
-1. **Requested Role**: The role requested during agent dispatch (e.g., using the `--role` flag in the CLI). If not specified, defaults to `baseline`.
-2. **User Ceiling**: Capped by the user's own system permissions. A standard `hub:member` has an agent role ceiling of `baseline`. Only a `hub:admin` has a ceiling of `full`.
+1. **Requested Role**: The role requested during agent dispatch (e.g., using the `--role` flag in the CLI). If not specified, the role defaults to the project-level or Hub-level `default_agent_role`.
+   - **Default Role Update**: For better usability, the default fallback role has been changed from `baseline` to `full`.
+   - **Configuration Options**: You can specify `default_agent_role` globally under `agent_defaults` in the Hub settings (via settings/admin UI) or customize it per-project using the admin UI dropdown or the project setting `scion.io/default-agent-role`.
+2. **User Ceiling**: Capped by the user's own system permissions. (Note: The user-ceiling gate is currently configured as a pass-through where all Hub users receive a ceiling of `full`, making the project's maximum role the primary operational limiter).
 3. **Project Max**: Set by the project's `max_agent_role` setting, which defaults to the global Hub configuration (`default_max_agent_role` under `agent_defaults`).
+
+#### Fallback and Fail-Closed Security
+To guard against unauthorized escalations, the role fallback chain and parent lookup enforce fail-closed behavior:
+- **Parent Agent Lookup Failure**: If parent agent lookup fails (e.g., due to transient database issues or invalid parent ID) when spawning a sub-agent, the sub-agent role ceiling defaults to `baseline` instead of failing open.
+- **Corrupted Stored Roles**: If a parent agent's stored role is corrupted or invalid, it is treated as `baseline` for sub-agent creations to ensure robust security.
 
 #### Sub-Agent No-Escalation Enforcement
 To prevent security bypasses via sub-agent creation, Scion enforces strict no-escalation rules:

--- a/docs-site/src/content/docs/hosted/single-node/auth.md
+++ b/docs-site/src/content/docs/hosted/single-node/auth.md
@@ -144,8 +144,22 @@ Use this token to authenticate agents to external services like HashiCorp Vault,
 
 Scion supports inbound OIDC-based federation authentication. This allows external identities (such as other Scion Hubs, Google Cloud Service Accounts, or Firebase/Google users) to authenticate against the Hub API using OIDC ID tokens from trusted issuers.
 
-### Configuration
-Federation is feature-gated and configured under the `server.federation` block in `settings.yaml`:
+### Configuration and Runtime Management
+
+Federation authentication is feature-gated. It can be configured initially at bootstrap via the `server.federation` block in `settings.yaml`, or managed dynamically at runtime via the **Admin UI** (using the `opsettings` pattern).
+
+#### Runtime Administration (Admin UI)
+When running in database mode, administrators can manage OIDC federation configuration directly in the Admin UI without restarting the Hub:
+* **Issuer CRUD**: Create, read, update, and delete trusted OIDC issuers dynamically. The interface provides conditional input fields based on the selected identity/issuer type.
+* **Hot-Reloading**: Changes saved in the UI are immediately applied cluster-wide. The backend utilizes an `atomic.Pointer` to hot-reload the `FederationAuthenticator`, ensuring a zero-downtime, lock-free path for inbound federated requests.
+* **Semantic Validation**: The Admin API performs strict semantic validation on save, preventing malformed issuer rules or invalid URLs from reaching the live runtime.
+
+#### Static Bootstrap Configuration (`settings.yaml`)
+Alternatively, or for initial bootstrapping, you can configure federation statically in your configuration file.
+
+:::note[OIDC Wiring Guarantee]
+Federation and OIDC configurations are fully wired end-to-end into the server's config schemas (`hub.ServerConfig` and `V1ServerConfig`), ensuring no federation fields are silently dropped on file load. In combo-server setups, standard `/.well-known/` discovery endpoints are routed correctly and are not intercepted by the SPA catch-all routing.
+:::
 
 ```yaml
 server:

--- a/docs-site/src/content/docs/hosted/single-node/auth.md
+++ b/docs-site/src/content/docs/hosted/single-node/auth.md
@@ -158,7 +158,7 @@ When running in database mode, administrators can manage OIDC federation configu
 Alternatively, or for initial bootstrapping, you can configure federation statically in your configuration file.
 
 :::note[OIDC Wiring Guarantee]
-Federation and OIDC configurations are fully wired end-to-end into the server's config schemas (`hub.ServerConfig` and `V1ServerConfig`), ensuring no federation fields are silently dropped on file load. In combo-server setups, standard `/.well-known/` discovery endpoints are routed correctly and are not intercepted by the SPA catch-all routing.
+Federation and OIDC configurations are fully wired end-to-end into the server's config schemas (`config.GlobalConfig` and `V1ServerConfig`), ensuring no federation fields are silently dropped on file load. In combo-server setups, standard `/.well-known/` discovery endpoints are routed correctly and are not intercepted by the SPA catch-all routing.
 :::
 
 ```yaml

--- a/docs-site/src/content/docs/reference/admin-settings.md
+++ b/docs-site/src/content/docs/reference/admin-settings.md
@@ -22,7 +22,7 @@ Settings are classified into two layers:
 | Layer | Examples | Behavior |
 |-------|----------|----------|
 | **Layer-0** (bootstrap) | `server.mode`, `server.database.*`, `server.storage.*`, `server.secrets.*`, `server.hub.port`, `server.auth.dev_mode` | Always resolved from bootstrap configuration. Cannot be changed via the admin UI in database mode. |
-| **Layer-1** (operational) | `server.hub.admin_emails`, `server.auth.user_access_mode`, `telemetry.*`, `agent_defaults.*`, `server.github_app.*`, `server.notification_channels` | In database mode, stored in the database and editable via the admin UI. Bootstrap values serve as initial defaults. |
+| **Layer-1** (operational) | `server.hub.admin_emails`, `server.auth.user_access_mode`, `telemetry.*`, `agent_defaults.*`, `server.github_app.*`, `server.notification_channels`, `server.federation.*` | In database mode, stored in the database and editable via the admin UI. Bootstrap values serve as initial defaults. |
 
 ### Database Mode
 
@@ -165,7 +165,7 @@ To streamline management of complex environments, the **General** settings tab i
 1. **General Card**: Houses central Hub identity, registration endpoints, and core server configurations.
 2. **Agent Defaults Card** (with dedicated sub-tabs):
    - Configures default resource constraints (`max_turns`, `max_duration`, limits). These fields can be cleared to blank in the UI, which persists them as `null` in the Hub settings database instead of preserving their previous values, allowing administrators to remove default constraints entirely.
-   - Introduces **Default Model** (`default_model`) and **Default Thinking Level** (`default_thinking_level`) fields directly into the agent default pipeline.
+   - Introduces **Default Model** (`default_model`), **Default Thinking Level** (`default_thinking_level`), and **Default Agent Role** (`default_agent_role`) fields directly into the agent default pipeline (with the default agent role updated from `baseline` to `full` for usability).
    - Houses the **Telemetry Toggle**, which has been moved to this card to keep telemetry configuration closely aligned with operational defaults.
 3. **Project Default Settings Card**: Configures platform-level default annotations and behaviors for newly created projects.
 

--- a/docs-site/src/content/docs/reference/server-config.md
+++ b/docs-site/src/content/docs/reference/server-config.md
@@ -481,7 +481,8 @@ Settings that can be changed at runtime and are shared across all replicas. Stor
 | `lifecycle` | `auto_suspend_stalled`, `soft_delete_retention`, `soft_delete_retain_files` |
 | `maintenance` | `admin_mode`, `maintenance_message` (durable + cluster-wide) |
 | `telemetry` | Full `telemetry.*` subtree (enabled, cloud, hub, local, filter, resource) |
-| `agent_defaults` | `default_template`, `default_harness_config`, `default_max_turns`, `default_max_model_calls`, `default_max_duration`, `default_resources`, `default_model`, `default_thinking_level`, `default_max_agent_role` |
+| `agent_defaults` | `default_template`, `default_harness_config`, `default_max_turns`, `default_max_model_calls`, `default_max_duration`, `default_resources`, `default_model`, `default_thinking_level`, `default_max_agent_role`, `default_agent_role` |
+| `federation` | `enabled`, `trusted_issuers[]`, `algorithms`, `refresh_interval`, `debounce_interval` |
 | `endpoints` | `hub.public_url`, `image_registry` |
 | `github_app` | `app_id`, `api_base_url`, `webhooks_enabled`, `installation_url`, `private_key_path` |
 | `notifications` | `notification_channels[]` |

--- a/docs-site/src/content/docs/release-notes.md
+++ b/docs-site/src/content/docs/release-notes.md
@@ -4,14 +4,15 @@ title: Release Notes
 
 Scion release notes are published weekly.
 
-## Latest: Week of July 27 -- August 2, 2026
+## Latest: Week of August 3 -- 9, 2026
 
-This week delivered a full-stack session metrics subsystem from agent-side telemetry aggregation through API endpoints and web UI dashboards, completed the config-driven auth migration that eliminates all hardcoded per-provider credentials, and shipped pre-start customization hooks at both project and hub scope. The A2A protocol bridge gained admin UI integration with live config management, Discord added one-step thread+agent creation and file retrieval commands, and a sustained chain of auth and injection fixes resolved a class of Vertex AI restart failures.
+This week marked a massive leap forward for Scion's production readiness, headlined by an end-to-end security and identity federation overhaul that includes OIDC provider capabilities, tiered agent authorization roles, and multi-issuer OIDC logins. Alongside these security enhancements, the platform introduced a comprehensive observability suite featuring real-time diagnostic logs, active health-monitoring alerts, and server-side OTel tracing. Additionally, a redesigned user onboarding flow and major high-availability updates to the A2A Protocol Bridge solidify Scion's capability to run at enterprise scale.
 
-[Read the full release notes for this week ->](/scion/release-notes/2026-07-27/)
+[Read the full release notes for this week ->](/scion/release-notes/2026-08-03/)
 
 ## Previous Weeks
 
+- [Week of July 27 -- August 2, 2026](/scion/release-notes/2026-07-27/)
 - [Week of July 19--25, 2026](/scion/release-notes/2026-07-19/)
 - [Week of July 12--19, 2026](/scion/release-notes/2026-07-12/)
 

--- a/docs-site/src/content/docs/release-notes/2026-08-03.md
+++ b/docs-site/src/content/docs/release-notes/2026-08-03.md
@@ -1,0 +1,87 @@
+---
+title: "Week of August 3 -- 9, 2026"
+---
+
+This week marked a massive leap forward for Scion's production readiness, headlined by an end-to-end security and identity federation overhaul that includes OIDC provider capabilities, tiered agent authorization roles, and multi-issuer OIDC logins. Alongside these security enhancements, the platform introduced a comprehensive observability suite featuring real-time diagnostic logs, active health-monitoring alerts, and server-side OTel tracing. Additionally, a redesigned user onboarding flow and major high-availability updates to the A2A Protocol Bridge solidify Scion's capability to run at enterprise scale.
+
+---
+
+## ⭐ Highlights
+
+### 1. Identity Federation, OIDC Agent Identity, and Tiered Authorization Roles
+Scion underwent a comprehensive enterprise-grade security redesign this week, introducing tiered agent authorization roles (none, readonly, baseline, full) with strict sub-agent role inheritance to prevent privilege escalation. Concurrently, the platform deployed multi-issuer OIDC federation authentication with RS256 JWKS caching to allow external system credentials to authenticate. Finally, the Hub became an OIDC Identity Provider itself, enabling running agents to retrieve signed OIDC identity tokens and authenticate directly with external systems like Google Cloud WIF, HashiCorp Vault, and AWS IRSA.
+
+### 2. Integrated Observability, Live Diagnostics, and Health Monitoring
+Monitoring and maintaining Scion became significantly more powerful with the rollout of integrated real-time diagnostics and active health-monitoring systems. A new diagnostics dashboard aggregates log streams across the Hub, Broker, and individual agents in real time, backed by a comprehensive Cloud Logging cleanup that deduplicates entries and links trace IDs. This is paired with an active health dashboard, `scion doctor` checks, Cloud Monitoring alert integrations, and server-side OpenTelemetry tracing that propagates spans across all Hub and Broker request handlers.
+
+### 3. Overhauled User Invitations & Unified Admin UI
+The platform's user membership and onboarding model has been refactored to replace the legacy email allow-list with a native `invited` status integrated directly into the User entity, eliminating deadlock issues. Supported by new admin API endpoints for single and bulk user invitations (supporting up to 1,000 imports via CSV or JSON), the release also delivers a unified admin Users dashboard. This new dashboard features real-time status badges, filtering options, an interactive invite dialog, and context-sensitive row actions to manage the full active, suspended, or invited user lifecycle.
+
+### 4. High-Availability A2A Protocol Bridge and GKE/IAP Support
+The A2A Protocol Bridge achieved full admin UI and visual project exposure editing, while simultaneously evolving to support high availability (HA) via a leaderless, multi-replica architecture. To streamline container deployments on Google Cloud Run, the bridge now utilizes h2c port multiplexing to route both HTTP A2A and gRPC Broker traffic on a single, shared port. Additionally, preflight audience validation was updated to support GKE/GCLB IAP audience formats, enabling robust, HA Hub deployments on GKE.
+
+---
+
+## 🔐 Auth & Security
+
+- **OIDC identity federation:** Deployed multi-issuer OIDC authentication feature-gated behind `federation.enabled`, allowing external identities to authenticate via trusted tokens with pinned RS256 JWKS caching.
+- **OIDC Identity Provider:** Enabled the Hub to act as an OIDC identity provider, publishing standard discovery and JWKS endpoints and adding a CLI command (`sciontool identity-token`) to generate signed, short-lived JWTs for secure access to external resources like Vault or GCP WIF.
+- **Federation configuration UI:** Built a dedicated admin UI for real-time federation management, allowing issuer CRUD, semantic validation, and lock-free `atomic.Pointer` hot-reloading of the federation authenticator.
+- **Tiered agent roles:** Introduced a secure authorization lattice (`none`/`readonly`/`baseline`/`full`) with CLI and UI configuration, and implemented a fail-loud sub-agent check to ensure parent agents cannot escalate children's roles.
+- **Agent runtime secrets API:** Shipped project-scoped secret retrieval endpoints with matching `scion` and `sciontool` CLI commands, allowing running agents to securely query runtime environment secrets.
+- **Antigravity ADC authentication:** Added application default credentials (ADC) support under the `vertex-ai` service configuration using the `AGY_ADC_AUTH` flag, while maintaining the keyring flow for standard tokens.
+- **Cross-user task data leak fix:** Patched a security issue in the A2A Bridge where `ScopedTaskStore` keyed ownership on the project:agent route without validating caller identity, now incorporating `UserID` in the owner key.
+
+## 📊 Observability & Diagnostics
+
+- **Unified diagnostics dashboard:** Rolled out a real-time log viewer in the Hub UI featuring SSE-based log streaming, level filtering, search, and direct navigation links to Google Cloud Logging.
+- **Active health monitoring:** Introduced automated diagnostic checks via `scion doctor`, 15 Cloud Monitoring alert policies, 4 uptime checks, and an admin UI health summary page.
+- **Server-side OTel tracing:** Implemented end-to-end OpenTelemetry tracing across the Hub and Broker request handlers, enabling operation-level spans and cross-component trace propagation.
+- **Cloud Logging optimization:** Swept logging behavior to prevent duplicate stdout logs on Cloud Run, scope diagnostics filters to Scion-specific names, clean up legacy tags, and attach trace links for integrated debugging.
+- **Hermes web dashboard:** Package-integrated the Hermes dashboard to auto-start on port 9119 as an internal Scion service, auto-exposed through the Hub reverse proxy.
+
+## 👥 User Onboarding & Management
+
+- **Invite-only membership refactor:** Replaced the legacy email allow-list with a native `invited` status in the User entity, resolving registration deadlocks and enabling automatic status transitions on first login.
+- **Single and bulk invitation APIs:** Added administrative endpoints to invite single users or batch-import up to 1,000 users via CSV or JSON, complete with audit event logging.
+- **Unified user management UI:** Delivered an admin Users dashboard that displays status badges (invited/active/suspended), filters, and contextual actions, replacing the legacy allow-list tab.
+
+## 🌉 A2A Protocol Bridge
+
+- **Visual exposure editor:** Completed Phase 4 of the A2A Bridge admin integration, introducing an interactive visual editor for managing project and agent exposures with real-time validation.
+- **Leaderless high-availability:** Upgraded the A2A Bridge with a stateless, interchangeable multi-replica architecture that requires no leader election or instance tracking to function.
+- **Single-port multiplexing:** Deployed h2c port multiplexing to dynamically route both HTTP A2A and gRPC Broker traffic on a single port, simplifying Google Cloud Run deployments.
+- **JSON-RPC interface configuration:** Added automated JSON-RPC transport registration to generated agent cards, resolving an issue where the `a2a-go` SDK clients were blocked by missing interfaces.
+- **Dev-mode rebuild target:** Added a local developer target (`make a2a-bridge`) and automated catalog descriptions to streamline development and setup.
+
+## 🛠️ Hub & Project Management
+
+- **Managed project templates:** Shipped full CRUD, SDK, CLI, and UI support for hub-level project templates, including a Git remote override feature to allow users to provide their own repositories.
+- **Configurable auto-suspend threshold:** Added a customizable `stalled_threshold` lifecycle setting, validated down to a 2-minute minimum, with matching admin UI inputs and JSON schema support.
+- **Administrative Hub restart:** Deployed a "Restart Hub" action on the admin maintenance page that triggers a fire-and-forget systemd restart of the Hub service.
+- **Remote hub shadowing:** Added `scion hub shadow` and `unshadow` commands to link local directories to remote Hub projects, enabling CLI actions on workstations without running a local broker.
+- **Configurable default agent roles:** Added default agent role configuration at both the Hub and project levels, promoting the default role to `full` and fixing fallback logic.
+- **Two-pass env-gather resolution:** Fixed a bug in the create-and-edit UI flow where `as_needed` env vars like `GOOGLE_CLOUD_PROJECT` failed to resolve, by introducing a two-pass resolution system.
+- **Directory cleanup API integration:** Fixed a bug where deleting a shared directory via the API only removed the database record, now fully cleaning up the host filesystem directories.
+
+## 🖥️ Web Terminal & UI Improvements
+
+- **Web terminal file uploads:** Added drag-and-drop file uploads (up to 50MB per file, 100MB total) directly into the web terminal, automatically quoting and inserting the container paths.
+- **Agent graph layout options:** Added left-to-right horizontal graph rendering, keyboard shortcuts, segmented toolbar controls, and corrected arrowhead alignment geometry.
+- **Harness configuration parallel refresh:** Added a "Refresh All from Source" button to parallelize harness catalog reimporting, complete with per-row progress indicators.
+- **Clearable agent limits:** Restored the ability to clear numeric agent execution limits (like max turns or duration) back to null value payloads.
+
+## 🔌 Chat Integrations & Broker Plugins
+
+- **Discord `/scion secret` commands:** Rolled out a slash command for listing, getting, setting (via modal), and deleting project secrets securely from Discord using HMAC-signed Hub API requests.
+- **Chat terminal commands:** Added a `/scion terminal` slash command to Discord and Telegram that resolves agent names via the Hub API and returns the direct web terminal URL.
+- **Inbound attachment routing:** Standardized path separators and routed inbound attachments through shared directory infrastructure, resolving delivery failures in isolated workspaces.
+- **Broker plugin restart fix:** Resolved a P0 bootstrap race condition that caused the Discord plugin to crash on Hub restarts, fixing double-dial stalls and goroutine leaks.
+- **Message broker type reconciliation:** Replaced startup-only message broker type loading with a full reconciliation routine, preventing plugins from silently losing message routing on updates.
+
+## ⚙️ Infrastructure & Database Stability
+
+- **Database upgrade crash-loop fixes:** Added pre-migration backfills for null `scope_id` values and pre-migration deduplication of unique constraint policies to prevent upgrade failures on Postgres.
+- **Advisory lock collision resolution:** Fixed a lock key collision where cache eviction and Telegram webhook handlers both attempted to acquire the same Postgres advisory lock.
+- **Thick workstation base image:** Built and verified a Google Cloud Workstations-based base image variant featuring an intermediate `thick-prep` layer, verified for amd64 architecture.
+- **Cloud Build pattern fix:** Anchored the `.gcloudignore` `internal/` exclusion pattern to the repository root, preventing transitively excluding essential A2A Bridge internal packages.


### PR DESCRIPTION
## Summary

Nightly documentation update covering the Aug 9 changelog.

- Documented federation admin UI runtime management and issuer CRUD
- Updated default_agent_role setting (changed from baseline to full) in permissions, auth, admin-settings, and server-config
- Documented OIDC wiring fixes and federation config fields in server-config

4 files changed, 29 insertions, 7 deletions.
