### PR TITLE
fix(auth): re-derive scopes from stored role on token refresh

### DIFF
--- a/pkg/hub/agenttoken.go
+++ b/pkg/hub/agenttoken.go
@@ -377,10 +377,11 @@ func RequireAgentSelfAccess(pathPrefix string) func(http.Handler) http.Handler {
 // is an agent (i.e., GetAgentIdentityFromContext returns non-nil).
 //
 // Backward compatibility note: legacy agents created before the role system
-// may not have ScopeProjectRead in their JWT. They must refresh their token,
-// which will mint scopes based on their effective role (defaulting to baseline,
-// which includes ScopeProjectRead). Token refresh is automatic and frequent,
-// so active legacy agents will have already refreshed.
+// may not have ScopeProjectRead in their JWT. Token refresh re-derives scopes
+// from the agent's stored role (via agentRoleAndScopes → ScopesForRole),
+// which includes ScopeProjectRead for baseline and above. Token refresh is
+// automatic and frequent, so active legacy agents will acquire the scope
+// on their next refresh cycle.
 func checkAgentReadScope(w http.ResponseWriter, r *http.Request) bool {
 	if agentIdent := GetAgentIdentityFromContext(r.Context()); agentIdent != nil {
 		if !agentIdent.HasScope(ScopeProjectRead) {

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -2346,20 +2346,41 @@ func (s *Server) handleAgentTokenRefresh(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	// Extract the current token from the request to refresh it
-	token := extractAgentToken(r)
-	if token == "" {
-		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest,
-			"no agent token found in request", nil)
+	// Look up the agent record to re-derive scopes from the stored role.
+	// This is critical for backward compatibility: legacy agents created
+	// before the role system have tokens with old scope sets (missing
+	// ScopeProjectRead, etc.). Copying old scopes verbatim on refresh
+	// would perpetuate the gap. By re-deriving from the stored role via
+	// agentRoleAndScopes → Server.GenerateAgentToken → ScopesForRole,
+	// the refreshed token always reflects the current role definition.
+	agent, err := s.store.GetAgent(r.Context(), id)
+	if err != nil {
+		slog.Warn("Token refresh: failed to look up agent for role-based scope derivation",
+			"agent_id", id, "error", err)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+			"failed to look up agent record", nil)
 		return
 	}
 
-	newToken, expiresAt, err := s.agentTokenService.RefreshAgentToken(token)
+	agentRole, additionalScopes := agentRoleAndScopes(agent)
+	newToken, err := s.GenerateAgentToken(
+		agent.ID, agent.ProjectID, agentIdent.Ancestry(),
+		agentRole, additionalScopes,
+	)
 	if err != nil {
-		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized,
-			"failed to refresh token: "+err.Error(), nil)
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+			"failed to generate refreshed token: "+err.Error(), nil)
 		return
 	}
+
+	// Parse the new token to extract the expiry for the response.
+	newClaims, err := s.agentTokenService.ValidateAgentToken(newToken)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+			"failed to validate refreshed token", nil)
+		return
+	}
+	expiresAt := newClaims.Expiry.Time()
 
 	// Build the generalized tokens[] array.
 	// App tokens are always present; transport tokens are added when


### PR DESCRIPTION
## Summary

Fixes a production regression where existing agents get 403 errors on all read endpoints (scion list, scion start, etc.) after the tiered agent roles feature merged.

Root cause: RefreshAgentToken copied old JWT scopes verbatim. Legacy agents never acquired ScopeProjectRead on refresh, so checkAgentReadScope blocked them.

Fix: Token refresh handler now looks up the agent record and re-derives scopes via agentRoleAndScopes -> ScopesForRole, matching the dispatch-time path. Config-based scopes (GCP tokens) preserved through additionalScopes merge.

Ref: ptone/scion#905
