### PR TITLE
fix(auth): default pre-role agents to full in agentRoleAndScopes

### DIFF
--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -205,8 +205,11 @@ func (d *HTTPAgentDispatcher) SetTokenGenerator(gen AgentTokenGenerator) {
 // scopes (e.g. GCP token) from the agent record. Used by all dispatch call
 // sites to keep role/scope computation in a single place.
 func agentRoleAndScopes(agent *store.Agent) (AgentRole, []AgentTokenScope) {
-	// Default to baseline for backward compat with pre-role agents.
-	role := AgentRoleBaseline
+	// Default to full for pre-role agents. This matches the design decision
+	// that null/unset agent role resolves to full (see ScopesForRole and
+	// roleOrdinal). Baseline would deny create/lifecycle/secret scopes that
+	// standing agents (coordinators, leads) need.
+	role := AgentRoleFull
 	if agent.AppliedConfig != nil && agent.AppliedConfig.AgentRole != "" {
 		role = AgentRole(agent.AppliedConfig.AgentRole)
 	}

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -205,6 +205,9 @@ func (d *HTTPAgentDispatcher) SetTokenGenerator(gen AgentTokenGenerator) {
 // scopes (e.g. GCP token) from the agent record. Used by all dispatch call
 // sites to keep role/scope computation in a single place.
 func agentRoleAndScopes(agent *store.Agent) (AgentRole, []AgentTokenScope) {
+	if agent == nil {
+		return AgentRoleFull, nil
+	}
 	// Default to full for pre-role agents. This matches the design decision
 	// that null/unset agent role resolves to full (see ScopesForRole and
 	// roleOrdinal). Baseline would deny create/lifecycle/secret scopes that


### PR DESCRIPTION
Fixes standing agents losing create/lifecycle/secret scopes after token refresh.

agentRoleAndScopes hardcoded AgentRoleBaseline as default for pre-role agents, excluding project:agent:create, project:agent:lifecycle, project:secret:read. Inconsistent with PR #1090 where null/unset resolves to full.

One-line fix: change default from AgentRoleBaseline to AgentRoleFull in agentRoleAndScopes.

Ref: ptone/scion#906
