### PR TITLE
fix: add settings.yaml support for project_defaults opsettings section

### DIFF
--- a/docs-site/src/content/docs/reference/server-config.md
+++ b/docs-site/src/content/docs/reference/server-config.md
@@ -473,7 +473,7 @@ Settings required before the database connection exists, or that are restart-bou
 
 ### Layer 1 — Operational (Postgres `hub_settings` table)
 
-Settings that can be changed at runtime and are shared across all replicas. Stored as section-per-row in the `hub_settings` table. In SQLite/workstation mode, these fall back to `settings.yaml` (unchanged behavior).
+Settings that can be changed at runtime and are shared across all replicas. Stored as section-per-row in the `hub_settings` table. In SQLite/workstation mode, these fall back to `settings.yaml` (unchanged behavior), except for the `maintenance` section which is runtime/API-only and has no `settings.yaml` representation (ephemeral in file/SQLite mode).
 
 | Section | Contents |
 | :--- | :--- |
@@ -520,7 +520,7 @@ Because env overrides on Layer-1 keys reintroduce per-node drift, the system war
 
 **Presence-aware clearing**: The PUT handler distinguishes **omitted** fields (preserve current DB value) from **explicitly-sent empty values** (`""`, `[]`, `null`) which **clear** the field. This enables clearing admin_emails, user_access_mode, authorized_domains, notification_channels, and public_url without sending every field.
 
-**Maintenance durability**: `PUT /api/v1/admin/maintenance` writes to the `maintenance` section in DB, making admin/maintenance mode durable across restarts and propagated to all replicas. `SCION_SERVER_ADMINMODE` env var still force-enables per node for break-glass access.
+**Maintenance durability**: `PUT /api/v1/admin/maintenance` writes to the `maintenance` section in DB, making admin/maintenance mode durable across restarts and propagated to all replicas. `SCION_SERVER_ADMINMODE` env var still force-enables per node for break-glass access. In file/SQLite mode, maintenance changes are ephemeral (in-memory only, lost on restart). Use `SCION_SERVER_ADMINMODE=true` env var for persistent control.
 
 **Schema endpoint**: `GET /api/v1/admin/server-config/schema` returns JSON-schema fragments and koanf key paths per section for UI form generation and CLI validation.
 

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -363,6 +363,11 @@ type GlobalConfig struct {
 	AdminMode          bool   `json:"adminMode" yaml:"adminMode" koanf:"adminMode"`
 	MaintenanceMessage string `json:"maintenanceMessage" yaml:"maintenanceMessage" koanf:"maintenanceMessage"`
 
+	// DefaultScratchpad controls whether new projects automatically get a
+	// "scratchpad" shared directory. Populated from settings.yaml
+	// project_defaults.default_scratchpad in file/SQLite mode.
+	DefaultScratchpad *bool `json:"-" yaml:"-" koanf:"-"`
+
 	// Telemetry default — when set, the Hub exposes this as the default telemetry opt-in
 	// state for new agents via GET /api/v1/settings/public.
 	TelemetryEnabled *bool `json:"telemetryEnabled,omitempty" yaml:"telemetryEnabled,omitempty" koanf:"telemetryEnabled"`
@@ -1277,6 +1282,18 @@ func loadServerFromSettingsFile(dir string) (*GlobalConfig, bool) {
 					gc.TelemetryEnabled = telCfg.Enabled
 				}
 				gc.TelemetryConfig = &telCfg
+			}
+		}
+	}
+
+	// Check for top-level "project_defaults" section — it lives outside
+	// "server" in settings.yaml and controls hub-level project creation defaults.
+	if pdRaw, ok := raw["project_defaults"]; ok && pdRaw != nil {
+		if pdMap, ok := pdRaw.(map[string]interface{}); ok {
+			if ds, ok := pdMap["default_scratchpad"]; ok {
+				if b, ok := ds.(bool); ok {
+					gc.DefaultScratchpad = &b
+				}
 			}
 		}
 	}

--- a/pkg/config/opsettings/koanf.go
+++ b/pkg/config/opsettings/koanf.go
@@ -108,6 +108,9 @@ var koanfPathToJSONField = map[string]map[string]string{
 	"auto_expose_ports": {
 		"auto_expose_ports.enabled": "enabled",
 	},
+	"project_defaults": {
+		"project_defaults.default_scratchpad": "default_scratchpad",
+	},
 	"federation": {
 		"server.federation.enabled":           "enabled",
 		"server.federation.trusted_issuers":   "trusted_issuers",
@@ -144,6 +147,9 @@ var jsonFieldToKoanfPaths = map[string]map[string]string{
 	},
 	"auto_expose_ports": {
 		"enabled": "auto_expose_ports.enabled",
+	},
+	"project_defaults": {
+		"default_scratchpad": "project_defaults.default_scratchpad",
 	},
 	"federation": {
 		"enabled":           "server.federation.enabled",

--- a/pkg/config/opsettings/opsettings_test.go
+++ b/pkg/config/opsettings/opsettings_test.go
@@ -67,8 +67,7 @@ func TestSectionMarshalUnmarshal(t *testing.T) {
 func TestSectionHasKoanfPaths(t *testing.T) {
 	// Sections that are DB-only (no settings.yaml representation).
 	dbOnlySections := map[string]bool{
-		"maintenance":      true,
-		"project_defaults": true,
+		"maintenance": true,
 	}
 	for _, sec := range Registry {
 		if dbOnlySections[sec.Name] {

--- a/pkg/config/opsettings/registry.go
+++ b/pkg/config/opsettings/registry.go
@@ -119,13 +119,14 @@ func init() {
 			New:        func() any { return &NotificationsSettings{} },
 		},
 		{
-			// project_defaults is durable via DB but has no settings.yaml
-			// representation. It controls hub-level defaults applied at
+			// project_defaults controls hub-level defaults applied at
 			// project creation time (e.g. default scratchpad shared dir).
 			// Absent DB row = compiled defaults (default_scratchpad=true).
-			Name:       "project_defaults",
-			KoanfPaths: nil,
-			New:        func() any { return &ProjectDefaultsSettings{} },
+			Name: "project_defaults",
+			KoanfPaths: []string{
+				"project_defaults.default_scratchpad",
+			},
+			New: func() any { return &ProjectDefaultsSettings{} },
 		},
 		{
 			Name: "federation",

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -300,11 +300,19 @@ type VersionedSettings struct {
 
 	// AutoExposePorts controls whether ports are automatically exposed in agent containers.
 	AutoExposePorts *AutoExposePortsSettings `json:"auto_expose_ports,omitempty" yaml:"auto_expose_ports,omitempty" koanf:"auto_expose_ports"`
+
+	// ProjectDefaults controls hub-level defaults applied at project creation time.
+	ProjectDefaults *ProjectDefaultsSettings `json:"project_defaults,omitempty" yaml:"project_defaults,omitempty" koanf:"project_defaults"`
 }
 
 // AutoExposePortsSettings holds the auto-expose ports configuration.
 type AutoExposePortsSettings struct {
 	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty" koanf:"enabled"`
+}
+
+// ProjectDefaultsSettings holds project creation defaults in settings.yaml.
+type ProjectDefaultsSettings struct {
+	DefaultScratchpad *bool `json:"default_scratchpad,omitempty" yaml:"default_scratchpad,omitempty" koanf:"default_scratchpad"`
 }
 
 // V1ServerConfig holds server-side configuration in the versioned settings format.

--- a/pkg/hub/admin_project_defaults.go
+++ b/pkg/hub/admin_project_defaults.go
@@ -55,9 +55,13 @@ func (s *Server) handleGetProjectDefaults(w http.ResponseWriter) {
 
 	if ops := s.GetOperationalSettings(); ops != nil {
 		enabled = ops.ProjectDefaultScratchpad()
-	} else if s.config.DefaultScratchpad != nil {
-		// File/SQLite mode: read from settings.yaml via ApplySnapshot.
-		enabled = *s.config.DefaultScratchpad
+	} else {
+		s.mu.RLock()
+		if s.config.DefaultScratchpad != nil {
+			// File/SQLite mode: read from settings.yaml via ApplySnapshot.
+			enabled = *s.config.DefaultScratchpad
+		}
+		s.mu.RUnlock()
 	}
 
 	writeJSON(w, http.StatusOK, opsettings.ProjectDefaultsSettings{

--- a/pkg/hub/admin_project_defaults.go
+++ b/pkg/hub/admin_project_defaults.go
@@ -55,6 +55,9 @@ func (s *Server) handleGetProjectDefaults(w http.ResponseWriter) {
 
 	if ops := s.GetOperationalSettings(); ops != nil {
 		enabled = ops.ProjectDefaultScratchpad()
+	} else if s.config.DefaultScratchpad != nil {
+		// File/SQLite mode: read from settings.yaml via ApplySnapshot.
+		enabled = *s.config.DefaultScratchpad
 	}
 
 	writeJSON(w, http.StatusOK, opsettings.ProjectDefaultsSettings{

--- a/pkg/hub/operational_settings.go
+++ b/pkg/hub/operational_settings.go
@@ -90,6 +90,9 @@ type Layer1Snapshot struct {
 	// Auto-expose ports
 	AutoExposePortsEnabled *bool
 
+	// Project defaults
+	DefaultScratchpad *bool
+
 	// Agent defaults
 	DefaultTemplate      string
 	DefaultHarnessConfig string
@@ -582,6 +585,12 @@ func buildSnapshotFromKoanf(k *koanf.Koanf) Layer1Snapshot {
 		v := k.Bool("auto_expose_ports.enabled")
 		snap.AutoExposePortsEnabled = &v
 	}
+
+	// Project defaults
+	if k.Exists("project_defaults.default_scratchpad") {
+		v := k.Bool("project_defaults.default_scratchpad")
+		snap.DefaultScratchpad = &v
+	}
 	teleSub := k.Cut("telemetry")
 	if teleSub != nil && len(teleSub.Keys()) > 0 {
 		data, err := json.Marshal(teleSub.Raw())
@@ -703,6 +712,9 @@ func BuildLayer1SnapshotFromFile(gc *config.GlobalConfig) Layer1Snapshot {
 	snap.GitHubInstallationURL = gc.GitHubApp.InstallationURL
 	snap.GitHubPrivateKeyPath = gc.GitHubApp.PrivateKeyPath
 
+	// Project defaults — read from settings.yaml project_defaults section
+	snap.DefaultScratchpad = gc.DefaultScratchpad
+
 	// Federation — read from GlobalConfig
 	if gc.Federation.Enabled || len(gc.Federation.TrustedIssuers) > 0 {
 		snap.FederationConfig = &gc.Federation
@@ -742,6 +754,15 @@ func ApplySnapshot(s *Server, snap Layer1Snapshot) map[string]interface{} {
 		s.config.AutoExposePortsDefault = snap.AutoExposePortsEnabled
 		if oldVal == nil || *oldVal != *snap.AutoExposePortsEnabled {
 			applied = append(applied, "auto_expose_ports_default")
+		}
+	}
+
+	// Project defaults
+	if snap.DefaultScratchpad != nil {
+		oldVal := s.config.DefaultScratchpad
+		s.config.DefaultScratchpad = snap.DefaultScratchpad
+		if oldVal == nil || *oldVal != *snap.DefaultScratchpad {
+			applied = append(applied, "default_scratchpad")
 		}
 	}
 

--- a/pkg/hub/project_defaults.go
+++ b/pkg/hub/project_defaults.go
@@ -26,8 +26,11 @@ func (s *Server) defaultProjectSharedDirs() []api.SharedDir {
 
 	if ops := s.GetOperationalSettings(); ops != nil {
 		enabled = ops.ProjectDefaultScratchpad()
+	} else if s.config.DefaultScratchpad != nil {
+		// File/SQLite mode: read from settings.yaml via ApplySnapshot.
+		enabled = *s.config.DefaultScratchpad
 	}
-	// File/SQLite mode: ops is nil → compiled default (ON) applies.
+	// File/SQLite mode with no settings.yaml override → compiled default (ON) applies.
 
 	if !enabled {
 		return nil

--- a/pkg/hub/project_defaults.go
+++ b/pkg/hub/project_defaults.go
@@ -20,15 +20,20 @@ import "github.com/GoogleCloudPlatform/scion/pkg/api"
 // for new projects. Returns a scratchpad shared dir when enabled (the
 // compiled default), or nil when the operator has explicitly disabled it.
 //
-// Thread-safe: reads from OperationalSettings under its internal lock.
+// Thread-safe: reads from OperationalSettings under its internal lock,
+// or from s.config.DefaultScratchpad under s.mu.
 func (s *Server) defaultProjectSharedDirs() []api.SharedDir {
 	enabled := true // compiled default: ON
 
 	if ops := s.GetOperationalSettings(); ops != nil {
 		enabled = ops.ProjectDefaultScratchpad()
-	} else if s.config.DefaultScratchpad != nil {
-		// File/SQLite mode: read from settings.yaml via ApplySnapshot.
-		enabled = *s.config.DefaultScratchpad
+	} else {
+		s.mu.RLock()
+		if s.config.DefaultScratchpad != nil {
+			// File/SQLite mode: read from settings.yaml via ApplySnapshot.
+			enabled = *s.config.DefaultScratchpad
+		}
+		s.mu.RUnlock()
 	}
 	// File/SQLite mode with no settings.yaml override → compiled default (ON) applies.
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -154,6 +154,9 @@ type ServerConfig struct {
 	// AutoExposePortsDefault is the default auto-expose-ports enabled state for new agents.
 	// Exposed via GET /api/v1/settings/public so the web UI can pre-populate the checkbox.
 	AutoExposePortsDefault *bool
+	// DefaultScratchpad controls whether new projects automatically get a
+	// "scratchpad" shared directory. When nil, the compiled default (true) applies.
+	DefaultScratchpad *bool
 	// TelemetryConfig is the full hub-level telemetry config from settings.yaml.
 	// Used to populate default telemetry config on new agents when no per-agent
 	// or template-level telemetry config is set.


### PR DESCRIPTION
Bridges the file/SQLite gap for the project_defaults opsettings section, following the exact auto_expose_ports pattern (KoanfPaths registration, forward/reverse koanf mappings, Layer1Snapshot field, BuildLayer1SnapshotFromFile/ApplySnapshot wiring, GET handler + defaultProjectSharedDirs file-mode fallback). Also documents the maintenance section's ephemeral behavior in file/SQLite mode. Ref: ptone/scion#903