### PR TITLE
feat: add agent role badge and expand GCP identity card

### DIFF
--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -1550,14 +1550,14 @@ export class ScionPageAgentDetail extends LitElement {
     const inline = cfg?.inlineConfig;
 
     return html`
-      ${this.renderIdentityCard(agent, cfg?.gcpIdentity)} ${this.renderLabelsCard(agent)}
+      ${this.renderIdentityCard(agent)} ${this.renderLabelsCard(agent)}
       ${this.renderHarnessModelCard(agent, cfg, inline)} ${this.renderRuntimeCard(agent, inline)}
       ${this.renderGCPIdentityCard(cfg?.gcpIdentity)} ${this.renderConfigLimitsCard(inline)}
       ${this.renderTelemetryCard(inline?.telemetry)} ${this.renderInitialTaskCard(cfg)}
     `;
   }
 
-  private renderIdentityCard(agent: Agent, gcpIdentity?: GCPIdentityConfig) {
+  private renderIdentityCard(agent: Agent) {
     return html`
       <div class="card">
         <h3 class="card-title">Identity</h3>
@@ -1596,6 +1596,27 @@ export class ScionPageAgentDetail extends LitElement {
                 </div>
               `
             : ''}
+          ${agent.appliedConfig?.agentRole
+            ? html`
+                <div class="info-item">
+                  <span class="info-label">Authorization Role</span>
+                  <span class="info-value">
+                    <sl-badge
+                      variant=${agent.appliedConfig.agentRole === 'full'
+                        ? 'success'
+                        : agent.appliedConfig.agentRole === 'baseline'
+                          ? 'primary'
+                          : agent.appliedConfig.agentRole === 'readonly'
+                            ? 'neutral'
+                            : agent.appliedConfig.agentRole === 'none'
+                              ? 'warning'
+                              : 'neutral'}
+                      >${agent.appliedConfig.agentRole}</sl-badge
+                    >
+                  </span>
+                </div>
+              `
+            : ''}
           ${agent.visibility
             ? html`
                 <div class="info-item">
@@ -1603,22 +1624,6 @@ export class ScionPageAgentDetail extends LitElement {
                   <span class="info-value">
                     <span class="visibility-badge">${agent.visibility}</span>
                   </span>
-                </div>
-              `
-            : ''}
-          ${gcpIdentity?.metadataMode === 'assign' && gcpIdentity.serviceAccountEmail
-            ? html`
-                <div class="info-item">
-                  <span class="info-label">GCP Service Account</span>
-                  <span class="info-value mono">${gcpIdentity.serviceAccountEmail}</span>
-                </div>
-              `
-            : ''}
-          ${gcpIdentity?.metadataMode === 'assign' && gcpIdentity.projectId
-            ? html`
-                <div class="info-item">
-                  <span class="info-label">GCP Project</span>
-                  <span class="info-value mono">${gcpIdentity.projectId}</span>
                 </div>
               `
             : ''}
@@ -1787,6 +1792,22 @@ export class ScionPageAgentDetail extends LitElement {
               <sl-badge variant=${modeVariant}>${gcpIdentity.metadataMode}</sl-badge>
             </span>
           </div>
+          ${gcpIdentity.serviceAccountEmail
+            ? html`
+                <div class="info-item">
+                  <span class="info-label">Service Account</span>
+                  <span class="info-value mono">${gcpIdentity.serviceAccountEmail}</span>
+                </div>
+              `
+            : ''}
+          ${gcpIdentity.projectId
+            ? html`
+                <div class="info-item">
+                  <span class="info-label">GCP Project</span>
+                  <span class="info-value mono">${gcpIdentity.projectId}</span>
+                </div>
+              `
+            : ''}
         </div>
       </div>
     `;


### PR DESCRIPTION
Adds a color-coded authorization role badge (full/baseline/readonly/none) to the agent detail Identity card, and expands the GCP Identity card to show service account email + GCP project for any identity mode (block/pass-through/assign), removing the now-duplicate GCP fields from the Identity card.