### PR TITLE
fix: add missing 'globe' icon to Shoelace icon copy script

### DIFF
--- a/web/scripts/copy-shoelace-icons.mjs
+++ b/web/scripts/copy-shoelace-icons.mjs
@@ -91,6 +91,7 @@ const USED_ICONS = [
   'funnel',
   'gear',
   'github',
+  'globe',
   'graph-up',
   'grid-3x3-gap',
   'hammer',


### PR DESCRIPTION
The federation admin page was missing its globe icon because 'globe' wasn't in the USED_ICONS allowlist in web/scripts/copy-shoelace-icons.mjs, the selective icon-copy script. One-line addition.