### PR TITLE
feat(web): unified agent creation form with advanced settings disclosure

### DIFF
--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -29,6 +29,21 @@ import { stateManager } from './state.js';
 import { debugLog } from './debug-log.js';
 import { setDocumentTitle } from './page-title.js';
 
+/**
+ * Strip the Vite base path prefix from a URL pathname so the client-side
+ * router can match application routes when served behind a reverse proxy.
+ * Uses import.meta.env.BASE_URL which Vite injects at build/dev time.
+ * When base is '/' (no proxy), this is a no-op.
+ */
+function stripBasePath(pathname: string): string {
+  const base = import.meta.env.BASE_URL;
+  if (base && base !== '/' && pathname.startsWith(base)) {
+    const stripped = pathname.slice(base.length - 1); // keep leading /
+    return stripped || '/';
+  }
+  return pathname;
+}
+
 // Inject theme CSS so it loads regardless of whether the page is served by
 // the Vite dev server (index.html) or the Go SPA shell template (web.go).
 {
@@ -70,6 +85,7 @@ import '@shoelace-style/shoelace/dist/components/radio-group/radio-group.js';
 import '@shoelace-style/shoelace/dist/components/radio-button/radio-button.js';
 import '@shoelace-style/shoelace/dist/components/range/range.js';
 import '@shoelace-style/shoelace/dist/components/switch/switch.js';
+import '@shoelace-style/shoelace/dist/components/details/details.js';
 import '@shoelace-style/shoelace/dist/components/tab-group/tab-group.js';
 import '@shoelace-style/shoelace/dist/components/tab/tab.js';
 import '@shoelace-style/shoelace/dist/components/tab-panel/tab-panel.js';
@@ -242,7 +258,7 @@ async function init(): Promise<void> {
 
   // First-run redirect: if the system hasn't completed onboarding, navigate to /onboarding
   const skipRedirectPaths = ['/onboarding', '/login', '/invite'];
-  if (!skipRedirectPaths.includes(window.location.pathname)) {
+  if (!skipRedirectPaths.includes(stripBasePath(window.location.pathname))) {
     try {
       const statusRes = await fetch('/api/v1/system/status', { credentials: 'include' });
       if (statusRes.ok) {
@@ -257,8 +273,8 @@ async function init(): Promise<void> {
     }
   }
 
-  // Render the initial page based on current URL
-  await renderRoute(window.location.pathname);
+  // Render the initial page based on current URL (strip proxy prefix for route matching)
+  await renderRoute(stripBasePath(window.location.pathname));
 
   // Setup client-side router for navigation
   setupRouter();
@@ -479,7 +495,7 @@ function setupRouter(): void {
 
   // Handle browser back/forward
   window.addEventListener('popstate', () => {
-    void renderRoute(window.location.pathname);
+    void renderRoute(stripBasePath(window.location.pathname));
   });
 }
 
@@ -487,9 +503,15 @@ function setupRouter(): void {
  * Navigates to a new path using the History API
  */
 function navigateTo(path: string): void {
-  if (path === window.location.pathname) return;
+  const currentAppPath = stripBasePath(window.location.pathname);
+  if (path === currentAppPath) return;
 
-  window.history.pushState({}, '', path);
+  // Prefix app-relative paths with the base path for the browser URL bar
+  const base = import.meta.env.BASE_URL;
+  const browserPath = base && base !== '/'
+    ? base.replace(/\/$/, '') + path
+    : path;
+  window.history.pushState({}, '', browserPath);
   void renderRoute(path);
 }
 

--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -37,10 +37,20 @@ import { setDocumentTitle } from './page-title.js';
  */
 function stripBasePath(pathname: string): string {
   const base = import.meta.env.BASE_URL;
-  if (base && base !== '/' && pathname.startsWith(base)) {
+  if (!base || base === '/') return pathname;
+
+  // Normalize: strip trailing slash from base for comparison
+  const baseNoSlash = base.replace(/\/$/, '');
+
+  // Exact match (base path without trailing slash, e.g. /foo)
+  if (pathname === baseNoSlash) return '/';
+
+  // Prefix match (e.g. /foo/bar → /bar)
+  if (pathname.startsWith(base)) {
     const stripped = pathname.slice(base.length - 1); // keep leading /
     return stripped || '/';
   }
+
   return pathname;
 }
 

--- a/web/src/components/pages/agent-configure.ts
+++ b/web/src/components/pages/agent-configure.ts
@@ -783,9 +783,7 @@ export class ScionPageAgentConfigure extends LitElement {
             variant="default"
             ?disabled=${isBusy}
             @click=${() => {
-              const url = new URL('/agents/new', window.location.origin);
-              url.searchParams.set('editingAgentId', this.agentId);
-              window.history.pushState({}, '', url.toString());
+              window.history.pushState({}, '', `/agents/${this.agentId}`);
               window.dispatchEvent(new PopStateEvent('popstate'));
             }}
           >

--- a/web/src/components/pages/agent-configure.ts
+++ b/web/src/components/pages/agent-configure.ts
@@ -25,6 +25,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 import { apiFetch, extractApiError } from '../../client/api.js';
+import { navigateTo } from '../../client/main.js';
 import { dispatchPageTitle } from '../../client/page-title.js';
 import type { Agent, CapabilityField, GCPIdentityConfig, GCPServiceAccount, HarnessAdvancedCapabilities } from '../../shared/types.js';
 import { normalizeModelAlias } from '../../shared/model-utils.js';
@@ -783,8 +784,7 @@ export class ScionPageAgentConfigure extends LitElement {
             variant="default"
             ?disabled=${isBusy}
             @click=${() => {
-              window.history.pushState({}, '', `/agents/${this.agentId}`);
-              window.dispatchEvent(new PopStateEvent('popstate'));
+              navigateTo(`/agents/${this.agentId}`);
             }}
           >
             <sl-icon slot="prefix" name="arrow-left"></sl-icon>

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -1012,11 +1012,21 @@ export class ScionPageAgentCreate extends LitElement {
         <sl-details
           summary="Additional Options"
           ?open=${this.advancedOpen}
-          @sl-show=${() => { this.advancedOpen = true; }}
+          @sl-show=${() => {
+            this.advancedOpen = true;
+            // Force the tab-group to show the General tab when disclosure opens.
+            // sl-tab-group may not initialize correctly when hidden inside sl-details.
+            requestAnimationFrame(() => {
+              const tabGroup = this.shadowRoot?.querySelector('sl-tab-group');
+              if (tabGroup) {
+                (tabGroup as any).show?.('general');
+              }
+            });
+          }}
           @sl-hide=${() => { this.advancedOpen = false; }}
         >
           <sl-tab-group>
-            <sl-tab slot="nav" panel="general">General</sl-tab>
+            <sl-tab slot="nav" panel="general" active>General</sl-tab>
             <sl-tab slot="nav" panel="auth-security">Auth &amp; Security</sl-tab>
             <sl-tab slot="nav" panel="env-labels">Environment &amp; Labels</sl-tab>
             <sl-tab slot="nav" panel="limits">Limits &amp; Resources</sl-tab>

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -820,8 +820,8 @@ export class ScionPageAgentCreate extends LitElement {
       }
     }
 
-    // Telemetry
-    env.SCION_TELEMETRY_ENABLED = this.telemetryEnabled ? 'true' : 'false';
+    // Telemetry (use structured config property, matching agent-configure.ts)
+    config.telemetry = { enabled: this.telemetryEnabled };
 
     // Auto-expose ports
     env.SCION_AUTO_EXPOSE_PORTS = this.autoExposePortsEnabled ? 'true' : 'false';
@@ -844,7 +844,14 @@ export class ScionPageAgentCreate extends LitElement {
   // Submit
   // ═══════════════════════════════════════════════════════════════════
 
-  private async handleSubmit(_e: Event): Promise<void> {
+  /**
+   * Create the agent without starting it. Navigates to the agent detail page.
+   */
+  private async handleCreateOnly(_e: Event): Promise<void> {
+    return this.handleSubmit(_e, true);
+  }
+
+  private async handleSubmit(_e: Event, provisionOnly = false): Promise<void> {
     if (!this.name.trim()) {
       this.error = 'Agent name is required.';
       return;
@@ -878,6 +885,7 @@ export class ScionPageAgentCreate extends LitElement {
       if (this.profile) body.profile = this.profile;
       if (this.task.trim()) body.task = this.task.trim();
       if (this.agentRole) body.agentRole = this.agentRole;
+      if (provisionOnly) body.provisionOnly = true;
 
       const builtLabels = this.buildLabels();
       if (builtLabels) body.labels = builtLabels;
@@ -928,16 +936,18 @@ export class ScionPageAgentCreate extends LitElement {
         throw new Error('No agent ID in response');
       }
 
-      // Start the agent if not already started
-      const startedPhases = ['running', 'provisioning', 'cloning', 'starting'];
-      const alreadyStarted = agent?.phase ? startedPhases.includes(agent.phase) : false;
-      if (!alreadyStarted) {
-        const startResp = await fetch(`/api/v1/agents/${agentId}/start`, {
-          method: 'POST',
-          credentials: 'include',
-        });
-        if (!startResp.ok) {
-          console.warn('Agent created but failed to start:', startResp.status);
+      // Start the agent unless provisionOnly was requested
+      if (!provisionOnly) {
+        const startedPhases = ['running', 'provisioning', 'cloning', 'starting'];
+        const alreadyStarted = agent?.phase ? startedPhases.includes(agent.phase) : false;
+        if (!alreadyStarted) {
+          const startResp = await fetch(`/api/v1/agents/${agentId}/start`, {
+            method: 'POST',
+            credentials: 'include',
+          });
+          if (!startResp.ok) {
+            console.warn('Agent created but failed to start:', startResp.status);
+          }
         }
       }
 
@@ -1050,6 +1060,13 @@ export class ScionPageAgentCreate extends LitElement {
           >
             <sl-icon slot="prefix" name="play-circle"></sl-icon>
             Start
+          </sl-button>
+          <sl-button
+            variant="default"
+            ?disabled=${this.submitting}
+            @click=${(e: Event) => this.handleCreateOnly(e)}
+          >
+            Create
           </sl-button>
           <sl-button
             variant="text"

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -46,6 +46,7 @@ import { isSharedWorkspace } from '../../shared/types.js';
 import { KNOWN_HARNESS_NAMES, harnessDisplayName } from '../../shared/harness-utils.js';
 import { normalizeModelAlias } from '../../shared/model-utils.js';
 import { apiFetch, parseApiError } from '../../client/api.js';
+import { navigateTo } from '../../client/main.js';
 import type { EnvEntry } from '../shared/env-editor.js';
 import '../shared/env-editor.js';
 import '../shared/status-badge.js';
@@ -481,8 +482,17 @@ export class ScionPageAgentCreate extends LitElement {
     }
   }
 
-  /** Apply project-settings defaults to advanced fields */
+  /** Apply project-settings defaults to advanced fields.
+   *  Resets all project-defaultable fields first so that switching projects
+   *  does not leak the previous project's defaults into the new one. */
   private async applyProjectDefaults(): Promise<void> {
+    // Reset to base defaults before applying new project settings
+    this.maxTurns = 0;
+    this.maxModelCalls = 0;
+    this.maxDuration = '';
+    this.modelSelection = '';
+    this.customModelId = '';
+
     const settings = await this.fetchProjectSettings(this.projectId);
     if (!settings) return;
 
@@ -952,8 +962,7 @@ export class ScionPageAgentCreate extends LitElement {
       }
 
       // Navigate to agent detail page
-      window.history.pushState({}, '', `/agents/${agentId}`);
-      window.dispatchEvent(new PopStateEvent('popstate'));
+      navigateTo(`/agents/${agentId}`);
     } catch (err) {
       console.error('Failed to create agent:', err);
       this.error = err instanceof Error ? err.message : 'Failed to create agent';
@@ -1073,8 +1082,7 @@ export class ScionPageAgentCreate extends LitElement {
             ?disabled=${this.submitting}
             @click=${() => {
               const dest = this.sourceProject ? `/projects/${this.sourceProject.id}` : '/agents';
-              window.history.pushState({}, '', dest);
-              window.dispatchEvent(new PopStateEvent('popstate'));
+              navigateTo(dest);
             }}
           >
             Cancel

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -15,16 +15,18 @@
  */
 
 /**
- * Agent creation page component
+ * Unified agent creation page component
  *
- * Form for creating and starting a new agent
+ * Single-surface form for creating and starting a new agent. All settings
+ * (previously split between agent-create and agent-configure) are available
+ * in a default section + an "Additional Options" disclosure with tabbed
+ * advanced settings.
  */
 
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 import type {
-  Agent,
   Project,
   RuntimeBroker,
   Template,
@@ -39,96 +41,82 @@ interface HarnessConfigEntry {
   harness: string;
   scope: string;
 }
+
 import { isSharedWorkspace } from '../../shared/types.js';
 import { KNOWN_HARNESS_NAMES, harnessDisplayName } from '../../shared/harness-utils.js';
+import { normalizeModelAlias } from '../../shared/model-utils.js';
 import { apiFetch, parseApiError } from '../../client/api.js';
+import type { EnvEntry } from '../shared/env-editor.js';
+import '../shared/env-editor.js';
 import '../shared/status-badge.js';
 
 @customElement('scion-page-agent-create')
 export class ScionPageAgentCreate extends LitElement {
-  @state()
-  private projects: Project[] = [];
+  // ── Data from API ───────────────────────────────────────────────────
+  @state() private projects: Project[] = [];
+  @state() private brokers: RuntimeBroker[] = [];
+  @state() private templates: Template[] = [];
+  @state() private harnessConfigs: HarnessConfigEntry[] = [];
+  @state() private gcpServiceAccounts: GCPServiceAccount[] = [];
 
-  @state()
-  private brokers: RuntimeBroker[] = [];
+  // ── UI State ────────────────────────────────────────────────────────
+  @state() private loading = true;
+  @state() private submitting = false;
+  @state() private error: string | null = null;
+  @state() private errorLinks: Array<{ label: string; href: string }> = [];
+  @state() private advancedOpen = false;
 
-  @state()
-  private templates: Template[] = [];
+  // ── Default Section Fields ──────────────────────────────────────────
+  @state() private name = '';
+  @state() private projectId = '';
+  @state() private templateId = '';
+  @state() private harness = 'gemini-cli';
+  @state() private customHarness = '';
+  @state() private brokerId = '';
+  @state() private profile = '';
+  @state() private task = '';
+  @state() private notify = true;
 
-  @state()
-  private loading = true;
+  // ── Additional Options > General Tab ────────────────────────────────
+  @state() private branch = '';
+  @state() private modelSelection: '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other' = '';
+  @state() private customModelId = '';
+  @state() private thinkingLevel: number | null = null;
+  @state() private image = '';
+  @state() private containerUser = '';
+  @state() private telemetryEnabled = false;
+  @state() private autoExposePortsEnabled = false;
+  @state() private autoExposePortsMode = 'allowlist';
+  @state() private autoExposePortsList = '';
+  @state() private autoExposePortsInterval = '3s';
 
-  @state()
-  private submitting = false;
+  // ── Additional Options > Auth & Security Tab ────────────────────────
+  @state() private agentRole = '';
+  @state() private harnessAuth = '';
+  @state() private gcpMetadataMode: 'block' | 'passthrough' | 'assign' = 'block';
+  @state() private gcpServiceAccountId = '';
 
-  @state()
-  private submittingEdit = false;
+  // ── Additional Options > Prompts Tab ────────────────────────────────
+  @state() private systemPrompt = '';
+  @state() private agentInstructions = '';
 
-  @state()
-  private error: string | null = null;
+  // ── Additional Options > Limits & Resources Tab ─────────────────────
+  @state() private maxTurns = 0;
+  @state() private maxModelCalls = 0;
+  @state() private maxDuration = '';
+  @state() private cpuRequest = '';
+  @state() private memoryRequest = '';
+  @state() private cpuLimit = '';
+  @state() private memoryLimit = '';
+  @state() private disk = '';
 
-  @state()
-  private errorLinks: Array<{ label: string; href: string }> = [];
+  // ── Additional Options > Environment & Labels Tab ───────────────────
+  @state() private envEntries: EnvEntry[] = [];
+  @state() private labelEntries: Array<{ key: string; value: string }> = [];
 
-  /** Form field values */
-  @state()
-  private name = '';
+  // ── Internal ────────────────────────────────────────────────────────
 
-  @state()
-  private projectId = '';
-
-  @state()
-  private templateId = '';
-
-  @state()
-  private harness = 'gemini-cli';
-
-  @state()
-  private customHarness = '';
-
-  @state()
-  private harnessAuth = '';
-
-  @state()
-  private brokerId = '';
-
-  @state()
-  private profile = '';
-
-  @state()
-  private branch = '';
-
-  @state()
-  private agentRole = '';
-
-  @state()
-  private task = '';
-
-  @state()
-  private notify = true;
-
-  @state()
-  private labelEntries: Array<{ key: string; value: string }> = [];
-
-  @state()
-  private telemetryEnabled = false;
-
-  @state()
-  private gcpMetadataMode: 'block' | 'passthrough' | 'assign' = 'block';
-
-  @state()
-  private gcpServiceAccountId = '';
-
-  @state()
-  private gcpServiceAccounts: GCPServiceAccount[] = [];
-
-  @state()
-  private harnessConfigs: HarnessConfigEntry[] = [];
-
-  /** ID of an existing agent we're editing (came back from configure page) */
-  private editingAgentId: string | null = null;
-
-  /** Whether the projectId was explicitly passed via URL query param (user navigated from project page) */
+  /** Whether the projectId was explicitly passed via URL query param */
   private projectFromUrl = false;
 
   /** Cached project settings keyed by projectId */
@@ -142,6 +130,7 @@ export class ScionPageAgentCreate extends LitElement {
       defaultMaxDuration?: string;
       defaultGCPIdentityMode?: string;
       defaultGCPIdentityServiceAccountID?: string;
+      defaultModel?: string;
     }
   > = new Map();
 
@@ -151,6 +140,26 @@ export class ScionPageAgentCreate extends LitElement {
     const broker = this.brokers.find((b) => b.id === this.brokerId);
     return broker?.profiles?.filter((p) => p.available) ?? [];
   }
+
+  /** The currently selected project */
+  private get selectedProject(): Project | undefined {
+    return this.projects.find((p) => p.id === this.projectId);
+  }
+
+  /** The project matching the URL-provided projectId, used for back-navigation */
+  private get sourceProject(): Project | undefined {
+    if (!this.projectFromUrl) return undefined;
+    return this.projects.find((p) => p.id === this.projectId);
+  }
+
+  /** Verified GCP service accounts for the assign dropdown */
+  private get verifiedGCPServiceAccounts(): GCPServiceAccount[] {
+    return this.gcpServiceAccounts.filter((sa) => sa.verified);
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Styles
+  // ═══════════════════════════════════════════════════════════════════
 
   static override styles = css`
     :host {
@@ -196,12 +205,19 @@ export class ScionPageAgentCreate extends LitElement {
       font-size: 0.875rem;
     }
 
+    .page-header .project-subtitle {
+      color: var(--scion-text-secondary, #475569);
+      margin: 0.25rem 0 0 0;
+      font-size: 0.875rem;
+      font-weight: 500;
+    }
+
     .form-card {
       background: var(--scion-surface, #ffffff);
       border: 1px solid var(--scion-border, #e2e8f0);
       border-radius: var(--scion-radius-lg, 0.75rem);
       padding: 1.5rem;
-      max-width: 640px;
+      max-width: 720px;
     }
 
     .form-field {
@@ -240,31 +256,6 @@ export class ScionPageAgentCreate extends LitElement {
       margin-left: 0.5rem;
       background: var(--scion-bg-subtle, #f1f5f9);
       border-radius: 0 var(--scion-radius, 0.5rem) var(--scion-radius, 0.5rem) 0;
-    }
-
-    .broker-option {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
-
-    .broker-dot {
-      width: 8px;
-      height: 8px;
-      border-radius: 50%;
-      flex-shrink: 0;
-    }
-
-    .broker-dot.online {
-      background: var(--sl-color-success-500, #22c55e);
-    }
-
-    .broker-dot.offline {
-      background: var(--sl-color-neutral-400, #9ca3af);
-    }
-
-    .broker-dot.degraded {
-      background: var(--sl-color-warning-500, #f59e0b);
     }
 
     .notify-field {
@@ -338,7 +329,63 @@ export class ScionPageAgentCreate extends LitElement {
       font-size: 2rem;
       margin-bottom: 1rem;
     }
+
+    /* ── Additional Options Disclosure ───────────────────────────── */
+
+    sl-details::part(base) {
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius, 0.5rem);
+    }
+
+    sl-details::part(header) {
+      font-size: 0.9375rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+      padding: 0.875rem 1rem;
+    }
+
+    sl-details::part(content) {
+      padding: 0 1rem 1rem 1rem;
+    }
+
+    sl-tab-group {
+      --indicator-color: var(--scion-primary, #3b82f6);
+    }
+
+    sl-tab-group::part(body) {
+      padding-top: 1.25rem;
+    }
+
+    .field-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
   `;
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Lifecycle
+  // ═══════════════════════════════════════════════════════════════════
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+
+      const projectParam = params.get('projectId');
+      if (projectParam) {
+        this.projectId = projectParam;
+        this.projectFromUrl = true;
+      }
+
+      if (params.get('advanced') === '1') {
+        this.advancedOpen = true;
+      }
+    }
+
+    void this.loadFormData();
+  }
 
   override updated(changedProperties: Map<string, unknown>): void {
     super.updated(changedProperties);
@@ -347,39 +394,9 @@ export class ScionPageAgentCreate extends LitElement {
     }
   }
 
-  override connectedCallback(): void {
-    super.connectedCallback();
-
-    if (typeof window !== 'undefined') {
-      const params = new URLSearchParams(window.location.search);
-
-      // Pre-select projectId from URL query param if present
-      const projectParam = params.get('projectId');
-      if (projectParam) {
-        this.projectId = projectParam;
-        this.projectFromUrl = true;
-      }
-
-      // Check if returning from configure page with an existing agent
-      const editingParam = params.get('editingAgentId');
-      if (editingParam) {
-        this.editingAgentId = editingParam;
-      }
-    }
-
-    void this.loadFormData();
-  }
-
-  /** The currently selected project */
-  private get selectedProject(): Project | undefined {
-    return this.projects.find((p) => p.id === this.projectId);
-  }
-
-  /** The project matching the URL-provided projectId, used for back-navigation */
-  private get sourceProject(): Project | undefined {
-    if (!this.projectFromUrl) return undefined;
-    return this.projects.find((p) => p.id === this.projectId);
-  }
+  // ═══════════════════════════════════════════════════════════════════
+  // Data Loading
+  // ═══════════════════════════════════════════════════════════════════
 
   private async loadFormData(): Promise<void> {
     this.loading = true;
@@ -414,8 +431,10 @@ export class ScionPageAgentCreate extends LitElement {
       if (settingsRes.ok) {
         const data = (await settingsRes.json()) as {
           telemetryEnabled?: boolean;
+          autoExposePortsEnabled?: boolean;
         };
         this.telemetryEnabled = data.telemetryEnabled ?? false;
+        this.autoExposePortsEnabled = data.autoExposePortsEnabled ?? false;
       }
 
       if (harnessConfigsRes.ok) {
@@ -427,32 +446,30 @@ export class ScionPageAgentCreate extends LitElement {
         );
       }
 
-      // If returning from configure page, populate form from existing agent
-      if (this.editingAgentId) {
-        await this.populateFromAgent(this.editingAgentId);
-      } else {
-        // Auto-select first project if none selected
-        if (!this.projectId && this.projects.length > 0) {
-          this.projectId = this.projects[0].id;
-        }
-
-        // Auto-select broker based on project's default
-        this.selectBrokerForProject();
-
-        // Auto-select template based on project settings, then fallback
-        if (!this.templateId) {
-          await this.selectDefaultTemplate();
-        }
-
-        // Load GCP service accounts for selected project
-        if (this.projectId) {
-          await this.loadGCPServiceAccounts();
-        }
+      // Auto-select first project if none selected
+      if (!this.projectId && this.projects.length > 0) {
+        this.projectId = this.projects[0].id;
       }
 
-      // Reload harness configs scoped to the selected project (the initial
-      // fetch above has no projectId filter and returns configs from all
-      // projects, which causes duplicates in the dropdown).
+      // Auto-select broker based on project's default
+      this.selectBrokerForProject();
+
+      // Auto-select template based on project settings, then fallback
+      if (!this.templateId) {
+        await this.selectDefaultTemplate();
+      }
+
+      // Load GCP service accounts for selected project
+      if (this.projectId) {
+        await this.loadGCPServiceAccounts();
+      }
+
+      // Apply project-settings defaults to advanced fields
+      if (this.projectId) {
+        await this.applyProjectDefaults();
+      }
+
+      // Reload harness configs scoped to the selected project
       if (this.projectId) {
         await this.loadHarnessConfigs();
       }
@@ -464,289 +481,49 @@ export class ScionPageAgentCreate extends LitElement {
     }
   }
 
-  private buildLabels(): Record<string, string> | undefined {
-    const valid = this.labelEntries.filter(l => l.key.trim());
-    if (valid.length === 0) return undefined;
-    const labels: Record<string, string> = {};
-    for (const l of valid) {
-      labels[l.key.trim()] = l.value.trim();
+  /** Apply project-settings defaults to advanced fields */
+  private async applyProjectDefaults(): Promise<void> {
+    const settings = await this.fetchProjectSettings(this.projectId);
+    if (!settings) return;
+
+    if (settings.defaultMaxTurns) this.maxTurns = settings.defaultMaxTurns;
+    if (settings.defaultMaxModelCalls) this.maxModelCalls = settings.defaultMaxModelCalls;
+    if (settings.defaultMaxDuration) this.maxDuration = settings.defaultMaxDuration;
+    if (settings.defaultModel) {
+      const derived = this.deriveModelSelection(settings.defaultModel);
+      this.modelSelection = derived.selection;
+      this.customModelId = derived.customId;
     }
-    return labels;
   }
 
-  private async handleSubmit(_e: Event): Promise<void> {
-    // Validate required fields
-    if (!this.name.trim()) {
-      this.error = 'Agent name is required.';
-      return;
+  private deriveModelSelection(model: string): {
+    selection: '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other';
+    customId: string;
+  } {
+    if (!model) return { selection: '', customId: '' };
+    const normalized = normalizeModelAlias(model);
+    if (['small', 'medium', 'large', 'extra-large'].includes(normalized)) {
+      return { selection: normalized as 'small' | 'medium' | 'large' | 'extra-large', customId: '' };
     }
-    if (!this.projectId) {
-      this.error = 'Please select a project.';
-      return;
-    }
+    return { selection: 'other', customId: model };
+  }
 
-    this.submitting = true;
-    this.error = null;
-    this.errorLinks = [];
-
-    try {
-      // If returning from configure, delete the old agent first
-      if (this.editingAgentId) {
-        await this.deleteEditingAgent();
-        this.editingAgentId = null;
-      }
-
-      const body: Record<string, unknown> = {
-        name: this.slugify(this.name),
-        projectId: this.projectId,
-        harnessConfig: this.resolvedHarness,
-        notify: this.notify,
-      };
-
-      if (this.branch.trim()) {
-        body.branch = this.branch.trim();
-      }
-      if (this.harnessAuth) {
-        body.harnessAuth = this.harnessAuth;
-      }
-      if (this.templateId) {
-        body.template = this.templateId;
-      }
-      if (this.brokerId) {
-        body.runtimeBrokerId = this.brokerId;
-      }
-      if (this.profile) {
-        body.profile = this.profile;
-      }
-      if (this.task.trim()) {
-        body.task = this.task.trim();
-      }
-      if (this.agentRole) {
-        body.agentRole = this.agentRole;
-      }
-
-      const builtLabels = this.buildLabels();
-      if (builtLabels) {
-        body.labels = builtLabels;
-      }
-
-      // GCP identity assignment
-      if (this.gcpMetadataMode === 'assign' && this.gcpServiceAccountId) {
-        body.gcp_identity = {
-          metadata_mode: 'assign',
-          service_account_id: this.gcpServiceAccountId,
-        };
-      } else if (this.gcpMetadataMode === 'passthrough') {
-        body.gcp_identity = {
-          metadata_mode: 'passthrough',
-        };
-      } else if (this.gcpMetadataMode === 'block') {
-        body.gcp_identity = {
-          metadata_mode: 'block',
-        };
-      }
-
-      // Pass config options
-      const env: Record<string, string> = {
-        SCION_TELEMETRY_ENABLED: this.telemetryEnabled ? 'true' : 'false',
-      };
-      const config: Record<string, unknown> = { env };
-
-      body.config = config;
-
-      // Validate GCP assign mode
-      if (this.gcpMetadataMode === 'assign' && !this.gcpServiceAccountId) {
-        this.error = 'Please select a service account for GCP identity assignment.';
-        this.submitting = false;
+  /**
+   * Select the best broker for the currently selected project.
+   * Prefers the project's default broker; falls back to first online broker.
+   */
+  private selectBrokerForProject(): void {
+    const project = this.projects.find((p) => p.id === this.projectId);
+    if (project?.defaultRuntimeBrokerId) {
+      const defaultBroker = this.brokers.find((b) => b.id === project.defaultRuntimeBrokerId);
+      if (defaultBroker) {
+        this.brokerId = defaultBroker.id;
+        this.autoSelectProfile();
         return;
       }
-
-      const response = await fetch('/api/v1/agents', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-
-      if (!response.ok) {
-        const apiErr = await parseApiError(response, `HTTP ${response.status}`);
-        if (apiErr.code === 'missing_env_vars') {
-          this.errorLinks = [
-            ...(this.projectId ? [{ label: 'Project Settings', href: `/projects/${this.projectId}/settings` }] : []),
-            { label: 'Profile Secrets', href: '/profile/secrets' },
-          ];
-        }
-        throw new Error(apiErr.message);
-      }
-
-      const result = (await response.json()) as {
-        agent?: { id: string; status?: string; phase?: string };
-        id?: string;
-      };
-      const agent = result.agent;
-      const agentId = agent?.id || result.id;
-
-      if (!agentId) {
-        throw new Error('No agent ID in response');
-      }
-
-      // If the backend didn't already start the agent, explicitly start it.
-      const startedPhases = ['running', 'provisioning', 'cloning', 'starting'];
-      const alreadyStarted = agent?.phase ? startedPhases.includes(agent.phase) : false;
-      if (!alreadyStarted) {
-        const startResp = await fetch(`/api/v1/agents/${agentId}/start`, {
-          method: 'POST',
-          credentials: 'include',
-        });
-        if (!startResp.ok) {
-          console.warn('Agent created but failed to start:', startResp.status);
-        }
-      }
-
-      // Navigate to agent detail page
-      window.history.pushState({}, '', `/agents/${agentId}`);
-      window.dispatchEvent(new PopStateEvent('popstate'));
-    } catch (err) {
-      console.error('Failed to create agent:', err);
-      this.error = err instanceof Error ? err.message : 'Failed to create agent';
-    } finally {
-      this.submitting = false;
-    }
-  }
-
-  private async handleCreateAndEdit(_e: Event): Promise<void> {
-    if (!this.name.trim()) {
-      this.error = 'Agent name is required.';
-      return;
-    }
-    if (!this.projectId) {
-      this.error = 'Please select a project.';
-      return;
     }
 
-    this.submittingEdit = true;
-    this.error = null;
-    this.errorLinks = [];
-
-    try {
-      // If returning from configure, delete the old agent first
-      if (this.editingAgentId) {
-        await this.deleteEditingAgent();
-        this.editingAgentId = null;
-      }
-
-      const body: Record<string, unknown> = {
-        name: this.slugify(this.name),
-        projectId: this.projectId,
-        harnessConfig: this.resolvedHarness,
-        notify: this.notify,
-        provisionOnly: true,
-      };
-
-      if (this.branch.trim()) {
-        body.branch = this.branch.trim();
-      }
-      if (this.harnessAuth) {
-        body.harnessAuth = this.harnessAuth;
-      }
-      if (this.templateId) {
-        body.template = this.templateId;
-      }
-      if (this.brokerId) {
-        body.runtimeBrokerId = this.brokerId;
-      }
-      if (this.profile) {
-        body.profile = this.profile;
-      }
-      if (this.task.trim()) {
-        body.task = this.task.trim();
-      }
-      if (this.agentRole) {
-        body.agentRole = this.agentRole;
-      }
-
-      const builtLabels = this.buildLabels();
-      if (builtLabels) {
-        body.labels = builtLabels;
-      }
-
-      // GCP identity assignment
-      if (this.gcpMetadataMode === 'assign' && this.gcpServiceAccountId) {
-        body.gcp_identity = {
-          metadata_mode: 'assign',
-          service_account_id: this.gcpServiceAccountId,
-        };
-      } else if (this.gcpMetadataMode === 'passthrough') {
-        body.gcp_identity = {
-          metadata_mode: 'passthrough',
-        };
-      } else if (this.gcpMetadataMode === 'block') {
-        body.gcp_identity = {
-          metadata_mode: 'block',
-        };
-      }
-
-      // Validate GCP assign mode
-      if (this.gcpMetadataMode === 'assign' && !this.gcpServiceAccountId) {
-        this.error = 'Please select a service account for GCP identity assignment.';
-        this.submittingEdit = false;
-        return;
-      }
-
-      const response = await fetch('/api/v1/agents', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-
-      if (!response.ok) {
-        const apiErr = await parseApiError(response, `HTTP ${response.status}`);
-        if (apiErr.code === 'missing_env_vars') {
-          this.errorLinks = [
-            ...(this.projectId ? [{ label: 'Project Settings', href: `/projects/${this.projectId}/settings` }] : []),
-            { label: 'Profile Secrets', href: '/profile/secrets' },
-          ];
-        }
-        throw new Error(apiErr.message);
-      }
-
-      const result = (await response.json()) as {
-        agent?: { id: string };
-        id?: string;
-      };
-      const agentId = result.agent?.id || result.id;
-
-      if (!agentId) {
-        throw new Error('No agent ID in response');
-      }
-
-      // Navigate to the advanced configure page
-      window.history.pushState({}, '', `/agents/${agentId}/configure`);
-      window.dispatchEvent(new PopStateEvent('popstate'));
-    } catch (err) {
-      console.error('Failed to create agent:', err);
-      this.error = err instanceof Error ? err.message : 'Failed to create agent';
-    } finally {
-      this.submittingEdit = false;
-    }
-  }
-/**
- * Select the best broker for the currently selected project.
- * Prefers the project's default broker; falls back to first online broker.
- */
-private selectBrokerForProject(): void {
-  const project = this.projects.find((p) => p.id === this.projectId);
-  if (project?.defaultRuntimeBrokerId) {
-    const defaultBroker = this.brokers.find((b) => b.id === project.defaultRuntimeBrokerId);
-    if (defaultBroker) {
-      this.brokerId = defaultBroker.id;
-      this.autoSelectProfile();
-      return;
-    }
-  }
-
-  // Fallback: first online broker, then first broker
+    // Fallback: first online broker, then first broker
     const onlineBroker = this.brokers.find((b) => b.status === 'online');
     if (onlineBroker) {
       this.brokerId = onlineBroker.id;
@@ -754,7 +531,7 @@ private selectBrokerForProject(): void {
       this.brokerId = this.brokers[0].id;
     }
     this.autoSelectProfile();
-    }
+  }
 
   /**
    * Returns templates visible to the selected project: project-scoped templates
@@ -779,21 +556,17 @@ private selectBrokerForProject(): void {
   }
 
   /**
-   * Select the default template and harness config for the current project using project settings.
-   * Falls back to a template named "default", then the first available template.
-   * The harness config is determined by: template defaultHarnessConfig > template harness > project default > 'gemini-cli'.
+   * Select the default template and harness config for the current project.
    */
   private async selectDefaultTemplate(): Promise<void> {
     const visible = this.filteredTemplates;
 
-    // Fetch project settings (used for both template and harness defaults)
     const settings = this.projectId ? await this.fetchProjectSettings(this.projectId) : null;
     const harnessDefault = settings?.defaultHarnessConfig || 'gemini-cli';
 
     const harnessFor = (t: { defaultHarnessConfig?: string; harness?: string }) =>
       t.defaultHarnessConfig || t.harness || harnessDefault;
 
-    // Try project settings default template first
     let templateResolved = false;
     if (settings?.defaultTemplate) {
       const match = visible.find(
@@ -807,7 +580,6 @@ private selectBrokerForProject(): void {
     }
 
     if (!templateResolved) {
-      // Fallback: template named "default"
       const fallback = visible.find((t) => t.slug === 'default' || t.name === 'default');
       if (fallback) {
         this.templateId = fallback.id;
@@ -820,65 +592,14 @@ private selectBrokerForProject(): void {
         this.setHarnessFromValue(harnessDefault);
       }
     }
-
   }
 
-  /**
-   * Handle broker selection change: reset and auto-select profile.
-   */
-  private onBrokerChange(): void {
-    this.autoSelectProfile();
-  }
-
-  /**
-   * Auto-select the profile for the current broker.
-   * If only one available profile exists, select it; otherwise clear selection.
-   */
   private autoSelectProfile(): void {
     const profiles = this.selectedBrokerProfiles;
     if (profiles.length === 1) {
       this.profile = profiles[0].name;
     } else {
       this.profile = '';
-    }
-  }
-
-  /**
-   * Populate form fields from an existing agent (when returning from configure page).
-   */
-  private async populateFromAgent(agentId: string): Promise<void> {
-    try {
-      const res = await apiFetch(`/api/v1/agents/${agentId}`);
-      if (!res.ok) {
-        // Agent may have been deleted; clear editing state and fall back to defaults
-        this.editingAgentId = null;
-        return;
-      }
-      const data = (await res.json()) as { agent?: Agent } | Agent;
-      const agent: Agent = 'agent' in data && data.agent ? data.agent : (data as Agent);
-
-      this.name = agent.name || '';
-      this.projectId = agent.projectId || '';
-      if (agent.harnessConfig) this.setHarnessFromValue(agent.harnessConfig);
-      if (agent.harnessAuth) this.harnessAuth = agent.harnessAuth;
-      if (agent.template) this.templateId = agent.template;
-      if (agent.runtimeBrokerId) this.brokerId = agent.runtimeBrokerId;
-      if (agent.appliedConfig?.profile) this.profile = agent.appliedConfig.profile;
-    } catch {
-      // If fetch fails, clear editing state
-      this.editingAgentId = null;
-    }
-  }
-
-  /**
-   * Delete the agent being edited (used when cancelling after returning from configure).
-   */
-  private async deleteEditingAgent(): Promise<void> {
-    if (!this.editingAgentId) return;
-    try {
-      await apiFetch(`/api/v1/agents/${this.editingAgentId}`, { method: 'DELETE' });
-    } catch {
-      // Best-effort deletion; navigate away regardless
     }
   }
 
@@ -910,14 +631,12 @@ private selectBrokerForProject(): void {
       const res = await apiFetch(`/api/v1/projects/${this.projectId}/gcp-service-accounts`);
       if (res.ok) {
         const data = (await res.json()) as
-          | {
-              items?: GCPServiceAccount[];
-            }
+          | { items?: GCPServiceAccount[] }
           | GCPServiceAccount[];
         this.gcpServiceAccounts = Array.isArray(data) ? data : data.items || [];
       }
     } catch {
-      // Non-critical — just won't show GCP identity section
+      // Non-critical
     }
 
     // Apply project default GCP identity if configured
@@ -933,21 +652,12 @@ private selectBrokerForProject(): void {
           this.gcpMetadataMode = 'assign';
           this.gcpServiceAccountId = match.id;
         }
-        // If the configured SA isn't found/verified, fall through to block
       } else if (mode === 'passthrough' || mode === 'block') {
         this.gcpMetadataMode = mode;
       }
     }
   }
 
-  private get verifiedGCPServiceAccounts(): GCPServiceAccount[] {
-    return this.gcpServiceAccounts.filter((sa) => sa.verified);
-  }
-
-  /**
-   * Fetch project settings and return the defaultTemplate value (if any).
-   * Results are cached per projectId to avoid redundant requests.
-   */
   private async fetchProjectSettings(
     projectId: string
   ): Promise<{
@@ -982,10 +692,14 @@ private selectBrokerForProject(): void {
         return data;
       }
     } catch {
-      // Non-critical — fall back to generic default
+      // Non-critical
     }
     return null;
   }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Form Helpers
+  // ═══════════════════════════════════════════════════════════════════
 
   private slugify(text: string): string {
     return text
@@ -1006,10 +720,6 @@ private selectBrokerForProject(): void {
     }
   }
 
-  /**
-   * Set harness from a value, falling back to "Other" if the value doesn't
-   * match any known harness config in the dropdown.
-   */
   private setHarnessFromValue(value: string): void {
     const knownNames = this.harnessConfigs.map((hc) => hc.name);
     const available: readonly string[] = knownNames.length > 0 ? knownNames : KNOWN_HARNESS_NAMES;
@@ -1023,12 +733,12 @@ private selectBrokerForProject(): void {
     }
   }
 
-  /** Resolved harness config name for submission. */
+  /** Resolved harness config name for submission */
   private get resolvedHarness(): string {
     return this.harness === '__other__' ? this.customHarness : this.harness;
   }
 
-  /** Hint text showing when the selected harness config matches the template's default. */
+  /** Hint text when the selected harness matches or differs from the template's default */
   private get templateHarnessHint(): string {
     const template = this.templates.find((t) => t.id === this.templateId);
     const configName = template?.defaultHarnessConfig || template?.harness;
@@ -1040,6 +750,212 @@ private selectBrokerForProject(): void {
     return `Template suggests: ${configName}`;
   }
 
+  private buildLabels(): Record<string, string> | undefined {
+    const valid = this.labelEntries.filter((l) => l.key.trim());
+    if (valid.length === 0) return undefined;
+    const labels: Record<string, string> = {};
+    for (const l of valid) {
+      labels[l.key.trim()] = l.value.trim();
+    }
+    return labels;
+  }
+
+  /**
+   * Build the config payload for advanced fields (mirrors agent-configure.ts buildConfig).
+   */
+  private buildConfig(): Record<string, unknown> {
+    const config: Record<string, unknown> = {};
+
+    // Model
+    const model = this.modelSelection === 'other'
+      ? this.customModelId
+      : this.modelSelection;
+    if (model) config.model = model;
+
+    // Thinking level
+    config.thinking_level = this.thinkingLevel;
+
+    // Container
+    if (this.image) config.image = this.image;
+    if (this.containerUser) config.user = this.containerUser;
+
+    // Auth
+    if (this.harnessAuth) config.auth_selectedType = this.harnessAuth;
+
+    // Prompts
+    if (this.systemPrompt) config.system_prompt = this.systemPrompt;
+    if (this.agentInstructions) config.agent_instructions = this.agentInstructions;
+
+    // Limits
+    if (this.maxTurns) config.max_turns = this.maxTurns;
+    if (this.maxModelCalls) config.max_model_calls = this.maxModelCalls;
+    if (this.maxDuration) config.max_duration = this.maxDuration;
+
+    // Resources
+    const hasResources =
+      this.cpuRequest || this.memoryRequest || this.cpuLimit || this.memoryLimit || this.disk;
+    if (hasResources) {
+      const resources: Record<string, unknown> = {};
+      if (this.cpuRequest || this.memoryRequest) {
+        const requests: Record<string, string> = {};
+        if (this.cpuRequest) requests.cpu = this.cpuRequest;
+        if (this.memoryRequest) requests.memory = this.memoryRequest;
+        resources.requests = requests;
+      }
+      if (this.cpuLimit || this.memoryLimit) {
+        const limits: Record<string, string> = {};
+        if (this.cpuLimit) limits.cpu = this.cpuLimit;
+        if (this.memoryLimit) limits.memory = this.memoryLimit;
+        resources.limits = limits;
+      }
+      if (this.disk) resources.disk = this.disk;
+      config.resources = resources;
+    }
+
+    // Environment variables
+    const env: Record<string, string> = {};
+    for (const entry of this.envEntries) {
+      if (entry.key) {
+        env[entry.key] = entry.value;
+      }
+    }
+
+    // Telemetry
+    env.SCION_TELEMETRY_ENABLED = this.telemetryEnabled ? 'true' : 'false';
+
+    // Auto-expose ports
+    env.SCION_AUTO_EXPOSE_PORTS = this.autoExposePortsEnabled ? 'true' : 'false';
+    if (this.autoExposePortsEnabled) {
+      env.SCION_AUTO_EXPOSE_MODE = this.autoExposePortsMode;
+      if (this.autoExposePortsList) {
+        env.SCION_AUTO_EXPOSE_PORTS_LIST = this.autoExposePortsList;
+      }
+      env.SCION_AUTO_EXPOSE_INTERVAL = this.autoExposePortsInterval || '3s';
+    }
+
+    if (Object.keys(env).length > 0) {
+      config.env = env;
+    }
+
+    return config;
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Submit
+  // ═══════════════════════════════════════════════════════════════════
+
+  private async handleSubmit(_e: Event): Promise<void> {
+    if (!this.name.trim()) {
+      this.error = 'Agent name is required.';
+      return;
+    }
+    if (!this.projectId) {
+      this.error = 'Please select a project.';
+      return;
+    }
+
+    // Validate GCP assign mode
+    if (this.gcpMetadataMode === 'assign' && !this.gcpServiceAccountId) {
+      this.error = 'Please select a service account for GCP identity assignment.';
+      return;
+    }
+
+    this.submitting = true;
+    this.error = null;
+    this.errorLinks = [];
+
+    try {
+      const body: Record<string, unknown> = {
+        name: this.slugify(this.name),
+        projectId: this.projectId,
+        harnessConfig: this.resolvedHarness,
+        notify: this.notify,
+      };
+
+      if (this.branch.trim()) body.branch = this.branch.trim();
+      if (this.templateId) body.template = this.templateId;
+      if (this.brokerId) body.runtimeBrokerId = this.brokerId;
+      if (this.profile) body.profile = this.profile;
+      if (this.task.trim()) body.task = this.task.trim();
+      if (this.agentRole) body.agentRole = this.agentRole;
+
+      const builtLabels = this.buildLabels();
+      if (builtLabels) body.labels = builtLabels;
+
+      // GCP identity
+      if (this.gcpMetadataMode === 'assign' && this.gcpServiceAccountId) {
+        body.gcp_identity = {
+          metadata_mode: 'assign',
+          service_account_id: this.gcpServiceAccountId,
+        };
+      } else if (this.gcpMetadataMode === 'passthrough') {
+        body.gcp_identity = { metadata_mode: 'passthrough' };
+      } else if (this.gcpMetadataMode === 'block') {
+        body.gcp_identity = { metadata_mode: 'block' };
+      }
+
+      // Advanced config
+      body.config = this.buildConfig();
+
+      const response = await fetch('/api/v1/agents', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const apiErr = await parseApiError(response, `HTTP ${response.status}`);
+        if (apiErr.code === 'missing_env_vars') {
+          this.errorLinks = [
+            ...(this.projectId
+              ? [{ label: 'Project Settings', href: `/projects/${this.projectId}/settings` }]
+              : []),
+            { label: 'Profile Secrets', href: '/profile/secrets' },
+          ];
+        }
+        throw new Error(apiErr.message);
+      }
+
+      const result = (await response.json()) as {
+        agent?: { id: string; status?: string; phase?: string };
+        id?: string;
+      };
+      const agent = result.agent;
+      const agentId = agent?.id || result.id;
+
+      if (!agentId) {
+        throw new Error('No agent ID in response');
+      }
+
+      // Start the agent if not already started
+      const startedPhases = ['running', 'provisioning', 'cloning', 'starting'];
+      const alreadyStarted = agent?.phase ? startedPhases.includes(agent.phase) : false;
+      if (!alreadyStarted) {
+        const startResp = await fetch(`/api/v1/agents/${agentId}/start`, {
+          method: 'POST',
+          credentials: 'include',
+        });
+        if (!startResp.ok) {
+          console.warn('Agent created but failed to start:', startResp.status);
+        }
+      }
+
+      // Navigate to agent detail page
+      window.history.pushState({}, '', `/agents/${agentId}`);
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    } catch (err) {
+      console.error('Failed to create agent:', err);
+      this.error = err instanceof Error ? err.message : 'Failed to create agent';
+    } finally {
+      this.submitting = false;
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Render
+  // ═══════════════════════════════════════════════════════════════════
+
   override render() {
     if (this.loading) {
       return html`
@@ -1050,13 +966,13 @@ private selectBrokerForProject(): void {
       `;
     }
 
+    const backHref = this.sourceProject ? `/projects/${this.sourceProject.id}` : '/agents';
+    const backLabel = this.sourceProject ? `To ${this.sourceProject.name}` : 'Back to Agents';
+
     return html`
-      <a
-        href="${this.sourceProject ? `/projects/${this.sourceProject.id}` : '/agents'}"
-        class="back-link"
-      >
+      <a href="${backHref}" class="back-link">
         <sl-icon name="arrow-left"></sl-icon>
-        ${this.sourceProject ? `To ${this.sourceProject.name}` : 'Back to Agents'}
+        ${backLabel}
       </a>
 
       <div class="page-header">
@@ -1065,6 +981,9 @@ private selectBrokerForProject(): void {
           Create Agent
         </h1>
         <p>Configure and start a new AI agent.</p>
+        ${this.projectFromUrl && this.sourceProject
+          ? html`<p class="project-subtitle">Project: ${this.sourceProject.name}</p>`
+          : nothing}
       </div>
 
       <div class="form-card">
@@ -1077,7 +996,8 @@ private selectBrokerForProject(): void {
                   ? html`<span class="error-links"
                       >&nbsp;&mdash;
                       ${this.errorLinks.map(
-                        (link, i) => html`${i > 0 ? html` or ` : nothing}<a href=${link.href}>${link.label}</a>`
+                        (link, i) =>
+                          html`${i > 0 ? html` or ` : nothing}<a href=${link.href}>${link.label}</a>`
                       )}</span
                     >`
                   : nothing}
@@ -1085,400 +1005,785 @@ private selectBrokerForProject(): void {
             `
           : ''}
 
-        <div>
-          <div class="form-field">
-            <label for="name">Agent Name</label>
-            <sl-input
-              id="name"
-              placeholder="my-agent"
-              .value=${this.name}
-              @sl-input=${(e: Event) => {
-                this.name = (e.target as HTMLElement & { value: string }).value;
-              }}
-              required
-            ></sl-input>
-          </div>
+        <!-- ═══════ Default Section ═══════ -->
+        ${this.renderDefaultSection()}
 
-          ${this.selectedProject?.gitRemote && !isSharedWorkspace(this.selectedProject)
-            ? html`
-                <div class="form-field">
-                  <label for="branch">Branch</label>
-                  <sl-input
-                    id="branch"
-                    placeholder="defaults to agent name"
-                    .value=${this.branch}
-                    @sl-input=${(e: Event) => {
-                      this.branch = (e.target as HTMLElement & { value: string }).value;
-                    }}
-                  ></sl-input>
-                  <div class="hint">Git branch for this agent's workspace.</div>
-                </div>
-              `
-            : ''}
+        <!-- ═══════ Additional Options Disclosure ═══════ -->
+        <sl-details
+          summary="Additional Options"
+          ?open=${this.advancedOpen}
+          @sl-show=${() => { this.advancedOpen = true; }}
+          @sl-hide=${() => { this.advancedOpen = false; }}
+        >
+          <sl-tab-group>
+            <sl-tab slot="nav" panel="general">General</sl-tab>
+            <sl-tab slot="nav" panel="auth-security">Auth &amp; Security</sl-tab>
+            <sl-tab slot="nav" panel="env-labels">Environment &amp; Labels</sl-tab>
+            <sl-tab slot="nav" panel="limits">Limits &amp; Resources</sl-tab>
+            <sl-tab slot="nav" panel="prompts">Prompts</sl-tab>
 
-          <div class="form-field">
-            <label for="project">Project</label>
-            <sl-select
-              id="project"
-              placeholder="Select a project..."
-              .value=${this.projectId}
-              @sl-change=${(e: Event) => {
-                this.projectId = (e.target as HTMLElement & { value: string }).value;
-                this.selectBrokerForProject();
-                void this.selectDefaultTemplate();
-                void this.loadHarnessConfigs();
-                void this.loadGCPServiceAccounts();
-                // Clear branch if new project is not git-based
-                if (!this.selectedProject?.gitRemote) {
-                  this.branch = '';
-                }
-              }}
-              required
-            >
-              ${this.projects.map((p) => html`<sl-option value=${p.id}>${p.name}</sl-option>`)}
-            </sl-select>
-            <div class="hint">The project workspace for this agent.</div>
-          </div>
+            <sl-tab-panel name="general">${this.renderGeneralTab()}</sl-tab-panel>
+            <sl-tab-panel name="auth-security">${this.renderAuthSecurityTab()}</sl-tab-panel>
+            <sl-tab-panel name="env-labels">${this.renderEnvironmentTab()}</sl-tab-panel>
+            <sl-tab-panel name="limits">${this.renderLimitsTab()}</sl-tab-panel>
+            <sl-tab-panel name="prompts">${this.renderPromptsTab()}</sl-tab-panel>
+          </sl-tab-group>
+        </sl-details>
 
-          <div class="form-field">
-            <label for="template">Template</label>
-            <sl-select
-              id="template"
-              placeholder="Select a template..."
-              .value=${this.templateId}
-              @sl-change=${(e: Event) => this.onTemplateChange(e)}
-            >
-              ${this.filteredTemplates.map(
-                (t) =>
-                  html`<sl-option value=${t.id}
-                    >${t.displayName || t.name}${t.scope === 'project'
-                      ? ' (project)'
-                      : ''}${t.description ? ` - ${t.description}` : ''}</sl-option
-                  >`
-              )}
-            </sl-select>
-            <div class="hint">Agent configuration template.</div>
-          </div>
-
-          <div class="form-field">
-            <label for="harness">Harness Config</label>
-            <sl-select
-              id="harness"
-              placeholder="Select a harness..."
-              .value=${this.harness}
-              @sl-change=${(e: Event) => {
-                this.harness = (e.target as HTMLElement & { value: string }).value;
-                if (this.harness !== '__other__') {
-                  this.customHarness = '';
-                }
-              }}
-            >
-              ${this.harnessConfigs.length > 0
-                ? this.harnessConfigs.map(
-                    (hc) => html`
-                      <sl-option value=${hc.name}>
-                        ${hc.displayName || hc.name}
-                        ${hc.harness ? html` <small>(${hc.harness})</small>` : ''}
-                      </sl-option>
-                    `
-                  )
-                : KNOWN_HARNESS_NAMES.map(
-                    (name) => html`
-                      <sl-option value=${name}>${harnessDisplayName(name)}</sl-option>
-                    `
-                  )}
-              <sl-option value="__other__">Other...</sl-option>
-            </sl-select>
-            <div class="hint">
-              ${this.templateHarnessHint
-                ? this.templateHarnessHint
-                : 'The LLM harness configuration to use.'}
-            </div>
-          </div>
-          ${this.harness === '__other__'
-            ? html`
-                <div class="form-field">
-                  <label for="custom-harness">Custom Harness Config Name</label>
-                  <sl-input
-                    id="custom-harness"
-                    placeholder="e.g. my-custom-harness"
-                    .value=${this.customHarness}
-                    @sl-input=${(e: Event) => {
-                      this.customHarness = (e.target as HTMLElement & { value: string }).value;
-                    }}
-                    required
-                  ></sl-input>
-                  <div class="hint">
-                    Name of the harness config directory (from .scion/harness-configs/).
-                  </div>
-                </div>
-              `
-            : ''}
-
-          <div class="form-field">
-            <label for="harness-auth">Harness Authentication</label>
-            <sl-select
-              id="harness-auth"
-              placeholder="Select auth method..."
-              .value=${this.harnessAuth}
-              @sl-change=${(e: Event) => {
-                this.harnessAuth = (e.target as HTMLElement & { value: string }).value;
-              }}
-            >
-              <sl-option value="">Auto Detected</sl-option>
-              <sl-option value="api-key">Provider API Key</sl-option>
-              <sl-option value="oauth-token">OAuth Token (env var)</sl-option>
-              <sl-option value="vertex-ai">Vertex Model Garden</sl-option>
-              <sl-option value="auth-file">Harness credential file</sl-option>
-              <sl-option value="none">No Authentication</sl-option>
-            </sl-select>
-            <div class="hint">Override the authentication method for the harness.</div>
-          </div>
-
-          <div class="form-field">
-            <label for="agent-role">Agent Role</label>
-            <sl-select
-              id="agent-role"
-              placeholder="Select a role..."
-              .value=${this.agentRole}
-              @sl-change=${(e: Event) => {
-                this.agentRole = (e.target as HTMLElement & { value: string }).value;
-              }}
-            >
-              <sl-option value="">Default (determined by project settings)</sl-option>
-              <sl-option value="none">None (no hub access)</sl-option>
-              <sl-option value="readonly">Read-only</sl-option>
-              <sl-option value="baseline">Baseline (standard)</sl-option>
-              <sl-option value="full">Full (requires admin)</sl-option>
-            </sl-select>
-            <div class="hint">Authorization role for hub API access. Determines which operations the agent can perform.</div>
-          </div>
-
-          <div class="form-field">
-            <label for="broker">Runtime Broker</label>
-            <sl-select
-              id="broker"
-              placeholder="Select a broker..."
-              .value=${this.brokerId}
-              @sl-change=${(e: Event) => {
-                this.brokerId = (e.target as HTMLElement & { value: string }).value;
-                this.onBrokerChange();
-              }}
-            >
-              ${this.brokers.map(
-                (b) =>
-                  html`<sl-option value=${b.id} ?disabled=${b.status === 'offline'}>
-                    ${b.name} (${b.status})
-                  </sl-option>`
-              )}
-            </sl-select>
-            <div class="hint">The compute node that will run this agent.</div>
-          </div>
-
-          ${this.selectedBrokerProfiles.length > 0
-            ? html`
-                <div class="form-field">
-                  <label for="profile">Runtime Profile</label>
-                  <sl-select
-                    id="profile"
-                    .value=${this.profile}
-                    @sl-change=${(e: Event) => {
-                      this.profile = (e.target as HTMLElement & { value: string }).value;
-                    }}
-                  >
-                    <sl-option value="">Use broker default</sl-option>
-                    ${this.selectedBrokerProfiles.map(
-                      (p) => html`<sl-option value=${p.name}>${p.name} (${p.type})</sl-option>`
-                    )}
-                  </sl-select>
-                  <div class="hint">The runtime profile on the selected broker.</div>
-                </div>
-              `
-            : ''}
-
-          <div class="form-field">
-            <label for="gcp-mode">GCP Identity</label>
-            <sl-select
-              id="gcp-mode"
-              .value=${this.gcpMetadataMode}
-              @sl-change=${(e: Event) => {
-                this.gcpMetadataMode = (e.target as HTMLElement & { value: string }).value as
-                  | 'block'
-                  | 'passthrough'
-                  | 'assign';
-                if (this.gcpMetadataMode !== 'assign') {
-                  this.gcpServiceAccountId = '';
-                }
-              }}
-            >
-              <sl-option value="block">Block</sl-option>
-              ${this.gcpServiceAccounts.length > 0
-                ? html`<sl-option value="assign">Assign Service Account</sl-option>`
-                : ''}
-              <sl-option value="passthrough">Passthrough</sl-option>
-            </sl-select>
-            <div class="hint">
-              ${this.gcpMetadataMode === 'block'
-                ? 'Prevents the agent from accessing any GCP identity. Token requests are denied.'
-                : this.gcpMetadataMode === 'assign'
-                  ? 'Assigns a registered GCP service account. GCP client libraries will authenticate automatically.'
-                  : 'No metadata interception. The agent inherits the broker\'s GCP identity. Requires broker ownership.'}
-            </div>
-          </div>
-
-          ${this.gcpMetadataMode === 'assign'
-            ? html`
-                <div class="form-field">
-                  <label for="gcp-sa">Service Account</label>
-                  ${this.verifiedGCPServiceAccounts.length > 0
-                    ? html`
-                        <sl-select
-                          id="gcp-sa"
-                          placeholder="Select a service account..."
-                          .value=${this.gcpServiceAccountId}
-                          @sl-change=${(e: Event) => {
-                            this.gcpServiceAccountId = (
-                              e.target as HTMLElement & { value: string }
-                            ).value;
-                          }}
-                        >
-                          ${this.verifiedGCPServiceAccounts.map(
-                            (sa) =>
-                              html`<sl-option value=${sa.id}>
-                                ${sa.email}${sa.displayName ? ` (${sa.displayName})` : ''}
-                              </sl-option>`
-                          )}
-                        </sl-select>
-                      `
-                    : html`
-                        <div class="hint" style="margin-top: 0;">
-                          No verified service accounts available. Register and verify service
-                          accounts in project settings.
-                        </div>
-                      `}
-                </div>
-              `
-            : ''}
-
-          <div class="form-field">
-            <label for="task">Initial Task</label>
-            <sl-textarea
-              id="task"
-              placeholder="Describe what this agent should work on..."
-              .value=${this.task}
-              @sl-input=${(e: Event) => {
-                this.task = (e.target as HTMLElement & { value: string }).value;
-              }}
-              rows="4"
-              resize="auto"
-            ></sl-textarea>
-            <div class="hint">The task or prompt to start the agent with.</div>
-          </div>
-
-          <div class="form-field">
-            <label>Labels</label>
-            ${this.labelEntries.map(
-              (entry, i) => html`
-                <div style="display: flex; gap: 0.5em; margin-bottom: 0.5em; align-items: center;">
-                  <sl-input
-                    size="small"
-                    placeholder="key"
-                    .value=${entry.key}
-                    @sl-input=${(e: Event) => {
-                      const updated = [...this.labelEntries];
-                      updated[i] = { ...updated[i], key: (e.target as HTMLElement & { value: string }).value };
-                      this.labelEntries = updated;
-                    }}
-                    style="flex: 1;"
-                  ></sl-input>
-                  <sl-input
-                    size="small"
-                    placeholder="value"
-                    .value=${entry.value}
-                    @sl-input=${(e: Event) => {
-                      const updated = [...this.labelEntries];
-                      updated[i] = { ...updated[i], value: (e.target as HTMLElement & { value: string }).value };
-                      this.labelEntries = updated;
-                    }}
-                    style="flex: 1;"
-                  ></sl-input>
-                  <sl-icon-button
-                    name="x-lg"
-                    label="Remove"
-                    @click=${() => {
-                      this.labelEntries = this.labelEntries.filter((_, idx) => idx !== i);
-                    }}
-                  ></sl-icon-button>
-                </div>
-              `
-            )}
-            ${this.labelEntries.length < 16
-              ? html`<sl-button
-                  size="small"
-                  variant="text"
-                  @click=${() => {
-                    this.labelEntries = [...this.labelEntries, { key: '', value: '' }];
-                  }}
-                >
-                  <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                  Add label
-                </sl-button>`
-              : ''}
-            <div class="hint">Optional key-value labels to organize agents (max 16).</div>
-          </div>
-
-          <div class="notify-field">
-            <sl-checkbox
-              ?checked=${this.notify}
-              @sl-change=${(e: Event) => {
-                this.notify = (e.target as HTMLInputElement).checked;
-              }}
-            >
-              Notify me on important agent state changes
-            </sl-checkbox>
-            <sl-tooltip
-              content="You will be notified when this agent reaches: Completed, Waiting for Input, or Limits Exceeded."
-              hoist
-            >
-              <span class="help-badge">?</span>
-            </sl-tooltip>
-          </div>
-
-          <div class="form-actions">
-            <sl-button
-              variant="default"
-              ?loading=${this.submittingEdit}
-              ?disabled=${this.submitting || this.submittingEdit}
-              @click=${(e: Event) => this.handleCreateAndEdit(e)}
-            >
-              <sl-icon slot="prefix" name="sliders"></sl-icon>
-              Create &amp; Edit
-            </sl-button>
-            <sl-button
-              variant="primary"
-              ?loading=${this.submitting}
-              ?disabled=${this.submitting || this.submittingEdit}
-              @click=${(e: Event) => this.handleSubmit(e)}
-            >
-              <sl-icon slot="prefix" name="play-circle"></sl-icon>
-              Create &amp; Start Agent
-            </sl-button>
-            <sl-button
-              variant="default"
-              ?disabled=${this.submitting || this.submittingEdit}
-              @click=${async () => {
-                if (this.editingAgentId) {
-                  await this.deleteEditingAgent();
-                }
-                const dest = this.sourceProject ? `/projects/${this.sourceProject.id}` : '/agents';
-                window.history.pushState({}, '', dest);
-                window.dispatchEvent(new PopStateEvent('popstate'));
-              }}
-            >
-              Cancel
-            </sl-button>
-          </div>
+        <!-- ═══════ Form Actions ═══════ -->
+        <div class="form-actions">
+          <sl-button
+            variant="primary"
+            ?loading=${this.submitting}
+            ?disabled=${this.submitting}
+            @click=${(e: Event) => this.handleSubmit(e)}
+          >
+            <sl-icon slot="prefix" name="play-circle"></sl-icon>
+            Start
+          </sl-button>
+          <sl-button
+            variant="text"
+            ?disabled=${this.submitting}
+            @click=${() => {
+              const dest = this.sourceProject ? `/projects/${this.sourceProject.id}` : '/agents';
+              window.history.pushState({}, '', dest);
+              window.dispatchEvent(new PopStateEvent('popstate'));
+            }}
+          >
+            Cancel
+          </sl-button>
         </div>
+      </div>
+    `;
+  }
+
+  // ── Default Section ───────────────────────────────────────────────
+
+  private renderDefaultSection() {
+    return html`
+      <!-- Agent Name -->
+      <div class="form-field">
+        <label for="name">Agent Name</label>
+        <sl-input
+          id="name"
+          placeholder="my-agent"
+          .value=${this.name}
+          @sl-input=${(e: Event) => {
+            this.name = (e.target as HTMLElement & { value: string }).value;
+          }}
+          required
+        ></sl-input>
+      </div>
+
+      <!-- Project (hidden when projectFromUrl) -->
+      ${!this.projectFromUrl
+        ? html`
+            <div class="form-field">
+              <label for="project">Project</label>
+              <sl-select
+                id="project"
+                placeholder="Select a project..."
+                .value=${this.projectId}
+                @sl-change=${(e: Event) => {
+                  this.projectId = (e.target as HTMLElement & { value: string }).value;
+                  this.selectBrokerForProject();
+                  void this.selectDefaultTemplate();
+                  void this.loadHarnessConfigs();
+                  void this.loadGCPServiceAccounts();
+                  void this.applyProjectDefaults();
+                  if (!this.selectedProject?.gitRemote) {
+                    this.branch = '';
+                  }
+                }}
+                required
+              >
+                ${this.projects.map(
+                  (p) => html`<sl-option value=${p.id}>${p.name}</sl-option>`
+                )}
+              </sl-select>
+              <div class="hint">The project workspace for this agent.</div>
+            </div>
+          `
+        : nothing}
+
+      <!-- Template -->
+      <div class="form-field">
+        <label for="template">Template</label>
+        <sl-select
+          id="template"
+          placeholder="Select a template..."
+          .value=${this.templateId}
+          @sl-change=${(e: Event) => this.onTemplateChange(e)}
+        >
+          ${this.filteredTemplates.map(
+            (t) =>
+              html`<sl-option value=${t.id}
+                >${t.displayName || t.name}${t.scope === 'project'
+                  ? ' (project)'
+                  : ''}${t.description ? ` - ${t.description}` : ''}</sl-option
+              >`
+          )}
+        </sl-select>
+        <div class="hint">Agent configuration template.</div>
+      </div>
+
+      <!-- Harness Config -->
+      <div class="form-field">
+        <label for="harness">Harness Config</label>
+        <sl-select
+          id="harness"
+          placeholder="Select a harness..."
+          .value=${this.harness}
+          @sl-change=${(e: Event) => {
+            this.harness = (e.target as HTMLElement & { value: string }).value;
+            if (this.harness !== '__other__') {
+              this.customHarness = '';
+            }
+          }}
+        >
+          ${this.harnessConfigs.length > 0
+            ? this.harnessConfigs.map(
+                (hc) => html`
+                  <sl-option value=${hc.name}>
+                    ${hc.displayName || hc.name}
+                    ${hc.harness ? html` <small>(${hc.harness})</small>` : ''}
+                  </sl-option>
+                `
+              )
+            : KNOWN_HARNESS_NAMES.map(
+                (name) => html`
+                  <sl-option value=${name}>${harnessDisplayName(name)}</sl-option>
+                `
+              )}
+          <sl-option value="__other__">Other...</sl-option>
+        </sl-select>
+        <div class="hint">
+          ${this.templateHarnessHint
+            ? this.templateHarnessHint
+            : 'The LLM harness configuration to use.'}
+        </div>
+      </div>
+
+      <!-- Custom Harness Config Name (conditional) -->
+      ${this.harness === '__other__'
+        ? html`
+            <div class="form-field">
+              <label for="custom-harness">Custom Harness Config Name</label>
+              <sl-input
+                id="custom-harness"
+                placeholder="e.g. my-custom-harness"
+                .value=${this.customHarness}
+                @sl-input=${(e: Event) => {
+                  this.customHarness = (e.target as HTMLElement & { value: string }).value;
+                }}
+                required
+              ></sl-input>
+              <div class="hint">
+                Name of the harness config directory (from .scion/harness-configs/).
+              </div>
+            </div>
+          `
+        : nothing}
+
+      <!-- Runtime Broker -->
+      <div class="form-field">
+        <label for="broker">Runtime Broker</label>
+        <sl-select
+          id="broker"
+          placeholder="Select a broker..."
+          .value=${this.brokerId}
+          @sl-change=${(e: Event) => {
+            this.brokerId = (e.target as HTMLElement & { value: string }).value;
+            this.autoSelectProfile();
+          }}
+        >
+          ${this.brokers.map(
+            (b) =>
+              html`<sl-option value=${b.id} ?disabled=${b.status === 'offline'}>
+                ${b.name} (${b.status})
+              </sl-option>`
+          )}
+        </sl-select>
+        <div class="hint">The compute node that will run this agent.</div>
+      </div>
+
+      <!-- Runtime Profile (conditional: broker has profiles) -->
+      ${this.selectedBrokerProfiles.length > 0
+        ? html`
+            <div class="form-field">
+              <label for="profile">Runtime Profile</label>
+              <sl-select
+                id="profile"
+                .value=${this.profile}
+                @sl-change=${(e: Event) => {
+                  this.profile = (e.target as HTMLElement & { value: string }).value;
+                }}
+              >
+                <sl-option value="">Use broker default</sl-option>
+                ${this.selectedBrokerProfiles.map(
+                  (p) => html`<sl-option value=${p.name}>${p.name} (${p.type})</sl-option>`
+                )}
+              </sl-select>
+              <div class="hint">The runtime profile on the selected broker.</div>
+            </div>
+          `
+        : nothing}
+
+      <!-- Task -->
+      <div class="form-field">
+        <label for="task">Task</label>
+        <sl-textarea
+          id="task"
+          placeholder="Describe what this agent should work on..."
+          .value=${this.task}
+          @sl-input=${(e: Event) => {
+            this.task = (e.target as HTMLElement & { value: string }).value;
+          }}
+          rows="4"
+          resize="auto"
+        ></sl-textarea>
+        <div class="hint">The task or prompt to start the agent with.</div>
+      </div>
+
+      <!-- Notify -->
+      <div class="notify-field">
+        <sl-checkbox
+          ?checked=${this.notify}
+          @sl-change=${(e: Event) => {
+            this.notify = (e.target as HTMLInputElement).checked;
+          }}
+        >
+          Notify me on important agent state changes
+        </sl-checkbox>
+        <sl-tooltip
+          content="You will be notified when this agent reaches: Completed, Waiting for Input, or Limits Exceeded."
+          hoist
+        >
+          <span class="help-badge">?</span>
+        </sl-tooltip>
+      </div>
+    `;
+  }
+
+  // ── Additional Options > General Tab ──────────────────────────────
+
+  private renderGeneralTab() {
+    return html`
+      <!-- Branch (conditional: project has gitRemote and is not shared workspace) -->
+      ${this.selectedProject?.gitRemote && !isSharedWorkspace(this.selectedProject)
+        ? html`
+            <div class="form-field">
+              <label>Branch</label>
+              <sl-input
+                placeholder="defaults to agent name"
+                .value=${this.branch}
+                @sl-input=${(e: Event) => {
+                  this.branch = (e.target as HTMLElement & { value: string }).value;
+                }}
+              ></sl-input>
+              <div class="hint">Git branch for this agent's workspace.</div>
+            </div>
+          `
+        : nothing}
+
+      <!-- Model -->
+      <div class="form-field">
+        <label>Model</label>
+        <sl-select
+          placeholder="Use harness default"
+          .value=${this.modelSelection}
+          clearable
+          @sl-change=${(e: Event) => {
+            this.modelSelection = (e.target as HTMLElement & { value: string }).value as typeof this.modelSelection;
+            if (this.modelSelection !== 'other') this.customModelId = '';
+          }}
+        >
+          <sl-option value="small">Small</sl-option>
+          <sl-option value="medium">Medium</sl-option>
+          <sl-option value="large">Large</sl-option>
+          <sl-option value="extra-large">Extra Large</sl-option>
+          <sl-option value="other">Other (specify)</sl-option>
+        </sl-select>
+      </div>
+
+      <!-- Custom Model ID (conditional) -->
+      ${this.modelSelection === 'other'
+        ? html`
+            <div class="form-field">
+              <label>Custom Model ID</label>
+              <sl-input
+                placeholder="e.g. claude-opus-4-8"
+                .value=${this.customModelId}
+                @sl-input=${(e: Event) => {
+                  this.customModelId = (e.target as HTMLElement & { value: string }).value;
+                }}
+              ></sl-input>
+            </div>
+          `
+        : nothing}
+
+      <!-- Thinking Level -->
+      <div class="form-field">
+        <label>
+          Thinking Level${this.thinkingLevel !== null
+            ? html` <span style="font-weight:normal;color:var(--sl-color-neutral-500)">(${this.thinkingLevel})</span>`
+            : nothing}
+        </label>
+        <div style="display:flex;align-items:center;gap:0.75rem">
+          <sl-range
+            min="0"
+            max="100"
+            step="1"
+            .value=${this.thinkingLevel ?? 50}
+            ?disabled=${this.thinkingLevel === null}
+            style="flex:1"
+            @sl-input=${(e: Event) => {
+              this.thinkingLevel = (e.target as HTMLElement & { value: number }).value;
+            }}
+          ></sl-range>
+          <sl-checkbox
+            ?checked=${this.thinkingLevel !== null}
+            @sl-change=${(e: Event) => {
+              this.thinkingLevel = (e.target as HTMLInputElement).checked ? 50 : null;
+            }}
+          >
+            Set
+          </sl-checkbox>
+        </div>
+        <div class="hint" style="display:flex;justify-content:space-between;margin-top:0.25rem">
+          <span>0 = minimal reasoning</span>
+          <span>${this.thinkingLevel === null ? 'Using harness default' : ''}</span>
+          <span>100 = maximum reasoning</span>
+        </div>
+      </div>
+
+      <!-- Container Image -->
+      <div class="form-field">
+        <label>Container Image</label>
+        <sl-input
+          placeholder="Container image override"
+          .value=${this.image}
+          @sl-input=${(e: Event) => {
+            this.image = (e.target as HTMLElement & { value: string }).value;
+          }}
+        ></sl-input>
+        <div class="hint">Override the default container image.</div>
+      </div>
+
+      <!-- Container User -->
+      <div class="form-field">
+        <label>Container User</label>
+        <sl-input
+          placeholder="Unix user inside container"
+          .value=${this.containerUser}
+          @sl-input=${(e: Event) => {
+            this.containerUser = (e.target as HTMLElement & { value: string }).value;
+          }}
+        ></sl-input>
+      </div>
+
+      <!-- Telemetry -->
+      <div class="notify-field">
+        <sl-checkbox
+          ?checked=${this.telemetryEnabled}
+          @sl-change=${(e: Event) => {
+            this.telemetryEnabled = (e.target as HTMLInputElement).checked;
+          }}
+        >
+          Enable Telemetry
+        </sl-checkbox>
+        <sl-tooltip content="Collect telemetry data for this agent." hoist>
+          <span class="help-badge">?</span>
+        </sl-tooltip>
+      </div>
+
+      <!-- Auto-Expose Ports -->
+      <div class="notify-field">
+        <sl-checkbox
+          ?checked=${this.autoExposePortsEnabled}
+          @sl-change=${(e: Event) => {
+            this.autoExposePortsEnabled = (e.target as HTMLInputElement).checked;
+          }}
+        >
+          Enable Auto-Expose Ports
+        </sl-checkbox>
+        <sl-tooltip
+          content="Automatically detect and expose TCP listening ports from this agent's container."
+          hoist
+        >
+          <span class="help-badge">?</span>
+        </sl-tooltip>
+      </div>
+
+      <!-- Auto-Expose Sub-fields (conditional) -->
+      ${this.autoExposePortsEnabled
+        ? html`
+            <div class="form-field">
+              <label>Port Filter Mode</label>
+              <sl-select
+                .value=${this.autoExposePortsMode}
+                @sl-change=${(e: Event) => {
+                  this.autoExposePortsMode = (e.target as HTMLElement & { value: string }).value;
+                }}
+              >
+                <sl-option value="allowlist">Allowlist</sl-option>
+                <sl-option value="denylist">Denylist</sl-option>
+              </sl-select>
+              <div class="hint">
+                ${this.autoExposePortsMode === 'allowlist'
+                  ? 'Only expose ports in the filter list below.'
+                  : 'Expose all ports except those in the filter list below.'}
+              </div>
+            </div>
+            <div class="form-field">
+              <label>Port Filter List</label>
+              <sl-input
+                placeholder="e.g. 3000,5173,8080"
+                .value=${this.autoExposePortsList}
+                @sl-input=${(e: Event) => {
+                  this.autoExposePortsList = (e.target as HTMLElement & { value: string }).value;
+                }}
+              ></sl-input>
+              <div class="hint">
+                Comma-separated list of ports to
+                ${this.autoExposePortsMode === 'allowlist' ? 'allow' : 'deny'}.
+              </div>
+            </div>
+            <div class="form-field">
+              <label>Scan Interval</label>
+              <sl-input
+                placeholder="3s"
+                .value=${this.autoExposePortsInterval}
+                @sl-input=${(e: Event) => {
+                  this.autoExposePortsInterval = (e.target as HTMLElement & { value: string }).value;
+                }}
+              ></sl-input>
+              <div class="hint">How often to scan for new listening ports (e.g. 3s, 5s).</div>
+            </div>
+          `
+        : nothing}
+    `;
+  }
+
+  // ── Additional Options > Auth & Security Tab ──────────────────────
+
+  private renderAuthSecurityTab() {
+    return html`
+      <!-- Agent Role -->
+      <div class="form-field">
+        <label>Agent Role</label>
+        <sl-select
+          placeholder="Select a role..."
+          .value=${this.agentRole}
+          @sl-change=${(e: Event) => {
+            this.agentRole = (e.target as HTMLElement & { value: string }).value;
+          }}
+        >
+          <sl-option value="">Default (determined by project settings)</sl-option>
+          <sl-option value="none">None (no hub access)</sl-option>
+          <sl-option value="readonly">Read-only</sl-option>
+          <sl-option value="baseline">Baseline (standard)</sl-option>
+          <sl-option value="full">Full (requires admin)</sl-option>
+        </sl-select>
+        <div class="hint">Authorization role for hub API access.</div>
+      </div>
+
+      <!-- Harness Authentication -->
+      <div class="form-field">
+        <label>Harness Authentication</label>
+        <sl-select
+          placeholder="Select auth method..."
+          .value=${this.harnessAuth}
+          @sl-change=${(e: Event) => {
+            this.harnessAuth = (e.target as HTMLElement & { value: string }).value;
+          }}
+        >
+          <sl-option value="">Auto Detected</sl-option>
+          <sl-option value="api-key">Provider API Key</sl-option>
+          <sl-option value="oauth-token">OAuth Token (env var)</sl-option>
+          <sl-option value="vertex-ai">Vertex Model Garden</sl-option>
+          <sl-option value="auth-file">Harness credential file</sl-option>
+          <sl-option value="none">No Authentication</sl-option>
+        </sl-select>
+        <div class="hint">Override the authentication method for the harness.</div>
+      </div>
+
+      <!-- GCP Identity -->
+      <div class="form-field">
+        <label>GCP Identity</label>
+        <sl-select
+          .value=${this.gcpMetadataMode}
+          @sl-change=${(e: Event) => {
+            this.gcpMetadataMode = (e.target as HTMLElement & { value: string }).value as
+              | 'block'
+              | 'passthrough'
+              | 'assign';
+            if (this.gcpMetadataMode !== 'assign') {
+              this.gcpServiceAccountId = '';
+            }
+          }}
+        >
+          <sl-option value="block">Block</sl-option>
+          ${this.gcpServiceAccounts.length > 0
+            ? html`<sl-option value="assign">Assign Service Account</sl-option>`
+            : ''}
+          <sl-option value="passthrough">Passthrough</sl-option>
+        </sl-select>
+        <div class="hint">
+          ${this.gcpMetadataMode === 'block'
+            ? 'Prevents the agent from accessing any GCP identity. Token requests are denied.'
+            : this.gcpMetadataMode === 'assign'
+              ? 'Assigns a registered GCP service account. GCP client libraries will authenticate automatically.'
+              : 'No metadata interception. The agent inherits the broker\'s GCP identity. Requires broker ownership.'}
+        </div>
+      </div>
+
+      <!-- GCP Service Account (conditional) -->
+      ${this.gcpMetadataMode === 'assign'
+        ? html`
+            <div class="form-field">
+              <label>Service Account</label>
+              ${this.verifiedGCPServiceAccounts.length > 0
+                ? html`
+                    <sl-select
+                      placeholder="Select a service account..."
+                      .value=${this.gcpServiceAccountId}
+                      @sl-change=${(e: Event) => {
+                        this.gcpServiceAccountId = (
+                          e.target as HTMLElement & { value: string }
+                        ).value;
+                      }}
+                    >
+                      ${this.verifiedGCPServiceAccounts.map(
+                        (sa) =>
+                          html`<sl-option value=${sa.id}>
+                            ${sa.email}${sa.displayName ? ` (${sa.displayName})` : ''}
+                          </sl-option>`
+                      )}
+                    </sl-select>
+                  `
+                : html`
+                    <div class="hint" style="margin-top: 0;">
+                      No verified service accounts available. Register and verify service
+                      accounts in project settings.
+                    </div>
+                  `}
+            </div>
+          `
+        : nothing}
+    `;
+  }
+
+  // ── Additional Options > Prompts Tab ──────────────────────────────
+
+  private renderPromptsTab() {
+    return html`
+      <div class="form-field">
+        <label>System Prompt</label>
+        <sl-textarea
+          placeholder="System prompt content or file:// URI..."
+          .value=${this.systemPrompt}
+          @sl-input=${(e: Event) => {
+            this.systemPrompt = (e.target as HTMLElement & { value: string }).value;
+          }}
+          rows="6"
+          resize="auto"
+        ></sl-textarea>
+        <div class="hint">Custom system prompt for the agent. Can be inline text or a file:// URI.</div>
+      </div>
+
+      <div class="form-field">
+        <label>Agent Instructions</label>
+        <sl-textarea
+          placeholder="Agent instructions content or file:// URI..."
+          .value=${this.agentInstructions}
+          @sl-input=${(e: Event) => {
+            this.agentInstructions = (e.target as HTMLElement & { value: string }).value;
+          }}
+          rows="6"
+          resize="auto"
+        ></sl-textarea>
+        <div class="hint">Additional instructions for the agent. Can be inline text or a file:// URI.</div>
+      </div>
+    `;
+  }
+
+  // ── Additional Options > Limits & Resources Tab ───────────────────
+
+  private renderLimitsTab() {
+    return html`
+      <div class="field-row">
+        <div class="form-field">
+          <label>Max Turns</label>
+          <sl-input
+            type="number"
+            placeholder="0 = unlimited"
+            .value=${String(this.maxTurns || '')}
+            @sl-input=${(e: Event) => {
+              this.maxTurns =
+                parseInt((e.target as HTMLElement & { value: string }).value) || 0;
+            }}
+          ></sl-input>
+        </div>
+        <div class="form-field">
+          <label>Max Model Calls</label>
+          <sl-input
+            type="number"
+            placeholder="0 = unlimited"
+            .value=${String(this.maxModelCalls || '')}
+            @sl-input=${(e: Event) => {
+              this.maxModelCalls =
+                parseInt((e.target as HTMLElement & { value: string }).value) || 0;
+            }}
+          ></sl-input>
+        </div>
+      </div>
+
+      <div class="form-field">
+        <label>Max Duration</label>
+        <sl-input
+          placeholder="e.g. 30m, 2h"
+          .value=${this.maxDuration}
+          @sl-input=${(e: Event) => {
+            this.maxDuration = (e.target as HTMLElement & { value: string }).value;
+          }}
+        ></sl-input>
+        <div class="hint">Go duration string. Empty means no limit.</div>
+      </div>
+
+      <div class="field-row">
+        <div class="form-field">
+          <label>CPU Request</label>
+          <sl-input
+            placeholder='e.g. "2", "500m"'
+            .value=${this.cpuRequest}
+            @sl-input=${(e: Event) => {
+              this.cpuRequest = (e.target as HTMLElement & { value: string }).value;
+            }}
+          ></sl-input>
+        </div>
+        <div class="form-field">
+          <label>Memory Request</label>
+          <sl-input
+            placeholder='e.g. "4Gi"'
+            .value=${this.memoryRequest}
+            @sl-input=${(e: Event) => {
+              this.memoryRequest = (e.target as HTMLElement & { value: string }).value;
+            }}
+          ></sl-input>
+        </div>
+      </div>
+
+      <div class="field-row">
+        <div class="form-field">
+          <label>CPU Limit</label>
+          <sl-input
+            placeholder='e.g. "4"'
+            .value=${this.cpuLimit}
+            @sl-input=${(e: Event) => {
+              this.cpuLimit = (e.target as HTMLElement & { value: string }).value;
+            }}
+          ></sl-input>
+        </div>
+        <div class="form-field">
+          <label>Memory Limit</label>
+          <sl-input
+            placeholder='e.g. "8Gi"'
+            .value=${this.memoryLimit}
+            @sl-input=${(e: Event) => {
+              this.memoryLimit = (e.target as HTMLElement & { value: string }).value;
+            }}
+          ></sl-input>
+        </div>
+      </div>
+
+      <div class="form-field">
+        <label>Disk</label>
+        <sl-input
+          placeholder='e.g. "20Gi"'
+          .value=${this.disk}
+          @sl-input=${(e: Event) => {
+            this.disk = (e.target as HTMLElement & { value: string }).value;
+          }}
+        ></sl-input>
+      </div>
+    `;
+  }
+
+  // ── Additional Options > Environment & Labels Tab ─────────────────
+
+  private renderEnvironmentTab() {
+    return html`
+      <!-- Environment Variables -->
+      <div class="form-field">
+        <label>Environment Variables</label>
+        <scion-env-editor
+          .entries=${this.envEntries}
+          @env-change=${(e: CustomEvent<{ entries: EnvEntry[] }>) => {
+            this.envEntries = e.detail.entries;
+          }}
+        ></scion-env-editor>
+      </div>
+
+      <!-- Labels -->
+      <div class="form-field" style="margin-top: 1.5rem;">
+        <label>Labels</label>
+        ${this.labelEntries.map(
+          (entry, i) => html`
+            <div
+              style="display: flex; gap: 0.5em; margin-bottom: 0.5em; align-items: center;"
+            >
+              <sl-input
+                size="small"
+                placeholder="key"
+                .value=${entry.key}
+                @sl-input=${(e: Event) => {
+                  const updated = [...this.labelEntries];
+                  updated[i] = {
+                    ...updated[i],
+                    key: (e.target as HTMLElement & { value: string }).value,
+                  };
+                  this.labelEntries = updated;
+                }}
+                style="flex: 1;"
+              ></sl-input>
+              <sl-input
+                size="small"
+                placeholder="value"
+                .value=${entry.value}
+                @sl-input=${(e: Event) => {
+                  const updated = [...this.labelEntries];
+                  updated[i] = {
+                    ...updated[i],
+                    value: (e.target as HTMLElement & { value: string }).value,
+                  };
+                  this.labelEntries = updated;
+                }}
+                style="flex: 1;"
+              ></sl-input>
+              <sl-icon-button
+                name="x-lg"
+                label="Remove"
+                @click=${() => {
+                  this.labelEntries = this.labelEntries.filter((_, idx) => idx !== i);
+                }}
+              ></sl-icon-button>
+            </div>
+          `
+        )}
+        ${this.labelEntries.length < 16
+          ? html`<sl-button
+              size="small"
+              variant="text"
+              @click=${() => {
+                this.labelEntries = [...this.labelEntries, { key: '', value: '' }];
+              }}
+            >
+              <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+              Add label
+            </sl-button>`
+          : nothing}
+        <div class="hint">Optional key-value labels to organize agents (max 16).</div>
       </div>
     `;
   }

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/// <reference types="vite/client" />
+
 /**
  * Vite-specific module declarations
  *

--- a/web/tsconfig.client.json
+++ b/web/tsconfig.client.json
@@ -7,6 +7,7 @@
         "moduleResolution": "bundler"
     },
     "include": [
+        "src/vite-env.d.ts",
         "src/client/**/*",
         "src/components/**/*",
         "src/shared/**/*"

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -126,6 +126,11 @@ export default defineConfig({
     // Set base to the proxy path so HTML asset URLs and dynamic imports
     // use the full proxy prefix. The proxyPrefixRestorePlugin re-adds
     // the prefix to incoming requests (which the hub proxy strips).
+    //
+    // IMPORTANT: PROXY_BASE_PATH must NEVER be set in production/CI builds.
+    // It is a dev-only env var for previewing the Vite dev server through
+    // the hub's port proxy. In production, base must be '/' so the Go
+    // server can serve the built assets at the site root.
     base: proxyBase || '/',
     // SPA mode: serve index.html for all unmatched routes (history API fallback)
     appType: 'spa',

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -18,16 +18,74 @@ import { defineConfig, type Plugin } from 'vite';
 import { resolve } from 'path';
 
 /**
+ * When running behind the Scion hub proxy, the proxy strips the
+ * base-path prefix from incoming requests before forwarding them
+ * to Vite. But Vite's `base` config makes it expect the prefix on
+ * all incoming requests. This middleware re-adds the prefix so
+ * Vite can function with its `base` set correctly (which ensures
+ * HTML asset URLs and dynamic-import paths all include the prefix
+ * for the browser).
+ *
+ * Flow:
+ *   Browser → hub/.../proxy/src/main.ts
+ *   Hub proxy strips prefix → Vite receives /src/main.ts
+ *   This middleware prepends prefix → /api/v1/.../proxy/src/main.ts
+ *   Vite (base = prefix) serves the file normally.
+ */
+function proxyPrefixRestorePlugin(): Plugin {
+    const proxyBase = process.env.PROXY_BASE_PATH; // e.g. /api/v1/agents/.../proxy/
+    if (!proxyBase) {
+        return { name: 'proxy-prefix-restore-noop' };
+    }
+
+    // Strip trailing slash for prefix matching
+    const prefix = proxyBase.replace(/\/$/, '');
+
+    return {
+        name: 'proxy-prefix-restore',
+        configureServer(server) {
+            // Must run before Vite's own middleware (use unshift-style
+            // by returning a function from configureServer — Vite calls
+            // the returned function *after* its internal middleware is
+            // installed). Instead, we hook via server.middlewares.use
+            // at plugin apply time which runs *before* Vite internals.
+            server.middlewares.use((req, _res, next) => {
+                // If the URL already has the prefix (shouldn't happen
+                // through the hub proxy, but guard against double-prefix)
+                if (req.url?.startsWith(prefix)) {
+                    next();
+                    return;
+                }
+                // Re-add the prefix so Vite's base-path routing works
+                req.url = prefix + (req.url || '/');
+                // Also fix req.originalUrl if present
+                if (req.originalUrl && !req.originalUrl.startsWith(prefix)) {
+                    req.originalUrl = prefix + req.originalUrl;
+                }
+                next();
+            });
+        },
+    };
+}
+
+/**
  * Vite plugin that returns empty JSON arrays for /api/* routes
  * when running without the Go backend. This lets page components
  * render their empty states instead of JSON parse errors.
  */
 function mockApiPlugin(): Plugin {
+    const proxyBase = process.env.PROXY_BASE_PATH;
+    // When behind proxy, mock API paths are prefixed
+    const apiPrefix = proxyBase ? proxyBase.replace(/\/$/, '') + '/api/v1/' : '/api/v1/';
+    const authMePrefix = proxyBase ? proxyBase.replace(/\/$/, '') + '/auth/me' : '/auth/me';
+    const authProvidersPrefix = proxyBase ? proxyBase.replace(/\/$/, '') + '/auth/providers' : '/auth/providers';
+    const authDebugPrefix = proxyBase ? proxyBase.replace(/\/$/, '') + '/auth/debug' : '/auth/debug';
+
     return {
         name: 'mock-api',
         configureServer(server) {
             server.middlewares.use((req, res, next) => {
-                if (req.url === '/auth/me') {
+                if (req.url === authMePrefix) {
                     res.setHeader('Content-Type', 'application/json');
                     res.statusCode = 200;
                     res.end(JSON.stringify({
@@ -37,18 +95,18 @@ function mockApiPlugin(): Plugin {
                     }));
                     return;
                 }
-                if (req.url === '/auth/providers') {
+                if (req.url === authProvidersPrefix) {
                     res.setHeader('Content-Type', 'application/json');
                     res.statusCode = 200;
                     res.end(JSON.stringify({ google: true, github: true }));
                     return;
                 }
-                if (req.url === '/auth/debug') {
+                if (req.url === authDebugPrefix) {
                     res.statusCode = 404;
                     res.end();
                     return;
                 }
-                if (req.url?.startsWith('/api/v1/')) {
+                if (req.url?.startsWith(apiPrefix)) {
                     res.setHeader('Content-Type', 'application/json');
                     res.statusCode = 200;
                     res.end('[]');
@@ -60,12 +118,18 @@ function mockApiPlugin(): Plugin {
     };
 }
 
+const proxyBase = process.env.PROXY_BASE_PATH;
+
 export default defineConfig({
     root: '.',
     publicDir: 'public',
+    // Set base to the proxy path so HTML asset URLs and dynamic imports
+    // use the full proxy prefix. The proxyPrefixRestorePlugin re-adds
+    // the prefix to incoming requests (which the hub proxy strips).
+    base: proxyBase || '/',
     // SPA mode: serve index.html for all unmatched routes (history API fallback)
     appType: 'spa',
-    plugins: [mockApiPlugin()],
+    plugins: [proxyPrefixRestorePlugin(), mockApiPlugin()],
     build: {
         outDir: 'dist/client',
         emptyOutDir: true,


### PR DESCRIPTION
Merges the two-phase agent create/configure flow into a single unified form.

Default section shows Name, Project, Template, Harness, Broker, Profile, Task, and Notify.
Advanced settings in a collapsible disclosure area with 5 tabs: General, Auth & Security, Environment & Labels, Limits & Resources, Prompts.

Removes the editingAgentId round-trip flow. Adds vite-env.d.ts fixing 4 pre-existing TS errors. Zero new TypeScript errors.