### PR TITLE
chore: bump antigravity CLI version to 1.1.11

### DIFF
--- a/harnesses/antigravity/Dockerfile
+++ b/harnesses/antigravity/Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir -p /home/scion/.gemini/antigravity-cli \
   && chown -R scion:scion /home/scion/.gemini /home/scion/.agents
 
 # Pin the CLI to a specific release version.
-ARG AGY_VERSION=1.1.10
+ARG AGY_VERSION=1.1.11
 
 RUN ARCH=$(case "${TARGETARCH:-amd64}" in amd64) echo "x64";; arm64) echo "arm64";; *) echo "${TARGETARCH}";; esac) \
   && curl -fsSL -o /tmp/cli.tar.gz \


### PR DESCRIPTION
Bump antigravity CLI from 1.1.10 to 1.1.11.

Single-line change in Dockerfile ARG. The >= 1.1.10 version gates in provision.py (ADC auth check) remain correct for 1.1.11.

Ref: ptone/scion#910
