### PR TITLE
fix(cli): send encoding raw for plaintext secret values

### DIFF
--- a/cmd/hub_env.go
+++ b/cmd/hub_env.go
@@ -370,6 +370,7 @@ func runEnvSet(cmd *cobra.Command, args []string) error {
 	if envSecret {
 		secretReq := &hubclient.SetSecretRequest{
 			Value:         value,
+			Encoding:      "raw", // plaintext from CLI; server defaults to base64-decode without this
 			Scope:         scope,
 			ScopeID:       scopeID,
 			InjectionMode: injectionMode,

--- a/cmd/hub_secret.go
+++ b/cmd/hub_secret.go
@@ -291,7 +291,8 @@ func runSecretSet(cmd *cobra.Command, args []string) error {
 	}
 
 	// Handle @filename prefix for file secrets: read file content and base64-encode
-	if strings.HasPrefix(value, "@") {
+	isFileValue := strings.HasPrefix(value, "@")
+	if isFileValue {
 		filePath := value[1:]
 		// Expand ~ in source file path for reading
 		if strings.HasPrefix(filePath, "~/") {
@@ -362,6 +363,13 @@ func runSecretSet(cmd *cobra.Command, args []string) error {
 		Type:         secretType,
 		Target:       secretTarget,
 		AllowProgeny: secretAllowProgeny,
+	}
+
+	// Plaintext values (not from @file syntax) must be sent with encoding "raw"
+	// so the server stores them as-is instead of attempting base64-decode.
+	// File values are already base64-encoded above and use the server's default.
+	if !isFileValue {
+		req.Encoding = "raw"
 	}
 
 	resp, err := client.Secrets().Set(ctx, key, req)

--- a/cmd/hub_secret_test.go
+++ b/cmd/hub_secret_test.go
@@ -324,6 +324,104 @@ func TestResolveSecretScope_ScopeConflictsWithBroker(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot specify more than one")
 }
 
+// newSecretSetMockServer creates a mock Hub server that captures secret set request bodies.
+func newSecretSetMockServer(t *testing.T, captured *map[string]interface{}) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/healthz" && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+
+		case r.Method == http.MethodPut && len(r.URL.Path) > len("/api/v1/secrets/"):
+			// Capture the request body
+			var body map[string]interface{}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("failed to decode request body: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			*captured = body
+
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"secret":  map[string]interface{}{"key": "TEST_KEY", "scope": "user", "type": "environment", "version": 1, "created": "2026-01-01T00:00:00Z", "updated": "2026-01-01T00:00:00Z"},
+				"created": true,
+			})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	return server
+}
+
+func TestRunSecretSet_PlaintextSendsEncodingRaw(t *testing.T) {
+	orig := saveSecretTestState()
+	defer orig.restore()
+
+	var captured map[string]interface{}
+	server := newSecretSetMockServer(t, &captured)
+	defer server.Close()
+
+	tmpHome := t.TempDir()
+	_ = os.Setenv("HOME", tmpHome)
+	t.Setenv("SCION_HUB_ENDPOINT", server.URL)
+
+	projectDir := setupSecretProject(t, tmpHome, server.URL)
+	projectPath = projectDir
+
+	secretProjectScope = ""
+	secretBrokerScope = ""
+	secretScope = ""
+	secretType = ""
+	secretTarget = ""
+	secretAllowProgeny = false
+
+	err := runSecretSet(hubSecretSetCmd, []string{"API_KEY", "sk-abc123"})
+	require.NoError(t, err)
+
+	// Plaintext value must include encoding: "raw"
+	assert.Equal(t, "raw", captured["encoding"], "plaintext values should send encoding=raw")
+	assert.Equal(t, "sk-abc123", captured["value"], "value should be the plaintext input")
+}
+
+func TestRunSecretSet_FileSendsNoEncoding(t *testing.T) {
+	orig := saveSecretTestState()
+	defer orig.restore()
+
+	var captured map[string]interface{}
+	server := newSecretSetMockServer(t, &captured)
+	defer server.Close()
+
+	tmpHome := t.TempDir()
+	_ = os.Setenv("HOME", tmpHome)
+	t.Setenv("SCION_HUB_ENDPOINT", server.URL)
+
+	projectDir := setupSecretProject(t, tmpHome, server.URL)
+	projectPath = projectDir
+
+	secretProjectScope = ""
+	secretBrokerScope = ""
+	secretScope = ""
+	secretType = ""
+	secretTarget = ""
+	secretAllowProgeny = false
+
+	// Create a temp file to read via @file syntax
+	tmpFile := filepath.Join(tmpHome, "secret.txt")
+	require.NoError(t, os.WriteFile(tmpFile, []byte("file-contents"), 0644))
+
+	err := runSecretSet(hubSecretSetCmd, []string{"TLS_CERT", "@" + tmpFile})
+	require.NoError(t, err)
+
+	// @file values are base64-encoded by the CLI; encoding field should be absent
+	_, hasEncoding := captured["encoding"]
+	assert.False(t, hasEncoding, "@file values should not send encoding field")
+}
+
 func TestHubSecretListCmd_ScopeFlag(t *testing.T) {
 	// Verify the --scope flag is registered on all secret subcommands.
 	for _, cmd := range []*cobra.Command{hubSecretSetCmd, hubSecretGetCmd, hubSecretListCmd, hubSecretClearCmd} {

--- a/cmd/hub_secret_test.go
+++ b/cmd/hub_secret_test.go
@@ -420,6 +420,9 @@ func TestRunSecretSet_FileSendsNoEncoding(t *testing.T) {
 	// @file values are base64-encoded by the CLI; encoding field should be absent
 	_, hasEncoding := captured["encoding"]
 	assert.False(t, hasEncoding, "@file values should not send encoding field")
+
+	// Verify the value is the base64-encoded form of "file-contents"
+	assert.Equal(t, "ZmlsZS1jb250ZW50cw==", captured["value"], "@file value should be base64-encoded")
 }
 
 func TestHubSecretListCmd_ScopeFlag(t *testing.T) {

--- a/cmd/hub_secret_test.go
+++ b/cmd/hub_secret_test.go
@@ -367,7 +367,7 @@ func TestRunSecretSet_PlaintextSendsEncodingRaw(t *testing.T) {
 	defer server.Close()
 
 	tmpHome := t.TempDir()
-	_ = os.Setenv("HOME", tmpHome)
+	t.Setenv("HOME", tmpHome)
 	t.Setenv("SCION_HUB_ENDPOINT", server.URL)
 
 	projectDir := setupSecretProject(t, tmpHome, server.URL)
@@ -397,7 +397,7 @@ func TestRunSecretSet_FileSendsNoEncoding(t *testing.T) {
 	defer server.Close()
 
 	tmpHome := t.TempDir()
-	_ = os.Setenv("HOME", tmpHome)
+	t.Setenv("HOME", tmpHome)
 	t.Setenv("SCION_HUB_ENDPOINT", server.URL)
 
 	projectDir := setupSecretProject(t, tmpHome, server.URL)

--- a/pkg/hubclient/secrets.go
+++ b/pkg/hubclient/secrets.go
@@ -67,6 +67,7 @@ type SecretScopeOptions struct {
 // SetSecretRequest is the request for setting a secret.
 type SetSecretRequest struct {
 	Value         string `json:"value"`                   // Required: secret value (write-only)
+	Encoding      string `json:"encoding,omitempty"`      // Value encoding: "raw" (plaintext) or "" (default: base64)
 	Scope         string `json:"scope,omitempty"`         // Scope type (default: user)
 	ScopeID       string `json:"scopeId,omitempty"`       // Required for project/runtime_broker scope
 	Description   string `json:"description,omitempty"`   // Optional description


### PR DESCRIPTION
Adds an Encoding field to hubclient.SetSecretRequest and sets encoding: raw for plaintext CLI args in scion hub secret set, so the server stores the value as-is instead of attempting a base64-decode. @file values (already base64-encoded by the CLI) are unchanged. Includes tests for both paths. Ref: ptone/scion#750