### PR TITLE
feat: add Google Chat (chat-app) to hub plugin catalog and admin UI

### DIFF
--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -1083,6 +1083,12 @@ func createSelfManagedAdminConfig(pluginName, configFilePath string) error {
 		content += "provider_org: \"\"\n"
 		content += "provider_url: \"\"\n"
 		content += "projects_json: \"[]\"\n"
+	case "chat-app":
+		content += "project_id: \"\"\n"
+		content += "credentials: \"\"\n"
+		content += "listen_address: \":8443\"\n"
+		content += "external_url: \"\"\n"
+		content += "service_account_email: \"\"\n"
 	}
 
 	return os.WriteFile(resolved, []byte(content), 0600)
@@ -1103,19 +1109,43 @@ func createBridgeConfigTemplate(name, configFilePath, hubEndpoint string) error 
 		return fmt.Errorf("create config dir: %w", err)
 	}
 
-	content := "# Scion A2A bridge bootstrap configuration\n"
-	content += "# This file is operator-managed. Edit it to configure listen addresses,\n"
-	content += "# TLS, state database, and signing key settings.\n"
-	content += "hub:\n"
-	content += "  endpoint: \"" + hubEndpoint + "\"\n"
-	content += "plugin:\n"
-	content += "  listen_address: \"localhost:9090\"\n"
-	content += "# bridge:\n"
-	content += "#   listen_address: \":8081\"\n"
-	content += "# state:\n"
-	content += "#   database: \"~/.scion/scion-a2a-bridge.db\"\n"
-	content += "# logging:\n"
-	content += "#   level: \"info\"\n"
+	var content string
+	switch name {
+	case "chat-app":
+		content = "# Scion Google Chat app bootstrap configuration\n"
+		content += "# This file is operator-managed. Edit it to configure listen addresses,\n"
+		content += "# GCP credentials, and state database settings.\n"
+		content += "hub:\n"
+		content += "  endpoint: \"" + hubEndpoint + "\"\n"
+		content += "plugin:\n"
+		content += "  listen_address: \"localhost:9090\"\n"
+		content += "platforms:\n"
+		content += "  google_chat:\n"
+		content += "    enabled: true\n"
+		content += "    project_id: \"\"\n"
+		content += "    credentials: \"\"\n"
+		content += "    listen_address: \":8443\"\n"
+		content += "    external_url: \"\"\n"
+		content += "    service_account_email: \"\"\n"
+		content += "# state:\n"
+		content += "#   database: \"~/.scion/scion-chat-app.db\"\n"
+		content += "# logging:\n"
+		content += "#   level: \"info\"\n"
+	default:
+		content = "# Scion A2A bridge bootstrap configuration\n"
+		content += "# This file is operator-managed. Edit it to configure listen addresses,\n"
+		content += "# TLS, state database, and signing key settings.\n"
+		content += "hub:\n"
+		content += "  endpoint: \"" + hubEndpoint + "\"\n"
+		content += "plugin:\n"
+		content += "  listen_address: \"localhost:9090\"\n"
+		content += "# bridge:\n"
+		content += "#   listen_address: \":8081\"\n"
+		content += "# state:\n"
+		content += "#   database: \"~/.scion/scion-a2a-bridge.db\"\n"
+		content += "# logging:\n"
+		content += "#   level: \"info\"\n"
+	}
 
 	return os.WriteFile(resolved, []byte(content), 0600)
 }

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -166,6 +166,7 @@ var knownPluginCatalog = []KnownPlugin{
 	{Name: "discord", Platform: "discord", BinaryName: "scion-plugin-discord", SourceDir: "extras/scion-discord", Description: "Chat integration — built and managed by the Hub"},
 	{Name: "slack", Platform: "slack", BinaryName: "scion-plugin-slack", SourceDir: "extras/scion-slack", Description: "Chat integration — built and managed by the Hub"},
 	{Name: "a2a-bridge", Platform: "a2a", BinaryName: "scion-a2a-bridge", SourceDir: "extras/scion-a2a-bridge", SelfManaged: true, Description: "External service — installed separately, managed via admin UI"},
+	{Name: "chat-app", Platform: "gchat", BinaryName: "scion-chat-app", SourceDir: "extras/scion-chat-app", SelfManaged: true, Description: "Google Chat integration — installed separately, managed via admin UI"},
 }
 
 var knownPluginSet = func() map[string]bool {

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -191,8 +191,6 @@ const PLATFORM_FIELDS: Record<string, PlatformFieldDef[]> = {
     { key: 'listen_address', label: 'Webhook Listen Address', description: 'HTTP listen address for webhook mode', defaultValue: ':8443' },
     { key: 'external_url', label: 'External URL', description: 'Public URL where Google Chat sends events', defaultValue: '' },
     { key: 'service_account_email', label: 'Service Account Email', description: 'Email of the GCP service account (for JWT verification)', defaultValue: '' },
-    { key: 'ingress_mode', label: 'Ingress Mode', description: 'How Google Chat events are received', defaultValue: 'http', type: 'select', options: [{ label: 'HTTP Webhook', value: 'http' }, { label: 'Cloud Pub/Sub', value: 'pubsub' }] },
-    { key: 'pubsub_subscription', label: 'Pub/Sub Subscription', description: 'Full Pub/Sub subscription name (projects/PROJECT/subscriptions/SUB)', defaultValue: '' },
   ],
 };
 

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -103,6 +103,9 @@ const PLATFORM_SECRETS: Record<string, PlatformSecretDef[]> = {
   a2a: [
     { key: 'api_key', label: 'API Key', description: 'Static API key for apiKey/bearer auth schemes' },
   ],
+  gchat: [
+    { key: 'signing_key', label: 'Hub Signing Key', description: 'Shared signing key for hub authentication (HS256 JWT)', required: true },
+  ],
 };
 
 function resolvePlatform(name: string): string {
@@ -181,6 +184,15 @@ const PLATFORM_FIELDS: Record<string, PlatformFieldDef[]> = {
     { key: 'uat_cache_ttl', label: 'UAT Cache TTL',
       description: 'How long to cache UAT validation results',
       defaultValue: '60s', placeholder: '60s' },
+  ],
+  gchat: [
+    { key: 'project_id', label: 'GCP Project ID', description: 'Google Cloud project ID hosting the Chat app', defaultValue: '' },
+    { key: 'credentials', label: 'Credentials Path', description: 'Path to service account key JSON file (leave empty for ADC)', defaultValue: '' },
+    { key: 'listen_address', label: 'Webhook Listen Address', description: 'HTTP listen address for webhook mode', defaultValue: ':8443' },
+    { key: 'external_url', label: 'External URL', description: 'Public URL where Google Chat sends events', defaultValue: '' },
+    { key: 'service_account_email', label: 'Service Account Email', description: 'Email of the GCP service account (for JWT verification)', defaultValue: '' },
+    { key: 'ingress_mode', label: 'Ingress Mode', description: 'How Google Chat events are received', defaultValue: 'http', type: 'select', options: [{ label: 'HTTP Webhook', value: 'http' }, { label: 'Cloud Pub/Sub', value: 'pubsub' }] },
+    { key: 'pubsub_subscription', label: 'Pub/Sub Subscription', description: 'Full Pub/Sub subscription name (projects/PROJECT/subscriptions/SUB)', defaultValue: '' },
   ],
 };
 

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -1004,7 +1004,7 @@ export class ScionPageAdminIntegrations extends LitElement {
 
       ${this.renderStatusSection(d.status)}
       ${this.renderSetupBanner(d)}
-      ${this.renderA2ASetupSection(d)}
+      ${this.renderSelfManagedSetupSection(d)}
       ${this.renderSecretsSection(d)}
       ${this.renderConfigSection(d)}
       ${this.renderA2AProjectsSection(d)}
@@ -1483,25 +1483,41 @@ export class ScionPageAdminIntegrations extends LitElement {
     `;
   }
 
-  private renderA2ASetupSection(d: IntegrationDetail) {
+  private renderSelfManagedSetupSection(d: IntegrationDetail) {
     const platform = resolvePlatform(d.name);
-    if (platform !== 'a2a') return nothing;
 
-    // Only show the setup section when the bridge is not connected.
+    // Determine binary/config/label per self-managed platform.
+    let binaryName: string;
+    let configFile: string;
+    let label: string;
+    switch (platform) {
+      case 'a2a':
+        binaryName = 'scion-a2a-bridge';
+        configFile = '~/.scion/scion-a2a-bridge.yaml';
+        label = 'A2A bridge';
+        break;
+      case 'gchat':
+        binaryName = 'scion-chat-app';
+        configFile = '~/.scion/scion-chat-app.yaml';
+        label = 'Google Chat app';
+        break;
+      default:
+        return nothing;
+    }
+
+    // Only show the setup section when the process is not connected.
     if (d.status?.connected) return nothing;
 
-    const binaryName = 'scion-a2a-bridge';
-    const configFile = '~/.scion/scion-a2a-bridge.yaml';
     const startCommand = `${binaryName} -config ${configFile}`;
 
     return html`
       <div class="section">
-        <h3 class="section-title">Bridge Setup</h3>
+        <h3 class="section-title">Service Setup</h3>
         <div class="setup-banner">
           <sl-icon name="info-circle"></sl-icon>
           <div>
-            <strong>The A2A bridge process is not connected</strong>
-            Start the bridge process and click Reconnect to activate.
+            <strong>The ${label} process is not connected</strong>
+            Start the process and click Reconnect to activate.
           </div>
         </div>
         <div style="font-size: 0.875rem; display: flex; flex-direction: column; gap: 0.5rem;">


### PR DESCRIPTION
Register chat-app as a self-managed plugin in knownPluginCatalog (following a2a-bridge pattern). Add gchat platform fields and secrets to the admin integrations UI.

Key changes:
- pkg/hub/handlers_integrations.go: chat-app entry in knownPluginCatalog (SelfManaged: true)
- web/src/components/pages/admin-integrations.ts: gchat PLATFORM_FIELDS (project_id, credentials, listen_address, external_url, service_account_email) and PLATFORM_SECRETS (signing_key)

Ref: ptone/scion#914
