### PR TITLE
feat(chat): add thread-level default agent routing for Google Chat

### DIFF
--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -421,6 +421,10 @@ func (r *CommandRouter) handleSpaceJoin(ctx context.Context, event *ChatEvent) e
 
 // handleSpaceRemove is called when the bot is removed from a space.
 func (r *CommandRouter) handleSpaceRemove(ctx context.Context, event *ChatEvent) error {
+	// Clean up thread defaults for this space
+	if err := r.store.DeleteThreadDefaultsForSpace(event.SpaceID); err != nil {
+		r.log.Error("cleaning up thread defaults on removal", "error", err)
+	}
 	// Clean up space link
 	if err := r.store.DeleteSpaceLink(event.SpaceID, event.Platform); err != nil {
 		r.log.Error("cleaning up space link on removal", "error", err)
@@ -656,6 +660,11 @@ func (r *CommandRouter) cmdUnlink(ctx context.Context, event *ChatEvent, args []
 		if err := r.broker.CancelSubscription(pattern); err != nil {
 			r.log.Warn("failed to cancel project subscription", "project_id", link.ProjectID, "error", err)
 		}
+	}
+
+	// Clean up thread defaults for this space.
+	if err := r.store.DeleteThreadDefaultsForSpace(event.SpaceID); err != nil {
+		r.log.Warn("failed to clean up thread defaults on unlink", "error", err)
 	}
 
 	if err := r.store.DeleteSpaceLink(event.SpaceID, event.Platform); err != nil {
@@ -1058,16 +1067,20 @@ func (r *CommandRouter) cmdMessage(ctx context.Context, event *ChatEvent, args [
 	// default agent is configured, treat the entire input as the message text.
 	agent, err := client.ProjectAgents(link.ProjectID).Get(ctx, agentSlug)
 	if err != nil {
-		if link.DefaultAgent == "" {
+		defaultAgent, resolveErr := r.resolveDefaultAgent(event.SpaceID, event.ThreadID)
+		if resolveErr != nil {
+			return textResponse(event, fmt.Sprintf("Failed to resolve default agent: %v", resolveErr)), nil
+		}
+		if defaultAgent == "" {
 			return textResponse(event, fmt.Sprintf("Agent `%s` not found: %v", agentSlug, err)), nil
 		}
 		r.log.Warn("agent slug lookup failed, falling back to default agent",
 			"original_slug", agentSlug,
-			"default_agent", link.DefaultAgent,
+			"default_agent", defaultAgent,
 			"project_id", link.ProjectID,
 			"error", err,
 		)
-		agentSlug = link.DefaultAgent
+		agentSlug = defaultAgent
 		messageText = strings.Join(remaining, " ")
 		agent, err = client.ProjectAgents(link.ProjectID).Get(ctx, agentSlug)
 		if err != nil {
@@ -1105,15 +1118,46 @@ func (r *CommandRouter) cmdSetDefault(ctx context.Context, event *ChatEvent, arg
 		return linkResp, nil
 	}
 
-	if len(args) == 0 {
+	// Parse --thread flag from args.
+	threadMode := false
+	var filtered []string
+	for _, a := range args {
+		if a == "--thread" {
+			threadMode = true
+		} else {
+			filtered = append(filtered, a)
+		}
+	}
+
+	if threadMode && event.ThreadID == "" {
+		return textResponse(event, "The `--thread` flag can only be used inside a thread."), nil
+	}
+
+	if len(filtered) == 0 {
+		if threadMode {
+			agent, err := r.store.GetThreadDefault(event.SpaceID, event.ThreadID)
+			if err != nil {
+				return textResponse(event, fmt.Sprintf("Failed to get thread default: %v", err)), nil
+			}
+			if agent == "" {
+				return textResponse(event, "No thread-level default agent is set. Usage: `/scionAdmin set-default <agent-slug> --thread`"), nil
+			}
+			return textResponse(event, fmt.Sprintf("Thread default agent is `%s`. Use `/scionAdmin set-default clear --thread` to remove.", agent)), nil
+		}
 		if link.DefaultAgent == "" {
 			return textResponse(event, "No default agent is set. Usage: `/scionAdmin set-default <agent-slug>`"), nil
 		}
 		return textResponse(event, fmt.Sprintf("Default agent is `%s`. Use `/scionAdmin set-default clear` to remove.", link.DefaultAgent)), nil
 	}
 
-	arg := strings.ToLower(args[0])
+	arg := strings.ToLower(filtered[0])
 	if arg == "clear" || arg == "none" {
+		if threadMode {
+			if err := r.store.DeleteThreadDefault(event.SpaceID, event.ThreadID); err != nil {
+				return textResponse(event, fmt.Sprintf("Failed to clear thread default agent: %v", err)), nil
+			}
+			return textResponse(event, "Thread-level default agent cleared."), nil
+		}
 		if err := r.store.ClearDefaultAgent(event.SpaceID, event.Platform); err != nil {
 			return textResponse(event, fmt.Sprintf("Failed to clear default agent: %v", err)), nil
 		}
@@ -1125,9 +1169,16 @@ func (r *CommandRouter) cmdSetDefault(ctx context.Context, event *ChatEvent, arg
 		return textResponse(event, "Authentication required. Use `/scionAdmin register` first."), nil
 	}
 
-	agent, err := client.ProjectAgents(link.ProjectID).Get(ctx, args[0])
+	agent, err := client.ProjectAgents(link.ProjectID).Get(ctx, filtered[0])
 	if err != nil {
-		return textResponse(event, fmt.Sprintf("Agent `%s` not found: %v", args[0], err)), nil
+		return textResponse(event, fmt.Sprintf("Agent `%s` not found: %v", filtered[0], err)), nil
+	}
+
+	if threadMode {
+		if err := r.store.SetThreadDefault(event.SpaceID, event.ThreadID, agent.Slug, event.UserEmail); err != nil {
+			return textResponse(event, fmt.Sprintf("Failed to set thread default agent: %v", err)), nil
+		}
+		return textResponse(event, fmt.Sprintf("Thread default agent set to `%s`. Messages in this thread that don't match an agent name will be sent here.", agent.Slug)), nil
 	}
 
 	if err := r.store.SetDefaultAgent(event.SpaceID, event.Platform, agent.Slug); err != nil {
@@ -1234,6 +1285,7 @@ func (r *CommandRouter) cmdAdminHelp(ctx context.Context, event *ChatEvent) (*Ev
 • ` + "`/scionAdmin delete <agent>`" + ` — Delete an agent (with confirmation)
 • ` + "`/scionAdmin logs <agent>`" + ` — View recent agent logs
 • ` + "`/scionAdmin set-default <agent>`" + ` — Set default agent for ` + "`/scion`" + ` messages (clear with ` + "`clear`" + `)
+• ` + "`/scionAdmin set-default <agent> --thread`" + ` — Set default agent for the current thread (clear with ` + "`clear --thread`" + `)
 
 *Space & Identity:*
 • ` + "`/scionAdmin info`" + ` — Show registration, project link, and agent info
@@ -1249,6 +1301,29 @@ func (r *CommandRouter) cmdAdminHelp(ctx context.Context, event *ChatEvent) (*Ev
 Use ` + "`/scion <text>`" + ` to message agents directly.`
 
 	return textResponse(event, help), nil
+}
+
+// resolveDefaultAgent returns the default agent for a message, checking
+// thread-level defaults first (if threadID is non-empty), then falling back
+// to the space-level default agent.
+func (r *CommandRouter) resolveDefaultAgent(spaceID, threadID string) (string, error) {
+	if threadID != "" {
+		agent, err := r.store.GetThreadDefault(spaceID, threadID)
+		if err != nil {
+			return "", err
+		}
+		if agent != "" {
+			return agent, nil
+		}
+	}
+	link, err := r.store.GetSpaceLink(spaceID, "google_chat")
+	if err != nil {
+		return "", err
+	}
+	if link != nil {
+		return link.DefaultAgent, nil
+	}
+	return "", nil
 }
 
 // --- Helper methods ---

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -469,7 +469,11 @@ func (r *CommandRouter) cmdList(ctx context.Context, event *ChatEvent, args []st
 	// Check for a thread-level default if we're in a thread.
 	var threadDefault string
 	if event.ThreadID != "" {
-		threadDefault, _ = r.store.GetThreadDefault(event.SpaceID, event.ThreadID)
+		var err error
+		threadDefault, err = r.store.GetThreadDefault(event.SpaceID, event.ThreadID, event.Platform)
+		if err != nil {
+			r.log.Error("failed to get thread default", "error", err)
+		}
 	}
 
 	var sb strings.Builder
@@ -1085,7 +1089,11 @@ func (r *CommandRouter) cmdMessage(ctx context.Context, event *ChatEvent, args [
 	// default agent is configured, treat the entire input as the message text.
 	agent, err := client.ProjectAgents(link.ProjectID).Get(ctx, agentSlug)
 	if err != nil {
-		defaultAgent, resolveErr := r.resolveDefaultAgent(event.SpaceID, event.ThreadID, link.DefaultAgent)
+		targetThread := threadID
+		if targetThread == "" {
+			targetThread = event.ThreadID
+		}
+		defaultAgent, resolveErr := r.resolveDefaultAgent(event.SpaceID, targetThread, event.Platform, link.DefaultAgent)
 		if resolveErr != nil {
 			return textResponse(event, fmt.Sprintf("Failed to resolve default agent: %v", resolveErr)), nil
 		}
@@ -1153,7 +1161,7 @@ func (r *CommandRouter) cmdSetDefault(ctx context.Context, event *ChatEvent, arg
 
 	if len(filtered) == 0 {
 		if threadMode {
-			agent, err := r.store.GetThreadDefault(event.SpaceID, event.ThreadID)
+			agent, err := r.store.GetThreadDefault(event.SpaceID, event.ThreadID, event.Platform)
 			if err != nil {
 				return textResponse(event, fmt.Sprintf("Failed to get thread default: %v", err)), nil
 			}
@@ -1171,7 +1179,7 @@ func (r *CommandRouter) cmdSetDefault(ctx context.Context, event *ChatEvent, arg
 	arg := strings.ToLower(filtered[0])
 	if arg == "clear" || arg == "none" {
 		if threadMode {
-			if err := r.store.DeleteThreadDefault(event.SpaceID, event.ThreadID); err != nil {
+			if err := r.store.DeleteThreadDefault(event.SpaceID, event.ThreadID, event.Platform); err != nil {
 				return textResponse(event, fmt.Sprintf("Failed to clear thread default agent: %v", err)), nil
 			}
 			return textResponse(event, "Thread-level default agent cleared."), nil
@@ -1193,7 +1201,7 @@ func (r *CommandRouter) cmdSetDefault(ctx context.Context, event *ChatEvent, arg
 	}
 
 	if threadMode {
-		if err := r.store.SetThreadDefault(event.SpaceID, event.ThreadID, agent.Slug, event.UserEmail); err != nil {
+		if err := r.store.SetThreadDefault(event.SpaceID, event.ThreadID, event.Platform, agent.Slug, event.UserEmail); err != nil {
 			return textResponse(event, fmt.Sprintf("Failed to set thread default agent: %v", err)), nil
 		}
 		return textResponse(event, fmt.Sprintf("Thread default agent set to `%s`. Messages in this thread that don't match an agent name will be sent here.", agent.Slug)), nil
@@ -1257,8 +1265,10 @@ func (r *CommandRouter) cmdInfo(ctx context.Context, event *ChatEvent, args []st
 		widgets = append(widgets, Widget{Type: WidgetKeyValue, Label: "Default Agent", Content: link.DefaultAgent})
 	}
 	if link != nil && event.ThreadID != "" {
-		threadAgent, threadErr := r.store.GetThreadDefault(event.SpaceID, event.ThreadID)
-		if threadErr == nil && threadAgent != "" {
+		threadAgent, threadErr := r.store.GetThreadDefault(event.SpaceID, event.ThreadID, event.Platform)
+		if threadErr != nil {
+			r.log.Error("failed to get thread default", "error", threadErr)
+		} else if threadAgent != "" {
 			widgets = append(widgets, Widget{Type: WidgetKeyValue, Label: "Thread Default", Content: threadAgent})
 		}
 	}
@@ -1330,9 +1340,9 @@ Use ` + "`/scion <text>`" + ` to message agents directly.`
 // resolveDefaultAgent returns the default agent for a message, checking
 // thread-level defaults first (if threadID is non-empty), then falling back
 // to the provided space-level default.
-func (r *CommandRouter) resolveDefaultAgent(spaceID, threadID, spaceDefault string) (string, error) {
+func (r *CommandRouter) resolveDefaultAgent(spaceID, threadID, platform, spaceDefault string) (string, error) {
 	if threadID != "" {
-		agent, err := r.store.GetThreadDefault(spaceID, threadID)
+		agent, err := r.store.GetThreadDefault(spaceID, threadID, platform)
 		if err != nil {
 			return "", err
 		}

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -466,6 +466,12 @@ func (r *CommandRouter) cmdList(ctx context.Context, event *ChatEvent, args []st
 		return textResponse(event, fmt.Sprintf("No agents in project `%s`.", proj.Slug)), nil
 	}
 
+	// Check for a thread-level default if we're in a thread.
+	var threadDefault string
+	if event.ThreadID != "" {
+		threadDefault, _ = r.store.GetThreadDefault(event.SpaceID, event.ThreadID)
+	}
+
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("*Agents in %s:*\n", proj.Slug))
 	for _, a := range agents.Agents {
@@ -474,13 +480,25 @@ func (r *CommandRouter) cmdList(ctx context.Context, event *ChatEvent, args []st
 			status = a.Phase
 		}
 		marker := ""
-		if link.DefaultAgent != "" && a.Slug == link.DefaultAgent {
+		if threadDefault != "" && a.Slug == threadDefault {
+			marker = " †"
+		} else if link.DefaultAgent != "" && a.Slug == link.DefaultAgent {
 			marker = " *"
 		}
 		sb.WriteString(fmt.Sprintf("• `%s` — %s%s\n", a.Slug, status, marker))
 	}
+	hasLegend := false
 	if link.DefaultAgent != "" {
 		sb.WriteString("\n_* default agent_")
+		hasLegend = true
+	}
+	if threadDefault != "" {
+		if hasLegend {
+			sb.WriteString("  ")
+		} else {
+			sb.WriteString("\n")
+		}
+		sb.WriteString("_† thread default_")
 	}
 	return textResponse(event, sb.String()), nil
 }
@@ -1067,7 +1085,7 @@ func (r *CommandRouter) cmdMessage(ctx context.Context, event *ChatEvent, args [
 	// default agent is configured, treat the entire input as the message text.
 	agent, err := client.ProjectAgents(link.ProjectID).Get(ctx, agentSlug)
 	if err != nil {
-		defaultAgent, resolveErr := r.resolveDefaultAgent(event.SpaceID, event.ThreadID)
+		defaultAgent, resolveErr := r.resolveDefaultAgent(event.SpaceID, event.ThreadID, link.DefaultAgent)
 		if resolveErr != nil {
 			return textResponse(event, fmt.Sprintf("Failed to resolve default agent: %v", resolveErr)), nil
 		}
@@ -1238,6 +1256,12 @@ func (r *CommandRouter) cmdInfo(ctx context.Context, event *ChatEvent, args []st
 	if link != nil && link.DefaultAgent != "" {
 		widgets = append(widgets, Widget{Type: WidgetKeyValue, Label: "Default Agent", Content: link.DefaultAgent})
 	}
+	if link != nil && event.ThreadID != "" {
+		threadAgent, threadErr := r.store.GetThreadDefault(event.SpaceID, event.ThreadID)
+		if threadErr == nil && threadAgent != "" {
+			widgets = append(widgets, Widget{Type: WidgetKeyValue, Label: "Thread Default", Content: threadAgent})
+		}
+	}
 
 	card := Card{
 		Header: CardHeader{
@@ -1305,8 +1329,8 @@ Use ` + "`/scion <text>`" + ` to message agents directly.`
 
 // resolveDefaultAgent returns the default agent for a message, checking
 // thread-level defaults first (if threadID is non-empty), then falling back
-// to the space-level default agent.
-func (r *CommandRouter) resolveDefaultAgent(spaceID, threadID string) (string, error) {
+// to the provided space-level default.
+func (r *CommandRouter) resolveDefaultAgent(spaceID, threadID, spaceDefault string) (string, error) {
 	if threadID != "" {
 		agent, err := r.store.GetThreadDefault(spaceID, threadID)
 		if err != nil {
@@ -1316,14 +1340,7 @@ func (r *CommandRouter) resolveDefaultAgent(spaceID, threadID string) (string, e
 			return agent, nil
 		}
 	}
-	link, err := r.store.GetSpaceLink(spaceID, "google_chat")
-	if err != nil {
-		return "", err
-	}
-	if link != nil {
-		return link.DefaultAgent, nil
-	}
-	return "", nil
+	return spaceDefault, nil
 }
 
 // --- Helper methods ---

--- a/extras/scion-chat-app/internal/chatapp/commands_test.go
+++ b/extras/scion-chat-app/internal/chatapp/commands_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/extras/scion-chat-app/internal/state"
 )
 
 // newTestRouter creates a CommandRouter backed by an ephemeral store and a
@@ -250,5 +252,204 @@ func TestDialogSubmitRespond_RequiresSpaceLink(t *testing.T) {
 	}
 	if !strings.Contains(fm.messages[0].Text, "not linked") {
 		t.Errorf("expected 'not linked' reply, got: %s", fm.messages[0].Text)
+	}
+}
+
+// --- Thread Default Routing Tests ---
+
+func TestResolveDefaultAgent_ThreadDefaultTakesPrecedence(t *testing.T) {
+	router, _ := newTestRouter(t)
+
+	// Set up a space link with a space-level default.
+	router.store.SetSpaceLink(&state.SpaceLink{
+		SpaceID:      "spaces/test",
+		Platform:     "googlechat",
+		ProjectID:    "proj-1",
+		ProjectSlug:  "my-project",
+		LinkedBy:     "user-1",
+		DefaultAgent: "space-agent",
+	})
+	// Set a thread-level default.
+	router.store.SetThreadDefault("spaces/test", "thread-1", "thread-agent", "user@example.com")
+
+	agent, err := router.resolveDefaultAgent("spaces/test", "thread-1", "space-agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agent != "thread-agent" {
+		t.Errorf("expected thread-agent, got %q", agent)
+	}
+}
+
+func TestResolveDefaultAgent_FallsBackToSpaceDefault(t *testing.T) {
+	router, _ := newTestRouter(t)
+
+	// Space link with default, no thread default set.
+	router.store.SetSpaceLink(&state.SpaceLink{
+		SpaceID:      "spaces/test",
+		Platform:     "googlechat",
+		ProjectID:    "proj-1",
+		ProjectSlug:  "my-project",
+		LinkedBy:     "user-1",
+		DefaultAgent: "space-agent",
+	})
+
+	agent, err := router.resolveDefaultAgent("spaces/test", "thread-1", "space-agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agent != "space-agent" {
+		t.Errorf("expected space-agent, got %q", agent)
+	}
+}
+
+func TestResolveDefaultAgent_EmptyWhenNeitherSet(t *testing.T) {
+	router, _ := newTestRouter(t)
+
+	agent, err := router.resolveDefaultAgent("spaces/test", "thread-1", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agent != "" {
+		t.Errorf("expected empty, got %q", agent)
+	}
+}
+
+func TestResolveDefaultAgent_EmptyThreadIDSkipsLookup(t *testing.T) {
+	router, _ := newTestRouter(t)
+
+	// Even with a thread default set, passing empty threadID should skip it.
+	router.store.SetThreadDefault("spaces/test", "thread-1", "thread-agent", "u")
+
+	agent, err := router.resolveDefaultAgent("spaces/test", "", "space-agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agent != "space-agent" {
+		t.Errorf("expected space-agent when threadID is empty, got %q", agent)
+	}
+}
+
+func TestCmdSetDefault_ThreadFlag(t *testing.T) {
+	router, _ := newTestRouter(t)
+
+	// Link the space first.
+	router.store.SetSpaceLink(&state.SpaceLink{
+		SpaceID:     "spaces/test",
+		Platform:    "googlechat",
+		ProjectID:   "proj-1",
+		ProjectSlug: "my-project",
+		LinkedBy:    "user-1",
+	})
+
+	tests := []struct {
+		name        string
+		args        []string
+		threadID    string
+		wantContain string
+	}{
+		{
+			name:        "thread flag without thread context",
+			args:        []string{"my-agent", "--thread"},
+			threadID:    "",
+			wantContain: "only be used inside a thread",
+		},
+		{
+			name:        "thread flag with clear",
+			args:        []string{"clear", "--thread"},
+			threadID:    "thread-1",
+			wantContain: "Thread-level default agent cleared",
+		},
+		{
+			name:        "query thread default when none set",
+			args:        []string{"--thread"},
+			threadID:    "thread-1",
+			wantContain: "No thread-level default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &ChatEvent{
+				Type:     EventCommand,
+				Platform: "googlechat",
+				SpaceID:  "spaces/test",
+				UserID:   "user-1",
+				ThreadID: tt.threadID,
+			}
+
+			resp, err := router.cmdSetDefault(context.Background(), event, tt.args)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp == nil || resp.Message == nil {
+				t.Fatal("expected a response")
+			}
+			if !strings.Contains(resp.Message.Text, tt.wantContain) {
+				t.Errorf("expected response to contain %q, got: %s", tt.wantContain, resp.Message.Text)
+			}
+		})
+	}
+}
+
+func TestCmdSetDefault_ThreadQueryShowsCurrentDefault(t *testing.T) {
+	router, _ := newTestRouter(t)
+
+	router.store.SetSpaceLink(&state.SpaceLink{
+		SpaceID:     "spaces/test",
+		Platform:    "googlechat",
+		ProjectID:   "proj-1",
+		ProjectSlug: "my-project",
+		LinkedBy:    "user-1",
+	})
+	router.store.SetThreadDefault("spaces/test", "thread-1", "my-agent", "u")
+
+	event := &ChatEvent{
+		Type:     EventCommand,
+		Platform: "googlechat",
+		SpaceID:  "spaces/test",
+		UserID:   "user-1",
+		ThreadID: "thread-1",
+	}
+
+	resp, err := router.cmdSetDefault(context.Background(), event, []string{"--thread"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(resp.Message.Text, "my-agent") {
+		t.Errorf("expected response to mention my-agent, got: %s", resp.Message.Text)
+	}
+}
+
+func TestHandleSpaceRemove_CleansUpThreadDefaults(t *testing.T) {
+	router, _ := newTestRouter(t)
+
+	// Set up space link and thread defaults.
+	router.store.SetSpaceLink(&state.SpaceLink{
+		SpaceID:     "spaces/test",
+		Platform:    "googlechat",
+		ProjectID:   "proj-1",
+		ProjectSlug: "my-project",
+		LinkedBy:    "user-1",
+	})
+	router.store.SetThreadDefault("spaces/test", "thread-1", "agent-a", "u")
+	router.store.SetThreadDefault("spaces/test", "thread-2", "agent-b", "u")
+
+	event := &ChatEvent{
+		Type:     EventSpaceRemove,
+		Platform: "googlechat",
+		SpaceID:  "spaces/test",
+		UserID:   "user-1",
+	}
+
+	if err := router.handleSpaceRemove(context.Background(), event); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify thread defaults are cleaned up.
+	got1, _ := router.store.GetThreadDefault("spaces/test", "thread-1")
+	got2, _ := router.store.GetThreadDefault("spaces/test", "thread-2")
+	if got1 != "" || got2 != "" {
+		t.Errorf("thread defaults should be cleaned up after space removal, got thread-1=%q, thread-2=%q", got1, got2)
 	}
 }

--- a/extras/scion-chat-app/internal/chatapp/commands_test.go
+++ b/extras/scion-chat-app/internal/chatapp/commands_test.go
@@ -270,9 +270,9 @@ func TestResolveDefaultAgent_ThreadDefaultTakesPrecedence(t *testing.T) {
 		DefaultAgent: "space-agent",
 	})
 	// Set a thread-level default.
-	router.store.SetThreadDefault("spaces/test", "thread-1", "thread-agent", "user@example.com")
+	router.store.SetThreadDefault("spaces/test", "thread-1", "googlechat", "thread-agent", "user@example.com")
 
-	agent, err := router.resolveDefaultAgent("spaces/test", "thread-1", "space-agent")
+	agent, err := router.resolveDefaultAgent("spaces/test", "thread-1", "googlechat", "space-agent")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -294,7 +294,7 @@ func TestResolveDefaultAgent_FallsBackToSpaceDefault(t *testing.T) {
 		DefaultAgent: "space-agent",
 	})
 
-	agent, err := router.resolveDefaultAgent("spaces/test", "thread-1", "space-agent")
+	agent, err := router.resolveDefaultAgent("spaces/test", "thread-1", "googlechat", "space-agent")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -306,7 +306,7 @@ func TestResolveDefaultAgent_FallsBackToSpaceDefault(t *testing.T) {
 func TestResolveDefaultAgent_EmptyWhenNeitherSet(t *testing.T) {
 	router, _ := newTestRouter(t)
 
-	agent, err := router.resolveDefaultAgent("spaces/test", "thread-1", "")
+	agent, err := router.resolveDefaultAgent("spaces/test", "thread-1", "googlechat", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -319,9 +319,9 @@ func TestResolveDefaultAgent_EmptyThreadIDSkipsLookup(t *testing.T) {
 	router, _ := newTestRouter(t)
 
 	// Even with a thread default set, passing empty threadID should skip it.
-	router.store.SetThreadDefault("spaces/test", "thread-1", "thread-agent", "u")
+	router.store.SetThreadDefault("spaces/test", "thread-1", "googlechat", "thread-agent", "u")
 
-	agent, err := router.resolveDefaultAgent("spaces/test", "", "space-agent")
+	agent, err := router.resolveDefaultAgent("spaces/test", "", "googlechat", "space-agent")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -402,7 +402,7 @@ func TestCmdSetDefault_ThreadQueryShowsCurrentDefault(t *testing.T) {
 		ProjectSlug: "my-project",
 		LinkedBy:    "user-1",
 	})
-	router.store.SetThreadDefault("spaces/test", "thread-1", "my-agent", "u")
+	router.store.SetThreadDefault("spaces/test", "thread-1", "googlechat", "my-agent", "u")
 
 	event := &ChatEvent{
 		Type:     EventCommand,
@@ -432,8 +432,8 @@ func TestHandleSpaceRemove_CleansUpThreadDefaults(t *testing.T) {
 		ProjectSlug: "my-project",
 		LinkedBy:    "user-1",
 	})
-	router.store.SetThreadDefault("spaces/test", "thread-1", "agent-a", "u")
-	router.store.SetThreadDefault("spaces/test", "thread-2", "agent-b", "u")
+	router.store.SetThreadDefault("spaces/test", "thread-1", "googlechat", "agent-a", "u")
+	router.store.SetThreadDefault("spaces/test", "thread-2", "googlechat", "agent-b", "u")
 
 	event := &ChatEvent{
 		Type:     EventSpaceRemove,
@@ -447,8 +447,8 @@ func TestHandleSpaceRemove_CleansUpThreadDefaults(t *testing.T) {
 	}
 
 	// Verify thread defaults are cleaned up.
-	got1, _ := router.store.GetThreadDefault("spaces/test", "thread-1")
-	got2, _ := router.store.GetThreadDefault("spaces/test", "thread-2")
+	got1, _ := router.store.GetThreadDefault("spaces/test", "thread-1", "googlechat")
+	got2, _ := router.store.GetThreadDefault("spaces/test", "thread-2", "googlechat")
 	if got1 != "" || got2 != "" {
 		t.Errorf("thread defaults should be cleaned up after space removal, got thread-1=%q, thread-2=%q", got1, got2)
 	}

--- a/extras/scion-chat-app/internal/state/state.go
+++ b/extras/scion-chat-app/internal/state/state.go
@@ -114,6 +114,15 @@ func (s *Store) migrate() error {
 			subscribed_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			PRIMARY KEY (platform_user_id, platform, agent_id, grove_id)
 		)`,
+		`CREATE TABLE IF NOT EXISTS thread_defaults (
+			space_id    TEXT NOT NULL,
+			thread_id   TEXT NOT NULL,
+			agent_slug  TEXT NOT NULL,
+			platform    TEXT NOT NULL DEFAULT 'google_chat',
+			set_by      TEXT NOT NULL DEFAULT '',
+			set_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (space_id, thread_id)
+		)`,
 	}
 
 	for _, m := range migrations {
@@ -402,6 +411,61 @@ func (s *Store) ListAgentSubscriptions(agentID, projectID string) ([]AgentSubscr
 		subs = append(subs, sub)
 	}
 	return subs, rows.Err()
+}
+
+// --- Thread Defaults ---
+
+// GetThreadDefault returns the agent slug for the given thread, or "" if not set.
+func (s *Store) GetThreadDefault(spaceID, threadID string) (string, error) {
+	var agentSlug string
+	err := s.db.QueryRow(
+		`SELECT agent_slug FROM thread_defaults WHERE space_id = ? AND thread_id = ?`,
+		spaceID, threadID,
+	).Scan(&agentSlug)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("get thread default: %w", err)
+	}
+	return agentSlug, nil
+}
+
+// SetThreadDefault inserts or replaces a thread-level default agent.
+func (s *Store) SetThreadDefault(spaceID, threadID, agentSlug, setBy string) error {
+	_, err := s.db.Exec(
+		`INSERT OR REPLACE INTO thread_defaults (space_id, thread_id, agent_slug, set_by, set_at)
+		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		spaceID, threadID, agentSlug, setBy,
+	)
+	if err != nil {
+		return fmt.Errorf("set thread default: %w", err)
+	}
+	return nil
+}
+
+// DeleteThreadDefault removes a thread-level default agent.
+func (s *Store) DeleteThreadDefault(spaceID, threadID string) error {
+	_, err := s.db.Exec(
+		`DELETE FROM thread_defaults WHERE space_id = ? AND thread_id = ?`,
+		spaceID, threadID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete thread default: %w", err)
+	}
+	return nil
+}
+
+// DeleteThreadDefaultsForSpace removes all thread-level defaults for a space.
+func (s *Store) DeleteThreadDefaultsForSpace(spaceID string) error {
+	_, err := s.db.Exec(
+		`DELETE FROM thread_defaults WHERE space_id = ?`,
+		spaceID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete thread defaults for space: %w", err)
+	}
+	return nil
 }
 
 // ListUserSubscriptions returns all subscriptions for the given platform user.

--- a/extras/scion-chat-app/internal/state/state.go
+++ b/extras/scion-chat-app/internal/state/state.go
@@ -121,7 +121,7 @@ func (s *Store) migrate() error {
 			platform    TEXT NOT NULL DEFAULT 'google_chat',
 			set_by      TEXT NOT NULL DEFAULT '',
 			set_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-			PRIMARY KEY (space_id, thread_id)
+			PRIMARY KEY (space_id, thread_id, platform)
 		)`,
 	}
 
@@ -416,11 +416,11 @@ func (s *Store) ListAgentSubscriptions(agentID, projectID string) ([]AgentSubscr
 // --- Thread Defaults ---
 
 // GetThreadDefault returns the agent slug for the given thread, or "" if not set.
-func (s *Store) GetThreadDefault(spaceID, threadID string) (string, error) {
+func (s *Store) GetThreadDefault(spaceID, threadID, platform string) (string, error) {
 	var agentSlug string
 	err := s.db.QueryRow(
-		`SELECT agent_slug FROM thread_defaults WHERE space_id = ? AND thread_id = ?`,
-		spaceID, threadID,
+		`SELECT agent_slug FROM thread_defaults WHERE space_id = ? AND thread_id = ? AND platform = ?`,
+		spaceID, threadID, platform,
 	).Scan(&agentSlug)
 	if err == sql.ErrNoRows {
 		return "", nil
@@ -432,11 +432,11 @@ func (s *Store) GetThreadDefault(spaceID, threadID string) (string, error) {
 }
 
 // SetThreadDefault inserts or replaces a thread-level default agent.
-func (s *Store) SetThreadDefault(spaceID, threadID, agentSlug, setBy string) error {
+func (s *Store) SetThreadDefault(spaceID, threadID, platform, agentSlug, setBy string) error {
 	_, err := s.db.Exec(
-		`INSERT OR REPLACE INTO thread_defaults (space_id, thread_id, agent_slug, set_by, set_at)
-		 VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)`,
-		spaceID, threadID, agentSlug, setBy,
+		`INSERT OR REPLACE INTO thread_defaults (space_id, thread_id, platform, agent_slug, set_by, set_at)
+		 VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		spaceID, threadID, platform, agentSlug, setBy,
 	)
 	if err != nil {
 		return fmt.Errorf("set thread default: %w", err)
@@ -445,10 +445,10 @@ func (s *Store) SetThreadDefault(spaceID, threadID, agentSlug, setBy string) err
 }
 
 // DeleteThreadDefault removes a thread-level default agent.
-func (s *Store) DeleteThreadDefault(spaceID, threadID string) error {
+func (s *Store) DeleteThreadDefault(spaceID, threadID, platform string) error {
 	_, err := s.db.Exec(
-		`DELETE FROM thread_defaults WHERE space_id = ? AND thread_id = ?`,
-		spaceID, threadID,
+		`DELETE FROM thread_defaults WHERE space_id = ? AND thread_id = ? AND platform = ?`,
+		spaceID, threadID, platform,
 	)
 	if err != nil {
 		return fmt.Errorf("delete thread default: %w", err)

--- a/extras/scion-chat-app/internal/state/state_test.go
+++ b/extras/scion-chat-app/internal/state/state_test.go
@@ -286,3 +286,148 @@ func openDB(dbPath string) (*sql.DB, error) {
 	}
 	return db, nil
 }
+
+// --- Thread Defaults Tests ---
+
+func TestThreadDefaults_MigrationCreatesTable(t *testing.T) {
+	s := newTestStore(t)
+
+	// Verify the table exists by running a query against it.
+	var count int
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM thread_defaults`).Scan(&count)
+	if err != nil {
+		t.Fatalf("thread_defaults table should exist after migration: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 rows in fresh table, got %d", count)
+	}
+}
+
+func TestGetThreadDefault_ReturnsEmptyWhenNotSet(t *testing.T) {
+	s := newTestStore(t)
+
+	agent, err := s.GetThreadDefault("space-1", "thread-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agent != "" {
+		t.Errorf("expected empty string for unset thread default, got %q", agent)
+	}
+}
+
+func TestSetThreadDefault_InsertAndRetrieve(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.SetThreadDefault("space-1", "thread-1", "my-agent", "user@example.com"); err != nil {
+		t.Fatalf("set thread default: %v", err)
+	}
+
+	agent, err := s.GetThreadDefault("space-1", "thread-1")
+	if err != nil {
+		t.Fatalf("get thread default: %v", err)
+	}
+	if agent != "my-agent" {
+		t.Errorf("expected %q, got %q", "my-agent", agent)
+	}
+}
+
+func TestSetThreadDefault_ReplaceExisting(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.SetThreadDefault("space-1", "thread-1", "agent-a", "user@example.com"); err != nil {
+		t.Fatalf("set initial: %v", err)
+	}
+	if err := s.SetThreadDefault("space-1", "thread-1", "agent-b", "user@example.com"); err != nil {
+		t.Fatalf("set replacement: %v", err)
+	}
+
+	agent, err := s.GetThreadDefault("space-1", "thread-1")
+	if err != nil {
+		t.Fatalf("get thread default: %v", err)
+	}
+	if agent != "agent-b" {
+		t.Errorf("expected %q after replace, got %q", "agent-b", agent)
+	}
+}
+
+func TestSetThreadDefault_IsolatedPerThread(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.SetThreadDefault("space-1", "thread-1", "agent-a", "user@example.com"); err != nil {
+		t.Fatalf("set thread-1: %v", err)
+	}
+	if err := s.SetThreadDefault("space-1", "thread-2", "agent-b", "user@example.com"); err != nil {
+		t.Fatalf("set thread-2: %v", err)
+	}
+
+	got1, _ := s.GetThreadDefault("space-1", "thread-1")
+	got2, _ := s.GetThreadDefault("space-1", "thread-2")
+
+	if got1 != "agent-a" {
+		t.Errorf("thread-1: expected %q, got %q", "agent-a", got1)
+	}
+	if got2 != "agent-b" {
+		t.Errorf("thread-2: expected %q, got %q", "agent-b", got2)
+	}
+}
+
+func TestDeleteThreadDefault(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.SetThreadDefault("space-1", "thread-1", "my-agent", "user@example.com"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := s.DeleteThreadDefault("space-1", "thread-1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	agent, err := s.GetThreadDefault("space-1", "thread-1")
+	if err != nil {
+		t.Fatalf("get after delete: %v", err)
+	}
+	if agent != "" {
+		t.Errorf("expected empty after delete, got %q", agent)
+	}
+}
+
+func TestDeleteThreadDefault_NoErrorWhenNotExists(t *testing.T) {
+	s := newTestStore(t)
+
+	// Deleting a non-existent thread default should not error.
+	if err := s.DeleteThreadDefault("space-1", "nonexistent"); err != nil {
+		t.Fatalf("unexpected error deleting nonexistent: %v", err)
+	}
+}
+
+func TestDeleteThreadDefaultsForSpace(t *testing.T) {
+	s := newTestStore(t)
+
+	// Set defaults across two spaces, multiple threads.
+	if err := s.SetThreadDefault("space-1", "thread-1", "agent-a", "u"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := s.SetThreadDefault("space-1", "thread-2", "agent-b", "u"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := s.SetThreadDefault("space-2", "thread-3", "agent-c", "u"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	// Delete all for space-1.
+	if err := s.DeleteThreadDefaultsForSpace("space-1"); err != nil {
+		t.Fatalf("delete for space: %v", err)
+	}
+
+	// space-1 threads should be gone.
+	got1, _ := s.GetThreadDefault("space-1", "thread-1")
+	got2, _ := s.GetThreadDefault("space-1", "thread-2")
+	if got1 != "" || got2 != "" {
+		t.Errorf("space-1 threads should be cleared, got thread-1=%q, thread-2=%q", got1, got2)
+	}
+
+	// space-2 should be unaffected.
+	got3, _ := s.GetThreadDefault("space-2", "thread-3")
+	if got3 != "agent-c" {
+		t.Errorf("space-2 thread-3 should be unaffected, got %q", got3)
+	}
+}

--- a/extras/scion-chat-app/internal/state/state_test.go
+++ b/extras/scion-chat-app/internal/state/state_test.go
@@ -306,7 +306,7 @@ func TestThreadDefaults_MigrationCreatesTable(t *testing.T) {
 func TestGetThreadDefault_ReturnsEmptyWhenNotSet(t *testing.T) {
 	s := newTestStore(t)
 
-	agent, err := s.GetThreadDefault("space-1", "thread-1")
+	agent, err := s.GetThreadDefault("space-1", "thread-1", "google_chat")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -318,11 +318,11 @@ func TestGetThreadDefault_ReturnsEmptyWhenNotSet(t *testing.T) {
 func TestSetThreadDefault_InsertAndRetrieve(t *testing.T) {
 	s := newTestStore(t)
 
-	if err := s.SetThreadDefault("space-1", "thread-1", "my-agent", "user@example.com"); err != nil {
+	if err := s.SetThreadDefault("space-1", "thread-1", "google_chat", "my-agent", "user@example.com"); err != nil {
 		t.Fatalf("set thread default: %v", err)
 	}
 
-	agent, err := s.GetThreadDefault("space-1", "thread-1")
+	agent, err := s.GetThreadDefault("space-1", "thread-1", "google_chat")
 	if err != nil {
 		t.Fatalf("get thread default: %v", err)
 	}
@@ -334,14 +334,14 @@ func TestSetThreadDefault_InsertAndRetrieve(t *testing.T) {
 func TestSetThreadDefault_ReplaceExisting(t *testing.T) {
 	s := newTestStore(t)
 
-	if err := s.SetThreadDefault("space-1", "thread-1", "agent-a", "user@example.com"); err != nil {
+	if err := s.SetThreadDefault("space-1", "thread-1", "google_chat", "agent-a", "user@example.com"); err != nil {
 		t.Fatalf("set initial: %v", err)
 	}
-	if err := s.SetThreadDefault("space-1", "thread-1", "agent-b", "user@example.com"); err != nil {
+	if err := s.SetThreadDefault("space-1", "thread-1", "google_chat", "agent-b", "user@example.com"); err != nil {
 		t.Fatalf("set replacement: %v", err)
 	}
 
-	agent, err := s.GetThreadDefault("space-1", "thread-1")
+	agent, err := s.GetThreadDefault("space-1", "thread-1", "google_chat")
 	if err != nil {
 		t.Fatalf("get thread default: %v", err)
 	}
@@ -353,15 +353,15 @@ func TestSetThreadDefault_ReplaceExisting(t *testing.T) {
 func TestSetThreadDefault_IsolatedPerThread(t *testing.T) {
 	s := newTestStore(t)
 
-	if err := s.SetThreadDefault("space-1", "thread-1", "agent-a", "user@example.com"); err != nil {
+	if err := s.SetThreadDefault("space-1", "thread-1", "google_chat", "agent-a", "user@example.com"); err != nil {
 		t.Fatalf("set thread-1: %v", err)
 	}
-	if err := s.SetThreadDefault("space-1", "thread-2", "agent-b", "user@example.com"); err != nil {
+	if err := s.SetThreadDefault("space-1", "thread-2", "google_chat", "agent-b", "user@example.com"); err != nil {
 		t.Fatalf("set thread-2: %v", err)
 	}
 
-	got1, _ := s.GetThreadDefault("space-1", "thread-1")
-	got2, _ := s.GetThreadDefault("space-1", "thread-2")
+	got1, _ := s.GetThreadDefault("space-1", "thread-1", "google_chat")
+	got2, _ := s.GetThreadDefault("space-1", "thread-2", "google_chat")
 
 	if got1 != "agent-a" {
 		t.Errorf("thread-1: expected %q, got %q", "agent-a", got1)
@@ -374,14 +374,14 @@ func TestSetThreadDefault_IsolatedPerThread(t *testing.T) {
 func TestDeleteThreadDefault(t *testing.T) {
 	s := newTestStore(t)
 
-	if err := s.SetThreadDefault("space-1", "thread-1", "my-agent", "user@example.com"); err != nil {
+	if err := s.SetThreadDefault("space-1", "thread-1", "google_chat", "my-agent", "user@example.com"); err != nil {
 		t.Fatalf("set: %v", err)
 	}
-	if err := s.DeleteThreadDefault("space-1", "thread-1"); err != nil {
+	if err := s.DeleteThreadDefault("space-1", "thread-1", "google_chat"); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 
-	agent, err := s.GetThreadDefault("space-1", "thread-1")
+	agent, err := s.GetThreadDefault("space-1", "thread-1", "google_chat")
 	if err != nil {
 		t.Fatalf("get after delete: %v", err)
 	}
@@ -394,7 +394,7 @@ func TestDeleteThreadDefault_NoErrorWhenNotExists(t *testing.T) {
 	s := newTestStore(t)
 
 	// Deleting a non-existent thread default should not error.
-	if err := s.DeleteThreadDefault("space-1", "nonexistent"); err != nil {
+	if err := s.DeleteThreadDefault("space-1", "nonexistent", "google_chat"); err != nil {
 		t.Fatalf("unexpected error deleting nonexistent: %v", err)
 	}
 }
@@ -403,13 +403,13 @@ func TestDeleteThreadDefaultsForSpace(t *testing.T) {
 	s := newTestStore(t)
 
 	// Set defaults across two spaces, multiple threads.
-	if err := s.SetThreadDefault("space-1", "thread-1", "agent-a", "u"); err != nil {
+	if err := s.SetThreadDefault("space-1", "thread-1", "google_chat", "agent-a", "u"); err != nil {
 		t.Fatalf("set: %v", err)
 	}
-	if err := s.SetThreadDefault("space-1", "thread-2", "agent-b", "u"); err != nil {
+	if err := s.SetThreadDefault("space-1", "thread-2", "google_chat", "agent-b", "u"); err != nil {
 		t.Fatalf("set: %v", err)
 	}
-	if err := s.SetThreadDefault("space-2", "thread-3", "agent-c", "u"); err != nil {
+	if err := s.SetThreadDefault("space-2", "thread-3", "google_chat", "agent-c", "u"); err != nil {
 		t.Fatalf("set: %v", err)
 	}
 
@@ -419,14 +419,14 @@ func TestDeleteThreadDefaultsForSpace(t *testing.T) {
 	}
 
 	// space-1 threads should be gone.
-	got1, _ := s.GetThreadDefault("space-1", "thread-1")
-	got2, _ := s.GetThreadDefault("space-1", "thread-2")
+	got1, _ := s.GetThreadDefault("space-1", "thread-1", "google_chat")
+	got2, _ := s.GetThreadDefault("space-1", "thread-2", "google_chat")
 	if got1 != "" || got2 != "" {
 		t.Errorf("space-1 threads should be cleared, got thread-1=%q, thread-2=%q", got1, got2)
 	}
 
 	// space-2 should be unaffected.
-	got3, _ := s.GetThreadDefault("space-2", "thread-3")
+	got3, _ := s.GetThreadDefault("space-2", "thread-3", "google_chat")
 	if got3 != "agent-c" {
 		t.Errorf("space-2 thread-3 should be unaffected, got %q", got3)
 	}


### PR DESCRIPTION
Add per-thread agent binding so messages in a thread route to a different default agent than the space-level default, mirroring Discord thread_defaults.

Key changes:
- extras/scion-chat-app/internal/state/state.go: thread_defaults SQLite table with CRUD methods
- extras/scion-chat-app/internal/chatapp/commands.go: resolveDefaultAgent with thread-priority-over-space fallback, --thread flag for set-default, thread default visibility in info/list
- 15 tests covering migration, CRUD, precedence, cleanup

Ref: ptone/scion#914
