### PR TITLE
feat(chat-app): add message dedup and per-space send queue for reliability

### DIFF
--- a/extras/scion-chat-app/cmd/scion-chat-app/main.go
+++ b/extras/scion-chat-app/cmd/scion-chat-app/main.go
@@ -243,13 +243,13 @@ func main() {
 			messenger,
 			log.With("component", "sendqueue"),
 			cfg.Platforms.GoogleChat.SendQueueSize,
-			cfg.Platforms.GoogleChat.SendMinDelay,
+			cfg.Platforms.GoogleChat.SendMinDelay.Duration,
 		)
 		relay.SetSendQueue(sendQueue)
 		defer sendQueue.Close()
 		log.Info("send queue initialized",
 			"queue_size", cfg.Platforms.GoogleChat.SendQueueSize,
-			"min_delay", cfg.Platforms.GoogleChat.SendMinDelay,
+			"min_delay", cfg.Platforms.GoogleChat.SendMinDelay.Duration,
 		)
 	}
 

--- a/extras/scion-chat-app/cmd/scion-chat-app/main.go
+++ b/extras/scion-chat-app/cmd/scion-chat-app/main.go
@@ -236,6 +236,23 @@ func main() {
 
 	// Create notification relay and wire it as the broker's message handler.
 	relay := chatapp.NewNotificationRelay(store, messenger, log.With("component", "notifications"))
+
+	// Create send queue to rate-limit outbound messages per space.
+	if messenger != nil {
+		sendQueue := chatapp.NewSendQueue(
+			messenger,
+			log.With("component", "sendqueue"),
+			cfg.Platforms.GoogleChat.SendQueueSize,
+			cfg.Platforms.GoogleChat.SendMinDelay,
+		)
+		relay.SetSendQueue(sendQueue)
+		defer sendQueue.Close()
+		log.Info("send queue initialized",
+			"queue_size", cfg.Platforms.GoogleChat.SendQueueSize,
+			"min_delay", cfg.Platforms.GoogleChat.SendMinDelay,
+		)
+	}
+
 	broker.SetHandler(relay.HandleBrokerMessage)
 
 	// Load existing space-project links and request broker subscriptions.

--- a/extras/scion-chat-app/internal/chatapp/broker.go
+++ b/extras/scion-chat-app/internal/chatapp/broker.go
@@ -70,6 +70,8 @@ func NewBrokerServer(handler MessageHandler, log *slog.Logger) *BrokerServer {
 // SetHandler replaces the message handler after construction, allowing
 // deferred wiring (e.g. to a notification relay created later).
 func (b *BrokerServer) SetHandler(handler MessageHandler) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.handler = handler
 }
 
@@ -117,8 +119,11 @@ func (b *BrokerServer) Publish(ctx context.Context, topic string, msg *messages.
 		"sender", msg.Sender,
 		"type", msg.Type,
 	)
-	if b.handler != nil {
-		return b.handler(ctx, topic, msg)
+	b.mu.RLock()
+	h := b.handler
+	b.mu.RUnlock()
+	if h != nil {
+		return h(ctx, topic, msg)
 	}
 	return nil
 }

--- a/extras/scion-chat-app/internal/chatapp/broker.go
+++ b/extras/scion-chat-app/internal/chatapp/broker.go
@@ -16,6 +16,8 @@ package chatapp
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"log/slog"
@@ -26,6 +28,11 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/plugin"
 	goplugin "github.com/hashicorp/go-plugin"
+)
+
+const (
+	// dedupTTL is how long a message fingerprint is remembered for deduplication.
+	dedupTTL = 5 * time.Minute
 )
 
 // MessageHandler is called when a message is received from the Hub via the broker plugin.
@@ -41,6 +48,9 @@ type BrokerServer struct {
 	subscriptions map[string]bool
 	configured    bool
 	channelName   string
+
+	sentIDs   map[string]time.Time
+	sentIDsMu sync.Mutex
 }
 
 // Compile-time interface checks.
@@ -53,6 +63,7 @@ func NewBrokerServer(handler MessageHandler, log *slog.Logger) *BrokerServer {
 		handler:       handler,
 		log:           log,
 		subscriptions: make(map[string]bool),
+		sentIDs:       make(map[string]time.Time),
 	}
 }
 
@@ -82,6 +93,25 @@ func (b *BrokerServer) Publish(ctx context.Context, topic string, msg *messages.
 	if msg == nil {
 		return nil
 	}
+
+	// Dedup check: compute SHA256 fingerprint and skip if seen within TTL.
+	dedupKey := msgDedupKey(msg)
+	if dedupKey != "" {
+		b.sentIDsMu.Lock()
+		if t, ok := b.sentIDs[dedupKey]; ok && time.Since(t) < dedupTTL {
+			b.sentIDsMu.Unlock()
+			b.log.Debug("skipping duplicate message",
+				"topic", topic,
+				"sender", msg.Sender,
+				"dedup_key", dedupKey,
+			)
+			return nil
+		}
+		b.sentIDs[dedupKey] = time.Now()
+		b.pruneSentIDsLocked()
+		b.sentIDsMu.Unlock()
+	}
+
 	b.log.Debug("received message via broker",
 		"topic", topic,
 		"sender", msg.Sender,
@@ -91,6 +121,36 @@ func (b *BrokerServer) Publish(ctx context.Context, topic string, msg *messages.
 		return b.handler(ctx, topic, msg)
 	}
 	return nil
+}
+
+// msgDedupKey returns a stable SHA256 fingerprint for a message, used to detect
+// duplicate deliveries of the same logical message.
+func msgDedupKey(msg *messages.StructuredMessage) string {
+	if msg == nil || msg.Msg == "" {
+		return ""
+	}
+	h := sha256.New()
+	h.Write([]byte(msg.Sender))
+	h.Write([]byte("|"))
+	h.Write([]byte(msg.Recipient))
+	h.Write([]byte("|"))
+	h.Write([]byte(msg.Timestamp))
+	h.Write([]byte("|"))
+	h.Write([]byte(msg.Type))
+	h.Write([]byte("|"))
+	h.Write([]byte(msg.Msg))
+	return hex.EncodeToString(h.Sum(nil)[:16])
+}
+
+// pruneSentIDsLocked removes dedup entries older than dedupTTL.
+// Must be called with b.sentIDsMu held.
+func (b *BrokerServer) pruneSentIDsLocked() {
+	now := time.Now()
+	for k, t := range b.sentIDs {
+		if now.Sub(t) > dedupTTL {
+			delete(b.sentIDs, k)
+		}
+	}
 }
 
 // ChannelName returns the configured channel name in a thread-safe manner.

--- a/extras/scion-chat-app/internal/chatapp/config.go
+++ b/extras/scion-chat-app/internal/chatapp/config.go
@@ -14,7 +14,36 @@
 
 package chatapp
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
+
+// Duration is a time.Duration that supports human-readable YAML values
+// like "100ms", "5s", or "2m30s" via time.ParseDuration.
+type Duration struct {
+	time.Duration
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler to parse human-readable durations.
+func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		// Fall back to numeric value (nanoseconds) for backward compatibility.
+		var ns int64
+		if numErr := unmarshal(&ns); numErr != nil {
+			return fmt.Errorf("duration must be a string (e.g. \"100ms\") or integer nanoseconds: %w", err)
+		}
+		d.Duration = time.Duration(ns)
+		return nil
+	}
+	parsed, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("invalid duration %q: %w", s, err)
+	}
+	d.Duration = parsed
+	return nil
+}
 
 // Config holds the chat app configuration.
 type Config struct {
@@ -55,8 +84,8 @@ type GoogleChatConfig struct {
 	ExternalURL         string            `yaml:"external_url"`
 	ServiceAccountEmail string            `yaml:"service_account_email"`
 	CommandIDMap        map[string]string `yaml:"command_id_map"`
-	SendQueueSize       int               `yaml:"send_queue_size"` // default 100
-	SendMinDelay        time.Duration     `yaml:"send_min_delay"`  // default 100ms
+	SendQueueSize int      `yaml:"send_queue_size"` // default 100
+	SendMinDelay  Duration `yaml:"send_min_delay"`  // default "100ms"
 }
 
 // SlackConfig holds settings for the Slack adapter (future).

--- a/extras/scion-chat-app/internal/chatapp/config.go
+++ b/extras/scion-chat-app/internal/chatapp/config.go
@@ -16,11 +16,13 @@ package chatapp
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 )
 
 // Duration is a time.Duration that supports human-readable YAML values
-// like "100ms", "5s", or "2m30s" via time.ParseDuration.
+// like "100ms", "5s", or "2m30s" via time.ParseDuration. Bare integers
+// are treated as nanoseconds for backward compatibility.
 type Duration struct {
 	time.Duration
 }
@@ -29,20 +31,22 @@ type Duration struct {
 func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
-		// Fall back to numeric value (nanoseconds) for backward compatibility.
-		var ns int64
-		if numErr := unmarshal(&ns); numErr != nil {
-			return fmt.Errorf("duration must be a string (e.g. \"100ms\") or integer nanoseconds: %w", err)
-		}
+		return fmt.Errorf("duration must be a string (e.g. \"100ms\") or integer nanoseconds: %w", err)
+	}
+
+	// Try human-readable duration first (e.g. "100ms", "5s").
+	if parsed, err := time.ParseDuration(s); err == nil {
+		d.Duration = parsed
+		return nil
+	}
+
+	// Fall back to bare integer as nanoseconds for backward compatibility.
+	if ns, err := strconv.ParseInt(s, 10, 64); err == nil {
 		d.Duration = time.Duration(ns)
 		return nil
 	}
-	parsed, err := time.ParseDuration(s)
-	if err != nil {
-		return fmt.Errorf("invalid duration %q: %w", s, err)
-	}
-	d.Duration = parsed
-	return nil
+
+	return fmt.Errorf("invalid duration %q: must be a duration string (e.g. \"100ms\") or integer nanoseconds", s)
 }
 
 // Config holds the chat app configuration.
@@ -84,8 +88,8 @@ type GoogleChatConfig struct {
 	ExternalURL         string            `yaml:"external_url"`
 	ServiceAccountEmail string            `yaml:"service_account_email"`
 	CommandIDMap        map[string]string `yaml:"command_id_map"`
-	SendQueueSize int      `yaml:"send_queue_size"` // default 100
-	SendMinDelay  Duration `yaml:"send_min_delay"`  // default "100ms"
+	SendQueueSize       int               `yaml:"send_queue_size"` // default 100
+	SendMinDelay        Duration           `yaml:"send_min_delay"`  // default "100ms"
 }
 
 // SlackConfig holds settings for the Slack adapter (future).

--- a/extras/scion-chat-app/internal/chatapp/config.go
+++ b/extras/scion-chat-app/internal/chatapp/config.go
@@ -89,7 +89,7 @@ type GoogleChatConfig struct {
 	ServiceAccountEmail string            `yaml:"service_account_email"`
 	CommandIDMap        map[string]string `yaml:"command_id_map"`
 	SendQueueSize       int               `yaml:"send_queue_size"` // default 100
-	SendMinDelay        Duration           `yaml:"send_min_delay"`  // default "100ms"
+	SendMinDelay        Duration          `yaml:"send_min_delay"`  // default "100ms"
 }
 
 // SlackConfig holds settings for the Slack adapter (future).

--- a/extras/scion-chat-app/internal/chatapp/config.go
+++ b/extras/scion-chat-app/internal/chatapp/config.go
@@ -14,6 +14,8 @@
 
 package chatapp
 
+import "time"
+
 // Config holds the chat app configuration.
 type Config struct {
 	Hub           HubConfig           `yaml:"hub"`
@@ -53,6 +55,8 @@ type GoogleChatConfig struct {
 	ExternalURL         string            `yaml:"external_url"`
 	ServiceAccountEmail string            `yaml:"service_account_email"`
 	CommandIDMap        map[string]string `yaml:"command_id_map"`
+	SendQueueSize       int               `yaml:"send_queue_size"` // default 100
+	SendMinDelay        time.Duration     `yaml:"send_min_delay"`  // default 100ms
 }
 
 // SlackConfig holds settings for the Slack adapter (future).

--- a/extras/scion-chat-app/internal/chatapp/config_test.go
+++ b/extras/scion-chat-app/internal/chatapp/config_test.go
@@ -53,8 +53,8 @@ func TestDuration_UnmarshalYAML_Int64Nanoseconds(t *testing.T) {
 		input string
 		want  time.Duration
 	}{
-		{"100000000", 100 * time.Millisecond},   // 100ms in ns
-		{"5000000000", 5 * time.Second},          // 5s in ns
+		{"100000000", 100 * time.Millisecond}, // 100ms in ns
+		{"5000000000", 5 * time.Second},       // 5s in ns
 		{"0", 0},
 	}
 

--- a/extras/scion-chat-app/internal/chatapp/config_test.go
+++ b/extras/scion-chat-app/internal/chatapp/config_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chatapp
+
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestDuration_UnmarshalYAML_HumanReadable(t *testing.T) {
+	tests := []struct {
+		input string
+		want  time.Duration
+	}{
+		{`"100ms"`, 100 * time.Millisecond},
+		{`"5s"`, 5 * time.Second},
+		{`"2m30s"`, 2*time.Minute + 30*time.Second},
+		{`"1h"`, time.Hour},
+		{`"500us"`, 500 * time.Microsecond},
+		{`"0s"`, 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			var d Duration
+			if err := yaml.Unmarshal([]byte(tc.input), &d); err != nil {
+				t.Fatalf("UnmarshalYAML(%s) failed: %v", tc.input, err)
+			}
+			if d.Duration != tc.want {
+				t.Errorf("UnmarshalYAML(%s) = %v, want %v", tc.input, d.Duration, tc.want)
+			}
+		})
+	}
+}
+
+func TestDuration_UnmarshalYAML_Int64Nanoseconds(t *testing.T) {
+	// YAML integer → nanoseconds fallback for backward compatibility.
+	tests := []struct {
+		input string
+		want  time.Duration
+	}{
+		{"100000000", 100 * time.Millisecond},   // 100ms in ns
+		{"5000000000", 5 * time.Second},          // 5s in ns
+		{"0", 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			var d Duration
+			if err := yaml.Unmarshal([]byte(tc.input), &d); err != nil {
+				t.Fatalf("UnmarshalYAML(%s) failed: %v", tc.input, err)
+			}
+			if d.Duration != tc.want {
+				t.Errorf("UnmarshalYAML(%s) = %v, want %v", tc.input, d.Duration, tc.want)
+			}
+		})
+	}
+}
+
+func TestDuration_UnmarshalYAML_InvalidString(t *testing.T) {
+	var d Duration
+	err := yaml.Unmarshal([]byte(`"not-a-duration"`), &d)
+	if err == nil {
+		t.Error("expected error for invalid duration string, got nil")
+	}
+}
+
+func TestDuration_UnmarshalYAML_InStruct(t *testing.T) {
+	// Verify Duration works embedded in a config struct, as it would in
+	// a real YAML config file.
+	type testConfig struct {
+		Delay Duration `yaml:"delay"`
+	}
+
+	input := `delay: "250ms"`
+	var cfg testConfig
+	if err := yaml.Unmarshal([]byte(input), &cfg); err != nil {
+		t.Fatalf("UnmarshalYAML in struct failed: %v", err)
+	}
+	if cfg.Delay.Duration != 250*time.Millisecond {
+		t.Errorf("got %v, want 250ms", cfg.Delay.Duration)
+	}
+}

--- a/extras/scion-chat-app/internal/chatapp/dedup_test.go
+++ b/extras/scion-chat-app/internal/chatapp/dedup_test.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chatapp
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+)
+
+func TestMsgDedupKey(t *testing.T) {
+	// Nil message returns empty.
+	if got := msgDedupKey(nil); got != "" {
+		t.Errorf("nil message: expected empty key, got %q", got)
+	}
+
+	// Empty Msg field returns empty (no fingerprint needed).
+	if got := msgDedupKey(&messages.StructuredMessage{Sender: "a"}); got != "" {
+		t.Errorf("empty Msg field: expected empty key, got %q", got)
+	}
+
+	// Deterministic: same input yields the same key.
+	msg := &messages.StructuredMessage{
+		Sender:    "agent:test",
+		Recipient: "user:alice",
+		Timestamp: "2026-08-11T12:00:00Z",
+		Type:      messages.TypeInstruction,
+		Msg:       "hello world",
+	}
+	key1 := msgDedupKey(msg)
+	key2 := msgDedupKey(msg)
+	if key1 == "" {
+		t.Fatal("expected non-empty key for valid message")
+	}
+	if key1 != key2 {
+		t.Errorf("determinism: key1 %q != key2 %q", key1, key2)
+	}
+
+	// Different messages produce different keys.
+	msg2 := &messages.StructuredMessage{
+		Sender:    "agent:test",
+		Recipient: "user:alice",
+		Timestamp: "2026-08-11T12:00:00Z",
+		Type:      messages.TypeInstruction,
+		Msg:       "different content",
+	}
+	key3 := msgDedupKey(msg2)
+	if key1 == key3 {
+		t.Errorf("expected different keys for different messages, both got %q", key1)
+	}
+
+	// Changing sender also produces a different key.
+	msg3 := &messages.StructuredMessage{
+		Sender:    "agent:other",
+		Recipient: "user:alice",
+		Timestamp: "2026-08-11T12:00:00Z",
+		Type:      messages.TypeInstruction,
+		Msg:       "hello world",
+	}
+	key4 := msgDedupKey(msg3)
+	if key1 == key4 {
+		t.Errorf("expected different keys for different senders, both got %q", key1)
+	}
+
+	// Changing timestamp produces a different key.
+	msg4 := &messages.StructuredMessage{
+		Sender:    "agent:test",
+		Recipient: "user:alice",
+		Timestamp: "2026-08-11T12:01:00Z",
+		Type:      messages.TypeInstruction,
+		Msg:       "hello world",
+	}
+	key5 := msgDedupKey(msg4)
+	if key1 == key5 {
+		t.Errorf("expected different keys for different timestamps, both got %q", key1)
+	}
+}
+
+func TestBrokerPublish_Dedup(t *testing.T) {
+	log := slog.Default()
+
+	t.Run("same message within TTL is skipped", func(t *testing.T) {
+		var callCount atomic.Int32
+		handler := func(_ context.Context, _ string, _ *messages.StructuredMessage) error {
+			callCount.Add(1)
+			return nil
+		}
+		broker := NewBrokerServer(handler, log)
+
+		msg := &messages.StructuredMessage{
+			Sender:    "agent:test",
+			Recipient: "user:alice",
+			Timestamp: "2026-08-11T12:00:00Z",
+			Type:      messages.TypeInstruction,
+			Msg:       "hello world",
+		}
+
+		ctx := context.Background()
+
+		// First publish should succeed.
+		if err := broker.Publish(ctx, "topic.test", msg); err != nil {
+			t.Fatalf("first Publish failed: %v", err)
+		}
+		if got := callCount.Load(); got != 1 {
+			t.Fatalf("expected handler called once, got %d", got)
+		}
+
+		// Second publish with identical message should be skipped.
+		if err := broker.Publish(ctx, "topic.test", msg); err != nil {
+			t.Fatalf("second Publish failed: %v", err)
+		}
+		if got := callCount.Load(); got != 1 {
+			t.Errorf("expected handler still called once (dedup), got %d", got)
+		}
+	})
+
+	t.Run("different message is not skipped", func(t *testing.T) {
+		var callCount atomic.Int32
+		handler := func(_ context.Context, _ string, _ *messages.StructuredMessage) error {
+			callCount.Add(1)
+			return nil
+		}
+		broker := NewBrokerServer(handler, log)
+
+		ctx := context.Background()
+
+		msg1 := &messages.StructuredMessage{
+			Sender: "agent:test", Recipient: "user:alice",
+			Timestamp: "2026-08-11T12:00:00Z", Type: messages.TypeInstruction,
+			Msg: "message one",
+		}
+		msg2 := &messages.StructuredMessage{
+			Sender: "agent:test", Recipient: "user:alice",
+			Timestamp: "2026-08-11T12:00:01Z", Type: messages.TypeInstruction,
+			Msg: "message two",
+		}
+
+		if err := broker.Publish(ctx, "topic.test", msg1); err != nil {
+			t.Fatalf("Publish msg1 failed: %v", err)
+		}
+		if err := broker.Publish(ctx, "topic.test", msg2); err != nil {
+			t.Fatalf("Publish msg2 failed: %v", err)
+		}
+		if got := callCount.Load(); got != 2 {
+			t.Errorf("expected handler called twice, got %d", got)
+		}
+	})
+
+	t.Run("message after TTL expiry is not skipped", func(t *testing.T) {
+		var callCount atomic.Int32
+		handler := func(_ context.Context, _ string, _ *messages.StructuredMessage) error {
+			callCount.Add(1)
+			return nil
+		}
+		broker := NewBrokerServer(handler, log)
+
+		msg := &messages.StructuredMessage{
+			Sender:    "agent:test",
+			Recipient: "user:alice",
+			Timestamp: "2026-08-11T12:00:00Z",
+			Type:      messages.TypeInstruction,
+			Msg:       "hello world",
+		}
+
+		ctx := context.Background()
+
+		// First publish.
+		if err := broker.Publish(ctx, "topic.test", msg); err != nil {
+			t.Fatalf("first Publish failed: %v", err)
+		}
+
+		// Simulate TTL expiry by backdating the entry.
+		key := msgDedupKey(msg)
+		broker.sentIDsMu.Lock()
+		broker.sentIDs[key] = time.Now().Add(-(dedupTTL + time.Second))
+		broker.sentIDsMu.Unlock()
+
+		// Second publish should succeed after TTL expiry.
+		if err := broker.Publish(ctx, "topic.test", msg); err != nil {
+			t.Fatalf("second Publish after TTL failed: %v", err)
+		}
+		if got := callCount.Load(); got != 2 {
+			t.Errorf("expected handler called twice after TTL expiry, got %d", got)
+		}
+	})
+
+	t.Run("nil message is not deduped", func(t *testing.T) {
+		broker := NewBrokerServer(nil, log)
+		if err := broker.Publish(context.Background(), "topic.test", nil); err != nil {
+			t.Fatalf("Publish(nil) failed: %v", err)
+		}
+	})
+
+	t.Run("empty Msg field skips dedup", func(t *testing.T) {
+		var callCount atomic.Int32
+		handler := func(_ context.Context, _ string, _ *messages.StructuredMessage) error {
+			callCount.Add(1)
+			return nil
+		}
+		broker := NewBrokerServer(handler, log)
+
+		msg := &messages.StructuredMessage{
+			Sender: "agent:test",
+			Type:   messages.TypeInstruction,
+			// Msg intentionally empty — no dedup key is generated.
+		}
+
+		ctx := context.Background()
+		// Both publishes should go through because dedup is skipped.
+		_ = broker.Publish(ctx, "topic.test", msg)
+		_ = broker.Publish(ctx, "topic.test", msg)
+		if got := callCount.Load(); got != 2 {
+			t.Errorf("expected handler called twice for empty-msg messages, got %d", got)
+		}
+	})
+}

--- a/extras/scion-chat-app/internal/chatapp/notifications.go
+++ b/extras/scion-chat-app/internal/chatapp/notifications.go
@@ -110,8 +110,14 @@ func (n *NotificationRelay) handleAgentNotification(ctx context.Context, project
 				SpaceID: link.SpaceID,
 				Card:    &card,
 			})
-		} else {
+		} else if n.messenger != nil {
 			_, sendErr = n.messenger.SendCard(ctx, link.SpaceID, card)
+		} else {
+			n.log.Warn("no messenger or send queue configured, skipping notification",
+				"space_id", link.SpaceID,
+				"project_id", projectID,
+			)
+			continue
 		}
 		if sendErr != nil {
 			n.log.Error("failed to send notification card",
@@ -205,8 +211,14 @@ func (n *NotificationRelay) handleUserMessage(ctx context.Context, projectID str
 		var sendErr error
 		if n.sendQueue != nil {
 			_, sendErr = n.sendQueue.Send(ctx, sendReq)
-		} else {
+		} else if n.messenger != nil {
 			_, sendErr = n.messenger.SendMessage(ctx, sendReq)
+		} else {
+			n.log.Warn("no messenger or send queue configured, skipping user message relay",
+				"space_id", link.SpaceID,
+				"recipient", msg.RecipientID,
+			)
+			continue
 		}
 		if sendErr != nil {
 			n.log.Error("failed to relay user message",

--- a/extras/scion-chat-app/internal/chatapp/notifications.go
+++ b/extras/scion-chat-app/internal/chatapp/notifications.go
@@ -28,6 +28,7 @@ import (
 type NotificationRelay struct {
 	store     *state.Store
 	messenger Messenger
+	sendQueue *SendQueue
 	log       *slog.Logger
 }
 
@@ -38,6 +39,12 @@ func NewNotificationRelay(store *state.Store, messenger Messenger, log *slog.Log
 		messenger: messenger,
 		log:       log,
 	}
+}
+
+// SetSendQueue attaches a send queue to route outbound messages through
+// per-space workers instead of sending directly via the messenger.
+func (n *NotificationRelay) SetSendQueue(sq *SendQueue) {
+	n.sendQueue = sq
 }
 
 // HandleBrokerMessage processes a message received via the broker plugin's Publish() path.
@@ -97,11 +104,20 @@ func (n *NotificationRelay) handleAgentNotification(ctx context.Context, project
 			})
 		}
 
-		if _, err := n.messenger.SendCard(ctx, link.SpaceID, card); err != nil {
+		var sendErr error
+		if n.sendQueue != nil {
+			_, sendErr = n.sendQueue.Send(ctx, SendMessageRequest{
+				SpaceID: link.SpaceID,
+				Card:    &card,
+			})
+		} else {
+			_, sendErr = n.messenger.SendCard(ctx, link.SpaceID, card)
+		}
+		if sendErr != nil {
 			n.log.Error("failed to send notification card",
 				"space_id", link.SpaceID,
 				"project_id", projectID,
-				"error", err,
+				"error", sendErr,
 			)
 			// Continue to other spaces
 		}
@@ -180,16 +196,23 @@ func (n *NotificationRelay) handleUserMessage(ctx context.Context, projectID str
 		// Chat API renders them as interactive user pills.
 		mentions := n.buildMentions(mapping.PlatformUserID, agentSlug, link)
 
-		if _, err := n.messenger.SendMessage(ctx, SendMessageRequest{
+		sendReq := SendMessageRequest{
 			SpaceID:  link.SpaceID,
 			ThreadID: msg.ThreadID,
 			Text:     mentions,
 			Card:     &card,
-		}); err != nil {
+		}
+		var sendErr error
+		if n.sendQueue != nil {
+			_, sendErr = n.sendQueue.Send(ctx, sendReq)
+		} else {
+			_, sendErr = n.messenger.SendMessage(ctx, sendReq)
+		}
+		if sendErr != nil {
 			n.log.Error("failed to relay user message",
 				"space_id", link.SpaceID,
 				"recipient", msg.RecipientID,
-				"error", err,
+				"error", sendErr,
 			)
 		}
 	}

--- a/extras/scion-chat-app/internal/chatapp/sendqueue.go
+++ b/extras/scion-chat-app/internal/chatapp/sendqueue.go
@@ -191,6 +191,12 @@ func (q *SendQueue) worker(spaceID string, w *spaceWorker) {
 			}
 			idleTimer.Reset(defaultSendIdleTimeout)
 
+			// Check if context is already cancelled before sending.
+			if err := sr.ctx.Err(); err != nil {
+				sr.result <- sendResult{err: err}
+				continue
+			}
+
 			// Send the message via the Messenger.
 			msgID, err := q.sendOne(sr)
 			sr.result <- sendResult{messageID: msgID, err: err}
@@ -228,4 +234,3 @@ func (q *SendQueue) worker(spaceID string, w *spaceWorker) {
 func (q *SendQueue) sendOne(sr sendRequest) (string, error) {
 	return q.messenger.SendMessage(sr.ctx, sr.req)
 }
-

--- a/extras/scion-chat-app/internal/chatapp/sendqueue.go
+++ b/extras/scion-chat-app/internal/chatapp/sendqueue.go
@@ -170,7 +170,6 @@ func (q *SendQueue) getOrCreateWorkerLocked(spaceID string) *spaceWorker {
 // timeout and is cleaned up.
 func (q *SendQueue) worker(spaceID string, w *spaceWorker) {
 	defer q.wg.Done()
-	defer q.removeWorker(spaceID)
 
 	idleTimer := time.NewTimer(defaultSendIdleTimeout)
 	defer idleTimer.Stop()
@@ -230,9 +229,3 @@ func (q *SendQueue) sendOne(sr sendRequest) (string, error) {
 	return q.messenger.SendMessage(sr.ctx, sr.req)
 }
 
-// removeWorker removes the per-space worker from the map when it exits.
-func (q *SendQueue) removeWorker(spaceID string) {
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	delete(q.workers, spaceID)
-}

--- a/extras/scion-chat-app/internal/chatapp/sendqueue.go
+++ b/extras/scion-chat-app/internal/chatapp/sendqueue.go
@@ -41,10 +41,9 @@ type sendResult struct {
 	err       error
 }
 
-// spaceWorker holds a per-space buffered channel and done signal.
+// spaceWorker holds a per-space buffered channel.
 type spaceWorker struct {
-	ch   chan sendRequest
-	done chan struct{}
+	ch chan sendRequest
 }
 
 // SendQueue manages per-space outbound message workers to prevent
@@ -106,8 +105,7 @@ func (q *SendQueue) Send(ctx context.Context, req SendMessageRequest) (string, e
 	}
 }
 
-// Close stops all workers and waits for them to finish.
-// Messages still in the queues receive errors.
+// Close stops all workers and waits for them to drain remaining messages.
 func (q *SendQueue) Close() {
 	q.mu.Lock()
 	q.closed = true
@@ -157,8 +155,7 @@ func (q *SendQueue) getOrCreateWorkerLocked(spaceID string) *spaceWorker {
 	}
 
 	w = &spaceWorker{
-		ch:   make(chan sendRequest, q.bufSize),
-		done: make(chan struct{}),
+		ch: make(chan sendRequest, q.bufSize),
 	}
 	q.workers[spaceID] = w
 
@@ -174,7 +171,6 @@ func (q *SendQueue) getOrCreateWorkerLocked(spaceID string) *spaceWorker {
 func (q *SendQueue) worker(spaceID string, w *spaceWorker) {
 	defer q.wg.Done()
 	defer q.removeWorker(spaceID)
-	defer close(w.done)
 
 	idleTimer := time.NewTimer(defaultSendIdleTimeout)
 	defer idleTimer.Stop()
@@ -209,6 +205,19 @@ func (q *SendQueue) worker(spaceID string, w *spaceWorker) {
 			time.Sleep(q.minDelay)
 
 		case <-idleTimer.C:
+			// Check under the lock that the channel is still empty.
+			// Between the timer firing and here, enqueue() may have
+			// written a message — if so, reset the timer and continue.
+			q.mu.Lock()
+			if len(w.ch) > 0 {
+				q.mu.Unlock()
+				idleTimer.Reset(defaultSendIdleTimeout)
+				continue
+			}
+			// Still empty — remove the worker while holding the lock
+			// so no new messages can be enqueued to a dead worker.
+			delete(q.workers, spaceID)
+			q.mu.Unlock()
 			q.log.Debug("send queue worker idle, exiting", "space_id", spaceID)
 			return
 		}
@@ -216,8 +225,7 @@ func (q *SendQueue) worker(spaceID string, w *spaceWorker) {
 }
 
 // sendOne dispatches a single outbound message to the Chat API via the
-// Messenger interface. If the request has a Card but no Text, it uses
-// SendCard; otherwise it uses SendMessage.
+// Messenger.SendMessage method.
 func (q *SendQueue) sendOne(sr sendRequest) (string, error) {
 	return q.messenger.SendMessage(sr.ctx, sr.req)
 }

--- a/extras/scion-chat-app/internal/chatapp/sendqueue.go
+++ b/extras/scion-chat-app/internal/chatapp/sendqueue.go
@@ -1,0 +1,230 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chatapp
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const (
+	defaultSendQueueSize   = 100
+	defaultSendMinDelay    = 100 * time.Millisecond
+	defaultSendIdleTimeout = 5 * time.Minute
+)
+
+// sendRequest represents a message waiting to be sent through the queue.
+type sendRequest struct {
+	ctx    context.Context
+	req    SendMessageRequest
+	result chan<- sendResult
+}
+
+// sendResult carries the outcome of a queued send back to the caller.
+type sendResult struct {
+	messageID string
+	err       error
+}
+
+// spaceWorker holds a per-space buffered channel and done signal.
+type spaceWorker struct {
+	ch   chan sendRequest
+	done chan struct{}
+}
+
+// SendQueue manages per-space outbound message workers to prevent
+// Chat API rate-limit errors. Each space gets its own goroutine
+// that serializes sends with a configurable minimum delay.
+type SendQueue struct {
+	messenger Messenger
+	log       *slog.Logger
+	bufSize   int
+	minDelay  time.Duration
+
+	mu      sync.Mutex
+	workers map[string]*spaceWorker
+	closed  bool
+	wg      sync.WaitGroup
+}
+
+// NewSendQueue creates a new SendQueue. Pass 0 for bufSize or minDelay
+// to use the defaults (100 messages, 100ms).
+func NewSendQueue(messenger Messenger, log *slog.Logger, bufSize int, minDelay time.Duration) *SendQueue {
+	if bufSize <= 0 {
+		bufSize = defaultSendQueueSize
+	}
+	if minDelay <= 0 {
+		minDelay = defaultSendMinDelay
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &SendQueue{
+		messenger: messenger,
+		log:       log,
+		bufSize:   bufSize,
+		minDelay:  minDelay,
+		workers:   make(map[string]*spaceWorker),
+	}
+}
+
+// Send enqueues a message and blocks until it is sent (or the context is
+// cancelled). It returns the message ID from the Chat API or an error.
+func (q *SendQueue) Send(ctx context.Context, req SendMessageRequest) (string, error) {
+	resultCh := make(chan sendResult, 1)
+
+	sr := sendRequest{
+		ctx:    ctx,
+		req:    req,
+		result: resultCh,
+	}
+
+	if err := q.enqueue(req.SpaceID, sr); err != nil {
+		return "", err
+	}
+
+	select {
+	case res := <-resultCh:
+		return res.messageID, res.err
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+// Close stops all workers and waits for them to finish.
+// Messages still in the queues receive errors.
+func (q *SendQueue) Close() {
+	q.mu.Lock()
+	q.closed = true
+	for spaceID, w := range q.workers {
+		close(w.ch)
+		delete(q.workers, spaceID)
+	}
+	q.mu.Unlock()
+
+	q.wg.Wait()
+}
+
+// enqueue gets-or-creates the per-space worker and writes the request to it.
+func (q *SendQueue) enqueue(spaceID string, sr sendRequest) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.closed {
+		return errors.New("send queue is closed")
+	}
+
+	w := q.getOrCreateWorkerLocked(spaceID)
+
+	// Try non-blocking send; if full, drop the oldest and retry.
+	select {
+	case w.ch <- sr:
+	default:
+		select {
+		case dropped := <-w.ch:
+			dropped.result <- sendResult{err: errors.New("dropped: send queue overflow")}
+			q.log.Warn("send queue overflow, dropped oldest message",
+				"space_id", spaceID, "queue_size", q.bufSize)
+		default:
+		}
+		w.ch <- sr
+	}
+
+	return nil
+}
+
+// getOrCreateWorkerLocked returns the existing worker for a space, or creates
+// a new one. Must be called with q.mu held.
+func (q *SendQueue) getOrCreateWorkerLocked(spaceID string) *spaceWorker {
+	w, ok := q.workers[spaceID]
+	if ok {
+		return w
+	}
+
+	w = &spaceWorker{
+		ch:   make(chan sendRequest, q.bufSize),
+		done: make(chan struct{}),
+	}
+	q.workers[spaceID] = w
+
+	q.wg.Add(1)
+	go q.worker(spaceID, w)
+
+	return w
+}
+
+// worker is the per-space send goroutine. It reads messages from the channel
+// and sends them via the Messenger with rate limiting. It exits after an idle
+// timeout and is cleaned up.
+func (q *SendQueue) worker(spaceID string, w *spaceWorker) {
+	defer q.wg.Done()
+	defer q.removeWorker(spaceID)
+	defer close(w.done)
+
+	idleTimer := time.NewTimer(defaultSendIdleTimeout)
+	defer idleTimer.Stop()
+
+	for {
+		select {
+		case sr, ok := <-w.ch:
+			if !ok {
+				// Channel closed — worker should exit.
+				return
+			}
+
+			// Reset idle timer on activity.
+			if !idleTimer.Stop() {
+				select {
+				case <-idleTimer.C:
+				default:
+				}
+			}
+			idleTimer.Reset(defaultSendIdleTimeout)
+
+			// Send the message via the Messenger.
+			msgID, err := q.sendOne(sr)
+			sr.result <- sendResult{messageID: msgID, err: err}
+
+			if err != nil {
+				q.log.Error("send queue delivery failed",
+					"space_id", spaceID, "error", err)
+			}
+
+			// Enforce minimum delay between sends.
+			time.Sleep(q.minDelay)
+
+		case <-idleTimer.C:
+			q.log.Debug("send queue worker idle, exiting", "space_id", spaceID)
+			return
+		}
+	}
+}
+
+// sendOne dispatches a single outbound message to the Chat API via the
+// Messenger interface. If the request has a Card but no Text, it uses
+// SendCard; otherwise it uses SendMessage.
+func (q *SendQueue) sendOne(sr sendRequest) (string, error) {
+	return q.messenger.SendMessage(sr.ctx, sr.req)
+}
+
+// removeWorker removes the per-space worker from the map when it exits.
+func (q *SendQueue) removeWorker(spaceID string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	delete(q.workers, spaceID)
+}

--- a/extras/scion-chat-app/internal/chatapp/sendqueue_test.go
+++ b/extras/scion-chat-app/internal/chatapp/sendqueue_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chatapp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recordingMessenger records all SendMessage calls for test assertions.
+type recordingMessenger struct {
+	mu       sync.Mutex
+	calls    []SendMessageRequest
+	delay    time.Duration // optional per-send delay
+	failNext bool         // if set, next send returns an error
+}
+
+func (m *recordingMessenger) SendMessage(_ context.Context, req SendMessageRequest) (string, error) {
+	if m.delay > 0 {
+		time.Sleep(m.delay)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.failNext {
+		m.failNext = false
+		return "", fmt.Errorf("simulated send failure")
+	}
+	m.calls = append(m.calls, req)
+	return fmt.Sprintf("msg-%d", len(m.calls)), nil
+}
+
+func (m *recordingMessenger) SendCard(_ context.Context, spaceID string, card Card) (string, error) {
+	return m.SendMessage(context.Background(), SendMessageRequest{SpaceID: spaceID, Card: &card})
+}
+func (m *recordingMessenger) UpdateMessage(context.Context, string, SendMessageRequest) error {
+	return nil
+}
+func (m *recordingMessenger) OpenDialog(context.Context, string, Dialog) error  { return nil }
+func (m *recordingMessenger) UpdateDialog(context.Context, string, Dialog) error { return nil }
+func (m *recordingMessenger) GetUser(context.Context, string) (*ChatUser, error) {
+	return nil, nil
+}
+func (m *recordingMessenger) SetAgentIdentity(context.Context, AgentIdentity) error { return nil }
+
+func (m *recordingMessenger) getCalls() []SendMessageRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]SendMessageRequest, len(m.calls))
+	copy(out, m.calls)
+	return out
+}
+
+func TestSendQueue_SendAndClose(t *testing.T) {
+	rm := &recordingMessenger{}
+	log := slog.Default()
+	sq := NewSendQueue(rm, log, 10, 1*time.Millisecond)
+
+	ctx := context.Background()
+
+	// Send three messages to the same space.
+	for i := 0; i < 3; i++ {
+		msgID, err := sq.Send(ctx, SendMessageRequest{
+			SpaceID: "spaces/test1",
+			Text:    fmt.Sprintf("message-%d", i),
+		})
+		if err != nil {
+			t.Fatalf("Send(%d) failed: %v", i, err)
+		}
+		if msgID == "" {
+			t.Errorf("Send(%d) returned empty message ID", i)
+		}
+	}
+
+	// Send to a different space to verify per-space workers.
+	msgID, err := sq.Send(ctx, SendMessageRequest{
+		SpaceID: "spaces/test2",
+		Text:    "other-space-message",
+	})
+	if err != nil {
+		t.Fatalf("Send to second space failed: %v", err)
+	}
+	if msgID == "" {
+		t.Error("Send to second space returned empty message ID")
+	}
+
+	// Close the queue — should drain cleanly.
+	sq.Close()
+
+	calls := rm.getCalls()
+	if len(calls) != 4 {
+		t.Fatalf("expected 4 sends, got %d", len(calls))
+	}
+
+	// Verify messages were sent to the correct spaces.
+	space1Count := 0
+	space2Count := 0
+	for _, c := range calls {
+		switch c.SpaceID {
+		case "spaces/test1":
+			space1Count++
+		case "spaces/test2":
+			space2Count++
+		}
+	}
+	if space1Count != 3 {
+		t.Errorf("expected 3 messages to spaces/test1, got %d", space1Count)
+	}
+	if space2Count != 1 {
+		t.Errorf("expected 1 message to spaces/test2, got %d", space2Count)
+	}
+
+	// Sending after close should return an error.
+	_, err = sq.Send(ctx, SendMessageRequest{SpaceID: "spaces/test1", Text: "after-close"})
+	if err == nil {
+		t.Error("expected error sending after Close(), got nil")
+	}
+}
+
+func TestSendQueue_Overflow(t *testing.T) {
+	// Use a slow messenger to fill up the queue.
+	rm := &recordingMessenger{delay: 50 * time.Millisecond}
+	log := slog.Default()
+	// Buffer size of 2 so we can overflow.
+	sq := NewSendQueue(rm, log, 2, 1*time.Millisecond)
+
+	ctx := context.Background()
+
+	// Send first message — it will be picked up by the worker and block.
+	go sq.Send(ctx, SendMessageRequest{SpaceID: "spaces/overflow", Text: "msg-0"})
+	// Brief wait for the worker to pick up msg-0.
+	time.Sleep(10 * time.Millisecond)
+
+	// Fill the buffer (2 slots).
+	go sq.Send(ctx, SendMessageRequest{SpaceID: "spaces/overflow", Text: "msg-1"})
+	go sq.Send(ctx, SendMessageRequest{SpaceID: "spaces/overflow", Text: "msg-2"})
+	time.Sleep(10 * time.Millisecond)
+
+	// This should trigger overflow — drops oldest queued message.
+	go sq.Send(ctx, SendMessageRequest{SpaceID: "spaces/overflow", Text: "msg-3"})
+	time.Sleep(10 * time.Millisecond)
+
+	// Wait for all messages to drain.
+	sq.Close()
+
+	calls := rm.getCalls()
+	// At least the first message and the overflow replacement should have been sent.
+	// The exact count depends on timing, but we should have at least 3 delivered
+	// (msg-0 was already being sent, one of msg-1/msg-2 was dropped, msg-3 was enqueued).
+	if len(calls) < 3 {
+		t.Errorf("expected at least 3 delivered messages after overflow, got %d", len(calls))
+	}
+}
+
+func TestSendQueue_ContextCancellation(t *testing.T) {
+	// Slow messenger so the message stays queued.
+	rm := &recordingMessenger{delay: 500 * time.Millisecond}
+	log := slog.Default()
+	sq := NewSendQueue(rm, log, 10, 1*time.Millisecond)
+	defer sq.Close()
+
+	// Block the worker with a first message.
+	go sq.Send(context.Background(), SendMessageRequest{SpaceID: "spaces/cancel", Text: "blocking"})
+	time.Sleep(10 * time.Millisecond)
+
+	// Send with a short-lived context.
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err := sq.Send(ctx, SendMessageRequest{SpaceID: "spaces/cancel", Text: "should-timeout"})
+	if err == nil {
+		t.Error("expected context deadline error, got nil")
+	}
+}

--- a/extras/scion-chat-app/internal/chatapp/sendqueue_test.go
+++ b/extras/scion-chat-app/internal/chatapp/sendqueue_test.go
@@ -28,7 +28,7 @@ type recordingMessenger struct {
 	mu       sync.Mutex
 	calls    []SendMessageRequest
 	delay    time.Duration // optional per-send delay
-	failNext bool         // if set, next send returns an error
+	failNext bool          // if set, next send returns an error
 }
 
 func (m *recordingMessenger) SendMessage(_ context.Context, req SendMessageRequest) (string, error) {
@@ -51,7 +51,7 @@ func (m *recordingMessenger) SendCard(_ context.Context, spaceID string, card Ca
 func (m *recordingMessenger) UpdateMessage(context.Context, string, SendMessageRequest) error {
 	return nil
 }
-func (m *recordingMessenger) OpenDialog(context.Context, string, Dialog) error  { return nil }
+func (m *recordingMessenger) OpenDialog(context.Context, string, Dialog) error   { return nil }
 func (m *recordingMessenger) UpdateDialog(context.Context, string, Dialog) error { return nil }
 func (m *recordingMessenger) GetUser(context.Context, string) (*ChatUser, error) {
 	return nil, nil


### PR DESCRIPTION
Prevent echo loops and API rate-limit violations by adding message deduplication and a send queue to the Google Chat plugin.

Key changes:
- extras/scion-chat-app/internal/chatapp/broker.go: SHA256 message dedup with 5-min TTL
- extras/scion-chat-app/internal/chatapp/sendqueue.go: per-space send queue with configurable rate limiting
- extras/scion-chat-app/internal/chatapp/config.go: custom Duration YAML type for send_min_delay
- 22 tests passing with race detector

Ref: ptone/scion#914
