### PR TITLE
feat(chat-app): add bidirectional attachment handling for Google Chat

### DIFF
--- a/extras/scion-chat-app/internal/chatapp/attachment_test.go
+++ b/extras/scion-chat-app/internal/chatapp/attachment_test.go
@@ -1,0 +1,387 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chatapp
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- sanitizePathComponent tests ---
+
+func TestSanitizePathComponent(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "simple filename", input: "report.pdf", want: "report.pdf"},
+		{name: "filename with spaces", input: "my report.pdf", want: "my report.pdf"},
+		{name: "traversal ../../etc/passwd", input: "../../etc/passwd", want: "passwd"},
+		{name: "absolute path /etc/passwd", input: "/etc/passwd", want: "passwd"},
+		{name: "null bytes", input: "file\x00name.txt", want: "file_name.txt"},
+		{name: "backslash traversal", input: `..\..\etc\passwd`, want: ".._.._etc_passwd"},
+		{name: "dot only", input: ".", want: ""},
+		{name: "double dot only", input: "..", want: ""},
+		{name: "empty string", input: "", want: ""},
+		{name: "forward slash in name", input: "path/file.txt", want: "file.txt"},
+		{name: "mixed separators", input: `a/b\c`, want: "b_c"},
+		{name: "leading dot file", input: ".hidden", want: ".hidden"},
+		{name: "symlink-like name", input: "link -> target", want: "link -> target"},
+		{name: "just slashes", input: "///", want: "_"},
+		{name: "unicode filename", input: "résumé.pdf", want: "résumé.pdf"},
+		{name: "deeply nested traversal", input: "../../../../../../../etc/shadow", want: "shadow"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizePathComponent(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizePathComponent(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- resolveAgentPath tests ---
+
+func TestResolveAgentPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		agentPath   string
+		projectSlug string
+		projectID   string
+		wantEmpty   bool   // true if we expect ""
+		wantPrefix  string // prefix the result should start with (if not empty)
+	}{
+		{
+			name:        "scion-volumes path resolves",
+			agentPath:   "/scion-volumes/scratchpad/data/file.txt",
+			projectSlug: "test-proj",
+			projectID:   "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			wantEmpty:   false,
+			wantPrefix:  filepath.Join(os.Getenv("HOME"), ".scion"),
+		},
+		{
+			name:        "workspace scion-volumes path resolves",
+			agentPath:   "/workspace/.scion-volumes/scratchpad/data/file.txt",
+			projectSlug: "test-proj",
+			projectID:   "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			wantEmpty:   false,
+			wantPrefix:  filepath.Join(os.Getenv("HOME"), ".scion"),
+		},
+		{
+			name:        "traversal via scion-volumes rejected",
+			agentPath:   "/scion-volumes/scratchpad/../../../etc/passwd",
+			projectSlug: "test-proj",
+			projectID:   "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			wantEmpty:   true,
+		},
+		{
+			name:        "empty path returns empty",
+			agentPath:   "",
+			projectSlug: "test-proj",
+			projectID:   "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			wantEmpty:   true,
+		},
+		{
+			name:        "empty project slug returns empty for scion-volumes",
+			agentPath:   "/scion-volumes/scratchpad/file.txt",
+			projectSlug: "",
+			projectID:   "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			wantEmpty:   true,
+		},
+		{
+			name:        "empty project ID returns empty for scion-volumes",
+			agentPath:   "/scion-volumes/scratchpad/file.txt",
+			projectSlug: "test-proj",
+			projectID:   "",
+			wantEmpty:   true,
+		},
+		{
+			name:        "relative path returns empty",
+			agentPath:   "relative/path.txt",
+			projectSlug: "test-proj",
+			projectID:   "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			wantEmpty:   true,
+		},
+		{
+			name:        "arbitrary absolute path outside safe dirs rejected",
+			agentPath:   "/etc/passwd",
+			projectSlug: "test-proj",
+			projectID:   "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			wantEmpty:   true,
+		},
+		{
+			name:        "absolute path with traversal out of workspace rejected",
+			agentPath:   "/workspace/../etc/passwd",
+			projectSlug: "test-proj",
+			projectID:   "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			wantEmpty:   true,
+		},
+		{
+			name:        "dot-dot shared dir name rejected",
+			agentPath:   "/scion-volumes/../secret",
+			projectSlug: "test-proj",
+			projectID:   "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+			wantEmpty:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveAgentPath(tt.agentPath, tt.projectSlug, tt.projectID)
+			if tt.wantEmpty && got != "" {
+				t.Errorf("resolveAgentPath(%q) = %q, want empty", tt.agentPath, got)
+			}
+			if !tt.wantEmpty && got == "" {
+				t.Errorf("resolveAgentPath(%q) = empty, want non-empty with prefix %q", tt.agentPath, tt.wantPrefix)
+			}
+			if !tt.wantEmpty && tt.wantPrefix != "" && !strings.HasPrefix(got, tt.wantPrefix) {
+				t.Errorf("resolveAgentPath(%q) = %q, want prefix %q", tt.agentPath, got, tt.wantPrefix)
+			}
+		})
+	}
+}
+
+// TestResolveAgentPath_WorkspacePath verifies that workspace paths are accepted
+// only when the file exists and the cleaned path stays under /workspace/.
+func TestResolveAgentPath_WorkspacePath(t *testing.T) {
+	// Create a temp file under a workspace-like directory.
+	dir := t.TempDir()
+	testFile := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Workspace paths resolve only for existing files. Since /workspace/
+	// may not exist in the test environment, just verify that the safe-prefix
+	// check blocks non-workspace absolute paths.
+	got := resolveAgentPath("/tmp/should-not-resolve", "proj", "id-1234")
+	if got != "" {
+		t.Errorf("expected /tmp path to be rejected, got %q", got)
+	}
+}
+
+// --- resolveSharedDirPath tests ---
+
+func TestResolveSharedDirPath(t *testing.T) {
+	tests := []struct {
+		name          string
+		containerPath string
+		projectSlug   string
+		projectID     string
+		wantEmpty     bool
+	}{
+		{
+			name:          "valid path",
+			containerPath: "/scion-volumes/scratchpad/data/file.txt",
+			projectSlug:   "myproj",
+			projectID:     "12345678-abcd-efgh-ijkl-000000000000",
+			wantEmpty:     false,
+		},
+		{
+			name:          "traversal in relPath rejected",
+			containerPath: "/scion-volumes/scratchpad/../../../etc/passwd",
+			projectSlug:   "myproj",
+			projectID:     "12345678-abcd-efgh-ijkl-000000000000",
+			wantEmpty:     true,
+		},
+		{
+			name:          "shared dir name is dot rejected",
+			containerPath: "/scion-volumes/./file",
+			projectSlug:   "myproj",
+			projectID:     "12345678-abcd-efgh-ijkl-000000000000",
+			wantEmpty:     true,
+		},
+		{
+			name:          "shared dir name is dotdot rejected",
+			containerPath: "/scion-volumes/../file",
+			projectSlug:   "myproj",
+			projectID:     "12345678-abcd-efgh-ijkl-000000000000",
+			wantEmpty:     true,
+		},
+		{
+			name:          "empty trimmed path rejected",
+			containerPath: "/scion-volumes/",
+			projectSlug:   "myproj",
+			projectID:     "12345678-abcd-efgh-ijkl-000000000000",
+			wantEmpty:     true,
+		},
+		{
+			name:          "just shared dir name, no file",
+			containerPath: "/scion-volumes/scratchpad",
+			projectSlug:   "myproj",
+			projectID:     "12345678-abcd-efgh-ijkl-000000000000",
+			wantEmpty:     false,
+		},
+		{
+			name:          "empty project slug",
+			containerPath: "/scion-volumes/scratchpad/file",
+			projectSlug:   "",
+			projectID:     "12345678-abcd-efgh-ijkl-000000000000",
+			wantEmpty:     true,
+		},
+		{
+			name:          "double slash creates absolute relPath which is rejected",
+			containerPath: "/scion-volumes/scratchpad//etc/passwd",
+			projectSlug:   "myproj",
+			projectID:     "12345678-abcd-efgh-ijkl-000000000000",
+			wantEmpty:     true, // SplitN produces "/etc/passwd" which is absolute
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveSharedDirPath(tt.containerPath, tt.projectSlug, tt.projectID)
+			if tt.wantEmpty && got != "" {
+				t.Errorf("resolveSharedDirPath(%q) = %q, want empty", tt.containerPath, got)
+			}
+			if !tt.wantEmpty && got == "" {
+				t.Errorf("resolveSharedDirPath(%q) = empty, want non-empty", tt.containerPath)
+			}
+		})
+	}
+}
+
+// --- SizeLimitErrorCard tests ---
+
+func TestSizeLimitErrorCard(t *testing.T) {
+	tests := []struct {
+		name           string
+		filename       string
+		size           int64
+		wantContain    string
+		wantNotContain string
+	}{
+		{
+			name:        "known size shows formatted size",
+			filename:    "big.zip",
+			size:        30 * 1024 * 1024,
+			wantContain: "30.0 MB",
+		},
+		{
+			name:           "zero size omits size info",
+			filename:       "unknown.dat",
+			size:           0,
+			wantContain:    "exceeds the 25 MB attachment limit",
+			wantNotContain: "0.0 KB",
+		},
+		{
+			name:        "small known size shows KB",
+			filename:    "tiny.txt",
+			size:        512 * 1024,
+			wantContain: "512.0 KB",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			card := SizeLimitErrorCard(tt.filename, tt.size)
+			if card.Header.Title != "⚠️ Attachment Too Large" {
+				t.Errorf("unexpected title: %s", card.Header.Title)
+			}
+			if card.Header.Subtitle != tt.filename {
+				t.Errorf("subtitle = %q, want %q", card.Header.Subtitle, tt.filename)
+			}
+			if len(card.Sections) == 0 || len(card.Sections[0].Widgets) == 0 {
+				t.Fatal("expected at least one section with a widget")
+			}
+			content := card.Sections[0].Widgets[0].Content
+			if tt.wantContain != "" && !strings.Contains(content, tt.wantContain) {
+				t.Errorf("content should contain %q, got: %s", tt.wantContain, content)
+			}
+			if tt.wantNotContain != "" && strings.Contains(content, tt.wantNotContain) {
+				t.Errorf("content should NOT contain %q, got: %s", tt.wantNotContain, content)
+			}
+		})
+	}
+}
+
+// --- ResolveOutboundAttachments tests ---
+
+func TestResolveOutboundAttachments_SizeLimit(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Create a temp directory with test files.
+	dir := t.TempDir()
+
+	// Create a file exactly at the limit.
+	atLimitFile := filepath.Join(dir, "at_limit.bin")
+	if err := os.WriteFile(atLimitFile, make([]byte, MaxAttachmentSize), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a file over the limit.
+	overLimitFile := filepath.Join(dir, "over_limit.bin")
+	if err := os.WriteFile(overLimitFile, make([]byte, MaxAttachmentSize+1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a small file.
+	smallFile := filepath.Join(dir, "small.txt")
+	if err := os.WriteFile(smallFile, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		paths     []string
+		wantCount int
+	}{
+		{
+			name:      "empty paths returns nil",
+			paths:     nil,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ResolveOutboundAttachments(log, tt.paths, "proj", "id-1234")
+			if len(result) != tt.wantCount {
+				t.Errorf("got %d attachments, want %d", len(result), tt.wantCount)
+			}
+		})
+	}
+}
+
+// --- formatFileSize tests ---
+
+func TestFormatFileSize(t *testing.T) {
+	tests := []struct {
+		name  string
+		bytes int64
+		want  string
+	}{
+		{name: "zero bytes", bytes: 0, want: "0.0 KB"},
+		{name: "1 KB", bytes: 1024, want: "1.0 KB"},
+		{name: "500 KB", bytes: 500 * 1024, want: "500.0 KB"},
+		{name: "1 MB", bytes: 1024 * 1024, want: "1.0 MB"},
+		{name: "25 MB", bytes: 25 * 1024 * 1024, want: "25.0 MB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatFileSize(tt.bytes)
+			if got != tt.want {
+				t.Errorf("formatFileSize(%d) = %q, want %q", tt.bytes, got, tt.want)
+			}
+		})
+	}
+}

--- a/extras/scion-chat-app/internal/chatapp/broker.go
+++ b/extras/scion-chat-app/internal/chatapp/broker.go
@@ -393,6 +393,12 @@ func ResolveOutboundAttachments(log *slog.Logger, attachmentPaths []string, proj
 				"error", err)
 			continue
 		}
+		if fi.IsDir() {
+			log.Warn("attachment path is a directory, skipping",
+				"agent_path", agentPath,
+				"host_path", hostPath)
+			continue
+		}
 		if fi.Size() > MaxAttachmentSize {
 			log.Warn("attachment file too large, skipping",
 				"agent_path", agentPath,
@@ -485,7 +491,7 @@ func resolveAgentPath(agentPath, projectSlug, projectID string) string {
 		safePrefixes := []string{"/workspace/", "/scion-volumes/"}
 		for _, prefix := range safePrefixes {
 			if strings.HasPrefix(agentPath, prefix) {
-				clean := filepath.Clean(agentPath)
+				clean := filepath.ToSlash(filepath.Clean(agentPath))
 				// Re-check prefix after Clean to prevent traversal (e.g. /workspace/../etc/passwd).
 				if strings.HasPrefix(clean, prefix) {
 					if _, err := os.Stat(clean); err == nil {
@@ -513,7 +519,7 @@ func resolveSharedDirPath(containerPath, projectSlug, projectID string) string {
 
 	parts := strings.SplitN(trimmed, "/", 2)
 	sharedDirName := parts[0]
-	if sharedDirName == "" || sharedDirName == "." || sharedDirName == ".." {
+	if sharedDirName == "" || sharedDirName == "." || sharedDirName == ".." || strings.ContainsAny(sharedDirName, "/\\") {
 		return ""
 	}
 

--- a/extras/scion-chat-app/internal/chatapp/broker.go
+++ b/extras/scion-chat-app/internal/chatapp/broker.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"log/slog"
 	"net"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -356,92 +355,13 @@ func (s *PluginServer) Close() error {
 // --- Attachment helpers ---
 
 const (
-	// maxGChatAttachmentSize is the maximum file size for uploads (25 MB).
-	maxGChatAttachmentSize = 25 * 1024 * 1024
+	// MaxAttachmentSize is the maximum file size for chat attachment uploads (25 MB).
+	// Shared by all platform adapters (Google Chat, Discord, etc.).
+	MaxAttachmentSize = 25 * 1024 * 1024
 
 	// gchatAttachmentDir is the subdirectory under .attachments for Google Chat files.
 	gchatAttachmentDir = "_gchat"
 )
-
-// DownloadEventAttachment downloads a file from a Google Chat event attachment
-// and saves it to the shared volume. Returns the agent-visible path.
-//
-// Files are saved to:
-//
-//	/scion-volumes/scratchpad/.attachments/_gchat/<conversationID>/<filename>
-//
-// The httpClient must be authenticated for the Google Chat API.
-func DownloadEventAttachment(ctx context.Context, httpClient *http.Client, att EventAttachment, conversationID, projectSlug, projectID string) (agentPath string, err error) {
-	if att.DownloadURI == "" {
-		return "", fmt.Errorf("attachment has no download URI")
-	}
-	if att.Name == "" {
-		return "", fmt.Errorf("attachment has no name")
-	}
-
-	// Sanitize the conversation ID for use as a directory name.
-	safeConvID := sanitizePathComponent(conversationID)
-	if safeConvID == "" {
-		safeConvID = "unknown"
-	}
-
-	// Resolve the host-side directory for the shared volume.
-	hostDir, err := resolveGChatAttachmentDir(projectSlug, projectID, safeConvID)
-	if err != nil {
-		return "", fmt.Errorf("resolving attachment directory: %w", err)
-	}
-
-	if err := os.MkdirAll(hostDir, 0o755); err != nil {
-		return "", fmt.Errorf("creating attachment directory: %w", err)
-	}
-
-	// Download the file.
-	req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, att.DownloadURI, nil)
-	if reqErr != nil {
-		return "", fmt.Errorf("creating download request: %w", reqErr)
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("downloading attachment %q: %w", att.Name, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("download %q failed: HTTP %d", att.Name, resp.StatusCode)
-	}
-
-	// Use a timestamped filename to avoid collisions.
-	safeName := sanitizePathComponent(att.Name)
-	if safeName == "" {
-		safeName = "attachment"
-	}
-	destName := fmt.Sprintf("%d_%s", time.Now().UnixNano(), safeName)
-	destPath := filepath.Join(hostDir, destName)
-
-	f, err := os.Create(destPath)
-	if err != nil {
-		return "", fmt.Errorf("creating file: %w", err)
-	}
-	defer f.Close()
-
-	written, err := io.Copy(f, io.LimitReader(resp.Body, maxGChatAttachmentSize+1))
-	if err != nil {
-		os.Remove(destPath)
-		return "", fmt.Errorf("writing attachment: %w", err)
-	}
-	if written > maxGChatAttachmentSize {
-		os.Remove(destPath)
-		return "", fmt.Errorf("attachment %q too large (%d bytes, max %d)", att.Name, written, maxGChatAttachmentSize)
-	}
-
-	// Build the agent-visible path.
-	agentPath = filepath.ToSlash(filepath.Join(
-		"/scion-volumes/scratchpad/.attachments", gchatAttachmentDir, safeConvID, destName,
-	))
-
-	return agentPath, nil
-}
 
 // ResolveOutboundAttachments converts agent-side attachment paths from a
 // StructuredMessage into Attachment structs with resolved host-side paths.
@@ -473,11 +393,11 @@ func ResolveOutboundAttachments(log *slog.Logger, attachmentPaths []string, proj
 				"error", err)
 			continue
 		}
-		if fi.Size() > maxGChatAttachmentSize {
+		if fi.Size() > MaxAttachmentSize {
 			log.Warn("attachment file too large, skipping",
 				"agent_path", agentPath,
 				"size", fi.Size(),
-				"max", maxGChatAttachmentSize)
+				"max", MaxAttachmentSize)
 			continue
 		}
 
@@ -491,8 +411,22 @@ func ResolveOutboundAttachments(log *slog.Logger, attachmentPaths []string, proj
 }
 
 // SizeLimitErrorCard returns a Card notifying the user that an attachment
-// exceeds the size limit.
+// exceeds the size limit. When size is 0 (unknown), the message omits the
+// specific file size.
 func SizeLimitErrorCard(filename string, size int64) Card {
+	var detail string
+	if size > 0 {
+		detail = fmt.Sprintf(
+			"The file `%s` is %s, which exceeds the 25 MB attachment limit.\n\nPlease reduce the file size and try again.",
+			filename,
+			formatFileSize(size),
+		)
+	} else {
+		detail = fmt.Sprintf(
+			"The file `%s` exceeds the 25 MB attachment limit.\n\nPlease reduce the file size and try again.",
+			filename,
+		)
+	}
 	return Card{
 		Header: CardHeader{
 			Title:    "⚠️ Attachment Too Large",
@@ -502,12 +436,8 @@ func SizeLimitErrorCard(filename string, size int64) Card {
 			{
 				Widgets: []Widget{
 					{
-						Type: WidgetText,
-						Content: fmt.Sprintf(
-							"The file `%s` is %s, which exceeds the 25 MB attachment limit.\n\nPlease reduce the file size and try again.",
-							filename,
-							formatFileSize(size),
-						),
+						Type:    WidgetText,
+						Content: detail,
 					},
 				},
 			},
@@ -549,10 +479,21 @@ func resolveAgentPath(agentPath, projectSlug, projectID string) string {
 		return resolveSharedDirPath(containerPath, projectSlug, projectID)
 	}
 
-	// For absolute paths that aren't container paths, try as host paths.
+	// For absolute paths that aren't container paths, only allow paths
+	// under known safe directories to prevent arbitrary file exfiltration.
 	if strings.HasPrefix(agentPath, "/") {
-		if _, err := os.Stat(agentPath); err == nil {
-			return agentPath
+		safePrefixes := []string{"/workspace/", "/scion-volumes/"}
+		for _, prefix := range safePrefixes {
+			if strings.HasPrefix(agentPath, prefix) {
+				clean := filepath.Clean(agentPath)
+				// Re-check prefix after Clean to prevent traversal (e.g. /workspace/../etc/passwd).
+				if strings.HasPrefix(clean, prefix) {
+					if _, err := os.Stat(clean); err == nil {
+						return clean
+					}
+				}
+				break
+			}
 		}
 	}
 

--- a/extras/scion-chat-app/internal/chatapp/broker.go
+++ b/extras/scion-chat-app/internal/chatapp/broker.go
@@ -22,6 +22,10 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -347,4 +351,292 @@ func (s *PluginServer) Close() error {
 		return s.listener.Close()
 	}
 	return nil
+}
+
+// --- Attachment helpers ---
+
+const (
+	// maxGChatAttachmentSize is the maximum file size for uploads (25 MB).
+	maxGChatAttachmentSize = 25 * 1024 * 1024
+
+	// gchatAttachmentDir is the subdirectory under .attachments for Google Chat files.
+	gchatAttachmentDir = "_gchat"
+)
+
+// DownloadEventAttachment downloads a file from a Google Chat event attachment
+// and saves it to the shared volume. Returns the agent-visible path.
+//
+// Files are saved to:
+//
+//	/scion-volumes/scratchpad/.attachments/_gchat/<conversationID>/<filename>
+//
+// The httpClient must be authenticated for the Google Chat API.
+func DownloadEventAttachment(ctx context.Context, httpClient *http.Client, att EventAttachment, conversationID, projectSlug, projectID string) (agentPath string, err error) {
+	if att.DownloadURI == "" {
+		return "", fmt.Errorf("attachment has no download URI")
+	}
+	if att.Name == "" {
+		return "", fmt.Errorf("attachment has no name")
+	}
+
+	// Sanitize the conversation ID for use as a directory name.
+	safeConvID := sanitizePathComponent(conversationID)
+	if safeConvID == "" {
+		safeConvID = "unknown"
+	}
+
+	// Resolve the host-side directory for the shared volume.
+	hostDir, err := resolveGChatAttachmentDir(projectSlug, projectID, safeConvID)
+	if err != nil {
+		return "", fmt.Errorf("resolving attachment directory: %w", err)
+	}
+
+	if err := os.MkdirAll(hostDir, 0o755); err != nil {
+		return "", fmt.Errorf("creating attachment directory: %w", err)
+	}
+
+	// Download the file.
+	req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, att.DownloadURI, nil)
+	if reqErr != nil {
+		return "", fmt.Errorf("creating download request: %w", reqErr)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("downloading attachment %q: %w", att.Name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download %q failed: HTTP %d", att.Name, resp.StatusCode)
+	}
+
+	// Use a timestamped filename to avoid collisions.
+	safeName := sanitizePathComponent(att.Name)
+	if safeName == "" {
+		safeName = "attachment"
+	}
+	destName := fmt.Sprintf("%d_%s", time.Now().UnixNano(), safeName)
+	destPath := filepath.Join(hostDir, destName)
+
+	f, err := os.Create(destPath)
+	if err != nil {
+		return "", fmt.Errorf("creating file: %w", err)
+	}
+	defer f.Close()
+
+	written, err := io.Copy(f, io.LimitReader(resp.Body, maxGChatAttachmentSize+1))
+	if err != nil {
+		os.Remove(destPath)
+		return "", fmt.Errorf("writing attachment: %w", err)
+	}
+	if written > maxGChatAttachmentSize {
+		os.Remove(destPath)
+		return "", fmt.Errorf("attachment %q too large (%d bytes, max %d)", att.Name, written, maxGChatAttachmentSize)
+	}
+
+	// Build the agent-visible path.
+	agentPath = filepath.ToSlash(filepath.Join(
+		"/scion-volumes/scratchpad/.attachments", gchatAttachmentDir, safeConvID, destName,
+	))
+
+	return agentPath, nil
+}
+
+// ResolveOutboundAttachments converts agent-side attachment paths from a
+// StructuredMessage into Attachment structs with resolved host-side paths.
+// Paths that cannot be resolved or exceed the size limit are skipped with a
+// logged warning.
+func ResolveOutboundAttachments(log *slog.Logger, attachmentPaths []string, projectSlug, projectID string) []Attachment {
+	if len(attachmentPaths) == 0 {
+		return nil
+	}
+
+	var result []Attachment
+	for _, agentPath := range attachmentPaths {
+		if agentPath == "" {
+			continue
+		}
+
+		hostPath := resolveAgentPath(agentPath, projectSlug, projectID)
+		if hostPath == "" {
+			log.Warn("cannot resolve attachment path, skipping",
+				"agent_path", agentPath)
+			continue
+		}
+
+		fi, err := os.Stat(hostPath)
+		if err != nil {
+			log.Warn("attachment file not found, skipping",
+				"agent_path", agentPath,
+				"host_path", hostPath,
+				"error", err)
+			continue
+		}
+		if fi.Size() > maxGChatAttachmentSize {
+			log.Warn("attachment file too large, skipping",
+				"agent_path", agentPath,
+				"size", fi.Size(),
+				"max", maxGChatAttachmentSize)
+			continue
+		}
+
+		result = append(result, Attachment{
+			Filename: filepath.Base(hostPath),
+			Path:     hostPath,
+			Size:     fi.Size(),
+		})
+	}
+	return result
+}
+
+// SizeLimitErrorCard returns a Card notifying the user that an attachment
+// exceeds the size limit.
+func SizeLimitErrorCard(filename string, size int64) Card {
+	return Card{
+		Header: CardHeader{
+			Title:    "⚠️ Attachment Too Large",
+			Subtitle: filename,
+		},
+		Sections: []CardSection{
+			{
+				Widgets: []Widget{
+					{
+						Type: WidgetText,
+						Content: fmt.Sprintf(
+							"The file `%s` is %s, which exceeds the 25 MB attachment limit.\n\nPlease reduce the file size and try again.",
+							filename,
+							formatFileSize(size),
+						),
+					},
+				},
+			},
+		},
+	}
+}
+
+// resolveGChatAttachmentDir returns the host-side directory for storing
+// Google Chat attachments in the shared scratchpad volume.
+func resolveGChatAttachmentDir(projectSlug, projectID, conversationID string) (string, error) {
+	if projectSlug == "" || projectID == "" {
+		return "", fmt.Errorf("project slug or ID is empty")
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+
+	sharedDirBase := sharedDirHostPath(home, projectSlug, projectID, "scratchpad")
+	return filepath.Join(sharedDirBase, ".attachments", gchatAttachmentDir, conversationID), nil
+}
+
+// resolveAgentPath translates agent-side container paths to host-side paths.
+//
+// Supported paths:
+//   - /scion-volumes/<name>/<file> → shared dir host path
+//   - /workspace/.scion-volumes/<name>/<file> → same as above
+//   - Absolute paths starting with / that are already host paths → returned as-is
+func resolveAgentPath(agentPath, projectSlug, projectID string) string {
+	// Handle /scion-volumes/<name>/... paths.
+	if strings.HasPrefix(agentPath, "/scion-volumes/") {
+		return resolveSharedDirPath(agentPath, projectSlug, projectID)
+	}
+
+	// Handle /workspace/.scion-volumes/<name>/... paths.
+	if strings.HasPrefix(agentPath, "/workspace/.scion-volumes/") {
+		containerPath := "/scion-volumes/" + strings.TrimPrefix(agentPath, "/workspace/.scion-volumes/")
+		return resolveSharedDirPath(containerPath, projectSlug, projectID)
+	}
+
+	// For absolute paths that aren't container paths, try as host paths.
+	if strings.HasPrefix(agentPath, "/") {
+		if _, err := os.Stat(agentPath); err == nil {
+			return agentPath
+		}
+	}
+
+	return ""
+}
+
+// resolveSharedDirPath converts a /scion-volumes/<name>/... path to the host-side path.
+func resolveSharedDirPath(containerPath, projectSlug, projectID string) string {
+	if projectSlug == "" || projectID == "" {
+		return ""
+	}
+
+	trimmed := strings.TrimPrefix(containerPath, "/scion-volumes/")
+	if trimmed == "" || trimmed == containerPath {
+		return ""
+	}
+
+	parts := strings.SplitN(trimmed, "/", 2)
+	sharedDirName := parts[0]
+	if sharedDirName == "" || sharedDirName == "." || sharedDirName == ".." {
+		return ""
+	}
+
+	relPath := ""
+	if len(parts) > 1 {
+		relPath = filepath.Clean(parts[1])
+		if strings.HasPrefix(relPath, "..") || filepath.IsAbs(relPath) {
+			return ""
+		}
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	base := sharedDirHostPath(home, projectSlug, projectID, sharedDirName)
+	if relPath == "" || relPath == "." {
+		return base
+	}
+
+	hostPath := filepath.Join(base, relPath)
+	// Verify the resolved path doesn't escape the shared dir.
+	if !strings.HasPrefix(hostPath, base+string(filepath.Separator)) {
+		return ""
+	}
+	return hostPath
+}
+
+// sanitizePathComponent removes characters that are unsafe in file paths.
+func sanitizePathComponent(s string) string {
+	s = filepath.Base(s)
+	s = strings.Map(func(r rune) rune {
+		if r == '/' || r == '\\' || r == '\x00' {
+			return '_'
+		}
+		return r
+	}, s)
+	if s == "." || s == ".." || s == "" {
+		return ""
+	}
+	return s
+}
+
+// formatFileSize returns a human-readable file size string.
+func formatFileSize(bytes int64) string {
+	const mb = 1024 * 1024
+	if bytes >= mb {
+		return fmt.Sprintf("%.1f MB", float64(bytes)/float64(mb))
+	}
+	return fmt.Sprintf("%.1f KB", float64(bytes)/1024.0)
+}
+
+// sharedDirHostPath computes the host-side directory path for a shared
+// directory. This replicates the logic from pkg/config.SharedDirHostPath
+// to avoid pulling in the full config package with its heavy transitive
+// dependencies (ent, koanf, rclone, etc.).
+//
+// Path format: ~/.scion/project-configs/<slug>__<shortUUID>/shared-dirs/<name>
+func sharedDirHostPath(home, slug, projectID, sharedDirName string) string {
+	shortUUID := strings.ReplaceAll(projectID, "-", "")
+	if len(shortUUID) > 8 {
+		shortUUID = shortUUID[:8]
+	}
+	dirName := fmt.Sprintf("%s__%s", slug, shortUUID)
+	return filepath.Join(home, ".scion", "project-configs", dirName, "shared-dirs", sharedDirName)
 }

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -2056,14 +2056,14 @@ func (r *CommandRouter) downloadInboundAttachment(ctx context.Context, att Event
 	}
 	defer f.Close()
 
-	written, copyErr := io.Copy(f, io.LimitReader(body, maxGChatAttachmentSize+1))
+	written, copyErr := io.Copy(f, io.LimitReader(body, MaxAttachmentSize+1))
 	if copyErr != nil {
 		os.Remove(destPath)
 		return "", fmt.Errorf("writing attachment: %w", copyErr)
 	}
-	if written > maxGChatAttachmentSize {
+	if written > MaxAttachmentSize {
 		os.Remove(destPath)
-		return "", fmt.Errorf("attachment %q too large (%d bytes, max %d)", att.Name, written, maxGChatAttachmentSize)
+		return "", fmt.Errorf("attachment %q too large (%d bytes, max %d)", att.Name, written, MaxAttachmentSize)
 	}
 
 	agentPath := filepath.ToSlash(filepath.Join(

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -57,14 +57,14 @@ type pendingDeviceAuth struct {
 
 // CommandRouter parses and executes chat commands.
 type CommandRouter struct {
-	adminClient    hubclient.Client
-	hubURL         string
-	store          *state.Store
-	idMapper       *identity.Mapper
-	messenger      Messenger
-	downloader     AttachmentDownloader
-	broker         *BrokerServer
-	log            *slog.Logger
+	adminClient hubclient.Client
+	hubURL      string
+	store       *state.Store
+	idMapper    *identity.Mapper
+	messenger   Messenger
+	downloader  AttachmentDownloader
+	broker      *BrokerServer
+	log         *slog.Logger
 
 	mu             sync.Mutex
 	pendingAuth    map[string]*pendingDeviceAuth // keyed by platformUserID+platform
@@ -2058,10 +2058,12 @@ func (r *CommandRouter) downloadInboundAttachment(ctx context.Context, att Event
 
 	written, copyErr := io.Copy(f, io.LimitReader(body, MaxAttachmentSize+1))
 	if copyErr != nil {
+		f.Close()
 		os.Remove(destPath)
 		return "", fmt.Errorf("writing attachment: %w", copyErr)
 	}
 	if written > MaxAttachmentSize {
+		f.Close()
 		os.Remove(destPath)
 		return "", fmt.Errorf("attachment %q too large (%d bytes, max %d)", att.Name, written, MaxAttachmentSize)
 	}

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -17,8 +17,11 @@ package chatapp
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -54,13 +57,14 @@ type pendingDeviceAuth struct {
 
 // CommandRouter parses and executes chat commands.
 type CommandRouter struct {
-	adminClient hubclient.Client
-	hubURL      string
-	store       *state.Store
-	idMapper    *identity.Mapper
-	messenger   Messenger
-	broker      *BrokerServer
-	log         *slog.Logger
+	adminClient    hubclient.Client
+	hubURL         string
+	store          *state.Store
+	idMapper       *identity.Mapper
+	messenger      Messenger
+	downloader     AttachmentDownloader
+	broker         *BrokerServer
+	log            *slog.Logger
 
 	mu             sync.Mutex
 	pendingAuth    map[string]*pendingDeviceAuth // keyed by platformUserID+platform
@@ -105,6 +109,16 @@ func (r *CommandRouter) hubHostname() string {
 // circular dependency between the command router and chat adapter.
 func (r *CommandRouter) SetMessenger(m Messenger) {
 	r.messenger = m
+	// If the messenger also implements AttachmentDownloader, wire it up.
+	if d, ok := m.(AttachmentDownloader); ok {
+		r.downloader = d
+	}
+}
+
+// SetDownloader sets the attachment downloader (used for downloading files
+// from chat platform events).
+func (r *CommandRouter) SetDownloader(d AttachmentDownloader) {
+	r.downloader = d
 }
 
 // HandleEvent processes a ChatEvent and routes it to the appropriate handler.
@@ -1259,6 +1273,33 @@ func (r *CommandRouter) cmdMessage(ctx context.Context, event *ChatEvent, args [
 		msg.ThreadID = event.ThreadID
 	}
 
+	// Download and attach any files uploaded with the message.
+	if len(event.Attachments) > 0 && r.downloader != nil {
+		for _, att := range event.Attachments {
+			agentPath, dlErr := r.downloadInboundAttachment(
+				ctx, att, event.SpaceID, link.ProjectSlug, link.ProjectID,
+			)
+			if dlErr != nil {
+				r.log.Error("failed to download attachment",
+					"filename", att.Name, "error", dlErr)
+				if strings.Contains(dlErr.Error(), "too large") {
+					errCard := SizeLimitErrorCard(att.Name, 0)
+					if _, sendErr := r.messenger.SendCard(ctx, event.SpaceID, errCard); sendErr != nil {
+						r.log.Error("failed to send size limit card", "error", sendErr)
+					}
+				}
+				continue
+			}
+			msg.Attachments = append(msg.Attachments, agentPath)
+			if messageText != "" {
+				messageText += "\n"
+			}
+			messageText += fmt.Sprintf("[Attachment: %s (%s)]", att.Name, att.ContentType)
+		}
+		// Update the message body with attachment placeholders.
+		msg.Msg = messageText
+	}
+
 	if _, err := client.ProjectAgents(link.ProjectID).SendStructuredMessage(ctx, agentSlug, msg, false, false, false); err != nil {
 		return textResponse(event, fmt.Sprintf("Failed to send message to `%s`: %v", agentSlug, err)), nil
 	}
@@ -1968,6 +2009,74 @@ func (r *CommandRouter) handleSettingsAction(ctx context.Context, event *ChatEve
 		return err
 	}
 	return nil
+}
+
+// --- Attachment handling ---
+
+// downloadInboundAttachment downloads a user-uploaded file from Google Chat and
+// saves it to the shared volume. Returns the agent-visible path.
+func (r *CommandRouter) downloadInboundAttachment(ctx context.Context, att EventAttachment, spaceID, projectSlug, projectID string) (string, error) {
+	if r.downloader == nil {
+		return "", fmt.Errorf("no attachment downloader configured")
+	}
+
+	// Sanitize the conversation ID (space name) for use as a directory.
+	safeConvID := sanitizePathComponent(spaceID)
+	if safeConvID == "" {
+		safeConvID = "unknown"
+	}
+
+	// Resolve the host-side directory.
+	hostDir, err := resolveGChatAttachmentDir(projectSlug, projectID, safeConvID)
+	if err != nil {
+		return "", fmt.Errorf("resolving attachment directory: %w", err)
+	}
+	if mkErr := os.MkdirAll(hostDir, 0o755); mkErr != nil {
+		return "", fmt.Errorf("creating attachment directory: %w", mkErr)
+	}
+
+	// Download the file via the authenticated downloader.
+	body, err := r.downloader.DownloadAttachment(ctx, att.DownloadURI)
+	if err != nil {
+		return "", fmt.Errorf("downloading %q: %w", att.Name, err)
+	}
+	defer body.Close()
+
+	// Build a timestamped filename.
+	safeName := sanitizePathComponent(att.Name)
+	if safeName == "" {
+		safeName = "attachment"
+	}
+	destName := fmt.Sprintf("%d_%s", time.Now().UnixNano(), safeName)
+	destPath := filepath.Join(hostDir, destName)
+
+	f, fErr := os.Create(destPath)
+	if fErr != nil {
+		return "", fmt.Errorf("creating file: %w", fErr)
+	}
+	defer f.Close()
+
+	written, copyErr := io.Copy(f, io.LimitReader(body, maxGChatAttachmentSize+1))
+	if copyErr != nil {
+		os.Remove(destPath)
+		return "", fmt.Errorf("writing attachment: %w", copyErr)
+	}
+	if written > maxGChatAttachmentSize {
+		os.Remove(destPath)
+		return "", fmt.Errorf("attachment %q too large (%d bytes, max %d)", att.Name, written, maxGChatAttachmentSize)
+	}
+
+	agentPath := filepath.ToSlash(filepath.Join(
+		"/scion-volumes/scratchpad/.attachments", gchatAttachmentDir, safeConvID, destName,
+	))
+
+	r.log.Info("downloaded Google Chat attachment",
+		"filename", att.Name,
+		"content_type", att.ContentType,
+		"agent_path", agentPath,
+	)
+
+	return agentPath, nil
 }
 
 // --- Helper methods ---

--- a/extras/scion-chat-app/internal/chatapp/events.go
+++ b/extras/scion-chat-app/internal/chatapp/events.go
@@ -30,8 +30,16 @@ type ChatEvent struct {
 	ActionID        string
 	ActionData      string
 	DialogData      map[string]string
-	InteractionAdd  bool // true when added to space via @mention (multi-turn)
-	IsDialogEvent   bool // true when the event is a dialog request/submit
+	Attachments     []EventAttachment // files uploaded by the user
+	InteractionAdd  bool              // true when added to space via @mention (multi-turn)
+	IsDialogEvent   bool              // true when the event is a dialog request/submit
+}
+
+// EventAttachment represents a file attached to an inbound chat event.
+type EventAttachment struct {
+	Name        string // display name of the file
+	ContentType string // MIME type
+	DownloadURI string // URL to download the file content (requires authenticated client)
 }
 
 // EventResponse holds an optional synchronous response to return in the HTTP body.

--- a/extras/scion-chat-app/internal/chatapp/messenger.go
+++ b/extras/scion-chat-app/internal/chatapp/messenger.go
@@ -14,7 +14,10 @@
 
 package chatapp
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 // Messenger abstracts chat platform operations.
 type Messenger interface {
@@ -25,16 +28,26 @@ type Messenger interface {
 	UpdateDialog(ctx context.Context, triggerID string, dialog Dialog) error
 	GetUser(ctx context.Context, userID string) (*ChatUser, error)
 	SetAgentIdentity(ctx context.Context, agent AgentIdentity) error
+	UploadMedia(ctx context.Context, spaceID, filename string, content io.Reader) (string, error)
 }
 
 // SendMessageRequest contains parameters for sending a message to a chat space.
 type SendMessageRequest struct {
-	SpaceID   string
-	ThreadID  string
-	ThreadKey string // Platform-specific thread key for creating new threads.
-	Text      string
-	Card      *Card
-	AgentID   string
+	SpaceID     string
+	ThreadID    string
+	ThreadKey   string // Platform-specific thread key for creating new threads.
+	Text        string
+	Card        *Card
+	AgentID     string
+	Attachments []Attachment
+}
+
+// Attachment describes a file to send or received from a chat platform.
+type Attachment struct {
+	Filename string // display name of the file
+	Path     string // local file path (for outbound)
+	URL      string // download URL (for inbound)
+	Size     int64
 }
 
 // AgentIdentity represents the visual identity of an agent in chat.
@@ -50,4 +63,9 @@ type ChatUser struct {
 	PlatformID  string
 	DisplayName string
 	Email       string
+}
+
+// AttachmentDownloader can download files from chat platform attachment URIs.
+type AttachmentDownloader interface {
+	DownloadAttachment(ctx context.Context, downloadURI string) (io.ReadCloser, error)
 }

--- a/extras/scion-chat-app/internal/chatapp/notifications.go
+++ b/extras/scion-chat-app/internal/chatapp/notifications.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"regexp"
 	"strings"
 
@@ -291,6 +292,24 @@ func (n *NotificationRelay) handleUserMessage(ctx context.Context, projectID str
 		return fmt.Errorf("listing space links: %w", err)
 	}
 
+	// Resolve outbound attachments from agent-side paths.
+	var attachments []Attachment
+	var projectSlug string
+	if len(msg.Attachments) > 0 {
+		for _, link := range links {
+			if link.ProjectID == projectID {
+				projectSlug = link.ProjectSlug
+				attachments = ResolveOutboundAttachments(n.log, msg.Attachments, link.ProjectSlug, link.ProjectID)
+				break
+			}
+		}
+
+		// Check for oversized files and send error cards.
+		if projectSlug != "" {
+			n.sendOversizeErrorCards(ctx, msg.Attachments, projectSlug, projectID, mapping.Platform, links)
+		}
+	}
+
 	for _, link := range links {
 		if link.ProjectID != projectID || link.Platform != mapping.Platform {
 			continue
@@ -313,11 +332,18 @@ func (n *NotificationRelay) handleUserMessage(ctx context.Context, projectID str
 		// Chat API renders them as interactive user pills.
 		mentions := n.buildMentions(mapping.PlatformUserID, agentSlug, link)
 
+		// Re-resolve attachments with this link's project info if not yet resolved.
+		linkAttachments := attachments
+		if linkAttachments == nil && len(msg.Attachments) > 0 {
+			linkAttachments = ResolveOutboundAttachments(n.log, msg.Attachments, link.ProjectSlug, link.ProjectID)
+		}
+
 		sendReq := SendMessageRequest{
-			SpaceID:  link.SpaceID,
-			ThreadID: msg.ThreadID,
-			Text:     mentions,
-			Card:     &card,
+			SpaceID:     link.SpaceID,
+			ThreadID:    msg.ThreadID,
+			Text:        mentions,
+			Card:        &card,
+			Attachments: linkAttachments,
 		}
 		var sendErr error
 		if n.sendQueue != nil {
@@ -569,6 +595,36 @@ func (n *NotificationRelay) resolveOutboundMentions(text string) string {
 
 	b.WriteString(text[prev:])
 	return b.String()
+}
+
+// sendOversizeErrorCards checks agent-side attachment paths for files exceeding
+// the size limit and sends error cards to the relevant spaces.
+func (n *NotificationRelay) sendOversizeErrorCards(ctx context.Context, attachPaths []string, projectSlug, projectID, platform string, links []state.SpaceLink) {
+	for _, agentPath := range attachPaths {
+		if agentPath == "" {
+			continue
+		}
+		hostPath := resolveAgentPath(agentPath, projectSlug, projectID)
+		if hostPath == "" {
+			continue
+		}
+		fi, err := os.Stat(hostPath)
+		if err != nil {
+			continue
+		}
+		if fi.Size() > maxGChatAttachmentSize {
+			errCard := SizeLimitErrorCard(fi.Name(), fi.Size())
+			for _, link := range links {
+				if link.ProjectID != projectID || link.Platform != platform {
+					continue
+				}
+				if _, sendErr := n.messenger.SendCard(ctx, link.SpaceID, errCard); sendErr != nil {
+					n.log.Error("failed to send size limit error card",
+						"space_id", link.SpaceID, "error", sendErr)
+				}
+			}
+		}
+	}
 }
 
 // buildMentions returns a formatted @mention string for a user-targeted message.

--- a/extras/scion-chat-app/internal/chatapp/notifications.go
+++ b/extras/scion-chat-app/internal/chatapp/notifications.go
@@ -332,18 +332,12 @@ func (n *NotificationRelay) handleUserMessage(ctx context.Context, projectID str
 		// Chat API renders them as interactive user pills.
 		mentions := n.buildMentions(mapping.PlatformUserID, agentSlug, link)
 
-		// Re-resolve attachments with this link's project info if not yet resolved.
-		linkAttachments := attachments
-		if linkAttachments == nil && len(msg.Attachments) > 0 {
-			linkAttachments = ResolveOutboundAttachments(n.log, msg.Attachments, link.ProjectSlug, link.ProjectID)
-		}
-
 		sendReq := SendMessageRequest{
 			SpaceID:     link.SpaceID,
 			ThreadID:    msg.ThreadID,
 			Text:        mentions,
 			Card:        &card,
-			Attachments: linkAttachments,
+			Attachments: attachments,
 		}
 		var sendErr error
 		if n.sendQueue != nil {

--- a/extras/scion-chat-app/internal/chatapp/notifications.go
+++ b/extras/scion-chat-app/internal/chatapp/notifications.go
@@ -612,7 +612,7 @@ func (n *NotificationRelay) sendOversizeErrorCards(ctx context.Context, attachPa
 		if err != nil {
 			continue
 		}
-		if fi.Size() > maxGChatAttachmentSize {
+		if fi.Size() > MaxAttachmentSize {
 			errCard := SizeLimitErrorCard(fi.Name(), fi.Size())
 			for _, link := range links {
 				if link.ProjectID != projectID || link.Platform != platform {

--- a/extras/scion-chat-app/internal/chatapp/notifications_test.go
+++ b/extras/scion-chat-app/internal/chatapp/notifications_test.go
@@ -16,6 +16,7 @@ package chatapp
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -90,6 +91,9 @@ func (f *fakeMessenger) OpenDialog(context.Context, string, Dialog) error       
 func (f *fakeMessenger) UpdateDialog(context.Context, string, Dialog) error              { return nil }
 func (f *fakeMessenger) GetUser(context.Context, string) (*ChatUser, error)              { return nil, nil }
 func (f *fakeMessenger) SetAgentIdentity(context.Context, AgentIdentity) error           { return nil }
+func (f *fakeMessenger) UploadMedia(_ context.Context, _, _ string, _ io.Reader) (string, error) {
+	return "uploaded-ref", nil
+}
 
 // newTestStore creates an ephemeral SQLite store in a temp directory.
 func newTestStore(t *testing.T) *state.Store {

--- a/extras/scion-chat-app/internal/googlechat/adapter.go
+++ b/extras/scion-chat-app/internal/googlechat/adapter.go
@@ -15,13 +15,18 @@
 package googlechat
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
+	"mime/multipart"
 	"net"
 	"net/http"
+	"net/textproto"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -31,6 +36,10 @@ import (
 const (
 	PlatformName = "google_chat"
 	chatAPIBase  = "https://chat.googleapis.com/v1"
+	uploadAPIBase = "https://chat.googleapis.com/upload/v1"
+
+	// maxAttachmentSize is the maximum file size for uploads (25 MB, matching Discord).
+	maxAttachmentSize = 25 * 1024 * 1024
 )
 
 // EventHandler processes normalized chat events and returns an optional synchronous response.
@@ -490,12 +499,25 @@ type rawSpace struct {
 }
 
 type rawMessage struct {
-	Name         string           `json:"name"`
-	Text         string           `json:"text"`
-	ArgumentText string           `json:"argumentText"`
-	Thread       *rawThread       `json:"thread,omitempty"`
-	Annotations  []rawAnnotation  `json:"annotations,omitempty"`
-	SlashCommand *rawSlashCommand `json:"slashCommand,omitempty"`
+	Name         string            `json:"name"`
+	Text         string            `json:"text"`
+	ArgumentText string            `json:"argumentText"`
+	Thread       *rawThread        `json:"thread,omitempty"`
+	Annotations  []rawAnnotation   `json:"annotations,omitempty"`
+	SlashCommand *rawSlashCommand  `json:"slashCommand,omitempty"`
+	Attachment   []rawAttachment   `json:"attachment,omitempty"`
+}
+
+type rawAttachment struct {
+	Name              string                `json:"name"`
+	ContentName       string                `json:"contentName"`
+	ContentType       string                `json:"contentType"`
+	DownloadURI       string                `json:"downloadUri"`
+	AttachmentDataRef *rawAttachmentDataRef `json:"attachmentDataRef,omitempty"`
+}
+
+type rawAttachmentDataRef struct {
+	ResourceName string `json:"resourceName"`
 }
 
 type rawSlashCommand struct {
@@ -612,6 +634,8 @@ func (a *Adapter) normalizeEvent(raw *rawEvent) *chatapp.ChatEvent {
 		if p.Message.Thread != nil {
 			event.ThreadID = p.Message.Thread.Name
 		}
+		// Extract attachments from message.
+		event.Attachments = extractAttachments(p.Message)
 		if p.Message.SlashCommand != nil {
 			event.Type = chatapp.EventCommand
 			cmdID := p.Message.SlashCommand.CommandId.String()
@@ -692,6 +716,29 @@ func commandNameFromText(msg *rawMessage) string {
 	return "scion"
 }
 
+// extractAttachments converts raw message attachments to normalized EventAttachment structs.
+func extractAttachments(msg *rawMessage) []chatapp.EventAttachment {
+	if msg == nil || len(msg.Attachment) == 0 {
+		return nil
+	}
+	var attachments []chatapp.EventAttachment
+	for _, a := range msg.Attachment {
+		if a.DownloadURI == "" {
+			continue
+		}
+		name := a.ContentName
+		if name == "" {
+			name = filepath.Base(a.Name)
+		}
+		attachments = append(attachments, chatapp.EventAttachment{
+			Name:        name,
+			ContentType: a.ContentType,
+			DownloadURI: a.DownloadURI,
+		})
+	}
+	return attachments
+}
+
 // getParameters extracts action parameters from commonEventObject.
 func (a *Adapter) getParameters(raw *rawEvent) map[string]string {
 	if raw.CommonEventObject != nil && raw.CommonEventObject.Parameters != nil {
@@ -724,6 +771,8 @@ func (a *Adapter) getFormInputs(raw *rawEvent) map[string]string {
 }
 
 // SendMessage sends a text or card message to a Google Chat space.
+// If the request includes attachments, each file is uploaded via UploadMedia
+// and attached to the message.
 func (a *Adapter) SendMessage(ctx context.Context, req chatapp.SendMessageRequest) (string, error) {
 	payload := map[string]any{}
 
@@ -740,6 +789,29 @@ func (a *Adapter) SendMessage(ctx context.Context, req chatapp.SendMessageReques
 				"cardId": "scion_card",
 				"card":   a.renderCardV2(req.Card),
 			},
+		}
+	}
+
+	// Upload attachments and include references in the message.
+	if len(req.Attachments) > 0 {
+		var attachmentRefs []map[string]any
+		for _, att := range req.Attachments {
+			resourceName, uploadErr := a.uploadAttachment(ctx, req.SpaceID, att)
+			if uploadErr != nil {
+				a.log.Error("failed to upload attachment",
+					"filename", att.Filename,
+					"error", uploadErr,
+				)
+				continue
+			}
+			attachmentRefs = append(attachmentRefs, map[string]any{
+				"attachmentDataRef": map[string]string{
+					"resourceName": resourceName,
+				},
+			})
+		}
+		if len(attachmentRefs) > 0 {
+			payload["attachment"] = attachmentRefs
 		}
 	}
 
@@ -763,6 +835,7 @@ func (a *Adapter) SendMessage(ctx context.Context, req chatapp.SendMessageReques
 		"thread", req.ThreadID,
 		"has_text", hasText,
 		"has_card", hasCard,
+		"has_attachments", len(req.Attachments) > 0,
 		"text_len", len(req.Text),
 	)
 
@@ -780,6 +853,35 @@ func (a *Adapter) SendMessage(ctx context.Context, req chatapp.SendMessageReques
 	}
 	a.log.Info("async message sent", "message_id", result.Name, "space", req.SpaceID)
 	return result.Name, nil
+}
+
+// uploadAttachment opens a local file (or reads from URL) and uploads it via UploadMedia.
+// Returns the attachment resource name. Enforces the 25 MB size limit.
+func (a *Adapter) uploadAttachment(ctx context.Context, spaceID string, att chatapp.Attachment) (string, error) {
+	if att.Path == "" {
+		return "", fmt.Errorf("attachment has no path")
+	}
+
+	fi, err := os.Stat(att.Path)
+	if err != nil {
+		return "", fmt.Errorf("stat attachment %q: %w", att.Path, err)
+	}
+	if fi.Size() > maxAttachmentSize {
+		return "", fmt.Errorf("attachment %q too large (%d bytes, max %d)", att.Filename, fi.Size(), maxAttachmentSize)
+	}
+
+	f, err := os.Open(att.Path)
+	if err != nil {
+		return "", fmt.Errorf("open attachment %q: %w", att.Path, err)
+	}
+	defer f.Close()
+
+	filename := att.Filename
+	if filename == "" {
+		filename = filepath.Base(att.Path)
+	}
+
+	return a.UploadMedia(ctx, spaceID, filename, f)
 }
 
 // SendCard sends a card-only message to a Google Chat space.
@@ -839,6 +941,104 @@ func (a *Adapter) GetUser(ctx context.Context, userID string) (*chatapp.ChatUser
 func (a *Adapter) SetAgentIdentity(ctx context.Context, agent chatapp.AgentIdentity) error {
 	a.log.Debug("agent identity set (used in card headers)", "slug", agent.Slug)
 	return nil
+}
+
+// UploadMedia uploads a file to a Google Chat space and returns the attachment
+// resource name for inclusion in messages.
+//
+// The upload uses the media.upload endpoint with multipart/form-data containing:
+//   - A JSON metadata part with the filename
+//   - The file content part
+//
+// See https://developers.google.com/workspace/chat/api/reference/rest/v1/media/upload
+func (a *Adapter) UploadMedia(ctx context.Context, spaceID, filename string, content io.Reader) (string, error) {
+	url := fmt.Sprintf("%s/%s/attachments:upload", uploadAPIBase, spaceID)
+
+	// Build multipart body: JSON metadata + file content.
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	// Part 1: JSON metadata with filename.
+	metaHeader := make(textproto.MIMEHeader)
+	metaHeader.Set("Content-Type", "application/json")
+	metaPart, err := writer.CreatePart(metaHeader)
+	if err != nil {
+		return "", fmt.Errorf("creating metadata part: %w", err)
+	}
+	metadata := map[string]string{"filename": filename}
+	if err := json.NewEncoder(metaPart).Encode(metadata); err != nil {
+		return "", fmt.Errorf("encoding metadata: %w", err)
+	}
+
+	// Part 2: file content.
+	filePart, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		return "", fmt.Errorf("creating file part: %w", err)
+	}
+	if _, err := io.Copy(filePart, content); err != nil {
+		return "", fmt.Errorf("copying file content: %w", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return "", fmt.Errorf("closing multipart writer: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, &body)
+	if err != nil {
+		return "", fmt.Errorf("creating upload request: %w", err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("uploading media: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading upload response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("upload failed (HTTP %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		AttachmentDataRef struct {
+			ResourceName string `json:"resourceName"`
+		} `json:"attachmentDataRef"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("parsing upload response: %w", err)
+	}
+
+	a.log.Info("uploaded media to Google Chat",
+		"space", spaceID,
+		"filename", filename,
+		"resource_name", result.AttachmentDataRef.ResourceName,
+	)
+	return result.AttachmentDataRef.ResourceName, nil
+}
+
+// DownloadAttachment downloads a file from a Google Chat attachment download URI.
+// The download requires authentication, which is handled by the adapter's httpClient.
+func (a *Adapter) DownloadAttachment(ctx context.Context, downloadURI string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURI, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating download request: %w", err)
+	}
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("downloading attachment: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("download failed (HTTP %d)", resp.StatusCode)
+	}
+
+	return resp.Body, nil
 }
 
 // renderCardV2 converts a platform-agnostic Card to Google Chat Cards V2 format.

--- a/extras/scion-chat-app/internal/googlechat/adapter.go
+++ b/extras/scion-chat-app/internal/googlechat/adapter.go
@@ -15,7 +15,6 @@
 package googlechat
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -38,8 +37,6 @@ const (
 	chatAPIBase  = "https://chat.googleapis.com/v1"
 	uploadAPIBase = "https://chat.googleapis.com/upload/v1"
 
-	// maxAttachmentSize is the maximum file size for uploads (25 MB, matching Discord).
-	maxAttachmentSize = 25 * 1024 * 1024
 )
 
 // EventHandler processes normalized chat events and returns an optional synchronous response.
@@ -795,6 +792,7 @@ func (a *Adapter) SendMessage(ctx context.Context, req chatapp.SendMessageReques
 	// Upload attachments and include references in the message.
 	if len(req.Attachments) > 0 {
 		var attachmentRefs []map[string]any
+		var failedAttachments []string
 		for _, att := range req.Attachments {
 			resourceName, uploadErr := a.uploadAttachment(ctx, req.SpaceID, att)
 			if uploadErr != nil {
@@ -802,6 +800,7 @@ func (a *Adapter) SendMessage(ctx context.Context, req chatapp.SendMessageReques
 					"filename", att.Filename,
 					"error", uploadErr,
 				)
+				failedAttachments = append(failedAttachments, att.Filename)
 				continue
 			}
 			attachmentRefs = append(attachmentRefs, map[string]any{
@@ -812,6 +811,16 @@ func (a *Adapter) SendMessage(ctx context.Context, req chatapp.SendMessageReques
 		}
 		if len(attachmentRefs) > 0 {
 			payload["attachment"] = attachmentRefs
+		}
+		// Surface upload failures in the message text so recipients know
+		// an attachment was intended but could not be delivered.
+		if len(failedAttachments) > 0 {
+			errNote := "\n\n_[Failed to upload: " + strings.Join(failedAttachments, ", ") + "]_"
+			if existing, ok := payload["text"].(string); ok {
+				payload["text"] = existing + errNote
+			} else {
+				payload["text"] = errNote
+			}
 		}
 	}
 
@@ -866,8 +875,8 @@ func (a *Adapter) uploadAttachment(ctx context.Context, spaceID string, att chat
 	if err != nil {
 		return "", fmt.Errorf("stat attachment %q: %w", att.Path, err)
 	}
-	if fi.Size() > maxAttachmentSize {
-		return "", fmt.Errorf("attachment %q too large (%d bytes, max %d)", att.Filename, fi.Size(), maxAttachmentSize)
+	if fi.Size() > chatapp.MaxAttachmentSize {
+		return "", fmt.Errorf("attachment %q too large (%d bytes, max %d)", att.Filename, fi.Size(), chatapp.MaxAttachmentSize)
 	}
 
 	f, err := os.Open(att.Path)
@@ -946,54 +955,82 @@ func (a *Adapter) SetAgentIdentity(ctx context.Context, agent chatapp.AgentIdent
 // UploadMedia uploads a file to a Google Chat space and returns the attachment
 // resource name for inclusion in messages.
 //
-// The upload uses the media.upload endpoint with multipart/form-data containing:
-//   - A JSON metadata part with the filename
-//   - The file content part
+// The upload uses the media.upload endpoint with multipart/related containing:
+//   - Part 1: JSON metadata with the filename (Content-Type: application/json)
+//   - Part 2: File content (Content-Type: application/octet-stream)
+//
+// The multipart body is streamed via io.Pipe to avoid buffering the entire file
+// in memory.
 //
 // See https://developers.google.com/workspace/chat/api/reference/rest/v1/media/upload
 func (a *Adapter) UploadMedia(ctx context.Context, spaceID, filename string, content io.Reader) (string, error) {
 	url := fmt.Sprintf("%s/%s/attachments:upload", uploadAPIBase, spaceID)
+	return a.uploadMediaToURL(ctx, url, filename, content)
+}
 
-	// Build multipart body: JSON metadata + file content.
-	var body bytes.Buffer
-	writer := multipart.NewWriter(&body)
+// uploadMediaToURL performs the actual multipart/related upload to the given URL.
+// Extracted from UploadMedia to allow tests to provide a test-server URL.
+func (a *Adapter) uploadMediaToURL(ctx context.Context, url, filename string, content io.Reader) (string, error) {
+	// Use io.Pipe to stream the multipart body without buffering the entire
+	// file in memory.
+	pr, pw := io.Pipe()
+	writer := multipart.NewWriter(pw)
+	contentType := fmt.Sprintf("multipart/related; boundary=%s", writer.Boundary())
 
-	// Part 1: JSON metadata with filename.
-	metaHeader := make(textproto.MIMEHeader)
-	metaHeader.Set("Content-Type", "application/json")
-	metaPart, err := writer.CreatePart(metaHeader)
-	if err != nil {
-		return "", fmt.Errorf("creating metadata part: %w", err)
-	}
-	metadata := map[string]string{"filename": filename}
-	if err := json.NewEncoder(metaPart).Encode(metadata); err != nil {
-		return "", fmt.Errorf("encoding metadata: %w", err)
-	}
+	// Write multipart parts in a goroutine so the HTTP request can read from
+	// the pipe reader concurrently.
+	var writeErr error
+	go func() {
+		defer pw.Close()
 
-	// Part 2: file content.
-	filePart, err := writer.CreateFormFile("file", filename)
-	if err != nil {
-		return "", fmt.Errorf("creating file part: %w", err)
-	}
-	if _, err := io.Copy(filePart, content); err != nil {
-		return "", fmt.Errorf("copying file content: %w", err)
-	}
+		// Part 1: JSON metadata.
+		metaHeader := make(textproto.MIMEHeader)
+		metaHeader.Set("Content-Type", "application/json")
+		metaPart, err := writer.CreatePart(metaHeader)
+		if err != nil {
+			writeErr = fmt.Errorf("creating metadata part: %w", err)
+			return
+		}
+		metadata := map[string]string{"filename": filename}
+		if err := json.NewEncoder(metaPart).Encode(metadata); err != nil {
+			writeErr = fmt.Errorf("encoding metadata: %w", err)
+			return
+		}
 
-	if err := writer.Close(); err != nil {
-		return "", fmt.Errorf("closing multipart writer: %w", err)
-	}
+		// Part 2: file content with explicit Content-Type header.
+		fileHeader := make(textproto.MIMEHeader)
+		fileHeader.Set("Content-Type", "application/octet-stream")
+		filePart, err := writer.CreatePart(fileHeader)
+		if err != nil {
+			writeErr = fmt.Errorf("creating file part: %w", err)
+			return
+		}
+		if _, err := io.Copy(filePart, content); err != nil {
+			writeErr = fmt.Errorf("copying file content: %w", err)
+			return
+		}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, &body)
+		if err := writer.Close(); err != nil {
+			writeErr = fmt.Errorf("closing multipart writer: %w", err)
+		}
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, pr)
 	if err != nil {
 		return "", fmt.Errorf("creating upload request: %w", err)
 	}
-	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Content-Type", contentType)
 
 	resp, err := a.httpClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("uploading media: %w", err)
 	}
 	defer resp.Body.Close()
+
+	// Check for errors from the writer goroutine.
+	if writeErr != nil {
+		return "", writeErr
+	}
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -1014,7 +1051,7 @@ func (a *Adapter) UploadMedia(ctx context.Context, spaceID, filename string, con
 	}
 
 	a.log.Info("uploaded media to Google Chat",
-		"space", spaceID,
+		"url", url,
 		"filename", filename,
 		"resource_name", result.AttachmentDataRef.ResourceName,
 	)

--- a/extras/scion-chat-app/internal/googlechat/adapter.go
+++ b/extras/scion-chat-app/internal/googlechat/adapter.go
@@ -33,10 +33,9 @@ import (
 )
 
 const (
-	PlatformName = "google_chat"
-	chatAPIBase  = "https://chat.googleapis.com/v1"
+	PlatformName  = "google_chat"
+	chatAPIBase   = "https://chat.googleapis.com/v1"
 	uploadAPIBase = "https://chat.googleapis.com/upload/v1"
-
 )
 
 // EventHandler processes normalized chat events and returns an optional synchronous response.
@@ -496,13 +495,13 @@ type rawSpace struct {
 }
 
 type rawMessage struct {
-	Name         string            `json:"name"`
-	Text         string            `json:"text"`
-	ArgumentText string            `json:"argumentText"`
-	Thread       *rawThread        `json:"thread,omitempty"`
-	Annotations  []rawAnnotation   `json:"annotations,omitempty"`
-	SlashCommand *rawSlashCommand  `json:"slashCommand,omitempty"`
-	Attachment   []rawAttachment   `json:"attachment,omitempty"`
+	Name         string           `json:"name"`
+	Text         string           `json:"text"`
+	ArgumentText string           `json:"argumentText"`
+	Thread       *rawThread       `json:"thread,omitempty"`
+	Annotations  []rawAnnotation  `json:"annotations,omitempty"`
+	SlashCommand *rawSlashCommand `json:"slashCommand,omitempty"`
+	Attachment   []rawAttachment  `json:"attachment,omitempty"`
 }
 
 type rawAttachment struct {
@@ -979,9 +978,17 @@ func (a *Adapter) uploadMediaToURL(ctx context.Context, url, filename string, co
 
 	// Write multipart parts in a goroutine so the HTTP request can read from
 	// the pipe reader concurrently.
-	var writeErr error
+	errChan := make(chan error, 1)
 	go func() {
-		defer pw.Close()
+		var writeErr error
+		defer func() {
+			if writeErr != nil {
+				pw.CloseWithError(writeErr)
+			} else {
+				pw.Close()
+			}
+			errChan <- writeErr
+		}()
 
 		// Part 1: JSON metadata.
 		metaHeader := make(textproto.MIMEHeader)
@@ -1028,7 +1035,7 @@ func (a *Adapter) uploadMediaToURL(ctx context.Context, url, filename string, co
 	defer resp.Body.Close()
 
 	// Check for errors from the writer goroutine.
-	if writeErr != nil {
+	if writeErr := <-errChan; writeErr != nil {
 		return "", writeErr
 	}
 

--- a/extras/scion-chat-app/internal/googlechat/adapter_test.go
+++ b/extras/scion-chat-app/internal/googlechat/adapter_test.go
@@ -401,8 +401,8 @@ func TestExtractAttachments(t *testing.T) {
 			msg: &rawMessage{
 				Attachment: []rawAttachment{
 					{Name: "a/1", ContentName: "file1.txt", DownloadURI: "https://example.com/1"},
-					{Name: "a/2", ContentName: "", DownloadURI: "https://example.com/2"},       // empty content name, uses Name
-					{Name: "a/3", ContentName: "file3.txt", DownloadURI: ""},                    // skipped: no URI
+					{Name: "a/2", ContentName: "", DownloadURI: "https://example.com/2"}, // empty content name, uses Name
+					{Name: "a/3", ContentName: "file3.txt", DownloadURI: ""},             // skipped: no URI
 					{Name: "a/4", ContentName: "file4.txt", DownloadURI: "https://example.com/4"},
 				},
 			},

--- a/extras/scion-chat-app/internal/googlechat/adapter_test.go
+++ b/extras/scion-chat-app/internal/googlechat/adapter_test.go
@@ -15,8 +15,15 @@
 package googlechat
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/extras/scion-chat-app/internal/chatapp"
@@ -340,6 +347,272 @@ func TestNormalizeEvent_NilChat(t *testing.T) {
 	event := adapter.normalizeEvent(&rawEvent{})
 	if event != nil {
 		t.Errorf("expected nil event for empty rawEvent, got %+v", event)
+	}
+}
+
+// --- extractAttachments tests ---
+
+func TestExtractAttachments(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *rawMessage
+		want int // number of attachments expected
+	}{
+		{
+			name: "nil message returns nil",
+			msg:  nil,
+			want: 0,
+		},
+		{
+			name: "message with no attachments",
+			msg:  &rawMessage{Text: "hello"},
+			want: 0,
+		},
+		{
+			name: "single attachment",
+			msg: &rawMessage{
+				Attachment: []rawAttachment{
+					{
+						Name:        "attachments/abc",
+						ContentName: "report.pdf",
+						ContentType: "application/pdf",
+						DownloadURI: "https://example.com/download/abc",
+					},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "attachment without download URI is skipped",
+			msg: &rawMessage{
+				Attachment: []rawAttachment{
+					{
+						Name:        "attachments/abc",
+						ContentName: "report.pdf",
+						ContentType: "application/pdf",
+						DownloadURI: "", // empty
+					},
+				},
+			},
+			want: 0,
+		},
+		{
+			name: "multiple attachments mixed",
+			msg: &rawMessage{
+				Attachment: []rawAttachment{
+					{Name: "a/1", ContentName: "file1.txt", DownloadURI: "https://example.com/1"},
+					{Name: "a/2", ContentName: "", DownloadURI: "https://example.com/2"},       // empty content name, uses Name
+					{Name: "a/3", ContentName: "file3.txt", DownloadURI: ""},                    // skipped: no URI
+					{Name: "a/4", ContentName: "file4.txt", DownloadURI: "https://example.com/4"},
+				},
+			},
+			want: 3, // a/1, a/2, a/4
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractAttachments(tt.msg)
+			if len(got) != tt.want {
+				t.Errorf("extractAttachments returned %d attachments, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractAttachments_FallbackName(t *testing.T) {
+	msg := &rawMessage{
+		Attachment: []rawAttachment{
+			{
+				Name:        "attachments/some-id/report.pdf",
+				ContentName: "", // empty content name
+				ContentType: "application/pdf",
+				DownloadURI: "https://example.com/download",
+			},
+		},
+	}
+	got := extractAttachments(msg)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(got))
+	}
+	// Should fall back to filepath.Base(Name) = "report.pdf"
+	if got[0].Name != "report.pdf" {
+		t.Errorf("Name = %q, want %q", got[0].Name, "report.pdf")
+	}
+}
+
+func TestExtractAttachments_PreferContentName(t *testing.T) {
+	msg := &rawMessage{
+		Attachment: []rawAttachment{
+			{
+				Name:        "attachments/id",
+				ContentName: "user-named.docx",
+				ContentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+				DownloadURI: "https://example.com/download",
+			},
+		},
+	}
+	got := extractAttachments(msg)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(got))
+	}
+	if got[0].Name != "user-named.docx" {
+		t.Errorf("Name = %q, want %q", got[0].Name, "user-named.docx")
+	}
+}
+
+// --- extractAttachments via normalizeEvent integration ---
+
+func TestNormalizeEvent_MessageWithAttachments(t *testing.T) {
+	adapter := NewAdapter(Config{}, nil, nil, slog.Default())
+
+	event := adapter.normalizeEvent(&rawEvent{
+		Chat: &rawChatPayload{
+			User: &rawUser{Name: "users/1", Email: "u@e.com"},
+			MessagePayload: &rawMessagePayload{
+				Space: &rawSpace{Name: "spaces/s"},
+				Message: &rawMessage{
+					Text: "here are the files",
+					Attachment: []rawAttachment{
+						{
+							ContentName: "data.csv",
+							ContentType: "text/csv",
+							DownloadURI: "https://example.com/dl/1",
+						},
+						{
+							ContentName: "image.png",
+							ContentType: "image/png",
+							DownloadURI: "https://example.com/dl/2",
+						},
+					},
+				},
+			},
+		},
+	})
+	if event == nil {
+		t.Fatal("normalizeEvent returned nil")
+	}
+	if event.Type != chatapp.EventMessage {
+		t.Errorf("Type = %q, want %q", event.Type, chatapp.EventMessage)
+	}
+	if len(event.Attachments) != 2 {
+		t.Errorf("got %d attachments, want 2", len(event.Attachments))
+	}
+	if event.Attachments[0].Name != "data.csv" {
+		t.Errorf("Attachments[0].Name = %q, want %q", event.Attachments[0].Name, "data.csv")
+	}
+}
+
+// --- UploadMedia tests ---
+
+func TestUploadMedia_MultipartRelatedFormat(t *testing.T) {
+	// Set up a test server that captures the request to verify multipart format.
+	var capturedContentType string
+	var capturedBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedContentType = r.Header.Get("Content-Type")
+		var err error
+		capturedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"attachmentDataRef":{"resourceName":"spaces/abc/attachments/123"}}`))
+	}))
+	defer server.Close()
+
+	adapter := NewAdapter(Config{}, nil, server.Client(), slog.Default())
+	// Override the upload URL base for testing.
+	content := strings.NewReader("file content here")
+
+	// We need to override the URL. Since UploadMedia constructs the URL internally,
+	// we'll test via the captured request. We need to make the adapter point to our
+	// test server. Let's test directly by calling with a space that routes to our server.
+	// Patch the upload URL by using the test server URL.
+	result, err := adapter.uploadMediaToURL(context.Background(), server.URL+"/upload", "test.txt", content)
+	if err != nil {
+		t.Fatalf("UploadMedia failed: %v", err)
+	}
+	if result != "spaces/abc/attachments/123" {
+		t.Errorf("resource name = %q, want %q", result, "spaces/abc/attachments/123")
+	}
+
+	// Verify Content-Type is multipart/related, not multipart/form-data.
+	if !strings.HasPrefix(capturedContentType, "multipart/related") {
+		t.Errorf("Content-Type = %q, want multipart/related prefix", capturedContentType)
+	}
+
+	// Parse the multipart body and verify both parts use CreatePart style.
+	_, params, err := mime.ParseMediaType(capturedContentType)
+	if err != nil {
+		t.Fatalf("parsing Content-Type: %v", err)
+	}
+	boundary := params["boundary"]
+	if boundary == "" {
+		t.Fatal("no boundary in Content-Type")
+	}
+
+	reader := multipart.NewReader(strings.NewReader(string(capturedBody)), boundary)
+
+	// Part 1: JSON metadata.
+	part1, err := reader.NextPart()
+	if err != nil {
+		t.Fatalf("reading part 1: %v", err)
+	}
+	if ct := part1.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("part 1 Content-Type = %q, want %q", ct, "application/json")
+	}
+	// Part 1 should NOT have Content-Disposition: form-data.
+	if cd := part1.Header.Get("Content-Disposition"); strings.Contains(cd, "form-data") {
+		t.Errorf("part 1 should not have form-data disposition, got: %q", cd)
+	}
+	meta, _ := io.ReadAll(part1)
+	if !strings.Contains(string(meta), "test.txt") {
+		t.Errorf("metadata should contain filename, got: %s", string(meta))
+	}
+
+	// Part 2: file content.
+	part2, err := reader.NextPart()
+	if err != nil {
+		t.Fatalf("reading part 2: %v", err)
+	}
+	if ct := part2.Header.Get("Content-Type"); ct != "application/octet-stream" {
+		t.Errorf("part 2 Content-Type = %q, want %q", ct, "application/octet-stream")
+	}
+	// Part 2 should NOT have Content-Disposition: form-data.
+	if cd := part2.Header.Get("Content-Disposition"); strings.Contains(cd, "form-data") {
+		t.Errorf("part 2 should not have form-data disposition, got: %q", cd)
+	}
+	fileContent, _ := io.ReadAll(part2)
+	if string(fileContent) != "file content here" {
+		t.Errorf("file content = %q, want %q", string(fileContent), "file content here")
+	}
+
+	// Should be no more parts.
+	_, err = reader.NextPart()
+	if err != io.EOF {
+		t.Errorf("expected EOF after 2 parts, got: %v", err)
+	}
+}
+
+func TestUploadMedia_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"error":"permission denied"}`))
+	}))
+	defer server.Close()
+
+	adapter := NewAdapter(Config{}, nil, server.Client(), slog.Default())
+	content := strings.NewReader("data")
+
+	_, err := adapter.uploadMediaToURL(context.Background(), server.URL+"/upload", "test.txt", content)
+	if err == nil {
+		t.Fatal("expected error for HTTP 403")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error should mention status code 403, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Enable bidirectional file transfer between agents and Google Chat via the Chat API media.upload endpoint.

Key changes:
- extras/scion-chat-app/internal/googlechat/adapter.go: UploadMedia via streaming multipart/related (no full-file buffering)
- extras/scion-chat-app/internal/chatapp/broker.go: inbound attachment download to shared volume, outbound attachment resolution and upload
- extras/scion-chat-app/internal/chatapp/messenger.go: Attachment type and UploadMedia interface method
- 25 MB size limit, path traversal defenses, 52+ tests

Ref: ptone/scion#914
