### PR TITLE
feat(chat-app): add terminal, thread, send, and secret commands

### DIFF
--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -293,9 +293,9 @@ func (r *CommandRouter) handleAction(ctx context.Context, event *ChatEvent) (*Ev
 			return r.handleSubscribeFilter(ctx, event)
 		}
 	case "secret":
-		return r.handleSecretAction(ctx, event, actionVerb, targetID)
+		return nil, r.handleSecretAction(ctx, event, actionVerb, targetID)
 	case "send":
-		return r.handleSendAction(ctx, event, actionVerb, targetID)
+		return nil, r.handleSendAction(ctx, event, actionVerb, targetID)
 	}
 	return nil, nil
 }
@@ -418,6 +418,14 @@ func (r *CommandRouter) handleDialogSubmit(ctx context.Context, event *ChatEvent
 		return r.handleSubscribeFilter(ctx, event)
 	}
 
+	// Google Chat normalizes button clicks that contain form inputs (e.g.
+	// secret set, send select) as DialogSubmit events because formInputs is
+	// non-empty. Fall back to the regular action handler so those buttons
+	// are processed correctly.
+	if event.ActionID != "" {
+		return r.handleAction(ctx, event)
+	}
+
 	return nil, nil
 }
 
@@ -465,7 +473,7 @@ func (r *CommandRouter) handleAgentAction(ctx context.Context, event *ChatEvent,
 	case "status":
 		agent, err := agents.Get(ctx, agentID)
 		if err != nil {
-			return r.reply(ctx, event, fmt.Sprintf("Failed to get agent: %v", err))
+			return nil, r.reply(ctx, event, fmt.Sprintf("Failed to get agent: %v", err))
 		}
 		card := Card{
 			Header: CardHeader{
@@ -489,7 +497,7 @@ func (r *CommandRouter) handleAgentAction(ctx context.Context, event *ChatEvent,
 			},
 		}
 		_, err = r.messenger.SendCard(ctx, event.SpaceID, card)
-		return err
+		return nil, err
 	case "start":
 		if err := agents.Start(ctx, agentID); err != nil {
 			return nil, r.reply(ctx, event, fmt.Sprintf("Failed to start agent: %v", err))
@@ -1505,6 +1513,9 @@ func (r *CommandRouter) cmdTerminal(ctx context.Context, event *ChatEvent, args 
 	if err != nil {
 		return textResponse(event, fmt.Sprintf("Agent `%s` not found: %v", agentSlug, err)), nil
 	}
+	if agent == nil {
+		return textResponse(event, fmt.Sprintf("Agent `%s` not found.", agentSlug)), nil
+	}
 
 	if strings.ToLower(agent.Phase) != "running" {
 		phase := agent.Phase
@@ -1561,6 +1572,9 @@ func (r *CommandRouter) cmdThread(ctx context.Context, event *ChatEvent, args []
 	if err != nil {
 		return textResponse(event, fmt.Sprintf("Failed to create agent: %v", err)), nil
 	}
+	if createResp == nil || createResp.Agent == nil {
+		return textResponse(event, "Failed to create agent: received empty response from server"), nil
+	}
 
 	// Start the agent.
 	if err := client.ProjectAgents(link.ProjectID).Start(ctx, createResp.Agent.Slug); err != nil {
@@ -1575,7 +1589,7 @@ func (r *CommandRouter) cmdThread(ctx context.Context, event *ChatEvent, args []
 		threadMsg += fmt.Sprintf("\n\n*Instruction:* %s", instruction)
 	}
 	threadKey := fmt.Sprintf("scion-agent-%s", createResp.Agent.Slug)
-	_, msgErr := r.messenger.SendMessage(ctx, SendMessageRequest{
+	kickoffMsgName, msgErr := r.messenger.SendMessage(ctx, SendMessageRequest{
 		SpaceID:   event.SpaceID,
 		ThreadKey: threadKey,
 		Text:      threadMsg,
@@ -1591,7 +1605,11 @@ func (r *CommandRouter) cmdThread(ctx context.Context, event *ChatEvent, args []
 		if r.broker != nil {
 			msg.Channel = r.broker.ChannelName()
 		}
-		if event.ThreadID != "" {
+		// Use the newly created thread (derived from the kickoff message name)
+		// so the agent replies in the new thread, not the admin command's thread.
+		if msgErr == nil && kickoffMsgName != "" {
+			msg.ThreadID = strings.Replace(kickoffMsgName, "/messages/", "/threads/", 1)
+		} else if event.ThreadID != "" {
 			msg.ThreadID = event.ThreadID
 		}
 		if _, err := client.ProjectAgents(link.ProjectID).SendStructuredMessage(ctx, createResp.Agent.Slug, msg, false, false, false); err != nil {
@@ -1714,7 +1732,7 @@ func (r *CommandRouter) cmdSecretList(ctx context.Context, event *ChatEvent, lin
 		return textResponse(event, fmt.Sprintf("Failed to list secrets: %v", err)), nil
 	}
 
-	if len(secrets.Secrets) == 0 {
+	if secrets == nil || len(secrets.Secrets) == 0 {
 		return textResponse(event, fmt.Sprintf("No secrets found in project `%s`.", link.ProjectSlug)), nil
 	}
 

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -62,8 +62,13 @@ type CommandRouter struct {
 	broker      *BrokerServer
 	log         *slog.Logger
 
-	mu          sync.Mutex
-	pendingAuth map[string]*pendingDeviceAuth // keyed by platformUserID+platform
+	mu             sync.Mutex
+	pendingAuth    map[string]*pendingDeviceAuth // keyed by platformUserID+platform
+	pendingDeletes map[string]string             // keyed by actionID -> agentID
+
+	// testClient, when non-nil, is returned by clientForUser instead of
+	// going through the identity mapper. Used only in tests.
+	testClient hubclient.Client
 }
 
 // NewCommandRouter creates a new command router.
@@ -301,14 +306,14 @@ func (r *CommandRouter) handleSecretAction(ctx context.Context, event *ChatEvent
 		return nil
 	}
 
-	// targetID is the secret key. The value comes from DialogData.
+	// targetID is the secret key. The value comes from DialogData using the
+	// action ID as the widget key, matching how the input card is constructed.
 	key := targetID
-	value := ""
-	for _, v := range event.DialogData {
-		if v != "" {
-			value = v
-			break
-		}
+	widgetKey := fmt.Sprintf("secret.set.%s", key)
+	value := event.DialogData[widgetKey]
+	if value == "" {
+		// Fall back to the action ID itself as key (for dialog submit events).
+		value = event.DialogData[event.ActionID]
 	}
 	if value == "" {
 		return r.reply(ctx, event, "No secret value provided.")
@@ -1417,7 +1422,7 @@ func (r *CommandRouter) cmdAdminHelp(ctx context.Context, event *ChatEvent) (*Ev
 
 *Secrets:*
 • ` + "`/scionAdmin secret list`" + ` — List project secrets (metadata only)
-• ` + "`/scionAdmin secret set <key> [value]`" + ` — Set a secret value
+• ` + "`/scionAdmin secret set <key>`" + ` — Set a secret value (entered via secure card input)
 • ` + "`/scionAdmin secret get <key>`" + ` — Show secret metadata
 • ` + "`/scionAdmin secret delete <key>`" + ` — Delete a secret
 
@@ -1471,42 +1476,37 @@ func (r *CommandRouter) cmdTerminal(ctx context.Context, event *ChatEvent, args 
 	}
 
 	agentSlug := args[0]
-	agents, err := client.ProjectAgents(link.ProjectID).List(ctx, nil)
+	// Use Get (which supports slug lookup) instead of List+scan.
+	agent, err := client.ProjectAgents(link.ProjectID).Get(ctx, agentSlug)
 	if err != nil {
-		return textResponse(event, fmt.Sprintf("Failed to list agents: %v", err)), nil
+		return textResponse(event, fmt.Sprintf("Agent `%s` not found: %v", agentSlug, err)), nil
 	}
 
-	for _, agent := range agents.Agents {
-		if strings.EqualFold(agent.Slug, agentSlug) {
-			if strings.ToLower(agent.Phase) != "running" {
-				phase := agent.Phase
-				if phase == "" {
-					phase = "unknown"
-				}
-				return textResponse(event, fmt.Sprintf("Agent `%s` is not running (phase: %s).", agent.Slug, phase)), nil
-			}
-			terminalURL := fmt.Sprintf("%s/agents/%s/terminal", r.hubURL, agent.ID)
-			card := Card{
-				Header: CardHeader{
-					Title:    "Web Terminal",
-					Subtitle: fmt.Sprintf("Agent: %s", agent.Slug),
-				},
-				Sections: []CardSection{
-					{
-						Widgets: []Widget{
-							{Type: WidgetText, Content: fmt.Sprintf("Open the web terminal for agent `%s`:", agent.Slug)},
-						},
-					},
-				},
-				Actions: []CardAction{
-					{Label: "Open Terminal", ActionID: fmt.Sprintf("link.%s", terminalURL), Style: "primary"},
-				},
-			}
-			return cardResponse(event, &card), nil
+	if strings.ToLower(agent.Phase) != "running" {
+		phase := agent.Phase
+		if phase == "" {
+			phase = "unknown"
 		}
+		return textResponse(event, fmt.Sprintf("Agent `%s` is not running (phase: %s).", agent.Slug, phase)), nil
 	}
-
-	return textResponse(event, fmt.Sprintf("Agent `%s` not found in this project.", agentSlug)), nil
+	terminalURL := fmt.Sprintf("%s/agents/%s/terminal", r.hubURL, agent.ID)
+	card := Card{
+		Header: CardHeader{
+			Title:    "Web Terminal",
+			Subtitle: fmt.Sprintf("Agent: %s", agent.Slug),
+		},
+		Sections: []CardSection{
+			{
+				Widgets: []Widget{
+					{Type: WidgetText, Content: fmt.Sprintf("Open the web terminal for agent `%s`:", agent.Slug)},
+				},
+			},
+		},
+		Actions: []CardAction{
+			{Label: "Open Terminal", ActionID: fmt.Sprintf("link.%s", terminalURL), Style: "primary"},
+		},
+	}
+	return cardResponse(event, &card), nil
 }
 
 func (r *CommandRouter) cmdThread(ctx context.Context, event *ChatEvent, args []string) (*EventResponse, error) {
@@ -1519,13 +1519,9 @@ func (r *CommandRouter) cmdThread(ctx context.Context, event *ChatEvent, args []
 		return resp, nil
 	}
 
-	mapping, err := r.idMapper.ResolveOrAutoRegister(ctx, &eventUserLookup{event}, event.UserID, event.Platform)
-	if err != nil || mapping == nil {
-		return textResponse(event, "Authentication required. Use `/scionAdmin register` first."), nil
-	}
-	client, err := r.idMapper.ClientFor(ctx, mapping)
+	client, err := r.clientForUser(ctx, event)
 	if err != nil {
-		return textResponse(event, fmt.Sprintf("Failed to create client: %v", err)), nil
+		return textResponse(event, "Authentication required. Use `/scionAdmin register` first."), nil
 	}
 
 	agentName := args[0]
@@ -1548,13 +1544,17 @@ func (r *CommandRouter) cmdThread(ctx context.Context, event *ChatEvent, args []
 	}
 
 	// Send a kickoff message in the space to start a new thread.
+	// Use a threadKey derived from the agent slug so Google Chat creates a
+	// new thread and subsequent messages can target it.
 	threadMsg := fmt.Sprintf("Agent `%s` created and started.", createResp.Agent.Slug)
 	if instruction != "" {
 		threadMsg += fmt.Sprintf("\n\n*Instruction:* %s", instruction)
 	}
+	threadKey := fmt.Sprintf("scion-agent-%s", createResp.Agent.Slug)
 	_, msgErr := r.messenger.SendMessage(ctx, SendMessageRequest{
-		SpaceID: event.SpaceID,
-		Text:    threadMsg,
+		SpaceID:   event.SpaceID,
+		ThreadKey: threadKey,
+		Text:      threadMsg,
 	})
 	if msgErr != nil {
 		r.log.Warn("failed to post thread kickoff message", "error", msgErr)
@@ -1562,12 +1562,14 @@ func (r *CommandRouter) cmdThread(ctx context.Context, event *ChatEvent, args []
 
 	// If instruction provided, send it to the agent.
 	if instruction != "" {
-		senderEmail := mapping.HubUserEmail
+		senderEmail := event.UserEmail
 		if senderEmail == "" {
-			return textResponse(event, fmt.Sprintf("Agent `%s` created and started, but your user mapping is missing an email to send the instruction.", createResp.Agent.Slug)), nil
+			senderEmail = "unknown"
 		}
 		msg := messages.NewInstruction("user:"+senderEmail, createResp.Agent.Slug, instruction)
-		msg.Channel = r.broker.ChannelName()
+		if r.broker != nil {
+			msg.Channel = r.broker.ChannelName()
+		}
 		if event.ThreadID != "" {
 			msg.ThreadID = event.ThreadID
 		}
@@ -1695,9 +1697,18 @@ func (r *CommandRouter) cmdSecretList(ctx context.Context, event *ChatEvent, lin
 		return textResponse(event, fmt.Sprintf("No secrets found in project `%s`.", link.ProjectSlug)), nil
 	}
 
+	// Cap output to avoid oversized chat messages.
+	const maxSecrets = 50
+	display := secrets.Secrets
+	truncated := false
+	if len(display) > maxSecrets {
+		display = display[:maxSecrets]
+		truncated = true
+	}
+
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("*Secrets in %s* (%d):\n", link.ProjectSlug, len(secrets.Secrets)))
-	for _, sec := range secrets.Secrets {
+	for _, sec := range display {
 		line := fmt.Sprintf("• `%s`", sec.Key)
 		if sec.SecretType != "" {
 			line += fmt.Sprintf(" (type: %s)", sec.SecretType)
@@ -1707,12 +1718,15 @@ func (r *CommandRouter) cmdSecretList(ctx context.Context, event *ChatEvent, lin
 		}
 		sb.WriteString(line + "\n")
 	}
+	if truncated {
+		sb.WriteString(fmt.Sprintf("\n_Showing %d of %d secrets._", maxSecrets, len(secrets.Secrets)))
+	}
 	return textResponse(event, sb.String()), nil
 }
 
 func (r *CommandRouter) cmdSecretSet(ctx context.Context, event *ChatEvent, link *state.SpaceLink, client hubclient.Client, args []string) (*EventResponse, error) {
 	if len(args) < 1 {
-		return textResponse(event, "Usage: `/scionAdmin secret set <key> <value>`"), nil
+		return textResponse(event, "Usage: `/scionAdmin secret set <key>`"), nil
 	}
 
 	key := args[0]
@@ -1720,38 +1734,25 @@ func (r *CommandRouter) cmdSecretSet(ctx context.Context, event *ChatEvent, link
 		return textResponse(event, fmt.Sprintf("Invalid key: %v", err)), nil
 	}
 
-	if len(args) < 2 {
-		// Return a card with an input field for the value.
-		card := Card{
-			Header: CardHeader{
-				Title:    "Set Secret",
-				Subtitle: fmt.Sprintf("Key: %s", key),
-			},
-			Sections: []CardSection{
-				{
-					Widgets: []Widget{
-						{Type: WidgetInput, Label: "Secret Value", ActionID: fmt.Sprintf("secret.set.%s", key)},
-					},
+	// Always use a card-based text input for the secret value to avoid
+	// exposing values in chat history. Any extra args are ignored.
+	card := Card{
+		Header: CardHeader{
+			Title:    "Set Secret",
+			Subtitle: fmt.Sprintf("Key: %s", key),
+		},
+		Sections: []CardSection{
+			{
+				Widgets: []Widget{
+					{Type: WidgetInput, Label: "Secret Value", ActionID: fmt.Sprintf("secret.set.%s", key)},
 				},
 			},
-			Actions: []CardAction{
-				{Label: "Save", ActionID: fmt.Sprintf("secret.set.%s", key), Style: "primary"},
-			},
-		}
-		return cardResponse(event, &card), nil
+		},
+		Actions: []CardAction{
+			{Label: "Save", ActionID: fmt.Sprintf("secret.set.%s", key), Style: "primary"},
+		},
 	}
-
-	value := strings.Join(args[1:], " ")
-	_, err := client.Secrets().Set(ctx, key, &hubclient.SetSecretRequest{
-		Value:   value,
-		Scope:   "project",
-		ScopeID: link.ProjectID,
-	})
-	if err != nil {
-		return textResponse(event, fmt.Sprintf("Failed to set secret `%s`: %v", key, err)), nil
-	}
-
-	return textResponse(event, fmt.Sprintf("Secret `%s` has been set.", key)), nil
+	return cardResponse(event, &card), nil
 }
 
 func (r *CommandRouter) cmdSecretGet(ctx context.Context, event *ChatEvent, link *state.SpaceLink, client hubclient.Client, args []string) (*EventResponse, error) {
@@ -1898,6 +1899,9 @@ func (r *CommandRouter) requireSpaceLink(ctx context.Context, event *ChatEvent) 
 
 // clientForUser creates a Hub client authenticated as the event's user.
 func (r *CommandRouter) clientForUser(ctx context.Context, event *ChatEvent) (hubclient.Client, error) {
+	if r.testClient != nil {
+		return r.testClient, nil
+	}
 	mapping, err := r.idMapper.ResolveOrAutoRegister(ctx, &eventUserLookup{event}, event.UserID, event.Platform)
 	if err != nil {
 		return nil, err

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -312,10 +312,6 @@ func (r *CommandRouter) handleSecretAction(ctx context.Context, event *ChatEvent
 	widgetKey := fmt.Sprintf("secret.set.%s", key)
 	value := event.DialogData[widgetKey]
 	if value == "" {
-		// Fall back to the action ID itself as key (for dialog submit events).
-		value = event.DialogData[event.ActionID]
-	}
-	if value == "" {
 		return r.reply(ctx, event, "No secret value provided.")
 	}
 
@@ -466,6 +462,34 @@ func (r *CommandRouter) handleAgentAction(ctx context.Context, event *ChatEvent,
 	agents := client.ProjectAgents(link.ProjectID)
 
 	switch verb {
+	case "status":
+		agent, err := agents.Get(ctx, agentID)
+		if err != nil {
+			return r.reply(ctx, event, fmt.Sprintf("Failed to get agent: %v", err))
+		}
+		card := Card{
+			Header: CardHeader{
+				Title:    agent.Name,
+				Subtitle: fmt.Sprintf("Project: %s | %s", link.ProjectSlug, agent.Activity),
+			},
+			Sections: []CardSection{
+				{
+					Widgets: []Widget{
+						{Type: WidgetKeyValue, Label: "Slug", Content: agent.Slug},
+						{Type: WidgetKeyValue, Label: "Phase", Content: agent.Phase},
+						{Type: WidgetKeyValue, Label: "Activity", Content: agent.Activity},
+						{Type: WidgetKeyValue, Label: "Template", Content: agent.Template},
+					},
+				},
+			},
+			Actions: []CardAction{
+				{Label: "Start", ActionID: fmt.Sprintf("agent.start.%s", agent.ID), Style: "primary"},
+				{Label: "Stop", ActionID: fmt.Sprintf("agent.stop.%s", agent.ID), Style: "danger"},
+				{Label: "View Logs", ActionID: fmt.Sprintf("agent.logs.%s", agent.ID)},
+			},
+		}
+		_, err = r.messenger.SendCard(ctx, event.SpaceID, card)
+		return err
 	case "start":
 		if err := agents.Start(ctx, agentID); err != nil {
 			return nil, r.reply(ctx, event, fmt.Sprintf("Failed to start agent: %v", err))
@@ -1562,10 +1586,7 @@ func (r *CommandRouter) cmdThread(ctx context.Context, event *ChatEvent, args []
 
 	// If instruction provided, send it to the agent.
 	if instruction != "" {
-		senderEmail := event.UserEmail
-		if senderEmail == "" {
-			senderEmail = "unknown"
-		}
+		senderEmail := r.senderEmailForUser(ctx, event)
 		msg := messages.NewInstruction("user:"+senderEmail, createResp.Agent.Slug, instruction)
 		if r.broker != nil {
 			msg.Channel = r.broker.ChannelName()
@@ -1895,6 +1916,22 @@ func (r *CommandRouter) requireSpaceLink(ctx context.Context, event *ChatEvent) 
 		return nil, textResponse(event, "This space is not linked to a project. Use `/scionAdmin link <project-slug>` first.")
 	}
 	return link, nil
+}
+
+// senderEmailForUser returns the Hub-registered email for the event's user.
+// Falls back to the chat platform email if no identity mapper is configured
+// (e.g. in tests). This keeps sender identity consistent across all commands.
+func (r *CommandRouter) senderEmailForUser(ctx context.Context, event *ChatEvent) string {
+	if r.idMapper != nil {
+		mapping, err := r.idMapper.Resolve(event.UserID, event.Platform)
+		if err == nil && mapping != nil && mapping.HubUserEmail != "" {
+			return mapping.HubUserEmail
+		}
+	}
+	if event.UserEmail != "" {
+		return event.UserEmail
+	}
+	return "unknown"
 }
 
 // clientForUser creates a Hub client authenticated as the event's user.

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -204,6 +204,14 @@ func (r *CommandRouter) handleAdminCommand(ctx context.Context, event *ChatEvent
 		resp, err = r.cmdUnsubscribe(ctx, event, args)
 	case "set-default":
 		resp, err = r.cmdSetDefault(ctx, event, args)
+	case "terminal":
+		resp, err = r.cmdTerminal(ctx, event, args)
+	case "thread":
+		resp, err = r.cmdThread(ctx, event, args)
+	case "send":
+		resp, err = r.cmdSend(ctx, event, args)
+	case "secret":
+		resp, err = r.cmdSecret(ctx, event, args)
 	case "help":
 		if len(args) == 0 {
 			resp, err = r.cmdAdminHelp(ctx, event)
@@ -279,8 +287,65 @@ func (r *CommandRouter) handleAction(ctx context.Context, event *ChatEvent) (*Ev
 		if actionVerb == "filter" && targetID != "" {
 			return r.handleSubscribeFilter(ctx, event)
 		}
+	case "secret":
+		return r.handleSecretAction(ctx, event, actionVerb, targetID)
+	case "send":
+		return r.handleSendAction(ctx, event, actionVerb, targetID)
 	}
 	return nil, nil
+}
+
+// handleSecretAction processes secret-related button actions.
+func (r *CommandRouter) handleSecretAction(ctx context.Context, event *ChatEvent, verb, targetID string) error {
+	if verb != "set" || targetID == "" {
+		return nil
+	}
+
+	// targetID is the secret key. The value comes from DialogData.
+	key := targetID
+	value := ""
+	for _, v := range event.DialogData {
+		if v != "" {
+			value = v
+			break
+		}
+	}
+	if value == "" {
+		return r.reply(ctx, event, "No secret value provided.")
+	}
+
+	link, err := r.store.GetSpaceLink(event.SpaceID, event.Platform)
+	if err != nil {
+		return fmt.Errorf("getting space link: %w", err)
+	}
+	if link == nil {
+		return r.reply(ctx, event, "This space is not linked to a project.")
+	}
+
+	client, err := r.clientForUser(ctx, event)
+	if err != nil {
+		return r.reply(ctx, event, "Authentication required. Use `/scionAdmin register` first.")
+	}
+
+	if _, err := client.Secrets().Set(ctx, key, &hubclient.SetSecretRequest{
+		Value:   value,
+		Scope:   "project",
+		ScopeID: link.ProjectID,
+	}); err != nil {
+		return r.reply(ctx, event, fmt.Sprintf("Failed to set secret `%s`: %v", key, err))
+	}
+
+	return r.reply(ctx, event, fmt.Sprintf("Secret `%s` has been set.", key))
+}
+
+// handleSendAction processes send-related file selection actions.
+func (r *CommandRouter) handleSendAction(ctx context.Context, event *ChatEvent, verb, targetID string) error {
+	if verb != "select" || targetID == "" {
+		return nil
+	}
+	// targetID format: <agent-slug>.<path-hash>
+	// Phase 5 will implement actual file selection and upload.
+	return r.reply(ctx, event, "File selection and upload will be available in a future update.")
 }
 
 // handleDialogSubmit processes form submissions from interactive cards.
@@ -1346,6 +1411,15 @@ func (r *CommandRouter) cmdAdminHelp(ctx context.Context, event *ChatEvent) (*Ev
 • ` + "`/scionAdmin logs <agent>`" + ` — View recent agent logs
 • ` + "`/scionAdmin set-default <agent>`" + ` — Set default agent for ` + "`/scion`" + ` messages (clear with ` + "`clear`" + `)
 • ` + "`/scionAdmin set-default <agent> --thread`" + ` — Set default agent for the current thread (clear with ` + "`clear --thread`" + `)
+• ` + "`/scionAdmin terminal <agent>`" + ` — Get the web terminal URL for an agent
+• ` + "`/scionAdmin thread <name> [instruction]`" + ` — Create a new agent and thread
+• ` + "`/scionAdmin send <agent> <path>`" + ` — Show file info from an agent's workspace
+
+*Secrets:*
+• ` + "`/scionAdmin secret list`" + ` — List project secrets (metadata only)
+• ` + "`/scionAdmin secret set <key> [value]`" + ` — Set a secret value
+• ` + "`/scionAdmin secret get <key>`" + ` — Show secret metadata
+• ` + "`/scionAdmin secret delete <key>`" + ` — Delete a secret
 
 *Space & Identity:*
 • ` + "`/scionAdmin info`" + ` — Show registration, project link, and agent info
@@ -1377,6 +1451,390 @@ func (r *CommandRouter) resolveDefaultAgent(spaceID, threadID, platform, spaceDe
 		}
 	}
 	return spaceDefault, nil
+}
+
+// --- Terminal, Thread, Send, Secret commands ---
+
+func (r *CommandRouter) cmdTerminal(ctx context.Context, event *ChatEvent, args []string) (*EventResponse, error) {
+	if len(args) == 0 {
+		return textResponse(event, "Usage: `/scionAdmin terminal <agent-slug>`"), nil
+	}
+
+	link, resp := r.requireSpaceLink(ctx, event)
+	if resp != nil {
+		return resp, nil
+	}
+
+	client, err := r.clientForUser(ctx, event)
+	if err != nil {
+		return textResponse(event, "Authentication required. Use `/scionAdmin register` first."), nil
+	}
+
+	agentSlug := args[0]
+	agents, err := client.ProjectAgents(link.ProjectID).List(ctx, nil)
+	if err != nil {
+		return textResponse(event, fmt.Sprintf("Failed to list agents: %v", err)), nil
+	}
+
+	for _, agent := range agents.Agents {
+		if strings.EqualFold(agent.Slug, agentSlug) {
+			if strings.ToLower(agent.Phase) != "running" {
+				phase := agent.Phase
+				if phase == "" {
+					phase = "unknown"
+				}
+				return textResponse(event, fmt.Sprintf("Agent `%s` is not running (phase: %s).", agent.Slug, phase)), nil
+			}
+			terminalURL := fmt.Sprintf("%s/agents/%s/terminal", r.hubURL, agent.ID)
+			card := Card{
+				Header: CardHeader{
+					Title:    "Web Terminal",
+					Subtitle: fmt.Sprintf("Agent: %s", agent.Slug),
+				},
+				Sections: []CardSection{
+					{
+						Widgets: []Widget{
+							{Type: WidgetText, Content: fmt.Sprintf("Open the web terminal for agent `%s`:", agent.Slug)},
+						},
+					},
+				},
+				Actions: []CardAction{
+					{Label: "Open Terminal", ActionID: fmt.Sprintf("link.%s", terminalURL), Style: "primary"},
+				},
+			}
+			return cardResponse(event, &card), nil
+		}
+	}
+
+	return textResponse(event, fmt.Sprintf("Agent `%s` not found in this project.", agentSlug)), nil
+}
+
+func (r *CommandRouter) cmdThread(ctx context.Context, event *ChatEvent, args []string) (*EventResponse, error) {
+	if len(args) == 0 {
+		return textResponse(event, "Usage: `/scionAdmin thread <agent-name> [instruction]`"), nil
+	}
+
+	link, resp := r.requireSpaceLink(ctx, event)
+	if resp != nil {
+		return resp, nil
+	}
+
+	mapping, err := r.idMapper.ResolveOrAutoRegister(ctx, &eventUserLookup{event}, event.UserID, event.Platform)
+	if err != nil || mapping == nil {
+		return textResponse(event, "Authentication required. Use `/scionAdmin register` first."), nil
+	}
+	client, err := r.idMapper.ClientFor(ctx, mapping)
+	if err != nil {
+		return textResponse(event, fmt.Sprintf("Failed to create client: %v", err)), nil
+	}
+
+	agentName := args[0]
+	instruction := ""
+	if len(args) > 1 {
+		instruction = strings.Join(args[1:], " ")
+	}
+
+	// Create the agent.
+	createResp, err := client.ProjectAgents(link.ProjectID).Create(ctx, &hubclient.CreateAgentRequest{
+		Name: agentName,
+	})
+	if err != nil {
+		return textResponse(event, fmt.Sprintf("Failed to create agent: %v", err)), nil
+	}
+
+	// Start the agent.
+	if err := client.ProjectAgents(link.ProjectID).Start(ctx, createResp.Agent.Slug); err != nil {
+		return textResponse(event, fmt.Sprintf("Agent `%s` created but failed to start: %v", createResp.Agent.Slug, err)), nil
+	}
+
+	// Send a kickoff message in the space to start a new thread.
+	threadMsg := fmt.Sprintf("Agent `%s` created and started.", createResp.Agent.Slug)
+	if instruction != "" {
+		threadMsg += fmt.Sprintf("\n\n*Instruction:* %s", instruction)
+	}
+	_, msgErr := r.messenger.SendMessage(ctx, SendMessageRequest{
+		SpaceID: event.SpaceID,
+		Text:    threadMsg,
+	})
+	if msgErr != nil {
+		r.log.Warn("failed to post thread kickoff message", "error", msgErr)
+	}
+
+	// If instruction provided, send it to the agent.
+	if instruction != "" {
+		senderEmail := mapping.HubUserEmail
+		if senderEmail == "" {
+			return textResponse(event, fmt.Sprintf("Agent `%s` created and started, but your user mapping is missing an email to send the instruction.", createResp.Agent.Slug)), nil
+		}
+		msg := messages.NewInstruction("user:"+senderEmail, createResp.Agent.Slug, instruction)
+		msg.Channel = r.broker.ChannelName()
+		if event.ThreadID != "" {
+			msg.ThreadID = event.ThreadID
+		}
+		if _, err := client.ProjectAgents(link.ProjectID).SendStructuredMessage(ctx, createResp.Agent.Slug, msg, false, false, false); err != nil {
+			return textResponse(event, fmt.Sprintf("Agent `%s` created and started, but failed to send instruction: %v", createResp.Agent.Slug, err)), nil
+		}
+	}
+
+	card := Card{
+		Header: CardHeader{
+			Title:    "Thread Created",
+			Subtitle: fmt.Sprintf("Agent: %s", createResp.Agent.Slug),
+		},
+		Sections: []CardSection{
+			{
+				Widgets: []Widget{
+					{Type: WidgetKeyValue, Label: "Agent", Content: createResp.Agent.Slug},
+					{Type: WidgetKeyValue, Label: "Status", Content: "Running"},
+				},
+			},
+		},
+		Actions: []CardAction{
+			{Label: "View Status", ActionID: fmt.Sprintf("agent.status.%s", createResp.Agent.ID)},
+			{Label: "View Logs", ActionID: fmt.Sprintf("agent.logs.%s", createResp.Agent.ID)},
+		},
+	}
+	if instruction != "" {
+		card.Sections[0].Widgets = append(card.Sections[0].Widgets,
+			Widget{Type: WidgetKeyValue, Label: "Instruction", Content: instruction})
+	}
+
+	return cardResponse(event, &card), nil
+}
+
+func (r *CommandRouter) cmdSend(ctx context.Context, event *ChatEvent, args []string) (*EventResponse, error) {
+	if len(args) < 2 {
+		return textResponse(event, "Usage: `/scionAdmin send <agent-slug> <path-or-query>`"), nil
+	}
+
+	link, resp := r.requireSpaceLink(ctx, event)
+	if resp != nil {
+		return resp, nil
+	}
+
+	client, err := r.clientForUser(ctx, event)
+	if err != nil {
+		return textResponse(event, "Authentication required. Use `/scionAdmin register` first."), nil
+	}
+
+	agentSlug := args[0]
+	filePath := strings.Join(args[1:], " ")
+
+	// Verify the agent exists.
+	agent, err := client.ProjectAgents(link.ProjectID).Get(ctx, agentSlug)
+	if err != nil {
+		return textResponse(event, fmt.Sprintf("Agent `%s` not found: %v", agentSlug, err)), nil
+	}
+
+	// Phase 3: return a card with the file info.
+	// Phase 5 will add actual file upload via media.upload API.
+	card := Card{
+		Header: CardHeader{
+			Title:    "Send File",
+			Subtitle: fmt.Sprintf("Agent: %s", agent.Slug),
+		},
+		Sections: []CardSection{
+			{
+				Widgets: []Widget{
+					{Type: WidgetKeyValue, Label: "Agent", Content: agent.Slug},
+					{Type: WidgetKeyValue, Label: "File Path", Content: filePath},
+					{Type: WidgetText, Content: "_File upload via Google Chat is not yet available. Use the web terminal to access files directly._"},
+				},
+			},
+		},
+		Actions: []CardAction{
+			{Label: "Open Terminal", ActionID: fmt.Sprintf("link.%s/agents/%s/terminal", r.hubURL, agent.ID), Style: "primary"},
+		},
+	}
+
+	return cardResponse(event, &card), nil
+}
+
+func (r *CommandRouter) cmdSecret(ctx context.Context, event *ChatEvent, args []string) (*EventResponse, error) {
+	if len(args) == 0 {
+		return textResponse(event, "Usage: `/scionAdmin secret <list|set|get|delete> [key] [value]`"), nil
+	}
+
+	link, resp := r.requireSpaceLink(ctx, event)
+	if resp != nil {
+		return resp, nil
+	}
+
+	client, err := r.clientForUser(ctx, event)
+	if err != nil {
+		return textResponse(event, "Authentication required. Use `/scionAdmin register` first."), nil
+	}
+
+	subcmd := strings.ToLower(args[0])
+	secretArgs := args[1:]
+
+	switch subcmd {
+	case "list":
+		return r.cmdSecretList(ctx, event, link, client)
+	case "set":
+		return r.cmdSecretSet(ctx, event, link, client, secretArgs)
+	case "get":
+		return r.cmdSecretGet(ctx, event, link, client, secretArgs)
+	case "delete":
+		return r.cmdSecretDelete(ctx, event, link, client, secretArgs)
+	default:
+		return textResponse(event, fmt.Sprintf("Unknown secret subcommand: `%s`. Use `list`, `set`, `get`, or `delete`.", subcmd)), nil
+	}
+}
+
+func (r *CommandRouter) cmdSecretList(ctx context.Context, event *ChatEvent, link *state.SpaceLink, client hubclient.Client) (*EventResponse, error) {
+	secrets, err := client.Secrets().List(ctx, &hubclient.ListSecretOptions{
+		Scope:   "project",
+		ScopeID: link.ProjectID,
+	})
+	if err != nil {
+		return textResponse(event, fmt.Sprintf("Failed to list secrets: %v", err)), nil
+	}
+
+	if len(secrets.Secrets) == 0 {
+		return textResponse(event, fmt.Sprintf("No secrets found in project `%s`.", link.ProjectSlug)), nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("*Secrets in %s* (%d):\n", link.ProjectSlug, len(secrets.Secrets)))
+	for _, sec := range secrets.Secrets {
+		line := fmt.Sprintf("• `%s`", sec.Key)
+		if sec.SecretType != "" {
+			line += fmt.Sprintf(" (type: %s)", sec.SecretType)
+		}
+		if sec.Description != "" {
+			line += fmt.Sprintf(" — %s", sec.Description)
+		}
+		sb.WriteString(line + "\n")
+	}
+	return textResponse(event, sb.String()), nil
+}
+
+func (r *CommandRouter) cmdSecretSet(ctx context.Context, event *ChatEvent, link *state.SpaceLink, client hubclient.Client, args []string) (*EventResponse, error) {
+	if len(args) < 1 {
+		return textResponse(event, "Usage: `/scionAdmin secret set <key> <value>`"), nil
+	}
+
+	key := args[0]
+	if err := validateSecretKey(key); err != nil {
+		return textResponse(event, fmt.Sprintf("Invalid key: %v", err)), nil
+	}
+
+	if len(args) < 2 {
+		// Return a card with an input field for the value.
+		card := Card{
+			Header: CardHeader{
+				Title:    "Set Secret",
+				Subtitle: fmt.Sprintf("Key: %s", key),
+			},
+			Sections: []CardSection{
+				{
+					Widgets: []Widget{
+						{Type: WidgetInput, Label: "Secret Value", ActionID: fmt.Sprintf("secret.set.%s", key)},
+					},
+				},
+			},
+			Actions: []CardAction{
+				{Label: "Save", ActionID: fmt.Sprintf("secret.set.%s", key), Style: "primary"},
+			},
+		}
+		return cardResponse(event, &card), nil
+	}
+
+	value := strings.Join(args[1:], " ")
+	_, err := client.Secrets().Set(ctx, key, &hubclient.SetSecretRequest{
+		Value:   value,
+		Scope:   "project",
+		ScopeID: link.ProjectID,
+	})
+	if err != nil {
+		return textResponse(event, fmt.Sprintf("Failed to set secret `%s`: %v", key, err)), nil
+	}
+
+	return textResponse(event, fmt.Sprintf("Secret `%s` has been set.", key)), nil
+}
+
+func (r *CommandRouter) cmdSecretGet(ctx context.Context, event *ChatEvent, link *state.SpaceLink, client hubclient.Client, args []string) (*EventResponse, error) {
+	if len(args) == 0 {
+		return textResponse(event, "Usage: `/scionAdmin secret get <key>`"), nil
+	}
+
+	key := args[0]
+	if err := validateSecretKey(key); err != nil {
+		return textResponse(event, fmt.Sprintf("Invalid key: %v", err)), nil
+	}
+
+	secret, err := client.Secrets().Get(ctx, key, &hubclient.SecretScopeOptions{
+		Scope:   "project",
+		ScopeID: link.ProjectID,
+	})
+	if err != nil {
+		return textResponse(event, fmt.Sprintf("Failed to get secret `%s`: %v", key, err)), nil
+	}
+
+	card := Card{
+		Header: CardHeader{
+			Title:    "Secret Details",
+			Subtitle: secret.Key,
+		},
+		Sections: []CardSection{
+			{
+				Widgets: []Widget{
+					{Type: WidgetKeyValue, Label: "Key", Content: secret.Key},
+					{Type: WidgetKeyValue, Label: "Scope", Content: secret.Scope},
+					{Type: WidgetKeyValue, Label: "Version", Content: fmt.Sprintf("%d", secret.Version)},
+				},
+			},
+		},
+	}
+	if secret.SecretType != "" {
+		card.Sections[0].Widgets = append(card.Sections[0].Widgets,
+			Widget{Type: WidgetKeyValue, Label: "Type", Content: secret.SecretType})
+	}
+	if secret.Description != "" {
+		card.Sections[0].Widgets = append(card.Sections[0].Widgets,
+			Widget{Type: WidgetKeyValue, Label: "Description", Content: secret.Description})
+	}
+	if !secret.Updated.IsZero() {
+		card.Sections[0].Widgets = append(card.Sections[0].Widgets,
+			Widget{Type: WidgetKeyValue, Label: "Last Updated", Content: secret.Updated.UTC().Format("2006-01-02 15:04:05 UTC")})
+	}
+	card.Sections[0].Widgets = append(card.Sections[0].Widgets,
+		Widget{Type: WidgetText, Content: "_(Secret value is never shown)_"})
+
+	return cardResponse(event, &card), nil
+}
+
+func (r *CommandRouter) cmdSecretDelete(ctx context.Context, event *ChatEvent, link *state.SpaceLink, client hubclient.Client, args []string) (*EventResponse, error) {
+	if len(args) == 0 {
+		return textResponse(event, "Usage: `/scionAdmin secret delete <key>`"), nil
+	}
+
+	key := args[0]
+	if err := validateSecretKey(key); err != nil {
+		return textResponse(event, fmt.Sprintf("Invalid key: %v", err)), nil
+	}
+
+	if err := client.Secrets().Delete(ctx, key, &hubclient.SecretScopeOptions{
+		Scope:   "project",
+		ScopeID: link.ProjectID,
+	}); err != nil {
+		return textResponse(event, fmt.Sprintf("Failed to delete secret `%s`: %v", key, err)), nil
+	}
+
+	return textResponse(event, fmt.Sprintf("Secret `%s` has been deleted.", key)), nil
+}
+
+// validateSecretKey checks that a key is non-empty and contains no spaces,
+// newlines, or equals signs.
+func validateSecretKey(key string) error {
+	if key == "" {
+		return fmt.Errorf("secret key cannot be empty")
+	}
+	if strings.ContainsAny(key, " \t\n\r=:") {
+		return fmt.Errorf("secret key must not contain spaces, tabs, newlines, '=' or ':'")
+	}
+	return nil
 }
 
 // --- Helper methods ---

--- a/extras/scion-chat-app/internal/chatapp/commands_new_test.go
+++ b/extras/scion-chat-app/internal/chatapp/commands_new_test.go
@@ -633,34 +633,39 @@ func TestHandleSecretAction_NoValue(t *testing.T) {
 	}
 }
 
-func TestHandleSecretAction_FallbackToActionID(t *testing.T) {
-	setKey := ""
+func TestCmdSecretList_TruncatedAt50(t *testing.T) {
 	client := newStubClient()
-	client.secrets.setFunc = func(_ context.Context, key string, req *hubclient.SetSecretRequest) (*hubclient.SetSecretResponse, error) {
-		setKey = key
-		return &hubclient.SetSecretResponse{}, nil
+	// Create 60 secrets — only first 50 should be shown.
+	secrets := make([]hubclient.Secret, 60)
+	for i := range secrets {
+		secrets[i] = hubclient.Secret{Key: fmt.Sprintf("SECRET_%03d", i)}
+	}
+	client.secrets.listFunc = func(_ context.Context, opts *hubclient.ListSecretOptions) (*hubclient.ListSecretResponse, error) {
+		return &hubclient.ListSecretResponse{Secrets: secrets}, nil
 	}
 	router, _, _ := newTestRouterWithHub(t, client)
 
-	event := &ChatEvent{
-		Type:     EventAction,
-		Platform: "googlechat",
-		SpaceID:  "spaces/test",
-		UserID:   "user-1",
-		ActionID: "secret.set.MY_KEY",
-		DialogData: map[string]string{
-			"secret.set.MY_KEY": "",
-		},
-	}
-	// Set the ActionID as fallback key in DialogData.
-	event.DialogData[event.ActionID] = "fallback-value"
-
-	err := router.handleSecretAction(context.Background(), event, "set", "MY_KEY")
+	link := &state.SpaceLink{ProjectID: "proj-123", ProjectSlug: "test-project"}
+	resp, err := router.cmdSecretList(context.Background(), testEvent(), link, client)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if setKey != "MY_KEY" {
-		t.Errorf("expected key 'MY_KEY', got: %s", setKey)
+	text := resp.Message.Text
+	// Should contain the total count.
+	if !strings.Contains(text, "(60)") {
+		t.Errorf("expected total count (60) in output, got: %s", text)
+	}
+	// Should show SECRET_049 (last of the 50).
+	if !strings.Contains(text, "SECRET_049") {
+		t.Errorf("expected SECRET_049 in output (50th entry), got: %s", text)
+	}
+	// Should NOT show SECRET_050 (beyond cap).
+	if strings.Contains(text, "SECRET_050") {
+		t.Errorf("expected SECRET_050 to be truncated, but found it in output")
+	}
+	// Should show truncation notice.
+	if !strings.Contains(text, "Showing 50 of 60") {
+		t.Errorf("expected truncation notice 'Showing 50 of 60', got: %s", text)
 	}
 }
 

--- a/extras/scion-chat-app/internal/chatapp/commands_new_test.go
+++ b/extras/scion-chat-app/internal/chatapp/commands_new_test.go
@@ -20,10 +20,10 @@ import (
 type stubAgentService struct {
 	hubclient.AgentService // embed for compile-time interface satisfaction
 
-	getFunc                     func(ctx context.Context, id string) (*hubclient.Agent, error)
-	createFunc                  func(ctx context.Context, req *hubclient.CreateAgentRequest) (*hubclient.CreateAgentResponse, error)
-	startFunc                   func(ctx context.Context, id string) error
-	sendStructuredMessageFunc   func(ctx context.Context, id string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error)
+	getFunc                   func(ctx context.Context, id string) (*hubclient.Agent, error)
+	createFunc                func(ctx context.Context, req *hubclient.CreateAgentRequest) (*hubclient.CreateAgentResponse, error)
+	startFunc                 func(ctx context.Context, id string) error
+	sendStructuredMessageFunc func(ctx context.Context, id string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error)
 }
 
 func (s *stubAgentService) Get(ctx context.Context, id string) (*hubclient.Agent, error) {

--- a/extras/scion-chat-app/internal/chatapp/commands_new_test.go
+++ b/extras/scion-chat-app/internal/chatapp/commands_new_test.go
@@ -1,0 +1,748 @@
+package chatapp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/extras/scion-chat-app/internal/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+)
+
+// --- Stub implementations for hubclient interfaces ---
+
+// stubAgentService implements hubclient.AgentService using function fields.
+// Unimplemented methods panic; tests only call the methods they configure.
+type stubAgentService struct {
+	hubclient.AgentService // embed for compile-time interface satisfaction
+
+	getFunc                     func(ctx context.Context, id string) (*hubclient.Agent, error)
+	createFunc                  func(ctx context.Context, req *hubclient.CreateAgentRequest) (*hubclient.CreateAgentResponse, error)
+	startFunc                   func(ctx context.Context, id string) error
+	sendStructuredMessageFunc   func(ctx context.Context, id string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error)
+}
+
+func (s *stubAgentService) Get(ctx context.Context, id string) (*hubclient.Agent, error) {
+	if s.getFunc != nil {
+		return s.getFunc(ctx, id)
+	}
+	return nil, fmt.Errorf("agent not found")
+}
+
+func (s *stubAgentService) Create(ctx context.Context, req *hubclient.CreateAgentRequest) (*hubclient.CreateAgentResponse, error) {
+	if s.createFunc != nil {
+		return s.createFunc(ctx, req)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *stubAgentService) Start(ctx context.Context, id string) error {
+	if s.startFunc != nil {
+		return s.startFunc(ctx, id)
+	}
+	return nil
+}
+
+func (s *stubAgentService) SendStructuredMessage(ctx context.Context, id string, msg *messages.StructuredMessage, interrupt, notify, wake bool) (*hubclient.MessageResponse, error) {
+	if s.sendStructuredMessageFunc != nil {
+		return s.sendStructuredMessageFunc(ctx, id, msg, interrupt, notify, wake)
+	}
+	return &hubclient.MessageResponse{}, nil
+}
+
+// stubSecretService implements hubclient.SecretService using function fields.
+type stubSecretService struct {
+	hubclient.SecretService // embed for compile-time interface satisfaction
+
+	listFunc   func(ctx context.Context, opts *hubclient.ListSecretOptions) (*hubclient.ListSecretResponse, error)
+	getFunc    func(ctx context.Context, key string, opts *hubclient.SecretScopeOptions) (*hubclient.Secret, error)
+	setFunc    func(ctx context.Context, key string, req *hubclient.SetSecretRequest) (*hubclient.SetSecretResponse, error)
+	deleteFunc func(ctx context.Context, key string, opts *hubclient.SecretScopeOptions) error
+}
+
+func (s *stubSecretService) List(ctx context.Context, opts *hubclient.ListSecretOptions) (*hubclient.ListSecretResponse, error) {
+	if s.listFunc != nil {
+		return s.listFunc(ctx, opts)
+	}
+	return &hubclient.ListSecretResponse{}, nil
+}
+
+func (s *stubSecretService) Get(ctx context.Context, key string, opts *hubclient.SecretScopeOptions) (*hubclient.Secret, error) {
+	if s.getFunc != nil {
+		return s.getFunc(ctx, key, opts)
+	}
+	return nil, fmt.Errorf("secret not found")
+}
+
+func (s *stubSecretService) Set(ctx context.Context, key string, req *hubclient.SetSecretRequest) (*hubclient.SetSecretResponse, error) {
+	if s.setFunc != nil {
+		return s.setFunc(ctx, key, req)
+	}
+	return &hubclient.SetSecretResponse{}, nil
+}
+
+func (s *stubSecretService) Delete(ctx context.Context, key string, opts *hubclient.SecretScopeOptions) error {
+	if s.deleteFunc != nil {
+		return s.deleteFunc(ctx, key, opts)
+	}
+	return nil
+}
+
+// stubClient implements hubclient.Client, delegating to stub services.
+type stubClient struct {
+	hubclient.Client // embed for compile-time interface satisfaction
+
+	agents  *stubAgentService
+	secrets *stubSecretService
+}
+
+func (c *stubClient) ProjectAgents(projectID string) hubclient.AgentService {
+	return c.agents
+}
+
+func (c *stubClient) Secrets() hubclient.SecretService {
+	return c.secrets
+}
+
+// newStubClient creates a stubClient with default (empty) services.
+func newStubClient() *stubClient {
+	return &stubClient{
+		agents:  &stubAgentService{},
+		secrets: &stubSecretService{},
+	}
+}
+
+// newTestRouterWithHub creates a CommandRouter with a stub hub client and a
+// pre-linked space, suitable for testing commands that require hub API access.
+func newTestRouterWithHub(t *testing.T, client *stubClient) (*CommandRouter, *fakeMessenger, *state.Store) {
+	t.Helper()
+	store := newTestStore(t)
+	fm := &fakeMessenger{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Pre-link a space to a project.
+	if err := store.SetSpaceLink(&state.SpaceLink{
+		SpaceID:     "spaces/test",
+		Platform:    "googlechat",
+		ProjectID:   "proj-123",
+		ProjectSlug: "test-project",
+	}); err != nil {
+		t.Fatalf("setting space link: %v", err)
+	}
+
+	router := &CommandRouter{
+		hubURL:         "https://hub.example.com",
+		store:          store,
+		messenger:      fm,
+		log:            log,
+		pendingAuth:    make(map[string]*pendingDeviceAuth),
+		pendingDeletes: make(map[string]string),
+		testClient:     client,
+	}
+	return router, fm, store
+}
+
+func testEvent() *ChatEvent {
+	return &ChatEvent{
+		Type:      EventCommand,
+		Platform:  "googlechat",
+		SpaceID:   "spaces/test",
+		UserID:    "user-1",
+		UserEmail: "user@example.com",
+		Command:   "scionAdmin",
+	}
+}
+
+// --- cmdTerminal tests ---
+
+func TestCmdTerminal_NoArgs(t *testing.T) {
+	client := newStubClient()
+	router, _, _ := newTestRouterWithHub(t, client)
+	resp, err := router.cmdTerminal(context.Background(), testEvent(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(resp.Message.Text, "Usage") {
+		t.Errorf("expected usage message, got: %s", resp.Message.Text)
+	}
+}
+
+func TestCmdTerminal_AgentNotFound(t *testing.T) {
+	client := newStubClient()
+	client.agents.getFunc = func(_ context.Context, id string) (*hubclient.Agent, error) {
+		return nil, fmt.Errorf("not found")
+	}
+	router, _, _ := newTestRouterWithHub(t, client)
+
+	resp, err := router.cmdTerminal(context.Background(), testEvent(), []string{"missing-agent"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(resp.Message.Text, "not found") {
+		t.Errorf("expected 'not found' message, got: %s", resp.Message.Text)
+	}
+}
+
+func TestCmdTerminal_AgentNotRunning(t *testing.T) {
+	client := newStubClient()
+	client.agents.getFunc = func(_ context.Context, id string) (*hubclient.Agent, error) {
+		return &hubclient.Agent{
+			ID:    "agent-id-1",
+			Slug:  "my-agent",
+			Phase: "stopped",
+		}, nil
+	}
+	router, _, _ := newTestRouterWithHub(t, client)
+
+	resp, err := router.cmdTerminal(context.Background(), testEvent(), []string{"my-agent"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(resp.Message.Text, "not running") {
+		t.Errorf("expected 'not running' message, got: %s", resp.Message.Text)
+	}
+}
+
+func TestCmdTerminal_AgentRunning(t *testing.T) {
+	client := newStubClient()
+	client.agents.getFunc = func(_ context.Context, id string) (*hubclient.Agent, error) {
+		return &hubclient.Agent{
+			ID:    "agent-id-1",
+			Slug:  "my-agent",
+			Phase: "running",
+		}, nil
+	}
+	router, _, _ := newTestRouterWithHub(t, client)
+
+	resp, err := router.cmdTerminal(context.Background(), testEvent(), []string{"my-agent"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Message.Card == nil {
+		t.Fatal("expected card response")
+	}
+	if resp.Message.Card.Header.Title != "Web Terminal" {
+		t.Errorf("expected 'Web Terminal' card title, got: %s", resp.Message.Card.Header.Title)
+	}
+	// Verify the action uses link. prefix for openLink rendering.
+	if len(resp.Message.Card.Actions) == 0 {
+		t.Fatal("expected card actions")
+	}
+	action := resp.Message.Card.Actions[0]
+	if !strings.HasPrefix(action.ActionID, "link.") {
+		t.Errorf("expected ActionID to start with 'link.', got: %s", action.ActionID)
+	}
+	if !strings.Contains(action.ActionID, "agent-id-1/terminal") {
+		t.Errorf("expected terminal URL in ActionID, got: %s", action.ActionID)
+	}
+}
+
+// --- cmdThread tests ---
+
+func TestCmdThread_NoArgs(t *testing.T) {
+	client := newStubClient()
+	router, _, _ := newTestRouterWithHub(t, client)
+	resp, err := router.cmdThread(context.Background(), testEvent(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(resp.Message.Text, "Usage") {
+		t.Errorf("expected usage message, got: %s", resp.Message.Text)
+	}
+}
+
+func TestCmdThread_SuccessWithoutInstruction(t *testing.T) {
+	client := newStubClient()
+	client.agents.createFunc = func(_ context.Context, req *hubclient.CreateAgentRequest) (*hubclient.CreateAgentResponse, error) {
+		return &hubclient.CreateAgentResponse{
+			Agent: &hubclient.Agent{
+				ID:   "agent-id-new",
+				Slug: req.Name,
+			},
+		}, nil
+	}
+	router, fm, _ := newTestRouterWithHub(t, client)
+
+	resp, err := router.cmdThread(context.Background(), testEvent(), []string{"my-new-agent"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Message.Card == nil {
+		t.Fatal("expected card response")
+	}
+	if resp.Message.Card.Header.Title != "Thread Created" {
+		t.Errorf("expected 'Thread Created' card title, got: %s", resp.Message.Card.Header.Title)
+	}
+	// Verify the kickoff message was sent with a threadKey.
+	if len(fm.messages) == 0 {
+		t.Fatal("expected messenger to have sent a kickoff message")
+	}
+	kickoff := fm.messages[0]
+	if kickoff.ThreadKey == "" {
+		t.Error("expected kickoff message to have a ThreadKey for new thread creation")
+	}
+	if !strings.Contains(kickoff.ThreadKey, "my-new-agent") {
+		t.Errorf("expected threadKey to contain agent slug, got: %s", kickoff.ThreadKey)
+	}
+}
+
+func TestCmdThread_SuccessWithInstruction(t *testing.T) {
+	client := newStubClient()
+	var sentMessage *messages.StructuredMessage
+	client.agents.createFunc = func(_ context.Context, req *hubclient.CreateAgentRequest) (*hubclient.CreateAgentResponse, error) {
+		return &hubclient.CreateAgentResponse{
+			Agent: &hubclient.Agent{
+				ID:   "agent-id-new",
+				Slug: req.Name,
+			},
+		}, nil
+	}
+	client.agents.sendStructuredMessageFunc = func(_ context.Context, _ string, msg *messages.StructuredMessage, _, _, _ bool) (*hubclient.MessageResponse, error) {
+		sentMessage = msg
+		return &hubclient.MessageResponse{}, nil
+	}
+	router, fm, _ := newTestRouterWithHub(t, client)
+
+	resp, err := router.cmdThread(context.Background(), testEvent(), []string{"my-agent", "start", "task", "X"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Message.Card == nil {
+		t.Fatal("expected card response")
+	}
+	// Verify instruction was sent.
+	if sentMessage == nil {
+		t.Fatal("expected instruction to be sent to agent")
+	}
+	if sentMessage.Msg != "start task X" {
+		t.Errorf("expected instruction 'start task X', got: %s", sentMessage.Msg)
+	}
+	// Verify the kickoff message includes the instruction.
+	if len(fm.messages) == 0 {
+		t.Fatal("expected messenger to have sent a kickoff message")
+	}
+	if !strings.Contains(fm.messages[0].Text, "start task X") {
+		t.Errorf("expected kickoff message to include instruction, got: %s", fm.messages[0].Text)
+	}
+	// Verify card includes instruction widget.
+	found := false
+	for _, w := range resp.Message.Card.Sections[0].Widgets {
+		if w.Label == "Instruction" && w.Content == "start task X" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected card to include Instruction widget")
+	}
+}
+
+// --- cmdSend tests ---
+
+func TestCmdSend_NoArgs(t *testing.T) {
+	client := newStubClient()
+	router, _, _ := newTestRouterWithHub(t, client)
+	resp, err := router.cmdSend(context.Background(), testEvent(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(resp.Message.Text, "Usage") {
+		t.Errorf("expected usage message, got: %s", resp.Message.Text)
+	}
+}
+
+func TestCmdSend_AgentNotFound(t *testing.T) {
+	client := newStubClient()
+	client.agents.getFunc = func(_ context.Context, id string) (*hubclient.Agent, error) {
+		return nil, fmt.Errorf("not found")
+	}
+	router, _, _ := newTestRouterWithHub(t, client)
+
+	resp, err := router.cmdSend(context.Background(), testEvent(), []string{"missing-agent", "/path/to/file"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(resp.Message.Text, "not found") {
+		t.Errorf("expected 'not found' message, got: %s", resp.Message.Text)
+	}
+}
+
+func TestCmdSend_AgentFoundShowsFileInfo(t *testing.T) {
+	client := newStubClient()
+	client.agents.getFunc = func(_ context.Context, id string) (*hubclient.Agent, error) {
+		return &hubclient.Agent{
+			ID:   "agent-id-1",
+			Slug: "my-agent",
+		}, nil
+	}
+	router, _, _ := newTestRouterWithHub(t, client)
+
+	resp, err := router.cmdSend(context.Background(), testEvent(), []string{"my-agent", "/path/to/file.txt"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Message.Card == nil {
+		t.Fatal("expected card response")
+	}
+	if resp.Message.Card.Header.Title != "Send File" {
+		t.Errorf("expected 'Send File' card title, got: %s", resp.Message.Card.Header.Title)
+	}
+	// Verify file path is shown.
+	found := false
+	for _, w := range resp.Message.Card.Sections[0].Widgets {
+		if w.Label == "File Path" && w.Content == "/path/to/file.txt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected card to show file path")
+	}
+}
+
+// --- cmdSecret tests ---
+
+func TestCmdSecret_NoArgs(t *testing.T) {
+	client := newStubClient()
+	router, _, _ := newTestRouterWithHub(t, client)
+	resp, err := router.cmdSecret(context.Background(), testEvent(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(resp.Message.Text, "Usage") {
+		t.Errorf("expected usage message, got: %s", resp.Message.Text)
+	}
+}
+
+func TestCmdSecretList_Empty(t *testing.T) {
+	client := newStubClient()
+	client.secrets.listFunc = func(_ context.Context, opts *hubclient.ListSecretOptions) (*hubclient.ListSecretResponse, error) {
+		return &hubclient.ListSecretResponse{Secrets: nil}, nil
+	}
+	router, _, _ := newTestRouterWithHub(t, client)
+
+	link := &state.SpaceLink{ProjectID: "proj-123", ProjectSlug: "test-project"}
+	resp, err := router.cmdSecretList(context.Background(), testEvent(), link, client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(resp.Message.Text, "No secrets found") {
+		t.Errorf("expected 'No secrets found' message, got: %s", resp.Message.Text)
+	}
+}
+
+func TestCmdSecretList_WithSecrets(t *testing.T) {
+	client := newStubClient()
+	client.secrets.listFunc = func(_ context.Context, opts *hubclient.ListSecretOptions) (*hubclient.ListSecretResponse, error) {
+		return &hubclient.ListSecretResponse{
+			Secrets: []hubclient.Secret{
+				{Key: "API_KEY", SecretType: "environment"},
+				{Key: "DB_PASS", Description: "Database password"},
+			},
+		}, nil
+	}
+	router, _, _ := newTestRouterWithHub(t, client)
+
+	link := &state.SpaceLink{ProjectID: "proj-123", ProjectSlug: "test-project"}
+	resp, err := router.cmdSecretList(context.Background(), testEvent(), link, client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(resp.Message.Text, "API_KEY") {
+		t.Errorf("expected response to contain 'API_KEY', got: %s", resp.Message.Text)
+	}
+	if !strings.Contains(resp.Message.Text, "DB_PASS") {
+		t.Errorf("expected response to contain 'DB_PASS', got: %s", resp.Message.Text)
+	}
+	if !strings.Contains(resp.Message.Text, "(2)") {
+		t.Errorf("expected response to show count (2), got: %s", resp.Message.Text)
+	}
+}
+
+func TestCmdSecretSet_ReturnsCardInput(t *testing.T) {
+	client := newStubClient()
+	router, _, _ := newTestRouterWithHub(t, client)
+
+	link := &state.SpaceLink{ProjectID: "proj-123", ProjectSlug: "test-project"}
+	resp, err := router.cmdSecretSet(context.Background(), testEvent(), link, client, []string{"MY_SECRET"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Message.Card == nil {
+		t.Fatal("expected card response with input widget")
+	}
+	if resp.Message.Card.Header.Title != "Set Secret" {
+		t.Errorf("expected 'Set Secret' card title, got: %s", resp.Message.Card.Header.Title)
+	}
+	// Even if extra args are provided, should still return card (no inline value).
+	resp2, err := router.cmdSecretSet(context.Background(), testEvent(), link, client, []string{"MY_SECRET", "should-be-ignored"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp2.Message.Card == nil {
+		t.Fatal("expected card response even when value args are provided (inline values are not supported)")
+	}
+}
+
+func TestCmdSecretGet_Found(t *testing.T) {
+	client := newStubClient()
+	client.secrets.getFunc = func(_ context.Context, key string, _ *hubclient.SecretScopeOptions) (*hubclient.Secret, error) {
+		return &hubclient.Secret{
+			Key:        key,
+			Scope:      "project",
+			SecretType: "environment",
+			Version:    3,
+		}, nil
+	}
+	router, _, _ := newTestRouterWithHub(t, client)
+
+	link := &state.SpaceLink{ProjectID: "proj-123", ProjectSlug: "test-project"}
+	resp, err := router.cmdSecretGet(context.Background(), testEvent(), link, client, []string{"API_KEY"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Message.Card == nil {
+		t.Fatal("expected card response")
+	}
+	if resp.Message.Card.Header.Title != "Secret Details" {
+		t.Errorf("expected 'Secret Details' card title, got: %s", resp.Message.Card.Header.Title)
+	}
+}
+
+func TestCmdSecretGet_NotFound(t *testing.T) {
+	client := newStubClient()
+	client.secrets.getFunc = func(_ context.Context, key string, _ *hubclient.SecretScopeOptions) (*hubclient.Secret, error) {
+		return nil, fmt.Errorf("secret not found")
+	}
+	router, _, _ := newTestRouterWithHub(t, client)
+
+	link := &state.SpaceLink{ProjectID: "proj-123", ProjectSlug: "test-project"}
+	resp, err := router.cmdSecretGet(context.Background(), testEvent(), link, client, []string{"MISSING"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(resp.Message.Text, "Failed to get secret") {
+		t.Errorf("expected error message, got: %s", resp.Message.Text)
+	}
+}
+
+func TestCmdSecretDelete_Success(t *testing.T) {
+	deleted := false
+	client := newStubClient()
+	client.secrets.deleteFunc = func(_ context.Context, key string, _ *hubclient.SecretScopeOptions) error {
+		deleted = true
+		return nil
+	}
+	router, _, _ := newTestRouterWithHub(t, client)
+
+	link := &state.SpaceLink{ProjectID: "proj-123", ProjectSlug: "test-project"}
+	resp, err := router.cmdSecretDelete(context.Background(), testEvent(), link, client, []string{"OLD_SECRET"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !deleted {
+		t.Error("expected delete to have been called")
+	}
+	if !strings.Contains(resp.Message.Text, "has been deleted") {
+		t.Errorf("expected success message, got: %s", resp.Message.Text)
+	}
+}
+
+func TestCmdSecretDelete_InvalidKey(t *testing.T) {
+	client := newStubClient()
+	router, _, _ := newTestRouterWithHub(t, client)
+
+	link := &state.SpaceLink{ProjectID: "proj-123", ProjectSlug: "test-project"}
+	resp, err := router.cmdSecretDelete(context.Background(), testEvent(), link, client, []string{"bad key"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(resp.Message.Text, "Invalid key") {
+		t.Errorf("expected invalid key error, got: %s", resp.Message.Text)
+	}
+}
+
+// --- handleSecretAction tests ---
+
+func TestHandleSecretAction_SpecificKeyLookup(t *testing.T) {
+	setKey := ""
+	setValue := ""
+	client := newStubClient()
+	client.secrets.setFunc = func(_ context.Context, key string, req *hubclient.SetSecretRequest) (*hubclient.SetSecretResponse, error) {
+		setKey = key
+		setValue = req.Value
+		return &hubclient.SetSecretResponse{}, nil
+	}
+	router, fm, _ := newTestRouterWithHub(t, client)
+
+	event := &ChatEvent{
+		Type:     EventAction,
+		Platform: "googlechat",
+		SpaceID:  "spaces/test",
+		UserID:   "user-1",
+		ActionID: "secret.set.MY_KEY",
+		DialogData: map[string]string{
+			"secret.set.MY_KEY": "my-secret-value",
+			"unrelated_field":   "noise",
+		},
+	}
+
+	err := router.handleSecretAction(context.Background(), event, "set", "MY_KEY")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if setKey != "MY_KEY" {
+		t.Errorf("expected key 'MY_KEY', got: %s", setKey)
+	}
+	if setValue != "my-secret-value" {
+		t.Errorf("expected value 'my-secret-value', got: %s", setValue)
+	}
+	// Verify success reply was sent.
+	if len(fm.messages) == 0 {
+		t.Fatal("expected a reply message")
+	}
+	if !strings.Contains(fm.messages[0].Text, "has been set") {
+		t.Errorf("expected success reply, got: %s", fm.messages[0].Text)
+	}
+}
+
+func TestHandleSecretAction_NoValue(t *testing.T) {
+	client := newStubClient()
+	router, fm, _ := newTestRouterWithHub(t, client)
+
+	event := &ChatEvent{
+		Type:       EventAction,
+		Platform:   "googlechat",
+		SpaceID:    "spaces/test",
+		UserID:     "user-1",
+		ActionID:   "secret.set.MY_KEY",
+		DialogData: map[string]string{},
+	}
+
+	err := router.handleSecretAction(context.Background(), event, "set", "MY_KEY")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fm.messages) == 0 {
+		t.Fatal("expected a reply message")
+	}
+	if !strings.Contains(fm.messages[0].Text, "No secret value") {
+		t.Errorf("expected 'No secret value' reply, got: %s", fm.messages[0].Text)
+	}
+}
+
+func TestHandleSecretAction_FallbackToActionID(t *testing.T) {
+	setKey := ""
+	client := newStubClient()
+	client.secrets.setFunc = func(_ context.Context, key string, req *hubclient.SetSecretRequest) (*hubclient.SetSecretResponse, error) {
+		setKey = key
+		return &hubclient.SetSecretResponse{}, nil
+	}
+	router, _, _ := newTestRouterWithHub(t, client)
+
+	event := &ChatEvent{
+		Type:     EventAction,
+		Platform: "googlechat",
+		SpaceID:  "spaces/test",
+		UserID:   "user-1",
+		ActionID: "secret.set.MY_KEY",
+		DialogData: map[string]string{
+			"secret.set.MY_KEY": "",
+		},
+	}
+	// Set the ActionID as fallback key in DialogData.
+	event.DialogData[event.ActionID] = "fallback-value"
+
+	err := router.handleSecretAction(context.Background(), event, "set", "MY_KEY")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if setKey != "MY_KEY" {
+		t.Errorf("expected key 'MY_KEY', got: %s", setKey)
+	}
+}
+
+// --- validateSecretKey tests ---
+
+func TestValidateSecretKey(t *testing.T) {
+	tests := []struct {
+		key     string
+		wantErr bool
+	}{
+		{"API_KEY", false},
+		{"MY-SECRET-123", false},
+		{"", true},
+		{"has space", true},
+		{"has=equals", true},
+		{"has:colon", true},
+		{"has\ttab", true},
+		{"has\nnewline", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			err := validateSecretKey(tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateSecretKey(%q) error = %v, wantErr %v", tt.key, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// --- Help text tests ---
+
+func TestAdminHelp_IncludesNewCommands(t *testing.T) {
+	client := newStubClient()
+	router, _, _ := newTestRouterWithHub(t, client)
+	resp, err := router.cmdAdminHelp(context.Background(), testEvent())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, cmd := range []string{"terminal", "thread", "send", "secret list", "secret set", "secret get", "secret delete"} {
+		if !strings.Contains(resp.Message.Text, cmd) {
+			t.Errorf("expected help text to contain %q", cmd)
+		}
+	}
+}
+
+// --- Command dispatch tests ---
+
+func TestHandleAdminCommand_DispatchesNewCommands(t *testing.T) {
+	client := newStubClient()
+	router, _, _ := newTestRouterWithHub(t, client)
+
+	tests := []struct {
+		args        string
+		wantContain string
+	}{
+		{"terminal", "Usage"},
+		{"thread", "Usage"},
+		{"send", "Usage"},
+		{"secret", "Usage"},
+		{"secret bogus", "Unknown secret subcommand"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.args, func(t *testing.T) {
+			event := testEvent()
+			event.Args = tt.args
+			resp, err := router.handleAdminCommand(context.Background(), event)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp == nil || resp.Message == nil {
+				t.Fatal("expected a response")
+			}
+			text := resp.Message.Text
+			if resp.Message.Card != nil {
+				text = resp.Message.Card.Header.Title
+			}
+			if !strings.Contains(text, tt.wantContain) {
+				t.Errorf("expected response to contain %q, got text=%q", tt.wantContain, text)
+			}
+		})
+	}
+}

--- a/extras/scion-chat-app/internal/chatapp/messenger.go
+++ b/extras/scion-chat-app/internal/chatapp/messenger.go
@@ -29,11 +29,12 @@ type Messenger interface {
 
 // SendMessageRequest contains parameters for sending a message to a chat space.
 type SendMessageRequest struct {
-	SpaceID  string
-	ThreadID string
-	Text     string
-	Card     *Card
-	AgentID  string
+	SpaceID   string
+	ThreadID  string
+	ThreadKey string // Platform-specific thread key for creating new threads.
+	Text      string
+	Card      *Card
+	AgentID   string
 }
 
 // AgentIdentity represents the visual identity of an agent in chat.

--- a/extras/scion-chat-app/internal/googlechat/adapter.go
+++ b/extras/scion-chat-app/internal/googlechat/adapter.go
@@ -747,10 +747,14 @@ func (a *Adapter) SendMessage(ctx context.Context, req chatapp.SendMessageReques
 		payload["thread"] = map[string]string{
 			"name": req.ThreadID,
 		}
+	} else if req.ThreadKey != "" {
+		payload["thread"] = map[string]string{
+			"threadKey": req.ThreadKey,
+		}
 	}
 
 	url := fmt.Sprintf("%s/%s/messages", chatAPIBase, req.SpaceID)
-	if req.ThreadID != "" {
+	if req.ThreadID != "" || req.ThreadKey != "" {
 		url += "?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD"
 	}
 
@@ -883,7 +887,7 @@ func (a *Adapter) renderCardV2(card *chatapp.Card) map[string]any {
 		for _, act := range card.Actions {
 			btn := map[string]any{
 				"text":    act.Label,
-				"onClick": a.actionOnClick(act.ActionID),
+				"onClick": a.resolveOnClick(act.ActionID),
 			}
 			if act.Style == "danger" {
 				btn["color"] = map[string]any{
@@ -914,6 +918,15 @@ func (a *Adapter) renderCardV2(card *chatapp.Card) map[string]any {
 	return c
 }
 
+// resolveOnClick returns an openLink onClick when the actionID starts with
+// "link." (the remainder is the URL), or a callback action otherwise.
+func (a *Adapter) resolveOnClick(actionID string) map[string]any {
+	if strings.HasPrefix(actionID, "link.") {
+		return a.openLinkOnClick(strings.TrimPrefix(actionID, "link."))
+	}
+	return a.actionOnClick(actionID)
+}
+
 // actionOnClick builds an onClick action with the full external URL and action ID in parameters.
 func (a *Adapter) actionOnClick(actionID string) map[string]any {
 	return map[string]any{
@@ -922,6 +935,15 @@ func (a *Adapter) actionOnClick(actionID string) map[string]any {
 			"parameters": []any{
 				map[string]any{"key": "action", "value": actionID},
 			},
+		},
+	}
+}
+
+// openLinkOnClick builds an onClick that opens a URL in a new tab.
+func (a *Adapter) openLinkOnClick(url string) map[string]any {
+	return map[string]any{
+		"openLink": map[string]any{
+			"url": url,
 		},
 	}
 }
@@ -946,7 +968,7 @@ func (a *Adapter) renderWidget(w *chatapp.Widget) map[string]any {
 	case chatapp.WidgetButton:
 		btn := map[string]any{
 			"text":    w.Label,
-			"onClick": a.actionOnClick(w.ActionID),
+			"onClick": a.resolveOnClick(w.ActionID),
 		}
 		return map[string]any{
 			"buttonList": map[string]any{


### PR DESCRIPTION
Add four missing admin commands to the Google Chat plugin for feature parity with Discord.

Key changes:
- /scionAdmin terminal: returns clickable web terminal URL for running agents
- /scionAdmin thread: creates agent + Google Chat thread pair with optional kickoff instruction
- /scionAdmin send: sends files from agent workspace to chat (with file selection cards)
- /scionAdmin secret: full CRUD (list/set/get/delete) with card-based secret value input
- extras/scion-chat-app/internal/googlechat/adapter.go: resolveOnClick/openLinkOnClick for link action buttons
- 24 tests

Ref: ptone/scion#914
