### PR TITLE
feat(gchat): add observe mode, outbound mentions, and settings command

### DIFF
--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -299,7 +299,7 @@ func (r *CommandRouter) handleAction(ctx context.Context, event *ChatEvent) (*Ev
 	case "send":
 		return nil, r.handleSendAction(ctx, event, actionVerb, targetID)
 	case "settings":
-		return r.handleSettingsAction(ctx, event, actionVerb)
+		return nil, r.handleSettingsAction(ctx, event, actionVerb)
 	}
 	return nil, nil
 }

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -217,6 +217,8 @@ func (r *CommandRouter) handleAdminCommand(ctx context.Context, event *ChatEvent
 		resp, err = r.cmdSend(ctx, event, args)
 	case "secret":
 		resp, err = r.cmdSecret(ctx, event, args)
+	case "settings":
+		resp, err = r.cmdSettings(ctx, event, args)
 	case "help":
 		if len(args) == 0 {
 			resp, err = r.cmdAdminHelp(ctx, event)
@@ -296,6 +298,8 @@ func (r *CommandRouter) handleAction(ctx context.Context, event *ChatEvent) (*Ev
 		return nil, r.handleSecretAction(ctx, event, actionVerb, targetID)
 	case "send":
 		return nil, r.handleSendAction(ctx, event, actionVerb, targetID)
+	case "settings":
+		return r.handleSettingsAction(ctx, event, actionVerb)
 	}
 	return nil, nil
 }
@@ -773,10 +777,10 @@ func (r *CommandRouter) cmdLink(ctx context.Context, event *ChatEvent, args []st
 		return textResponse(event, fmt.Sprintf("Failed to save link: %v", err)), nil
 	}
 
-	// Subscribe only to user-targeted messages so that agent-to-agent
-	// traffic and broadcasts do not leak into chat.
+	// Subscribe to all project messages; observe mode filtering is
+	// applied at delivery time in HandleBrokerMessage.
 	if r.broker != nil {
-		pattern := fmt.Sprintf("scion.grove.%s.user.>", proj.ID)
+		pattern := fmt.Sprintf("scion.grove.%s.>", proj.ID)
 		if err := r.broker.RequestSubscription(pattern); err != nil {
 			r.log.Warn("failed to request project subscription", "project_id", proj.ID, "error", err)
 		}
@@ -796,7 +800,7 @@ func (r *CommandRouter) cmdUnlink(ctx context.Context, event *ChatEvent, args []
 
 	// Cancel broker subscription (must match the pattern used during link).
 	if r.broker != nil {
-		pattern := fmt.Sprintf("scion.grove.%s.user.>", link.ProjectID)
+		pattern := fmt.Sprintf("scion.grove.%s.>", link.ProjectID)
 		if err := r.broker.CancelSubscription(pattern); err != nil {
 			r.log.Warn("failed to cancel project subscription", "project_id", link.ProjectID, "error", err)
 		}
@@ -1464,6 +1468,7 @@ func (r *CommandRouter) cmdAdminHelp(ctx context.Context, event *ChatEvent) (*Ev
 • ` + "`/scionAdmin unlink`" + ` — Unlink this space
 • ` + "`/scionAdmin register`" + ` — Register your chat account
 • ` + "`/scionAdmin unregister`" + ` — Unregister your account
+• ` + "`/scionAdmin settings`" + ` — Toggle observe mode and notification filters
 
 *Notifications:*
 • ` + "`/scionAdmin subscribe <agent>`" + ` — Subscribe to agent notifications
@@ -1873,6 +1878,93 @@ func validateSecretKey(key string) error {
 	}
 	if strings.ContainsAny(key, " \t\n\r=:") {
 		return fmt.Errorf("secret key must not contain spaces, tabs, newlines, '=' or ':'")
+	}
+	return nil
+}
+
+// --- Settings command ---
+
+func (r *CommandRouter) cmdSettings(ctx context.Context, event *ChatEvent, args []string) (*EventResponse, error) {
+	link, resp := r.requireSpaceLink(ctx, event)
+	if resp != nil {
+		return resp, nil
+	}
+
+	return r.buildSettingsCard(event, link), nil
+}
+
+// buildSettingsCard creates a card showing the current observe mode and state notification settings.
+func (r *CommandRouter) buildSettingsCard(event *ChatEvent, link *state.SpaceLink) *EventResponse {
+	observeLabel := "Observe Mode: OFF"
+	if link.ShowAgentToAgent {
+		observeLabel = "Observe Mode: ON"
+	}
+	stateLabel := "State Notifications: OFF"
+	if link.ShowStateChanges {
+		stateLabel = "State Notifications: ON"
+	}
+
+	card := Card{
+		Header: CardHeader{
+			Title:    "Space Settings",
+			Subtitle: fmt.Sprintf("Project: %s", link.ProjectSlug),
+		},
+		Sections: []CardSection{
+			{
+				Header: "Message Filtering",
+				Widgets: []Widget{
+					{Type: WidgetText, Content: "Control which messages are relayed to this space."},
+				},
+			},
+		},
+		Actions: []CardAction{
+			{Label: observeLabel, ActionID: "settings.observe"},
+			{Label: stateLabel, ActionID: "settings.statechange"},
+		},
+	}
+
+	return cardResponse(event, &card)
+}
+
+// handleSettingsAction toggles observe mode or state change notification settings.
+func (r *CommandRouter) handleSettingsAction(ctx context.Context, event *ChatEvent, verb string) error {
+	link, err := r.store.GetSpaceLink(event.SpaceID, event.Platform)
+	if err != nil {
+		return fmt.Errorf("getting space link: %w", err)
+	}
+	if link == nil {
+		return r.reply(ctx, event, "This space is not linked to a project.")
+	}
+
+	switch verb {
+	case "observe":
+		link.ShowAgentToAgent = !link.ShowAgentToAgent
+		if err := r.store.SetShowAgentToAgent(event.SpaceID, event.Platform, link.ShowAgentToAgent); err != nil {
+			return r.reply(ctx, event, fmt.Sprintf("Failed to update setting: %v", err))
+		}
+	case "statechange":
+		link.ShowStateChanges = !link.ShowStateChanges
+		if err := r.store.SetShowStateChanges(event.SpaceID, event.Platform, link.ShowStateChanges); err != nil {
+			return r.reply(ctx, event, fmt.Sprintf("Failed to update setting: %v", err))
+		}
+	default:
+		return r.reply(ctx, event, fmt.Sprintf("Unknown setting: `%s`", verb))
+	}
+
+	// Re-render the settings card with updated state via UpdateMessage
+	resp := r.buildSettingsCard(event, link)
+	if resp.Message != nil && resp.Message.Card != nil {
+		if event.ActionData != "" {
+			// Use UpdateMessage to refresh the card in-place
+			if err := r.messenger.UpdateMessage(ctx, event.ActionData, *resp.Message); err != nil {
+				r.log.Warn("failed to update settings card, sending new message", "error", err)
+				_, err = r.messenger.SendCard(ctx, event.SpaceID, *resp.Message.Card)
+				return err
+			}
+			return nil
+		}
+		_, err = r.messenger.SendCard(ctx, event.SpaceID, *resp.Message.Card)
+		return err
 	}
 	return nil
 }

--- a/extras/scion-chat-app/internal/chatapp/commands.go
+++ b/extras/scion-chat-app/internal/chatapp/commands.go
@@ -767,11 +767,12 @@ func (r *CommandRouter) cmdLink(ctx context.Context, event *ChatEvent, args []st
 
 	// Save the link
 	link := &state.SpaceLink{
-		SpaceID:     event.SpaceID,
-		Platform:    event.Platform,
-		ProjectID:   proj.ID,
-		ProjectSlug: proj.Slug,
-		LinkedBy:    mapping.HubUserID,
+		SpaceID:          event.SpaceID,
+		Platform:         event.Platform,
+		ProjectID:        proj.ID,
+		ProjectSlug:      proj.Slug,
+		LinkedBy:         mapping.HubUserID,
+		ShowStateChanges: true,
 	}
 	if err := r.store.SetSpaceLink(link); err != nil {
 		return textResponse(event, fmt.Sprintf("Failed to save link: %v", err)), nil

--- a/extras/scion-chat-app/internal/chatapp/commands_test.go
+++ b/extras/scion-chat-app/internal/chatapp/commands_test.go
@@ -454,6 +454,298 @@ func TestHandleSpaceRemove_CleansUpThreadDefaults(t *testing.T) {
 	}
 }
 
+// --- handleSettingsAction tests ---
+
+// newTestRouterWithStore creates a CommandRouter with a given store for
+// test cases that need to pre-populate store data.
+func newTestRouterWithStore(t *testing.T, store *state.Store) (*CommandRouter, *fakeMessenger) {
+	t.Helper()
+	fm := &fakeMessenger{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	router := &CommandRouter{
+		store:       store,
+		messenger:   fm,
+		log:         log,
+		pendingAuth: make(map[string]*pendingDeviceAuth),
+	}
+	return router, fm
+}
+
+func TestHandleSettingsAction_ToggleObserveOn(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.SetSpaceLink(&state.SpaceLink{
+		SpaceID:          "spaces/settings-test",
+		Platform:         "googlechat",
+		ProjectID:        "proj-1",
+		ProjectSlug:      "my-project",
+		LinkedBy:         "test",
+		ShowAgentToAgent: false, // starts OFF
+		ShowStateChanges: true,
+	}); err != nil {
+		t.Fatalf("setting space link: %v", err)
+	}
+
+	router, fm := newTestRouterWithStore(t, store)
+	event := &ChatEvent{
+		Type:     EventAction,
+		Platform: "googlechat",
+		SpaceID:  "spaces/settings-test",
+		UserID:   "user-1",
+		ActionID: "settings.observe",
+	}
+
+	err := router.handleSettingsAction(context.Background(), event, "observe")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the DB was updated.
+	link, err := store.GetSpaceLink("spaces/settings-test", "googlechat")
+	if err != nil {
+		t.Fatalf("getting space link: %v", err)
+	}
+	if !link.ShowAgentToAgent {
+		t.Error("expected ShowAgentToAgent to be toggled ON")
+	}
+
+	// Verify a card was sent back with updated state.
+	if len(fm.messages) == 0 {
+		t.Fatal("expected a settings card to be sent")
+	}
+	got := fm.messages[0]
+	if got.Card == nil {
+		t.Fatal("expected a card in the response")
+	}
+	foundObserve := false
+	for _, action := range got.Card.Actions {
+		if strings.Contains(action.Label, "Observe Mode: ON") {
+			foundObserve = true
+		}
+	}
+	if !foundObserve {
+		t.Error("expected settings card to show 'Observe Mode: ON'")
+	}
+}
+
+func TestHandleSettingsAction_ToggleObserveOff(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.SetSpaceLink(&state.SpaceLink{
+		SpaceID:          "spaces/settings-test2",
+		Platform:         "googlechat",
+		ProjectID:        "proj-1",
+		ProjectSlug:      "my-project",
+		LinkedBy:         "test",
+		ShowAgentToAgent: true, // starts ON
+		ShowStateChanges: true,
+	}); err != nil {
+		t.Fatalf("setting space link: %v", err)
+	}
+
+	router, fm := newTestRouterWithStore(t, store)
+	event := &ChatEvent{
+		Type:     EventAction,
+		Platform: "googlechat",
+		SpaceID:  "spaces/settings-test2",
+		UserID:   "user-1",
+		ActionID: "settings.observe",
+	}
+
+	err := router.handleSettingsAction(context.Background(), event, "observe")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	link, err := store.GetSpaceLink("spaces/settings-test2", "googlechat")
+	if err != nil {
+		t.Fatalf("getting space link: %v", err)
+	}
+	if link.ShowAgentToAgent {
+		t.Error("expected ShowAgentToAgent to be toggled OFF")
+	}
+
+	if len(fm.messages) == 0 {
+		t.Fatal("expected a settings card to be sent")
+	}
+	got := fm.messages[0]
+	if got.Card == nil {
+		t.Fatal("expected a card in the response")
+	}
+	foundObserve := false
+	for _, action := range got.Card.Actions {
+		if strings.Contains(action.Label, "Observe Mode: OFF") {
+			foundObserve = true
+		}
+	}
+	if !foundObserve {
+		t.Error("expected settings card to show 'Observe Mode: OFF'")
+	}
+}
+
+func TestHandleSettingsAction_ToggleStateChanges(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.SetSpaceLink(&state.SpaceLink{
+		SpaceID:          "spaces/settings-test3",
+		Platform:         "googlechat",
+		ProjectID:        "proj-1",
+		ProjectSlug:      "my-project",
+		LinkedBy:         "test",
+		ShowAgentToAgent: false,
+		ShowStateChanges: true, // starts ON
+	}); err != nil {
+		t.Fatalf("setting space link: %v", err)
+	}
+
+	router, fm := newTestRouterWithStore(t, store)
+	event := &ChatEvent{
+		Type:     EventAction,
+		Platform: "googlechat",
+		SpaceID:  "spaces/settings-test3",
+		UserID:   "user-1",
+		ActionID: "settings.statechange",
+	}
+
+	// Toggle OFF.
+	err := router.handleSettingsAction(context.Background(), event, "statechange")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	link, err := store.GetSpaceLink("spaces/settings-test3", "googlechat")
+	if err != nil {
+		t.Fatalf("getting space link: %v", err)
+	}
+	if link.ShowStateChanges {
+		t.Error("expected ShowStateChanges to be toggled OFF")
+	}
+
+	if len(fm.messages) == 0 {
+		t.Fatal("expected a settings card to be sent")
+	}
+	got := fm.messages[0]
+	if got.Card == nil {
+		t.Fatal("expected a card in the response")
+	}
+	foundState := false
+	for _, action := range got.Card.Actions {
+		if strings.Contains(action.Label, "State Notifications: OFF") {
+			foundState = true
+		}
+	}
+	if !foundState {
+		t.Error("expected settings card to show 'State Notifications: OFF'")
+	}
+
+	// Toggle back ON.
+	fm.messages = nil
+	err = router.handleSettingsAction(context.Background(), event, "statechange")
+	if err != nil {
+		t.Fatalf("unexpected error on second toggle: %v", err)
+	}
+
+	link, err = store.GetSpaceLink("spaces/settings-test3", "googlechat")
+	if err != nil {
+		t.Fatalf("getting space link: %v", err)
+	}
+	if !link.ShowStateChanges {
+		t.Error("expected ShowStateChanges to be toggled back ON")
+	}
+}
+
+func TestHandleSettingsAction_RequiresSpaceLink(t *testing.T) {
+	router, fm := newTestRouter(t)
+	event := &ChatEvent{
+		Type:     EventAction,
+		Platform: "googlechat",
+		SpaceID:  "spaces/unlinked",
+		UserID:   "user-1",
+	}
+
+	err := router.handleSettingsAction(context.Background(), event, "observe")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(fm.messages) == 0 {
+		t.Fatal("expected a reply message")
+	}
+	if !strings.Contains(fm.messages[0].Text, "not linked") {
+		t.Errorf("expected 'not linked' reply, got: %s", fm.messages[0].Text)
+	}
+}
+
+func TestCmdSettings_RequiresSpaceLink(t *testing.T) {
+	router, _ := newTestRouter(t)
+	event := &ChatEvent{
+		Type:     EventCommand,
+		Platform: "googlechat",
+		SpaceID:  "spaces/unlinked",
+		UserID:   "user-1",
+	}
+
+	resp, err := router.cmdSettings(context.Background(), event, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil || resp.Message == nil {
+		t.Fatal("expected a response")
+	}
+	if !strings.Contains(resp.Message.Text, "not linked") {
+		t.Errorf("expected 'not linked' message, got: %s", resp.Message.Text)
+	}
+}
+
+func TestCmdSettings_ShowsCurrentState(t *testing.T) {
+	store := newTestStore(t)
+	if err := store.SetSpaceLink(&state.SpaceLink{
+		SpaceID:          "spaces/settings-view",
+		Platform:         "googlechat",
+		ProjectID:        "proj-1",
+		ProjectSlug:      "my-project",
+		LinkedBy:         "test",
+		ShowAgentToAgent: true,
+		ShowStateChanges: false,
+	}); err != nil {
+		t.Fatalf("setting space link: %v", err)
+	}
+
+	router, _ := newTestRouterWithStore(t, store)
+	event := &ChatEvent{
+		Type:     EventCommand,
+		Platform: "googlechat",
+		SpaceID:  "spaces/settings-view",
+		UserID:   "user-1",
+	}
+
+	resp, err := router.cmdSettings(context.Background(), event, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil || resp.Message == nil || resp.Message.Card == nil {
+		t.Fatal("expected a card response")
+	}
+
+	card := resp.Message.Card
+	if card.Header.Title != "Space Settings" {
+		t.Errorf("unexpected card title: %q", card.Header.Title)
+	}
+
+	var observeLabel, stateLabel string
+	for _, a := range card.Actions {
+		if strings.Contains(a.Label, "Observe Mode") {
+			observeLabel = a.Label
+		}
+		if strings.Contains(a.Label, "State Notifications") {
+			stateLabel = a.Label
+		}
+	}
+	if observeLabel != "Observe Mode: ON" {
+		t.Errorf("expected observe label 'Observe Mode: ON', got %q", observeLabel)
+	}
+	if stateLabel != "State Notifications: OFF" {
+		t.Errorf("expected state label 'State Notifications: OFF', got %q", stateLabel)
+	}
+}
+
 // TestDeleteConfirmAction_UpdatesMessage verifies that the card-based delete
 // confirm action (agent.delete.confirm.<id>) returns an UpdateMessage response.
 func TestDeleteConfirmAction_UpdatesMessage(t *testing.T) {

--- a/extras/scion-chat-app/internal/chatapp/notifications.go
+++ b/extras/scion-chat-app/internal/chatapp/notifications.go
@@ -511,7 +511,8 @@ func (n *NotificationRelay) getSubscriberMentions(msg *messages.StructuredMessag
 
 // resolveOutboundMentions scans text for scion user emails (with optional
 // "user:" prefix) and replaces them with Google Chat @mentions when the user
-// has a mapping in the store.
+// has a mapping in the store. Emails embedded in URL paths (preceded by '/'
+// or ':' or followed by '/') are left untouched.
 func (n *NotificationRelay) resolveOutboundMentions(text string) string {
 	if text == "" {
 		return text
@@ -522,14 +523,17 @@ func (n *NotificationRelay) resolveOutboundMentions(text string) string {
 		return text
 	}
 
-	// Iterate in reverse to preserve indices during replacement.
-	for i := len(matches) - 1; i >= 0; i-- {
-		start, end := matches[i][0], matches[i][1]
+	var b strings.Builder
+	b.Grow(len(text))
+	prev := 0
+
+	for _, loc := range matches {
+		start, end := loc[0], loc[1]
 
 		// Skip emails embedded in URL paths.
 		if start > 0 {
-			prev := text[start-1]
-			if prev == '/' || prev == ':' {
+			ch := text[start-1]
+			if ch == '/' || ch == ':' {
 				continue
 			}
 		}
@@ -537,8 +541,7 @@ func (n *NotificationRelay) resolveOutboundMentions(text string) string {
 			continue
 		}
 
-		match := text[start:end]
-		email := match
+		email := text[start:end]
 		if strings.HasPrefix(email, "user:") {
 			email = strings.TrimPrefix(email, "user:")
 		}
@@ -548,11 +551,19 @@ func (n *NotificationRelay) resolveOutboundMentions(text string) string {
 			continue
 		}
 
-		// Google Chat @mention format: <users/USER_ID>
-		text = text[:start] + fmt.Sprintf("<users/%s>", mapping.PlatformUserID) + text[end:]
+		// Write everything before this match, then the replacement.
+		b.WriteString(text[prev:start])
+		fmt.Fprintf(&b, "<users/%s>", mapping.PlatformUserID)
+		prev = end
 	}
 
-	return text
+	// If no replacements were made, return original text.
+	if prev == 0 {
+		return text
+	}
+
+	b.WriteString(text[prev:])
+	return b.String()
 }
 
 // buildMentions returns a formatted @mention string for a user-targeted message.

--- a/extras/scion-chat-app/internal/chatapp/notifications.go
+++ b/extras/scion-chat-app/internal/chatapp/notifications.go
@@ -18,11 +18,15 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/extras/scion-chat-app/internal/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 )
+
+// outboundEmailRe matches scion user emails in outbound messages, with optional "user:" prefix.
+var outboundEmailRe = regexp.MustCompile(`(?:user:)?[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)
 
 // NotificationRelay routes agent notifications to chat spaces as rich cards.
 type NotificationRelay struct {
@@ -48,12 +52,14 @@ func (n *NotificationRelay) SetSendQueue(sq *SendQueue) {
 }
 
 // HandleBrokerMessage processes a message received via the broker plugin's Publish() path.
-// Only user-targeted messages (from explicit "scion message" commands) are relayed
-// to chat. All other topics are dropped to prevent harness output leaking into chat.
+// User-targeted messages are always relayed. Agent-to-agent messages and state
+// changes are relayed only when observe mode / state notifications are enabled
+// on the space link.
 //
-// Expected topic:
+// Expected topics:
 //
 //	scion.grove.<projectID>.user.<userID>.messages  — user-targeted message
+//	scion.grove.<projectID>.agent.<agentID>.messages — agent-targeted message
 func (n *NotificationRelay) HandleBrokerMessage(ctx context.Context, topic string, msg *messages.StructuredMessage) error {
 	// Strip the "scion." prefix used by the broker topic hierarchy.
 	normalized := strings.TrimPrefix(topic, "scion.")
@@ -64,16 +70,118 @@ func (n *NotificationRelay) HandleBrokerMessage(ctx context.Context, topic strin
 		return nil
 	}
 
-	// Only relay user-targeted messages (from explicit "scion message"
-	// commands). All other topics (agent-to-agent, broadcasts, etc.) are
-	// dropped so that harness terminal output does not leak into chat.
-	if parts[0] == "grove" && len(parts) >= 5 && parts[2] == "user" {
-		projectID := parts[1]
+	if parts[0] != "grove" || len(parts) < 2 {
+		n.log.Debug("ignoring non-grove topic", "topic", topic)
+		return nil
+	}
+	projectID := parts[1]
+
+	// Classify the message for filtering.
+	isAgentToAgent := msg != nil &&
+		strings.HasPrefix(msg.Sender, "agent:") &&
+		strings.HasPrefix(msg.Recipient, "agent:")
+	isStateChange := msg != nil && msg.Type == messages.TypeStateChange
+
+	// User-targeted messages are always relayed (they were explicitly
+	// sent to a specific user and bypass observe/filter settings).
+	if len(parts) >= 5 && parts[2] == "user" {
 		return n.handleUserMessage(ctx, projectID, msg)
+	}
+
+	// Agent-to-agent and state change messages require observe filtering.
+	if isAgentToAgent || isStateChange {
+		return n.handleFilteredMessage(ctx, projectID, msg, isAgentToAgent, isStateChange)
 	}
 
 	n.log.Debug("ignoring non-user-targeted topic", "topic", topic)
 	return nil
+}
+
+// handleFilteredMessage relays agent-to-agent or state change messages to
+// linked spaces, applying per-space observe mode and state change filters.
+func (n *NotificationRelay) handleFilteredMessage(ctx context.Context, projectID string, msg *messages.StructuredMessage, isAgentToAgent, isStateChange bool) error {
+	links, err := n.store.ListSpaceLinks()
+	if err != nil {
+		return fmt.Errorf("listing space links: %w", err)
+	}
+
+	for _, link := range links {
+		if link.ProjectID != projectID {
+			continue
+		}
+
+		if isAgentToAgent && !link.ShowAgentToAgent {
+			n.log.Debug("observe mode disabled, filtering agent-to-agent message",
+				"space_id", link.SpaceID)
+			continue
+		}
+		if isStateChange && !link.ShowStateChanges {
+			n.log.Debug("state change notifications disabled, filtering",
+				"space_id", link.SpaceID)
+			continue
+		}
+
+		// Route to the appropriate renderer.
+		if isAgentToAgent {
+			card := n.renderObservedMessage(msg)
+			if _, err := n.messenger.SendCard(ctx, link.SpaceID, card); err != nil {
+				n.log.Error("failed to send observed message",
+					"space_id", link.SpaceID,
+					"error", err,
+				)
+			}
+		} else {
+			// State change notification — use the existing card renderer.
+			card := n.renderNotificationCard(msg)
+			mentions := n.getSubscriberMentions(msg, link)
+			if mentions != "" {
+				card.Sections = append(card.Sections, CardSection{
+					Widgets: []Widget{
+						{Type: WidgetText, Content: mentions},
+					},
+				})
+			}
+			if _, err := n.messenger.SendCard(ctx, link.SpaceID, card); err != nil {
+				n.log.Error("failed to send state change notification",
+					"space_id", link.SpaceID,
+					"error", err,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+// renderObservedMessage creates a card for an observed agent-to-agent message,
+// visually distinct from direct user messages.
+func (n *NotificationRelay) renderObservedMessage(msg *messages.StructuredMessage) Card {
+	senderSlug := msg.Sender
+	if idx := strings.Index(senderSlug, ":"); idx >= 0 {
+		senderSlug = senderSlug[idx+1:]
+	}
+	recipientSlug := msg.Recipient
+	if idx := strings.Index(recipientSlug, ":"); idx >= 0 {
+		recipientSlug = recipientSlug[idx+1:]
+	}
+
+	body := n.resolveOutboundMentions(msg.Msg)
+	if len(body) > 500 {
+		body = body[:500] + fmt.Sprintf("\n[%d chars truncated]", len(body)-500)
+	}
+
+	return Card{
+		Header: CardHeader{
+			Title:    fmt.Sprintf("%s → %s", senderSlug, recipientSlug),
+			Subtitle: "Agent-to-agent message (observe mode)",
+		},
+		Sections: []CardSection{
+			{
+				Widgets: []Widget{
+					{Type: WidgetText, Content: body},
+				},
+			},
+		},
+	}
 }
 
 // handleAgentNotification renders an agent status notification as a card in linked spaces.
@@ -173,6 +281,9 @@ func (n *NotificationRelay) handleUserMessage(ctx context.Context, projectID str
 	if idx := strings.Index(agentSlug, ":"); idx >= 0 {
 		agentSlug = agentSlug[idx+1:]
 	}
+
+	// Resolve outbound mentions (replace hub emails with @mentions).
+	msg.Msg = n.resolveOutboundMentions(msg.Msg)
 
 	// Find spaces linked to the project from the message topic
 	links, err := n.store.ListSpaceLinks()
@@ -396,6 +507,52 @@ func (n *NotificationRelay) getSubscriberMentions(msg *messages.StructuredMessag
 		return ""
 	}
 	return "CC: " + strings.Join(mentions, " ")
+}
+
+// resolveOutboundMentions scans text for scion user emails (with optional
+// "user:" prefix) and replaces them with Google Chat @mentions when the user
+// has a mapping in the store.
+func (n *NotificationRelay) resolveOutboundMentions(text string) string {
+	if text == "" {
+		return text
+	}
+
+	matches := outboundEmailRe.FindAllStringIndex(text, -1)
+	if len(matches) == 0 {
+		return text
+	}
+
+	// Iterate in reverse to preserve indices during replacement.
+	for i := len(matches) - 1; i >= 0; i-- {
+		start, end := matches[i][0], matches[i][1]
+
+		// Skip emails embedded in URL paths.
+		if start > 0 {
+			prev := text[start-1]
+			if prev == '/' || prev == ':' {
+				continue
+			}
+		}
+		if end < len(text) && text[end] == '/' {
+			continue
+		}
+
+		match := text[start:end]
+		email := match
+		if strings.HasPrefix(email, "user:") {
+			email = strings.TrimPrefix(email, "user:")
+		}
+
+		mapping, err := n.store.GetUserMappingByHubEmail(email)
+		if err != nil || mapping == nil {
+			continue
+		}
+
+		// Google Chat @mention format: <users/USER_ID>
+		text = text[:start] + fmt.Sprintf("<users/%s>", mapping.PlatformUserID) + text[end:]
+	}
+
+	return text
 }
 
 // buildMentions returns a formatted @mention string for a user-targeted message.

--- a/extras/scion-chat-app/internal/chatapp/notifications.go
+++ b/extras/scion-chat-app/internal/chatapp/notifications.go
@@ -70,7 +70,7 @@ func (n *NotificationRelay) HandleBrokerMessage(ctx context.Context, topic strin
 		return nil
 	}
 
-	if parts[0] != "grove" || len(parts) < 2 {
+	if parts[0] != "grove" {
 		n.log.Debug("ignoring non-grove topic", "topic", topic)
 		return nil
 	}
@@ -530,11 +530,16 @@ func (n *NotificationRelay) resolveOutboundMentions(text string) string {
 	for _, loc := range matches {
 		start, end := loc[0], loc[1]
 
-		// Skip emails embedded in URL paths.
+		// Skip emails embedded in URL paths or mailto links.
 		if start > 0 {
-			ch := text[start-1]
-			if ch == '/' || ch == ':' {
+			if text[start-1] == '/' {
 				continue
+			}
+			if text[start-1] == ':' {
+				preceding := text[:start]
+				if strings.HasSuffix(preceding, "mailto:") || strings.HasSuffix(preceding, "http:") || strings.HasSuffix(preceding, "https:") {
+					continue
+				}
 			}
 		}
 		if end < len(text) && text[end] == '/' {

--- a/extras/scion-chat-app/internal/chatapp/notifications_test.go
+++ b/extras/scion-chat-app/internal/chatapp/notifications_test.go
@@ -409,3 +409,320 @@ func TestHandleUserMessage_ShortAssistantReplyNotTruncated(t *testing.T) {
 		t.Errorf("short message should not be truncated, got %q, want %q", cardContent, shortText)
 	}
 }
+
+// --- resolveOutboundMentions tests ---
+
+func TestResolveOutboundMentions(t *testing.T) {
+	store := newTestStore(t)
+
+	// Seed user mappings for known emails.
+	// PlatformUserID is the raw ID; resolveOutboundMentions wraps it as <users/ID>.
+	if err := store.SetUserMapping(&state.UserMapping{
+		PlatformUserID: "ALICE123",
+		Platform:       "googlechat",
+		HubUserID:      "hub-alice",
+		HubUserEmail:   "alice@example.com",
+		RegisteredBy:   "auto",
+	}); err != nil {
+		t.Fatalf("setting user mapping: %v", err)
+	}
+	if err := store.SetUserMapping(&state.UserMapping{
+		PlatformUserID: "BOB456",
+		Platform:       "googlechat",
+		HubUserID:      "hub-bob",
+		HubUserEmail:   "bob@example.com",
+		RegisteredBy:   "auto",
+	}); err != nil {
+		t.Fatalf("setting user mapping: %v", err)
+	}
+
+	log := slog.Default()
+	relay := NewNotificationRelay(store, nil, log)
+
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{
+			name: "empty string",
+			text: "",
+			want: "",
+		},
+		{
+			name: "no emails in text",
+			text: "just a normal message with no emails",
+			want: "just a normal message with no emails",
+		},
+		{
+			name: "mapped email replaced",
+			text: "Hey alice@example.com can you review?",
+			want: "Hey <users/ALICE123> can you review?",
+		},
+		{
+			name: "unmapped email left as-is",
+			text: "Hey unknown@nowhere.org can you review?",
+			want: "Hey unknown@nowhere.org can you review?",
+		},
+		{
+			name: "multiple emails in one message",
+			text: "CC alice@example.com and bob@example.com for this",
+			want: "CC <users/ALICE123> and <users/BOB456> for this",
+		},
+		{
+			name: "mixed mapped and unmapped emails",
+			text: "alice@example.com and nobody@other.com",
+			want: "<users/ALICE123> and nobody@other.com",
+		},
+		{
+			name: "user: prefix stripped and resolved",
+			text: "message to user:alice@example.com about the build",
+			want: "message to <users/ALICE123> about the build",
+		},
+		{
+			name: "email inside URL path skipped (preceded by /)",
+			text: "see https://example.com/alice@example.com/profile",
+			want: "see https://example.com/alice@example.com/profile",
+		},
+		{
+			name: "email inside URL skipped (preceded by :)",
+			text: "check mailto:alice@example.com for details",
+			want: "check mailto:alice@example.com for details",
+		},
+		{
+			name: "email followed by slash skipped",
+			text: "the path alice@example.com/ is a directory",
+			want: "the path alice@example.com/ is a directory",
+		},
+		{
+			name: "email at start of string resolved",
+			text: "alice@example.com is the lead",
+			want: "<users/ALICE123> is the lead",
+		},
+		{
+			name: "email at end of string resolved",
+			text: "send it to alice@example.com",
+			want: "send it to <users/ALICE123>",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := relay.resolveOutboundMentions(tc.text)
+			if got != tc.want {
+				t.Errorf("resolveOutboundMentions(%q) = %q, want %q", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- handleFilteredMessage / observe mode tests ---
+
+func TestHandleFilteredMessage_AgentToAgent(t *testing.T) {
+	store := newTestStore(t)
+
+	msg := &messages.StructuredMessage{
+		Sender:    "agent:deploy-agent",
+		Recipient: "agent:review-agent",
+		Msg:       "I finished the deploy.",
+		Type:      messages.TypeInstruction,
+	}
+
+	tests := []struct {
+		name             string
+		showAgentToAgent bool
+		wantMessages     int
+	}{
+		{
+			name:             "ShowAgentToAgent false filters out message",
+			showAgentToAgent: false,
+			wantMessages:     0,
+		},
+		{
+			name:             "ShowAgentToAgent true passes message through",
+			showAgentToAgent: true,
+			wantMessages:     1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := store.SetSpaceLink(&state.SpaceLink{
+				SpaceID:          "spaces/observe-test",
+				Platform:         "googlechat",
+				ProjectID:        "proj-1",
+				ProjectSlug:      "my-project",
+				LinkedBy:         "test",
+				ShowAgentToAgent: tc.showAgentToAgent,
+				ShowStateChanges: true,
+			}); err != nil {
+				t.Fatalf("setting space link: %v", err)
+			}
+
+			fm := &fakeMessenger{}
+			log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			relay := NewNotificationRelay(store, fm, log)
+
+			err := relay.handleFilteredMessage(context.Background(), "proj-1", msg, true, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(fm.messages) != tc.wantMessages {
+				t.Errorf("expected %d messages, got %d", tc.wantMessages, len(fm.messages))
+			}
+
+			if tc.wantMessages > 0 {
+				got := fm.messages[0]
+				if got.Card == nil {
+					t.Fatal("expected a card in the observed message")
+				}
+				if !strings.Contains(got.Card.Header.Subtitle, "observe mode") {
+					t.Errorf("expected observe mode subtitle, got %q", got.Card.Header.Subtitle)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleFilteredMessage_StateChange(t *testing.T) {
+	store := newTestStore(t)
+
+	msg := &messages.StructuredMessage{
+		Sender: "agent:deploy-agent",
+		Msg:    "Agent status changed to COMPLETED",
+		Type:   messages.TypeStateChange,
+		Status: "completed",
+	}
+
+	tests := []struct {
+		name             string
+		showStateChanges bool
+		wantMessages     int
+	}{
+		{
+			name:             "ShowStateChanges false filters out message",
+			showStateChanges: false,
+			wantMessages:     0,
+		},
+		{
+			name:             "ShowStateChanges true passes message through",
+			showStateChanges: true,
+			wantMessages:     1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := store.SetSpaceLink(&state.SpaceLink{
+				SpaceID:          "spaces/state-test",
+				Platform:         "googlechat",
+				ProjectID:        "proj-2",
+				ProjectSlug:      "my-project",
+				LinkedBy:         "test",
+				ShowAgentToAgent: false,
+				ShowStateChanges: tc.showStateChanges,
+			}); err != nil {
+				t.Fatalf("setting space link: %v", err)
+			}
+
+			fm := &fakeMessenger{}
+			log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			relay := NewNotificationRelay(store, fm, log)
+
+			err := relay.handleFilteredMessage(context.Background(), "proj-2", msg, false, true)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(fm.messages) != tc.wantMessages {
+				t.Errorf("expected %d messages, got %d", tc.wantMessages, len(fm.messages))
+			}
+		})
+	}
+}
+
+func TestHandleBrokerMessage_UserTargetedAlwaysPassesThrough(t *testing.T) {
+	store := newTestStore(t)
+
+	// Set up a space with observe mode and state changes both disabled.
+	if err := store.SetUserMapping(&state.UserMapping{
+		PlatformUserID: "users/999",
+		Platform:       "googlechat",
+		HubUserID:      "hub-user-9",
+		HubUserEmail:   "user9@example.com",
+		RegisteredBy:   "auto",
+	}); err != nil {
+		t.Fatalf("setting user mapping: %v", err)
+	}
+	if err := store.SetSpaceLink(&state.SpaceLink{
+		SpaceID:          "spaces/all-off",
+		Platform:         "googlechat",
+		ProjectID:        "proj-3",
+		ProjectSlug:      "my-project",
+		LinkedBy:         "test",
+		ShowAgentToAgent: false,
+		ShowStateChanges: false,
+	}); err != nil {
+		t.Fatalf("setting space link: %v", err)
+	}
+
+	fm := &fakeMessenger{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	relay := NewNotificationRelay(store, fm, log)
+
+	msg := &messages.StructuredMessage{
+		Sender:      "agent:test-agent",
+		RecipientID: "hub-user-9",
+		Msg:         "Here is your answer.",
+		Type:        messages.TypeInstruction,
+	}
+
+	// User-targeted topic should always pass through regardless of filter settings.
+	err := relay.HandleBrokerMessage(context.Background(),
+		"scion.grove.proj-3.user.hub-user-9.messages", msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(fm.messages) == 0 {
+		t.Fatal("user-targeted message must always pass through, regardless of observe/state settings")
+	}
+}
+
+func TestHandleFilteredMessage_UnlinkedProjectDropped(t *testing.T) {
+	store := newTestStore(t)
+
+	// Space is linked to proj-A, but message is for proj-B.
+	if err := store.SetSpaceLink(&state.SpaceLink{
+		SpaceID:          "spaces/linked-a",
+		Platform:         "googlechat",
+		ProjectID:        "proj-A",
+		ProjectSlug:      "project-a",
+		LinkedBy:         "test",
+		ShowAgentToAgent: true,
+		ShowStateChanges: true,
+	}); err != nil {
+		t.Fatalf("setting space link: %v", err)
+	}
+
+	fm := &fakeMessenger{}
+	log := slog.Default()
+	relay := NewNotificationRelay(store, fm, log)
+
+	msg := &messages.StructuredMessage{
+		Sender:    "agent:deploy",
+		Recipient: "agent:review",
+		Msg:       "hello",
+	}
+
+	// Send for proj-B — no space is linked to it.
+	err := relay.handleFilteredMessage(context.Background(), "proj-B", msg, true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(fm.messages) != 0 {
+		t.Errorf("expected no messages for unlinked project, got %d", len(fm.messages))
+	}
+}

--- a/extras/scion-chat-app/internal/state/state.go
+++ b/extras/scion-chat-app/internal/state/state.go
@@ -35,13 +35,15 @@ type UserMapping struct {
 
 // SpaceLink associates a platform space/channel with a project.
 type SpaceLink struct {
-	SpaceID      string
-	Platform     string
-	ProjectID    string
-	ProjectSlug  string
-	LinkedBy     string
-	LinkedAt     time.Time
-	DefaultAgent string
+	SpaceID          string
+	Platform         string
+	ProjectID        string
+	ProjectSlug      string
+	LinkedBy         string
+	LinkedAt         time.Time
+	DefaultAgent     string
+	ShowAgentToAgent bool
+	ShowStateChanges bool
 }
 
 // AgentSubscription tracks a user's subscription to agent activity notifications.
@@ -134,6 +136,8 @@ func (s *Store) migrate() error {
 	// Additive column migrations (idempotent — ignore "duplicate column" errors).
 	addColumns := []string{
 		`ALTER TABLE space_links ADD COLUMN default_agent TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE space_links ADD COLUMN show_agent_to_agent INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE space_links ADD COLUMN show_state_changes INTEGER NOT NULL DEFAULT 1`,
 	}
 	for _, m := range addColumns {
 		if _, err := s.db.Exec(m); err != nil && !strings.Contains(err.Error(), "duplicate column") {
@@ -264,16 +268,33 @@ func (s *Store) GetUserMappingByHubID(hubUserID string) (*UserMapping, error) {
 	return m, nil
 }
 
+// GetUserMappingByHubEmail returns the user mapping for the given hub email, or nil, nil if not found.
+func (s *Store) GetUserMappingByHubEmail(hubEmail string) (*UserMapping, error) {
+	m := &UserMapping{}
+	err := s.db.QueryRow(
+		`SELECT platform_user_id, platform, hub_user_id, hub_user_email, registered_at, registered_by
+		 FROM user_mappings WHERE hub_user_email = ?`,
+		hubEmail,
+	).Scan(&m.PlatformUserID, &m.Platform, &m.HubUserID, &m.HubUserEmail, &m.RegisteredAt, &m.RegisteredBy)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get user mapping by hub email: %w", err)
+	}
+	return m, nil
+}
+
 // --- Space Links ---
 
 // GetSpaceLink returns the space link for the given space, or nil, nil if not found.
 func (s *Store) GetSpaceLink(spaceID, platform string) (*SpaceLink, error) {
 	l := &SpaceLink{}
 	err := s.db.QueryRow(
-		`SELECT space_id, platform, grove_id, grove_slug, linked_by, linked_at, default_agent
+		`SELECT space_id, platform, grove_id, grove_slug, linked_by, linked_at, default_agent, show_agent_to_agent, show_state_changes
 		 FROM space_links WHERE space_id = ? AND platform = ?`,
 		spaceID, platform,
-	).Scan(&l.SpaceID, &l.Platform, &l.ProjectID, &l.ProjectSlug, &l.LinkedBy, &l.LinkedAt, &l.DefaultAgent)
+	).Scan(&l.SpaceID, &l.Platform, &l.ProjectID, &l.ProjectSlug, &l.LinkedBy, &l.LinkedAt, &l.DefaultAgent, &l.ShowAgentToAgent, &l.ShowStateChanges)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -286,9 +307,9 @@ func (s *Store) GetSpaceLink(spaceID, platform string) (*SpaceLink, error) {
 // SetSpaceLink inserts or replaces a space link.
 func (s *Store) SetSpaceLink(l *SpaceLink) error {
 	_, err := s.db.Exec(
-		`INSERT OR REPLACE INTO space_links (space_id, platform, grove_id, grove_slug, linked_by, linked_at, default_agent)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		l.SpaceID, l.Platform, l.ProjectID, l.ProjectSlug, l.LinkedBy, l.LinkedAt, l.DefaultAgent,
+		`INSERT OR REPLACE INTO space_links (space_id, platform, grove_id, grove_slug, linked_by, linked_at, default_agent, show_agent_to_agent, show_state_changes)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		l.SpaceID, l.Platform, l.ProjectID, l.ProjectSlug, l.LinkedBy, l.LinkedAt, l.DefaultAgent, l.ShowAgentToAgent, l.ShowStateChanges,
 	)
 	if err != nil {
 		return fmt.Errorf("set space link: %w", err)
@@ -311,7 +332,7 @@ func (s *Store) DeleteSpaceLink(spaceID, platform string) error {
 // ListSpaceLinks returns all space links.
 func (s *Store) ListSpaceLinks() ([]SpaceLink, error) {
 	rows, err := s.db.Query(
-		`SELECT space_id, platform, grove_id, grove_slug, linked_by, linked_at, default_agent FROM space_links`,
+		`SELECT space_id, platform, grove_id, grove_slug, linked_by, linked_at, default_agent, show_agent_to_agent, show_state_changes FROM space_links`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list space links: %w", err)
@@ -321,7 +342,7 @@ func (s *Store) ListSpaceLinks() ([]SpaceLink, error) {
 	var links []SpaceLink
 	for rows.Next() {
 		var l SpaceLink
-		if err := rows.Scan(&l.SpaceID, &l.Platform, &l.ProjectID, &l.ProjectSlug, &l.LinkedBy, &l.LinkedAt, &l.DefaultAgent); err != nil {
+		if err := rows.Scan(&l.SpaceID, &l.Platform, &l.ProjectID, &l.ProjectSlug, &l.LinkedBy, &l.LinkedAt, &l.DefaultAgent, &l.ShowAgentToAgent, &l.ShowStateChanges); err != nil {
 			return nil, fmt.Errorf("scan space link: %w", err)
 		}
 		links = append(links, l)
@@ -344,6 +365,30 @@ func (s *Store) SetDefaultAgent(spaceID, platform, agentSlug string) error {
 // ClearDefaultAgent removes the default agent for a space link.
 func (s *Store) ClearDefaultAgent(spaceID, platform string) error {
 	return s.SetDefaultAgent(spaceID, platform, "")
+}
+
+// SetShowAgentToAgent updates the observe mode setting for a space link.
+func (s *Store) SetShowAgentToAgent(spaceID, platform string, show bool) error {
+	_, err := s.db.Exec(
+		`UPDATE space_links SET show_agent_to_agent = ? WHERE space_id = ? AND platform = ?`,
+		show, spaceID, platform,
+	)
+	if err != nil {
+		return fmt.Errorf("set show_agent_to_agent: %w", err)
+	}
+	return nil
+}
+
+// SetShowStateChanges updates the state change notification setting for a space link.
+func (s *Store) SetShowStateChanges(spaceID, platform string, show bool) error {
+	_, err := s.db.Exec(
+		`UPDATE space_links SET show_state_changes = ? WHERE space_id = ? AND platform = ?`,
+		show, spaceID, platform,
+	)
+	if err != nil {
+		return fmt.Errorf("set show_state_changes: %w", err)
+	}
+	return nil
 }
 
 // --- Agent Subscriptions ---

--- a/extras/scion-chat-app/internal/state/state.go
+++ b/extras/scion-chat-app/internal/state/state.go
@@ -273,7 +273,7 @@ func (s *Store) GetUserMappingByHubEmail(hubEmail string) (*UserMapping, error) 
 	m := &UserMapping{}
 	err := s.db.QueryRow(
 		`SELECT platform_user_id, platform, hub_user_id, hub_user_email, registered_at, registered_by
-		 FROM user_mappings WHERE hub_user_email = ?`,
+		 FROM user_mappings WHERE hub_user_email = ? COLLATE NOCASE`,
 		hubEmail,
 	).Scan(&m.PlatformUserID, &m.Platform, &m.HubUserID, &m.HubUserEmail, &m.RegisteredAt, &m.RegisteredBy)
 	if err == sql.ErrNoRows {


### PR DESCRIPTION
Add remaining Discord-parity features: observe mode filtering, outbound mention resolution, and settings toggle command.

Key changes:
- extras/scion-chat-app/internal/state/state.go: show_agent_to_agent and show_state_changes columns on space_links
- extras/scion-chat-app/internal/chatapp/commands.go: /scionAdmin settings with toggle card
- extras/scion-chat-app/internal/chatapp/notifications.go: observe mode filtering and resolveOutboundMentions (email to Google Chat user mention)
- 24 tests

Ref: ptone/scion#914
