### PR TITLE
feat(teams): add Teams admin web UI integration and manifest download

### DIFF
--- a/pkg/hub/handlers_chat_secrets.go
+++ b/pkg/hub/handlers_chat_secrets.go
@@ -108,6 +108,8 @@ func ChatSecretDescription(secretKey string) string {
 		return "Discord application public key"
 	case config.SecretGChatSigningKey:
 		return "Google Chat signing key"
+	case config.SecretTeamsAppSecret:
+		return "Microsoft Teams app secret (Azure App Registration client secret)"
 	default:
 		slog.Warn("Unknown chat secret key", "key", secretKey)
 		return "Chat integration secret"

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -167,6 +167,7 @@ var knownPluginCatalog = []KnownPlugin{
 	{Name: "slack", Platform: "slack", BinaryName: "scion-plugin-slack", SourceDir: "extras/scion-slack", Description: "Chat integration — built and managed by the Hub"},
 	{Name: "a2a-bridge", Platform: "a2a", BinaryName: "scion-a2a-bridge", SourceDir: "extras/scion-a2a-bridge", SelfManaged: true, Description: "External service — installed separately, managed via admin UI"},
 	{Name: "chat-app", Platform: "gchat", BinaryName: "scion-chat-app", SourceDir: "extras/scion-chat-app", SelfManaged: true, Description: "Google Chat integration — installed separately, managed via admin UI"},
+	{Name: "teams", Platform: "teams", BinaryName: "scion-plugin-teams", SourceDir: "extras/scion-teams", Description: "Microsoft Teams chat integration"},
 }
 
 var knownPluginSet = func() map[string]bool {
@@ -1377,6 +1378,8 @@ func resolvePlatform(name string) string {
 		return "gchat"
 	case "a2a-bridge":
 		return "a2a"
+	case "teams":
+		return "teams"
 	default:
 		return name
 	}

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -167,7 +167,7 @@ var knownPluginCatalog = []KnownPlugin{
 	{Name: "slack", Platform: "slack", BinaryName: "scion-plugin-slack", SourceDir: "extras/scion-slack", Description: "Chat integration — built and managed by the Hub"},
 	{Name: "a2a-bridge", Platform: "a2a", BinaryName: "scion-a2a-bridge", SourceDir: "extras/scion-a2a-bridge", SelfManaged: true, Description: "External service — installed separately, managed via admin UI"},
 	{Name: "chat-app", Platform: "gchat", BinaryName: "scion-chat-app", SourceDir: "extras/scion-chat-app", SelfManaged: true, Description: "Google Chat integration — installed separately, managed via admin UI"},
-	{Name: "teams", Platform: "teams", BinaryName: "scion-plugin-teams", SourceDir: "extras/scion-teams", Description: "Microsoft Teams chat integration"},
+	{Name: "teams", Platform: "teams", BinaryName: "scion-plugin-teams", SourceDir: "extras/scion-teams", Description: "Chat integration — built and managed by the Hub"},
 }
 
 var knownPluginSet = func() map[string]bool {

--- a/pkg/hub/handlers_teams_manifest.go
+++ b/pkg/hub/handlers_teams_manifest.go
@@ -24,8 +24,19 @@ import (
 	"image/png"
 	"log/slog"
 	"net/http"
+	"sync"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// Cached placeholder PNGs — generated once, reused on every request.
+var (
+	colorPNGOnce     sync.Once
+	outlinePNGOnce   sync.Once
+	cachedColorPNG   []byte
+	cachedOutlinePNG []byte
+	colorPNGErr      error
+	outlinePNGErr    error
 )
 
 // teamsManifest mirrors the Azure Teams app manifest schema (v1.16).
@@ -138,10 +149,12 @@ func (s *Server) handleTeamsManifestDownload(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Add color.png (192x192).
-	colorPNG, err := generatePlaceholderPNG(192, color.RGBA{R: 74, G: 144, B: 217, A: 255})
-	if err != nil {
-		slog.Error("failed to generate color.png", "error", err)
+	// Add color.png (192x192) — uses cached, pre-generated image.
+	colorPNGOnce.Do(func() {
+		cachedColorPNG, colorPNGErr = generatePlaceholderPNG(192, color.RGBA{R: 74, G: 144, B: 217, A: 255})
+	})
+	if colorPNGErr != nil {
+		slog.Error("failed to generate color.png", "error", colorPNGErr)
 		http.Error(w, "internal error generating manifest", http.StatusInternalServerError)
 		return
 	}
@@ -151,16 +164,18 @@ func (s *Server) handleTeamsManifestDownload(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "internal error generating zip", http.StatusInternalServerError)
 		return
 	}
-	if _, err := cf.Write(colorPNG); err != nil {
+	if _, err := cf.Write(cachedColorPNG); err != nil {
 		slog.Error("failed to write color.png", "error", err)
 		http.Error(w, "internal error generating zip", http.StatusInternalServerError)
 		return
 	}
 
-	// Add outline.png (32x32).
-	outlinePNG, err := generatePlaceholderPNG(32, color.RGBA{R: 255, G: 255, B: 255, A: 255})
-	if err != nil {
-		slog.Error("failed to generate outline.png", "error", err)
+	// Add outline.png (32x32) — uses cached, pre-generated image.
+	outlinePNGOnce.Do(func() {
+		cachedOutlinePNG, outlinePNGErr = generatePlaceholderPNG(32, color.RGBA{R: 255, G: 255, B: 255, A: 255})
+	})
+	if outlinePNGErr != nil {
+		slog.Error("failed to generate outline.png", "error", outlinePNGErr)
 		http.Error(w, "internal error generating manifest", http.StatusInternalServerError)
 		return
 	}
@@ -170,7 +185,7 @@ func (s *Server) handleTeamsManifestDownload(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "internal error generating zip", http.StatusInternalServerError)
 		return
 	}
-	if _, err := of.Write(outlinePNG); err != nil {
+	if _, err := of.Write(cachedOutlinePNG); err != nil {
 		slog.Error("failed to write outline.png", "error", err)
 		http.Error(w, "internal error generating zip", http.StatusInternalServerError)
 		return

--- a/pkg/hub/handlers_teams_manifest.go
+++ b/pkg/hub/handlers_teams_manifest.go
@@ -1,0 +1,264 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"log/slog"
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// teamsManifest mirrors the Azure Teams app manifest schema (v1.16).
+type teamsManifest struct {
+	Schema          string           `json:"$schema"`
+	ManifestVersion string           `json:"manifestVersion"`
+	Version         string           `json:"version"`
+	ID              string           `json:"id"`
+	Developer       teamsDevInfo     `json:"developer"`
+	Name            teamsName        `json:"name"`
+	Description     teamsDescription `json:"description"`
+	Icons           teamsIcons       `json:"icons"`
+	AccentColor     string           `json:"accentColor"`
+	Bots            []teamsBot       `json:"bots"`
+	Permissions     []string         `json:"permissions"`
+	ValidDomains    []string         `json:"validDomains"`
+}
+
+type teamsDevInfo struct {
+	Name          string `json:"name"`
+	WebsiteURL    string `json:"websiteUrl"`
+	PrivacyURL    string `json:"privacyUrl"`
+	TermsOfUseURL string `json:"termsOfUseUrl"`
+}
+
+type teamsName struct {
+	Short string `json:"short"`
+	Full  string `json:"full"`
+}
+
+type teamsDescription struct {
+	Short string `json:"short"`
+	Full  string `json:"full"`
+}
+
+type teamsIcons struct {
+	Color   string `json:"color"`
+	Outline string `json:"outline"`
+}
+
+type teamsBot struct {
+	BotID              string             `json:"botId"`
+	Scopes             []string           `json:"scopes"`
+	SupportsFiles      bool               `json:"supportsFiles"`
+	IsNotificationOnly bool               `json:"isNotificationOnly"`
+	CommandLists       []teamsBotCommands `json:"commandLists"`
+}
+
+type teamsBotCommands struct {
+	Scopes   []string          `json:"scopes"`
+	Commands []teamsBotCommand `json:"commands"`
+}
+
+type teamsBotCommand struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+// handleTeamsManifestDownload generates and returns a Teams app manifest .zip.
+// GET /api/v1/admin/integrations/teams/manifest
+func (s *Server) handleTeamsManifestDownload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil || user.Role() != "admin" {
+		Forbidden(w)
+		return
+	}
+
+	// Read current Teams config to get app_id and tenant_id.
+	cfg, err := s.loadTeamsConfig()
+	if err != nil {
+		slog.Error("failed to load Teams config for manifest", "error", err)
+		http.Error(w, "Teams integration is not configured", http.StatusBadRequest)
+		return
+	}
+
+	appID := cfg["app_id"]
+	if appID == "" {
+		http.Error(w, "app_id is not configured — set it in the Teams integration settings first", http.StatusBadRequest)
+		return
+	}
+
+	manifest := buildTeamsManifest(appID)
+
+	manifestJSON, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		slog.Error("failed to marshal Teams manifest", "error", err)
+		http.Error(w, "internal error generating manifest", http.StatusInternalServerError)
+		return
+	}
+
+	// Build zip archive in memory.
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	// Add manifest.json.
+	mf, err := zw.Create("manifest.json")
+	if err != nil {
+		slog.Error("failed to create manifest.json in zip", "error", err)
+		http.Error(w, "internal error generating zip", http.StatusInternalServerError)
+		return
+	}
+	if _, err := mf.Write(manifestJSON); err != nil {
+		slog.Error("failed to write manifest.json", "error", err)
+		http.Error(w, "internal error generating zip", http.StatusInternalServerError)
+		return
+	}
+
+	// Add color.png (192x192).
+	colorPNG := generatePlaceholderPNG(192, color.RGBA{R: 74, G: 144, B: 217, A: 255})
+	cf, err := zw.Create("color.png")
+	if err != nil {
+		slog.Error("failed to create color.png in zip", "error", err)
+		http.Error(w, "internal error generating zip", http.StatusInternalServerError)
+		return
+	}
+	if _, err := cf.Write(colorPNG); err != nil {
+		slog.Error("failed to write color.png", "error", err)
+		http.Error(w, "internal error generating zip", http.StatusInternalServerError)
+		return
+	}
+
+	// Add outline.png (32x32).
+	outlinePNG := generatePlaceholderPNG(32, color.RGBA{R: 255, G: 255, B: 255, A: 255})
+	of, err := zw.Create("outline.png")
+	if err != nil {
+		slog.Error("failed to create outline.png in zip", "error", err)
+		http.Error(w, "internal error generating zip", http.StatusInternalServerError)
+		return
+	}
+	if _, err := of.Write(outlinePNG); err != nil {
+		slog.Error("failed to write outline.png", "error", err)
+		http.Error(w, "internal error generating zip", http.StatusInternalServerError)
+		return
+	}
+
+	if err := zw.Close(); err != nil {
+		slog.Error("failed to finalize zip", "error", err)
+		http.Error(w, "internal error generating zip", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/zip")
+	w.Header().Set("Content-Disposition", `attachment; filename="teams-app.zip"`)
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", buf.Len()))
+	w.WriteHeader(http.StatusOK)
+	w.Write(buf.Bytes())
+}
+
+// loadTeamsConfig reads the current Teams integration config.
+func (s *Server) loadTeamsConfig() (map[string]string, error) {
+	s.mu.RLock()
+	mgr := s.pluginManager
+	s.mu.RUnlock()
+
+	if mgr == nil {
+		return nil, fmt.Errorf("plugin manager not available")
+	}
+
+	configFile := mgr.GetPluginConfigFile("broker", "teams")
+	cfg, err := config.ResolvePluginConfig(configFile, nil)
+	if err != nil {
+		return nil, fmt.Errorf("resolve plugin config: %w", err)
+	}
+	return cfg, nil
+}
+
+// buildTeamsManifest constructs a Teams app manifest from config values.
+func buildTeamsManifest(appID string) teamsManifest {
+	return teamsManifest{
+		Schema:          "https://developer.microsoft.com/json-schemas/teams/v1.16/MicrosoftTeams.schema.json",
+		ManifestVersion: "1.16",
+		Version:         "1.0.0",
+		ID:              appID,
+		Developer: teamsDevInfo{
+			Name:          "Scion",
+			WebsiteURL:    "https://github.com/GoogleCloudPlatform/scion",
+			PrivacyURL:    "https://github.com/GoogleCloudPlatform/scion",
+			TermsOfUseURL: "https://github.com/GoogleCloudPlatform/scion",
+		},
+		Name: teamsName{
+			Short: "Scion",
+			Full:  "Scion Agent Orchestration",
+		},
+		Description: teamsDescription{
+			Short: "Chat with Scion agents from Microsoft Teams",
+			Full:  "Scion Teams integration provides bidirectional messaging between Microsoft Teams channels and Scion agents. Link channels to projects, message agents via @-mention, receive status updates and interactive prompts via Adaptive Cards, and manage your agent workflows directly from Teams.",
+		},
+		Icons: teamsIcons{
+			Color:   "color.png",
+			Outline: "outline.png",
+		},
+		AccentColor: "#4A90D9",
+		Bots: []teamsBot{
+			{
+				BotID:              appID,
+				Scopes:             []string{"personal", "team", "groupChat"},
+				SupportsFiles:      false,
+				IsNotificationOnly: false,
+				CommandLists: []teamsBotCommands{
+					{
+						Scopes: []string{"personal", "team", "groupChat"},
+						Commands: []teamsBotCommand{
+							{Title: "setup", Description: "Link this channel to a Scion project"},
+							{Title: "unlink", Description: "Unlink this channel from its project"},
+							{Title: "agents", Description: "List agents in the linked project"},
+							{Title: "status", Description: "Show project or agent status"},
+							{Title: "register", Description: "Link your Teams account to your Scion identity"},
+							{Title: "unregister", Description: "Unlink your Teams account from Scion"},
+							{Title: "help", Description: "Show available commands"},
+						},
+					},
+				},
+			},
+		},
+		Permissions:  []string{"identity", "messageTeamMembers"},
+		ValidDomains: []string{},
+	}
+}
+
+// generatePlaceholderPNG creates a minimal solid-color PNG of the given size.
+func generatePlaceholderPNG(size int, c color.Color) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, size, size))
+	for y := 0; y < size; y++ {
+		for x := 0; x < size; x++ {
+			img.Set(x, y, c)
+		}
+	}
+	var buf bytes.Buffer
+	_ = png.Encode(&buf, img)
+	return buf.Bytes()
+}

--- a/pkg/hub/handlers_teams_manifest.go
+++ b/pkg/hub/handlers_teams_manifest.go
@@ -139,7 +139,12 @@ func (s *Server) handleTeamsManifestDownload(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Add color.png (192x192).
-	colorPNG := generatePlaceholderPNG(192, color.RGBA{R: 74, G: 144, B: 217, A: 255})
+	colorPNG, err := generatePlaceholderPNG(192, color.RGBA{R: 74, G: 144, B: 217, A: 255})
+	if err != nil {
+		slog.Error("failed to generate color.png", "error", err)
+		http.Error(w, "internal error generating manifest", http.StatusInternalServerError)
+		return
+	}
 	cf, err := zw.Create("color.png")
 	if err != nil {
 		slog.Error("failed to create color.png in zip", "error", err)
@@ -153,7 +158,12 @@ func (s *Server) handleTeamsManifestDownload(w http.ResponseWriter, r *http.Requ
 	}
 
 	// Add outline.png (32x32).
-	outlinePNG := generatePlaceholderPNG(32, color.RGBA{R: 255, G: 255, B: 255, A: 255})
+	outlinePNG, err := generatePlaceholderPNG(32, color.RGBA{R: 255, G: 255, B: 255, A: 255})
+	if err != nil {
+		slog.Error("failed to generate outline.png", "error", err)
+		http.Error(w, "internal error generating manifest", http.StatusInternalServerError)
+		return
+	}
 	of, err := zw.Create("outline.png")
 	if err != nil {
 		slog.Error("failed to create outline.png in zip", "error", err)
@@ -176,7 +186,9 @@ func (s *Server) handleTeamsManifestDownload(w http.ResponseWriter, r *http.Requ
 	w.Header().Set("Content-Disposition", `attachment; filename="teams-app.zip"`)
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", buf.Len()))
 	w.WriteHeader(http.StatusOK)
-	w.Write(buf.Bytes())
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		slog.Error("failed to write manifest zip response", "error", err)
+	}
 }
 
 // loadTeamsConfig reads the current Teams integration config.
@@ -251,7 +263,7 @@ func buildTeamsManifest(appID string) teamsManifest {
 }
 
 // generatePlaceholderPNG creates a minimal solid-color PNG of the given size.
-func generatePlaceholderPNG(size int, c color.Color) []byte {
+func generatePlaceholderPNG(size int, c color.Color) ([]byte, error) {
 	img := image.NewRGBA(image.Rect(0, 0, size, size))
 	for y := 0; y < size; y++ {
 		for x := 0; x < size; x++ {
@@ -259,6 +271,8 @@ func generatePlaceholderPNG(size int, c color.Color) []byte {
 		}
 	}
 	var buf bytes.Buffer
-	_ = png.Encode(&buf, img)
-	return buf.Bytes()
+	if err := png.Encode(&buf, img); err != nil {
+		return nil, fmt.Errorf("encode PNG: %w", err)
+	}
+	return buf.Bytes(), nil
 }

--- a/pkg/hub/handlers_teams_manifest_test.go
+++ b/pkg/hub/handlers_teams_manifest_test.go
@@ -1,0 +1,277 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"image/color"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- Teams Manifest handler tests ---
+
+func TestHandleTeamsManifestDownload_AuthGate_Unauthenticated(t *testing.T) {
+	srv := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/teams/manifest", nil)
+	rr := httptest.NewRecorder()
+	srv.handleTeamsManifestDownload(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for unauthenticated request, got %d", rr.Code)
+	}
+}
+
+func TestHandleTeamsManifestDownload_AuthGate_NonAdmin(t *testing.T) {
+	srv := &Server{}
+	member := NewAuthenticatedUser("u1", "member@example.com", "Member", "member", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/teams/manifest", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), member))
+	rr := httptest.NewRecorder()
+	srv.handleTeamsManifestDownload(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-admin, got %d", rr.Code)
+	}
+}
+
+func TestHandleTeamsManifestDownload_MethodNotAllowed(t *testing.T) {
+	srv := &Server{}
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		req := httptest.NewRequest(method, "/api/v1/admin/integrations/teams/manifest", nil)
+		req = req.WithContext(contextWithIdentity(req.Context(), admin))
+		rr := httptest.NewRecorder()
+		srv.handleTeamsManifestDownload(rr, req)
+
+		if rr.Code != http.StatusMethodNotAllowed {
+			t.Errorf("%s: expected 405, got %d", method, rr.Code)
+		}
+	}
+}
+
+func TestHandleTeamsManifestDownload_MissingConfig(t *testing.T) {
+	// No plugin manager → loadTeamsConfig returns error.
+	srv := &Server{}
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/teams/manifest", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleTeamsManifestDownload(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when config unavailable, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleTeamsManifestDownload_MissingAppID(t *testing.T) {
+	// Plugin manager returns a config file with no app_id.
+	tmpDir := t.TempDir()
+	cfgFile := filepath.Join(tmpDir, "teams.yaml")
+	if err := os.WriteFile(cfgFile, []byte("tenant_id: \"some-tenant\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := newMockIntegrationManager()
+	mgr.plugins["teams"] = map[string]string{"config_file": cfgFile}
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/teams/manifest", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleTeamsManifestDownload(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when app_id missing, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleTeamsManifestDownload_HappyPath(t *testing.T) {
+	testAppID := "test-app-id-12345"
+
+	tmpDir := t.TempDir()
+	cfgFile := filepath.Join(tmpDir, "teams.yaml")
+	cfgContent := "app_id: \"" + testAppID + "\"\ntenant_id: \"test-tenant\"\n"
+	if err := os.WriteFile(cfgFile, []byte(cfgContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := newMockIntegrationManager()
+	mgr.plugins["teams"] = map[string]string{"config_file": cfgFile}
+
+	srv := &Server{}
+	srv.pluginManager = mgr
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/teams/manifest", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleTeamsManifestDownload(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify Content-Type header.
+	if ct := rr.Header().Get("Content-Type"); ct != "application/zip" {
+		t.Errorf("expected Content-Type application/zip, got %q", ct)
+	}
+
+	// Verify Content-Disposition header.
+	if cd := rr.Header().Get("Content-Disposition"); cd != `attachment; filename="teams-app.zip"` {
+		t.Errorf("expected Content-Disposition with teams-app.zip, got %q", cd)
+	}
+
+	// Open as zip and verify contents.
+	zipReader, err := zip.NewReader(bytes.NewReader(rr.Body.Bytes()), int64(rr.Body.Len()))
+	if err != nil {
+		t.Fatalf("failed to open response as zip: %v", err)
+	}
+
+	fileNames := make(map[string]bool)
+	for _, f := range zipReader.File {
+		fileNames[f.Name] = true
+	}
+
+	// Verify all three files are present.
+	for _, want := range []string{"manifest.json", "color.png", "outline.png"} {
+		if !fileNames[want] {
+			t.Errorf("zip missing file %q; got %v", want, fileNames)
+		}
+	}
+
+	// Verify manifest.json has the correct app_id.
+	for _, f := range zipReader.File {
+		if f.Name != "manifest.json" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("failed to open manifest.json from zip: %v", err)
+		}
+		defer rc.Close()
+
+		var manifest teamsManifest
+		if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
+			t.Fatalf("failed to decode manifest.json: %v", err)
+		}
+		if manifest.ID != testAppID {
+			t.Errorf("manifest ID: got %q, want %q", manifest.ID, testAppID)
+		}
+		if manifest.Bots[0].BotID != testAppID {
+			t.Errorf("manifest bot ID: got %q, want %q", manifest.Bots[0].BotID, testAppID)
+		}
+		if manifest.ManifestVersion != "1.16" {
+			t.Errorf("manifest version: got %q, want %q", manifest.ManifestVersion, "1.16")
+		}
+	}
+
+	// Verify color.png is a valid PNG.
+	for _, f := range zipReader.File {
+		if f.Name != "color.png" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("failed to open color.png from zip: %v", err)
+		}
+		defer rc.Close()
+
+		img, err := png.Decode(rc)
+		if err != nil {
+			t.Fatalf("color.png is not a valid PNG: %v", err)
+		}
+		bounds := img.Bounds()
+		if bounds.Dx() != 192 || bounds.Dy() != 192 {
+			t.Errorf("color.png: expected 192x192, got %dx%d", bounds.Dx(), bounds.Dy())
+		}
+	}
+
+	// Verify outline.png is a valid PNG.
+	for _, f := range zipReader.File {
+		if f.Name != "outline.png" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("failed to open outline.png from zip: %v", err)
+		}
+		defer rc.Close()
+
+		img, err := png.Decode(rc)
+		if err != nil {
+			t.Fatalf("outline.png is not a valid PNG: %v", err)
+		}
+		bounds := img.Bounds()
+		if bounds.Dx() != 32 || bounds.Dy() != 32 {
+			t.Errorf("outline.png: expected 32x32, got %dx%d", bounds.Dx(), bounds.Dy())
+		}
+	}
+}
+
+// --- Unit tests for helpers ---
+
+func TestBuildTeamsManifest(t *testing.T) {
+	appID := "test-uuid-1234"
+	m := buildTeamsManifest(appID)
+
+	if m.ID != appID {
+		t.Errorf("expected ID %q, got %q", appID, m.ID)
+	}
+	if m.ManifestVersion != "1.16" {
+		t.Errorf("expected manifestVersion 1.16, got %q", m.ManifestVersion)
+	}
+	if len(m.Bots) != 1 {
+		t.Fatalf("expected 1 bot, got %d", len(m.Bots))
+	}
+	if m.Bots[0].BotID != appID {
+		t.Errorf("expected bot ID %q, got %q", appID, m.Bots[0].BotID)
+	}
+	if m.Icons.Color != "color.png" {
+		t.Errorf("expected color icon color.png, got %q", m.Icons.Color)
+	}
+	if m.Icons.Outline != "outline.png" {
+		t.Errorf("expected outline icon outline.png, got %q", m.Icons.Outline)
+	}
+}
+
+func TestGeneratePlaceholderPNG(t *testing.T) {
+	data, err := generatePlaceholderPNG(64, color.RGBA{R: 128, G: 128, B: 128, A: 255})
+	if err != nil {
+		t.Fatalf("generatePlaceholderPNG returned error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("generatePlaceholderPNG returned empty data")
+	}
+
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("output is not valid PNG: %v", err)
+	}
+	bounds := img.Bounds()
+	if bounds.Dx() != 64 || bounds.Dy() != 64 {
+		t.Errorf("expected 64x64, got %dx%d", bounds.Dx(), bounds.Dy())
+	}
+}

--- a/pkg/hub/handlers_teams_manifest_test.go
+++ b/pkg/hub/handlers_teams_manifest_test.go
@@ -171,7 +171,7 @@ func TestHandleTeamsManifestDownload_HappyPath(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to open manifest.json from zip: %v", err)
 		}
-		defer rc.Close()
+		defer func() { _ = rc.Close() }()
 
 		var manifest teamsManifest
 		if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
@@ -197,7 +197,7 @@ func TestHandleTeamsManifestDownload_HappyPath(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to open color.png from zip: %v", err)
 		}
-		defer rc.Close()
+		defer func() { _ = rc.Close() }()
 
 		img, err := png.Decode(rc)
 		if err != nil {
@@ -218,7 +218,7 @@ func TestHandleTeamsManifestDownload_HappyPath(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to open outline.png from zip: %v", err)
 		}
-		defer rc.Close()
+		defer func() { _ = rc.Close() }()
 
 		img, err := png.Decode(rc)
 		if err != nil {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3160,6 +3160,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/admin/lifecycle-hooks/", s.handleAdminLifecycleHookByID)
 	s.mux.HandleFunc("/api/v1/admin/validate-resources", s.handleAdminValidateResources)
 	s.mux.HandleFunc("/api/v1/admin/integrations", s.handleAdminIntegrations)
+	s.mux.HandleFunc("/api/v1/admin/integrations/teams/manifest", s.handleTeamsManifestDownload)
 	s.mux.HandleFunc("/api/v1/admin/integrations/", s.handleAdminIntegrationByName)
 	s.mux.HandleFunc("/api/v1/admin/diagnostics/logs/stream", s.handleDiagnosticsLogsStream)
 	s.mux.HandleFunc("/api/v1/admin/diagnostics/logs", s.handleDiagnosticsLogs)

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -1498,8 +1498,8 @@ export class ScionPageAdminIntegrations extends LitElement {
     const platform = resolvePlatform(d.name);
     if (platform !== 'teams') return nothing;
 
-    const appId = (this.editedSettings['app_id'] ?? '').trim();
-    const tenantId = (this.editedSettings['tenant_id'] ?? '').trim();
+    const appId = (d.settings['app_id'] ?? '').trim();
+    const tenantId = (d.settings['tenant_id'] ?? '').trim();
     if (!appId || !tenantId) return nothing;
 
     const downloadUrl = '/api/v1/admin/integrations/teams/manifest';

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -106,6 +106,9 @@ const PLATFORM_SECRETS: Record<string, PlatformSecretDef[]> = {
   gchat: [
     { key: 'signing_key', label: 'Hub Signing Key', description: 'Shared signing key for hub authentication (HS256 JWT)', required: true },
   ],
+  teams: [
+    { key: 'TEAMS_APP_SECRET', label: 'App Secret', description: 'Azure App Registration client secret' },
+  ],
 };
 
 function resolvePlatform(name: string): string {
@@ -115,6 +118,7 @@ function resolvePlatform(name: string): string {
     case 'slack': return 'slack';
     case 'chat-app': return 'gchat';
     case 'a2a-bridge': return 'a2a';
+    case 'teams': return 'teams';
     default: return name;
   }
 }
@@ -191,6 +195,12 @@ const PLATFORM_FIELDS: Record<string, PlatformFieldDef[]> = {
     { key: 'listen_address', label: 'Webhook Listen Address', description: 'HTTP listen address for webhook mode', defaultValue: ':8443' },
     { key: 'external_url', label: 'External URL', description: 'Public URL where Google Chat sends events', defaultValue: '' },
     { key: 'service_account_email', label: 'Service Account Email', description: 'Email of the GCP service account (for JWT verification)', defaultValue: '' },
+  ],
+  teams: [
+    { key: 'app_id', label: 'Application (Client) ID', description: 'Azure App Registration Client ID', defaultValue: '', placeholder: 'e.g. 12345678-abcd-1234-efgh-123456789012' },
+    { key: 'tenant_id', label: 'Tenant ID', description: 'Azure AD Tenant ID (GUID)', defaultValue: '', placeholder: 'e.g. 12345678-abcd-1234-efgh-123456789012' },
+    { key: 'listen_address', label: 'Listen Address', description: 'HTTP listen address for the Teams webhook endpoint', defaultValue: ':3978', placeholder: ':3978' },
+    { key: 'db_path', label: 'Database Path', description: 'Path to SQLite database', defaultValue: '~/.scion/scion-teams.db', placeholder: '~/.scion/scion-teams.db' },
   ],
 };
 
@@ -1009,6 +1019,7 @@ export class ScionPageAdminIntegrations extends LitElement {
       ${this.renderConfigSection(d)}
       ${this.renderA2AProjectsSection(d)}
       ${this.renderDiscordInviteLink(d)}
+      ${this.renderTeamsSetupSection(d)}
       ${this.renderActionsSection()}
     `;
   }
@@ -1483,6 +1494,43 @@ export class ScionPageAdminIntegrations extends LitElement {
     `;
   }
 
+  private renderTeamsSetupSection(d: IntegrationDetail) {
+    const platform = resolvePlatform(d.name);
+    if (platform !== 'teams') return nothing;
+
+    const appId = (this.editedSettings['app_id'] ?? '').trim();
+    const tenantId = (this.editedSettings['tenant_id'] ?? '').trim();
+    if (!appId || !tenantId) return nothing;
+
+    const downloadUrl = '/api/v1/admin/integrations/teams/manifest';
+
+    return html`
+      <div class="section">
+        <h3 class="section-title">Teams App Package</h3>
+        <div class="invite-link-container">
+          <div class="invite-link-info">
+            <sl-icon name="download"></sl-icon>
+            <div>
+              <p class="invite-link-description">Download the Teams app package (.zip)</p>
+              <p class="invite-link-permissions">
+                Upload it to your Microsoft Teams Admin Center or sideload it in Teams to enable the bot integration.
+              </p>
+            </div>
+          </div>
+          <sl-button
+            variant="primary"
+            size="small"
+            href=${downloadUrl}
+            download="teams-app.zip"
+          >
+            <sl-icon slot="prefix" name="download"></sl-icon>
+            Download App Package
+          </sl-button>
+        </div>
+      </div>
+    `;
+  }
+
   private renderSelfManagedSetupSection(d: IntegrationDetail) {
     const platform = resolvePlatform(d.name);
 
@@ -1742,6 +1790,8 @@ export class ScionPageAdminIntegrations extends LitElement {
         return 'Google Chat';
       case 'a2a':
         return 'A2A Bridge';
+      case 'teams':
+        return 'Microsoft Teams';
       default:
         return platform;
     }


### PR DESCRIPTION
Adds Teams to the admin integrations page: install flow, config form (app_id, tenant_id, listen_address, db_path), secret management (TEAMS_APP_SECRET), health/status display, and a Download App Package button that generates a pre-packaged Teams app manifest .zip from configured values.