### PR TITLE
docs: Cloud Run HA deployment friction fixes

### DIFF
--- a/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
+++ b/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
@@ -135,8 +135,8 @@ When the Hub is behind IAP (or a Cloud Run invoker-only service), agents need a 
 
 | Layer | Header | Purpose |
 |-------|--------|---------|
-| **Outer (transport)** | `Authorization: Bearer <Google OIDC ID token>` | Satisfies the platform guard (IAP or Cloud Run invoker IAM check). |
-| **Inner (app)** | `X-Scion-Agent-Token: <scion JWT>` | Existing Hub agent authentication. Carried as a custom header so it never collides with the outer `Authorization`. |
+| **Outer (transport)** | `Authorization: Bearer <Google OIDC ID token>` <br/>*or*<br/> `Proxy-Authorization: Bearer <Google OIDC ID token>` | Satisfies the platform guard (IAP or Cloud Run invoker IAM check). Cloud Run native IAP fully supports `Proxy-Authorization`. |
+| **Inner (app)** | `X-Scion-Agent-Token: <scion JWT>` | Existing Hub agent authentication. Carried as a custom header so it never collides with the outer header. |
 
 ### How it works
 

--- a/docs-site/src/content/docs/hosted/ha/setup-gcp.md
+++ b/docs-site/src/content/docs/hosted/ha/setup-gcp.md
@@ -686,6 +686,26 @@ server:
     host: 127.0.0.1
 ```
 
+:::caution[Critical: Distinguishing IAP Audiences]
+Configuring IAP requires two different audience formats used in separate contexts:
+
+1. **`server.auth.proxy.iap.audience`** (Cloud Run native IAP audience path):
+   - **Format:** `/projects/PROJECT_NUMBER/locations/REGION/services/SERVICE_NAME`
+   - **Purpose:** Used by the Hub to validate incoming IAP-signed JWTs (from browsers and human API calls).
+   - **Where to find:** GCP Console → Security → Identity-Aware Proxy → Select your backend service → click the three dots → select **Signed Header JWT Audience**.
+
+2. **`server.auth.transport.oidc_audience`** (IAP OAuth Client ID):
+   - **Format:** `PROJECT_NUMBER-xxxx.apps.googleusercontent.com`
+   - **Purpose:** Used as the audience minted into OIDC tokens for dispatched agents and brokers to authenticate and traverse Google IAP. IAP requires the OAuth client ID format for validating programmatically minted OIDC tokens, *not* the Cloud Run resource path.
+   - **Where to find:** GCP Console → Security → Identity-Aware Proxy → Select your backend service → click the three dots → select **Edit OAuth Client**.
+
+Using the wrong format for either field will cause startup verification or agent authentication to fail.
+:::
+
+:::tip[Proxy-Authorization Support]
+Cloud Run native IAP fully supports the `Proxy-Authorization: Bearer <Google OIDC ID token>` header. Dispatched agents and brokers can use either `Authorization` or `Proxy-Authorization` for the outer transport layer to pass through IAP. This prevents collisions if your client needs to use the standard `Authorization` header for internal Hub authentication.
+:::
+
 Replace placeholders with your live values:
 ```bash
 sed -e "s|REGISTRY_PLACEHOLDER|$IMAGE_REGISTRY|" \

--- a/docs-site/src/content/docs/hosted/ha/setup-gcp.md
+++ b/docs-site/src/content/docs/hosted/ha/setup-gcp.md
@@ -817,6 +817,26 @@ export HUB_URL=$(gcloud run services describe scion-hub \
 echo "Hub URL: $HUB_URL"
 ```
 
+:::caution[Critical: New Cloud Run URL Format & Hub Endpoint Resolution]
+Cloud Run service URLs are provisioned in two formats:
+- **Legacy:** `https://scion-hub-PROJECT_NUMBER.REGION.run.app`
+- **New (default for newer projects):** `https://scion-hub-HASH-REGION.a.run.app`
+
+When the Hub is protected by IAP, it attempts to automatically resolve its own public URL from the IAP audience path. However, this automatic resolution **only works for the legacy format**. 
+
+If your printed `Hub URL` uses the new format containing a random hash (such as `.a.run.app`), the Hub's auto-derivation will fail, causing agent dispatching and OIDC federation to break. You **must set the `SCION_SERVER_BASE_URL` environment variable explicitly** to resolve this.
+
+**Action Required:**
+If your URL uses the new format, update your Cloud Run service to set this variable now:
+```bash
+gcloud run services update scion-hub \
+  --region=$REGION \
+  --project=$PROJECT_ID \
+  --update-env-vars="SCION_SERVER_BASE_URL=$HUB_URL"
+```
+For more information on how the Hub resolves endpoints, see the [Hub Endpoint Resolution Reference](/scion/reference/server-config/#hub-endpoint-resolution).
+:::
+
 Verify that unauthenticated endpoints are successfully blocked by IAP:
 ```bash
 curl -s -o /dev/null -w "%{http_code}" "$HUB_URL/"

--- a/docs-site/src/content/docs/hosted/ha/setup-gcp.md
+++ b/docs-site/src/content/docs/hosted/ha/setup-gcp.md
@@ -674,6 +674,19 @@ server:
       oidc_audience: IAP_CLIENT_ID_PLACEHOLDER
       platform_auth_sa: scion-transport@PROJECT_ID.iam.gserviceaccount.com
 
+  # === OIDC IDENTITY PROVIDER ===
+  # Enables the Hub to act as an OIDC provider, publishing JWKS endpoints
+  # and minting identity tokens for agents to authenticate to external resources.
+  oidc:
+    enabled: true                      # Enabled to support agent identity tokens
+    token_lifetime: 15m                # Lifetime of minted OIDC identity tokens
+
+  # === OIDC FEDERATION ===
+  # Enables inbound federation from trusted external OIDC providers.
+  federation:
+    enabled: false                     # Disabled by default, configure if needed
+    trusted_issuers: []
+
   secrets:
     backend: gcpsm
     gcp_project_id: PROJECT_ID
@@ -1139,6 +1152,19 @@ server:
       mode: iap
       oidc_audience: PROJECT_NUMBER-xxxx.apps.googleusercontent.com  # OAuth client ID
       platform_auth_sa: scion-transport@PROJECT_ID.iam.gserviceaccount.com
+
+  # === OIDC IDENTITY PROVIDER ===
+  # Enables the Hub to act as an OIDC provider, publishing JWKS endpoints
+  # and minting identity tokens for agents to authenticate to external resources.
+  oidc:
+    enabled: true                      # Enabled to support agent identity tokens
+    token_lifetime: 15m                # Lifetime of minted OIDC identity tokens
+
+  # === OIDC FEDERATION ===
+  # Enables inbound federation from trusted external OIDC providers.
+  federation:
+    enabled: false                     # Disabled by default, configure if needed
+    trusted_issuers: []
 
   secrets:
     backend: gcpsm

--- a/docs-site/src/content/docs/hosted/ha/setup-gcp.md
+++ b/docs-site/src/content/docs/hosted/ha/setup-gcp.md
@@ -544,6 +544,12 @@ $$\text{core-base} \longrightarrow \text{scion-base} \longrightarrow \text{harne
 2. **`scion-base`:** Copies repository code (`cmd/`, `pkg/`, etc.) and builds the `scion` and `sciontool` binaries on top of `core-base`.
 3. **Harnesses:** Pulls `scion-base` and adds target agent packages (like `@google/gemini-cli`).
 
+:::note[Compilation Constraint: `-tags no_embed_web`]
+By default, the Hub’s Go build process compiles and embeds the frontend web assets (`web/dist/`) into the final binary. However, compiling the frontend takes time and is not required for non-hub components.
+
+Any container or binary build for a **non-hub service** (such as the A2A bridge, Discord broker, custom harnesses, or utility binaries) that imports from the `pkg/` module **must compile with `-tags no_embed_web`**. If this tag is omitted, compilation will fail with errors in `web/embed.go` because the required frontend build artifacts do not exist.
+:::
+
 #### Single-Architecture AMD64 Speed Up
 :::tip[Avoid Emulation Build Timeouts]
 The official `cloudbuild-scion-base.yaml` compiles multi-platform (`linux/amd64,linux/arm64`). Under Cloud Build, `arm64` compiles run under slow QEMU emulation on standard `amd64` machines, which **routinely times out after 30 minutes**. 

--- a/docs-site/src/content/docs/hosted/single-node/auth.md
+++ b/docs-site/src/content/docs/hosted/single-node/auth.md
@@ -129,6 +129,39 @@ When active, the Hub exposes standard OIDC discovery and key endpoints:
 - **Key Rotation**: The Hub rotates signing keys every 24 hours automatically, maintaining a key overlap period to ensure seamless token verification during transitions.
 - **Audience Scope**: Tokens are minted targeting specific external audiences.
 
+### Agent Identity Token API
+For programmatic or custom integrations where `sciontool` is not available, agents can request OIDC identity tokens directly from the Hub's token endpoint.
+
+* **Endpoint:** `POST /api/v1/agent/identity-token`
+* **Authentication:** Requires a valid Agent Token header (e.g. `X-Scion-Agent-Token: <scion JWT>`).
+* **Request Body:** Must be JSON and include the mandatory `audience` parameter targeting the external service.
+
+**Example Request:**
+
+```http
+POST /api/v1/agent/identity-token HTTP/1.1
+Host: hub.scion.dev
+X-Scion-Agent-Token: <agent_jwt_token>
+Content-Type: application/json
+
+{
+  "audience": "https://vault.example.com"
+}
+```
+
+:::caution[Audience is Mandatory]
+The `audience` parameter is strictly required in the JSON body. If the `audience` field is missing, empty, or the request body is malformed, the Hub will immediately reject the call with an HTTP `400 Bad Request` status.
+:::
+
+**Example Response (HTTP 200 OK):**
+
+```json
+{
+  "token": "eyJhbGciOiJSUzI1NiIsImtpZCI6Ii4uLiJ9...",
+  "expires_at": "2026-08-11T12:15:00Z"
+}
+```
+
 ### In-Agent Retrieval
 From inside any authorized agent container, retrieve an OIDC identity token using `sciontool`:
 

--- a/docs-site/src/content/docs/hosted/user/a2a-bridge.md
+++ b/docs-site/src/content/docs/hosted/user/a2a-bridge.md
@@ -85,9 +85,9 @@ From your Scion repository root, compile the Go binary:
 # Using the project Makefile
 make build-a2a-bridge
 
-# Or compiling manually
+# Or compiling manually (requires the -tags no_embed_web flag to skip embedding frontend assets)
 cd extras/scion-a2a-bridge
-go build -o scion-a2a-bridge ./cmd/scion-a2a-bridge/
+go build -tags no_embed_web -o scion-a2a-bridge ./cmd/scion-a2a-bridge/
 ```
 
 Verify the binary is available:

--- a/docs-site/src/content/docs/reference/security.md
+++ b/docs-site/src/content/docs/reference/security.md
@@ -33,6 +33,13 @@ Agents running inside containers must report status back to the Hub without poss
 
 - **Hub-Issued JWT**: During provisioning, the Hub generates a short-lived JWT scoped specifically to that agent instance.
 - **Claims**: The token includes the `agent_id` (sub), `project_id`, and `scopes`.
+
+  :::caution[Scopes Field Plurality]
+  The agent token JWT strictly uses `"scopes"` (plural, array of strings like `["project:read", "agent:status:update"]`), **NOT** `"scope"` (singular string, which is the standard OAuth 2.0 convention). 
+  
+  Providing the singular `"scope"` field in a token will silently fail, resulting in an empty scopes list and a locked-down agent.
+  :::
+
 - **Role-Based Scopes**: Instead of raw template scopes (which are deprecated), an agent's scopes are governed by its assigned **Tiered Agent Role** (`none`, `readonly`, `baseline`, or `full`):
     - `project:read` (Readonly): Allows reading project state (agents, templates, etc.).
     - `agent:status:update`, `agent:token:refresh`, `project:agent:notify`, `agent:port:forward` (Baseline): Standard operational scopes allowing the agent to report progress, refresh its token, and hold port tunnels.


### PR DESCRIPTION
## Summary

Documentation fixes from a real Cloud Run HA deployment friction log (6 items).

Critical:
- Clarified IAP audience format distinction (proxy.iap.audience vs transport.oidc_audience)
- Added OIDC/federation sections to settings.yaml examples with correct server: nesting

Also:
- no_embed_web build tag requirement for non-hub containers
- identity-token endpoint audience parameter
- Agent token scopes (plural array) format
- Cloud Run URL formats and SCION_SERVER_BASE_URL

5 files changed, 116 insertions, 4 deletions.
