### PR TITLE
fix(teams): deduplicate secret field in admin UI

### DIFF
--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -107,7 +107,7 @@ const PLATFORM_SECRETS: Record<string, PlatformSecretDef[]> = {
     { key: 'signing_key', label: 'Hub Signing Key', description: 'Shared signing key for hub authentication (HS256 JWT)', required: true },
   ],
   teams: [
-    { key: 'TEAMS_APP_SECRET', label: 'App Secret', description: 'Azure App Registration client secret' },
+    { key: 'app_secret', label: 'App Secret', description: 'Azure App Registration client secret' },
   ],
 };
 


### PR DESCRIPTION
Fix duplicate App Secret fields in Teams admin page. Frontend PLATFORM_SECRETS used env var key (TEAMS_APP_SECRET) while API returns config key (app_secret). Aligns to app_secret to match other platforms.