### PR TITLE
refactor(harness): remove redundant Python-side model alias resolution

### DIFF
--- a/harnesses/claude/provision.py
+++ b/harnesses/claude/provision.py
@@ -78,22 +78,6 @@ CLAUDE_AUTH_FILE = "~/.claude/.credentials.json"
 # requested model impossible to apply.
 DEFAULT_MODEL = "opus"
 
-# The canonical size aliases, mirroring config.KnownModelAliases
-# (pkg/config/templates.go). Only these four resolve through config.yaml's
-# model_aliases map; anything else is treated as a concrete model name.
-KNOWN_MODEL_ALIASES = frozenset({"small", "medium", "large", "extra-large"})
-
-# Shorthand spellings for those aliases, mirroring config.NormalizeModelAlias
-# (pkg/config/templates.go). Deliberately no extra spellings: a form accepted
-# here but not there would make ANTHROPIC_MODEL disagree with the --model flag
-# the Go side computes from the same request.
-MODEL_ALIAS_SHORTHAND = {
-    "s": "small",
-    "m": "medium",
-    "l": "large",
-    "xl": "extra-large",
-}
-
 AUTH = scion_harness.AuthSpec(
     harness="claude",
     methods=[
@@ -240,70 +224,20 @@ def _update_project_paths(ctx: scion_harness.ProvisionContext) -> None:
     scion_harness.atomic_write_json(claude_json_path, cfg)
 
 
-def _normalize_model_alias(model: str) -> str:
-    """Lower-case a model string and expand the single-letter shorthands.
-
-    Mirrors config.NormalizeModelAlias (pkg/config/templates.go) exactly so the
-    model this script derives cannot disagree with the one the Go side derives
-    for --model / SCION_MODEL. Keep the two in sync.
-    """
-    normalized = model.strip().lower()
-    return MODEL_ALIAS_SHORTHAND.get(normalized, normalized)
-
-
-def _resolve_model_alias(ctx: scion_harness.ProvisionContext, raw_model: str) -> str:
-    """Resolve a size alias (e.g. 'medium') to a concrete Claude model name.
-
-    Mirrors config.ResolveModelAlias (pkg/config/templates.go): only the four
-    canonical tiers are treated as aliases, and the concrete name they map to
-    comes from config.yaml's model_aliases block so operators can re-point the
-    tiers without touching this script. Anything else (e.g. 'sonnet' or
-    'claude-sonnet-4-5') is a concrete model name and passes through.
-    """
-    if not raw_model:
-        return ""
-
-    normalized = _normalize_model_alias(raw_model)
-    if normalized not in KNOWN_MODEL_ALIASES:
-        return normalized
-
-    aliases = ctx.harness_config.get("model_aliases") or {}
-    if not isinstance(aliases, dict):
-        return normalized
-
-    concrete = aliases.get(normalized)
-    if not concrete:
-        return normalized
-
-    if str(concrete) != raw_model:
-        ctx.info(f"resolved model alias {raw_model!r} → {concrete!r}")
-    return str(concrete)
-
-
 def _apply_model(ctx: scion_harness.ProvisionContext, env: dict[str, str]) -> str:
-    """Resolve the requested model and publish it as ANTHROPIC_MODEL.
+    """Read the resolved model from SCION_MODEL and publish as ANTHROPIC_MODEL.
 
-    The request arrives as the SCION_MODEL env var, which Scion injects into
-    every agent container from the agent's applied config. (The manifest has no
-    model_resolution field — see changelog 2026-07-20 — so SCION_MODEL is the
-    only live channel, and it can still carry a raw tier name: an agent started
-    with `--model medium` reaches the container as SCION_MODEL=medium.)
-
-    Where this sits in Claude Code's precedence chain
-    (--model > ANTHROPIC_MODEL > settings.json `model`): when the agent has a
-    model configured, pkg/agent/run.go also prepends `--model <resolved>` to
-    the CLI args, and that outranks ANTHROPIC_MODEL. ANTHROPIC_MODEL is what
-    covers the rest — the default when nothing is requested, subprocesses the
-    harness spawns, and any consumer reading the env var directly — and this
-    keeps it agreeing with the flag instead of contradicting it.
+    SCION_MODEL arrives already resolved by the Go side (pkg/agent/provision.go
+    and pkg/hub/handlers_agent_create_helpers.go resolve size aliases before the
+    container starts). This function applies it as ANTHROPIC_MODEL and handles
+    the edge case where ANTHROPIC_MODEL is already set in the environment.
 
     Returns the concrete model name that was applied.
     """
-    requested = os.environ.get("SCION_MODEL", "").strip()
-    model = _resolve_model_alias(ctx, requested) or DEFAULT_MODEL
+    model = os.environ.get("SCION_MODEL", "").strip() or DEFAULT_MODEL
 
     preset = os.environ.get("ANTHROPIC_MODEL", "").strip()
-    if requested and preset and preset != model:
+    if model != DEFAULT_MODEL and preset and preset != model:
         ctx.warn(
             f"ANTHROPIC_MODEL={preset!r} is set in the container environment and "
             f"takes precedence over the requested model {model!r}. This usually "

--- a/harnesses/claude/provision.py
+++ b/harnesses/claude/provision.py
@@ -37,9 +37,8 @@ This script's job:
   3. Update .claude.json project paths to point at the container workspace.
   4. Translate universal MCP servers into Claude Code's native mcpServers
      format in .claude.json.
-  5. Resolve the requested model (the SCION_MODEL env var), mapping size
-     aliases (small/medium/large/extra-large) through config.yaml's
-     model_aliases, and publish it as ANTHROPIC_MODEL in the env overlay.
+  5. Publish the resolved model (the SCION_MODEL env var, already resolved
+     by the Go side) as ANTHROPIC_MODEL in the env overlay.
   6. Write outputs/resolved-auth.json describing the chosen method.
   7. Write outputs/env.json with env vars to project into the harness process
      (e.g. ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_MODEL, or
@@ -234,10 +233,11 @@ def _apply_model(ctx: scion_harness.ProvisionContext, env: dict[str, str]) -> st
 
     Returns the concrete model name that was applied.
     """
-    model = os.environ.get("SCION_MODEL", "").strip() or DEFAULT_MODEL
+    raw = os.environ.get("SCION_MODEL", "").strip()
+    model = raw or DEFAULT_MODEL
 
     preset = os.environ.get("ANTHROPIC_MODEL", "").strip()
-    if model != DEFAULT_MODEL and preset and preset != model:
+    if raw and preset and preset != model:
         ctx.warn(
             f"ANTHROPIC_MODEL={preset!r} is set in the container environment and "
             f"takes precedence over the requested model {model!r}. This usually "

--- a/harnesses/gemini-cli/provision.py
+++ b/harnesses/gemini-cli/provision.py
@@ -178,37 +178,18 @@ def _apply_native_system_prompt(ctx: scion_harness.ProvisionContext) -> bool:
     return _is_meaningful_system_prompt(system_prompt)
 
 
-def _resolve_model_alias(ctx: scion_harness.ProvisionContext) -> None:
-    """Resolve SCION_MODEL alias using harness_config model_aliases.
+def _apply_model(ctx: scion_harness.ProvisionContext) -> None:
+    """Apply resolved model from SCION_MODEL to ~/.gemini/settings.json.
 
-    When SCION_MODEL is a tier name (e.g. 'large', 'L', 'Small') rather
-    than a concrete model string, resolve it via the model_aliases map
-    from config.yaml and update ~/.gemini/settings.json accordingly.
+    SCION_MODEL arrives already resolved by the Go side (pkg/agent/provision.go
+    and pkg/hub/handlers_agent_create_helpers.go resolve size aliases before the
+    container starts). This function writes the concrete model into
+    ~/.gemini/settings.json so the Gemini CLI uses it.
     """
-    raw_model = os.environ.get("SCION_MODEL", "")
-    if not raw_model:
+    model = os.environ.get("SCION_MODEL", "").strip()
+    if not model:
         return
 
-    aliases: dict[str, str] = ctx.harness_config.get("model_aliases") or {}
-    if not aliases:
-        return
-
-    # Normalize: lowercase, handle single-letter and shorthand aliases.
-    normalized = raw_model.lower()
-    _shorthand = {"s": "small", "m": "medium", "l": "large", "xl": "extra-large"}
-    normalized = _shorthand.get(normalized, normalized)
-
-    concrete = aliases.get(normalized)
-    if not concrete:
-        # Already a concrete model name (not a known alias) — nothing to do.
-        return
-
-    if concrete == raw_model:
-        return
-
-    ctx.info(f"resolved model alias {raw_model!r} → {concrete!r}")
-
-    # Update Gemini settings.json so the CLI uses the resolved model.
     settings_path = scion_harness.expand_path(GEMINI_SETTINGS_FILE)
     settings: dict[str, Any] = {}
     if os.path.isfile(settings_path):
@@ -224,8 +205,9 @@ def _resolve_model_alias(ctx: scion_harness.ProvisionContext) -> None:
         model_section = {}
         settings["model"] = model_section
 
-    model_section["name"] = concrete
+    model_section["name"] = model
     scion_harness.atomic_write_json(settings_path, settings)
+    ctx.info(f"model={model}")
 
 
 def provision(ctx: scion_harness.ProvisionContext) -> None:
@@ -250,9 +232,9 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
     ctx.write_outputs(resolved, env=env, extra=extra)
     ctx.info(f"method={resolved.method}")
 
-    # Resolve model alias (e.g. 'large' → 'gemini-3.1-pro-preview') and
-    # update ~/.gemini/settings.json so the CLI uses the concrete model.
-    _resolve_model_alias(ctx)
+    # Apply the resolved model to ~/.gemini/settings.json. SCION_MODEL
+    # arrives already resolved by the Go side.
+    _apply_model(ctx)
 
     harness_cfg = ctx.harness_config
     instructions_file = str(harness_cfg.get("instructions_file") or ".gemini/GEMINI.md")


### PR DESCRIPTION
Remove redundant model alias resolution from claude and gemini-cli Python provisioners. The Go side already resolves size aliases (small/medium/large/extra-large and shorthands s/m/l/xl) before SCION_MODEL reaches the container — both hub-side (handlers_agent_create_helpers.go) and local-side (provision.go) call config.ResolveModelAlias before agent creation.

Changes:
- claude/provision.py: Remove KNOWN_MODEL_ALIASES, MODEL_ALIAS_SHORTHAND, _normalize_model_alias(), _resolve_model_alias(). Simplify _apply_model() to read pre-resolved SCION_MODEL directly. Update module docstring.
- gemini-cli/provision.py: Remove _resolve_model_alias() with inline shorthand dict. Replace with simplified _apply_model() that writes pre-resolved SCION_MODEL to settings.json.

No changes to scion_harness.py — resolution belongs in the Go CLI layer, not the Python provisioner layer.

21 lines added, 105 lines removed. No behavior change (alias resolution was redundant). Tests pass.
