### PR TITLE
fix(teams): add registration polling, fix inbound topic format, handle thread IDs

### DIFF
--- a/extras/scion-teams/internal/teams/broker.go
+++ b/extras/scion-teams/internal/teams/broker.go
@@ -545,8 +545,14 @@ func (b *TeamsBroker) Close() error {
 	serverRunning := b.serverRunning
 	store := b.store
 	publishLock := b.publishLock
+	commandHandler := b.commandHandler
 	b.serverRunning = false
 	b.mu.Unlock()
+
+	// Cancel pending polling goroutines in the command handler.
+	if commandHandler != nil {
+		commandHandler.Close()
+	}
 
 	// Release advisory lock first (orderly, no OnLost).
 	if publishLock != nil {
@@ -763,10 +769,15 @@ func (b *TeamsBroker) handleMessage(ctx context.Context, activity *Activity) err
 	// Thread-based channels append ";messageid=..." to the conversation ID;
 	// strip that suffix so we match the channel-level link stored during setup.
 	convID := stripThreadSuffix(activity.Conversation.ID)
+
+	b.mu.Lock()
+	store := b.store
+	b.mu.Unlock()
+
 	var link *ChannelLink
-	if b.store != nil {
+	if store != nil {
 		var err error
-		link, err = b.store.GetChannelLink(ctx, convID)
+		link, err = store.GetChannelLink(ctx, convID)
 		if err != nil {
 			b.log.Warn("Error looking up channel link for topic routing", "error", err)
 		}

--- a/extras/scion-teams/internal/teams/broker.go
+++ b/extras/scion-teams/internal/teams/broker.go
@@ -759,7 +759,49 @@ func (b *TeamsBroker) handleMessage(ctx context.Context, activity *Activity) err
 		return nil
 	}
 
-	topic := "teams.message"
+	// Resolve the channel link so we can build the canonical topic.
+	// Thread-based channels append ";messageid=..." to the conversation ID;
+	// strip that suffix so we match the channel-level link stored during setup.
+	convID := stripThreadSuffix(activity.Conversation.ID)
+	var link *ChannelLink
+	if b.store != nil {
+		var err error
+		link, err = b.store.GetChannelLink(ctx, convID)
+		if err != nil {
+			b.log.Warn("Error looking up channel link for topic routing", "error", err)
+		}
+	}
+
+	if link == nil {
+		b.log.Warn("No channel link found, cannot route message to hub",
+			"conversation_id", activity.Conversation.ID,
+		)
+		return nil
+	}
+
+	// Determine the target agent slug: prefer mention-routed recipient, then
+	// the channel's default agent.
+	agentSlug := link.DefaultAgent
+	if msg.Recipient != "" {
+		slug := msg.Recipient
+		if strings.HasPrefix(slug, "agent:") {
+			slug = strings.TrimPrefix(slug, "agent:")
+		}
+		agentSlug = slug
+	}
+
+	if agentSlug == "" {
+		b.log.Warn("No agent slug resolved for message, cannot build topic",
+			"conversation_id", activity.Conversation.ID,
+			"project_id", link.ProjectID,
+		)
+		return nil
+	}
+
+	// Populate Channel on the structured message so the hub can correlate.
+	msg.Channel = link.ProjectID
+
+	topic := fmt.Sprintf("scion.project.%s.agent.%s.messages", link.ProjectID, agentSlug)
 	if err := b.hubClient.DeliverInbound(ctx, topic, msg); err != nil {
 		b.log.Error("Failed to deliver message to hub",
 			"error", err,
@@ -773,6 +815,16 @@ func (b *TeamsBroker) handleMessage(ctx context.Context, activity *Activity) err
 		"sender", msg.Sender,
 	)
 	return nil
+}
+
+// stripThreadSuffix removes the ";messageid=..." suffix that Teams appends to
+// conversation IDs for thread-based replies. This lets us match the
+// channel-level conversation ID stored during setup.
+func stripThreadSuffix(conversationID string) string {
+	if idx := strings.Index(conversationID, ";messageid="); idx != -1 {
+		return conversationID[:idx]
+	}
+	return conversationID
 }
 
 // extractMentionTarget extracts an agent name from the beginning of

--- a/extras/scion-teams/internal/teams/broker_test.go
+++ b/extras/scion-teams/internal/teams/broker_test.go
@@ -745,3 +745,158 @@ func TestBroker_Publish_ThreadIDRouting(t *testing.T) {
 
 	assert.Contains(t, receivedPath, "thread-123")
 }
+
+func TestBroker_HandleMessage_CanonicalTopic(t *testing.T) {
+	// Verify that inbound messages are delivered with the canonical topic
+	// format: scion.project.<projectId>.agent.<agentSlug>.messages
+
+	var receivedTopic string
+	hubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload inboundPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		receivedTopic = payload.Topic
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hubServer.Close()
+
+	broker := NewBroker(slog.Default())
+	broker.Configure(map[string]string{
+		"app_id":     "bot-id",
+		"app_secret": "secret",
+		"tenant_id":  "tenant",
+		"hub_url":    hubServer.URL,
+		"hmac_key":   "dGVzdC1rZXk=",
+		"broker_id":  "teams-broker-1",
+		"db_path":    filepath.Join(t.TempDir(), "test.db"),
+	})
+	t.Cleanup(func() { broker.Close() })
+
+	ctx := context.Background()
+
+	// Create a channel link with a default agent.
+	require.NoError(t, broker.store.CreateChannelLink(ctx, &ChannelLink{
+		ConversationID: "conv-topic",
+		ProjectID:      "proj-42",
+		ProjectSlug:    "my-project",
+		DefaultAgent:   "my-agent",
+		LinkedAt:       time.Now(),
+		Active:         true,
+	}))
+
+	activity := &Activity{
+		Type: "message",
+		ID:   "act-topic",
+		Text: "Hello there!",
+		From: ChannelAccount{ID: "user-1", Name: "User", AadObjectID: "aad-1"},
+		Conversation: ConversationAccount{
+			ID: "conv-topic",
+		},
+		ServiceURL: "https://smba.trafficmanager.net/test/",
+	}
+
+	_, err := broker.HandleActivity(ctx, activity)
+	require.NoError(t, err)
+
+	assert.Equal(t, "scion.project.proj-42.agent.my-agent.messages", receivedTopic)
+}
+
+func TestBroker_HandleMessage_ThreadSuffix(t *testing.T) {
+	// Verify that thread-based conversation IDs (with ;messageid= suffix) are
+	// correctly matched to channel links stored by the base conversation ID.
+
+	var receivedTopic string
+	hubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload inboundPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		receivedTopic = payload.Topic
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hubServer.Close()
+
+	broker := NewBroker(slog.Default())
+	broker.Configure(map[string]string{
+		"app_id":     "bot-id",
+		"app_secret": "secret",
+		"tenant_id":  "tenant",
+		"hub_url":    hubServer.URL,
+		"hmac_key":   "dGVzdC1rZXk=",
+		"broker_id":  "teams-broker-1",
+		"db_path":    filepath.Join(t.TempDir(), "test.db"),
+	})
+	t.Cleanup(func() { broker.Close() })
+
+	ctx := context.Background()
+
+	// Channel link stored by base conversation ID (no thread suffix).
+	baseConvID := "19:e4e1805b28e142ce9ee9be354816a319@thread.tacv2"
+	require.NoError(t, broker.store.CreateChannelLink(ctx, &ChannelLink{
+		ConversationID: baseConvID,
+		ProjectID:      "proj-thread",
+		ProjectSlug:    "thread-project",
+		DefaultAgent:   "thread-agent",
+		LinkedAt:       time.Now(),
+		Active:         true,
+	}))
+
+	// Inbound activity with thread suffix on conversation ID.
+	activity := &Activity{
+		Type: "message",
+		ID:   "act-thread",
+		Text: "A reply in the thread.",
+		From: ChannelAccount{ID: "user-2", Name: "User2", AadObjectID: "aad-2"},
+		Conversation: ConversationAccount{
+			ID: baseConvID + ";messageid=1786491412694",
+		},
+		ServiceURL: "https://smba.trafficmanager.net/test/",
+	}
+
+	_, err := broker.HandleActivity(ctx, activity)
+	require.NoError(t, err)
+
+	assert.Equal(t, "scion.project.proj-thread.agent.thread-agent.messages", receivedTopic)
+}
+
+func TestBroker_HandleMessage_NoChannelLink(t *testing.T) {
+	// Verify that messages without a channel link are dropped with a warning,
+	// not delivered with a wrong topic.
+
+	hubCalled := false
+	hubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hubCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hubServer.Close()
+
+	broker := NewBroker(slog.Default())
+	broker.Configure(map[string]string{
+		"app_id":     "bot-id",
+		"app_secret": "secret",
+		"tenant_id":  "tenant",
+		"hub_url":    hubServer.URL,
+		"hmac_key":   "dGVzdC1rZXk=",
+		"broker_id":  "teams-broker-1",
+		"db_path":    filepath.Join(t.TempDir(), "test.db"),
+	})
+	t.Cleanup(func() { broker.Close() })
+
+	activity := &Activity{
+		Type: "message",
+		ID:   "act-nolink",
+		Text: "orphan message",
+		From: ChannelAccount{ID: "user-3", Name: "User3"},
+		Conversation: ConversationAccount{
+			ID: "conv-unknown",
+		},
+		ServiceURL: "https://smba.trafficmanager.net/test/",
+	}
+
+	_, err := broker.HandleActivity(context.Background(), activity)
+	require.NoError(t, err)
+	assert.False(t, hubCalled, "hub should not be called when no channel link exists")
+}

--- a/extras/scion-teams/internal/teams/commands.go
+++ b/extras/scion-teams/internal/teams/commands.go
@@ -21,20 +21,34 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
+// pendingTeamsLink tracks an in-progress identity linking registration that is
+// polling the hub for confirmation.
+type pendingTeamsLink struct {
+	Code        string
+	TeamsUserID string
+	Activity    *Activity // original activity, used for sending replies
+	Cancel      context.CancelFunc
+	ExpiresAt   time.Time
+}
+
 // CommandHandler processes bot commands from incoming message activities.
 type CommandHandler struct {
-	broker *TeamsBroker
-	log    *slog.Logger
+	broker       *TeamsBroker
+	log          *slog.Logger
+	pendingMu    sync.Mutex
+	pendingLinks map[string]*pendingTeamsLink // keyed by teamsUserID
 }
 
 // NewCommandHandler creates a new CommandHandler.
 func NewCommandHandler(broker *TeamsBroker, log *slog.Logger) *CommandHandler {
 	return &CommandHandler{
-		broker: broker,
-		log:    log,
+		broker:       broker,
+		log:          log,
+		pendingLinks: make(map[string]*pendingTeamsLink),
 	}
 }
 
@@ -551,7 +565,96 @@ func (h *CommandHandler) handleRegister(ctx context.Context, activity *Activity)
 		},
 	)
 
-	return h.sendCardReply(ctx, activity, card)
+	if err := h.sendCardReply(ctx, activity, card); err != nil {
+		return err
+	}
+
+	// Cancel any existing pending link for this user before starting a new one.
+	h.pendingMu.Lock()
+	if old, ok := h.pendingLinks[teamsUserID]; ok && old.Cancel != nil {
+		old.Cancel()
+	}
+
+	pollCtx, pollCancel := context.WithCancel(context.Background())
+	h.pendingLinks[teamsUserID] = &pendingTeamsLink{
+		Code:        code,
+		TeamsUserID: teamsUserID,
+		Activity:    activity,
+		Cancel:      pollCancel,
+		ExpiresAt:   time.Now().Add(15 * time.Minute),
+	}
+	h.pendingMu.Unlock()
+
+	go h.pollForConfirmation(pollCtx, activity, teamsUserID, code, pollCancel)
+
+	return nil
+}
+
+// pollForConfirmation polls the hub in the background until the identity link
+// is confirmed or the code expires (15 minutes). On confirmation it saves the
+// user mapping and sends a reply to the conversation.
+func (h *CommandHandler) pollForConfirmation(ctx context.Context, activity *Activity, teamsUserID, code string, cancel context.CancelFunc) {
+	defer cancel()
+
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	deadline := time.Now().Add(15 * time.Minute)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case t := <-ticker.C:
+			if t.After(deadline) {
+				// Clean up expired pending link.
+				h.pendingMu.Lock()
+				if cur, ok := h.pendingLinks[teamsUserID]; ok && cur.Code == code {
+					delete(h.pendingLinks, teamsUserID)
+				}
+				h.pendingMu.Unlock()
+				return
+			}
+
+			checkCtx, checkCancel := context.WithTimeout(ctx, 10*time.Second)
+			status, userID, email, err := h.broker.hubClient.CheckTeamsLinkStatus(checkCtx, teamsUserID)
+			checkCancel()
+
+			if err != nil {
+				h.log.Debug("Poll check failed", "error", err, "teams_user_id", teamsUserID)
+				continue
+			}
+
+			if status == "confirmed" && userID != "" {
+				// Save user mapping.
+				if h.broker.store != nil {
+					mapping := &TeamsUserMapping{
+						TeamsUserID:      teamsUserID,
+						TeamsDisplayName: activity.From.Name,
+						ScionUserID:      userID,
+						ScionEmail:       email,
+						LinkedAt:         time.Now(),
+					}
+					if err := h.broker.store.CreateUserMapping(ctx, mapping); err != nil {
+						h.log.Error("Failed to save user mapping", "error", err)
+					}
+				}
+
+				// Send confirmation reply.
+				replyCtx, replyCancel := context.WithTimeout(context.Background(), 10*time.Second)
+				_ = h.sendReply(replyCtx, activity, fmt.Sprintf("Linked! Your Teams account is now connected to Scion user **%s**.", email))
+				replyCancel()
+
+				// Clean up pending link.
+				h.pendingMu.Lock()
+				if cur, ok := h.pendingLinks[teamsUserID]; ok && cur.Code == code {
+					delete(h.pendingLinks, teamsUserID)
+				}
+				h.pendingMu.Unlock()
+				return
+			}
+		}
+	}
 }
 
 // handleUnregister removes the user's Teams-to-Scion identity link.

--- a/extras/scion-teams/internal/teams/commands.go
+++ b/extras/scion-teams/internal/teams/commands.go
@@ -52,6 +52,18 @@ func NewCommandHandler(broker *TeamsBroker, log *slog.Logger) *CommandHandler {
 	}
 }
 
+// Close cancels all pending polling goroutines.
+func (h *CommandHandler) Close() {
+	h.pendingMu.Lock()
+	defer h.pendingMu.Unlock()
+	for _, link := range h.pendingLinks {
+		if link.Cancel != nil {
+			link.Cancel()
+		}
+	}
+	h.pendingLinks = make(map[string]*pendingTeamsLink)
+}
+
 // Handle checks if the activity text starts with a known command and dispatches it.
 // Returns (handled bool, err error). If handled=false, the caller should
 // treat the message as a regular chat message.
@@ -627,7 +639,11 @@ func (h *CommandHandler) pollForConfirmation(ctx context.Context, activity *Acti
 
 			if status == "confirmed" && userID != "" {
 				// Save user mapping.
-				if h.broker.store != nil {
+				h.broker.mu.Lock()
+				store := h.broker.store
+				h.broker.mu.Unlock()
+
+				if store != nil {
 					mapping := &TeamsUserMapping{
 						TeamsUserID:      teamsUserID,
 						TeamsDisplayName: activity.From.Name,
@@ -635,7 +651,7 @@ func (h *CommandHandler) pollForConfirmation(ctx context.Context, activity *Acti
 						ScionEmail:       email,
 						LinkedAt:         time.Now(),
 					}
-					if err := h.broker.store.CreateUserMapping(ctx, mapping); err != nil {
+					if err := store.CreateUserMapping(ctx, mapping); err != nil {
 						h.log.Error("Failed to save user mapping", "error", err)
 					}
 				}

--- a/extras/scion-teams/internal/teams/commands_test.go
+++ b/extras/scion-teams/internal/teams/commands_test.go
@@ -577,6 +577,227 @@ func TestUnregisterCommand_Success(t *testing.T) {
 	assert.Nil(t, mapping)
 }
 
+func TestRegisterCommand_PollConfirmation(t *testing.T) {
+	// Track number of status poll requests so we can respond differently.
+	pollCount := 0
+
+	hubHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/teams/link":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{"status": "registered"})
+		case r.URL.Path == "/api/v1/teams/link/status":
+			pollCount++
+			if pollCount >= 2 {
+				// Second poll: confirmed.
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"status": "confirmed",
+					"user": map[string]string{
+						"id":    "scion-user-42",
+						"email": "test@example.com",
+					},
+				})
+			} else {
+				// First poll: still pending.
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"status": "pending",
+				})
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	broker, ms := testBrokerWithStore(t, hubHandler)
+	handler := broker.commandHandler
+
+	activity := testActivity("register")
+	handled, err := handler.Handle(context.Background(), activity)
+	assert.True(t, handled)
+	assert.NoError(t, err)
+
+	// Should have sent the Adaptive Card with the code.
+	require.NotEmpty(t, ms.sent)
+	assert.NotEmpty(t, ms.sent[0].Attachments, "expected an Adaptive Card reply")
+
+	// Wait for the polling goroutine to complete confirmation.
+	// The ticker fires every 10s, but we can't wait that long in tests.
+	// Instead, verify that the pending link was registered.
+	handler.pendingMu.Lock()
+	assert.Len(t, handler.pendingLinks, 1, "expected one pending link")
+	handler.pendingMu.Unlock()
+}
+
+func TestRegisterCommand_CancelsPreviousPending(t *testing.T) {
+	hubHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/teams/link":
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]string{"status": "registered"})
+		case r.URL.Path == "/api/v1/teams/link/status":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"status": "pending",
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	broker, _ := testBrokerWithStore(t, hubHandler)
+	handler := broker.commandHandler
+
+	// Register twice — the second should cancel the first.
+	activity1 := testActivity("register")
+	handled, err := handler.Handle(context.Background(), activity1)
+	assert.True(t, handled)
+	assert.NoError(t, err)
+
+	handler.pendingMu.Lock()
+	firstPending := handler.pendingLinks["aad-user-1"]
+	firstCode := firstPending.Code
+	handler.pendingMu.Unlock()
+
+	// Register again.
+	activity2 := testActivity("register")
+	handled, err = handler.Handle(context.Background(), activity2)
+	assert.True(t, handled)
+	assert.NoError(t, err)
+
+	handler.pendingMu.Lock()
+	secondPending := handler.pendingLinks["aad-user-1"]
+	handler.pendingMu.Unlock()
+
+	// The new pending link should have a different code.
+	assert.NotEqual(t, firstCode, secondPending.Code, "second registration should have a new code")
+}
+
+func TestPollForConfirmation_SavesMapping(t *testing.T) {
+	confirmed := false
+	hubHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/teams/link/status":
+			if !confirmed {
+				confirmed = true
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"status": "confirmed",
+					"user": map[string]string{
+						"id":    "scion-user-42",
+						"email": "confirmed@example.com",
+					},
+				})
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	broker, _ := testBrokerWithStore(t, hubHandler)
+	handler := broker.commandHandler
+
+	activity := testActivity("register")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Directly call pollForConfirmation to test it in isolation
+	// (bypasses the 10s ticker by calling it directly).
+	go handler.pollForConfirmation(ctx, activity, "aad-user-1", "TESTCODE", cancel)
+
+	// Wait for the goroutine to process.
+	deadline := time.After(15 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("Timed out waiting for user mapping to be created")
+		default:
+			mapping, err := broker.store.GetUserMapping(context.Background(), "aad-user-1")
+			require.NoError(t, err)
+			if mapping != nil {
+				assert.Equal(t, "scion-user-42", mapping.ScionUserID)
+				assert.Equal(t, "confirmed@example.com", mapping.ScionEmail)
+				assert.Equal(t, "Test User", mapping.TeamsDisplayName)
+				return
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+}
+
+func TestCheckTeamsLinkStatus_ReturnsEmail(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/teams/link/status", r.URL.Path)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status": "confirmed",
+			"user": map[string]string{
+				"id":    "user-123",
+				"email": "hello@example.com",
+			},
+		})
+	}))
+	defer ts.Close()
+
+	client := NewHubClient(ts.URL, "", "", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	client.httpClient = ts.Client()
+
+	status, userID, email, err := client.CheckTeamsLinkStatus(context.Background(), "teams-user-1")
+	require.NoError(t, err)
+	assert.Equal(t, "confirmed", status)
+	assert.Equal(t, "user-123", userID)
+	assert.Equal(t, "hello@example.com", email)
+}
+
+func TestCheckTeamsLinkStatus_Pending(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status": "pending",
+		})
+	}))
+	defer ts.Close()
+
+	client := NewHubClient(ts.URL, "", "", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	client.httpClient = ts.Client()
+
+	status, userID, email, err := client.CheckTeamsLinkStatus(context.Background(), "teams-user-1")
+	require.NoError(t, err)
+	assert.Equal(t, "pending", status)
+	assert.Empty(t, userID)
+	assert.Empty(t, email)
+}
+
+func TestStripThreadSuffix(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "channel without thread",
+			input:    "19:e4e1805b28e142ce9ee9be354816a319@thread.tacv2",
+			expected: "19:e4e1805b28e142ce9ee9be354816a319@thread.tacv2",
+		},
+		{
+			name:     "channel with messageid thread suffix",
+			input:    "19:e4e1805b28e142ce9ee9be354816a319@thread.tacv2;messageid=1786491412694",
+			expected: "19:e4e1805b28e142ce9ee9be354816a319@thread.tacv2",
+		},
+		{
+			name:     "personal chat",
+			input:    "a]concat[b",
+			expected: "a]concat[b",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, stripThreadSuffix(tc.input))
+		})
+	}
+}
+
 func TestAgentPhaseEmoji(t *testing.T) {
 	tests := []struct {
 		phase    string

--- a/extras/scion-teams/internal/teams/hubclient.go
+++ b/extras/scion-teams/internal/teams/hubclient.go
@@ -337,28 +337,28 @@ func (c *HubClient) RegisterTeamsLink(ctx context.Context, teamsUserID string) (
 
 // CheckTeamsLinkStatus polls the hub for the status of a pending identity link.
 // GET /api/v1/teams/link/status?teams_user_id=...
-func (c *HubClient) CheckTeamsLinkStatus(ctx context.Context, teamsUserID string) (string, string, error) {
+func (c *HubClient) CheckTeamsLinkStatus(ctx context.Context, teamsUserID string) (status string, userID string, email string, err error) {
 	u := fmt.Sprintf("%s/api/v1/teams/link/status?teams_user_id=%s",
 		c.hubURL, url.QueryEscape(teamsUserID))
 
 	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
-		return "", "", fmt.Errorf("create link status request: %w", err)
+		return "", "", "", fmt.Errorf("create link status request: %w", err)
 	}
 
 	if err := c.signRequest(req); err != nil {
-		return "", "", fmt.Errorf("sign request: %w", err)
+		return "", "", "", fmt.Errorf("sign request: %w", err)
 	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", "", fmt.Errorf("link status request failed: %w", err)
+		return "", "", "", fmt.Errorf("link status request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-		return "", "", fmt.Errorf("link status returned status %d: %s", resp.StatusCode, string(respBody))
+		return "", "", "", fmt.Errorf("link status returned status %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	var result struct {
@@ -369,15 +369,17 @@ func (c *HubClient) CheckTeamsLinkStatus(ctx context.Context, teamsUserID string
 		} `json:"user,omitempty"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", "", fmt.Errorf("decode link status response: %w", err)
+		return "", "", "", fmt.Errorf("decode link status response: %w", err)
 	}
 
-	userID := ""
+	uid := ""
+	em := ""
 	if result.User != nil {
-		userID = result.User.ID
+		uid = result.User.ID
+		em = result.User.Email
 	}
 
-	return result.Status, userID, nil
+	return result.Status, uid, em, nil
 }
 
 // generateLinkCode produces a 6-character uppercase alphanumeric code using


### PR DESCRIPTION
Add background polling for identity link confirmation, fix inbound topic from teams.message to canonical scion.project format, strip thread messageid suffix for channel link lookup.