### PR TITLE
fix(teams): handle bot mention ID prefix in channel contexts

### DIFF
--- a/extras/scion-teams/internal/teams/activities.go
+++ b/extras/scion-teams/internal/teams/activities.go
@@ -133,11 +133,14 @@ func stripBotMentionByEntity(text string, botID string, entities []Entity) strin
 // matchesBotID checks whether an entity's mention ID matches the bot's AppID.
 // Teams may prefix the ID with a scheme like "28:" in channel contexts.
 func matchesBotID(entityID, botID string) bool {
+	if entityID == "" || botID == "" {
+		return false
+	}
 	if entityID == botID {
 		return true
 	}
 	// Teams uses "28:<appid>" format for bots in channel contexts.
-	if strings.HasSuffix(entityID, ":"+botID) {
+	if len(entityID) > len(botID) && strings.HasSuffix(entityID, botID) && entityID[len(entityID)-len(botID)-1] == ':' {
 		return true
 	}
 	return false

--- a/extras/scion-teams/internal/teams/activities.go
+++ b/extras/scion-teams/internal/teams/activities.go
@@ -122,12 +122,25 @@ func stripBotMentionByEntity(text string, botID string, entities []Entity) strin
 	}
 
 	for _, e := range entities {
-		if e.Type == "mention" && e.Mentioned.ID == botID && e.Text != "" {
+		if e.Type == "mention" && matchesBotID(e.Mentioned.ID, botID) && e.Text != "" {
 			text = strings.Replace(text, e.Text, "", 1)
 		}
 	}
 
 	return strings.TrimSpace(text)
+}
+
+// matchesBotID checks whether an entity's mention ID matches the bot's AppID.
+// Teams may prefix the ID with a scheme like "28:" in channel contexts.
+func matchesBotID(entityID, botID string) bool {
+	if entityID == botID {
+		return true
+	}
+	// Teams uses "28:<appid>" format for bots in channel contexts.
+	if strings.HasSuffix(entityID, ":"+botID) {
+		return true
+	}
+	return false
 }
 
 // handleConversationUpdate logs member added/removed events.

--- a/extras/scion-teams/internal/teams/activities_test.go
+++ b/extras/scion-teams/internal/teams/activities_test.go
@@ -207,6 +207,41 @@ func TestStripBotMentionByEntity(t *testing.T) {
 	assert.Equal(t, "<at>Alice</at> hello", result)
 }
 
+func TestMatchesBotID(t *testing.T) {
+	tests := []struct {
+		name     string
+		entityID string
+		botID    string
+		expected bool
+	}{
+		{"exact match", "bot-1", "bot-1", true},
+		{"28 prefix", "28:bot-1", "bot-1", true},
+		{"other prefix", "29:bot-1", "bot-1", true},
+		{"no match", "other-bot", "bot-1", false},
+		{"partial match not suffix", "bot-1-extra", "bot-1", false},
+		{"empty entity", "", "bot-1", false},
+		{"empty bot", "28:bot-1", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, matchesBotID(tt.entityID, tt.botID))
+		})
+	}
+}
+
+func TestStripBotMentionByEntity_PrefixedID(t *testing.T) {
+	entities := []Entity{
+		{
+			Type:      "mention",
+			Mentioned: ChannelAccount{ID: "28:bot-1", Name: "ScionBot"},
+			Text:      "<at>ScionBot</at>",
+		},
+	}
+	text := "<at>ScionBot</at> setup"
+	result := stripBotMentionByEntity(text, "bot-1", entities)
+	assert.Equal(t, "setup", result)
+}
+
 func TestExtractMentionTarget(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- Fix stripBotMentionByEntity() to handle the 28: prefix Teams adds to bot entity IDs in channel contexts
- Without this fix, all slash commands (setup, register, etc.) fail silently in Teams channels because the bot @-mention tag is not stripped from the message text
- DMs were unaffected because no @-mention is needed

## Root Cause

Teams sends the bot mention entity Mentioned.ID as 28:<appid> in channel contexts, but the bot AppID (used as botID) is the bare UUID. The exact string comparison e.Mentioned.ID == botID always failed, leaving the <at>...</at> tag in the message text. The command handler then saw <at>Scion</at> setup and could not match any command.

## Changes

- Added matchesBotID() helper that accepts both exact matches and colon-prefixed formats (28:uuid, etc.)
- Updated stripBotMentionByEntity() to use matchesBotID() instead of direct equality
- Added 8 test cases covering prefix matching, edge cases, and integration with mention stripping

## Test plan

- [x] go test ./... -race passes
- [x] go build ./... clean
- [ ] Deploy to scion-gteam and verify @Scion setup works in a Teams channel