### PR TITLE
feat: add OIDC login provider support for web UI

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1466,6 +1466,7 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 		// new host that changed the HubID). Operators enabling this must supply a
 		// session secret or pre-provision the signing keys.
 		RequireStableSigningKey: os.Getenv("SCION_REQUIRE_STABLE_SIGNING_KEY") == "true",
+		OIDCLogin:               cfg.OIDCLogin,
 		OIDCConfig:              cfg.OIDC,
 		Federation:              cfg.Federation,
 	}

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -312,6 +312,26 @@ type OAuthConfig struct {
 	Device OAuthClientConfig `json:"device" yaml:"device" koanf:"device"`
 }
 
+// OIDCLoginConfig holds configuration for an external OIDC provider used
+// for web login (the Hub is the Relying Party, not the IdP).
+// This is distinct from OIDCProviderConfig, which configures the Hub as an IdP.
+type OIDCLoginConfig struct {
+	// Enabled controls whether OIDC login is active. Default: false.
+	Enabled bool `json:"enabled" yaml:"enabled" koanf:"enabled"`
+	// DisplayName is the human-readable label shown on the login button
+	// (e.g. "Corporate SSO", "JB Hunt SSO").
+	DisplayName string `json:"displayName" yaml:"displayName" koanf:"displayName"`
+	// IssuerURL is the OIDC issuer. The Hub will fetch
+	// {IssuerURL}/.well-known/openid-configuration to discover endpoints.
+	IssuerURL string `json:"issuerUrl" yaml:"issuerUrl" koanf:"issuerUrl"`
+	// ClientID is the OAuth2 client ID registered with the OIDC provider.
+	ClientID string `json:"clientId" yaml:"clientId" koanf:"clientId"`
+	// ClientSecret is the OAuth2 client secret.
+	ClientSecret string `json:"clientSecret" yaml:"clientSecret" koanf:"clientSecret"`
+	// Scopes overrides the default OIDC scopes. Default: ["openid", "email", "profile"].
+	Scopes []string `json:"scopes,omitempty" yaml:"scopes,omitempty" koanf:"scopes"`
+}
+
 // OIDCProviderConfig holds configuration for the OIDC Identity Provider feature.
 // When enabled, the Hub acts as a minimal OIDC IdP, issuing RS256-signed identity
 // tokens that agents can use to authenticate to external systems (Vault, GCP WIF, etc.).
@@ -348,6 +368,9 @@ type GlobalConfig struct {
 
 	// OAuth provider settings
 	OAuth OAuthConfig `json:"oauth" yaml:"oauth" koanf:"oauth"`
+
+	// OIDCLogin configures an external OIDC provider for web login.
+	OIDCLogin OIDCLoginConfig `json:"oidcLogin,omitempty" yaml:"oidcLogin,omitempty" koanf:"oidcLogin"`
 
 	// Storage settings
 	Storage StorageConfig `json:"storage" yaml:"storage" koanf:"storage"`
@@ -670,6 +693,12 @@ func loadGlobalConfigLegacy(configPath string) (*GlobalConfig, error) {
 		"oauth.device.google.clientSecret": "",
 		"oauth.device.github.clientId":     "",
 		"oauth.device.github.clientSecret": "",
+		// OIDC Login defaults (external OIDC provider for web login)
+		"oidcLogin.enabled":      false,
+		"oidcLogin.displayName":  "",
+		"oidcLogin.issuerUrl":    "",
+		"oidcLogin.clientId":     "",
+		"oidcLogin.clientSecret": "",
 		// Storage defaults
 		"storage.provider":  defaults.Storage.Provider,
 		"storage.bucket":    defaults.Storage.Bucket,

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -354,6 +354,10 @@ type V1ServerConfig struct {
 	// Scheduler configures the Hub background task scheduler.
 	Scheduler *V1SchedulerConfig `json:"scheduler,omitempty" yaml:"scheduler,omitempty" koanf:"scheduler"`
 
+	// OIDCLogin configures an external OIDC provider for web login
+	// (the Hub as Relying Party, not as IdP).
+	OIDCLogin *V1OIDCLoginConfig `json:"oidc_login,omitempty" yaml:"oidc_login,omitempty" koanf:"oidc_login"`
+
 	// OIDC configures the OIDC Identity Provider feature.
 	OIDC *OIDCProviderConfig `json:"oidc,omitempty" yaml:"oidc,omitempty" koanf:"oidc"`
 
@@ -386,6 +390,17 @@ type V1SchedulerConfig struct {
 	// pool saturation) is active out-of-the-box. Set to 0 for unlimited
 	// (pre-fix behavior), or a higher value for larger deployments.
 	MaxConcurrency *int `json:"max_concurrency,omitempty" yaml:"max_concurrency,omitempty" koanf:"max_concurrency"`
+}
+
+// V1OIDCLoginConfig holds configuration for an external OIDC login provider
+// in the versioned settings format (snake_case).
+type V1OIDCLoginConfig struct {
+	Enabled      *bool    `json:"enabled,omitempty" yaml:"enabled,omitempty" koanf:"enabled"`
+	DisplayName  string   `json:"display_name,omitempty" yaml:"display_name,omitempty" koanf:"display_name"`
+	IssuerURL    string   `json:"issuer_url,omitempty" yaml:"issuer_url,omitempty" koanf:"issuer_url"`
+	ClientID     string   `json:"client_id,omitempty" yaml:"client_id,omitempty" koanf:"client_id"`
+	ClientSecret string   `json:"client_secret,omitempty" yaml:"client_secret,omitempty" koanf:"client_secret"`
+	Scopes       []string `json:"scopes,omitempty" yaml:"scopes,omitempty" koanf:"scopes"`
 }
 
 // V1FederationConfig is the admin API wire format for federation settings.
@@ -1606,6 +1621,20 @@ func ConvertV1ServerToGlobalConfig(v1 *V1ServerConfig) *GlobalConfig {
 		gc.OIDC = *v1.OIDC
 	}
 
+	// OIDC Login (external OIDC provider for web login)
+	if v1.OIDCLogin != nil {
+		if v1.OIDCLogin.Enabled != nil {
+			gc.OIDCLogin.Enabled = *v1.OIDCLogin.Enabled
+		}
+		gc.OIDCLogin.DisplayName = v1.OIDCLogin.DisplayName
+		gc.OIDCLogin.IssuerURL = v1.OIDCLogin.IssuerURL
+		gc.OIDCLogin.ClientID = v1.OIDCLogin.ClientID
+		gc.OIDCLogin.ClientSecret = v1.OIDCLogin.ClientSecret
+		if len(v1.OIDCLogin.Scopes) > 0 {
+			gc.OIDCLogin.Scopes = v1.OIDCLogin.Scopes
+		}
+	}
+
 	// Federation
 	if v1.Federation != nil {
 		if v1.Federation.Enabled != nil {
@@ -1789,6 +1818,18 @@ func ConvertGlobalToV1ServerConfig(gc *GlobalConfig) *V1ServerConfig {
 		v1.Scheduler = &V1SchedulerConfig{
 			IntervalSeconds: gc.Scheduler.IntervalSeconds,
 			MaxConcurrency:  gc.Scheduler.MaxConcurrency,
+		}
+	}
+
+	// OIDC Login config (external OIDC provider for web login)
+	if gc.OIDCLogin.Enabled || gc.OIDCLogin.IssuerURL != "" {
+		v1.OIDCLogin = &V1OIDCLoginConfig{
+			Enabled:      &gc.OIDCLogin.Enabled,
+			DisplayName:  gc.OIDCLogin.DisplayName,
+			IssuerURL:    gc.OIDCLogin.IssuerURL,
+			ClientID:     gc.OIDCLogin.ClientID,
+			ClientSecret: gc.OIDCLogin.ClientSecret,
+			Scopes:       gc.OIDCLogin.Scopes,
 		}
 	}
 

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -4333,6 +4333,117 @@ func TestConvertV1FederationConfig_EnabledNilDereference(t *testing.T) {
 	assert.Equal(t, "https://hub-a.example.com", gc.Federation.TrustedIssuers[0].IssuerURL)
 }
 
+// --- OIDC Login Config Tests ---
+
+func TestConvertV1ServerToGlobalConfig_OIDCLogin(t *testing.T) {
+	enabled := true
+	v1 := &V1ServerConfig{
+		OIDCLogin: &V1OIDCLoginConfig{
+			Enabled:      &enabled,
+			DisplayName:  "Corporate SSO",
+			IssuerURL:    "https://sso.example.com/auth/realms/main",
+			ClientID:     "scion-client",
+			ClientSecret: "secret-value",
+			Scopes:       []string{"openid", "email", "custom-scope"},
+		},
+	}
+
+	gc := ConvertV1ServerToGlobalConfig(v1)
+
+	assert.True(t, gc.OIDCLogin.Enabled)
+	assert.Equal(t, "Corporate SSO", gc.OIDCLogin.DisplayName)
+	assert.Equal(t, "https://sso.example.com/auth/realms/main", gc.OIDCLogin.IssuerURL)
+	assert.Equal(t, "scion-client", gc.OIDCLogin.ClientID)
+	assert.Equal(t, "secret-value", gc.OIDCLogin.ClientSecret)
+	assert.Equal(t, []string{"openid", "email", "custom-scope"}, gc.OIDCLogin.Scopes)
+}
+
+func TestConvertV1ServerToGlobalConfig_OIDCLoginNil(t *testing.T) {
+	v1 := &V1ServerConfig{}
+	gc := ConvertV1ServerToGlobalConfig(v1)
+
+	assert.False(t, gc.OIDCLogin.Enabled)
+	assert.Empty(t, gc.OIDCLogin.DisplayName)
+	assert.Empty(t, gc.OIDCLogin.IssuerURL)
+	assert.Empty(t, gc.OIDCLogin.ClientID)
+	assert.Empty(t, gc.OIDCLogin.ClientSecret)
+	assert.Nil(t, gc.OIDCLogin.Scopes)
+}
+
+func TestConvertV1ServerToGlobalConfig_OIDCLoginDefaultScopes(t *testing.T) {
+	enabled := true
+	v1 := &V1ServerConfig{
+		OIDCLogin: &V1OIDCLoginConfig{
+			Enabled:   &enabled,
+			IssuerURL: "https://sso.example.com",
+			ClientID:  "client-id",
+			// Scopes not set — should remain nil (defaults applied at usage time)
+		},
+	}
+
+	gc := ConvertV1ServerToGlobalConfig(v1)
+	assert.True(t, gc.OIDCLogin.Enabled)
+	assert.Nil(t, gc.OIDCLogin.Scopes)
+}
+
+func TestConvertGlobalToV1ServerConfig_OIDCLogin(t *testing.T) {
+	gc := &GlobalConfig{
+		OIDCLogin: OIDCLoginConfig{
+			Enabled:      true,
+			DisplayName:  "JB Hunt SSO",
+			IssuerURL:    "https://sso.example.com/auth/realms/security360",
+			ClientID:     "scion-test",
+			ClientSecret: "test-secret",
+			Scopes:       []string{"openid", "email"},
+		},
+	}
+
+	v1 := ConvertGlobalToV1ServerConfig(gc)
+
+	require.NotNil(t, v1.OIDCLogin)
+	assert.Equal(t, boolPtr(true), v1.OIDCLogin.Enabled)
+	assert.Equal(t, "JB Hunt SSO", v1.OIDCLogin.DisplayName)
+	assert.Equal(t, "https://sso.example.com/auth/realms/security360", v1.OIDCLogin.IssuerURL)
+	assert.Equal(t, "scion-test", v1.OIDCLogin.ClientID)
+	assert.Equal(t, "test-secret", v1.OIDCLogin.ClientSecret)
+	assert.Equal(t, []string{"openid", "email"}, v1.OIDCLogin.Scopes)
+}
+
+func TestConvertGlobalToV1ServerConfig_OIDCLoginDisabledOmitted(t *testing.T) {
+	gc := &GlobalConfig{
+		OIDCLogin: OIDCLoginConfig{
+			Enabled: false,
+			// IssuerURL is empty too, so it should be omitted
+		},
+	}
+
+	v1 := ConvertGlobalToV1ServerConfig(gc)
+	assert.Nil(t, v1.OIDCLogin)
+}
+
+func TestConvertV1OIDCLoginConfig_RoundTrip(t *testing.T) {
+	original := &GlobalConfig{
+		OIDCLogin: OIDCLoginConfig{
+			Enabled:      true,
+			DisplayName:  "Test SSO",
+			IssuerURL:    "https://idp.example.com",
+			ClientID:     "client-123",
+			ClientSecret: "secret-456",
+			Scopes:       []string{"openid", "email", "profile"},
+		},
+	}
+
+	v1 := ConvertGlobalToV1ServerConfig(original)
+	roundTripped := ConvertV1ServerToGlobalConfig(v1)
+
+	assert.Equal(t, original.OIDCLogin.Enabled, roundTripped.OIDCLogin.Enabled)
+	assert.Equal(t, original.OIDCLogin.DisplayName, roundTripped.OIDCLogin.DisplayName)
+	assert.Equal(t, original.OIDCLogin.IssuerURL, roundTripped.OIDCLogin.IssuerURL)
+	assert.Equal(t, original.OIDCLogin.ClientID, roundTripped.OIDCLogin.ClientID)
+	assert.Equal(t, original.OIDCLogin.ClientSecret, roundTripped.OIDCLogin.ClientSecret)
+	assert.Equal(t, original.OIDCLogin.Scopes, roundTripped.OIDCLogin.Scopes)
+}
+
 // --- Helper ---
 
 func boolPtr(b bool) *bool {

--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/google/uuid"
 )
@@ -235,7 +236,7 @@ func (s *Server) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	provider := strings.ToLower(strings.TrimSpace(req.Provider))
-	if provider != "google" && provider != "github" {
+	if !hubclient.IsKnownOAuthProvider(provider) {
 		writeError(w, http.StatusBadRequest, "invalid_provider",
 			"unsupported OAuth provider", nil)
 		return
@@ -342,7 +343,7 @@ func (s *Server) handleAuthToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate provider is a known value
-	if provider != "google" && provider != "github" {
+	if !hubclient.IsKnownOAuthProvider(provider) {
 		writeError(w, http.StatusBadRequest, "invalid_provider",
 			"unsupported OAuth provider", nil)
 		return

--- a/pkg/hub/handlers_auth_test.go
+++ b/pkg/hub/handlers_auth_test.go
@@ -422,7 +422,7 @@ func TestCLIAuthProviders_ReturnsConfiguredProviders(t *testing.T) {
 				ClientSecret: "device-gh-secret",
 			},
 		},
-	})
+	}, nil)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/auth/providers?clientType=device", nil)
 	rec := httptest.NewRecorder()

--- a/pkg/hub/oauth.go
+++ b/pkg/hub/oauth.go
@@ -911,12 +911,12 @@ func (s *OAuthService) OIDCDisplayName() string {
 
 // oidcUserInfoResponse represents the standard OIDC userinfo response.
 type oidcUserInfoResponse struct {
-	Sub              string `json:"sub"`
-	Email            string `json:"email"`
-	EmailVerified    bool   `json:"email_verified"`
-	Name             string `json:"name"`
+	Sub               string `json:"sub"`
+	Email             string `json:"email"`
+	EmailVerified     bool   `json:"email_verified"`
+	Name              string `json:"name"`
 	PreferredUsername string `json:"preferred_username"`
-	Picture          string `json:"picture"`
+	Picture           string `json:"picture"`
 }
 
 // oidcScopes returns the configured scopes or the default OIDC scopes.
@@ -990,13 +990,20 @@ func (s *OAuthService) getOIDCUserInfo(ctx context.Context, accessToken, userinf
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		// Limit error body to 1 KB to avoid OOM on malicious responses.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<10))
 		return nil, fmt.Errorf("OIDC userinfo endpoint returned %d: %s", resp.StatusCode, string(body))
 	}
 
 	var userInfo oidcUserInfoResponse
-	if err := json.NewDecoder(resp.Body).Decode(&userInfo); err != nil {
+	// Limit userinfo response to 1 MB to prevent OOM from oversized payloads.
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&userInfo); err != nil {
 		return nil, fmt.Errorf("failed to decode OIDC userinfo response: %w", err)
+	}
+
+	// The "sub" claim is the primary user identifier in OIDC; it must be present.
+	if userInfo.Sub == "" {
+		return nil, fmt.Errorf("OIDC provider did not return a 'sub' claim; the identity provider must include a subject identifier")
 	}
 
 	if userInfo.Email == "" {
@@ -1008,10 +1015,13 @@ func (s *OAuthService) getOIDCUserInfo(ctx context.Context, accessToken, userinf
 			"the user must verify their email in the identity provider before logging in", userInfo.Email)
 	}
 
-	// Determine display name: prefer Name, fall back to PreferredUsername
+	// Determine display name: prefer Name, fall back to PreferredUsername, then Email.
 	displayName := userInfo.Name
 	if displayName == "" {
 		displayName = userInfo.PreferredUsername
+	}
+	if displayName == "" {
+		displayName = userInfo.Email
 	}
 
 	return &OAuthUserInfo{
@@ -1021,4 +1031,34 @@ func (s *OAuthService) getOIDCUserInfo(ctx context.Context, accessToken, userinf
 		AvatarURL:   userInfo.Picture,
 		Provider:    hubclient.OAuthProviderOIDC,
 	}, nil
+}
+
+// validateOIDCLoginConfig validates the OIDC login configuration at startup.
+// It ensures all required fields are present and the IssuerURL is well-formed.
+func validateOIDCLoginConfig(cfg *config.OIDCLoginConfig) error {
+	if cfg.IssuerURL == "" {
+		return fmt.Errorf("issuerUrl is required when OIDC login is enabled")
+	}
+	parsed, err := url.Parse(cfg.IssuerURL)
+	if err != nil {
+		return fmt.Errorf("issuerUrl is not a valid URL: %w", err)
+	}
+	// Require https, but allow http for localhost/127.0.0.1 (local dev).
+	host := parsed.Hostname()
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && (host == "localhost" || host == "127.0.0.1")) {
+		return fmt.Errorf("issuerUrl must use https scheme (got %q)", parsed.Scheme)
+	}
+	if parsed.RawQuery != "" {
+		return fmt.Errorf("issuerUrl must not contain query parameters")
+	}
+	if parsed.Fragment != "" {
+		return fmt.Errorf("issuerUrl must not contain a fragment")
+	}
+	if cfg.ClientID == "" {
+		return fmt.Errorf("clientId is required when OIDC login is enabled")
+	}
+	if cfg.ClientSecret == "" {
+		return fmt.Errorf("clientSecret is required when OIDC login is enabled")
+	}
+	return nil
 }

--- a/pkg/hub/oauth.go
+++ b/pkg/hub/oauth.go
@@ -938,15 +938,19 @@ func (s *OAuthService) getOIDCAuthURL(callbackURL, state string) (string, error)
 		return "", fmt.Errorf("OIDC discovery failed: %w", err)
 	}
 
-	params := url.Values{
-		"client_id":     {s.oidcLoginConfig.ClientID},
-		"redirect_uri":  {callbackURL},
-		"response_type": {"code"},
-		"scope":         {s.oidcScopes()},
-		"state":         {state},
+	u, err := url.Parse(doc.AuthorizationEndpoint)
+	if err != nil {
+		return "", fmt.Errorf("invalid authorization endpoint URL: %w", err)
 	}
+	q := u.Query()
+	q.Set("client_id", s.oidcLoginConfig.ClientID)
+	q.Set("redirect_uri", callbackURL)
+	q.Set("response_type", "code")
+	q.Set("scope", s.oidcScopes())
+	q.Set("state", state)
+	u.RawQuery = q.Encode()
 
-	return doc.AuthorizationEndpoint + "?" + params.Encode(), nil
+	return u.String(), nil
 }
 
 // exchangeOIDCCode exchanges an OIDC authorization code for user information.
@@ -997,6 +1001,11 @@ func (s *OAuthService) getOIDCUserInfo(ctx context.Context, accessToken, userinf
 
 	if userInfo.Email == "" {
 		return nil, fmt.Errorf("OIDC provider did not return an email claim; ensure the 'email' scope is requested and the user has an email address configured in the identity provider")
+	}
+
+	if !userInfo.EmailVerified {
+		return nil, fmt.Errorf("OIDC provider returned an unverified email address %q; "+
+			"the user must verify their email in the identity provider before logging in", userInfo.Email)
 	}
 
 	// Determine display name: prefer Name, fall back to PreferredUsername

--- a/pkg/hub/oauth.go
+++ b/pkg/hub/oauth.go
@@ -19,11 +19,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 )
 
@@ -106,20 +109,70 @@ func oauthProviderOrder() []string {
 	return hubclient.OAuthProviderOrder()
 }
 
+// oidcDiscoveryCache caches the OIDC discovery document with a TTL.
+// If the discovery fetch fails while a stale entry exists, the stale entry
+// is returned — this provides resilience against transient IdP outages.
+type oidcDiscoveryCache struct {
+	mu        sync.RWMutex
+	doc       *OIDCDiscoveryDoc
+	fetchedAt time.Time
+	ttl       time.Duration // default: 1 hour
+}
+
+// get returns the cached discovery document, fetching it if stale or absent.
+func (c *oidcDiscoveryCache) get(issuerURL string, client *http.Client) (*OIDCDiscoveryDoc, error) {
+	c.mu.RLock()
+	if c.doc != nil && time.Since(c.fetchedAt) < c.ttl {
+		doc := c.doc
+		c.mu.RUnlock()
+		return doc, nil
+	}
+	staleDoc := c.doc
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Double-check after acquiring write lock (another goroutine may have refreshed).
+	if c.doc != nil && time.Since(c.fetchedAt) < c.ttl {
+		return c.doc, nil
+	}
+
+	doc, err := discoverOIDCEndpoints(issuerURL, client)
+	if err != nil {
+		if staleDoc != nil {
+			slog.Warn("OIDC discovery refresh failed, using stale cache", "error", err)
+			return staleDoc, nil
+		}
+		return nil, err
+	}
+
+	c.doc = doc
+	c.fetchedAt = time.Now()
+	return doc, nil
+}
+
 // OAuthService handles OAuth operations for authentication.
 type OAuthService struct {
-	config     OAuthConfig
-	httpClient *http.Client
+	config          OAuthConfig
+	oidcLoginConfig *config.OIDCLoginConfig // nil when OIDC login is disabled
+	httpClient      *http.Client
+	oidcCache       *oidcDiscoveryCache // lazy-initialized when oidcLoginConfig != nil
 }
 
 // NewOAuthService creates a new OAuth service.
-func NewOAuthService(config OAuthConfig) *OAuthService {
-	return &OAuthService{
-		config: config,
+func NewOAuthService(cfg OAuthConfig, oidcLoginCfg *config.OIDCLoginConfig) *OAuthService {
+	svc := &OAuthService{
+		config:          cfg,
+		oidcLoginConfig: oidcLoginCfg,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
 	}
+	if oidcLoginCfg != nil && oidcLoginCfg.Enabled {
+		svc.oidcCache = &oidcDiscoveryCache{ttl: 1 * time.Hour}
+	}
+	return svc
 }
 
 // getClientConfig returns the appropriate OAuth client config for the given client type.
@@ -139,6 +192,14 @@ func (s *OAuthService) getClientConfig(clientType OAuthClientType) OAuthClientCo
 // IsProviderConfiguredForClient returns true if the specified provider is configured
 // for the given client type.
 func (s *OAuthService) IsProviderConfiguredForClient(clientType OAuthClientType, provider string) bool {
+	if provider == hubclient.OAuthProviderOIDC {
+		// V1: OIDC login is web-only
+		return clientType == OAuthClientTypeWeb &&
+			s.oidcLoginConfig != nil &&
+			s.oidcLoginConfig.Enabled &&
+			s.oidcLoginConfig.ClientID != "" &&
+			s.oidcLoginConfig.IssuerURL != ""
+	}
 	cfg := s.getClientConfig(clientType)
 	return cfg.IsProviderConfigured(provider)
 }
@@ -212,6 +273,8 @@ func (s *OAuthService) GetAuthorizationURLForClient(clientType OAuthClientType, 
 		return s.getGoogleAuthURLWithConfig(cfg.Google, callbackURL, state)
 	case hubclient.OAuthProviderGitHub:
 		return s.getGitHubAuthURLWithConfig(cfg.GitHub, callbackURL, state)
+	case hubclient.OAuthProviderOIDC:
+		return s.getOIDCAuthURL(callbackURL, state)
 	default:
 		return "", fmt.Errorf("unsupported OAuth provider: %s", provider)
 	}
@@ -282,6 +345,8 @@ func (s *OAuthService) ExchangeCodeForClient(ctx context.Context, clientType OAu
 		return s.exchangeGoogleCodeWithConfig(ctx, cfg.Google, code, callbackURL)
 	case "github":
 		return s.exchangeGitHubCodeWithConfig(ctx, cfg.GitHub, code, callbackURL)
+	case hubclient.OAuthProviderOIDC:
+		return s.exchangeOIDCCode(ctx, code, callbackURL)
 	default:
 		return nil, fmt.Errorf("unsupported OAuth provider: %s", provider)
 	}
@@ -831,4 +896,120 @@ func (s *OAuthService) pollGitHubDeviceToken(ctx context.Context, cfg OAuthProvi
 	}
 
 	return nil, fmt.Errorf("device token poll failed: %s - %s", resp.Status, string(body))
+}
+
+// --- OIDC Login Methods ---
+
+// OIDCDisplayName returns the human-readable name for the OIDC login provider.
+// Falls back to "SSO" if no display name is configured.
+func (s *OAuthService) OIDCDisplayName() string {
+	if s.oidcLoginConfig != nil && s.oidcLoginConfig.DisplayName != "" {
+		return s.oidcLoginConfig.DisplayName
+	}
+	return "SSO"
+}
+
+// oidcUserInfoResponse represents the standard OIDC userinfo response.
+type oidcUserInfoResponse struct {
+	Sub              string `json:"sub"`
+	Email            string `json:"email"`
+	EmailVerified    bool   `json:"email_verified"`
+	Name             string `json:"name"`
+	PreferredUsername string `json:"preferred_username"`
+	Picture          string `json:"picture"`
+}
+
+// oidcScopes returns the configured scopes or the default OIDC scopes.
+func (s *OAuthService) oidcScopes() string {
+	if s.oidcLoginConfig != nil && len(s.oidcLoginConfig.Scopes) > 0 {
+		return strings.Join(s.oidcLoginConfig.Scopes, " ")
+	}
+	return "openid email profile"
+}
+
+// getOIDCAuthURL generates an authorization URL for the configured OIDC provider.
+func (s *OAuthService) getOIDCAuthURL(callbackURL, state string) (string, error) {
+	if s.oidcLoginConfig == nil || !s.oidcLoginConfig.Enabled {
+		return "", fmt.Errorf("OIDC login is not configured")
+	}
+
+	doc, err := s.oidcCache.get(s.oidcLoginConfig.IssuerURL, s.httpClient)
+	if err != nil {
+		return "", fmt.Errorf("OIDC discovery failed: %w", err)
+	}
+
+	params := url.Values{
+		"client_id":     {s.oidcLoginConfig.ClientID},
+		"redirect_uri":  {callbackURL},
+		"response_type": {"code"},
+		"scope":         {s.oidcScopes()},
+		"state":         {state},
+	}
+
+	return doc.AuthorizationEndpoint + "?" + params.Encode(), nil
+}
+
+// exchangeOIDCCode exchanges an OIDC authorization code for user information.
+func (s *OAuthService) exchangeOIDCCode(ctx context.Context, code, callbackURL string) (*OAuthUserInfo, error) {
+	if s.oidcLoginConfig == nil || !s.oidcLoginConfig.Enabled {
+		return nil, fmt.Errorf("OIDC login is not configured")
+	}
+
+	doc, err := s.oidcCache.get(s.oidcLoginConfig.IssuerURL, s.httpClient)
+	if err != nil {
+		return nil, fmt.Errorf("OIDC discovery failed: %w", err)
+	}
+
+	// Reuse the existing generic token exchange
+	tokenResp, err := s.exchangeCodeForToken(ctx, doc.TokenEndpoint,
+		s.oidcLoginConfig.ClientID, s.oidcLoginConfig.ClientSecret,
+		code, callbackURL)
+	if err != nil {
+		return nil, fmt.Errorf("OIDC token exchange failed: %w", err)
+	}
+
+	return s.getOIDCUserInfo(ctx, tokenResp.AccessToken, doc.UserinfoEndpoint)
+}
+
+// getOIDCUserInfo fetches user information from the OIDC userinfo endpoint.
+func (s *OAuthService) getOIDCUserInfo(ctx context.Context, accessToken, userinfoURL string) (*OAuthUserInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", userinfoURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create userinfo request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch OIDC userinfo: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("OIDC userinfo endpoint returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var userInfo oidcUserInfoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&userInfo); err != nil {
+		return nil, fmt.Errorf("failed to decode OIDC userinfo response: %w", err)
+	}
+
+	if userInfo.Email == "" {
+		return nil, fmt.Errorf("OIDC provider did not return an email claim; ensure the 'email' scope is requested and the user has an email address configured in the identity provider")
+	}
+
+	// Determine display name: prefer Name, fall back to PreferredUsername
+	displayName := userInfo.Name
+	if displayName == "" {
+		displayName = userInfo.PreferredUsername
+	}
+
+	return &OAuthUserInfo{
+		ID:          userInfo.Sub,
+		Email:       userInfo.Email,
+		DisplayName: displayName,
+		AvatarURL:   userInfo.Picture,
+		Provider:    hubclient.OAuthProviderOIDC,
+	}, nil
 }

--- a/pkg/hub/oauth_test.go
+++ b/pkg/hub/oauth_test.go
@@ -15,8 +15,16 @@
 package hub
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 )
 
 func TestOAuthConfig_IsConfigured(t *testing.T) {
@@ -149,7 +157,7 @@ func TestOAuthService_GetAuthorizationURL(t *testing.T) {
 		},
 	}
 
-	service := NewOAuthService(config)
+	service := NewOAuthService(config, nil)
 
 	t.Run("google authorization URL", func(t *testing.T) {
 		url, err := service.GetAuthorizationURL("google", "http://localhost:18271/callback", "test-state")
@@ -199,7 +207,7 @@ func TestOAuthService_GetAuthorizationURL(t *testing.T) {
 func TestOAuthService_NotConfigured(t *testing.T) {
 	config := OAuthConfig{} // Empty config
 
-	service := NewOAuthService(config)
+	service := NewOAuthService(config, nil)
 
 	t.Run("google not configured", func(t *testing.T) {
 		_, err := service.GetAuthorizationURL("google", "http://localhost:18271/callback", "test-state")
@@ -369,7 +377,7 @@ func TestOAuthService_GetAuthorizationURLForClient(t *testing.T) {
 		},
 	}
 
-	service := NewOAuthService(config)
+	service := NewOAuthService(config, nil)
 
 	t.Run("web client uses web config", func(t *testing.T) {
 		url, err := service.GetAuthorizationURLForClient(OAuthClientTypeWeb, "google", "http://example.com/callback", "test-state")
@@ -409,7 +417,7 @@ func TestOAuthService_DefaultProviderForClient(t *testing.T) {
 				Google: OAuthProviderConfig{ClientID: "g-id", ClientSecret: "g-secret"},
 				GitHub: OAuthProviderConfig{ClientID: "gh-id", ClientSecret: "gh-secret"},
 			},
-		})
+		}, nil)
 		if got := service.DefaultProviderForClient(OAuthClientTypeCLI); got != "google" {
 			t.Errorf("DefaultProviderForClient(CLI) = %q, want %q", got, "google")
 		}
@@ -420,14 +428,14 @@ func TestOAuthService_DefaultProviderForClient(t *testing.T) {
 			CLI: OAuthClientConfig{
 				GitHub: OAuthProviderConfig{ClientID: "gh-id", ClientSecret: "gh-secret"},
 			},
-		})
+		}, nil)
 		if got := service.DefaultProviderForClient(OAuthClientTypeCLI); got != "github" {
 			t.Errorf("DefaultProviderForClient(CLI) = %q, want %q", got, "github")
 		}
 	})
 
 	t.Run("returns google when no providers configured", func(t *testing.T) {
-		service := NewOAuthService(OAuthConfig{})
+		service := NewOAuthService(OAuthConfig{}, nil)
 		if got := service.DefaultProviderForClient(OAuthClientTypeCLI); got != "google" {
 			t.Errorf("DefaultProviderForClient(CLI) = %q, want %q", got, "google")
 		}
@@ -456,7 +464,7 @@ func TestOAuthService_IsProviderConfiguredForClient(t *testing.T) {
 		},
 	}
 
-	service := NewOAuthService(config)
+	service := NewOAuthService(config, nil)
 
 	tests := []struct {
 		clientType OAuthClientType
@@ -479,5 +487,407 @@ func TestOAuthService_IsProviderConfiguredForClient(t *testing.T) {
 				t.Errorf("IsProviderConfiguredForClient(%s, %s) = %v, want %v", tc.clientType, tc.provider, got, tc.expected)
 			}
 		})
+	}
+}
+
+// --- OIDC Login Tests ---
+
+func TestOAuthService_IsProviderConfiguredForClient_OIDC(t *testing.T) {
+	t.Run("oidc configured for web", func(t *testing.T) {
+		oidcCfg := &config.OIDCLoginConfig{
+			Enabled:   true,
+			IssuerURL: "https://idp.example.com",
+			ClientID:  "client-id",
+		}
+		service := NewOAuthService(OAuthConfig{}, oidcCfg)
+
+		if !service.IsProviderConfiguredForClient(OAuthClientTypeWeb, hubclient.OAuthProviderOIDC) {
+			t.Error("expected OIDC configured for web")
+		}
+	})
+
+	t.Run("oidc not configured for cli", func(t *testing.T) {
+		oidcCfg := &config.OIDCLoginConfig{
+			Enabled:   true,
+			IssuerURL: "https://idp.example.com",
+			ClientID:  "client-id",
+		}
+		service := NewOAuthService(OAuthConfig{}, oidcCfg)
+
+		if service.IsProviderConfiguredForClient(OAuthClientTypeCLI, hubclient.OAuthProviderOIDC) {
+			t.Error("expected OIDC NOT configured for CLI")
+		}
+	})
+
+	t.Run("oidc not configured for device", func(t *testing.T) {
+		oidcCfg := &config.OIDCLoginConfig{
+			Enabled:   true,
+			IssuerURL: "https://idp.example.com",
+			ClientID:  "client-id",
+		}
+		service := NewOAuthService(OAuthConfig{}, oidcCfg)
+
+		if service.IsProviderConfiguredForClient(OAuthClientTypeDevice, hubclient.OAuthProviderOIDC) {
+			t.Error("expected OIDC NOT configured for device")
+		}
+	})
+
+	t.Run("oidc disabled", func(t *testing.T) {
+		oidcCfg := &config.OIDCLoginConfig{
+			Enabled:   false,
+			IssuerURL: "https://idp.example.com",
+			ClientID:  "client-id",
+		}
+		service := NewOAuthService(OAuthConfig{}, oidcCfg)
+
+		if service.IsProviderConfiguredForClient(OAuthClientTypeWeb, hubclient.OAuthProviderOIDC) {
+			t.Error("expected OIDC NOT configured when disabled")
+		}
+	})
+
+	t.Run("oidc nil config", func(t *testing.T) {
+		service := NewOAuthService(OAuthConfig{}, nil)
+
+		if service.IsProviderConfiguredForClient(OAuthClientTypeWeb, hubclient.OAuthProviderOIDC) {
+			t.Error("expected OIDC NOT configured when config is nil")
+		}
+	})
+
+	t.Run("oidc missing client id", func(t *testing.T) {
+		oidcCfg := &config.OIDCLoginConfig{
+			Enabled:   true,
+			IssuerURL: "https://idp.example.com",
+			// ClientID is empty
+		}
+		service := NewOAuthService(OAuthConfig{}, oidcCfg)
+
+		if service.IsProviderConfiguredForClient(OAuthClientTypeWeb, hubclient.OAuthProviderOIDC) {
+			t.Error("expected OIDC NOT configured when client ID is empty")
+		}
+	})
+}
+
+func TestOAuthService_OIDCDisplayName(t *testing.T) {
+	t.Run("returns configured display name", func(t *testing.T) {
+		oidcCfg := &config.OIDCLoginConfig{
+			DisplayName: "Corporate SSO",
+		}
+		service := NewOAuthService(OAuthConfig{}, oidcCfg)
+		if got := service.OIDCDisplayName(); got != "Corporate SSO" {
+			t.Errorf("OIDCDisplayName() = %q, want %q", got, "Corporate SSO")
+		}
+	})
+
+	t.Run("returns SSO when display name empty", func(t *testing.T) {
+		oidcCfg := &config.OIDCLoginConfig{}
+		service := NewOAuthService(OAuthConfig{}, oidcCfg)
+		if got := service.OIDCDisplayName(); got != "SSO" {
+			t.Errorf("OIDCDisplayName() = %q, want %q", got, "SSO")
+		}
+	})
+
+	t.Run("returns SSO when config nil", func(t *testing.T) {
+		service := NewOAuthService(OAuthConfig{}, nil)
+		if got := service.OIDCDisplayName(); got != "SSO" {
+			t.Errorf("OIDCDisplayName() = %q, want %q", got, "SSO")
+		}
+	})
+}
+
+func TestOAuthService_OIDCScopes(t *testing.T) {
+	t.Run("returns default scopes", func(t *testing.T) {
+		oidcCfg := &config.OIDCLoginConfig{Enabled: true}
+		service := NewOAuthService(OAuthConfig{}, oidcCfg)
+		if got := service.oidcScopes(); got != "openid email profile" {
+			t.Errorf("oidcScopes() = %q, want %q", got, "openid email profile")
+		}
+	})
+
+	t.Run("returns configured scopes", func(t *testing.T) {
+		oidcCfg := &config.OIDCLoginConfig{
+			Enabled: true,
+			Scopes:  []string{"openid", "email", "custom"},
+		}
+		service := NewOAuthService(OAuthConfig{}, oidcCfg)
+		if got := service.oidcScopes(); got != "openid email custom" {
+			t.Errorf("oidcScopes() = %q, want %q", got, "openid email custom")
+		}
+	})
+}
+
+func TestOIDCDiscoveryCache_Get(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(OIDCDiscoveryDoc{
+			Issuer:                "https://example.com",
+			AuthorizationEndpoint: "https://example.com/auth",
+			TokenEndpoint:         "https://example.com/token",
+			UserinfoEndpoint:      "https://example.com/userinfo",
+			JWKSURI:               "https://example.com/keys",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	cache := &oidcDiscoveryCache{ttl: 1 * time.Hour}
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	// First call should fetch
+	doc, err := cache.get(srv.URL, client)
+	if err != nil {
+		t.Fatalf("first get() failed: %v", err)
+	}
+	if doc.AuthorizationEndpoint != "https://example.com/auth" {
+		t.Errorf("unexpected auth endpoint: %s", doc.AuthorizationEndpoint)
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 fetch, got %d", callCount)
+	}
+
+	// Second call should use cache
+	doc2, err := cache.get(srv.URL, client)
+	if err != nil {
+		t.Fatalf("second get() failed: %v", err)
+	}
+	if doc2.AuthorizationEndpoint != "https://example.com/auth" {
+		t.Errorf("unexpected auth endpoint: %s", doc2.AuthorizationEndpoint)
+	}
+	if callCount != 1 {
+		t.Errorf("expected still 1 fetch (cached), got %d", callCount)
+	}
+}
+
+func TestOIDCDiscoveryCache_StaleOnError(t *testing.T) {
+	firstCall := true
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if firstCall {
+			firstCall = false
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(OIDCDiscoveryDoc{
+				Issuer:                "https://example.com",
+				AuthorizationEndpoint: "https://example.com/auth",
+				TokenEndpoint:         "https://example.com/token",
+				UserinfoEndpoint:      "https://example.com/userinfo",
+			})
+			return
+		}
+		// Subsequent calls fail
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	cache := &oidcDiscoveryCache{ttl: 1 * time.Millisecond} // Expire quickly
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	// First call populates cache
+	doc, err := cache.get(srv.URL, client)
+	if err != nil {
+		t.Fatalf("first get() failed: %v", err)
+	}
+
+	// Wait for TTL to expire
+	time.Sleep(5 * time.Millisecond)
+
+	// Second call should return stale doc (server returns 500)
+	doc2, err := cache.get(srv.URL, client)
+	if err != nil {
+		t.Fatalf("expected stale cache on error, got error: %v", err)
+	}
+	if doc2.AuthorizationEndpoint != doc.AuthorizationEndpoint {
+		t.Errorf("expected stale doc, got different: %s", doc2.AuthorizationEndpoint)
+	}
+}
+
+// newTestOIDCServer creates a test server that serves OIDC discovery, token, and userinfo endpoints.
+func newTestOIDCServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			w.Header().Set("Content-Type", "application/json")
+			// Use the test server's own URL as the base for endpoints
+			base := "http://" + r.Host
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"issuer":                 base,
+				"authorization_endpoint": base + "/auth",
+				"token_endpoint":         base + "/token",
+				"userinfo_endpoint":      base + "/userinfo",
+				"jwks_uri":               base + "/keys",
+			})
+
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "test-access-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+
+		case "/userinfo":
+			auth := r.Header.Get("Authorization")
+			if auth != "Bearer test-access-token" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"sub":                "user-123",
+				"email":              "user@example.com",
+				"email_verified":     true,
+				"name":               "Test User",
+				"preferred_username": "testuser",
+				"picture":            "https://example.com/photo.jpg",
+			})
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestOAuthService_GetOIDCAuthURL(t *testing.T) {
+	srv := newTestOIDCServer(t)
+
+	oidcCfg := &config.OIDCLoginConfig{
+		Enabled:   true,
+		IssuerURL: srv.URL,
+		ClientID:  "test-client-id",
+	}
+	service := NewOAuthService(OAuthConfig{}, oidcCfg)
+
+	authURL, err := service.getOIDCAuthURL("https://hub.example.com/auth/callback/oidc", "test-state")
+	if err != nil {
+		t.Fatalf("getOIDCAuthURL() failed: %v", err)
+	}
+
+	if !strings.Contains(authURL, "/auth?") {
+		t.Errorf("expected auth URL to contain /auth?, got: %s", authURL)
+	}
+	if !strings.Contains(authURL, "client_id=test-client-id") {
+		t.Errorf("expected client_id in URL, got: %s", authURL)
+	}
+	if !strings.Contains(authURL, "response_type=code") {
+		t.Errorf("expected response_type=code in URL, got: %s", authURL)
+	}
+	if !strings.Contains(authURL, "state=test-state") {
+		t.Errorf("expected state in URL, got: %s", authURL)
+	}
+	if !strings.Contains(authURL, "scope=openid+email+profile") {
+		t.Errorf("expected default scopes in URL, got: %s", authURL)
+	}
+}
+
+func TestOAuthService_ExchangeOIDCCode(t *testing.T) {
+	srv := newTestOIDCServer(t)
+
+	oidcCfg := &config.OIDCLoginConfig{
+		Enabled:      true,
+		IssuerURL:    srv.URL,
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+	}
+	service := NewOAuthService(OAuthConfig{}, oidcCfg)
+
+	userInfo, err := service.exchangeOIDCCode(context.Background(), "test-code", "https://hub.example.com/auth/callback/oidc")
+	if err != nil {
+		t.Fatalf("exchangeOIDCCode() failed: %v", err)
+	}
+
+	if userInfo.ID != "user-123" {
+		t.Errorf("expected ID %q, got %q", "user-123", userInfo.ID)
+	}
+	if userInfo.Email != "user@example.com" {
+		t.Errorf("expected Email %q, got %q", "user@example.com", userInfo.Email)
+	}
+	if userInfo.DisplayName != "Test User" {
+		t.Errorf("expected DisplayName %q, got %q", "Test User", userInfo.DisplayName)
+	}
+	if userInfo.AvatarURL != "https://example.com/photo.jpg" {
+		t.Errorf("expected AvatarURL %q, got %q", "https://example.com/photo.jpg", userInfo.AvatarURL)
+	}
+	if userInfo.Provider != "oidc" {
+		t.Errorf("expected Provider %q, got %q", "oidc", userInfo.Provider)
+	}
+}
+
+func TestOAuthService_GetOIDCUserInfo_MissingEmail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"sub":  "user-123",
+			"name": "Test User",
+			// email is missing
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	oidcCfg := &config.OIDCLoginConfig{Enabled: true}
+	service := NewOAuthService(OAuthConfig{}, oidcCfg)
+
+	_, err := service.getOIDCUserInfo(context.Background(), "test-token", srv.URL)
+	if err == nil {
+		t.Fatal("expected error for missing email")
+	}
+	if !strings.Contains(err.Error(), "email claim") {
+		t.Errorf("expected 'email claim' in error, got: %v", err)
+	}
+}
+
+func TestOAuthService_GetOIDCUserInfo_FallbackToPreferredUsername(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"sub":                "user-456",
+			"email":              "user@example.com",
+			"preferred_username": "jsmith",
+			// name is missing — should fall back to preferred_username
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	oidcCfg := &config.OIDCLoginConfig{Enabled: true}
+	service := NewOAuthService(OAuthConfig{}, oidcCfg)
+
+	userInfo, err := service.getOIDCUserInfo(context.Background(), "test-token", srv.URL)
+	if err != nil {
+		t.Fatalf("getOIDCUserInfo() failed: %v", err)
+	}
+	if userInfo.DisplayName != "jsmith" {
+		t.Errorf("expected DisplayName %q, got %q", "jsmith", userInfo.DisplayName)
+	}
+}
+
+func TestOAuthService_ConfiguredProvidersForClient_OIDC(t *testing.T) {
+	oidcCfg := &config.OIDCLoginConfig{
+		Enabled:   true,
+		IssuerURL: "https://idp.example.com",
+		ClientID:  "client-id",
+	}
+	oauthCfg := OAuthConfig{
+		Web: OAuthClientConfig{
+			Google: OAuthProviderConfig{ClientID: "g-id", ClientSecret: "g-secret"},
+		},
+	}
+	service := NewOAuthService(oauthCfg, oidcCfg)
+
+	webProviders := service.ConfiguredProvidersForClient(OAuthClientTypeWeb)
+	hasOIDC := false
+	for _, p := range webProviders {
+		if p == hubclient.OAuthProviderOIDC {
+			hasOIDC = true
+		}
+	}
+	if !hasOIDC {
+		t.Errorf("expected OIDC in web providers, got: %v", webProviders)
+	}
+
+	cliProviders := service.ConfiguredProvidersForClient(OAuthClientTypeCLI)
+	for _, p := range cliProviders {
+		if p == hubclient.OAuthProviderOIDC {
+			t.Errorf("did not expect OIDC in CLI providers, got: %v", cliProviders)
+		}
 	}
 }

--- a/pkg/hub/oauth_test.go
+++ b/pkg/hub/oauth_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -780,6 +781,49 @@ func TestOAuthService_GetOIDCAuthURL(t *testing.T) {
 	}
 }
 
+func TestOAuthService_GetOIDCAuthURL_EndpointWithQueryParams(t *testing.T) {
+	// Simulate an OIDC provider whose authorization_endpoint already has query params
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		base := "http://" + r.Host
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"issuer":                 base,
+			"authorization_endpoint": base + "/auth?tenant=abc",
+			"token_endpoint":         base + "/token",
+			"userinfo_endpoint":      base + "/userinfo",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	oidcCfg := &config.OIDCLoginConfig{
+		Enabled:   true,
+		IssuerURL: srv.URL,
+		ClientID:  "test-client",
+	}
+	service := NewOAuthService(OAuthConfig{}, oidcCfg)
+
+	authURL, err := service.getOIDCAuthURL("https://hub.example.com/callback", "s1")
+	if err != nil {
+		t.Fatalf("getOIDCAuthURL() failed: %v", err)
+	}
+
+	// The URL should properly merge params, not produce a double-? URL
+	parsed, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("auth URL is not parseable: %v", err)
+	}
+	q := parsed.Query()
+	if q.Get("tenant") != "abc" {
+		t.Errorf("expected existing query param 'tenant=abc' preserved, got: %s", authURL)
+	}
+	if q.Get("client_id") != "test-client" {
+		t.Errorf("expected client_id in merged URL, got: %s", authURL)
+	}
+	if strings.Count(authURL, "?") != 1 {
+		t.Errorf("expected exactly one '?' in URL, got: %s", authURL)
+	}
+}
+
 func TestOAuthService_ExchangeOIDCCode(t *testing.T) {
 	srv := newTestOIDCServer(t)
 
@@ -836,12 +880,37 @@ func TestOAuthService_GetOIDCUserInfo_MissingEmail(t *testing.T) {
 	}
 }
 
+func TestOAuthService_GetOIDCUserInfo_UnverifiedEmail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"sub":            "user-789",
+			"email":          "unverified@example.com",
+			"email_verified": false,
+			"name":           "Test User",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	oidcCfg := &config.OIDCLoginConfig{Enabled: true}
+	service := NewOAuthService(OAuthConfig{}, oidcCfg)
+
+	_, err := service.getOIDCUserInfo(context.Background(), "test-token", srv.URL)
+	if err == nil {
+		t.Fatal("expected error for unverified email")
+	}
+	if !strings.Contains(err.Error(), "unverified email") {
+		t.Errorf("expected 'unverified email' in error, got: %v", err)
+	}
+}
+
 func TestOAuthService_GetOIDCUserInfo_FallbackToPreferredUsername(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"sub":                "user-456",
 			"email":              "user@example.com",
+			"email_verified":     true,
 			"preferred_username": "jsmith",
 			// name is missing — should fall back to preferred_username
 		})

--- a/pkg/hub/oauth_test.go
+++ b/pkg/hub/oauth_test.go
@@ -960,3 +960,169 @@ func TestOAuthService_ConfiguredProvidersForClient_OIDC(t *testing.T) {
 		}
 	}
 }
+
+// --- Tests for G-1: sub claim validation and email fallback for display name ---
+
+func TestOAuthService_GetOIDCUserInfo_MissingSub(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"email":          "user@example.com",
+			"email_verified": true,
+			"name":           "Test User",
+			// sub is missing
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	oidcCfg := &config.OIDCLoginConfig{Enabled: true}
+	service := NewOAuthService(OAuthConfig{}, oidcCfg)
+
+	_, err := service.getOIDCUserInfo(context.Background(), "test-token", srv.URL)
+	if err == nil {
+		t.Fatal("expected error for missing sub claim")
+	}
+	if !strings.Contains(err.Error(), "sub") {
+		t.Errorf("expected 'sub' in error, got: %v", err)
+	}
+}
+
+func TestOAuthService_GetOIDCUserInfo_FallbackToEmail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"sub":            "user-789",
+			"email":          "fallback@example.com",
+			"email_verified": true,
+			// name and preferred_username are missing — should fall back to email
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	oidcCfg := &config.OIDCLoginConfig{Enabled: true}
+	service := NewOAuthService(OAuthConfig{}, oidcCfg)
+
+	userInfo, err := service.getOIDCUserInfo(context.Background(), "test-token", srv.URL)
+	if err != nil {
+		t.Fatalf("getOIDCUserInfo() failed: %v", err)
+	}
+	if userInfo.DisplayName != "fallback@example.com" {
+		t.Errorf("expected DisplayName %q, got %q", "fallback@example.com", userInfo.DisplayName)
+	}
+}
+
+// --- Tests for G-3: validateOIDCLoginConfig ---
+
+func TestValidateOIDCLoginConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       config.OIDCLoginConfig
+		wantError string // empty means no error expected
+	}{
+		{
+			name: "valid config",
+			cfg: config.OIDCLoginConfig{
+				Enabled:      true,
+				IssuerURL:    "https://idp.example.com",
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+			},
+			wantError: "",
+		},
+		{
+			name: "valid localhost config",
+			cfg: config.OIDCLoginConfig{
+				Enabled:      true,
+				IssuerURL:    "http://localhost:8080",
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+			},
+			wantError: "",
+		},
+		{
+			name: "valid 127.0.0.1 config",
+			cfg: config.OIDCLoginConfig{
+				Enabled:      true,
+				IssuerURL:    "http://127.0.0.1:9090",
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+			},
+			wantError: "",
+		},
+		{
+			name: "missing issuer URL",
+			cfg: config.OIDCLoginConfig{
+				Enabled:      true,
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+			},
+			wantError: "issuerUrl is required",
+		},
+		{
+			name: "http scheme rejected",
+			cfg: config.OIDCLoginConfig{
+				Enabled:      true,
+				IssuerURL:    "http://idp.example.com",
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+			},
+			wantError: "must use https",
+		},
+		{
+			name: "issuer URL with query params",
+			cfg: config.OIDCLoginConfig{
+				Enabled:      true,
+				IssuerURL:    "https://idp.example.com?foo=bar",
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+			},
+			wantError: "query parameters",
+		},
+		{
+			name: "issuer URL with fragment",
+			cfg: config.OIDCLoginConfig{
+				Enabled:      true,
+				IssuerURL:    "https://idp.example.com#section",
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+			},
+			wantError: "fragment",
+		},
+		{
+			name: "missing client ID",
+			cfg: config.OIDCLoginConfig{
+				Enabled:      true,
+				IssuerURL:    "https://idp.example.com",
+				ClientSecret: "client-secret",
+			},
+			wantError: "clientId is required",
+		},
+		{
+			name: "missing client secret",
+			cfg: config.OIDCLoginConfig{
+				Enabled:   true,
+				IssuerURL: "https://idp.example.com",
+				ClientID:  "client-id",
+			},
+			wantError: "clientSecret is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateOIDCLoginConfig(&tc.cfg)
+			if tc.wantError == "" {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantError)
+				}
+				if !strings.Contains(err.Error(), tc.wantError) {
+					t.Errorf("expected error containing %q, got: %v", tc.wantError, err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/hub/oidc_discovery.go
+++ b/pkg/hub/oidc_discovery.go
@@ -68,7 +68,36 @@ func discoverOIDCEndpoints(issuerURL string, client *http.Client) (*OIDCDiscover
 		return nil, fmt.Errorf("oidc discovery: no userinfo_endpoint in response from %s", discoveryURL)
 	}
 
+	// Validate that all discovered endpoints use HTTPS (allow http for localhost/127.0.0.1).
+	for name, ep := range map[string]string{
+		"authorization_endpoint": doc.AuthorizationEndpoint,
+		"token_endpoint":         doc.TokenEndpoint,
+		"userinfo_endpoint":      doc.UserinfoEndpoint,
+	} {
+		if err := validateOIDCEndpointScheme(ep, name); err != nil {
+			return nil, err
+		}
+	}
+
 	return &doc, nil
+}
+
+// validateOIDCEndpointScheme ensures an OIDC endpoint URL uses the https scheme.
+// http is permitted only for localhost (127.0.0.1) to support local development.
+func validateOIDCEndpointScheme(endpoint, fieldName string) error {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("oidc discovery: invalid %s URL %q: %w", fieldName, endpoint, err)
+	}
+	if parsed.Scheme == "https" {
+		return nil
+	}
+	// Allow http for localhost / 127.0.0.1 (local dev/testing).
+	host := parsed.Hostname()
+	if parsed.Scheme == "http" && (host == "localhost" || host == "127.0.0.1") {
+		return nil
+	}
+	return fmt.Errorf("oidc discovery: %s %q must use HTTPS scheme", fieldName, endpoint)
 }
 
 // discoverJWKSURL fetches the OIDC discovery document from the issuer and

--- a/pkg/hub/oidc_discovery.go
+++ b/pkg/hub/oidc_discovery.go
@@ -27,6 +27,50 @@ import (
 // to prevent DoS from oversized responses.
 const maxDiscoveryResponseSize = 1 << 20 // 1 MB
 
+// OIDCDiscoveryDoc holds the endpoints extracted from an OIDC
+// .well-known/openid-configuration response.
+type OIDCDiscoveryDoc struct {
+	Issuer                string `json:"issuer"`
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	UserinfoEndpoint      string `json:"userinfo_endpoint"`
+	JWKSURI               string `json:"jwks_uri"`
+}
+
+// discoverOIDCEndpoints fetches and parses the OIDC discovery document
+// from {issuerURL}/.well-known/openid-configuration.
+// Returns an error if any required endpoint (authorization, token, userinfo) is missing.
+func discoverOIDCEndpoints(issuerURL string, client *http.Client) (*OIDCDiscoveryDoc, error) {
+	discoveryURL := strings.TrimRight(issuerURL, "/") + "/.well-known/openid-configuration"
+	resp, err := client.Get(discoveryURL)
+	if err != nil {
+		return nil, fmt.Errorf("oidc discovery: failed to fetch %s: %w", discoveryURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("oidc discovery: %s returned status %d", discoveryURL, resp.StatusCode)
+	}
+
+	var doc OIDCDiscoveryDoc
+	limitedBody := io.LimitReader(resp.Body, maxDiscoveryResponseSize)
+	if err := json.NewDecoder(limitedBody).Decode(&doc); err != nil {
+		return nil, fmt.Errorf("oidc discovery: failed to parse response from %s: %w", discoveryURL, err)
+	}
+
+	if doc.AuthorizationEndpoint == "" {
+		return nil, fmt.Errorf("oidc discovery: no authorization_endpoint in response from %s", discoveryURL)
+	}
+	if doc.TokenEndpoint == "" {
+		return nil, fmt.Errorf("oidc discovery: no token_endpoint in response from %s", discoveryURL)
+	}
+	if doc.UserinfoEndpoint == "" {
+		return nil, fmt.Errorf("oidc discovery: no userinfo_endpoint in response from %s", discoveryURL)
+	}
+
+	return &doc, nil
+}
+
 // discoverJWKSURL fetches the OIDC discovery document from the issuer and
 // extracts the jwks_uri field. Returns an error if the discovery document
 // cannot be fetched or does not contain a jwks_uri.

--- a/pkg/hub/oidc_discovery_test.go
+++ b/pkg/hub/oidc_discovery_test.go
@@ -172,3 +172,178 @@ func TestDiscoverJWKSURL_RequireHTTPS_AcceptsHTTPS(t *testing.T) {
 		t.Errorf("expected jwks_uri %q, got %q", expectedJWKSURL, jwksURL)
 	}
 }
+
+// --- Tests for discoverOIDCEndpoints ---
+
+func TestDiscoverOIDCEndpoints_ValidDiscovery(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"issuer": "https://example.com",
+			"authorization_endpoint": "https://example.com/auth",
+			"token_endpoint": "https://example.com/token",
+			"userinfo_endpoint": "https://example.com/userinfo",
+			"jwks_uri": "https://example.com/keys"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	doc, err := discoverOIDCEndpoints(srv.URL, client)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if doc.Issuer != "https://example.com" {
+		t.Errorf("expected issuer %q, got %q", "https://example.com", doc.Issuer)
+	}
+	if doc.AuthorizationEndpoint != "https://example.com/auth" {
+		t.Errorf("expected authorization_endpoint %q, got %q", "https://example.com/auth", doc.AuthorizationEndpoint)
+	}
+	if doc.TokenEndpoint != "https://example.com/token" {
+		t.Errorf("expected token_endpoint %q, got %q", "https://example.com/token", doc.TokenEndpoint)
+	}
+	if doc.UserinfoEndpoint != "https://example.com/userinfo" {
+		t.Errorf("expected userinfo_endpoint %q, got %q", "https://example.com/userinfo", doc.UserinfoEndpoint)
+	}
+	if doc.JWKSURI != "https://example.com/keys" {
+		t.Errorf("expected jwks_uri %q, got %q", "https://example.com/keys", doc.JWKSURI)
+	}
+}
+
+func TestDiscoverOIDCEndpoints_MissingAuthorizationEndpoint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"issuer": "https://example.com",
+			"token_endpoint": "https://example.com/token",
+			"userinfo_endpoint": "https://example.com/userinfo"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := discoverOIDCEndpoints(srv.URL, client)
+	if err == nil {
+		t.Fatal("expected error for missing authorization_endpoint, got nil")
+	}
+	if !strings.Contains(err.Error(), "no authorization_endpoint") {
+		t.Errorf("expected 'no authorization_endpoint' in error, got: %v", err)
+	}
+}
+
+func TestDiscoverOIDCEndpoints_MissingTokenEndpoint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"issuer": "https://example.com",
+			"authorization_endpoint": "https://example.com/auth",
+			"userinfo_endpoint": "https://example.com/userinfo"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := discoverOIDCEndpoints(srv.URL, client)
+	if err == nil {
+		t.Fatal("expected error for missing token_endpoint, got nil")
+	}
+	if !strings.Contains(err.Error(), "no token_endpoint") {
+		t.Errorf("expected 'no token_endpoint' in error, got: %v", err)
+	}
+}
+
+func TestDiscoverOIDCEndpoints_MissingUserinfoEndpoint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"issuer": "https://example.com",
+			"authorization_endpoint": "https://example.com/auth",
+			"token_endpoint": "https://example.com/token"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := discoverOIDCEndpoints(srv.URL, client)
+	if err == nil {
+		t.Fatal("expected error for missing userinfo_endpoint, got nil")
+	}
+	if !strings.Contains(err.Error(), "no userinfo_endpoint") {
+		t.Errorf("expected 'no userinfo_endpoint' in error, got: %v", err)
+	}
+}
+
+func TestDiscoverOIDCEndpoints_Non200Status(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := discoverOIDCEndpoints(srv.URL, client)
+	if err == nil {
+		t.Fatal("expected error for non-200 status, got nil")
+	}
+	if !strings.Contains(err.Error(), "returned status 404") {
+		t.Errorf("expected 'returned status 404' in error, got: %v", err)
+	}
+}
+
+func TestDiscoverOIDCEndpoints_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`not valid json`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := discoverOIDCEndpoints(srv.URL, client)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to parse response") {
+		t.Errorf("expected 'failed to parse response' in error, got: %v", err)
+	}
+}
+
+func TestDiscoverOIDCEndpoints_TrailingSlashNormalization(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			t.Errorf("unexpected path %q (double slash?)", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"issuer": "https://example.com",
+			"authorization_endpoint": "https://example.com/auth",
+			"token_endpoint": "https://example.com/token",
+			"userinfo_endpoint": "https://example.com/userinfo"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	doc, err := discoverOIDCEndpoints(srv.URL+"/", client)
+	if err != nil {
+		t.Fatalf("expected success with trailing slash, got error: %v", err)
+	}
+	if doc.AuthorizationEndpoint != "https://example.com/auth" {
+		t.Errorf("expected authorization_endpoint %q, got %q", "https://example.com/auth", doc.AuthorizationEndpoint)
+	}
+}
+
+func TestDiscoverOIDCEndpoints_NetworkError(t *testing.T) {
+	client := &http.Client{Timeout: 1 * time.Second}
+	_, err := discoverOIDCEndpoints("http://127.0.0.1:1", client)
+	if err == nil {
+		t.Fatal("expected error for network error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to fetch") {
+		t.Errorf("expected 'failed to fetch' in error, got: %v", err)
+	}
+}

--- a/pkg/hub/oidc_discovery_test.go
+++ b/pkg/hub/oidc_discovery_test.go
@@ -347,3 +347,75 @@ func TestDiscoverOIDCEndpoints_NetworkError(t *testing.T) {
 		t.Errorf("expected 'failed to fetch' in error, got: %v", err)
 	}
 }
+
+// --- Tests for HTTPS endpoint scheme validation ---
+
+func TestDiscoverOIDCEndpoints_RejectsHTTPEndpoints(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"issuer": "https://example.com",
+			"authorization_endpoint": "http://evil.com/auth",
+			"token_endpoint": "https://example.com/token",
+			"userinfo_endpoint": "https://example.com/userinfo"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	_, err := discoverOIDCEndpoints(srv.URL, client)
+	if err == nil {
+		t.Fatal("expected error for HTTP authorization_endpoint, got nil")
+	}
+	if !strings.Contains(err.Error(), "must use HTTPS") {
+		t.Errorf("expected 'must use HTTPS' in error, got: %v", err)
+	}
+}
+
+func TestDiscoverOIDCEndpoints_AllowsHTTPLocalhostEndpoints(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"issuer": "http://localhost",
+			"authorization_endpoint": "http://localhost:8080/auth",
+			"token_endpoint": "http://127.0.0.1:8080/token",
+			"userinfo_endpoint": "http://localhost:8080/userinfo"
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	doc, err := discoverOIDCEndpoints(srv.URL, client)
+	if err != nil {
+		t.Fatalf("expected success for localhost HTTP endpoints, got error: %v", err)
+	}
+	if doc.AuthorizationEndpoint != "http://localhost:8080/auth" {
+		t.Errorf("unexpected authorization_endpoint: %s", doc.AuthorizationEndpoint)
+	}
+}
+
+func TestValidateOIDCEndpointScheme(t *testing.T) {
+	tests := []struct {
+		name      string
+		endpoint  string
+		wantError bool
+	}{
+		{"https is valid", "https://idp.example.com/auth", false},
+		{"http is rejected", "http://idp.example.com/auth", true},
+		{"http localhost is allowed", "http://localhost:8080/auth", false},
+		{"http 127.0.0.1 is allowed", "http://127.0.0.1:9090/token", false},
+		{"ftp is rejected", "ftp://example.com/auth", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateOIDCEndpointScheme(tc.endpoint, "test_endpoint")
+			if tc.wantError && err == nil {
+				t.Errorf("expected error for %q, got nil", tc.endpoint)
+			}
+			if !tc.wantError && err != nil {
+				t.Errorf("expected no error for %q, got: %v", tc.endpoint, err)
+			}
+		})
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -984,6 +984,13 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 	// Initialize Teams link service
 	srv.teamsLinkService = NewTeamsLinkService()
 
+	// Validate OIDC login configuration at startup (fail fast).
+	if cfg.OIDCLogin.Enabled {
+		if err := validateOIDCLoginConfig(&cfg.OIDCLogin); err != nil {
+			return nil, fmt.Errorf("invalid OIDC login configuration: %w", err)
+		}
+	}
+
 	// Initialize OAuth service if configured (traditional OAuth or OIDC login)
 	oidcLoginCfg := &cfg.OIDCLogin // may be zero-value (Enabled=false)
 	if cfg.OAuthConfig.IsConfigured() || cfg.OIDCLogin.Enabled {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -236,6 +236,8 @@ type ServerConfig struct {
 	// DevUserConfig holds optional identity overrides for the development user.
 	DevUserConfig DevUserConfig
 
+	// OIDCLogin holds configuration for an external OIDC provider for web login.
+	OIDCLogin config.OIDCLoginConfig
 	// OIDCConfig holds configuration for the OIDC Identity Provider feature.
 	// When Enabled, the hub initializes an OIDCKeyManager and exposes OIDC endpoints.
 	OIDCConfig config.OIDCProviderConfig
@@ -982,14 +984,20 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 	// Initialize Teams link service
 	srv.teamsLinkService = NewTeamsLinkService()
 
-	// Initialize OAuth service if configured
-	if cfg.OAuthConfig.IsConfigured() {
-		srv.oauthService = NewOAuthService(cfg.OAuthConfig)
+	// Initialize OAuth service if configured (traditional OAuth or OIDC login)
+	oidcLoginCfg := &cfg.OIDCLogin // may be zero-value (Enabled=false)
+	if cfg.OAuthConfig.IsConfigured() || cfg.OIDCLogin.Enabled {
+		srv.oauthService = NewOAuthService(cfg.OAuthConfig, oidcLoginCfg)
 		slog.Info("OAuth service initialized")
 		// Log which providers are configured
 		logOAuthProviders("Web", cfg.OAuthConfig.Web)
 		logOAuthProviders("CLI", cfg.OAuthConfig.CLI)
 		logOAuthProviders("Device", cfg.OAuthConfig.Device)
+		if cfg.OIDCLogin.Enabled {
+			slog.Info("OIDC login provider configured",
+				"displayName", cfg.OIDCLogin.DisplayName,
+				"issuerUrl", cfg.OIDCLogin.IssuerURL)
+		}
 	} else {
 		slog.Info("OAuth service NOT configured - no providers available")
 		slog.Info("To enable OAuth, set environment variables SCION_SERVER_OAUTH_CLI_GOOGLE_CLIENTID, etc.")

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
+	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
 	"github.com/GoogleCloudPlatform/scion/pkg/version"
@@ -1593,7 +1594,7 @@ func (ws *WebServer) handleOAuthLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate provider
-	if provider != "google" && provider != "github" {
+	if !hubclient.IsKnownOAuthProvider(provider) {
 		http.Error(w, "unsupported OAuth provider", http.StatusBadRequest)
 		return
 	}
@@ -1650,7 +1651,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 	provider := strings.TrimPrefix(r.URL.Path, "/auth/callback/")
 	provider = strings.TrimSuffix(provider, "/")
 
-	if provider != "google" && provider != "github" {
+	if !hubclient.IsKnownOAuthProvider(provider) {
 		http.Error(w, "unsupported OAuth provider", http.StatusBadRequest)
 		return
 	}
@@ -1914,17 +1915,39 @@ func (ws *WebServer) handleAuthMe(w http.ResponseWriter, r *http.Request) {
 // handleAuthProviders returns which OAuth providers are enabled for web login.
 // Route: GET /auth/providers
 func (ws *WebServer) handleAuthProviders(w http.ResponseWriter, r *http.Request) {
-	resp := map[string]interface{}{
-		"google": false,
-		"github": false,
+	type providerInfo struct {
+		ID      string `json:"id"`
+		Name    string `json:"name"`
+		Enabled bool   `json:"enabled"`
 	}
+
+	resp := struct {
+		Providers []providerInfo `json:"providers"`
+		AuthMode  string         `json:"authMode,omitempty"`
+	}{}
+
 	// In proxy mode, no OAuth providers are active (auth is handled by the proxy).
 	if ws.config.AuthMode == "proxy" {
-		resp["authMode"] = "proxy"
+		resp.AuthMode = "proxy"
 	} else if ws.oauthService != nil {
-		resp["google"] = ws.oauthService.IsProviderConfiguredForClient(OAuthClientTypeWeb, "google")
-		resp["github"] = ws.oauthService.IsProviderConfiguredForClient(OAuthClientTypeWeb, "github")
+		for _, pid := range hubclient.OAuthProviderOrder() {
+			enabled := ws.oauthService.IsProviderConfiguredForClient(OAuthClientTypeWeb, pid)
+			if pid == hubclient.OAuthProviderOIDC && !enabled {
+				continue // Don't list OIDC if not configured
+			}
+			info := providerInfo{ID: pid, Enabled: enabled}
+			switch pid {
+			case hubclient.OAuthProviderGoogle:
+				info.Name = "Google"
+			case hubclient.OAuthProviderGitHub:
+				info.Name = "GitHub"
+			case hubclient.OAuthProviderOIDC:
+				info.Name = ws.oauthService.OIDCDisplayName()
+			}
+			resp.Providers = append(resp.Providers, info)
+		}
 	}
+
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -27,6 +27,7 @@ import (
 	"testing/fstest"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -2112,10 +2113,16 @@ func TestAuthProviders_NoOAuthService(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	body, _ := io.ReadAll(resp.Body)
-	var result map[string]bool
+	var result struct {
+		Providers []struct {
+			ID      string `json:"id"`
+			Name    string `json:"name"`
+			Enabled bool   `json:"enabled"`
+		} `json:"providers"`
+	}
 	require.NoError(t, json.Unmarshal(body, &result))
-	assert.False(t, result["google"])
-	assert.False(t, result["github"])
+	// No OAuth service means no providers
+	assert.Nil(t, result.Providers)
 }
 
 func TestAuthProviders_WithProviders(t *testing.T) {
@@ -2138,10 +2145,63 @@ func TestAuthProviders_WithProviders(t *testing.T) {
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 
 	body, _ := io.ReadAll(resp.Body)
-	var result map[string]bool
+	var result struct {
+		Providers []struct {
+			ID      string `json:"id"`
+			Name    string `json:"name"`
+			Enabled bool   `json:"enabled"`
+		} `json:"providers"`
+	}
 	require.NoError(t, json.Unmarshal(body, &result))
-	assert.True(t, result["google"])
-	assert.False(t, result["github"])
+	// Google and GitHub should be in the list (OIDC omitted since not configured)
+	require.Len(t, result.Providers, 2)
+	assert.Equal(t, "google", result.Providers[0].ID)
+	assert.Equal(t, "Google", result.Providers[0].Name)
+	assert.True(t, result.Providers[0].Enabled)
+	assert.Equal(t, "github", result.Providers[1].ID)
+	assert.Equal(t, "GitHub", result.Providers[1].Name)
+	assert.False(t, result.Providers[1].Enabled)
+}
+
+func TestAuthProviders_WithOIDC(t *testing.T) {
+	ws := newTestWebServer(t, WebServerConfig{})
+	oidcCfg := &config.OIDCLoginConfig{
+		Enabled:      true,
+		DisplayName:  "Corporate SSO",
+		IssuerURL:    "https://idp.example.com",
+		ClientID:     "oidc-client-id",
+		ClientSecret: "oidc-secret",
+	}
+	ws.SetOAuthService(NewOAuthService(OAuthConfig{
+		Web: OAuthClientConfig{
+			Google: OAuthProviderConfig{
+				ClientID:     "g-id",
+				ClientSecret: "g-secret",
+			},
+		},
+	}, oidcCfg))
+
+	req := httptest.NewRequest("GET", "/auth/providers", nil)
+	rec := httptest.NewRecorder()
+	ws.Handler().ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	var result struct {
+		Providers []struct {
+			ID      string `json:"id"`
+			Name    string `json:"name"`
+			Enabled bool   `json:"enabled"`
+		} `json:"providers"`
+	}
+	require.NoError(t, json.Unmarshal(body, &result))
+	// Google, GitHub, and OIDC should be listed
+	require.Len(t, result.Providers, 3)
+	assert.Equal(t, "oidc", result.Providers[2].ID)
+	assert.Equal(t, "Corporate SSO", result.Providers[2].Name)
+	assert.True(t, result.Providers[2].Enabled)
 }
 
 // --- SSR Prefetch Tests ---

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -1207,7 +1207,7 @@ func TestOAuthLogin_Redirect(t *testing.T) {
 				ClientSecret: "test-client-secret",
 			},
 		},
-	})
+	}, nil)
 
 	req := httptest.NewRequest("GET", "/auth/login/google", nil)
 	rec := httptest.NewRecorder()
@@ -1237,7 +1237,7 @@ func TestOAuthLogin_ProviderNotConfigured(t *testing.T) {
 			},
 			// GitHub not configured
 		},
-	})
+	}, nil)
 
 	req := httptest.NewRequest("GET", "/auth/login/github", nil)
 	rec := httptest.NewRecorder()
@@ -1272,7 +1272,7 @@ func TestOAuthCallback_StateMismatch(t *testing.T) {
 				ClientSecret: "test-secret",
 			},
 		},
-	})
+	}, nil)
 	// Set a mock store so the handler doesn't short-circuit with 503
 	ws.store = &mockWebStore{}
 
@@ -1661,7 +1661,7 @@ func TestHandleOAuthCallback_CookieOverflowRetry(t *testing.T) {
 				ClientSecret: "test-client-secret",
 			},
 		},
-	})
+	}, nil)
 	// Use enterprise-sized identity fields. These values are embedded in both
 	// Hub JWT tokens (access + refresh), so longer values produce bigger tokens.
 	// Combined with identity session values and securecookie encoding overhead
@@ -1777,7 +1777,7 @@ func TestSetters(t *testing.T) {
 	ws := newTestWebServer(t, WebServerConfig{})
 
 	// Verify setters don't panic and fields are set
-	oauthSvc := NewOAuthService(OAuthConfig{})
+	oauthSvc := NewOAuthService(OAuthConfig{}, nil)
 	ws.SetOAuthService(oauthSvc)
 	assert.Equal(t, oauthSvc, ws.oauthService)
 
@@ -2083,7 +2083,7 @@ func TestLoginPageNoOAuthAttributes(t *testing.T) {
 				ClientSecret: "test-google-secret",
 			},
 		},
-	})
+	}, nil)
 	ws.SetOAuthService(oauthSvc)
 
 	req := httptest.NewRequest("GET", "/login", nil)
@@ -2127,7 +2127,7 @@ func TestAuthProviders_WithProviders(t *testing.T) {
 				ClientSecret: "g-secret",
 			},
 		},
-	}))
+	}, nil))
 
 	req := httptest.NewRequest("GET", "/auth/providers", nil)
 	rec := httptest.NewRecorder()

--- a/pkg/hubclient/auth.go
+++ b/pkg/hubclient/auth.go
@@ -28,6 +28,7 @@ type OAuthClientType string
 const (
 	OAuthProviderGoogle = "google"
 	OAuthProviderGitHub = "github"
+	OAuthProviderOIDC   = "oidc"
 
 	OAuthClientTypeWeb    OAuthClientType = "web"
 	OAuthClientTypeCLI    OAuthClientType = "cli"
@@ -38,6 +39,7 @@ func OAuthProviderOrder() []string {
 	return []string{
 		OAuthProviderGoogle,
 		OAuthProviderGitHub,
+		OAuthProviderOIDC,
 	}
 }
 

--- a/web/src/components/pages/login.ts
+++ b/web/src/components/pages/login.ts
@@ -335,9 +335,7 @@ export class ScionLoginPage extends LitElement {
 
         if (data.providers) {
           // New-style response with provider list
-          this._providers = data.providers
-            .filter((p) => p.enabled)
-            .map((p) => ({
+          this._providers = data.providers.map((p) => ({
               id: p.id,
               name: p.name,
               icon: p.id,

--- a/web/src/components/pages/login.ts
+++ b/web/src/components/pages/login.ts
@@ -48,16 +48,10 @@ export class ScionLoginPage extends LitElement {
   returnTo = '/';
 
   /**
-   * Whether Google OAuth is configured (fetched from server)
+   * Available OAuth providers (fetched from server)
    */
   @state()
-  private googleEnabled = false;
-
-  /**
-   * Whether GitHub OAuth is configured (fetched from server)
-   */
-  @state()
-  private githubEnabled = false;
+  private _providers: OAuthProvider[] = [];
 
   /**
    * Whether the server is in proxy auth mode (e.g., behind IAP)
@@ -332,13 +326,38 @@ export class ScionLoginPage extends LitElement {
     try {
       const resp = await fetch('/auth/providers');
       if (resp.ok) {
-        const data = (await resp.json()) as Record<string, unknown>;
-        this.googleEnabled = !!data.google;
-        this.githubEnabled = !!data.github;
+        const data = (await resp.json()) as {
+          providers?: { id: string; name: string; enabled: boolean }[];
+          authMode?: string;
+          google?: boolean;
+          github?: boolean;
+        };
+
+        if (data.providers) {
+          // New-style response with provider list
+          this._providers = data.providers
+            .filter((p) => p.enabled)
+            .map((p) => ({
+              id: p.id,
+              name: p.name,
+              icon: p.id,
+              available: p.enabled,
+            }));
+        } else {
+          // Legacy fallback (defensive — should not occur after deploy)
+          this._providers = [];
+          if (data.google) {
+            this._providers.push({ id: 'google', name: 'Google', icon: 'google', available: true });
+          }
+          if (data.github) {
+            this._providers.push({ id: 'github', name: 'GitHub', icon: 'github', available: true });
+          }
+        }
+
         this._proxyMode = data.authMode === 'proxy';
       }
     } catch {
-      // If the fetch fails, leave providers disabled
+      // If the fetch fails, leave providers empty
     } finally {
       this._providersLoading = false;
     }
@@ -429,20 +448,7 @@ export class ScionLoginPage extends LitElement {
   }
 
   private getProviders(): OAuthProvider[] {
-    return [
-      {
-        id: 'google',
-        name: 'Google',
-        icon: 'google',
-        available: this.googleEnabled,
-      },
-      {
-        id: 'github',
-        name: 'GitHub',
-        icon: 'github',
-        available: this.githubEnabled,
-      },
-    ];
+    return this._providers;
   }
 
   private renderProvider(provider: OAuthProvider) {


### PR DESCRIPTION
Adds support for an external OIDC provider (e.g. Keycloak) for web UI user login alongside existing Google/GitHub OAuth. New oidc_login config section with OIDC Discovery, 1-hour TTL cache, dynamic frontend provider rendering. Off by default, zero changes to existing flows. Related: ptone/scion#953