### PR TITLE
feat(a2a-bridge): add federation auth with flexible aud claim fix

### DIFF
--- a/extras/scion-a2a-bridge/README.md
+++ b/extras/scion-a2a-bridge/README.md
@@ -65,15 +65,15 @@ docker run -p 8443:8443 -p 9090:9090 \
 
 ### Supported JSON-RPC methods
 
-- `SendMessage` — send a message (blocking or non-blocking)
-- `SendStreamingMessage` — send a message with SSE streaming response
-- `GetTask` — retrieve task status by ID
-- `ListTasks` — list tasks by context ID
-- `CancelTask` — cancel an in-progress task
-- `SubscribeToTask` — re-attach an SSE stream to an active task
-- `CreateTaskPushNotificationConfig` — register a webhook for task updates
-- `GetTaskPushNotificationConfig` — get push notification config for a task
-- `DeleteTaskPushNotificationConfig` — remove a webhook
+- `message/send` — send a message (blocking or non-blocking)
+- `message/stream` — send a message with SSE streaming response
+- `tasks/get` — retrieve task status by ID
+- `tasks/list` — list tasks by context ID
+- `tasks/cancel` — cancel an in-progress task
+- `tasks/resubscribe` — re-attach an SSE stream to an active task
+- `tasks/pushNotification/set` — register a webhook for task updates
+- `tasks/pushNotification/get` — list webhooks for a task
+- `tasks/pushNotification/delete` — remove a webhook
 
 ## TLS
 
@@ -221,20 +221,18 @@ logging:
 
 ### 4. Configure the Hub
 
-Edit the Hub's `settings.yaml` to enable the message broker and register the bridge as a broker plugin.
+Edit the Hub's `settings.yaml` to enable the message broker and register the bridge as a plugin.
 
-Both `message_broker` and `plugins` are nested under the top-level `server` key. Plugin entries live under `server.plugins.broker.<name>`:
+Add or update these sections:
 
 ```yaml
-schema_version: "1"
-server:
-  message_broker:
-    enabled: true
-  plugins:
-    broker:
-      a2a-bridge:
-        self_managed: true
-        address: "localhost:9090"
+message_broker:
+  enabled: true
+
+plugins:
+  a2a-bridge:
+    type: self_managed
+    address: "localhost:9090"
 ```
 
 The `address` must match `plugin.listen_address` in the bridge config. Restart the Hub after making these changes.
@@ -273,7 +271,7 @@ curl -s http://localhost:8443/projects/PROJECT/agents/AGENT/.well-known/agent-ca
 
 ### 7. Test with a sample JSON-RPC request
 
-Send a `SendMessage` request to an agent's JSON-RPC endpoint:
+Send a `message/send` request to an agent's JSON-RPC endpoint:
 
 ```sh
 curl -s -X POST \
@@ -283,7 +281,7 @@ curl -s -X POST \
   -d '{
     "jsonrpc": "2.0",
     "id": "test-1",
-    "method": "SendMessage",
+    "method": "message/send",
     "params": {
       "message": {
         "role": "user",
@@ -322,7 +320,7 @@ The container runs as non-root user `bridge` (UID 1000). The state database dire
 ## Known Limitations
 
 - **No gRPC or REST transport.** The bridge only supports JSON-RPC 2.0 over HTTP. gRPC and HTTP+JSON/REST transports are not implemented.
-- **Blocking-mode `input-required` flows.** In blocking mode, state-change messages are skipped for waiters so the actual content reply is delivered. A blocking `SendMessage` against an agent that transitions to `input-required` without sending content will time out (default 120s). Use non-blocking mode with push notifications or SSE for `input-required` flows.
+- **Blocking-mode `input-required` flows.** In blocking mode, state-change messages are skipped for waiters so the actual content reply is delivered. A blocking `message/send` against an agent that transitions to `input-required` without sending content will time out (default 120s). Use non-blocking mode with push notifications or SSE for `input-required` flows.
 
 ## Security considerations
 

--- a/extras/scion-a2a-bridge/cmd/scion-a2a-bridge/main.go
+++ b/extras/scion-a2a-bridge/cmd/scion-a2a-bridge/main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/integration/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/plugin/grpcbroker"
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
 	"github.com/GoogleCloudPlatform/scion/pkg/util/logging"
 	brokerv1 "github.com/GoogleCloudPlatform/scion/proto/broker/v1"
 )
@@ -157,7 +158,14 @@ func main() {
 	}
 	adminAuth := identity.NewMintingAuth(minter, hubUserID, cfg.Hub.User, "admin", 15*time.Minute)
 
-	adminClient, err := hubclient.New(cfg.Hub.Endpoint, hubclient.WithAuthenticator(adminAuth))
+	transportSrc, transportMode := resolveTransportAuth(log)
+
+	hubOpts := []hubclient.Option{hubclient.WithAuthenticator(adminAuth)}
+	if transportSrc != nil {
+		hubOpts = append(hubOpts, hubclient.WithTransportAuth(transportSrc, transportMode))
+		log.Info("transport auth enabled for hub client", "mode", transportMode)
+	}
+	adminClient, err := hubclient.New(cfg.Hub.Endpoint, hubOpts...)
 	if err != nil {
 		log.Error("failed to create hub client", "error", err)
 		os.Exit(1)
@@ -169,8 +177,12 @@ func main() {
 
 	metrics := bridge.NewMetrics(prometheus.DefaultRegisterer)
 
-	// Create core bridge.
-	b := bridge.New(store, adminClient, minter, cfg, metrics, log.With("component", "bridge"))
+	// Create core bridge (pass transport auth so per-caller clients inherit it).
+	var bridgeOpts []bridge.BridgeOption
+	if transportSrc != nil {
+		bridgeOpts = append(bridgeOpts, bridge.WithTransportAuth(transportSrc, transportMode))
+	}
+	b := bridge.New(store, adminClient, minter, cfg, metrics, log.With("component", "bridge"), bridgeOpts...)
 
 	// Create broker server and wire the bridge as handler.
 	broker := bridge.NewBrokerServer(b.HandleBrokerMessage, log.With("component", "broker"), ctx)
@@ -413,7 +425,14 @@ func serveStandalone(cfg *bridge.Config, log *slog.Logger) {
 	}
 	adminAuth := identity.NewMintingAuth(minter, hubUserID, cfg.Hub.User, "admin", 15*time.Minute)
 
-	hubClient, err := hubclient.New(cfg.Hub.Endpoint, hubclient.WithAuthenticator(adminAuth))
+	transportSrc, transportMode := resolveTransportAuth(log)
+
+	hubOpts := []hubclient.Option{hubclient.WithAuthenticator(adminAuth)}
+	if transportSrc != nil {
+		hubOpts = append(hubOpts, hubclient.WithTransportAuth(transportSrc, transportMode))
+		log.Info("transport auth enabled for hub client", "mode", transportMode)
+	}
+	hubClient, err := hubclient.New(cfg.Hub.Endpoint, hubOpts...)
 	if err != nil {
 		log.Error("failed to create hub client", "error", err)
 		os.Exit(1)
@@ -426,8 +445,12 @@ func serveStandalone(cfg *bridge.Config, log *slog.Logger) {
 	baseCfg := *cfg
 	snapshot := bridge.NewSnapshotHolder(bridge.BuildSnapshot(*cfg))
 
-	// 8. Create core bridge.
-	b := bridge.New(store, hubClient, minter, cfg, metrics, log.With("component", "bridge"))
+	// 8. Create core bridge (pass transport auth so per-caller clients inherit it).
+	var bridgeOpts []bridge.BridgeOption
+	if transportSrc != nil {
+		bridgeOpts = append(bridgeOpts, bridge.WithTransportAuth(transportSrc, transportMode))
+	}
+	b := bridge.New(store, hubClient, minter, cfg, metrics, log.With("component", "bridge"), bridgeOpts...)
 
 	// Create and wire the NOTIFY accelerator for reduced latency on
 	// blocking SendMessage and SSE streaming. Purely additive — polling
@@ -572,6 +595,30 @@ func serveStandalone(cfg *bridge.Config, log *slog.Logger) {
 	notifier.Stop()
 	b.Shutdown()
 	log.Info("scion-a2a-bridge stopped (standalone)")
+}
+
+// resolveTransportAuth resolves the transport-layer OIDC token source and
+// header mode from settings and environment variables. Returns (nil, 0) when
+// transport auth is not configured.
+func resolveTransportAuth(log *slog.Logger) (transportauth.TokenSource, transportauth.HeaderMode) {
+	src, mode, err := transportauth.FromSettings(
+		&transportauth.TransportSettings{
+			Mode:     os.Getenv("SCION_TRANSPORT_MODE"),
+			Audience: os.Getenv("SCION_TRANSPORT_AUDIENCE"),
+		},
+		nil,
+	)
+	if err != nil {
+		log.Warn("transport auth setup failed, proceeding without", "error", err)
+	}
+	if src == nil {
+		var envErr error
+		src, envErr = transportauth.FromEnv()
+		if envErr != nil {
+			log.Warn("transport auth env detection failed", "error", envErr)
+		}
+	}
+	return src, mode
 }
 
 // applyRuntimeConfig merges runtime config values into the bridge config.

--- a/extras/scion-a2a-bridge/internal/bridge/adminoverlay.go
+++ b/extras/scion-a2a-bridge/internal/bridge/adminoverlay.go
@@ -27,11 +27,12 @@ import (
 
 // validAuthSchemes lists the recognized auth schemes for validation.
 var validAuthSchemes = map[string]bool{
-	"apiKey": true,
-	"bearer": true,
-	"none":   true,
-	"hubUAT": true,
-	"hubJWT": true,
+	"apiKey":     true,
+	"bearer":     true,
+	"none":       true,
+	"hubUAT":     true,
+	"hubJWT":     true,
+	"federation": true,
 }
 
 // AdminOverlay holds the parsed admin-managed config values.

--- a/extras/scion-a2a-bridge/internal/bridge/bridge.go
+++ b/extras/scion-a2a-bridge/internal/bridge/bridge.go
@@ -1149,19 +1149,28 @@ func (b *Bridge) callerHubClient(caller *CallerIdentity) (hubclient.Client, erro
 		}
 		mintAuth := identity.NewMintingAuth(b.minter,
 			hubUserID, b.config.Hub.User, "admin", 5*time.Minute)
+
 		// Compose: transport auth (IAP/invoker) → federation header injection.
 		base := http.DefaultTransport
 		if b.transportSrc != nil {
 			base = transportauth.Wrap(base, b.transportSrc, b.transportMode)
 		}
-		return hubclient.New(b.config.Hub.Endpoint,
-			hubclient.WithAuthenticator(mintAuth),
+
+		// WithHTTPClient must come before WithAuthenticator so that the
+		// federation header transport is set as the base before auth wraps it.
+		opts := []hubclient.Option{
 			hubclient.WithHTTPClient(&http.Client{
 				Transport: &federationHeaderTransport{
 					base:  base,
 					token: caller.RawToken,
 				},
-			}))
+			}),
+			hubclient.WithAuthenticator(mintAuth),
+		}
+		if b.transportSrc != nil {
+			opts = append(opts, hubclient.WithTransportAuth(b.transportSrc, b.transportMode))
+		}
+		return hubclient.New(b.config.Hub.Endpoint, opts...)
 	default:
 		return nil, fmt.Errorf("unknown token type: %s", caller.TokenType)
 	}

--- a/extras/scion-a2a-bridge/internal/bridge/bridge.go
+++ b/extras/scion-a2a-bridge/internal/bridge/bridge.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -34,6 +35,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
 )
 
 var (
@@ -84,6 +86,12 @@ type Bridge struct {
 	agentCacheMu sync.RWMutex
 	agentCache   map[string]*agentCacheEntry
 
+	// transportSrc and transportMode hold the resolved transport-layer OIDC
+	// auth (IAP / Cloud Run invoker). Stored so callerHubClient can compose
+	// transport auth into per-caller hub clients.
+	transportSrc  transportauth.TokenSource
+	transportMode transportauth.HeaderMode
+
 	// shutdownCtx is cancelled during graceful shutdown.
 	shutdownCtx    context.Context
 	shutdownCancel context.CancelFunc
@@ -101,8 +109,21 @@ type activeTaskEntry struct {
 	createdAt time.Time
 }
 
-// New creates a new Bridge instance.
-func New(store state.Store, hubClient hubclient.Client, minter *identity.TokenMinter, cfg *Config, metrics *Metrics, log *slog.Logger) *Bridge {
+// BridgeOption configures optional Bridge behaviour.
+type BridgeOption func(*Bridge)
+
+// WithTransportAuth stores the resolved transport-layer OIDC auth so that
+// per-caller hub clients include it in their HTTP transport chain.
+func WithTransportAuth(src transportauth.TokenSource, mode transportauth.HeaderMode) BridgeOption {
+	return func(b *Bridge) {
+		b.transportSrc = src
+		b.transportMode = mode
+	}
+}
+
+// New creates a new Bridge instance. Options (e.g. WithTransportAuth) are
+// applied after construction.
+func New(store state.Store, hubClient hubclient.Client, minter *identity.TokenMinter, cfg *Config, metrics *Metrics, log *slog.Logger, opts ...BridgeOption) *Bridge {
 	ctx, cancel := context.WithCancel(context.Background())
 	b := &Bridge{
 		store:          store,
@@ -118,6 +139,9 @@ func New(store state.Store, hubClient hubclient.Client, minter *identity.TokenMi
 		agentCache:     make(map[string]*agentCacheEntry),
 		shutdownCtx:    ctx,
 		shutdownCancel: cancel,
+	}
+	for _, opt := range opts {
+		opt(b)
 	}
 	b.wg.Add(1)
 	go b.janitor()
@@ -418,14 +442,14 @@ func (b *Bridge) SendMessage(ctx context.Context, projectSlug, agentSlug, contex
 	// In per-user mode, this is a short-lived client authenticated as the caller.
 	// In legacy mode, it's the bridge admin client.
 	writeClient := b.hubClient
-	senderUser := b.config.Hub.User
+	senderLabel := fmt.Sprintf("user:%s", b.config.Hub.User)
 
 	if caller != nil {
-		senderUser = caller.Email
+		senderLabel = caller.SenderLabel()
 		var clientErr error
 		writeClient, clientErr = b.callerHubClient(caller)
 		if clientErr != nil {
-			return nil, fmt.Errorf("creating per-user hub client: %w", clientErr)
+			return nil, fmt.Errorf("creating per-caller hub client: %w", clientErr)
 		}
 	}
 
@@ -444,7 +468,7 @@ func (b *Bridge) SendMessage(ctx context.Context, projectSlug, agentSlug, contex
 		Metadata:     "{}",
 	}
 	if caller != nil {
-		task.CallerUserID = caller.UserID
+		task.CallerUserID = caller.CallerKey()
 	}
 	if err := b.store.CreateTask(ctx, task); err != nil {
 		return nil, fmt.Errorf("create task: %w", err)
@@ -454,14 +478,16 @@ func (b *Bridge) SendMessage(ctx context.Context, projectSlug, agentSlug, contex
 	}
 
 	scionMsg := TranslateA2AToScion(parts)
-	scionMsg.Sender = fmt.Sprintf("user:%s", senderUser)
+	scionMsg.Sender = senderLabel
 	scionMsg.Recipient = fmt.Sprintf("agent:%s", agentCtx.AgentSlug)
 	scionMsg.Metadata = map[string]string{"a2aTaskId": taskID}
 
 	if b.broker != nil {
-		if caller != nil {
+		if caller != nil && !caller.IsAgent() {
 			b.subscribeAllUserTopics(agentCtx.ProjectID)
 		} else {
+			// Legacy and federation callers use admin subscriptions.
+			// Federation callers (agents) don't have personal user topics.
 			b.subscribeAdminUserTopics(agentCtx.ProjectID)
 		}
 	}
@@ -552,20 +578,20 @@ func (b *Bridge) sendFollowUp(ctx context.Context, projectSlug, agentSlug, taskI
 
 	caller := callerIdentityFromContext(ctx)
 
-	// Per-user isolation: the follow-up caller must match the task's owner.
-	if caller != nil && task.CallerUserID != "" && caller.UserID != task.CallerUserID {
+	// Per-user/agent isolation: the follow-up caller must match the task's owner.
+	if caller != nil && task.CallerUserID != "" && caller.CallerKey() != task.CallerUserID {
 		return nil, fmt.Errorf("%w: %s", ErrAgentNotFound, taskID)
 	}
 
-	// Use per-user client if caller identity is present.
+	// Use per-caller client if caller identity is present.
 	writeClient := b.hubClient
-	senderUser := b.config.Hub.User
+	senderLabel := fmt.Sprintf("user:%s", b.config.Hub.User)
 	if caller != nil {
-		senderUser = caller.Email
+		senderLabel = caller.SenderLabel()
 		var clientErr error
 		writeClient, clientErr = b.callerHubClient(caller)
 		if clientErr != nil {
-			return nil, fmt.Errorf("creating per-user hub client: %w", clientErr)
+			return nil, fmt.Errorf("creating per-caller hub client: %w", clientErr)
 		}
 	}
 
@@ -575,14 +601,14 @@ func (b *Bridge) sendFollowUp(ctx context.Context, projectSlug, agentSlug, taskI
 	}
 
 	scionMsg := TranslateA2AToScion(parts)
-	scionMsg.Sender = fmt.Sprintf("user:%s", senderUser)
+	scionMsg.Sender = senderLabel
 	scionMsg.Recipient = fmt.Sprintf("agent:%s", task.AgentSlug)
 	scionMsg.Metadata = map[string]string{"a2aTaskId": taskID}
 
 	// Re-request broker subscriptions in case the broker reconnected since
 	// the original task was created (subscriptions may have been lost).
 	if b.broker != nil {
-		if caller != nil {
+		if caller != nil && !caller.IsAgent() {
 			b.subscribeAllUserTopics(task.ProjectID)
 		} else {
 			b.subscribeAdminUserTopics(task.ProjectID)
@@ -656,16 +682,16 @@ func (b *Bridge) GetTask(ctx context.Context, taskID string) (*TaskResult, error
 		return nil, nil
 	}
 
-	// Per-user isolation: if the request has a caller identity AND the task
-	// was created by a per-user caller, deny access to other users.
+	// Per-user/agent isolation: if the request has a caller identity AND the
+	// task was created by a per-user/agent caller, deny access to other callers.
 	// Legacy tasks (CallerUserID == "") are visible to all legacy callers
-	// but NOT to per-user callers (prevents information leakage across modes).
+	// but NOT to per-user/agent callers (prevents information leakage across modes).
 	caller := callerIdentityFromContext(ctx)
-	if caller != nil && task.CallerUserID != "" && caller.UserID != task.CallerUserID {
+	if caller != nil && task.CallerUserID != "" && caller.CallerKey() != task.CallerUserID {
 		return nil, nil // not found (avoids leaking existence)
 	}
 	if caller != nil && task.CallerUserID == "" {
-		// Per-user caller cannot see legacy tasks — prevents mode mixing.
+		// Per-user/agent caller cannot see legacy tasks — prevents mode mixing.
 		return nil, nil
 	}
 
@@ -686,8 +712,8 @@ func (b *Bridge) ListTasks(ctx context.Context, contextID string) ([]TaskResult,
 	var tasks []state.Task
 	var err error
 	if caller != nil {
-		// Per-user mode: only list tasks created by this caller.
-		tasks, err = b.store.ListTasksByContextAndCaller(ctx, contextID, caller.UserID)
+		// Per-user/agent mode: only list tasks created by this caller.
+		tasks, err = b.store.ListTasksByContextAndCaller(ctx, contextID, caller.CallerKey())
 	} else {
 		tasks, err = b.store.ListTasksByContext(ctx, contextID)
 	}
@@ -719,13 +745,13 @@ func (b *Bridge) CancelTask(ctx context.Context, taskID string) (*TaskResult, er
 		return nil, nil
 	}
 
-	// Per-user isolation (same logic as GetTask).
+	// Per-user/agent isolation (same logic as GetTask).
 	caller := callerIdentityFromContext(ctx)
-	if caller != nil && task.CallerUserID != "" && caller.UserID != task.CallerUserID {
+	if caller != nil && task.CallerUserID != "" && caller.CallerKey() != task.CallerUserID {
 		return nil, nil // not found
 	}
 	if caller != nil && task.CallerUserID == "" {
-		return nil, nil // per-user caller cannot cancel legacy tasks
+		return nil, nil // per-user/agent caller cannot cancel legacy tasks
 	}
 
 	if IsTerminalState(task.State) {
@@ -745,20 +771,20 @@ func (b *Bridge) CancelTask(ctx context.Context, taskID string) (*TaskResult, er
 			targetAgentID = agent.ID
 		}
 		cancelClient := b.hubClient
-		senderUser := b.config.Hub.User
+		senderLabel := fmt.Sprintf("user:%s", b.config.Hub.User)
 		if caller != nil {
-			senderUser = caller.Email
+			senderLabel = caller.SenderLabel()
 			if cc, err := b.callerHubClient(caller); err == nil {
 				cancelClient = cc
 			} else {
-				b.log.Warn("CancelTask: failed to create per-user client, falling back to admin",
+				b.log.Warn("CancelTask: failed to create per-caller client, falling back to admin",
 					"error", err, "task_id", taskID)
 			}
 		}
 		interruptMsg := &messages.StructuredMessage{
 			Version:   1,
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
-			Sender:    fmt.Sprintf("user:%s", senderUser),
+			Sender:    senderLabel,
 			Recipient: fmt.Sprintf("agent:%s", task.AgentSlug),
 			Msg:       "Task cancelled by A2A client.",
 			Type:      messages.TypeInstruction,
@@ -1086,19 +1112,56 @@ func truncate(s string, n int) string {
 // callerHubClient creates a per-request Hub client authenticated as the caller.
 // For UAT callers, the original token is passed through to the Hub.
 // For JWT callers, a fresh 5-minute JWT is minted for the caller's identity.
+// For federation callers, the bridge's admin auth is used with the federation
+// token passed via X-Scion-Federation-Token header.
+//
+// All cases compose transport auth (IAP / Cloud Run invoker) into the HTTP
+// transport chain when configured, so per-caller clients can reach hubs behind
+// identity-aware proxies.
 func (b *Bridge) callerHubClient(caller *CallerIdentity) (hubclient.Client, error) {
 	switch caller.TokenType {
 	case "uat":
-		return hubclient.New(b.config.Hub.Endpoint,
-			hubclient.WithBearerToken(caller.RawToken))
+		opts := []hubclient.Option{hubclient.WithBearerToken(caller.RawToken)}
+		if b.transportSrc != nil {
+			opts = append(opts, hubclient.WithTransportAuth(b.transportSrc, b.transportMode))
+		}
+		return hubclient.New(b.config.Hub.Endpoint, opts...)
 	case "jwt":
 		// Re-mint a 5-minute JWT for the caller's identity using the bridge's
 		// signing key. This is the same infrastructure used for the bridge's
 		// own admin identity.
 		mintAuth := identity.NewMintingAuth(b.minter,
 			caller.UserID, caller.Email, caller.Role, 5*time.Minute)
+		opts := []hubclient.Option{hubclient.WithAuthenticator(mintAuth)}
+		if b.transportSrc != nil {
+			opts = append(opts, hubclient.WithTransportAuth(b.transportSrc, b.transportMode))
+		}
+		return hubclient.New(b.config.Hub.Endpoint, opts...)
+	case "federation":
+		// For federation callers, use the bridge's admin auth for Hub API
+		// access, but inject the X-Scion-Federation-Token header so the Hub
+		// can identify the federated agent. The bridge acts as a proxy:
+		// its admin identity authorizes the API call, the federation header
+		// carries the agent's identity for the Hub to validate.
+		hubUserID := b.config.Hub.UserID
+		if hubUserID == "" {
+			hubUserID = b.config.Hub.User
+		}
+		mintAuth := identity.NewMintingAuth(b.minter,
+			hubUserID, b.config.Hub.User, "admin", 5*time.Minute)
+		// Compose: transport auth (IAP/invoker) → federation header injection.
+		base := http.DefaultTransport
+		if b.transportSrc != nil {
+			base = transportauth.Wrap(base, b.transportSrc, b.transportMode)
+		}
 		return hubclient.New(b.config.Hub.Endpoint,
-			hubclient.WithAuthenticator(mintAuth))
+			hubclient.WithAuthenticator(mintAuth),
+			hubclient.WithHTTPClient(&http.Client{
+				Transport: &federationHeaderTransport{
+					base:  base,
+					token: caller.RawToken,
+				},
+			}))
 	default:
 		return nil, fmt.Errorf("unknown token type: %s", caller.TokenType)
 	}

--- a/extras/scion-a2a-bridge/internal/bridge/caller.go
+++ b/extras/scion-a2a-bridge/internal/bridge/caller.go
@@ -14,16 +14,65 @@
 
 package bridge
 
-import "context"
+import (
+	"context"
+	"net/url"
+)
 
 // CallerIdentity holds the per-request caller identity extracted from a
 // validated hub credential. Absent for legacy apiKey/bearer/none modes.
 type CallerIdentity struct {
+	// --- Existing fields (user callers) ---
 	UserID    string
 	Email     string
 	Role      string
-	RawToken  string // The original bearer token for UAT passthrough
-	TokenType string // "uat" or "jwt"
+	RawToken  string // The original bearer token for passthrough
+	TokenType string // "uat", "jwt", or "federation"
+
+	// --- New fields (agent/federation callers) ---
+
+	// AgentID is the agent's UUID (from JWT `sub` claim).
+	// Non-empty only for agent callers (TokenType == "federation").
+	AgentID string
+
+	// IssuerURL is the OIDC issuer URL (from JWT `iss` claim).
+	// Identifies which hub signed the token.
+	IssuerURL string
+
+	// ProjectID is the agent's project (from `project_id` claim).
+	ProjectID string
+
+	// Ancestry is the agent's lineage chain (from `ancestry` claim).
+	Ancestry []string
+}
+
+// IsAgent returns true if this identity represents an agent caller
+// (federation auth, not a local user).
+func (c *CallerIdentity) IsAgent() bool {
+	return c.AgentID != ""
+}
+
+// SenderLabel returns the formatted sender string for Hub messages.
+// Agent callers use "agent:<id>", user callers use "user:<email>".
+func (c *CallerIdentity) SenderLabel() string {
+	if c.IsAgent() {
+		return "agent:" + c.AgentID
+	}
+	return "user:" + c.Email
+}
+
+// CallerKey returns a stable identifier for task-store isolation.
+// For user callers: UserID.
+// For agent callers: "agent:<issuer-host>:<agent-id>".
+func (c *CallerIdentity) CallerKey() string {
+	if c.IsAgent() {
+		u, err := url.Parse(c.IssuerURL)
+		if err != nil || u.Host == "" {
+			return "agent:" + c.AgentID
+		}
+		return "agent:" + u.Host + ":" + c.AgentID
+	}
+	return c.UserID
 }
 
 type callerContextKey struct{}

--- a/extras/scion-a2a-bridge/internal/bridge/executor.go
+++ b/extras/scion-a2a-bridge/internal/bridge/executor.go
@@ -102,31 +102,31 @@ func (e *ScionExecutor) Execute(ctx context.Context, execCtx *a2asrv.ExecutorCon
 			}
 		}
 
-		// Per-user identity propagation: use the caller's credentials for Hub
+		// Per-user/agent identity propagation: use the caller's credentials for Hub
 		// writes, sender field, and broker subscriptions (mirrors Bridge.SendMessage).
 		caller := callerIdentityFromContext(ctx) // nil in legacy mode
 		var writeClient hubclient.Client = e.bridge.hubClient
-		senderUser := e.bridge.config.Hub.User
+		senderLabel := fmt.Sprintf("user:%s", e.bridge.config.Hub.User)
 
 		if caller != nil {
-			senderUser = caller.Email
+			senderLabel = caller.SenderLabel()
 			var clientErr error
 			writeClient, clientErr = e.bridge.callerHubClient(caller)
 			if clientErr != nil {
-				yield(nil, fmt.Errorf("creating per-user hub client: %w", clientErr))
+				yield(nil, fmt.Errorf("creating per-caller hub client: %w", clientErr))
 				return
 			}
 		}
 
 		// Translate A2A message parts to Scion format.
 		scionMsg := TranslateA2APartsToScion(execCtx.Message.Parts)
-		scionMsg.Sender = fmt.Sprintf("user:%s", senderUser)
+		scionMsg.Sender = senderLabel
 		scionMsg.Recipient = fmt.Sprintf("agent:%s", agentCtx.AgentSlug)
 		scionMsg.Metadata = map[string]string{"a2aTaskId": string(taskID)}
 
 		// Request broker subscription for responses.
 		if e.bridge.broker != nil {
-			if caller != nil {
+			if caller != nil && !caller.IsAgent() {
 				e.bridge.subscribeAllUserTopics(agentCtx.ProjectID)
 			} else {
 				e.bridge.subscribeAdminUserTopics(agentCtx.ProjectID)
@@ -265,16 +265,16 @@ func (e *ScionExecutor) Cancel(ctx context.Context, execCtx *a2asrv.ExecutorCont
 				return
 			}
 
-			// Per-user identity propagation for cancel interrupts.
+			// Per-user/agent identity propagation for cancel interrupts.
 			caller := callerIdentityFromContext(ctx)
 			var cancelClient hubclient.Client = e.bridge.hubClient
-			senderUser := e.bridge.config.Hub.User
+			senderLabel := fmt.Sprintf("user:%s", e.bridge.config.Hub.User)
 			if caller != nil {
-				senderUser = caller.Email
+				senderLabel = caller.SenderLabel()
 				if cc, err := e.bridge.callerHubClient(caller); err == nil {
 					cancelClient = cc
 				} else {
-					e.log.Warn("cancel: failed to create per-user client, falling back to admin",
+					e.log.Warn("cancel: failed to create per-caller client, falling back to admin",
 						"error", err, "task_id", taskID)
 				}
 			}
@@ -283,7 +283,7 @@ func (e *ScionExecutor) Cancel(ctx context.Context, execCtx *a2asrv.ExecutorCont
 				interruptMsg := &messages.StructuredMessage{
 					Version:   1,
 					Timestamp: time.Now().UTC().Format(time.RFC3339),
-					Sender:    fmt.Sprintf("user:%s", senderUser),
+					Sender:    senderLabel,
 					Recipient: fmt.Sprintf("agent:%s", route.AgentSlug),
 					Msg:       "Task cancelled by A2A client.",
 					Type:      messages.TypeInstruction,

--- a/extras/scion-a2a-bridge/internal/bridge/federation.go
+++ b/extras/scion-a2a-bridge/internal/bridge/federation.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// FederationTokenHeader is the HTTP header used to pass federation OIDC
+// identity tokens from the bridge to the hub.
+// IMPORTANT: must match pkg/hub/federation_auth.go:FederationTokenHeader.
+// See TestFederationTokenHeaderMatchesHub in federation_test.go.
+const FederationTokenHeader = "X-Scion-Federation-Token"
+
+// flexibleAudience handles the RFC 7519 aud claim which may be either a
+// single string or an array of strings.
+type flexibleAudience []string
+
+func (a *flexibleAudience) UnmarshalJSON(data []byte) error {
+	// Try string first.
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*a = []string{s}
+		return nil
+	}
+	// Fall back to array.
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err != nil {
+		return err
+	}
+	*a = arr
+	return nil
+}
+
+// federationJWTClaims holds the JWT claims we extract from a federation
+// token WITHOUT signature verification. The hub validates the token;
+// the bridge only decodes it for local bookkeeping (task isolation, logging).
+//
+// Mirrors the hub's federationClaims (pkg/hub/federation_auth.go).
+type federationJWTClaims struct {
+	Issuer    string           `json:"iss"`
+	Subject   string           `json:"sub"`
+	Audience  flexibleAudience `json:"aud"`
+	ProjectID string           `json:"project_id,omitempty"`
+	AgentName string           `json:"agent_name,omitempty"`
+	Ancestry  []string         `json:"ancestry,omitempty"`
+	RootUser  string           `json:"root_user,omitempty"`
+}
+
+// decodeFederationToken parses a JWT WITHOUT signature verification and
+// extracts caller identity fields for bridge-local bookkeeping (task store
+// isolation, logging, sender formatting). The hub validates the token via
+// its FederationAuthenticator when the bridge passes it in the
+// X-Scion-Federation-Token header.
+func decodeFederationToken(tokenString string) (*CallerIdentity, error) {
+	parts := strings.Split(tokenString, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("federation: token is not a valid JWT (expected 3 parts, got %d)", len(parts))
+	}
+
+	// Decode the payload (second part), adding padding if needed.
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("federation: failed to decode JWT payload: %w", err)
+	}
+
+	var claims federationJWTClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("federation: failed to parse JWT claims: %w", err)
+	}
+
+	if claims.Subject == "" {
+		return nil, fmt.Errorf("federation: JWT missing sub claim")
+	}
+
+	return &CallerIdentity{
+		TokenType: "federation",
+		RawToken:  tokenString,
+		AgentID:   claims.Subject,
+		IssuerURL: claims.Issuer,
+		ProjectID: claims.ProjectID,
+		Ancestry:  claims.Ancestry,
+	}, nil
+}
+
+// federationHeaderTransport wraps an http.RoundTripper and injects the
+// X-Scion-Federation-Token header on every request.
+type federationHeaderTransport struct {
+	base  http.RoundTripper
+	token string
+}
+
+func (t *federationHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.Header.Set(FederationTokenHeader, t.token)
+	return t.base.RoundTrip(clone)
+}

--- a/extras/scion-a2a-bridge/internal/bridge/federation.go
+++ b/extras/scion-a2a-bridge/internal/bridge/federation.go
@@ -75,7 +75,11 @@ func decodeFederationToken(tokenString string) (*CallerIdentity, error) {
 	}
 
 	// Decode the payload (second part), adding padding if needed.
-	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	payloadStr := parts[1]
+	if l := len(payloadStr) % 4; l > 0 {
+		payloadStr += strings.Repeat("=", 4-l)
+	}
+	payload, err := base64.URLEncoding.DecodeString(payloadStr)
 	if err != nil {
 		return nil, fmt.Errorf("federation: failed to decode JWT payload: %w", err)
 	}

--- a/extras/scion-a2a-bridge/internal/bridge/federation_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/federation_test.go
@@ -1,0 +1,520 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/extras/scion-a2a-bridge/internal/state"
+)
+
+// buildTestJWT creates a minimal unsigned JWT from the given claims for testing.
+// The signature segment is a placeholder — decodeFederationToken doesn't verify it.
+func buildTestJWT(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payloadBytes, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	payload := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	return header + "." + payload + ".fakesig"
+}
+
+func TestDecodeFederationToken_Valid(t *testing.T) {
+	token := buildTestJWT(t, map[string]interface{}{
+		"iss":        "https://hub.example.com",
+		"sub":        "agent-uuid-123",
+		"aud":        []string{"https://bridge.example.com"},
+		"project_id": "my-project",
+		"agent_name": "my-agent",
+		"ancestry":   []string{"parent-agent", "grandparent-agent"},
+		"root_user":  "alice@example.com",
+	})
+
+	caller, err := decodeFederationToken(token)
+	if err != nil {
+		t.Fatalf("decodeFederationToken returned error: %v", err)
+	}
+
+	if caller.TokenType != "federation" {
+		t.Errorf("TokenType = %q, want %q", caller.TokenType, "federation")
+	}
+	if caller.AgentID != "agent-uuid-123" {
+		t.Errorf("AgentID = %q, want %q", caller.AgentID, "agent-uuid-123")
+	}
+	if caller.IssuerURL != "https://hub.example.com" {
+		t.Errorf("IssuerURL = %q, want %q", caller.IssuerURL, "https://hub.example.com")
+	}
+	if caller.ProjectID != "my-project" {
+		t.Errorf("ProjectID = %q, want %q", caller.ProjectID, "my-project")
+	}
+	if len(caller.Ancestry) != 2 || caller.Ancestry[0] != "parent-agent" {
+		t.Errorf("Ancestry = %v, want [parent-agent grandparent-agent]", caller.Ancestry)
+	}
+	if caller.RawToken != token {
+		t.Error("RawToken should match the input token")
+	}
+	if !caller.IsAgent() {
+		t.Error("IsAgent() should return true for federation callers")
+	}
+}
+
+func TestDecodeFederationToken_MinimalClaims(t *testing.T) {
+	token := buildTestJWT(t, map[string]interface{}{
+		"sub": "minimal-agent",
+		"iss": "https://hub.example.com",
+	})
+
+	caller, err := decodeFederationToken(token)
+	if err != nil {
+		t.Fatalf("decodeFederationToken returned error: %v", err)
+	}
+
+	if caller.AgentID != "minimal-agent" {
+		t.Errorf("AgentID = %q, want %q", caller.AgentID, "minimal-agent")
+	}
+	if caller.ProjectID != "" {
+		t.Errorf("ProjectID = %q, want empty", caller.ProjectID)
+	}
+	if len(caller.Ancestry) != 0 {
+		t.Errorf("Ancestry = %v, want empty", caller.Ancestry)
+	}
+}
+
+func TestDecodeFederationToken_MissingSub(t *testing.T) {
+	token := buildTestJWT(t, map[string]interface{}{
+		"iss": "https://hub.example.com",
+		// no "sub"
+	})
+
+	_, err := decodeFederationToken(token)
+	if err == nil {
+		t.Fatal("expected error for missing sub claim, got nil")
+	}
+}
+
+func TestDecodeFederationToken_NotJWT(t *testing.T) {
+	_, err := decodeFederationToken("not-a-jwt")
+	if err == nil {
+		t.Fatal("expected error for non-JWT string, got nil")
+	}
+}
+
+func TestDecodeFederationToken_InvalidPayload(t *testing.T) {
+	// Two segments but second segment is not valid base64
+	_, err := decodeFederationToken("header.!!!invalid!!!.sig")
+	if err == nil {
+		t.Fatal("expected error for invalid base64 payload, got nil")
+	}
+}
+
+func TestDecodeFederationToken_InvalidJSON(t *testing.T) {
+	// Valid base64 but not valid JSON
+	payload := base64.RawURLEncoding.EncodeToString([]byte("not json"))
+	token := "header." + payload + ".sig"
+
+	_, err := decodeFederationToken(token)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON payload, got nil")
+	}
+}
+
+func TestFlexibleAudience(t *testing.T) {
+	t.Run("string aud", func(t *testing.T) {
+		// RFC 7519 section 4.1.3: aud may be a single string.
+		token := buildTestJWT(t, map[string]interface{}{
+			"iss": "https://hub.example.com",
+			"sub": "agent-string-aud",
+			"aud": "https://bridge.example.com",
+		})
+
+		caller, err := decodeFederationToken(token)
+		if err != nil {
+			t.Fatalf("decodeFederationToken returned error: %v", err)
+		}
+		if caller.AgentID != "agent-string-aud" {
+			t.Errorf("AgentID = %q, want %q", caller.AgentID, "agent-string-aud")
+		}
+	})
+
+	t.Run("array aud", func(t *testing.T) {
+		// RFC 7519 section 4.1.3: aud may be an array of strings.
+		token := buildTestJWT(t, map[string]interface{}{
+			"iss": "https://hub.example.com",
+			"sub": "agent-array-aud",
+			"aud": []string{"https://bridge.example.com", "https://other.example.com"},
+		})
+
+		caller, err := decodeFederationToken(token)
+		if err != nil {
+			t.Fatalf("decodeFederationToken returned error: %v", err)
+		}
+		if caller.AgentID != "agent-array-aud" {
+			t.Errorf("AgentID = %q, want %q", caller.AgentID, "agent-array-aud")
+		}
+	})
+
+	t.Run("missing aud", func(t *testing.T) {
+		// aud is optional — should still decode without error.
+		token := buildTestJWT(t, map[string]interface{}{
+			"iss": "https://hub.example.com",
+			"sub": "agent-no-aud",
+		})
+
+		caller, err := decodeFederationToken(token)
+		if err != nil {
+			t.Fatalf("decodeFederationToken returned error: %v", err)
+		}
+		if caller.AgentID != "agent-no-aud" {
+			t.Errorf("AgentID = %q, want %q", caller.AgentID, "agent-no-aud")
+		}
+	})
+}
+
+func TestCallerKey_Agent(t *testing.T) {
+	tests := []struct {
+		name    string
+		caller  CallerIdentity
+		wantKey string
+	}{
+		{
+			name: "agent with issuer host",
+			caller: CallerIdentity{
+				AgentID:   "agent-123",
+				IssuerURL: "https://hub.example.com",
+				TokenType: "federation",
+			},
+			wantKey: "agent:hub.example.com:agent-123",
+		},
+		{
+			name: "agent without issuer",
+			caller: CallerIdentity{
+				AgentID:   "agent-123",
+				TokenType: "federation",
+			},
+			wantKey: "agent:agent-123",
+		},
+		{
+			name: "agent with invalid issuer URL",
+			caller: CallerIdentity{
+				AgentID:   "agent-456",
+				IssuerURL: "://bad-url",
+				TokenType: "federation",
+			},
+			wantKey: "agent:agent-456",
+		},
+		{
+			name: "user caller",
+			caller: CallerIdentity{
+				UserID:    "user-alice",
+				Email:     "alice@example.com",
+				TokenType: "uat",
+			},
+			wantKey: "user-alice",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.caller.CallerKey()
+			if got != tt.wantKey {
+				t.Errorf("CallerKey() = %q, want %q", got, tt.wantKey)
+			}
+		})
+	}
+}
+
+func TestIsAgent(t *testing.T) {
+	agent := &CallerIdentity{AgentID: "agent-1", TokenType: "federation"}
+	if !agent.IsAgent() {
+		t.Error("IsAgent() should return true when AgentID is set")
+	}
+
+	user := &CallerIdentity{UserID: "user-1", TokenType: "uat"}
+	if user.IsAgent() {
+		t.Error("IsAgent() should return false when AgentID is empty")
+	}
+}
+
+func TestAuthMiddleware_Federation(t *testing.T) {
+	token := buildTestJWT(t, map[string]interface{}{
+		"iss":        "https://hub.example.com",
+		"sub":        "fed-agent-1",
+		"project_id": "test-project",
+	})
+
+	dir := t.TempDir()
+	store, err := state.NewSQLite(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	cfg := &Config{
+		Bridge: BridgeConfig{ExternalURL: "https://test"},
+		Hub:    HubConfig{Endpoint: "http://hub", User: "admin@test"},
+		Auth:   AuthConfig{Scheme: "federation"},
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := New(store, nil, nil, cfg, nil, log)
+
+	// Use a handler that echoes back the CallerIdentity fields.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		caller := callerIdentityFromContext(r.Context())
+		if caller != nil {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"agent_id":   caller.AgentID,
+				"issuer_url": caller.IssuerURL,
+				"project_id": caller.ProjectID,
+				"token_type": caller.TokenType,
+				"is_agent":   caller.IsAgent(),
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"caller":"none"}`))
+	})
+
+	srv := NewServer(b, cfg, nil, log, handler)
+	mw := srv.authMiddleware(handler)
+
+	t.Run("valid federation token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/projects/p/agents/a/jsonrpc", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		w := httptest.NewRecorder()
+		mw.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+		}
+
+		var body map[string]interface{}
+		json.NewDecoder(w.Body).Decode(&body)
+		if body["agent_id"] != "fed-agent-1" {
+			t.Errorf("agent_id = %v, want fed-agent-1", body["agent_id"])
+		}
+		if body["issuer_url"] != "https://hub.example.com" {
+			t.Errorf("issuer_url = %v, want https://hub.example.com", body["issuer_url"])
+		}
+		if body["token_type"] != "federation" {
+			t.Errorf("token_type = %v, want federation", body["token_type"])
+		}
+		if body["is_agent"] != true {
+			t.Errorf("is_agent = %v, want true", body["is_agent"])
+		}
+	})
+
+	t.Run("missing token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/projects/p/agents/a/jsonrpc", nil)
+		w := httptest.NewRecorder()
+		mw.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", w.Code)
+		}
+	})
+
+	t.Run("malformed token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/projects/p/agents/a/jsonrpc", nil)
+		req.Header.Set("Authorization", "Bearer not-a-jwt")
+		w := httptest.NewRecorder()
+		mw.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", w.Code)
+		}
+	})
+
+	t.Run("public endpoint bypasses auth", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/agent-card.json", nil)
+		// No Authorization header
+		w := httptest.NewRecorder()
+		mw.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("public endpoint: status = %d, want 200", w.Code)
+		}
+	})
+}
+
+func TestFederationHeaderTransport(t *testing.T) {
+	// Create a test server that echoes back the federation token header.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fedToken := r.Header.Get(FederationTokenHeader)
+		json.NewEncoder(w).Encode(map[string]string{
+			"federation_token": fedToken,
+		})
+	}))
+	defer srv.Close()
+
+	transport := &federationHeaderTransport{
+		base:  http.DefaultTransport,
+		token: "test-token-123",
+	}
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var body map[string]string
+	json.NewDecoder(resp.Body).Decode(&body)
+
+	if body["federation_token"] != "test-token-123" {
+		t.Errorf("federation_token = %q, want %q", body["federation_token"], "test-token-123")
+	}
+}
+
+func TestValidateConfig_Federation(t *testing.T) {
+	cfg := &Config{
+		Bridge: BridgeConfig{ExternalURL: "https://test"},
+		Hub:    HubConfig{Endpoint: "http://hub", User: "admin@test"},
+		Auth:   AuthConfig{Scheme: "federation"},
+	}
+
+	if err := ValidateConfig(cfg); err != nil {
+		t.Errorf("federation scheme should be valid: %v", err)
+	}
+}
+
+func TestPerAgentTaskIsolation(t *testing.T) {
+	dir := t.TempDir()
+	store, err := state.NewSQLite(filepath.Join(dir, "agent-iso-test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	cfg := &Config{
+		Bridge: BridgeConfig{ExternalURL: "https://test"},
+		Hub:    HubConfig{Endpoint: "http://hub", User: "admin@test"},
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := New(store, nil, nil, cfg, nil, log)
+
+	now := time.Now()
+
+	// Create tasks for a federation agent caller and a user caller.
+	agentCallerKey := "agent:hub.example.com:agent-123"
+	store.CreateTask(context.Background(), &state.Task{
+		ID: "task-agent", ContextID: "ctx-1", ProjectID: "proj-1",
+		AgentSlug: "agent-1", State: "working", CallerUserID: agentCallerKey,
+		CreatedAt: now, UpdatedAt: now, Metadata: "{}",
+	})
+	store.CreateTask(context.Background(), &state.Task{
+		ID: "task-user", ContextID: "ctx-1", ProjectID: "proj-1",
+		AgentSlug: "agent-1", State: "working", CallerUserID: "user-alice",
+		CreatedAt: now, UpdatedAt: now, Metadata: "{}",
+	})
+
+	agentCtx := withCallerIdentity(context.Background(), &CallerIdentity{
+		AgentID:   "agent-123",
+		IssuerURL: "https://hub.example.com",
+		TokenType: "federation",
+	})
+	userCtx := withCallerIdentity(context.Background(), &CallerIdentity{
+		UserID:    "user-alice",
+		Email:     "alice@test",
+		TokenType: "uat",
+	})
+
+	// Agent caller can see its own task.
+	result, err := b.GetTask(agentCtx, "task-agent")
+	if err != nil {
+		t.Fatalf("Agent GetTask own: %v", err)
+	}
+	if result == nil {
+		t.Fatal("Agent should be able to get its own task")
+	}
+
+	// Agent caller cannot see user's task.
+	result, err = b.GetTask(agentCtx, "task-user")
+	if err != nil {
+		t.Fatalf("Agent GetTask user: %v", err)
+	}
+	if result != nil {
+		t.Fatal("Agent should NOT be able to get user's task")
+	}
+
+	// User caller cannot see agent's task.
+	result, err = b.GetTask(userCtx, "task-agent")
+	if err != nil {
+		t.Fatalf("User GetTask agent: %v", err)
+	}
+	if result != nil {
+		t.Fatal("User should NOT be able to get agent's task")
+	}
+
+	// User caller can see its own task.
+	result, err = b.GetTask(userCtx, "task-user")
+	if err != nil {
+		t.Fatalf("User GetTask own: %v", err)
+	}
+	if result == nil {
+		t.Fatal("User should be able to get its own task")
+	}
+
+	// ListTasks: Agent sees only its tasks.
+	results, err := b.ListTasks(agentCtx, "ctx-1")
+	if err != nil {
+		t.Fatalf("Agent ListTasks: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != "task-agent" {
+		t.Errorf("Agent ListTasks = %d tasks, want 1 (task-agent)", len(results))
+	}
+
+	// ListTasks: User sees only their tasks.
+	results, err = b.ListTasks(userCtx, "ctx-1")
+	if err != nil {
+		t.Fatalf("User ListTasks: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != "task-user" {
+		t.Errorf("User ListTasks = %d tasks, want 1 (task-user)", len(results))
+	}
+
+	// CancelTask: Agent cannot cancel user's task.
+	cancelResult, err := b.CancelTask(agentCtx, "task-user")
+	if err != nil {
+		t.Fatalf("Agent CancelTask user: %v", err)
+	}
+	if cancelResult != nil {
+		t.Fatal("Agent should NOT be able to cancel user's task")
+	}
+}
+
+func TestFederationTokenHeaderMatchesHub(t *testing.T) {
+	// The bridge and hub define FederationTokenHeader independently because
+	// they live in different packages (internal/bridge vs pkg/hub). This test
+	// catches silent drift between the two constants.
+	const hubFederationTokenHeader = "X-Scion-Federation-Token" // from pkg/hub/federation_auth.go
+	if FederationTokenHeader != hubFederationTokenHeader {
+		t.Errorf("bridge.FederationTokenHeader = %q, want %q (must match pkg/hub/federation_auth.go)",
+			FederationTokenHeader, hubFederationTokenHeader)
+	}
+}

--- a/extras/scion-a2a-bridge/internal/bridge/scoped_store.go
+++ b/extras/scion-a2a-bridge/internal/bridge/scoped_store.go
@@ -62,14 +62,15 @@ func buildOwnerKey(ctx context.Context) (string, bool, error) {
 	}
 	key := route.ProjectSlug + ":" + route.AgentSlug
 	if caller := callerIdentityFromContext(ctx); caller != nil {
-		if caller.UserID != "" {
-			key += ":" + caller.UserID
+		callerKey := caller.CallerKey()
+		if callerKey != "" {
+			key += ":" + callerKey
 		} else {
-			slog.Warn("CallerIdentity present but UserID is empty; rejecting request",
+			slog.Warn("CallerIdentity present but CallerKey is empty; rejecting request",
 				"project", route.ProjectSlug,
 				"agent", route.AgentSlug,
 			)
-			return "", true, fmt.Errorf("CallerIdentity present but UserID is empty: %w", a2a.ErrUnauthenticated)
+			return "", true, fmt.Errorf("CallerIdentity present but CallerKey is empty: %w", a2a.ErrUnauthenticated)
 		}
 	}
 	return key, true, nil

--- a/extras/scion-a2a-bridge/internal/bridge/server.go
+++ b/extras/scion-a2a-bridge/internal/bridge/server.go
@@ -126,17 +126,17 @@ func ValidateConfig(cfg *Config) error {
 		return fmt.Errorf("hub.user is required")
 	}
 	switch cfg.Auth.Scheme {
-	case "", "apiKey", "bearer", "none", "hubUAT", "hubJWT":
+	case "", "apiKey", "bearer", "none", "hubUAT", "hubJWT", "federation":
 		// valid
 	default:
-		return fmt.Errorf("unsupported auth.scheme: %q (supported: apiKey, bearer, none, hubUAT, hubJWT)", cfg.Auth.Scheme)
+		return fmt.Errorf("unsupported auth.scheme: %q (supported: apiKey, bearer, none, hubUAT, hubJWT, federation)", cfg.Auth.Scheme)
 	}
 	if (cfg.Auth.Scheme == "apiKey" || cfg.Auth.Scheme == "bearer") && cfg.Auth.APIKey == "" {
 		return fmt.Errorf("auth.api_key is required when auth.scheme is %q", cfg.Auth.Scheme)
 	}
 	// api_key is required for legacy schemes and the default (empty) scheme.
-	// hubUAT and hubJWT do not use api_key — they validate per-user credentials instead.
-	if cfg.Auth.APIKey == "" && cfg.Auth.Scheme != "none" && cfg.Auth.Scheme != "hubUAT" && cfg.Auth.Scheme != "hubJWT" {
+	// hubUAT, hubJWT, and federation do not use api_key — they validate per-user/agent credentials instead.
+	if cfg.Auth.APIKey == "" && cfg.Auth.Scheme != "none" && cfg.Auth.Scheme != "hubUAT" && cfg.Auth.Scheme != "hubJWT" && cfg.Auth.Scheme != "federation" {
 		return fmt.Errorf("auth.api_key is required (set auth.scheme: \"none\" to explicitly disable authentication)")
 	}
 	if cfg.Auth.Scheme == "hubJWT" && cfg.Hub.SigningKey == "" && cfg.Hub.SigningKeySecret == "" {
@@ -168,6 +168,8 @@ func (s *Server) WarnOnOpenAuth() {
 		s.log.Info("bridge auth: hubUAT — per-user Scion UAT authentication enabled")
 	case "hubJWT":
 		s.log.Info("bridge auth: hubJWT — per-user Scion JWT authentication enabled")
+	case "federation":
+		s.log.Info("bridge auth: federation — pass-through OIDC federation authentication enabled (hub validates tokens)")
 	}
 	if cfg.RateLimit.TrustProxy {
 		s.log.Warn("rate_limit.trust_proxy is enabled — X-Forwarded-For is trusted unconditionally, which allows clients to spoof their IP and bypass per-IP rate limits; consider adding network-level proxy restrictions")
@@ -464,6 +466,25 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			if err != nil {
 				s.log.Debug("JWT validation failed", "error", err)
 				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			ctx := withCallerIdentity(r.Context(), caller)
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+
+		case "federation":
+			// Federation pass-through: decode the JWT WITHOUT verification
+			// for bridge-local bookkeeping (task isolation, logging).
+			// The hub validates the token via X-Scion-Federation-Token.
+			token := extractBearerToken(r)
+			if token == "" {
+				http.Error(w, "unauthorized: missing bearer token", http.StatusUnauthorized)
+				return
+			}
+			caller, err := decodeFederationToken(token)
+			if err != nil {
+				s.log.Debug("federation token decode failed", "error", err)
+				http.Error(w, "unauthorized: malformed token", http.StatusUnauthorized)
 				return
 			}
 			ctx := withCallerIdentity(r.Context(), caller)

--- a/extras/scion-a2a-bridge/internal/bridge/server.go
+++ b/extras/scion-a2a-bridge/internal/bridge/server.go
@@ -476,6 +476,12 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 			// Federation pass-through: decode the JWT WITHOUT verification
 			// for bridge-local bookkeeping (task isolation, logging).
 			// The hub validates the token via X-Scion-Federation-Token.
+			//
+			// NOTE: The bridge decodes federation tokens WITHOUT signature verification.
+			// This is by design: the hub validates the token via its FederationAuthenticator
+			// when the bridge passes it in the X-Scion-Federation-Token header.
+			// Bridge-level signature verification requires public OIDC discovery
+			// endpoints, which is tracked as issue #930.
 			token := extractBearerToken(r)
 			if token == "" {
 				http.Error(w, "unauthorized: missing bearer token", http.StatusUnauthorized)


### PR DESCRIPTION
Port federation auth from the validated scion/a2a-oidc-bridge branch. Adds OIDC token decoding for bridge-local bookkeeping, CallerIdentity extensions (CallerKey, IsAgent, SenderLabel), transport auth (IAP) wiring for per-caller hub clients, and federation auth scheme support. Fixes RFC 7519 aud claim handling (accepts both string and array). 10 files.

Ref: ptone/scion#929