### PR TITLE
feat(web-chat): add web channel spoke for native chat (Phase 1)

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -581,6 +582,29 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 						Name: bt, Bus: b, Observer: observer, ChannelID: channelID,
 					})
 					log.Printf("Message broker spoke added: name=%s channel_id=%s observer=%v", bt, channelID, observer)
+				}
+
+				// Register the native web channel spoke. It follows the same
+				// contract as every plugin adapter: Subscribe discards the handler
+				// (F7/F8, #944), Publish does real work (webchat_* state).
+				// Observer: true so a state-write failure degrades the thread rail
+				// rather than failing the user's message.
+				if dbProvider, ok := s.(interface{ DB() *sql.DB }); ok {
+					if rawDB := dbProvider.DB(); rawDB != nil {
+						webStore := hub.NewWebChatStore(rawDB)
+						if err := webStore.Init(); err != nil {
+							log.Printf("Warning: failed to initialize webchat store: %v", err)
+						} else {
+							webSpoke := hub.NewWebChannelBus(logging.Subsystem("hub.eventbus.web"), webStore)
+							namedBuses = append(namedBuses, eventbus.NamedEventBus{
+								Name:      "web",
+								ChannelID: "web",
+								Bus:       webSpoke,
+								Observer:  true,
+							})
+							log.Printf("Message broker spoke added: name=web channel_id=web observer=true")
+						}
+					}
 				}
 
 				fanout := eventbus.NewFanOutEventBus(namedBuses, logging.Subsystem("hub.eventbus.fanout"))

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -591,7 +591,7 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 				// rather than failing the user's message.
 				if dbProvider, ok := s.(interface{ DB() *sql.DB }); ok {
 					if rawDB := dbProvider.DB(); rawDB != nil {
-						webStore := hub.NewWebChatStore(rawDB)
+						webStore := hub.NewWebChatStore(rawDB, cfg.Database.Driver)
 						if err := webStore.Init(); err != nil {
 							log.Printf("Warning: failed to initialize webchat store: %v", err)
 						} else {

--- a/pkg/hub/webchannel.go
+++ b/pkg/hub/webchannel.go
@@ -50,6 +50,12 @@ type webChannelBus struct {
 
 // NewWebChannelBus creates a web channel spoke backed by the given store.
 func NewWebChannelBus(log *slog.Logger, store WebChatStore) eventbus.EventBus {
+	if log == nil {
+		log = slog.Default()
+	}
+	if store == nil {
+		panic("webchannel: store cannot be nil")
+	}
 	return &webChannelBus{
 		log:   log,
 		store: store,
@@ -70,7 +76,7 @@ func (b *webChannelBus) Publish(ctx context.Context, topic string, msg *messages
 		return nil
 	}
 
-	now := time.Now()
+	now := time.Now().UTC()
 
 	// 1. Thread watermark — this is what makes the Phase 5 rail endpoint
 	//    a single indexed read instead of an aggregate query.
@@ -118,6 +124,9 @@ func (webNoopSubscription) Unsubscribe() error { return nil }
 // topic and message. Returns false if the message is not a conversation-
 // scoped user message (e.g., broadcasts, global messages).
 func identityFromTopic(topic string, msg *messages.StructuredMessage) (userID, projectID, agentID string, ok bool) {
+	if msg == nil {
+		return "", "", "", false
+	}
 	parsed, err := projectcompat.ParseTopic(topic)
 	if err != nil {
 		return "", "", "", false

--- a/pkg/hub/webchannel.go
+++ b/pkg/hub/webchannel.go
@@ -60,7 +60,7 @@ func NewWebChannelBus(log *slog.Logger, store WebChatStore) eventbus.EventBus {
 // the canonical message row or emit the core SSE frame (deliverToUser
 // handles both on the inprocess path).
 func (b *webChannelBus) Publish(ctx context.Context, topic string, msg *messages.StructuredMessage) error {
-	if msg == nil {
+	if msg == nil || msg.ObserverOnly {
 		return nil
 	}
 
@@ -137,8 +137,15 @@ func identityFromTopic(topic string, msg *messages.StructuredMessage) (userID, p
 		}
 	case projectcompat.TopicKindAgent:
 		// User → agent message: topic has the agent slug, recipient is the agent.
+		// NOTE(O1): agentID here is the slug from the topic, whereas for
+		// TopicKindUser above it is msg.SenderID (a UUID). This inconsistency
+		// must be normalized to a single identifier form before Phase 6 to
+		// avoid duplicate webchat_thread rows for the same conversation. See
+		// review nc-p1-rev-2 O1.
 		agentID = parsed.Actor
-		userID = msg.SenderID
+		if strings.HasPrefix(msg.Sender, "user:") {
+			userID = msg.SenderID
+		}
 	default:
 		// Broadcast or other — not conversation-scoped.
 		return "", "", "", false

--- a/pkg/hub/webchannel.go
+++ b/pkg/hub/webchannel.go
@@ -44,9 +44,8 @@ import (
 // Registered as Observer: true, so a webchat_* write failure degrades the
 // rail rather than failing the user's message.
 type webChannelBus struct {
-	log      *slog.Logger
-	store    WebChatStore
-	patterns []string
+	log   *slog.Logger
+	store WebChatStore
 }
 
 // NewWebChannelBus creates a web channel spoke backed by the given store.
@@ -75,6 +74,11 @@ func (b *webChannelBus) Publish(ctx context.Context, topic string, msg *messages
 
 	// 1. Thread watermark — this is what makes the Phase 5 rail endpoint
 	//    a single indexed read instead of an aggregate query.
+	//
+	// messageID is "" because StructuredMessage has no ID field — the
+	// store-assigned ID is only available after deliverToUser persists the
+	// message on the inprocess spoke, which runs concurrently. Phase 5
+	// will address this gap (design §5.3).
 	if err := b.store.TouchThread(ctx, userID, projectID, agentID, "", now); err != nil {
 		b.log.Error("Failed to update thread watermark",
 			"user_id", userID, "project_id", projectID, "agent_id", agentID, "error", err)
@@ -91,11 +95,12 @@ func (b *webChannelBus) Publish(ctx context.Context, topic string, msg *messages
 	return nil
 }
 
-// Subscribe records the pattern and DISCARDS the handler. This is not a
-// shortcut — it is the same contract every plugin adapter follows (F7).
-// A real handler causes double-persist plus double-SSE (F8, issue #944).
-func (b *webChannelBus) Subscribe(pattern string, _ eventbus.EventHandler) (eventbus.Subscription, error) {
-	b.patterns = append(b.patterns, pattern)
+// Subscribe DISCARDS the handler. This is not a shortcut — it is the same
+// contract every plugin adapter follows (F7). A real handler causes
+// double-persist plus double-SSE (F8, issue #944). Unlike plugin adapters
+// that track activeSubs for reconnect replay, the web spoke has no
+// reconnect path, so patterns are not retained.
+func (b *webChannelBus) Subscribe(_ string, _ eventbus.EventHandler) (eventbus.Subscription, error) {
 	return webNoopSubscription{}, nil
 }
 

--- a/pkg/hub/webchannel.go
+++ b/pkg/hub/webchannel.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/eventbus"
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
+)
+
+// webChannelBus is a real broker spoke for the "web" channel. It follows the
+// same contract every plugin adapter follows:
+//
+//   - Subscribe — records the pattern and DISCARDS the handler. Inbound web
+//     messages arrive via the hub's own HTTP handlers, exactly as plugin
+//     inbound arrives via POST /api/v1/broker/inbound. Installing a real
+//     handler here would double-persist and double-stream every message,
+//     because FanOut hands the SAME handler to every spoke (F7/F8, #944).
+//
+//   - Publish — does real work: owns webchat_* state. It does NOT persist the
+//     message and does NOT emit the core SSE frame; deliverToUser already
+//     does both on the inprocess path. One persistence path remains the
+//     invariant.
+//
+//   - Close — releases the store handle. Returns nil.
+//
+// Registered as Observer: true, so a webchat_* write failure degrades the
+// rail rather than failing the user's message.
+type webChannelBus struct {
+	log      *slog.Logger
+	store    WebChatStore
+	patterns []string
+}
+
+// NewWebChannelBus creates a web channel spoke backed by the given store.
+func NewWebChannelBus(log *slog.Logger, store WebChatStore) eventbus.EventBus {
+	return &webChannelBus{
+		log:   log,
+		store: store,
+	}
+}
+
+// Publish does real work — updates webchat_* state. It does NOT persist
+// the canonical message row or emit the core SSE frame (deliverToUser
+// handles both on the inprocess path).
+func (b *webChannelBus) Publish(ctx context.Context, topic string, msg *messages.StructuredMessage) error {
+	if msg == nil {
+		return nil
+	}
+
+	userID, projectID, agentID, ok := identityFromTopic(topic, msg)
+	if !ok {
+		// Not a conversation-scoped message; nothing to record.
+		return nil
+	}
+
+	now := time.Now()
+
+	// 1. Thread watermark — this is what makes the Phase 5 rail endpoint
+	//    a single indexed read instead of an aggregate query.
+	if err := b.store.TouchThread(ctx, userID, projectID, agentID, "", now); err != nil {
+		b.log.Error("Failed to update thread watermark",
+			"user_id", userID, "project_id", projectID, "agent_id", agentID, "error", err)
+		return err
+	}
+
+	// 2. Reply affinity as a row, not a config flag.
+	if err := b.store.RecordChannel(ctx, userID, projectID, agentID, "web", now); err != nil {
+		b.log.Error("Failed to record conversation context",
+			"user_id", userID, "project_id", projectID, "agent_id", agentID, "error", err)
+		return err
+	}
+
+	return nil
+}
+
+// Subscribe records the pattern and DISCARDS the handler. This is not a
+// shortcut — it is the same contract every plugin adapter follows (F7).
+// A real handler causes double-persist plus double-SSE (F8, issue #944).
+func (b *webChannelBus) Subscribe(pattern string, _ eventbus.EventHandler) (eventbus.Subscription, error) {
+	b.patterns = append(b.patterns, pattern)
+	return webNoopSubscription{}, nil
+}
+
+// Close releases resources. The store handle is owned by the caller.
+func (b *webChannelBus) Close() error {
+	return nil
+}
+
+// webNoopSubscription is a subscription that does nothing on unsubscribe.
+type webNoopSubscription struct{}
+
+func (webNoopSubscription) Unsubscribe() error { return nil }
+
+// identityFromTopic extracts the user, project, and agent IDs from the
+// topic and message. Returns false if the message is not a conversation-
+// scoped user message (e.g., broadcasts, global messages).
+func identityFromTopic(topic string, msg *messages.StructuredMessage) (userID, projectID, agentID string, ok bool) {
+	parsed, err := projectcompat.ParseTopic(topic)
+	if err != nil {
+		return "", "", "", false
+	}
+
+	projectID = parsed.ProjectID
+
+	switch parsed.Kind {
+	case projectcompat.TopicKindUser:
+		// Agent → user message: topic has the user ID, sender is the agent.
+		userID = parsed.Actor
+		if strings.HasPrefix(msg.Sender, "agent:") {
+			agentID = msg.SenderID
+			if agentID == "" {
+				agentID = strings.TrimPrefix(msg.Sender, "agent:")
+			}
+		}
+	case projectcompat.TopicKindAgent:
+		// User → agent message: topic has the agent slug, recipient is the agent.
+		agentID = parsed.Actor
+		userID = msg.SenderID
+	default:
+		// Broadcast or other — not conversation-scoped.
+		return "", "", "", false
+	}
+
+	if userID == "" || projectID == "" || agentID == "" {
+		return "", "", "", false
+	}
+
+	return userID, projectID, agentID, true
+}

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// WebChatStore is the single access point for all webchat_* tables.
+// All webchat state goes through this interface — no scattered raw SQL.
+//
+// Tables are created with CREATE TABLE IF NOT EXISTS at Init time,
+// following the same convention as Discord and Telegram integrations
+// (see extras/scion-discord/internal/discord/store.go). They are NOT
+// Ent entities — this keeps the Ent migration graph clean and preserves
+// the option to extract native chat into a plugin binary later.
+type WebChatStore interface {
+	// Init creates the webchat_* tables if they do not exist.
+	Init() error
+
+	// TouchThread upserts the thread watermark for (user, project, agent).
+	// This is called from Publish on every message that passes through
+	// the web spoke, so the rail endpoint (Phase 5) can do a single
+	// indexed read instead of an aggregate query.
+	TouchThread(ctx context.Context, userID, projectID, agentID, messageID string, activityAt time.Time) error
+
+	// RecordChannel upserts reply-affinity context for (user, project, agent).
+	// Records the last channel a message was seen on, so the hub can route
+	// untagged replies back to the channel the user last spoke from.
+	RecordChannel(ctx context.Context, userID, projectID, agentID, channel string, messageAt time.Time) error
+}
+
+// sqlWebChatStore implements WebChatStore using a *sql.DB handle.
+// It uses portable SQL that works on both SQLite and Postgres.
+type sqlWebChatStore struct {
+	db *sql.DB
+}
+
+// NewWebChatStore creates a new WebChatStore backed by the given database.
+func NewWebChatStore(db *sql.DB) WebChatStore {
+	return &sqlWebChatStore{db: db}
+}
+
+// Init creates the webchat_* tables if they do not exist.
+// Uses portable SQL compatible with both SQLite and Postgres.
+func (s *sqlWebChatStore) Init() error {
+	const ddl = `
+CREATE TABLE IF NOT EXISTS webchat_thread (
+    user_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    last_message_id TEXT,
+    last_activity_at TIMESTAMP,
+    last_read_at TIMESTAMP,
+    PRIMARY KEY (user_id, project_id, agent_id)
+);
+
+CREATE TABLE IF NOT EXISTS webchat_conversation_context (
+    user_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    last_channel TEXT,
+    last_message_at TIMESTAMP,
+    PRIMARY KEY (user_id, project_id, agent_id)
+);
+
+CREATE TABLE IF NOT EXISTS webchat_thread_prefs (
+    user_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    visibility_mode TEXT DEFAULT 'conversation',
+    show_state_changes BOOLEAN DEFAULT true,
+    show_agent_to_agent BOOLEAN DEFAULT false,
+    muted BOOLEAN DEFAULT false,
+    PRIMARY KEY (user_id, project_id, agent_id)
+);
+`
+	_, err := s.db.Exec(ddl)
+	if err != nil {
+		return fmt.Errorf("webchat store: create tables: %w", err)
+	}
+	return nil
+}
+
+// TouchThread upserts the thread watermark for the given (user, project, agent) triple.
+//
+// Uses INSERT ... ON CONFLICT ... DO UPDATE which is portable across SQLite ≥3.24
+// and all supported Postgres versions.
+func (s *sqlWebChatStore) TouchThread(ctx context.Context, userID, projectID, agentID, messageID string, activityAt time.Time) error {
+	const query = `
+INSERT INTO webchat_thread (user_id, project_id, agent_id, last_message_id, last_activity_at)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT (user_id, project_id, agent_id)
+DO UPDATE SET
+    last_message_id = excluded.last_message_id,
+    last_activity_at = excluded.last_activity_at
+`
+	_, err := s.db.ExecContext(ctx, query, userID, projectID, agentID, messageID, activityAt)
+	if err != nil {
+		return fmt.Errorf("webchat store: touch thread: %w", err)
+	}
+	return nil
+}
+
+// RecordChannel upserts the reply-affinity context for the given (user, project, agent) triple.
+//
+// Uses INSERT ... ON CONFLICT ... DO UPDATE which is portable across SQLite ≥3.24
+// and all supported Postgres versions.
+func (s *sqlWebChatStore) RecordChannel(ctx context.Context, userID, projectID, agentID, channel string, messageAt time.Time) error {
+	const query = `
+INSERT INTO webchat_conversation_context (user_id, project_id, agent_id, last_channel, last_message_at)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT (user_id, project_id, agent_id)
+DO UPDATE SET
+    last_channel = excluded.last_channel,
+    last_message_at = excluded.last_message_at
+`
+	_, err := s.db.ExecContext(ctx, query, userID, projectID, agentID, channel, messageAt)
+	if err != nil {
+		return fmt.Errorf("webchat store: record channel: %w", err)
+	}
+	return nil
+}

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -29,6 +29,13 @@ import (
 // (see extras/scion-discord/internal/discord/store.go). They are NOT
 // Ent entities — this keeps the Ent migration graph clean and preserves
 // the option to extract native chat into a plugin binary later.
+//
+// Two implementations exist — one per dialect:
+//   - sqliteWebChatStore  (this file)       — uses ? placeholders, TEXT/INTEGER DDL
+//   - pgWebChatStore      (webchannel_store_postgres.go) — uses $N placeholders, TIMESTAMPTZ/BOOLEAN DDL
+//
+// This mirrors the Discord store split
+// (extras/scion-discord/internal/discord/store.go vs store_postgres.go).
 type WebChatStore interface {
 	// Init creates the webchat_* tables if they do not exist.
 	Init() error
@@ -45,28 +52,38 @@ type WebChatStore interface {
 	RecordChannel(ctx context.Context, userID, projectID, agentID, channel string, messageAt time.Time) error
 }
 
-// sqlWebChatStore implements WebChatStore using a *sql.DB handle.
-// It uses portable SQL that works on both SQLite and Postgres.
-type sqlWebChatStore struct {
+// NewWebChatStore creates a new WebChatStore backed by the given database.
+// The driverName selects the SQL dialect: "postgres" or "pgx" for Postgres,
+// anything else (including "" and "sqlite") for SQLite.
+func NewWebChatStore(db *sql.DB, driverName string) WebChatStore {
+	switch driverName {
+	case "postgres", "pgx":
+		return &pgWebChatStore{db: db}
+	default:
+		return &sqliteWebChatStore{db: db}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SQLite implementation
+// ---------------------------------------------------------------------------
+
+// sqliteWebChatStore implements WebChatStore for SQLite.
+// Uses ? placeholders and SQLite-appropriate DDL types (TEXT, INTEGER).
+type sqliteWebChatStore struct {
 	db *sql.DB
 }
 
-// NewWebChatStore creates a new WebChatStore backed by the given database.
-func NewWebChatStore(db *sql.DB) WebChatStore {
-	return &sqlWebChatStore{db: db}
-}
-
-// Init creates the webchat_* tables if they do not exist.
-// Uses portable SQL compatible with both SQLite and Postgres.
-func (s *sqlWebChatStore) Init() error {
+// Init creates the webchat_* tables using SQLite DDL conventions.
+func (s *sqliteWebChatStore) Init() error {
 	const ddl = `
 CREATE TABLE IF NOT EXISTS webchat_thread (
     user_id TEXT NOT NULL,
     project_id TEXT NOT NULL,
     agent_id TEXT NOT NULL,
     last_message_id TEXT,
-    last_activity_at TIMESTAMP,
-    last_read_at TIMESTAMP,
+    last_activity_at TEXT,
+    last_read_at TEXT,
     PRIMARY KEY (user_id, project_id, agent_id)
 );
 
@@ -75,7 +92,7 @@ CREATE TABLE IF NOT EXISTS webchat_conversation_context (
     project_id TEXT NOT NULL,
     agent_id TEXT NOT NULL,
     last_channel TEXT,
-    last_message_at TIMESTAMP,
+    last_message_at TEXT,
     PRIMARY KEY (user_id, project_id, agent_id)
 );
 
@@ -84,9 +101,9 @@ CREATE TABLE IF NOT EXISTS webchat_thread_prefs (
     project_id TEXT NOT NULL,
     agent_id TEXT NOT NULL,
     visibility_mode TEXT DEFAULT 'conversation',
-    show_state_changes BOOLEAN DEFAULT true,
-    show_agent_to_agent BOOLEAN DEFAULT false,
-    muted BOOLEAN DEFAULT false,
+    show_state_changes INTEGER DEFAULT 0,
+    show_agent_to_agent INTEGER DEFAULT 0,
+    muted INTEGER DEFAULT 0,
     PRIMARY KEY (user_id, project_id, agent_id)
 );
 `
@@ -98,10 +115,7 @@ CREATE TABLE IF NOT EXISTS webchat_thread_prefs (
 }
 
 // TouchThread upserts the thread watermark for the given (user, project, agent) triple.
-//
-// Uses INSERT ... ON CONFLICT ... DO UPDATE which is portable across SQLite ≥3.24
-// and all supported Postgres versions.
-func (s *sqlWebChatStore) TouchThread(ctx context.Context, userID, projectID, agentID, messageID string, activityAt time.Time) error {
+func (s *sqliteWebChatStore) TouchThread(ctx context.Context, userID, projectID, agentID, messageID string, activityAt time.Time) error {
 	const query = `
 INSERT INTO webchat_thread (user_id, project_id, agent_id, last_message_id, last_activity_at)
 VALUES (?, ?, ?, ?, ?)
@@ -118,10 +132,7 @@ DO UPDATE SET
 }
 
 // RecordChannel upserts the reply-affinity context for the given (user, project, agent) triple.
-//
-// Uses INSERT ... ON CONFLICT ... DO UPDATE which is portable across SQLite ≥3.24
-// and all supported Postgres versions.
-func (s *sqlWebChatStore) RecordChannel(ctx context.Context, userID, projectID, agentID, channel string, messageAt time.Time) error {
+func (s *sqliteWebChatStore) RecordChannel(ctx context.Context, userID, projectID, agentID, channel string, messageAt time.Time) error {
 	const query = `
 INSERT INTO webchat_conversation_context (user_id, project_id, agent_id, last_channel, last_message_at)
 VALUES (?, ?, ?, ?, ?)

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// pgWebChatStore implements WebChatStore for Postgres.
+// Uses $N placeholders and Postgres-appropriate DDL types (TIMESTAMPTZ, BOOLEAN).
+// This mirrors the Discord store split
+// (extras/scion-discord/internal/discord/store_postgres.go).
+type pgWebChatStore struct {
+	db *sql.DB
+}
+
+// Init creates the webchat_* tables using Postgres DDL conventions.
+func (s *pgWebChatStore) Init() error {
+	const ddl = `
+CREATE TABLE IF NOT EXISTS webchat_thread (
+    user_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    last_message_id TEXT,
+    last_activity_at TIMESTAMPTZ,
+    last_read_at TIMESTAMPTZ,
+    PRIMARY KEY (user_id, project_id, agent_id)
+);
+
+CREATE TABLE IF NOT EXISTS webchat_conversation_context (
+    user_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    last_channel TEXT,
+    last_message_at TIMESTAMPTZ,
+    PRIMARY KEY (user_id, project_id, agent_id)
+);
+
+CREATE TABLE IF NOT EXISTS webchat_thread_prefs (
+    user_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    visibility_mode TEXT DEFAULT 'conversation',
+    show_state_changes BOOLEAN DEFAULT FALSE,
+    show_agent_to_agent BOOLEAN DEFAULT FALSE,
+    muted BOOLEAN DEFAULT FALSE,
+    PRIMARY KEY (user_id, project_id, agent_id)
+);
+`
+	_, err := s.db.Exec(ddl)
+	if err != nil {
+		return fmt.Errorf("webchat store: create tables: %w", err)
+	}
+	return nil
+}
+
+// TouchThread upserts the thread watermark for the given (user, project, agent) triple.
+func (s *pgWebChatStore) TouchThread(ctx context.Context, userID, projectID, agentID, messageID string, activityAt time.Time) error {
+	const query = `
+INSERT INTO webchat_thread (user_id, project_id, agent_id, last_message_id, last_activity_at)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (user_id, project_id, agent_id)
+DO UPDATE SET
+    last_message_id = EXCLUDED.last_message_id,
+    last_activity_at = EXCLUDED.last_activity_at
+`
+	_, err := s.db.ExecContext(ctx, query, userID, projectID, agentID, messageID, activityAt)
+	if err != nil {
+		return fmt.Errorf("webchat store: touch thread: %w", err)
+	}
+	return nil
+}
+
+// RecordChannel upserts the reply-affinity context for the given (user, project, agent) triple.
+func (s *pgWebChatStore) RecordChannel(ctx context.Context, userID, projectID, agentID, channel string, messageAt time.Time) error {
+	const query = `
+INSERT INTO webchat_conversation_context (user_id, project_id, agent_id, last_channel, last_message_at)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (user_id, project_id, agent_id)
+DO UPDATE SET
+    last_channel = EXCLUDED.last_channel,
+    last_message_at = EXCLUDED.last_message_at
+`
+	_, err := s.db.ExecContext(ctx, query, userID, projectID, agentID, channel, messageAt)
+	if err != nil {
+		return fmt.Errorf("webchat store: record channel: %w", err)
+	}
+	return nil
+}

--- a/pkg/hub/webchannel_test.go
+++ b/pkg/hub/webchannel_test.go
@@ -233,6 +233,32 @@ func TestWebChannelBus_Publish_NilMessage(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestWebChannelBus_Publish_ObserverOnlyIgnored(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	log := slog.Default()
+	bus := NewWebChannelBus(log, store)
+
+	msg := &messages.StructuredMessage{
+		Version:      messages.Version,
+		Sender:       "agent:coder",
+		SenderID:     "agent-uuid-1",
+		Recipient:    "agent:reviewer",
+		RecipientID:  "agent-uuid-2",
+		Msg:          "agent-to-agent observation",
+		Type:         messages.TypeInstruction,
+		ObserverOnly: true,
+	}
+	err := bus.Publish(context.Background(), "scion.project.proj1.user.user1.messages", msg)
+	require.NoError(t, err)
+
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM webchat_thread").Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 0, count, "ObserverOnly messages must not create webchat_thread rows")
+}
+
 func TestWebChannelBus_Publish_BroadcastIgnored(t *testing.T) {
 	store, db := newTestWebChatStore(t)
 	defer db.Close() //nolint:errcheck

--- a/pkg/hub/webchannel_test.go
+++ b/pkg/hub/webchannel_test.go
@@ -34,7 +34,7 @@ func newTestWebChatStore(t *testing.T) (WebChatStore, *sql.DB) {
 	db, err := sql.Open("sqlite3", ":memory:")
 	require.NoError(t, err)
 
-	store := NewWebChatStore(db)
+	store := NewWebChatStore(db, "sqlite3")
 	require.NoError(t, store.Init())
 
 	return store, db
@@ -61,7 +61,7 @@ func TestWebChatStore_Init_Idempotent(t *testing.T) {
 	defer db.Close() //nolint:errcheck
 
 	// Init again should not fail.
-	store2 := NewWebChatStore(db)
+	store2 := NewWebChatStore(db, "sqlite3")
 	require.NoError(t, store2.Init())
 }
 
@@ -74,9 +74,9 @@ func TestWebChatStore_TouchThread_Insert(t *testing.T) {
 	err := store.TouchThread(ctx, "user1", "proj1", "agent1", "msg-123", now)
 	require.NoError(t, err)
 
-	// Verify the row was inserted.
-	var userID, projectID, agentID, messageID string
-	var activityAt time.Time
+	// Verify the row was inserted. SQLite stores timestamps as TEXT, so
+	// scan into a string rather than time.Time.
+	var userID, projectID, agentID, messageID, activityAt string
 	err = db.QueryRow(`SELECT user_id, project_id, agent_id, last_message_id, last_activity_at
 		FROM webchat_thread WHERE user_id = 'user1'`).Scan(&userID, &projectID, &agentID, &messageID, &activityAt)
 	require.NoError(t, err)
@@ -84,6 +84,7 @@ func TestWebChatStore_TouchThread_Insert(t *testing.T) {
 	require.Equal(t, "proj1", projectID)
 	require.Equal(t, "agent1", agentID)
 	require.Equal(t, "msg-123", messageID)
+	require.NotEmpty(t, activityAt)
 }
 
 func TestWebChatStore_TouchThread_Upsert(t *testing.T) {

--- a/pkg/hub/webchannel_test.go
+++ b/pkg/hub/webchannel_test.go
@@ -1,0 +1,360 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+)
+
+// newTestWebChatStore creates a WebChatStore backed by an in-memory SQLite DB
+// for testing. The caller should close the returned *sql.DB when done.
+func newTestWebChatStore(t *testing.T) (WebChatStore, *sql.DB) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+
+	store := NewWebChatStore(db)
+	require.NoError(t, store.Init())
+
+	return store, db
+}
+
+// --- WebChatStore tests ---
+
+func TestWebChatStore_Init_CreatesTables(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+	_ = store
+
+	// Verify tables exist by querying them.
+	for _, table := range []string{"webchat_thread", "webchat_conversation_context", "webchat_thread_prefs"} {
+		var count int
+		err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&count)
+		require.NoError(t, err, "table %s should exist", table)
+		require.Equal(t, 0, count)
+	}
+}
+
+func TestWebChatStore_Init_Idempotent(t *testing.T) {
+	_, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	// Init again should not fail.
+	store2 := NewWebChatStore(db)
+	require.NoError(t, store2.Init())
+}
+
+func TestWebChatStore_TouchThread_Insert(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	now := time.Now().Truncate(time.Second)
+	err := store.TouchThread(ctx, "user1", "proj1", "agent1", "msg-123", now)
+	require.NoError(t, err)
+
+	// Verify the row was inserted.
+	var userID, projectID, agentID, messageID string
+	var activityAt time.Time
+	err = db.QueryRow(`SELECT user_id, project_id, agent_id, last_message_id, last_activity_at
+		FROM webchat_thread WHERE user_id = 'user1'`).Scan(&userID, &projectID, &agentID, &messageID, &activityAt)
+	require.NoError(t, err)
+	require.Equal(t, "user1", userID)
+	require.Equal(t, "proj1", projectID)
+	require.Equal(t, "agent1", agentID)
+	require.Equal(t, "msg-123", messageID)
+}
+
+func TestWebChatStore_TouchThread_Upsert(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	t1 := time.Now().Truncate(time.Second)
+	t2 := t1.Add(5 * time.Minute)
+
+	err := store.TouchThread(ctx, "user1", "proj1", "agent1", "msg-1", t1)
+	require.NoError(t, err)
+
+	// Upsert with a newer message.
+	err = store.TouchThread(ctx, "user1", "proj1", "agent1", "msg-2", t2)
+	require.NoError(t, err)
+
+	// Verify only one row exists and it has the updated values.
+	var count int
+	err = db.QueryRow(`SELECT COUNT(*) FROM webchat_thread WHERE user_id = 'user1'`).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	var messageID string
+	err = db.QueryRow(`SELECT last_message_id FROM webchat_thread WHERE user_id = 'user1'`).Scan(&messageID)
+	require.NoError(t, err)
+	require.Equal(t, "msg-2", messageID)
+}
+
+func TestWebChatStore_RecordChannel_Insert(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	now := time.Now().Truncate(time.Second)
+	err := store.RecordChannel(ctx, "user1", "proj1", "agent1", "web", now)
+	require.NoError(t, err)
+
+	var channel string
+	err = db.QueryRow(`SELECT last_channel FROM webchat_conversation_context
+		WHERE user_id = 'user1' AND project_id = 'proj1' AND agent_id = 'agent1'`).Scan(&channel)
+	require.NoError(t, err)
+	require.Equal(t, "web", channel)
+}
+
+func TestWebChatStore_RecordChannel_Upsert(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	t1 := time.Now().Truncate(time.Second)
+	t2 := t1.Add(5 * time.Minute)
+
+	err := store.RecordChannel(ctx, "user1", "proj1", "agent1", "web", t1)
+	require.NoError(t, err)
+
+	err = store.RecordChannel(ctx, "user1", "proj1", "agent1", "discord", t2)
+	require.NoError(t, err)
+
+	var channel string
+	var count int
+	err = db.QueryRow(`SELECT COUNT(*) FROM webchat_conversation_context
+		WHERE user_id = 'user1' AND project_id = 'proj1' AND agent_id = 'agent1'`).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	err = db.QueryRow(`SELECT last_channel FROM webchat_conversation_context
+		WHERE user_id = 'user1' AND project_id = 'proj1' AND agent_id = 'agent1'`).Scan(&channel)
+	require.NoError(t, err)
+	require.Equal(t, "discord", channel)
+}
+
+// --- WebChannelBus tests ---
+
+func TestWebChannelBus_Subscribe_DiscardsHandler(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	log := slog.Default()
+	bus := NewWebChannelBus(log, store)
+
+	handlerCalled := false
+	handler := func(_ context.Context, _ string, _ *messages.StructuredMessage) {
+		handlerCalled = true
+	}
+
+	sub, err := bus.Subscribe("scion.project.*.agent.*.messages", handler)
+	require.NoError(t, err)
+	require.NotNil(t, sub)
+
+	// The handler should never be called — it is discarded.
+	require.False(t, handlerCalled)
+
+	// Unsubscribe should be a no-op.
+	require.NoError(t, sub.Unsubscribe())
+}
+
+func TestWebChannelBus_Publish_UpdatesState(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	log := slog.Default()
+	bus := NewWebChannelBus(log, store)
+
+	ctx := context.Background()
+	// Simulate an agent→user message on a user topic.
+	topic := "scion.project.proj1.user.user1.messages"
+	msg := &messages.StructuredMessage{
+		Version:   messages.Version,
+		Sender:    "agent:coder",
+		SenderID:  "agent-uuid-1",
+		Recipient: "user:alice",
+		Msg:       "Hello from the agent",
+		Type:      messages.TypeInstruction,
+		Channel:   "web",
+	}
+
+	err := bus.Publish(ctx, topic, msg)
+	require.NoError(t, err)
+
+	// Verify webchat_thread was updated.
+	var userID, projectID, agentID string
+	err = db.QueryRow(`SELECT user_id, project_id, agent_id FROM webchat_thread`).Scan(&userID, &projectID, &agentID)
+	require.NoError(t, err)
+	require.Equal(t, "user1", userID)
+	require.Equal(t, "proj1", projectID)
+	require.Equal(t, "agent-uuid-1", agentID)
+
+	// Verify webchat_conversation_context was updated.
+	var channel string
+	err = db.QueryRow(`SELECT last_channel FROM webchat_conversation_context
+		WHERE user_id = 'user1' AND project_id = 'proj1' AND agent_id = 'agent-uuid-1'`).Scan(&channel)
+	require.NoError(t, err)
+	require.Equal(t, "web", channel)
+}
+
+func TestWebChannelBus_Publish_NilMessage(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	log := slog.Default()
+	bus := NewWebChannelBus(log, store)
+
+	// Nil message should not panic and should return nil.
+	err := bus.Publish(context.Background(), "scion.project.proj1.user.user1.messages", nil)
+	require.NoError(t, err)
+}
+
+func TestWebChannelBus_Publish_BroadcastIgnored(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	log := slog.Default()
+	bus := NewWebChannelBus(log, store)
+
+	// Broadcast topic should be silently ignored (not conversation-scoped).
+	msg := &messages.StructuredMessage{
+		Version: messages.Version,
+		Sender:  "system",
+		Msg:     "broadcast",
+		Type:    messages.TypeSystem,
+	}
+	err := bus.Publish(context.Background(), "scion.project.proj1.broadcast", msg)
+	require.NoError(t, err)
+
+	var count int
+	err = db.QueryRow(`SELECT COUNT(*) FROM webchat_thread`).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+}
+
+func TestWebChannelBus_Publish_AgentTopic(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	log := slog.Default()
+	bus := NewWebChannelBus(log, store)
+
+	ctx := context.Background()
+	// Simulate a user→agent message on an agent topic.
+	topic := "scion.project.proj1.agent.coder.messages"
+	msg := &messages.StructuredMessage{
+		Version:     messages.Version,
+		Sender:      "user:alice",
+		SenderID:    "alice-uuid",
+		Recipient:   "agent:coder",
+		RecipientID: "coder-uuid",
+		Msg:         "Hello from user",
+		Type:        messages.TypeInstruction,
+		Channel:     "web",
+	}
+
+	err := bus.Publish(ctx, topic, msg)
+	require.NoError(t, err)
+
+	// For an agent topic, the agent slug comes from the topic, the user from SenderID.
+	var userID, agentID string
+	err = db.QueryRow(`SELECT user_id, agent_id FROM webchat_thread`).Scan(&userID, &agentID)
+	require.NoError(t, err)
+	require.Equal(t, "alice-uuid", userID)
+	require.Equal(t, "coder", agentID)
+}
+
+func TestWebChannelBus_Close(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	log := slog.Default()
+	bus := NewWebChannelBus(log, store)
+	require.NoError(t, bus.Close())
+}
+
+// --- identityFromTopic tests ---
+
+func TestIdentityFromTopic_UserTopic(t *testing.T) {
+	msg := &messages.StructuredMessage{
+		Sender:   "agent:coder",
+		SenderID: "agent-uuid",
+	}
+	userID, projectID, agentID, ok := identityFromTopic("scion.project.proj1.user.user1.messages", msg)
+	require.True(t, ok)
+	require.Equal(t, "user1", userID)
+	require.Equal(t, "proj1", projectID)
+	require.Equal(t, "agent-uuid", agentID)
+}
+
+func TestIdentityFromTopic_UserTopic_SenderIDFallback(t *testing.T) {
+	// When SenderID is empty, fall back to stripping "agent:" prefix from Sender.
+	msg := &messages.StructuredMessage{
+		Sender: "agent:coder",
+	}
+	userID, projectID, agentID, ok := identityFromTopic("scion.project.proj1.user.user1.messages", msg)
+	require.True(t, ok)
+	require.Equal(t, "user1", userID)
+	require.Equal(t, "proj1", projectID)
+	require.Equal(t, "coder", agentID)
+}
+
+func TestIdentityFromTopic_AgentTopic(t *testing.T) {
+	msg := &messages.StructuredMessage{
+		Sender:   "user:alice",
+		SenderID: "alice-uuid",
+	}
+	userID, projectID, agentID, ok := identityFromTopic("scion.project.proj1.agent.coder.messages", msg)
+	require.True(t, ok)
+	require.Equal(t, "alice-uuid", userID)
+	require.Equal(t, "proj1", projectID)
+	require.Equal(t, "coder", agentID)
+}
+
+func TestIdentityFromTopic_Broadcast_ReturnsFalse(t *testing.T) {
+	msg := &messages.StructuredMessage{
+		Sender: "system",
+	}
+	_, _, _, ok := identityFromTopic("scion.project.proj1.broadcast", msg)
+	require.False(t, ok)
+}
+
+func TestIdentityFromTopic_MalformedTopic_ReturnsFalse(t *testing.T) {
+	msg := &messages.StructuredMessage{
+		Sender: "agent:coder",
+	}
+	_, _, _, ok := identityFromTopic("not.a.valid.topic", msg)
+	require.False(t, ok)
+}
+
+func TestIdentityFromTopic_MissingUserID_ReturnsFalse(t *testing.T) {
+	// Agent topic, but sender has no SenderID and is not a user.
+	msg := &messages.StructuredMessage{
+		Sender: "agent:coder",
+	}
+	_, _, _, ok := identityFromTopic("scion.project.proj1.agent.coder.messages", msg)
+	require.False(t, ok)
+}


### PR DESCRIPTION
## Summary

- Register web channel spoke on FanOutEventBus (Discord/Telegram pattern)
- WebChannelBus with handler discard (F7/F8) and Publish (webchat_* state)
- WebChatStore with portable SQL (SQLite + Postgres)
- Observer:true spoke registration

Closes ptone/scion#949

## Test plan

- go build, go vet, make lint pass
- 19 tests pass