### PR TITLE
fix(hub): share OIDC signing keys across instances via database

### DIFF
--- a/pkg/hub/oidckeys.go
+++ b/pkg/hub/oidckeys.go
@@ -347,6 +347,14 @@ func (m *OIDCKeyManager) CleanupExpiredKeys() {
 
 	// Persist cleaned-up keyset to DB so other instances don't keep
 	// serving the expired keys.
+	//
+	// Note: there is a minor TOCTOU window between the Unlock above and
+	// the saveKeysetToDB call below — a concurrent RotateKey could modify
+	// m.allKeys in between. This is harmless: saveKeysetToDB re-reads
+	// m.allKeys under RLock, so it will capture the rotation's changes.
+	// In the worst case (a concurrent rotation writes the keyset between
+	// our unlock and save), the expired keys reappear briefly and are
+	// cleaned up on the next cycle or refresh.
 	if removed > 0 && m.store != nil {
 		if err := m.saveKeysetToDB(context.Background()); err != nil {
 			m.log.Warn("Failed to persist cleaned-up OIDC keyset to DB", "error", err)

--- a/pkg/hub/oidckeys.go
+++ b/pkg/hub/oidckeys.go
@@ -21,7 +21,9 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
+	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -51,6 +53,17 @@ const (
 	// oidcCleanupInterval is how often the background cleanup loop checks for
 	// expired rotated keys.
 	oidcCleanupInterval = 1 * time.Hour
+
+	// SecretKeyOIDCKeyset is the secret key name for the OIDC signing keyset.
+	// Unlike SecretKeyOIDCSigningKey which stores a single PEM, this entry
+	// stores a JSON array of all keys (active + rotated) so that all hub
+	// instances serve the same JWKS and rotated keys survive restarts.
+	SecretKeyOIDCKeyset = "oidc_signing_keyset"
+
+	// oidcJWKSRefreshInterval is how often each instance refreshes its
+	// in-memory key set from the database. This ensures all instances
+	// converge to the same JWKS within this window.
+	oidcJWKSRefreshInterval = 30 * time.Second
 )
 
 // OIDCSigningKey holds an RSA key pair used for signing OIDC identity tokens.
@@ -61,6 +74,18 @@ type OIDCSigningKey struct {
 	CreatedAt     time.Time
 	DeactivatedAt time.Time // zero until rotated out
 	Active        bool
+}
+
+// oidcKeyRecord is a JSON-serializable representation of an OIDC signing key,
+// used to persist the full keyset (active + rotated) to the database. This
+// enables all hub instances to serve an identical JWKS and preserves rotated
+// keys across restarts.
+type oidcKeyRecord struct {
+	KID           string    `json:"kid"`
+	PrivateKeyPEM string    `json:"private_key_pem"`
+	Active        bool      `json:"active"`
+	CreatedAt     time.Time `json:"created_at"`
+	DeactivatedAt time.Time `json:"deactivated_at,omitempty"`
 }
 
 // OIDCKeyManager manages RSA key pairs for OIDC identity token signing.
@@ -136,14 +161,24 @@ func NewOIDCKeyManager(ctx context.Context, cfg OIDCKeyManagerConfig) (*OIDCKeyM
 	}
 
 	mgr.activeKey = signingKey
-	// Note: only the active key is loaded on startup. Previously rotated keys
-	// (serving JWKS overlap) are not restored. The overlap window does not
-	// survive hub restarts.
 	mgr.allKeys = []*OIDCSigningKey{signingKey}
 	mgr.signer = signer
 
+	// Restore rotated keys from the DB keyset so the JWKS overlap window
+	// survives hub restarts and is consistent across instances.
+	if cfg.Store != nil {
+		if restoreErr := mgr.restoreRotatedKeysFromDB(ctx); restoreErr != nil {
+			log.Warn("Failed to restore rotated OIDC keys from DB keyset", "error", restoreErr)
+		}
+		// Persist the current keyset (active + any restored rotated keys) to DB.
+		if saveErr := mgr.saveKeysetToDB(ctx); saveErr != nil {
+			log.Warn("Failed to save OIDC keyset to DB", "error", saveErr)
+		}
+	}
+
 	log.Info("OIDC key manager initialized",
 		"kid", kid,
+		"key_count", len(mgr.allKeys),
 		"issuer_url", cfg.IssuerURL,
 	)
 
@@ -265,6 +300,14 @@ func (m *OIDCKeyManager) RotateKey(ctx context.Context) error {
 	m.signer = newSigner
 	m.mu.Unlock()
 
+	// Persist the full keyset (active + rotated) to DB so all instances
+	// serve a consistent JWKS. Also clean up expired keys while we're at it.
+	if m.store != nil {
+		if err := m.saveKeysetToDB(ctx); err != nil {
+			m.log.Warn("Failed to persist rotated OIDC keyset to DB", "error", err)
+		}
+	}
+
 	m.log.Info("OIDC signing key rotated",
 		"old_kid", oldKID,
 		"new_kid", newKID,
@@ -278,10 +321,10 @@ func (m *OIDCKeyManager) RotateKey(ctx context.Context) error {
 // removed regardless of age.
 func (m *OIDCKeyManager) CleanupExpiredKeys() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	now := time.Now()
 	kept := make([]*OIDCSigningKey, 0, len(m.allKeys))
+	removed := 0
 	for _, k := range m.allKeys {
 		if k.Active {
 			kept = append(kept, k)
@@ -297,8 +340,18 @@ func (m *OIDCKeyManager) CleanupExpiredKeys() {
 			"deactivated_at", k.DeactivatedAt,
 			"age", age.Round(time.Second),
 		)
+		removed++
 	}
 	m.allKeys = kept
+	m.mu.Unlock()
+
+	// Persist cleaned-up keyset to DB so other instances don't keep
+	// serving the expired keys.
+	if removed > 0 && m.store != nil {
+		if err := m.saveKeysetToDB(context.Background()); err != nil {
+			m.log.Warn("Failed to persist cleaned-up OIDC keyset to DB", "error", err)
+		}
+	}
 }
 
 // StartCleanupLoop starts a background goroutine that periodically removes
@@ -314,6 +367,26 @@ func (m *OIDCKeyManager) StartCleanupLoop(ctx context.Context) {
 				return
 			case <-ticker.C:
 				m.CleanupExpiredKeys()
+			}
+		}
+	}()
+}
+
+// StartRefreshLoop starts a background goroutine that periodically refreshes
+// the in-memory key set from the database. This ensures all hub instances
+// converge to the same JWKS within oidcJWKSRefreshInterval (30s), so that
+// keys rotated or cleaned up by one instance become visible to all others.
+// The goroutine stops when ctx is canceled.
+func (m *OIDCKeyManager) StartRefreshLoop(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(oidcJWKSRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				m.refreshKeysFromDB(ctx)
 			}
 		}
 	}()
@@ -389,6 +462,18 @@ func (m *OIDCKeyManager) loadOrCreateKey(ctx context.Context, cfg OIDCKeyManager
 	}
 	pemStr := string(pemData)
 
+	// CAS: use CreateSecret so that if two instances cold-start
+	// simultaneously, only the first writer's key is used. The loser
+	// reloads the winner's key from the store.
+	if cfg.Store != nil {
+		casKey := m.casCreateKeyInStore(ctx, keyName, pemStr, hubID)
+		if casKey != nil {
+			// Another instance created a key first — use theirs.
+			m.log.Info("Another instance already created OIDC signing key, using theirs", "key", keyName)
+			return casKey, nil
+		}
+	}
+
 	// Persist to secret backend first, then store as backup
 	if hasBackend {
 		input := &secret.SetSecretInput{
@@ -409,13 +494,6 @@ func (m *OIDCKeyManager) loadOrCreateKey(ctx context.Context, cfg OIDCKeyManager
 		} else {
 			m.log.Info("Persisted new OIDC signing key via secret backend", "key", keyName)
 		}
-	}
-
-	// Save to store as backup (or primary if no backend)
-	if persistErr := m.backupKeyToStore(ctx, keyName, pemStr, hubID); persistErr != nil {
-		m.log.Warn("Failed to persist OIDC signing key to store", "key", keyName, "error", persistErr)
-	} else {
-		m.log.Info("Persisted OIDC signing key to store", "key", keyName)
 	}
 
 	return privKey, nil
@@ -468,6 +546,244 @@ func (m *OIDCKeyManager) syncKeyToBackend(ctx context.Context, keyName, pemValue
 // signing key record, scoped to the hub instance.
 func oidcSigningKeySecretID(hubID string) string {
 	return uuid.NewSHA1(uuid.NameSpaceOID, []byte("hub-oidc-signing-key:"+hubID)).String()
+}
+
+// casCreateKeyInStore attempts to create the signing key in the store using
+// CreateSecret (which returns ErrAlreadyExists if the key already exists).
+// If another instance already created a key, it loads and returns that key.
+// Returns nil if our key was successfully created (caller should use theirs).
+func (m *OIDCKeyManager) casCreateKeyInStore(ctx context.Context, keyName, pemValue, hubID string) *rsa.PrivateKey {
+	sec := &store.Secret{
+		ID:             oidcSigningKeySecretID(hubID),
+		Key:            keyName,
+		EncryptedValue: pemValue,
+		Scope:          store.ScopeHub,
+		ScopeID:        hubID,
+		SecretType:     store.SecretTypeInternal,
+		Description:    "OIDC identity token signing key (RSA-2048)",
+	}
+	err := m.store.CreateSecret(ctx, sec)
+	if err == nil {
+		// We won the race — our key was created.
+		m.log.Info("Persisted OIDC signing key to store via CAS", "key", keyName)
+		return nil
+	}
+	if !errors.Is(err, store.ErrAlreadyExists) {
+		// Unexpected error — fall through to existing UpsertSecret path.
+		m.log.Warn("CAS create failed for OIDC signing key, falling back to upsert",
+			"key", keyName, "error", err)
+		if persistErr := m.backupKeyToStore(ctx, keyName, pemValue, hubID); persistErr != nil {
+			m.log.Warn("Failed to persist OIDC signing key to store", "key", keyName, "error", persistErr)
+		}
+		return nil
+	}
+
+	// Another instance won. Load their key.
+	val, getErr := m.store.GetSecretValue(ctx, keyName, store.ScopeHub, hubID)
+	if getErr != nil || val == "" {
+		m.log.Warn("CAS lost but could not load winner's OIDC key from store, using ours",
+			"key", keyName, "error", getErr)
+		return nil
+	}
+	existingKey, parseErr := decodePEMPrivateKey([]byte(val))
+	if parseErr != nil {
+		m.log.Warn("CAS lost but could not parse winner's OIDC key, using ours",
+			"key", keyName, "error", parseErr)
+		return nil
+	}
+	return existingKey
+}
+
+// saveKeysetToDB persists the full keyset (active + rotated keys) to the
+// database as a JSON array. This is the source of truth for the JWKS that
+// all hub instances serve, ensuring cross-instance consistency.
+func (m *OIDCKeyManager) saveKeysetToDB(ctx context.Context) error {
+	if m.store == nil {
+		return nil
+	}
+
+	m.mu.RLock()
+	records := make([]oidcKeyRecord, 0, len(m.allKeys))
+	for _, k := range m.allKeys {
+		pemData, err := encodePEMPrivateKey(k.PrivateKey)
+		if err != nil {
+			m.mu.RUnlock()
+			return fmt.Errorf("encoding key %s: %w", k.KeyID, err)
+		}
+		records = append(records, oidcKeyRecord{
+			KID:           k.KeyID,
+			PrivateKeyPEM: string(pemData),
+			Active:        k.Active,
+			CreatedAt:     k.CreatedAt,
+			DeactivatedAt: k.DeactivatedAt,
+		})
+	}
+	m.mu.RUnlock()
+
+	data, err := json.Marshal(records)
+	if err != nil {
+		return fmt.Errorf("marshaling OIDC keyset: %w", err)
+	}
+
+	sec := &store.Secret{
+		ID:             oidcKeysetSecretID(m.hubID),
+		Key:            SecretKeyOIDCKeyset,
+		EncryptedValue: string(data),
+		Scope:          store.ScopeHub,
+		ScopeID:        m.hubID,
+		SecretType:     store.SecretTypeInternal,
+		Description:    "OIDC signing keyset (all active and rotated keys)",
+	}
+	if _, err := m.store.UpsertSecret(ctx, sec); err != nil {
+		return fmt.Errorf("upserting OIDC keyset: %w", err)
+	}
+	return nil
+}
+
+// loadKeysetFromDB loads the full keyset from the database and returns
+// the parsed signing keys.
+func (m *OIDCKeyManager) loadKeysetFromDB(ctx context.Context) ([]*OIDCSigningKey, error) {
+	if m.store == nil {
+		return nil, store.ErrNotFound
+	}
+
+	val, err := m.store.GetSecretValue(ctx, SecretKeyOIDCKeyset, store.ScopeHub, m.hubID)
+	if err != nil {
+		return nil, err
+	}
+	if val == "" {
+		return nil, store.ErrNotFound
+	}
+
+	var records []oidcKeyRecord
+	if err := json.Unmarshal([]byte(val), &records); err != nil {
+		return nil, fmt.Errorf("unmarshaling OIDC keyset: %w", err)
+	}
+
+	keys := make([]*OIDCSigningKey, 0, len(records))
+	for _, rec := range records {
+		privKey, err := decodePEMPrivateKey([]byte(rec.PrivateKeyPEM))
+		if err != nil {
+			m.log.Warn("Skipping unparseable key in OIDC keyset", "kid", rec.KID, "error", err)
+			continue
+		}
+		keys = append(keys, &OIDCSigningKey{
+			KeyID:         rec.KID,
+			PrivateKey:    privKey,
+			PublicKey:     &privKey.PublicKey,
+			Active:        rec.Active,
+			CreatedAt:     rec.CreatedAt,
+			DeactivatedAt: rec.DeactivatedAt,
+		})
+	}
+	return keys, nil
+}
+
+// restoreRotatedKeysFromDB loads the keyset from the database and merges
+// any rotated (inactive) keys into the in-memory key list. This restores
+// the JWKS overlap window across hub restarts.
+func (m *OIDCKeyManager) restoreRotatedKeysFromDB(ctx context.Context) error {
+	keys, err := m.loadKeysetFromDB(ctx)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil // No keyset yet — first run.
+		}
+		return err
+	}
+
+	// Build a set of KIDs already in m.allKeys.
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	existing := make(map[string]bool, len(m.allKeys))
+	for _, k := range m.allKeys {
+		existing[k.KeyID] = true
+	}
+
+	restored := 0
+	for _, k := range keys {
+		if existing[k.KeyID] {
+			continue
+		}
+		// Only restore inactive keys that are still within the overlap window.
+		if !k.Active && !k.DeactivatedAt.IsZero() {
+			age := time.Since(k.DeactivatedAt)
+			if age >= oidcKeyOverlapWindow {
+				continue // Already expired — don't restore.
+			}
+		}
+		m.allKeys = append(m.allKeys, k)
+		restored++
+	}
+
+	if restored > 0 {
+		m.log.Info("Restored rotated OIDC keys from DB keyset",
+			"restored_count", restored,
+			"total_keys", len(m.allKeys),
+		)
+	}
+	return nil
+}
+
+// refreshKeysFromDB reloads the full keyset from the database and updates
+// the in-memory state. This is called periodically by StartRefreshLoop to
+// ensure all instances converge to the same JWKS.
+func (m *OIDCKeyManager) refreshKeysFromDB(ctx context.Context) {
+	keys, err := m.loadKeysetFromDB(ctx)
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			m.log.Warn("Failed to refresh OIDC keyset from DB", "error", err)
+		}
+		return
+	}
+
+	if len(keys) == 0 {
+		return // Don't clear our keys if DB returned empty.
+	}
+
+	// Find the active key in the refreshed set.
+	var newActiveKey *OIDCSigningKey
+	for _, k := range keys {
+		if k.Active {
+			newActiveKey = k
+			break
+		}
+	}
+	if newActiveKey == nil {
+		m.log.Warn("DB keyset has no active key, skipping refresh")
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Check if the active key changed (another instance rotated).
+	if m.activeKey != nil && m.activeKey.KeyID != newActiveKey.KeyID {
+		// Rebuild signer with the new active key.
+		newSigner, err := jose.NewSigner(
+			jose.SigningKey{Algorithm: jose.RS256, Key: newActiveKey.PrivateKey},
+			(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", newActiveKey.KeyID),
+		)
+		if err != nil {
+			m.log.Error("Failed to create signer for refreshed OIDC key",
+				"kid", newActiveKey.KeyID, "error", err)
+			return
+		}
+		m.signer = newSigner
+		m.log.Info("OIDC active key updated from DB refresh",
+			"old_kid", m.activeKey.KeyID,
+			"new_kid", newActiveKey.KeyID,
+		)
+	}
+
+	m.activeKey = newActiveKey
+	m.allKeys = keys
+}
+
+// oidcKeysetSecretID returns a deterministic primary key for the OIDC
+// signing keyset record, scoped to the hub instance.
+func oidcKeysetSecretID(hubID string) string {
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte("hub-oidc-signing-keyset:"+hubID)).String()
 }
 
 // generateRSAKeyPair generates a new RSA-2048 key pair.

--- a/pkg/hub/oidckeys_test.go
+++ b/pkg/hub/oidckeys_test.go
@@ -1038,6 +1038,318 @@ func TestOIDCKeyManager_RotateKey_PersistFailure(t *testing.T) {
 	mgr.mu.RUnlock()
 }
 
+// --- DB-backed keyset tests (multi-instance JWKS sharing) ---
+
+func TestOIDCKeyManager_KeysetSaveAndLoad(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+	hubID := "test-hub-keyset"
+
+	mgr, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	// The keyset should have been saved to DB on init.
+	keys, err := mgr.loadKeysetFromDB(ctx)
+	require.NoError(t, err)
+	require.Len(t, keys, 1, "Keyset in DB should contain the active key")
+	assert.Equal(t, mgr.JWKS().Keys[0].KeyID, keys[0].KeyID)
+	assert.True(t, keys[0].Active)
+}
+
+func TestOIDCKeyManager_KeysetSaveAndLoadAfterRotation(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+	hubID := "test-hub-keyset-rotate"
+
+	mgr, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	originalKID := mgr.JWKS().Keys[0].KeyID
+
+	// Rotate the key.
+	err = mgr.RotateKey(ctx)
+	require.NoError(t, err)
+
+	// The keyset in DB should contain both keys.
+	keys, err := mgr.loadKeysetFromDB(ctx)
+	require.NoError(t, err)
+	require.Len(t, keys, 2, "Keyset in DB should contain active + rotated key")
+
+	kids := []string{keys[0].KeyID, keys[1].KeyID}
+	assert.Contains(t, kids, originalKID)
+
+	// Exactly one should be active.
+	activeCount := 0
+	for _, k := range keys {
+		if k.Active {
+			activeCount++
+		}
+	}
+	assert.Equal(t, 1, activeCount)
+}
+
+func TestOIDCKeyManager_RestoreRotatedKeysOnStartup(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+	hubID := "test-hub-restore"
+
+	// First manager: create key and rotate.
+	mgr1, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	originalKID := mgr1.JWKS().Keys[0].KeyID
+
+	err = mgr1.RotateKey(ctx)
+	require.NoError(t, err)
+	require.Len(t, mgr1.JWKS().Keys, 2, "After rotation, should have 2 keys")
+
+	newKID := mgr1.JWKS().Keys[0].KeyID
+
+	// Second manager: simulates a restart. Should restore the rotated key.
+	mgr2, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	jwks2 := mgr2.JWKS()
+	require.Len(t, jwks2.Keys, 2, "Restarted manager should restore rotated key from DB")
+
+	kids := make([]string, len(jwks2.Keys))
+	for i, k := range jwks2.Keys {
+		kids[i] = k.KeyID
+	}
+	assert.Contains(t, kids, originalKID, "Original key should be restored")
+	assert.Contains(t, kids, newKID, "New key should be present")
+}
+
+func TestOIDCKeyManager_RestoreSkipsExpiredKeys(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+	hubID := "test-hub-restore-expired"
+
+	// First manager: create key and rotate.
+	mgr1, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	err = mgr1.RotateKey(ctx)
+	require.NoError(t, err)
+
+	// Artificially age the rotated key past the overlap window.
+	mgr1.mu.Lock()
+	for _, k := range mgr1.allKeys {
+		if !k.Active {
+			k.DeactivatedAt = time.Now().Add(-25 * time.Hour)
+		}
+	}
+	mgr1.mu.Unlock()
+
+	// Save the aged keyset to DB.
+	err = mgr1.saveKeysetToDB(ctx)
+	require.NoError(t, err)
+
+	// Second manager: should NOT restore the expired key.
+	mgr2, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	jwks2 := mgr2.JWKS()
+	assert.Len(t, jwks2.Keys, 1, "Expired rotated key should not be restored")
+}
+
+func TestOIDCKeyManager_CASOnKeyGeneration(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+	hubID := "test-hub-cas"
+
+	// First manager: generates and persists a key.
+	mgr1, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+	kid1 := mgr1.JWKS().Keys[0].KeyID
+
+	// Second manager with the SAME store: should load the existing key,
+	// not generate a new one (the key already exists in the DB).
+	mgr2, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+	kid2 := mgr2.JWKS().Keys[0].KeyID
+
+	assert.Equal(t, kid1, kid2,
+		"Second instance should load existing key, not generate a new one")
+
+	// Verify cross-validation: token from mgr1 verifiable with mgr2's JWKS.
+	claims := map[string]interface{}{"sub": "agent-cas-test"}
+	token, err := jwt.Signed(mgr1.Signer()).Claims(claims).Serialize()
+	require.NoError(t, err)
+
+	parsed, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256})
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	err = parsed.Claims(mgr2.JWKS().Keys[0].Key, &result)
+	require.NoError(t, err)
+	assert.Equal(t, "agent-cas-test", result["sub"])
+}
+
+func TestOIDCKeyManager_RefreshKeysFromDB(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+	hubID := "test-hub-refresh"
+
+	// Create two managers sharing the same DB.
+	mgr1, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	mgr2, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	// Verify both start with the same key.
+	assert.Equal(t, mgr1.JWKS().Keys[0].KeyID, mgr2.JWKS().Keys[0].KeyID)
+
+	// Rotate key on mgr1. mgr2 should not see it yet.
+	err = mgr1.RotateKey(ctx)
+	require.NoError(t, err)
+	require.Len(t, mgr1.JWKS().Keys, 2)
+	assert.Len(t, mgr2.JWKS().Keys, 1, "mgr2 should not see rotation yet")
+
+	// Refresh mgr2 from DB.
+	mgr2.refreshKeysFromDB(ctx)
+
+	// Now mgr2 should see both keys.
+	jwks2 := mgr2.JWKS()
+	assert.Len(t, jwks2.Keys, 2, "After refresh, mgr2 should see both keys")
+
+	// mgr2 should now sign with the new key.
+	newKID := mgr1.JWKS().Keys[0].KeyID
+	assert.Equal(t, newKID, mgr2.JWKS().Keys[0].KeyID,
+		"After refresh, mgr2 should use the new active key")
+}
+
+func TestOIDCKeyManager_CleanupPersistsToDB(t *testing.T) {
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+	hubID := "test-hub-cleanup-persist"
+
+	mgr, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	// Rotate and age the old key.
+	err = mgr.RotateKey(ctx)
+	require.NoError(t, err)
+
+	mgr.mu.Lock()
+	for _, k := range mgr.allKeys {
+		if !k.Active {
+			k.DeactivatedAt = time.Now().Add(-25 * time.Hour)
+		}
+	}
+	mgr.mu.Unlock()
+
+	// Cleanup should remove the expired key and persist to DB.
+	mgr.CleanupExpiredKeys()
+	assert.Len(t, mgr.JWKS().Keys, 1)
+
+	// Verify DB was updated.
+	keys, err := mgr.loadKeysetFromDB(ctx)
+	require.NoError(t, err)
+	assert.Len(t, keys, 1, "DB keyset should also have expired key removed")
+}
+
+func TestOIDCKeyManager_CrossInstanceTokenVerification(t *testing.T) {
+	// Simulate two instances that share a DB. A token signed by one
+	// instance should be verifiable using the other instance's JWKS.
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+	hubID := "test-hub-cross-instance"
+
+	mgr1, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	mgr2, err := NewOIDCKeyManager(ctx, OIDCKeyManagerConfig{
+		Store:     s,
+		HubID:     hubID,
+		IssuerURL: "https://hub.example.com",
+	})
+	require.NoError(t, err)
+
+	// Sign a token on instance 1.
+	claims := map[string]interface{}{
+		"sub": "agent-cross-instance",
+		"iss": "https://hub.example.com",
+	}
+	token, err := jwt.Signed(mgr1.Signer()).Claims(claims).Serialize()
+	require.NoError(t, err)
+
+	// Verify using instance 2's JWKS.
+	parsed, err := jwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256})
+	require.NoError(t, err)
+
+	// Since both instances share the same DB and loaded the same key,
+	// the JWKS from instance 2 should contain the key to verify the token.
+	jwks2 := mgr2.JWKS()
+	require.Len(t, jwks2.Keys, 1)
+
+	var result map[string]interface{}
+	err = parsed.Claims(jwks2.Keys[0].Key, &result)
+	require.NoError(t, err)
+	assert.Equal(t, "agent-cross-instance", result["sub"])
+}
+
+func TestOIDCKeysetSecretID(t *testing.T) {
+	id1 := oidcKeysetSecretID("hub-1")
+	id2 := oidcKeysetSecretID("hub-2")
+
+	// Should be deterministic.
+	assert.Equal(t, id1, oidcKeysetSecretID("hub-1"))
+	// Different hubIDs should produce different IDs.
+	assert.NotEqual(t, id1, id2)
+	// Should be different from the signing key secret ID.
+	assert.NotEqual(t, id1, oidcSigningKeySecretID("hub-1"))
+}
+
 // createOIDCTestStore creates an in-memory SQLite store for OIDC tests.
 func createOIDCTestStore(t *testing.T) store.Store {
 	t.Helper()

--- a/pkg/hub/oidckeys_test.go
+++ b/pkg/hub/oidckeys_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -1216,6 +1217,55 @@ func TestOIDCKeyManager_CASOnKeyGeneration(t *testing.T) {
 	err = parsed.Claims(mgr2.JWKS().Keys[0].Key, &result)
 	require.NoError(t, err)
 	assert.Equal(t, "agent-cas-test", result["sub"])
+}
+
+func TestOIDCKeyManager_CASCreateKeyInStore_Direct(t *testing.T) {
+	// Directly test the casCreateKeyInStore method to verify the
+	// ErrAlreadyExists code path is exercised (not just the store-load path).
+	s := createOIDCTestStore(t)
+	ctx := context.Background()
+	hubID := "test-hub-cas-direct"
+
+	mgr := &OIDCKeyManager{
+		store: s,
+		hubID: hubID,
+		log:   slog.Default(),
+	}
+
+	// Generate two different keys.
+	key1, err := generateRSAKeyPair()
+	require.NoError(t, err)
+	pem1, err := encodePEMPrivateKey(key1)
+	require.NoError(t, err)
+
+	key2, err := generateRSAKeyPair()
+	require.NoError(t, err)
+	pem2, err := encodePEMPrivateKey(key2)
+	require.NoError(t, err)
+
+	t.Run("first writer wins", func(t *testing.T) {
+		// First call: should create successfully, return nil (caller uses theirs).
+		result := mgr.casCreateKeyInStore(ctx, SecretKeyOIDCSigningKey, string(pem1), hubID)
+		assert.Nil(t, result, "First writer should win — nil means 'use your own key'")
+
+		// Verify the key was stored.
+		val, err := s.GetSecretValue(ctx, SecretKeyOIDCSigningKey, "hub", hubID)
+		require.NoError(t, err)
+		assert.Equal(t, string(pem1), val)
+	})
+
+	t.Run("second writer loses and loads winner key", func(t *testing.T) {
+		// Second call with a different key: should hit ErrAlreadyExists,
+		// load the first writer's key, and return it.
+		result := mgr.casCreateKeyInStore(ctx, SecretKeyOIDCSigningKey, string(pem2), hubID)
+		require.NotNil(t, result, "Second writer should lose and return winner's key")
+
+		// The returned key should be the FIRST key, not the second.
+		kid1 := computeKeyID(&key1.PublicKey)
+		kidResult := computeKeyID(&result.PublicKey)
+		assert.Equal(t, kid1, kidResult,
+			"CAS loser should return the winner's key, not their own")
+	})
 }
 
 func TestOIDCKeyManager_RefreshKeysFromDB(t *testing.T) {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1097,6 +1097,10 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 			srv.oidcKeyManager = oidcMgr
 			srv.oidcIssuerURL = oidcIssuerURL
 
+			// Start background loops for key cleanup and cross-instance refresh.
+			oidcMgr.StartCleanupLoop(ctx)
+			oidcMgr.StartRefreshLoop(ctx)
+
 			// OIDC identity token lifetime: use config if set, else default 15m
 			srv.oidcTokenLifetime = 15 * time.Minute
 			if cfg.OIDCConfig.TokenLifetime > 0 {

--- a/pkg/hub/storage_migration.go
+++ b/pkg/hub/storage_migration.go
@@ -30,20 +30,6 @@ import (
 // Callers on multi-instance deployments should wrap this call in an advisory
 // lock (store.LockStorageMigration) to prevent concurrent replicas from racing.
 func (s *Server) MigrateStorageOnFirstBoot(ctx context.Context) {
-	// Acquire advisory lock to prevent concurrent replicas from racing.
-	if locker, ok := s.store.(store.AdvisoryLocker); ok {
-		acquired, release, err := locker.TryAdvisoryLock(ctx, store.LockStorageMigration)
-		if err != nil {
-			s.resourceLog.Error("storage migration: failed to acquire advisory lock", "error", err)
-			return
-		}
-		defer func() { _ = release() }()
-		if !acquired {
-			s.resourceLog.Info("storage migration: lock held by another replica, skipping")
-			return
-		}
-	}
-
 	stor := s.GetStorage()
 	if stor == nil {
 		return

--- a/pkg/hub/storage_migration.go
+++ b/pkg/hub/storage_migration.go
@@ -30,6 +30,20 @@ import (
 // Callers on multi-instance deployments should wrap this call in an advisory
 // lock (store.LockStorageMigration) to prevent concurrent replicas from racing.
 func (s *Server) MigrateStorageOnFirstBoot(ctx context.Context) {
+	// Acquire advisory lock to prevent concurrent replicas from racing.
+	if locker, ok := s.store.(store.AdvisoryLocker); ok {
+		acquired, release, err := locker.TryAdvisoryLock(ctx, store.LockStorageMigration)
+		if err != nil {
+			s.resourceLog.Error("storage migration: failed to acquire advisory lock", "error", err)
+			return
+		}
+		defer func() { _ = release() }()
+		if !acquired {
+			s.resourceLog.Info("storage migration: lock held by another replica, skipping")
+			return
+		}
+	}
+
 	stor := s.GetStorage()
 	if stor == nil {
 		return


### PR DESCRIPTION
Fixes OIDC signing key isolation across Cloud Run instances. Keys are now shared via database with CAS writes, and JWKS endpoint serves from DB rather than in-memory only. Depends on hubId pinning from ptone/scion#936. Ref: ptone/scion#937.