### PR TITLE
fix(web): prevent tab events from bubbling to sl-details handlers

### DIFF
--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -1031,7 +1031,8 @@ export class ScionPageAgentCreate extends LitElement {
         <sl-details
           summary="Additional Options"
           ?open=${this.advancedOpen}
-          @sl-show=${() => {
+          @sl-show=${(e: Event) => {
+            if (e.target !== e.currentTarget) return;
             this.advancedOpen = true;
             // Force the tab-group to show the General tab when disclosure opens.
             // sl-tab-group may not initialize correctly when hidden inside sl-details.
@@ -1042,7 +1043,10 @@ export class ScionPageAgentCreate extends LitElement {
               }
             });
           }}
-          @sl-hide=${() => { this.advancedOpen = false; }}
+          @sl-hide=${(e: Event) => {
+            if (e.target !== e.currentTarget) return;
+            this.advancedOpen = false;
+          }}
         >
           <sl-tab-group>
             <sl-tab slot="nav" panel="general" active>General</sl-tab>


### PR DESCRIPTION
Adds e.target !== e.currentTarget guards to both @sl-show and @sl-hide handlers on the sl-details element in agent-create.ts to prevent nested sl-tab-panel events from triggering disclosure open/close.

Fixes ptone/scion#964