### PR TITLE
docs: GCP service account IAM authorization gates

### DIFF
--- a/docs-site/src/content/docs/hosted/ha/permissions.md
+++ b/docs-site/src/content/docs/hosted/ha/permissions.md
@@ -104,6 +104,42 @@ The cache is automatically invalidated for a target service account when that se
 
 For Policy Troubleshooter to evaluate a caller's IAM permission across the organization, the Scion Hub's own GCP service account must be granted the **IAM Security Reviewer** role (`roles/iam.securityReviewer`) at either the Google Cloud project or organization level.
 
+### Hub-Scoped Service Accounts
+
+Hub-scoped service accounts are defined globally at the Hub level rather than being restricted to a single project. This allows Platform Ops to make shared service accounts available for selection across multiple project-level workspaces.
+
+To prevent unauthorized assignment of global resources, Scion applies specialized security logic:
+- **Enforcement Mode Dependency**: Assignment of a hub-scoped service account is **unconditionally denied** if `gcp_iam_check_mode` is set to `off`. Because "off" mode disables the GCP IAM validation layer, letting users assign global service accounts without an `actAs` check would create a massive security risk. Hub-scoped service accounts require `gcp_iam_check_mode: enforce` to be assigned.
+- **Dynamic Membership Checks**: Only current, active members of the Hub or project who possess `ActionAssign` on the resource and pass the Policy Troubleshooter `actAs` check can bind the service account.
+- **Former-Member Denial**: If a user is removed from a project or leaves the organization, they immediately lose the ability to assign those service accounts—even if they were the user who originally created or registered the service account record in Scion. Ownership-based bypasses do not apply to hub-scoped service accounts.
+
+### Passthrough Mode Security & PATCH Parity
+
+In **Passthrough Mode**, an agent bypasses explicit service account binding and directly assumes the GCP identity of its GKE/GCE broker host. To prevent unauthorized access to host-level authority:
+1. **Broker-Owner Restriction**: The caller must have permission to use that specific broker in passthrough mode.
+2. **Host SA check**: The caller's GCP principal is checked via Policy Troubleshooter to confirm they hold `iam.serviceAccounts.actAs` permission on the broker's underlying host service account.
+
+To enforce this boundary reliably, Scion implements strict **PATCH Parity** across its API:
+- Previously, the `actAs` check only ran on agent creation (`POST /api/v1/agents`).
+- Now, the exact same validation function gates the update path (`PATCH /api/v1/agents/{id}`). This prevents users from sneaking past the delegation gates by creating a low-privilege or no-auth agent and then PATCHing it to use passthrough mode.
+
+### Service Account Minting Permissions
+
+**Minting** is the process where Scion Hub automatically provisions a brand-new GCP service account in the Hub's own project and registers it to the database on behalf of the user. Because minting creates new GCP authority and project IAM bindings, it operates under a highly secure flow:
+
+- **Enforced Regardless of Mode**: Unlike assignment checks (which can be toggled via `gcp_iam_check_mode`), **minting checks are always active**. SAs cannot be minted unless the requester passes GCP IAM checks, even if `gcp_iam_check_mode` is set to `off`. Skipping mint checks would create an instant privilege-creation bypass.
+- **Required GCP Permissions**: To mint a service account, the requester's GCP principal must have:
+  - `iam.serviceAccounts.create` on the Hub's GCP project (to create the service account).
+  - `aiplatform.endpoints.predict` on the target project (to authorize the minted SA to access the GCP Vertex AI Platform).
+- **Fail-Closed Minting Flow**: A minted service account is stored as `Verified` in Scion only if all required downstream GCP IAM mutations succeed—specifically, granting the Hub SA `roles/iam.serviceAccountTokenCreator` on the minted SA, and granting the requester `roles/iam.serviceAccountUser` on the minted SA. If any mutation fails, the status is recorded as failed and the service account remains unverified.
+
+### Web UI Integration & Identity Cards
+
+To make the service account lifecycle transparent and auditable for users and administrators, the Web Dashboard includes the following enhancements:
+- **Tiered Role Badges**: The agents list and agent detail pages display visible role badges (`none`, `readonly`, `baseline`, or `full`) highlighting the active execution role of each running container.
+- **GCP Identity Card**: The agent detail view features an interactive **GCP Identity Card**. In all authentication modes, it displays the bound service account email, verification status (e.g. `verified` or `failed`), and the corresponding GCP project ID.
+- **Service Account Status Manager**: Within project settings, owners can view registered service accounts, check their live Policy Troubleshooter verification status, and manually trigger verification probes.
+
 ---
 
 ## Roles

--- a/docs-site/src/content/docs/hosted/ha/permissions.md
+++ b/docs-site/src/content/docs/hosted/ha/permissions.md
@@ -69,6 +69,43 @@ A policy defines the rules for access:
 - **Effect**: Can be `allow` or `deny`.
 - **Conditions**: (Future) Optional rules based on resource labels or time-of-day.
 
+## GCP Service Account Assignment Gates
+
+To prevent lateral privilege escalation—where an agent with low privileges creates a child agent with high privileges, or a user assigns a highly privileged GCP service account they shouldn't have access to—Scion implements a secure, **two-layer gate** for binding a GCP service account to any agent:
+
+1. **Layer 1: Scion Hub Policy**: The Hub's built-in policy engine verifies the caller has the `ActionAssign` permission on the GCP service account resource within Scion.
+2. **Layer 2: GCP IAM Policy (`actAs`)**: If `gcp_iam_check_mode` is set to `enforce` (see [Server Configuration Reference](/scion/reference/server-config/)), the Hub evaluates Google Cloud's IAM delegation model via the **GCP Policy Troubleshooter v3 API**. It verifies that the caller's GCP principal possesses `iam.serviceAccounts.actAs` permission on the target service account.
+
+### The `actAs` Validation Gate
+
+The `actAs` (impersonation) check is critical because binding a service account to an agent grants that agent real cloud authority. 
+
+| Layer | Checked Authority | Action | Checked Principal |
+| :--- | :--- | :--- | :--- |
+| **Hub Policy** | Inside Scion | `ActionAssign` | Scion User/Agent |
+| **GCP IAM** | Inside Google Cloud | `iam.serviceAccounts.actAs` | Caller's GCP Principal |
+
+*Note: The Hub's own `roles/iam.serviceAccountTokenCreator` permission is used to perform impersonated credential probes. It is NOT the permission checked on the caller. The permission evaluated on the caller is `iam.serviceAccounts.actAs` (typically granted via `roles/iam.serviceAccountUser`).*
+
+### Fail-Closed Resolution
+
+If Policy Troubleshooter returns an indeterminate or unknown status (e.g., `ACCESS_STATE_UNKNOWN_CONDITIONAL` due to IAM conditions, or `ACCESS_STATE_UNKNOWN_INFO_DENIED` due to insufficient Hub reviewer permissions), Scion **fails closed** and denies the assignment immediately. There is no fallback to `getIamPolicy`, which can easily fail open or miss complex project-level, group-level, or org-level bindings.
+
+### Asymmetric Cache TTLs
+
+To maintain high API performance without violating security constraints, assignment decisions are cached using asymmetric TTLs:
+- **Allow TTL**: **60 seconds**
+- **Deny TTL**: **10 seconds**
+- **Indeterminate / Error States**: **Never cached**. Transient failures are retried immediately on the next request to prevent short outages from becoming fixed-length service blocks.
+
+The cache is automatically invalidated for a target service account when that service account is deleted, or when a Hub-initiated IAM mutation occurs.
+
+### IAM Prerequisites for Enforcement
+
+For Policy Troubleshooter to evaluate a caller's IAM permission across the organization, the Scion Hub's own GCP service account must be granted the **IAM Security Reviewer** role (`roles/iam.securityReviewer`) at either the Google Cloud project or organization level.
+
+---
+
 ## Roles
 
 To simplify management, Scion separates roles into **User Roles** (for human operators) and **Agent Roles** (for running agents).

--- a/docs-site/src/content/docs/hosted/ha/setup-gcp.md
+++ b/docs-site/src/content/docs/hosted/ha/setup-gcp.md
@@ -386,7 +386,29 @@ gcloud iam service-accounts add-iam-policy-binding \
 
 Without this binding, template generation will fail with: `Permission 'iam.serviceAccounts.signBlob' denied on resource`.
 
-### 2e. Transport SA — IAP Access
+### 2e. Hub Runner SA — IAM Security Reviewer (Optional, for Policy Troubleshooter)
+
+When you enable GCP IAM check mode (`gcp_iam_check_mode: enforce`), Scion verifies that human and agent callers possess `iam.serviceAccounts.actAs` permission on assigned service accounts via the **GCP Policy Troubleshooter v3 API**.
+
+For Policy Troubleshooter to evaluate permissions across your project (or your entire organization if you assign SAs from multiple projects), the Hub Runner SA must be granted the **IAM Security Reviewer** role (`roles/iam.securityReviewer`):
+
+```bash
+# Grant Security Reviewer at the project level
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:$SA_HUB" \
+  --role="roles/iam.securityReviewer" \
+  --quiet
+
+# (Optional) For multi-project or organization-wide SAs, grant at the org level instead:
+# export ORG_ID="your-gcp-organization-id"
+# gcloud organizations add-iam-policy-binding $ORG_ID \
+#   --member="serviceAccount:$SA_HUB" \
+#   --role="roles/iam.securityReviewer"
+```
+
+Without this permission, Policy Troubleshooter checks will fail with a `PermissionDenied` error, which results in a **fail-closed** denial of service account assignment in Scion.
+
+### 2f. Transport SA — IAP Access
 
 The transport SA's identity is used in the IAP token. IAP must allow this identity to access
 the Hub:
@@ -418,7 +440,7 @@ gcloud run services add-iam-policy-binding scion-hub \
 Make sure your deployer identity has `roles/run.admin` before running this, as it modifies service-level IAM.
 :::
 
-### 2f. Discord Runner SA — IAP Access
+### 2g. Discord Runner SA — IAP Access
 
 The Discord service calls Hub APIs through IAP (for registration, message routing, etc.):
 
@@ -438,7 +460,7 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
   --quiet
 ```
 
-### 2g. GKE Workload Identity — Agent Pod Secret Access
+### 2h. GKE Workload Identity — Agent Pod Secret Access
 
 Agent pods need Workload Identity (WI) bindings to access Secret Manager for CSI-mounted
 secrets:
@@ -506,6 +528,7 @@ gcloud projects get-iam-policy $PROJECT_ID \
 | `scion-hub-runner` | `roles/container.developer` | Project | GKE agent dispatch |
 | `scion-hub-runner` | `roles/iam.serviceAccountTokenCreator` | **On itself** | Generate GCS signed URLs |
 | `scion-hub-runner` | `roles/iam.serviceAccountTokenCreator` | **On `scion-transport` SA** | Mint IAP tokens for agents |
+| `scion-hub-runner` | `roles/iam.securityReviewer` | Project/Org | Policy Troubleshooter (Optional, for SA assignment gates) |
 | `scion-transport` | `roles/iap.httpsResourceAccessor` | Project | Allow IAP access to Hub |
 | `scion-transport` | `roles/run.invoker` | Hub service | Allow Cloud Run invocation |
 | `scion-discord-runner` | `roles/cloudsql.client` | Project | Cloud SQL connections |

--- a/docs-site/src/content/docs/hosted/ha/setup-gcp.md
+++ b/docs-site/src/content/docs/hosted/ha/setup-gcp.md
@@ -406,7 +406,7 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
 #   --role="roles/iam.securityReviewer"
 ```
 
-Without this permission, Policy Troubleshooter checks will fail with a `PermissionDenied` error, which results in a **fail-closed** denial of service account assignment in Scion.
+Without this permission, Policy Troubleshooter checks will return an indeterminate or unknown status (such as ACCESS_STATE_UNKNOWN_INFO_DENIED), which results in a **fail-closed** denial of service account assignment in Scion.
 
 ### 2f. Transport SA — IAP Access
 

--- a/docs-site/src/content/docs/local/agent-credentials.md
+++ b/docs-site/src/content/docs/local/agent-credentials.md
@@ -194,6 +194,14 @@ scion start --harness claude my-agent
 **Hub Setup:**
 For Hub mode, the recommended approach is to assign a GCP Service Account to the agent at creation time.
 
+:::note[IAM-Gated Service Account Assignment]
+Binding a GCP Service Account to an agent on a Hub requires satisfying two authorization gates:
+1. **Hub Authorization**: The caller must have `ActionAssign` on the service account resource inside Scion.
+2. **GCP IAM Authorization**: If the Hub is configured with `gcp_iam_check_mode: enforce`, binding requires the caller to have Google Cloud's `iam.serviceAccounts.actAs` permission on the target service account. The Hub queries Google's **Policy Troubleshooter API v3** to evaluate this.
+   - If Policy Troubleshooter is unable to reach a decision (due to unknown conditions, or missing Hub reviewer permissions), the check **fails closed** and assignment is denied.
+   - Results are cached (60s TTL for allows, 10s TTL for denies) to optimize performance.
+:::
+
 Alternatively, to use an ADC file secret:
 ```bash
 # 1. Upload the ADC credential file (written to ~/.config/gcloud/application_default_credentials.json in container)

--- a/docs-site/src/content/docs/local/agent-credentials.md
+++ b/docs-site/src/content/docs/local/agent-credentials.md
@@ -198,7 +198,7 @@ For Hub mode, the recommended approach is to assign a GCP Service Account to the
 Binding a GCP Service Account to an agent on a Hub requires satisfying two authorization gates:
 1. **Hub Authorization**: The caller must have `ActionAssign` on the service account resource inside Scion.
 2. **GCP IAM Authorization**: If the Hub is configured with `gcp_iam_check_mode: enforce`, binding requires the caller to have Google Cloud's `iam.serviceAccounts.actAs` permission on the target service account. The Hub queries Google's **Policy Troubleshooter API v3** to evaluate this.
-   - If Policy Troubleshooter is unable to reach a decision (due to unknown conditions, or missing Hub reviewer permissions), the check **fails closed** and assignment is denied.
+   - If Policy Troubleshooter is unable to reach a decision (due to unknown conditions, or missing Hub reviewer permissions), the check by default fails open if the allow policy is granted, but can be configured to fail closed via gcp_iam_deny_unknown_policy.
    - Results are cached (60s TTL for allows, 10s TTL for denies) to optimize performance.
 :::
 

--- a/docs-site/src/content/docs/reference/security.md
+++ b/docs-site/src/content/docs/reference/security.md
@@ -87,6 +87,18 @@ Scion implements a robust, hierarchical RBAC (Role-Based Access Control) and pol
 - **Actions**: Standardized CRUD actions (`create`, `read`, `update`, `delete`, `list`) plus resource-specific actions (`start`, `stop`, `attach`, `message`).
 - **Lattice-Based Agent Authorization**: Agents are assigned tiered roles (`none`, `readonly`, `baseline`, `full`) that restrict their JWT scopes via a two-gate authority lattice.
 
+### 3.3 GCP Service Account Assignment Gates
+
+To prevent lateral privilege escalation, Scion implements a strict two-layer delegation check when binding a GCP service account to any agent:
+- **Layer 1: Scion Hub Policy**: The Hub's policy engine checks if the caller holds the `ActionAssign` permission on the target GCP service account resource within Scion.
+- **Layer 2: GCP IAM (`actAs`)**: When `gcp_iam_check_mode` is set to `"enforce"`, the Hub performs an out-of-band call via Google's **Policy Troubleshooter v3 API** to verify that the caller's GCP principal possesses `iam.serviceAccounts.actAs` permission on the target service account.
+
+Key security attributes of the GCP IAM check include:
+- **Fail-Closed Design**: If the Policy Troubleshooter returns an indeterminate result (due to conditional bindings or insufficient Hub reviewer permissions), the check fails closed, and assignment is blocked. There is no fallback to insecure alternatives like `getIamPolicy`.
+- **Asymmetric Caching**: Approved assignments are cached for **60 seconds**, and denials are cached for **10 seconds**. Indeterminate or error states are never cached.
+- **Auditing**: Every service account assignment check—both allowed and denied—generates a permanent audit log entry detailing the principal, target service account, and Policy Troubleshooter decision.
+- **Hub-Scoped SAs**: Real hub-scoped service accounts can be assigned across projects. However, to prevent privilege bypasses, hub-scoped assignments are immediately rejected if `gcp_iam_check_mode` is not set to `"enforce"`.
+
 ## 4. Secret Management
 
 Scion provides a typed, scope-aware secret management system. Secret values are never stored in plaintext in the Hub database. For a user-facing guide, see [Secret Management](/scion/hosted/user/secrets/).

--- a/docs-site/src/content/docs/reference/security.md
+++ b/docs-site/src/content/docs/reference/security.md
@@ -94,7 +94,7 @@ To prevent lateral privilege escalation, Scion implements a strict two-layer del
 - **Layer 2: GCP IAM (`actAs`)**: When `gcp_iam_check_mode` is set to `"enforce"`, the Hub performs an out-of-band call via Google's **Policy Troubleshooter v3 API** to verify that the caller's GCP principal possesses `iam.serviceAccounts.actAs` permission on the target service account.
 
 Key security attributes of the GCP IAM check include:
-- **Fail-Closed Design**: If the Policy Troubleshooter returns an indeterminate result (due to conditional bindings or insufficient Hub reviewer permissions), the check fails closed, and assignment is blocked. There is no fallback to insecure alternatives like `getIamPolicy`.
+- **Fail-Closed Design**: If the Policy Troubleshooter returns an indeterminate result (due to conditional bindings, or due to insufficient Hub reviewer permissions when configured to fail-closed), the check fails closed and assignment is blocked. There is no fallback to insecure alternatives like getIamPolicy.
 - **Asymmetric Caching**: Approved assignments are cached for **60 seconds**, and denials are cached for **10 seconds**. Indeterminate or error states are never cached.
 - **Auditing**: Every service account assignment check—both allowed and denied—generates a permanent audit log entry detailing the principal, target service account, and Policy Troubleshooter decision.
 - **Hub-Scoped SAs**: Real hub-scoped service accounts can be assigned across projects. However, to prevent privilege bypasses, hub-scoped assignments are immediately rejected if `gcp_iam_check_mode` is not set to `"enforce"`.

--- a/docs-site/src/content/docs/reference/server-config.md
+++ b/docs-site/src/content/docs/reference/server-config.md
@@ -55,7 +55,8 @@ Controls the central Hub API server.
 | `host` | string | `"0.0.0.0"` | Network interface to bind to. |
 | `public_url` | string | | The externally accessible URL of the Hub (used for callbacks). |
 | `gcp_project_id` | string | | GCP project ID used for minting GCP Service Accounts. Auto-detected if running on GCE/Cloud Run. |
-| `gcp_iam_check_mode` | string | `"off"` | Controls IAM `actAs` permission checking for SA assignment: `"off"` (no check) or `"enforce"` (Policy Troubleshooter checks). See [GCP IAM Check Mode](#gcp-iam-check-mode). |
+| `gcp_iam_check_mode` | string | `"off"` | Controls whether IAM `actAs` permission is checked when binding a GCP service account to an agent. Supported values: `"off"` (no check; default) or `"enforce"` (uses Policy Troubleshooter to enforce `iam.serviceAccounts.actAs`). See the security/permissions reference for details on roles and caches. |
+| `gcp_iam_deny_unknown_policy` | string | `"fail-open"` | Behavior when Policy Troubleshooter cannot evaluate deny policies (e.g. if the Hub lacks org-level reviewer roles). Supported values: `"fail-open"` (allow if no explicit deny is found; default) or `"fail-closed"` (treat as indeterminate and deny). |
 | `read_timeout` | duration | `"30s"` | HTTP read timeout. |
 | `write_timeout` | duration | `"60s"` | HTTP write timeout. |
 | `admin_emails` | list | `[]` | List of emails granted super-admin access. |
@@ -271,6 +272,8 @@ All server settings can be overridden via environment variables using the `SCION
 **Examples:**
 - `server.hub.port` -> `SCION_SERVER_HUB_PORT`
 - `server.hub.gcp_project_id` -> `SCION_SERVER_HUB_GCPPROJECTID`
+- `server.hub.gcp_iam_check_mode` -> `SCION_SERVER_HUB_GCPIAMCHECKMODE`
+- `server.hub.gcp_iam_deny_unknown_policy` -> `SCION_SERVER_HUB_GCPIAMDENYUNKNOWNPOLICY`
 - `server.broker.enabled` -> `SCION_SERVER_BROKER_ENABLED`
 - `server.broker.container_hub_endpoint` -> `SCION_SERVER_BROKER_CONTAINERHUBENDPOINT`
 - `server.database.url` -> `SCION_SERVER_DATABASE_URL`


### PR DESCRIPTION
## Summary

Comprehensive documentation for PR #1034 — GCP service account IAM authorization gates.

- Two-layer SA assignment gate: Scion policy + GCP IAM (actAs via Policy Troubleshooter)
- New config fields: gcp_iam_check_mode, gcp_iam_deny_unknown_policy
- Hub-scoped SAs, passthrough security, minting permissions
- IAM Security Reviewer role requirements for Policy Troubleshooter
- Cache behavior, fail-closed semantics, Web UI integration

5 files changed, 123 insertions, 4 deletions.
