### PR TITLE
fix(teams): use broker endpoint for project listing and require registration before setup

### DIFF
--- a/extras/scion-teams/go.mod
+++ b/extras/scion-teams/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/hashicorp/go-plugin v1.7.0
 	github.com/jackc/pgx/v5 v5.9.2
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.84.0-dev.0.20260723093437-b6eac429d7b6
 	modernc.org/sqlite v1.56.0
@@ -24,6 +25,7 @@ require (
 	cloud.google.com/go/logging v1.13.2 // indirect
 	cloud.google.com/go/longrunning v1.0.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
+	cloud.google.com/go/policytroubleshooter v1.11.7 // indirect
 	cloud.google.com/go/secretmanager v1.16.0 // indirect
 	cloud.google.com/go/storage v1.59.1 // indirect
 	entgo.io/ent v0.14.5 // indirect
@@ -102,7 +104,6 @@ require (
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mattn/go-runewidth v0.0.24 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect

--- a/extras/scion-teams/go.sum
+++ b/extras/scion-teams/go.sum
@@ -20,6 +20,8 @@ cloud.google.com/go/longrunning v1.0.0 h1:lwzWEYD8+NkYV7dhexOz6kmlvajZA70+bW/xMh
 cloud.google.com/go/longrunning v1.0.0/go.mod h1:8nqFBPOO1U/XkhWl0I19AMZEphrHi73VNABIpKYaTwM=
 cloud.google.com/go/monitoring v1.24.3 h1:dde+gMNc0UhPZD1Azu6at2e79bfdztVDS5lvhOdsgaE=
 cloud.google.com/go/monitoring v1.24.3/go.mod h1:nYP6W0tm3N9H/bOw8am7t62YTzZY+zUeQ+Bi6+2eonI=
+cloud.google.com/go/policytroubleshooter v1.11.7 h1:Bbj1EiVh96u9mfO2p+JNoHrvvyC0Ms6zP+vxqQnsaG8=
+cloud.google.com/go/policytroubleshooter v1.11.7/go.mod h1:JP/aQ+bUkt4Gz6lQXBi/+A/6nyNRZ0Pvxui5Xl9ieyk=
 cloud.google.com/go/secretmanager v1.16.0 h1:19QT7ZsLJ8FSP1k+4esQvuCD7npMJml6hYzilxVyT+k=
 cloud.google.com/go/secretmanager v1.16.0/go.mod h1://C/e4I8D26SDTz1f3TQcddhcmiC3rMEl0S1Cakvs3Q=
 cloud.google.com/go/storage v1.59.1 h1:DXAZLcTimtiXdGqDSnebROVPd9QvRsFVVlptz02Wk58=

--- a/extras/scion-teams/internal/teams/commands.go
+++ b/extras/scion-teams/internal/teams/commands.go
@@ -225,7 +225,7 @@ func (h *CommandHandler) handleSetup(ctx context.Context, activity *Activity, ar
 
 // completeSetup finishes the setup process by creating the channel link.
 func (h *CommandHandler) completeSetup(ctx context.Context, activity *Activity, projectSlug string) error {
-	store := h.broker.store
+	store := h.getStore()
 	if store == nil {
 		return h.sendReply(ctx, activity, "Setup failed: store not initialized.")
 	}
@@ -302,7 +302,7 @@ func (h *CommandHandler) completeSetup(ctx context.Context, activity *Activity, 
 // handleUnlink removes the channel link for the current conversation.
 // Only the user who created the link is allowed to unlink it.
 func (h *CommandHandler) handleUnlink(ctx context.Context, activity *Activity) error {
-	store := h.broker.store
+	store := h.getStore()
 	if store == nil {
 		return h.sendReply(ctx, activity, "Unlink failed: store not initialized.")
 	}
@@ -364,7 +364,7 @@ func (h *CommandHandler) handleAgents(ctx context.Context, activity *Activity) e
 	}
 
 	// Cache agent slugs in store.
-	store := h.broker.store
+	store := h.getStore()
 	if store != nil {
 		slugs := make([]string, len(agents))
 		for i, a := range agents {
@@ -551,7 +551,7 @@ func (h *CommandHandler) handleRegister(ctx context.Context, activity *Activity)
 	}
 
 	// Check if already linked.
-	store := h.broker.store
+	store := h.getStore()
 	if store != nil {
 		existing, err := store.GetUserMapping(ctx, teamsUserID)
 		if err != nil {
@@ -676,9 +676,7 @@ func (h *CommandHandler) pollForConfirmation(ctx context.Context, activity *Acti
 
 			if status == "confirmed" && userID != "" {
 				// Save user mapping.
-				h.broker.mu.Lock()
-				store := h.broker.store
-				h.broker.mu.Unlock()
+				store := h.getStore()
 
 				if store != nil {
 					mapping := &TeamsUserMapping{
@@ -720,7 +718,7 @@ func (h *CommandHandler) handleUnregister(ctx context.Context, activity *Activit
 		return h.sendReply(ctx, activity, "Could not determine your Teams user ID. Please try again.")
 	}
 
-	store := h.broker.store
+	store := h.getStore()
 	if store == nil {
 		return h.sendReply(ctx, activity, "Store not initialized. Cannot unregister.")
 	}
@@ -791,7 +789,7 @@ func (h *CommandHandler) getStore() Store {
 // resolveChannelLink looks up the channel link for the current conversation.
 // Returns an error (with a reply sent to the user) if not linked.
 func (h *CommandHandler) resolveChannelLink(ctx context.Context, activity *Activity) (*ChannelLink, error) {
-	store := h.broker.store
+	store := h.getStore()
 	if store == nil {
 		_ = h.sendReply(ctx, activity, "Store not initialized.")
 		return nil, fmt.Errorf("store not initialized")

--- a/extras/scion-teams/internal/teams/commands.go
+++ b/extras/scion-teams/internal/teams/commands.go
@@ -118,7 +118,7 @@ func (h *CommandHandler) handleSetup(ctx context.Context, activity *Activity, ar
 	conversationID := activity.Conversation.ID
 
 	// Check if already linked.
-	store := h.broker.store
+	store := h.getStore()
 	if store != nil {
 		existing, err := store.GetChannelLink(ctx, conversationID)
 		if err != nil {
@@ -130,13 +130,54 @@ func (h *CommandHandler) handleSetup(ctx context.Context, activity *Activity, ar
 		}
 	}
 
+	// Check if user is registered.
+	teamsUserID := activity.From.AadObjectID
+	if teamsUserID == "" {
+		teamsUserID = activity.From.ID
+	}
+	var mapping *TeamsUserMapping
+	if store != nil {
+		var err error
+		mapping, err = store.GetUserMapping(ctx, teamsUserID)
+		if err != nil {
+			h.log.Warn("Error checking user mapping", "error", err)
+		}
+	}
+	if mapping == nil {
+		return h.sendReply(ctx, activity, "Please link your Teams account first with the `register` command.")
+	}
+
 	if len(args) > 0 {
 		// Direct setup with project slug.
 		projectSlug := args[0]
 		return h.completeSetup(ctx, activity, projectSlug)
 	}
 
-	// No project specified — send a card asking for the project slug.
+	// Get projects - try user-scoped first, then fall back to broker endpoint.
+	hubClient := h.broker.hubClient
+	var projects []ProjectOption
+	if hubClient != nil {
+		if mapping.ScionUserID != "" {
+			var err error
+			projects, err = hubClient.ListProjectsForUser(ctx, mapping.ScionUserID)
+			if err != nil {
+				h.log.Warn("Failed to list user projects", "error", err, "user_id", mapping.ScionUserID)
+			}
+		}
+		if len(projects) == 0 {
+			var err error
+			projects, err = hubClient.ListProjects(ctx)
+			if err != nil {
+				h.log.Warn("Failed to list projects from hub", "error", err)
+			}
+		}
+	}
+
+	if len(projects) == 0 {
+		return h.sendReply(ctx, activity, "No projects found. Create a project in the hub first.")
+	}
+
+	// Build Adaptive Card with project buttons.
 	card := NewAdaptiveCard()
 	card.Body = append(card.Body,
 		TextBlock{
@@ -147,52 +188,39 @@ func (h *CommandHandler) handleSetup(ctx context.Context, activity *Activity, ar
 		},
 		TextBlock{
 			Type:     "TextBlock",
-			Text:     "Enter the project slug or name to link this conversation.",
+			Text:     "Select a project to link this conversation.",
 			Wrap:     true,
+			IsSubtle: true,
+		},
+		TextBlock{
+			Type:     "TextBlock",
+			Text:     "Available projects:",
+			Weight:   "Bolder",
 			IsSubtle: true,
 		},
 	)
 
-	// If hub client is available, try to list projects.
-	hubClient := h.broker.hubClient
-	if hubClient != nil {
-		projects, err := hubClient.ListProjects(ctx)
-		if err != nil {
-			h.log.Warn("Failed to list projects from hub", "error", err)
-		} else if len(projects) > 0 {
-			card.Body = append(card.Body, TextBlock{
-				Type:     "TextBlock",
-				Text:     "Available projects:",
-				Weight:   "Bolder",
-				IsSubtle: true,
-			})
-
-			// Add submit buttons for each project (up to 6 to keep card manageable).
-			maxProjects := 6
-			if len(projects) < maxProjects {
-				maxProjects = len(projects)
-			}
-			for _, p := range projects[:maxProjects] {
-				displayName := p.Slug
-				if p.Name != "" && p.Name != p.Slug {
-					displayName = fmt.Sprintf("%s (%s)", p.Name, p.Slug)
-				}
-				card.Actions = append(card.Actions, ActionSubmit{
-					Type:  "Action.Submit",
-					Title: displayName,
-					Data: map[string]string{
-						"action":       "setup_confirm",
-						"project_slug": p.Slug,
-						"project_id":   p.ID,
-					},
-				})
-			}
-			return h.sendCardReply(ctx, activity, card)
-		}
+	// Add submit buttons for each project (up to 6 to keep card manageable).
+	maxProjects := 6
+	if len(projects) < maxProjects {
+		maxProjects = len(projects)
 	}
-
-	// Fallback: prompt user to type the project slug.
-	return h.sendReply(ctx, activity, "Please run `setup <project-slug>` with the project slug you want to link.")
+	for _, p := range projects[:maxProjects] {
+		displayName := p.Slug
+		if p.Name != "" && p.Name != p.Slug {
+			displayName = fmt.Sprintf("%s (%s)", p.Name, p.Slug)
+		}
+		card.Actions = append(card.Actions, ActionSubmit{
+			Type:  "Action.Submit",
+			Title: displayName,
+			Data: map[string]string{
+				"action":       "setup_confirm",
+				"project_slug": p.Slug,
+				"project_id":   p.ID,
+			},
+		})
+	}
+	return h.sendCardReply(ctx, activity, card)
 }
 
 // completeSetup finishes the setup process by creating the channel link.
@@ -748,6 +776,14 @@ func (h *CommandHandler) handleHelp(ctx context.Context, activity *Activity) err
 	}
 
 	return h.sendCardReply(ctx, activity, card)
+}
+
+// getStore returns the broker's store under the broker mutex.
+func (h *CommandHandler) getStore() Store {
+	h.broker.mu.Lock()
+	store := h.broker.store
+	h.broker.mu.Unlock()
+	return store
 }
 
 // --- Helpers ---

--- a/extras/scion-teams/internal/teams/commands_test.go
+++ b/extras/scion-teams/internal/teams/commands_test.go
@@ -210,10 +210,10 @@ func TestCommandDispatch_StripsBotMention(t *testing.T) {
 }
 
 func TestSetupCommand_WithProjectSlug(t *testing.T) {
-	// Mock hub that returns projects.
+	// Mock hub that returns projects via the broker endpoint.
 	hubHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/api/v1/projects":
+		case r.URL.Path == "/api/v1/broker/projects":
 			json.NewEncoder(w).Encode(hubProjectsResponse{
 				Projects: []hubProject{
 					{ID: "proj-1", Name: "My Project", Slug: "my-project"},
@@ -227,14 +227,24 @@ func TestSetupCommand_WithProjectSlug(t *testing.T) {
 	broker, ms := testBrokerWithStore(t, hubHandler)
 	handler := broker.commandHandler
 
+	// Pre-create a user mapping (registration required before setup).
+	err := broker.store.CreateUserMapping(context.Background(), &TeamsUserMapping{
+		TeamsUserID:      "aad-user-1",
+		TeamsDisplayName: "Test User",
+		ScionUserID:      "scion-1",
+		ScionEmail:       "user@example.com",
+		LinkedAt:         time.Now(),
+	})
+	require.NoError(t, err)
+
 	activity := testActivity("setup my-project")
-	handled, err := handler.Handle(context.Background(), activity)
+	handled, cmdErr := handler.Handle(context.Background(), activity)
 	assert.True(t, handled)
-	assert.NoError(t, err)
+	assert.NoError(t, cmdErr)
 
 	// Verify channel link was created.
-	link, err := broker.store.GetChannelLink(context.Background(), "conv-1")
-	require.NoError(t, err)
+	link, lookupErr := broker.store.GetChannelLink(context.Background(), "conv-1")
+	require.NoError(t, lookupErr)
 	require.NotNil(t, link)
 	assert.Equal(t, "my-project", link.ProjectSlug)
 	assert.Equal(t, "proj-1", link.ProjectID)
@@ -269,6 +279,44 @@ func TestSetupCommand_AlreadyLinked(t *testing.T) {
 }
 
 func TestSetupCommand_NoSlug(t *testing.T) {
+	// Mock hub that returns projects via the broker endpoint.
+	hubHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/broker/projects":
+			json.NewEncoder(w).Encode(hubProjectsResponse{
+				Projects: []hubProject{
+					{ID: "proj-1", Name: "My Project", Slug: "my-project"},
+				},
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	broker, ms := testBrokerWithStore(t, hubHandler)
+	handler := broker.commandHandler
+
+	// Pre-create a user mapping (registration required before setup).
+	err := broker.store.CreateUserMapping(context.Background(), &TeamsUserMapping{
+		TeamsUserID:      "aad-user-1",
+		TeamsDisplayName: "Test User",
+		ScionUserID:      "scion-1",
+		ScionEmail:       "user@example.com",
+		LinkedAt:         time.Now(),
+	})
+	require.NoError(t, err)
+
+	activity := testActivity("setup")
+	handled, cmdErr := handler.Handle(context.Background(), activity)
+	assert.True(t, handled)
+	assert.NoError(t, cmdErr)
+
+	// Should send a card with project buttons.
+	require.NotEmpty(t, ms.sent)
+	assert.NotEmpty(t, ms.sent[0].Attachments, "expected an Adaptive Card reply with project buttons")
+}
+
+func TestSetupCommand_NotRegistered(t *testing.T) {
 	broker, ms := testBrokerWithStore(t, nil)
 	handler := broker.commandHandler
 
@@ -277,8 +325,9 @@ func TestSetupCommand_NoSlug(t *testing.T) {
 	assert.True(t, handled)
 	assert.NoError(t, err)
 
-	// Should send a reply (either card with projects or plain text prompt).
-	assert.NotEmpty(t, ms.sent)
+	// Should tell user to register first.
+	require.NotEmpty(t, ms.sent)
+	assert.Contains(t, ms.sent[0].Text, "register")
 }
 
 func TestUnlinkCommand(t *testing.T) {

--- a/extras/scion-teams/internal/teams/hubclient.go
+++ b/extras/scion-teams/internal/teams/hubclient.go
@@ -260,7 +260,7 @@ func (c *HubClient) ListProjects(ctx context.Context) ([]ProjectOption, error) {
 // ListProjectsForUser returns projects owned by or associated with a specific user.
 // GET /api/v1/projects?ownerId=<ownerID>
 func (c *HubClient) ListProjectsForUser(ctx context.Context, ownerID string) ([]ProjectOption, error) {
-	u := c.hubURL + "/api/v1/projects?ownerId=" + ownerID
+	u := c.hubURL + "/api/v1/projects?ownerId=" + url.QueryEscape(ownerID)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {

--- a/extras/scion-teams/internal/teams/hubclient.go
+++ b/extras/scion-teams/internal/teams/hubclient.go
@@ -222,9 +222,9 @@ func (c *HubClient) ListAgents(ctx context.Context, projectID string) ([]AgentIn
 }
 
 // ListProjects returns all projects visible to the broker.
-// GET /api/v1/projects
+// GET /api/v1/broker/projects
 func (c *HubClient) ListProjects(ctx context.Context) ([]ProjectOption, error) {
-	u := c.hubURL + "/api/v1/projects"
+	u := c.hubURL + "/api/v1/broker/projects"
 
 	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
@@ -248,6 +248,42 @@ func (c *HubClient) ListProjects(ctx context.Context) ([]ProjectOption, error) {
 	var result hubProjectsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("decode list projects response: %w", err)
+	}
+
+	projects := make([]ProjectOption, len(result.Projects))
+	for i, p := range result.Projects {
+		projects[i] = ProjectOption{ID: p.ID, Name: p.Name, Slug: p.Slug}
+	}
+	return projects, nil
+}
+
+// ListProjectsForUser returns projects owned by or associated with a specific user.
+// GET /api/v1/projects?ownerId=<ownerID>
+func (c *HubClient) ListProjectsForUser(ctx context.Context, ownerID string) ([]ProjectOption, error) {
+	u := c.hubURL + "/api/v1/projects?ownerId=" + ownerID
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create list user projects request: %w", err)
+	}
+	if err := c.signRequest(req); err != nil {
+		return nil, fmt.Errorf("sign request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list user projects request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		return nil, fmt.Errorf("list user projects returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result hubProjectsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode list user projects response: %w", err)
 	}
 
 	projects := make([]ProjectOption, len(result.Projects))


### PR DESCRIPTION
## Summary

- Switch ListProjects from /api/v1/projects (authz-filtered, empty for broker identities) to /api/v1/broker/projects (dedicated broker endpoint, bypasses authz)
- Add ListProjectsForUser for owner-scoped project queries, matching Discord's setup flow
- Require user registration before setup command (like Discord)
- Add getStore() helper for mutex-safe store access
- Also includes registration polling, Close() lifecycle, and CheckTeamsLinkStatus email return (rebased on main after PR #1129 merge)

## Root Cause

The hub authz service has no case for broker identity type in precomputeForIdentity, so all projects were filtered out when calling /api/v1/projects. The /api/v1/broker/projects endpoint (already used by Discord) skips authz and returns all projects.

## Test plan

- [x] go test ./... -race passes
- [x] go build ./... clean
- [x] TestSetupCommand_WithProjectSlug updated for broker endpoint + registration
- [x] TestSetupCommand_NoSlug updated for broker endpoint + registration  
- [x] TestSetupCommand_NotRegistered added
- [ ] Deploy to scion-gteam and verify setup shows project picker card