### PR TITLE
feat(web-chat): add chat thread core components (Phase 2)

### DIFF
--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -1090,22 +1090,19 @@ export class ScionPageAgentDetail extends LitElement {
           </sl-radio-button>
         </sl-radio-group>
       </div>
-      ${this.chatViewActive
-        ? html`
-            <scion-chat-thread
-              agentId=${this.agentId}
-              agentName=${agent.name || ''}
-              ?canSend=${can(agent._capabilities, 'message')}
-            ></scion-chat-thread>
-          `
-        : html`
-            <scion-agent-message-viewer
-              agentId=${this.agentId}
-              agentName=${agent.name || ''}
-              ?canSend=${can(agent._capabilities, 'message')}
-              ?cloudLogging=${agent.cloudLogging || false}
-            ></scion-agent-message-viewer>
-          `}
+      <scion-chat-thread
+        agentId=${this.agentId}
+        agentName=${agent.name || ''}
+        ?canSend=${can(agent._capabilities, 'message')}
+        style="display: ${this.chatViewActive ? '' : 'none'}"
+      ></scion-chat-thread>
+      <scion-agent-message-viewer
+        agentId=${this.agentId}
+        agentName=${agent.name || ''}
+        ?canSend=${can(agent._capabilities, 'message')}
+        ?cloudLogging=${agent.cloudLogging || false}
+        style="display: ${this.chatViewActive ? 'none' : ''}"
+      ></scion-agent-message-viewer>
     `;
   }
 

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -56,6 +56,9 @@ import '../shared/agent-log-viewer.js';
 import type { ScionAgentLogViewer } from '../shared/agent-log-viewer.js';
 import '../shared/agent-message-viewer.js';
 import type { ScionAgentMessageViewer } from '../shared/agent-message-viewer.js';
+import '../shared/chat/chat-thread.js';
+import type { ScionChatThread } from '../shared/chat/chat-thread.js';
+import { isFeatureEnabled } from '../../utils/feature-flags.js';
 import '../shared/hash-display.js';
 import '../shared/quick-message-dialog.js';
 import { showToast } from '../../utils/toast.js';
@@ -142,6 +145,15 @@ export class ScionPageAgentDetail extends LitElement {
 
   @state()
   private quickMessageOpen = false;
+
+  /** Whether the Chat|Log toggle is in "chat" mode (vs "log" mode). */
+  @state()
+  private chatViewActive = true;
+
+  /** Whether the native chat feature flag is enabled. */
+  private get nativeChatEnabled(): boolean {
+    return isFeatureEnabled('web.native_chat');
+  }
 
   @state()
   private metricsSummary: AgentMetricsSummary | null = null;
@@ -935,10 +947,37 @@ export class ScionPageAgentDetail extends LitElement {
       viewer?.loadLogs();
     }
     if (e.detail.name === 'messages') {
-      const viewer = this.shadowRoot?.querySelector(
-        'scion-agent-message-viewer'
-      ) as ScionAgentMessageViewer | null;
-      viewer?.loadMessages();
+      if (this.nativeChatEnabled && this.chatViewActive) {
+        const chatThread = this.shadowRoot?.querySelector(
+          'scion-chat-thread'
+        ) as ScionChatThread | null;
+        chatThread?.loadHistory();
+      } else {
+        const viewer = this.shadowRoot?.querySelector(
+          'scion-agent-message-viewer'
+        ) as ScionAgentMessageViewer | null;
+        viewer?.loadMessages();
+      }
+    }
+  }
+
+  private handleMessageViewToggle(mode: 'chat' | 'log'): void {
+    this.chatViewActive = mode === 'chat';
+    // Trigger load for the newly active view
+    if (this.chatViewActive) {
+      this.updateComplete.then(() => {
+        const chatThread = this.shadowRoot?.querySelector(
+          'scion-chat-thread'
+        ) as ScionChatThread | null;
+        chatThread?.loadHistory();
+      });
+    } else {
+      this.updateComplete.then(() => {
+        const viewer = this.shadowRoot?.querySelector(
+          'scion-agent-message-viewer'
+        ) as ScionAgentMessageViewer | null;
+        viewer?.loadMessages();
+      });
     }
   }
 
@@ -996,12 +1035,7 @@ export class ScionPageAgentDetail extends LitElement {
           ></scion-agent-log-viewer>
         </sl-tab-panel>
         <sl-tab-panel name="messages">
-          <scion-agent-message-viewer
-            agentId=${this.agentId}
-            agentName=${this.agent.name || ''}
-            ?canSend=${can(this.agent._capabilities, 'message')}
-            ?cloudLogging=${this.agent.cloudLogging || false}
-          ></scion-agent-message-viewer>
+          ${this.renderMessagesPanel()}
         </sl-tab-panel>
         <sl-tab-panel name="configuration">${this.renderConfigurationTab()}</sl-tab-panel>
       </sl-tab-group>
@@ -1012,6 +1046,66 @@ export class ScionPageAgentDetail extends LitElement {
         ?open=${this.quickMessageOpen}
         @sl-request-close=${() => { this.quickMessageOpen = false; }}
       ></scion-quick-message-dialog>
+    `;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Messages Panel (Chat | Log toggle)
+  // ---------------------------------------------------------------------------
+
+  private renderMessagesPanel() {
+    const agent = this.agent!;
+
+    // When the feature flag is off, render exactly the existing message viewer
+    // (AC9 — byte-for-byte current Messages tab behaviour).
+    if (!this.nativeChatEnabled) {
+      return html`
+        <scion-agent-message-viewer
+          agentId=${this.agentId}
+          agentName=${agent.name || ''}
+          ?canSend=${can(agent._capabilities, 'message')}
+          ?cloudLogging=${agent.cloudLogging || false}
+        ></scion-agent-message-viewer>
+      `;
+    }
+
+    // Feature flag ON: show Chat|Log toggle, default to Chat
+    return html`
+      <div style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem;">
+        <sl-radio-group
+          value=${this.chatViewActive ? 'chat' : 'log'}
+          size="small"
+          @sl-change=${(e: Event) => {
+            const value = (e.target as HTMLInputElement).value as 'chat' | 'log';
+            this.handleMessageViewToggle(value);
+          }}
+        >
+          <sl-radio-button value="chat">
+            <sl-icon slot="prefix" name="chat-dots" style="font-size: 0.875rem"></sl-icon>
+            Chat
+          </sl-radio-button>
+          <sl-radio-button value="log">
+            <sl-icon slot="prefix" name="list-ul" style="font-size: 0.875rem"></sl-icon>
+            Log
+          </sl-radio-button>
+        </sl-radio-group>
+      </div>
+      ${this.chatViewActive
+        ? html`
+            <scion-chat-thread
+              agentId=${this.agentId}
+              agentName=${agent.name || ''}
+              ?canSend=${can(agent._capabilities, 'message')}
+            ></scion-chat-thread>
+          `
+        : html`
+            <scion-agent-message-viewer
+              agentId=${this.agentId}
+              agentName=${agent.name || ''}
+              ?canSend=${can(agent._capabilities, 'message')}
+              ?cloudLogging=${agent.cloudLogging || false}
+            ></scion-agent-message-viewer>
+          `}
     `;
   }
 

--- a/web/src/components/shared/chat/chat-composer.ts
+++ b/web/src/components/shared/chat/chat-composer.ts
@@ -1,0 +1,258 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Chat composer component.
+ *
+ * Textarea with:
+ * - Character counter (rune-aware via Intl.Segmenter where available)
+ * - 2000 character limit with visual feedback (AC10)
+ * - Defaults to plain: false (design section 4.7)
+ * - Sends via `chat-send` custom event: {text, plain, interrupt}
+ * - The composer knows nothing about the network
+ * - Send on Enter (Shift+Enter for newline)
+ * - Interrupt toggle
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+/** Maximum message length in rune count. */
+const MAX_MESSAGE_LENGTH = 2000;
+
+/** Event detail for the chat-send custom event. */
+export interface ChatSendDetail {
+  text: string;
+  plain: boolean;
+  interrupt: boolean;
+}
+
+/**
+ * Count "runes" (user-perceived characters) in a string.
+ * Uses Intl.Segmenter where available, falls back to spread length.
+ */
+function countRunes(text: string): number {
+  if (typeof Intl !== 'undefined' && 'Segmenter' in Intl) {
+    const segmenter = new Intl.Segmenter('en', { granularity: 'grapheme' });
+    let count = 0;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for (const _ of segmenter.segment(text)) count++;
+    return count;
+  }
+  // Fallback: spread into an array (handles surrogate pairs but not all grapheme clusters)
+  return [...text].length;
+}
+
+@customElement('scion-chat-composer')
+export class ScionChatComposer extends LitElement {
+  /** Whether the send button should be disabled (e.g. while sending). */
+  @property({ type: Boolean })
+  disabled = false;
+
+  @state() private text = '';
+  @state() private plain = false;
+  @state() private interrupt = false;
+  @state() private runeCount = 0;
+
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    .composer {
+      display: flex;
+      flex-direction: column;
+      gap: 0.375rem;
+      padding: 0.75rem 1rem;
+      border-top: 1px solid var(--scion-border, #e2e8f0);
+      background: var(--scion-surface, #ffffff);
+    }
+
+    .input-row {
+      display: flex;
+      align-items: flex-end;
+      gap: 0.5rem;
+    }
+
+    .textarea-wrapper {
+      flex: 1;
+      position: relative;
+    }
+
+    sl-textarea::part(base) {
+      font-size: 0.875rem;
+      border-radius: 0.75rem;
+    }
+
+    sl-textarea::part(textarea) {
+      resize: none;
+    }
+
+    .send-btn {
+      flex-shrink: 0;
+    }
+
+    .footer-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5rem;
+    }
+
+    .options {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .options label {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+      cursor: pointer;
+      white-space: nowrap;
+    }
+
+    .char-counter {
+      font-size: 0.6875rem;
+      color: var(--scion-text-muted, #64748b);
+      white-space: nowrap;
+    }
+
+    .char-counter.warn {
+      color: var(--scion-warning-600, #d97706);
+    }
+
+    .char-counter.over {
+      color: var(--scion-danger-600, #dc2626);
+      font-weight: 600;
+    }
+  `;
+
+  override render() {
+    const isOverLimit = this.runeCount > MAX_MESSAGE_LENGTH;
+    const isNearLimit = this.runeCount > MAX_MESSAGE_LENGTH * 0.9;
+    const canSend = this.text.trim().length > 0 && !isOverLimit && !this.disabled;
+
+    const counterClass = isOverLimit ? 'over' : isNearLimit ? 'warn' : '';
+
+    return html`
+      <div class="composer">
+        <div class="input-row">
+          <div class="textarea-wrapper">
+            <sl-textarea
+              placeholder="Send a message..."
+              size="small"
+              rows="1"
+              resize="auto"
+              .value=${this.text}
+              @sl-input=${this.handleInput}
+              @keydown=${this.handleKeydown}
+              ?disabled=${this.disabled}
+            ></sl-textarea>
+          </div>
+          <sl-button
+            class="send-btn"
+            size="small"
+            variant="primary"
+            ?disabled=${!canSend}
+            @click=${this.handleSend}
+          >
+            <sl-icon slot="prefix" name="send"></sl-icon>
+            Send
+          </sl-button>
+        </div>
+        <div class="footer-row">
+          <div class="options">
+            <label>
+              <sl-checkbox
+                size="small"
+                ?checked=${this.plain}
+                @sl-change=${this.handlePlainToggle}
+              ></sl-checkbox>
+              Plain
+            </label>
+            <label>
+              <sl-checkbox
+                size="small"
+                ?checked=${this.interrupt}
+                @sl-change=${this.handleInterruptToggle}
+              ></sl-checkbox>
+              Interrupt
+            </label>
+          </div>
+          ${this.runeCount > 0 || isNearLimit
+            ? html`
+                <span class="char-counter ${counterClass}">
+                  ${this.runeCount} / ${MAX_MESSAGE_LENGTH}
+                </span>
+              `
+            : nothing}
+        </div>
+      </div>
+    `;
+  }
+
+  private handleInput(e: Event): void {
+    const target = e.target as HTMLInputElement;
+    this.text = target.value;
+    this.runeCount = countRunes(this.text);
+  }
+
+  private handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      this.handleSend();
+    }
+  }
+
+  private handlePlainToggle(e: Event): void {
+    this.plain = (e.target as HTMLInputElement).checked;
+  }
+
+  private handleInterruptToggle(e: Event): void {
+    this.interrupt = (e.target as HTMLInputElement).checked;
+  }
+
+  private handleSend(): void {
+    const trimmed = this.text.trim();
+    if (!trimmed || this.runeCount > MAX_MESSAGE_LENGTH || this.disabled) return;
+
+    this.dispatchEvent(
+      new CustomEvent<ChatSendDetail>('chat-send', {
+        detail: {
+          text: trimmed,
+          plain: this.plain,
+          interrupt: this.interrupt,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+
+    // Clear the input after sending
+    this.text = '';
+    this.runeCount = 0;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-chat-composer': ScionChatComposer;
+  }
+}

--- a/web/src/components/shared/chat/chat-composer.ts
+++ b/web/src/components/shared/chat/chat-composer.ts
@@ -38,6 +38,7 @@ export interface ChatSendDetail {
   text: string;
   plain: boolean;
   interrupt: boolean;
+  onSuccess: () => void;
 }
 
 /**
@@ -215,7 +216,7 @@ export class ScionChatComposer extends LitElement {
   }
 
   private handleKeydown(e: KeyboardEvent): void {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
       e.preventDefault();
       this.handleSend();
     }
@@ -239,15 +240,15 @@ export class ScionChatComposer extends LitElement {
           text: trimmed,
           plain: this.plain,
           interrupt: this.interrupt,
+          onSuccess: () => {
+            this.text = '';
+            this.runeCount = 0;
+          },
         },
         bubbles: true,
         composed: true,
       })
     );
-
-    // Clear the input after sending
-    this.text = '';
-    this.runeCount = 0;
   }
 }
 

--- a/web/src/components/shared/chat/chat-message.ts
+++ b/web/src/components/shared/chat/chat-message.ts
@@ -79,6 +79,8 @@ export class ScionChatMessage extends LitElement {
   @state()
   private renderedHtml = '';
 
+  private renderTaskId = 0;
+
   static override styles = css`
     :host {
       display: block;
@@ -366,28 +368,28 @@ export class ScionChatMessage extends LitElement {
     if (changed.has('body') || changed.has('plain')) {
       void this.renderContent();
     }
-    this.injectCopyButtons();
+    if (changed.has('renderedHtml')) {
+      this.injectCopyButtons();
+    }
   }
 
   /** Inject copy buttons on all code blocks inside rendered markdown. */
   private injectCopyButtons(): void {
-    this.updateComplete.then(() => {
-      this.shadowRoot?.querySelectorAll('.md-content pre').forEach((pre) => {
-        if (pre.querySelector('.copy-btn')) return;
-        const btn = document.createElement('button');
-        btn.className = 'copy-btn';
-        btn.textContent = 'Copy';
-        btn.addEventListener('click', () => {
-          const code =
-            pre.querySelector('code')?.textContent ?? pre.textContent ?? '';
-          navigator.clipboard.writeText(code);
-          btn.textContent = 'Copied!';
-          setTimeout(() => {
-            btn.textContent = 'Copy';
-          }, 1500);
-        });
-        pre.appendChild(btn);
+    this.shadowRoot?.querySelectorAll('.md-content pre').forEach((pre) => {
+      if (pre.querySelector('.copy-btn')) return;
+      const btn = document.createElement('button');
+      btn.className = 'copy-btn';
+      btn.textContent = 'Copy';
+      btn.addEventListener('click', () => {
+        const code =
+          pre.querySelector('code')?.textContent ?? pre.textContent ?? '';
+        navigator.clipboard.writeText(code);
+        btn.textContent = 'Copied!';
+        setTimeout(() => {
+          btn.textContent = 'Copy';
+        }, 1500);
       });
+      pre.appendChild(btn);
     });
   }
 
@@ -396,11 +398,13 @@ export class ScionChatMessage extends LitElement {
       this.renderedHtml = '';
       return;
     }
+    const taskId = ++this.renderTaskId;
     try {
       const renderer = await getMarkdownRenderer();
+      if (taskId !== this.renderTaskId) return;
       this.renderedHtml = renderer.render(this.body);
     } catch {
-      // Fall back to plain text on error
+      if (taskId !== this.renderTaskId) return;
       this.renderedHtml = '';
     }
   }
@@ -496,7 +500,7 @@ export class ScionChatMessage extends LitElement {
       '#f59e0b', '#ef4444', '#ec4899', '#6366f1',
     ];
     let hash = 0;
-    const s = this.agentSlug || this.sender;
+    const s = this.agentSlug || this.sender || '';
     for (let i = 0; i < s.length; i++) {
       hash = s.charCodeAt(i) + ((hash << 5) - hash);
     }
@@ -505,7 +509,7 @@ export class ScionChatMessage extends LitElement {
 
   /** First two characters of the agent slug or sender name. */
   private getInitials(): string {
-    const s = this.agentSlug || this.sender;
+    const s = this.agentSlug || this.sender || '';
     return s.substring(0, 2);
   }
 

--- a/web/src/components/shared/chat/chat-message.ts
+++ b/web/src/components/shared/chat/chat-message.ts
@@ -1,0 +1,479 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Chat message bubble component.
+ *
+ * Renders one message in the chat thread. Handles:
+ * - User messages right-aligned, agent messages left-aligned
+ * - Agent avatar (colour + initials hashed from slug)
+ * - Markdown content via the shared utility (or preformatted for plain:true)
+ * - Code blocks: monospace, horizontal scroll, copy button (no syntax highlighting)
+ * - Attachments: chip showing basename, full path on hover, NOT clickable
+ * - Badges: urgent, broadcasted, channel provenance
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { getMarkdownRenderer } from '../../../utils/markdown.js';
+
+@customElement('scion-chat-message')
+export class ScionChatMessage extends LitElement {
+  /** The message body text. */
+  @property()
+  body = '';
+
+  /** Sender display name. */
+  @property()
+  sender = '';
+
+  /** Whether this is a message from the agent (left-aligned) or user (right-aligned). */
+  @property({ type: Boolean })
+  fromAgent = false;
+
+  /** Whether the message is plain text (no markdown rendering). */
+  @property({ type: Boolean })
+  plain = false;
+
+  /** Agent slug for avatar generation. */
+  @property()
+  agentSlug = '';
+
+  /** Timestamp string. */
+  @property()
+  timestamp = '';
+
+  /** Whether to show the sender header (false when grouped with previous message). */
+  @property({ type: Boolean })
+  showHeader = true;
+
+  /** Whether this message is marked urgent. */
+  @property({ type: Boolean })
+  urgent = false;
+
+  /** Whether this message was broadcasted. */
+  @property({ type: Boolean })
+  broadcasted = false;
+
+  /** Channel provenance (e.g. "discord", "telegram"). */
+  @property()
+  channel = '';
+
+  /** File attachment paths. */
+  @property({ type: Array })
+  attachments: string[] = [];
+
+  @state()
+  private renderedHtml = '';
+
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    .message-wrapper {
+      display: flex;
+      gap: 0.5rem;
+      padding: 0.125rem 1rem;
+    }
+
+    .message-wrapper.from-user {
+      flex-direction: row-reverse;
+    }
+
+    /* Avatar */
+    .avatar {
+      width: 2rem;
+      height: 2rem;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.75rem;
+      font-weight: 700;
+      color: #fff;
+      flex-shrink: 0;
+      text-transform: uppercase;
+      margin-top: 0.125rem;
+    }
+
+    .avatar-spacer {
+      width: 2rem;
+      flex-shrink: 0;
+    }
+
+    /* Bubble */
+    .bubble {
+      max-width: min(70%, 600px);
+      min-width: 3rem;
+    }
+
+    .bubble-header {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      margin-bottom: 0.125rem;
+    }
+
+    .sender-name {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .msg-time {
+      font-size: 0.6875rem;
+      color: var(--scion-text-muted, #64748b);
+      white-space: nowrap;
+    }
+
+    .bubble-content {
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.75rem;
+      line-height: 1.5;
+      font-size: 0.875rem;
+      word-break: break-word;
+    }
+
+    .from-agent .bubble-content {
+      background: var(--scion-bg-subtle, #f1f5f9);
+      color: var(--scion-text, #1e293b);
+      border-top-left-radius: 0.25rem;
+    }
+
+    .from-user .bubble-content {
+      background: var(--scion-primary-50, #eff6ff);
+      color: var(--scion-text, #1e293b);
+      border-top-right-radius: 0.25rem;
+    }
+
+    .from-user .bubble-header {
+      flex-direction: row-reverse;
+    }
+
+    /* Pre-formatted (plain) text */
+    .plain-text {
+      white-space: pre-wrap;
+      font-family: inherit;
+    }
+
+    /* Markdown content styles */
+    .md-content {
+      overflow-wrap: break-word;
+    }
+
+    .md-content p {
+      margin: 0 0 0.5em;
+    }
+
+    .md-content p:last-child {
+      margin-bottom: 0;
+    }
+
+    .md-content h1,
+    .md-content h2,
+    .md-content h3,
+    .md-content h4 {
+      margin: 0.75em 0 0.25em;
+      font-weight: 600;
+      line-height: 1.3;
+    }
+
+    .md-content h1:first-child,
+    .md-content h2:first-child,
+    .md-content h3:first-child {
+      margin-top: 0;
+    }
+
+    .md-content h1 { font-size: 1.25rem; }
+    .md-content h2 { font-size: 1.125rem; }
+    .md-content h3 { font-size: 1rem; }
+
+    .md-content a {
+      color: var(--sl-color-primary-600, #2563eb);
+      text-decoration: none;
+    }
+
+    .md-content a:hover {
+      text-decoration: underline;
+    }
+
+    .md-content code {
+      font-family: var(--scion-font-mono, 'SF Mono', 'Fira Code', monospace);
+      font-size: 0.8125em;
+      background: var(--scion-surface, #ffffff);
+      padding: 0.1em 0.3em;
+      border-radius: 0.25rem;
+      border: 1px solid var(--scion-border, #e2e8f0);
+    }
+
+    .md-content pre {
+      position: relative;
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.375rem;
+      padding: 0.75rem;
+      overflow-x: auto;
+      margin: 0.5em 0;
+    }
+
+    .md-content pre code {
+      background: none;
+      border: none;
+      padding: 0;
+      font-size: 0.8125rem;
+    }
+
+    .md-content ul,
+    .md-content ol {
+      margin: 0.25em 0 0.5em;
+      padding-left: 1.25em;
+    }
+
+    .md-content li {
+      margin-bottom: 0.125em;
+    }
+
+    .md-content blockquote {
+      border-left: 3px solid var(--scion-border, #e2e8f0);
+      margin: 0.5em 0;
+      padding: 0.25em 0.75em;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .md-content blockquote p:last-child {
+      margin-bottom: 0;
+    }
+
+    .md-content table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 0.5em 0;
+      font-size: 0.8125rem;
+    }
+
+    .md-content th,
+    .md-content td {
+      border: 1px solid var(--scion-border, #e2e8f0);
+      padding: 0.375em 0.5em;
+      text-align: left;
+    }
+
+    .md-content th {
+      background: var(--scion-bg-subtle, #f8fafc);
+      font-weight: 600;
+    }
+
+    /* Badges row */
+    .badges {
+      display: flex;
+      gap: 0.25rem;
+      margin-top: 0.25rem;
+    }
+
+    .badge {
+      display: inline-block;
+      padding: 0 0.375rem;
+      border-radius: 0.25rem;
+      font-size: 0.625rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      line-height: 1.25rem;
+    }
+
+    .badge-urgent {
+      background: var(--scion-danger-50, #fef2f2);
+      color: var(--scion-danger-700, #b91c1c);
+    }
+
+    .badge-broadcast {
+      background: var(--scion-warning-50, #fffbeb);
+      color: var(--scion-warning-700, #b45309);
+    }
+
+    .badge-channel {
+      background: var(--scion-neutral-100, #f1f5f9);
+      color: var(--scion-neutral-600, #475569);
+    }
+
+    /* Attachments */
+    .attachments {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.375rem;
+      margin-top: 0.375rem;
+    }
+
+    .attachment-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.125rem 0.5rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.375rem;
+      font-size: 0.6875rem;
+      color: var(--scion-text-muted, #64748b);
+      cursor: default;
+    }
+
+    .attachment-chip sl-icon {
+      font-size: 0.75rem;
+    }
+  `;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    void this.renderContent();
+  }
+
+  override updated(changed: Map<string, unknown>): void {
+    if (changed.has('body') || changed.has('plain')) {
+      void this.renderContent();
+    }
+  }
+
+  private async renderContent(): Promise<void> {
+    if (!this.body || this.plain) {
+      this.renderedHtml = '';
+      return;
+    }
+    try {
+      const renderer = await getMarkdownRenderer();
+      this.renderedHtml = renderer.render(this.body);
+    } catch {
+      // Fall back to plain text on error
+      this.renderedHtml = '';
+    }
+  }
+
+  override render() {
+    const dirClass = this.fromAgent ? 'from-agent' : 'from-user';
+
+    return html`
+      <div class="message-wrapper ${dirClass}">
+        ${this.showHeader && this.fromAgent
+          ? html`<div class="avatar" style="background: ${this.getAvatarColor()}">${this.getInitials()}</div>`
+          : this.fromAgent
+            ? html`<div class="avatar-spacer"></div>`
+            : nothing}
+        <div class="bubble">
+          ${this.showHeader
+            ? html`
+                <div class="bubble-header">
+                  <span class="sender-name">${this.sender}</span>
+                  <span class="msg-time">${this.formatTime()}</span>
+                </div>
+              `
+            : nothing}
+          <div class="bubble-content">
+            ${this.renderBody()}
+          </div>
+          ${this.renderBadges()}
+          ${this.renderAttachments()}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderBody() {
+    if (this.plain || !this.renderedHtml) {
+      return html`<div class="plain-text">${this.body}</div>`;
+    }
+    return html`<div class="md-content" .innerHTML=${this.renderedHtml}></div>`;
+  }
+
+  private renderBadges() {
+    const hasBadges = this.urgent || this.broadcasted || (this.channel && this.channel !== 'web');
+    if (!hasBadges) return nothing;
+
+    return html`
+      <div class="badges">
+        ${this.urgent ? html`<span class="badge badge-urgent">urgent</span>` : nothing}
+        ${this.broadcasted ? html`<span class="badge badge-broadcast">broadcast</span>` : nothing}
+        ${this.channel && this.channel !== 'web'
+          ? html`<span class="badge badge-channel">via ${this.channel}</span>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderAttachments() {
+    if (!this.attachments || this.attachments.length === 0) return nothing;
+
+    return html`
+      <div class="attachments">
+        ${this.attachments.map(
+          (path) => html`
+            <sl-tooltip content=${path} hoist>
+              <span class="attachment-chip">
+                <sl-icon name="paperclip"></sl-icon>
+                ${this.basename(path)}
+              </span>
+            </sl-tooltip>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  private formatTime(): string {
+    if (!this.timestamp) return '';
+    try {
+      const d = new Date(this.timestamp);
+      return d.toLocaleTimeString('en', {
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    } catch {
+      return '';
+    }
+  }
+
+  /** Simple deterministic colour from the agent slug. */
+  private getAvatarColor(): string {
+    const colors = [
+      '#3b82f6', '#8b5cf6', '#06b6d4', '#10b981',
+      '#f59e0b', '#ef4444', '#ec4899', '#6366f1',
+    ];
+    let hash = 0;
+    const s = this.agentSlug || this.sender;
+    for (let i = 0; i < s.length; i++) {
+      hash = s.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    return colors[Math.abs(hash) % colors.length];
+  }
+
+  /** First two characters of the agent slug or sender name. */
+  private getInitials(): string {
+    const s = this.agentSlug || this.sender;
+    return s.substring(0, 2);
+  }
+
+  /** Extract the file basename from a path. */
+  private basename(path: string): string {
+    const parts = path.split('/');
+    return parts[parts.length - 1] || path;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-chat-message': ScionChatMessage;
+  }
+}

--- a/web/src/components/shared/chat/chat-message.ts
+++ b/web/src/components/shared/chat/chat-message.ts
@@ -237,6 +237,27 @@ export class ScionChatMessage extends LitElement {
       font-size: 0.8125rem;
     }
 
+    .copy-btn {
+      position: absolute;
+      top: 0.375rem;
+      right: 0.375rem;
+      padding: 0.125rem 0.5rem;
+      font-size: 0.6875rem;
+      font-family: inherit;
+      line-height: 1.25rem;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.25rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      color: var(--scion-text-muted, #64748b);
+      cursor: pointer;
+      opacity: 0.6;
+      transition: opacity 0.15s;
+    }
+
+    .copy-btn:hover {
+      opacity: 1;
+    }
+
     .md-content ul,
     .md-content ol {
       margin: 0.25em 0 0.5em;
@@ -345,6 +366,29 @@ export class ScionChatMessage extends LitElement {
     if (changed.has('body') || changed.has('plain')) {
       void this.renderContent();
     }
+    this.injectCopyButtons();
+  }
+
+  /** Inject copy buttons on all code blocks inside rendered markdown. */
+  private injectCopyButtons(): void {
+    this.updateComplete.then(() => {
+      this.shadowRoot?.querySelectorAll('.md-content pre').forEach((pre) => {
+        if (pre.querySelector('.copy-btn')) return;
+        const btn = document.createElement('button');
+        btn.className = 'copy-btn';
+        btn.textContent = 'Copy';
+        btn.addEventListener('click', () => {
+          const code =
+            pre.querySelector('code')?.textContent ?? pre.textContent ?? '';
+          navigator.clipboard.writeText(code);
+          btn.textContent = 'Copied!';
+          setTimeout(() => {
+            btn.textContent = 'Copy';
+          }, 1500);
+        });
+        pre.appendChild(btn);
+      });
+    });
   }
 
   private async renderContent(): Promise<void> {

--- a/web/src/components/shared/chat/chat-system-line.ts
+++ b/web/src/components/shared/chat/chat-system-line.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Chat system line component.
+ *
+ * Renders system/state-change messages in a centered, muted style.
+ * Used for agent state transitions and other non-conversational events.
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+@customElement('scion-chat-system-line')
+export class ScionChatSystemLine extends LitElement {
+  /** The system message text. */
+  @property()
+  message = '';
+
+  /** Timestamp for the event. */
+  @property()
+  timestamp = '';
+
+  /** Optional category icon name (from metadata.system_category). */
+  @property()
+  category = '';
+
+  static override styles = css`
+    :host {
+      display: block;
+      padding: 0.25rem 1rem;
+    }
+
+    .system-line {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      padding: 0.375rem 0.75rem;
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+      text-align: center;
+    }
+
+    .system-line sl-icon {
+      font-size: 0.75rem;
+      flex-shrink: 0;
+    }
+
+    .system-text {
+      line-height: 1.4;
+    }
+
+    .system-time {
+      font-size: 0.6875rem;
+      opacity: 0.7;
+      white-space: nowrap;
+    }
+  `;
+
+  override render() {
+    const iconName = this.getCategoryIcon();
+    const timeStr = this.formatTime();
+
+    return html`
+      <div class="system-line">
+        ${iconName
+          ? html`<sl-icon name=${iconName}></sl-icon>`
+          : null}
+        <span class="system-text">${this.message}</span>
+        ${timeStr
+          ? html`<span class="system-time">${timeStr}</span>`
+          : null}
+      </div>
+    `;
+  }
+
+  private getCategoryIcon(): string {
+    switch (this.category) {
+      case 'lifecycle':
+        return 'arrow-repeat';
+      case 'error':
+        return 'exclamation-triangle';
+      case 'config':
+        return 'gear';
+      default:
+        return 'info-circle';
+    }
+  }
+
+  private formatTime(): string {
+    if (!this.timestamp) return '';
+    try {
+      const d = new Date(this.timestamp);
+      return d.toLocaleTimeString('en', {
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    } catch {
+      return '';
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-chat-system-line': ScionChatSystemLine;
+  }
+}

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -327,6 +327,11 @@ export class ScionChatThread extends LitElement {
   }
 
   private async backfillSince(): Promise<void> {
+    // Guard: skip backfill if we have no messages yet (initial load handles that).
+    // Note: lastKnownTimestamp is not sent in the request — the API does not
+    // support an `after`/`since` parameter (§5.1). We fetch the latest page and
+    // rely on mergeMessages() to deduplicate by ID. If >50 messages arrive
+    // during a single timeout gap, intermediate messages may be missed.
     if (!this.lastKnownTimestamp) return;
 
     const params = new URLSearchParams({
@@ -378,7 +383,7 @@ export class ScionChatThread extends LitElement {
   // ---------------------------------------------------------------------------
 
   private startStream(): void {
-    if (this.eventSource || !this.agentId) return;
+    if (!this.isConnected || this.eventSource || !this.agentId) return;
 
     const url = `/api/v1/agents/${this.agentId}/messages/stream`;
     this.eventSource = new EventSource(url);

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -1,0 +1,664 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Chat thread orchestrator component.
+ *
+ * `<scion-chat-thread>` — the main chat view component.
+ *
+ * Responsibilities:
+ * - Owns the message map (keyed by message ID for deduplication)
+ * - Manages EventSource (SSE stream) for real-time messages
+ * - Backfill-on-reconnect logic
+ * - Scroll anchoring (anchor to bottom, "jump to latest" pill when scrolled up)
+ * - Reverse-infinite-scroll upward using cursor pagination
+ * - Renders chat-message and chat-system-line children
+ * - 500-message buffer cap (MAX_BUFFER)
+ *
+ * Stream/backfill invariant (load-bearing):
+ *   on mount:     GET history (limit 50) -> seed map -> open EventSource
+ *   on 'message': parse UserMessageEvent -> upsert by id -> re-sort -> autoscroll if pinned
+ *   on 'timeout': close stream -> GET history since lastKnownTimestamp -> merge -> reopen
+ *   on error:     EventSource auto-reconnects; on 'open' after error, run same backfill
+ *   on scroll-top: GET history with cursor -> prepend -> preserve scroll offset
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { apiFetch, extractApiError } from '../../../client/api.js';
+import type { Message } from '../../../shared/types.js';
+import type { ChatSendDetail } from './chat-composer.js';
+import './chat-message.js';
+import './chat-system-line.js';
+import './chat-composer.js';
+
+/** Maximum messages kept in the buffer. */
+const MAX_BUFFER = 500;
+
+/** Number of messages to fetch per history request. */
+const HISTORY_PAGE_SIZE = 50;
+
+/** Threshold in pixels from top to trigger upward scroll loading. */
+const SCROLL_TOP_THRESHOLD = 100;
+
+/** Threshold in pixels from bottom to consider "pinned to bottom". */
+const SCROLL_BOTTOM_THRESHOLD = 80;
+
+/** Grouping window: consecutive messages from same sender within 5 min. */
+const GROUP_WINDOW_MS = 5 * 60 * 1000;
+
+/** System/state-change message types. */
+const SYSTEM_MESSAGE_TYPES = new Set(['state-change', 'system']);
+
+@customElement('scion-chat-thread')
+export class ScionChatThread extends LitElement {
+  @property()
+  agentId = '';
+
+  @property()
+  agentName = '';
+
+  @property({ type: Boolean })
+  canSend = false;
+
+  @property()
+  visibilityMode: 'conversation' | 'verbose' | 'full' = 'conversation';
+
+  @state() private messages: Message[] = [];
+  @state() private messageMap = new Map<string, Message>();
+  @state() private loading = false;
+  @state() private error: string | null = null;
+  @state() private streaming = false;
+  @state() private sending = false;
+  @state() private sendError: string | null = null;
+  @state() private pinnedToBottom = true;
+  @state() private loadingOlder = false;
+  @state() private hasOlderMessages = true;
+  @state() private loaded = false;
+
+  private eventSource: EventSource | null = null;
+  private nextCursor: string | null = null;
+  private lastKnownTimestamp: string | null = null;
+  private hadError = false;
+
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      min-height: 300px;
+    }
+
+    .thread-container {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      overflow: hidden;
+    }
+
+    /* Streaming indicator */
+    .stream-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.25rem 1rem;
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      background: var(--scion-surface, #ffffff);
+    }
+
+    .stream-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+    }
+
+    .stream-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--scion-success-500, #22c55e);
+      animation: pulse 1.5s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.3; }
+    }
+
+    /* Message scroll area */
+    .messages-scroll {
+      flex: 1;
+      overflow-y: auto;
+      overflow-x: hidden;
+      padding: 0.5rem 0;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .messages-list {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+      min-height: 100%;
+      justify-content: flex-end;
+    }
+
+    /* Loading older messages */
+    .loading-older {
+      display: flex;
+      justify-content: center;
+      padding: 0.5rem;
+    }
+
+    /* Jump to latest pill */
+    .jump-to-latest {
+      position: sticky;
+      bottom: 0.5rem;
+      align-self: center;
+      z-index: 10;
+    }
+
+    .jump-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0.375rem 0.75rem;
+      background: var(--scion-primary, #3b82f6);
+      color: #fff;
+      border: none;
+      border-radius: 1rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      cursor: pointer;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+      transition: background 0.15s;
+    }
+
+    .jump-btn:hover {
+      background: var(--scion-primary-600, #2563eb);
+    }
+
+    .jump-btn sl-icon {
+      font-size: 0.875rem;
+    }
+
+    /* Date divider */
+    .date-divider {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.75rem 1rem 0.25rem;
+    }
+
+    .date-divider::before,
+    .date-divider::after {
+      content: '';
+      flex: 1;
+      height: 1px;
+      background: var(--scion-border, #e2e8f0);
+    }
+
+    .date-label {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      color: var(--scion-text-muted, #64748b);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      white-space: nowrap;
+    }
+
+    /* Empty / Loading / Error states */
+    .state-msg {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 3rem 2rem;
+      color: var(--scion-text-muted, #64748b);
+      gap: 0.75rem;
+      flex: 1;
+    }
+
+    .state-msg sl-spinner {
+      font-size: 1.5rem;
+    }
+
+    .state-msg sl-icon {
+      font-size: 2rem;
+      opacity: 0.4;
+    }
+
+    /* Send error toast */
+    .send-error {
+      padding: 0.375rem 1rem;
+      font-size: 0.75rem;
+      color: var(--scion-danger-600, #dc2626);
+      background: var(--scion-danger-50, #fef2f2);
+      border-top: 1px solid var(--scion-danger-200, #fecaca);
+    }
+  `;
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.stopStream();
+  }
+
+  /** Called by the parent when the chat view is first shown. */
+  loadHistory(): void {
+    if (this.loaded) return;
+    this.loaded = true;
+    void this.initialLoad();
+  }
+
+  /** Stop the SSE stream. Called on tab hide / disconnect. */
+  stopStream(): void {
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+    this.streaming = false;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Data loading
+  // ---------------------------------------------------------------------------
+
+  private async initialLoad(): Promise<void> {
+    this.loading = true;
+    this.error = null;
+
+    try {
+      await this.fetchHistory();
+      this.startStream();
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to load messages';
+    } finally {
+      this.loading = false;
+      // On initial load, scroll to bottom
+      this.scrollToBottom();
+    }
+  }
+
+  private async fetchHistory(cursor?: string): Promise<void> {
+    const params = new URLSearchParams({ limit: String(HISTORY_PAGE_SIZE) });
+    if (cursor) {
+      params.set('cursor', cursor);
+    }
+
+    const res = await apiFetch(
+      `/api/v1/agents/${this.agentId}/messages?${params.toString()}`
+    );
+
+    if (!res.ok) {
+      throw new Error(await extractApiError(res, 'Failed to fetch messages'));
+    }
+
+    const data = (await res.json()) as {
+      items?: Message[];
+      nextCursor?: string;
+    };
+
+    const items = data?.items ?? [];
+
+    if (items.length < HISTORY_PAGE_SIZE) {
+      this.hasOlderMessages = false;
+    }
+
+    if (data?.nextCursor) {
+      this.nextCursor = data.nextCursor;
+    }
+
+    this.mergeMessages(items);
+  }
+
+  private async backfillSince(): Promise<void> {
+    if (!this.lastKnownTimestamp) return;
+
+    const params = new URLSearchParams({
+      limit: String(HISTORY_PAGE_SIZE),
+      before: new Date().toISOString(),
+    });
+
+    const res = await apiFetch(
+      `/api/v1/agents/${this.agentId}/messages?${params.toString()}`
+    );
+
+    if (!res.ok) return;
+
+    const data = (await res.json()) as { items?: Message[] };
+    const items = data?.items ?? [];
+    this.mergeMessages(items);
+  }
+
+  private mergeMessages(newMessages: Message[]): void {
+    for (const msg of newMessages) {
+      if (!this.messageMap.has(msg.id)) {
+        this.messageMap.set(msg.id, msg);
+      }
+    }
+
+    // Sort ascending by createdAt (oldest first for chat display)
+    const sorted = Array.from(this.messageMap.values()).sort(
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+    );
+
+    // Enforce buffer cap — remove oldest
+    if (sorted.length > MAX_BUFFER) {
+      const removed = sorted.splice(0, sorted.length - MAX_BUFFER);
+      for (const msg of removed) {
+        this.messageMap.delete(msg.id);
+      }
+    }
+
+    this.messages = sorted;
+
+    // Track last known timestamp for backfill
+    if (sorted.length > 0) {
+      this.lastKnownTimestamp = sorted[sorted.length - 1].createdAt;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // SSE Streaming
+  // ---------------------------------------------------------------------------
+
+  private startStream(): void {
+    if (this.eventSource || !this.agentId) return;
+
+    const url = `/api/v1/agents/${this.agentId}/messages/stream`;
+    this.eventSource = new EventSource(url);
+    this.streaming = true;
+
+    this.eventSource.addEventListener('message', (event: Event) => {
+      try {
+        const msg = JSON.parse((event as MessageEvent).data) as Message;
+        const wasPinned = this.pinnedToBottom;
+        this.mergeMessages([msg]);
+        if (wasPinned) {
+          this.updateComplete.then(() => this.scrollToBottom());
+        }
+      } catch {
+        // Skip unparseable entries
+      }
+    });
+
+    this.eventSource.addEventListener('timeout', () => {
+      this.stopStream();
+      void this.backfillSince().then(() => this.startStream());
+    });
+
+    this.eventSource.addEventListener('open', () => {
+      // If reconnecting after an error, backfill
+      if (this.hadError) {
+        this.hadError = false;
+        void this.backfillSince();
+      }
+    });
+
+    this.eventSource.onerror = () => {
+      this.hadError = true;
+      // EventSource will auto-reconnect
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scroll handling
+  // ---------------------------------------------------------------------------
+
+  private handleScroll(e: Event): void {
+    const el = e.target as HTMLElement;
+    const distFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    this.pinnedToBottom = distFromBottom < SCROLL_BOTTOM_THRESHOLD;
+
+    // Load older messages when scrolled near top
+    if (
+      el.scrollTop < SCROLL_TOP_THRESHOLD &&
+      !this.loadingOlder &&
+      this.hasOlderMessages &&
+      this.nextCursor
+    ) {
+      void this.loadOlderMessages(el);
+    }
+  }
+
+  private async loadOlderMessages(scrollEl: HTMLElement): Promise<void> {
+    this.loadingOlder = true;
+    const prevScrollHeight = scrollEl.scrollHeight;
+
+    try {
+      await this.fetchHistory(this.nextCursor || undefined);
+    } catch {
+      // Silently fail for older messages
+    } finally {
+      this.loadingOlder = false;
+      // Preserve scroll position after prepending
+      await this.updateComplete;
+      const newScrollHeight = scrollEl.scrollHeight;
+      scrollEl.scrollTop += newScrollHeight - prevScrollHeight;
+    }
+  }
+
+  private scrollToBottom(): void {
+    const scrollEl = this.shadowRoot?.querySelector('.messages-scroll') as HTMLElement | null;
+    if (scrollEl) {
+      scrollEl.scrollTop = scrollEl.scrollHeight;
+    }
+  }
+
+  private handleJumpToLatest(): void {
+    this.pinnedToBottom = true;
+    this.scrollToBottom();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Send message
+  // ---------------------------------------------------------------------------
+
+  private async handleChatSend(e: CustomEvent<ChatSendDetail>): Promise<void> {
+    const { text, plain, interrupt } = e.detail;
+    if (!text || this.sending) return;
+
+    this.sending = true;
+    this.sendError = null;
+
+    try {
+      const res = await apiFetch(`/api/v1/agents/${this.agentId}/message`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          structured_message: { msg: text, plain },
+          interrupt,
+        }),
+      });
+
+      if (!res.ok) {
+        this.sendError = await extractApiError(res, 'Failed to send message');
+      }
+    } catch (err) {
+      this.sendError = err instanceof Error ? err.message : 'Failed to send message';
+    } finally {
+      this.sending = false;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  override render() {
+    return html`
+      <div class="thread-container">
+        ${this.renderStreamBar()}
+        ${this.renderContent()}
+        ${this.sendError
+          ? html`<div class="send-error">${this.sendError}</div>`
+          : nothing}
+        ${this.canSend
+          ? html`
+              <scion-chat-composer
+                ?disabled=${this.sending}
+                @chat-send=${this.handleChatSend}
+              ></scion-chat-composer>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderStreamBar() {
+    if (!this.streaming) return nothing;
+    return html`
+      <div class="stream-bar">
+        <span class="stream-indicator">
+          <span class="stream-dot"></span>
+          Live
+        </span>
+      </div>
+    `;
+  }
+
+  private renderContent() {
+    if (this.loading && this.messages.length === 0) {
+      return html`
+        <div class="state-msg">
+          <sl-spinner></sl-spinner>
+          <span>Loading messages...</span>
+        </div>
+      `;
+    }
+
+    if (this.error && this.messages.length === 0) {
+      return html`
+        <div class="state-msg">
+          <sl-icon name="exclamation-triangle"></sl-icon>
+          <span>${this.error}</span>
+          <sl-button size="small" @click=${() => { this.loaded = false; this.loadHistory(); }}>
+            Retry
+          </sl-button>
+        </div>
+      `;
+    }
+
+    if (this.messages.length === 0) {
+      return html`
+        <div class="state-msg">
+          <sl-icon name="chat-dots"></sl-icon>
+          <span>No messages yet. Start a conversation!</span>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="messages-scroll" @scroll=${this.handleScroll}>
+        <div class="messages-list">
+          ${this.loadingOlder
+            ? html`<div class="loading-older"><sl-spinner></sl-spinner></div>`
+            : nothing}
+          ${this.renderMessages()}
+        </div>
+        ${!this.pinnedToBottom
+          ? html`
+              <div class="jump-to-latest">
+                <button class="jump-btn" @click=${this.handleJumpToLatest}>
+                  <sl-icon name="arrow-down"></sl-icon>
+                  Jump to latest
+                </button>
+              </div>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderMessages() {
+    const rows: unknown[] = [];
+    let lastDate = '';
+    let prevSender = '';
+    let prevTimestamp = 0;
+
+    for (const msg of this.messages) {
+      const d = new Date(msg.createdAt);
+      const dateStr = d.toLocaleDateString('en', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+
+      // Date divider
+      if (dateStr !== lastDate) {
+        lastDate = dateStr;
+        prevSender = '';
+        prevTimestamp = 0;
+        rows.push(html`
+          <div class="date-divider">
+            <span class="date-label">${dateStr}</span>
+          </div>
+        `);
+      }
+
+      // System/state-change messages
+      if (SYSTEM_MESSAGE_TYPES.has(msg.type)) {
+        prevSender = '';
+        prevTimestamp = 0;
+        rows.push(html`
+          <scion-chat-system-line
+            message=${msg.msg}
+            timestamp=${msg.createdAt}
+            category=${(msg.metadata?.['system_category'] as string) || ''}
+          ></scion-chat-system-line>
+        `);
+        continue;
+      }
+
+      // Grouping: consecutive messages from same sender within GROUP_WINDOW_MS
+      const msgTime = d.getTime();
+      const sameSender = msg.sender === prevSender;
+      const withinWindow = msgTime - prevTimestamp < GROUP_WINDOW_MS;
+      const showHeader = !sameSender || !withinWindow;
+
+      const isFromAgent = msg.senderId === this.agentId;
+
+      rows.push(html`
+        <scion-chat-message
+          body=${msg.msg}
+          sender=${msg.sender}
+          ?fromAgent=${isFromAgent}
+          ?plain=${msg.plain ?? false}
+          agentSlug=${isFromAgent ? (this.agentName || '') : ''}
+          timestamp=${msg.createdAt}
+          ?showHeader=${showHeader}
+          ?urgent=${msg.urgent ?? false}
+          ?broadcasted=${msg.broadcasted ?? false}
+          channel=${msg.channel || ''}
+          .attachments=${msg.attachments || []}
+        ></scion-chat-message>
+      `);
+
+      prevSender = msg.sender;
+      prevTimestamp = msgTime;
+    }
+
+    return rows;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-chat-thread': ScionChatThread;
+  }
+}

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -475,7 +475,7 @@ export class ScionChatThread extends LitElement {
   // ---------------------------------------------------------------------------
 
   private async handleChatSend(e: CustomEvent<ChatSendDetail>): Promise<void> {
-    const { text, plain, interrupt } = e.detail;
+    const { text, plain, interrupt, onSuccess } = e.detail;
     if (!text || this.sending) return;
 
     this.sending = true;
@@ -493,6 +493,8 @@ export class ScionChatThread extends LitElement {
 
       if (!res.ok) {
         this.sendError = await extractApiError(res, 'Failed to send message');
+      } else {
+        onSuccess();
       }
     } catch (err) {
       this.sendError = err instanceof Error ? err.message : 'Failed to send message';

--- a/web/src/components/shared/markdown-preview.ts
+++ b/web/src/components/shared/markdown-preview.ts
@@ -23,41 +23,7 @@
 
 import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-
-// ────────────────────────────────────────────────────────────
-// Lazy-loaded markdown rendering
-// ────────────────────────────────────────────────────────────
-
-interface MarkdownRenderer {
-  render(markdown: string): string;
-}
-
-let rendererPromise: Promise<MarkdownRenderer> | null = null;
-
-async function loadRenderer(): Promise<MarkdownRenderer> {
-  if (!rendererPromise) {
-    rendererPromise = (async () => {
-      const [{ marked }, DOMPurify] = await Promise.all([
-        import('marked'),
-        import('dompurify'),
-      ]);
-
-      const purify = DOMPurify.default ?? DOMPurify;
-
-      return {
-        render(markdown: string): string {
-          const rawHtml = marked.parse(markdown, { async: false }) as string;
-          return purify.sanitize(rawHtml);
-        },
-      };
-    })();
-  }
-  return rendererPromise;
-}
-
-// ────────────────────────────────────────────────────────────
-// Component
-// ────────────────────────────────────────────────────────────
+import { getMarkdownRenderer } from '../../utils/markdown.js';
 
 @customElement('scion-markdown-preview')
 export class ScionMarkdownPreview extends LitElement {
@@ -242,7 +208,7 @@ export class ScionMarkdownPreview extends LitElement {
     this.error = null;
 
     try {
-      const renderer = await loadRenderer();
+      const renderer = await getMarkdownRenderer();
       this.renderedHtml = renderer.render(this.content);
     } catch (err) {
       console.error('Failed to render markdown:', err);

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -653,6 +653,24 @@ export interface Message {
   read?: boolean;
   agentId: string;
   createdAt: string;
+  /** Channel the message was sent through (e.g. "web", "discord"). Phase 0 addition. */
+  channel?: string;
+  /** Thread identifier (e.g. "agent:<agentId>"). Phase 0 addition. */
+  threadId?: string;
+  /** Visibility level: "normal", "verbose", or "full". Phase 0 addition. */
+  visibility?: string;
+  /** Group identifier for related messages. */
+  groupId?: string;
+  /** Dispatch state: "pending", "dispatched", or "failed". */
+  dispatchState?: string;
+  /** Reason for dispatch failure, if any. */
+  dispatchFailureReason?: string;
+  /** Whether the message was sent with plain formatting. */
+  plain?: boolean;
+  /** File attachment paths. */
+  attachments?: string[];
+  /** Arbitrary metadata attached to the message. */
+  metadata?: Record<string, unknown>;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/utils/feature-flags.ts
+++ b/web/src/utils/feature-flags.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Feature flag utilities.
+ *
+ * Checks for feature flags in this order:
+ * 1. Server-injected `window.__SCION_FEATURES__` (set by the Go template)
+ * 2. localStorage override for development (key: `scion:feature:<name>`)
+ *
+ * Default is `false` (flag off) when not found in any source.
+ */
+
+declare global {
+  interface Window {
+    __SCION_FEATURES__?: Record<string, boolean>;
+  }
+}
+
+/**
+ * Check whether a feature flag is enabled.
+ *
+ * @param name - Dot-separated flag name (e.g. "web.native_chat")
+ * @returns true if the flag is enabled, false otherwise
+ */
+export function isFeatureEnabled(name: string): boolean {
+  // 1. Check server-injected features
+  if (typeof window !== 'undefined' && window.__SCION_FEATURES__) {
+    const value = window.__SCION_FEATURES__[name];
+    if (typeof value === 'boolean') return value;
+  }
+
+  // 2. Check localStorage override (dev convenience)
+  if (typeof localStorage !== 'undefined') {
+    try {
+      const stored = localStorage.getItem(`scion:feature:${name}`);
+      if (stored === 'true') return true;
+      if (stored === 'false') return false;
+    } catch {
+      // localStorage not available (e.g. SSR)
+    }
+  }
+
+  // Default: off
+  return false;
+}

--- a/web/src/utils/markdown.ts
+++ b/web/src/utils/markdown.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared markdown rendering utility.
+ *
+ * Provides a singleton lazy-loaded renderer using marked + DOMPurify.
+ * Both the markdown-preview component and the chat components share
+ * this instance so the parser is loaded at most once.
+ *
+ * All rendered HTML is sanitized via DOMPurify. A DOMPurify hook
+ * ensures anchors open in a new tab with rel="noopener noreferrer".
+ */
+
+/** Result of the lazy-loaded renderer. */
+export interface MarkdownRenderer {
+  render(markdown: string): string;
+}
+
+let rendererPromise: Promise<MarkdownRenderer> | null = null;
+
+/**
+ * Lazily load and return the shared markdown renderer.
+ * Both `marked` and `dompurify` are loaded on first call; subsequent
+ * calls return the cached promise.
+ */
+export async function getMarkdownRenderer(): Promise<MarkdownRenderer> {
+  if (!rendererPromise) {
+    rendererPromise = (async () => {
+      const [{ marked }, DOMPurify] = await Promise.all([
+        import('marked'),
+        import('dompurify'),
+      ]);
+
+      const purify = DOMPurify.default ?? DOMPurify;
+
+      // Add a hook so all anchors open in a new tab with noopener noreferrer.
+      purify.addHook('afterSanitizeAttributes', (node: Element) => {
+        if (node.tagName === 'A') {
+          node.setAttribute('target', '_blank');
+          node.setAttribute('rel', 'noopener noreferrer');
+        }
+      });
+
+      return {
+        render(markdown: string): string {
+          const rawHtml = marked.parse(markdown, { async: false }) as string;
+          return purify.sanitize(rawHtml);
+        },
+      };
+    })();
+  }
+  return rendererPromise;
+}


### PR DESCRIPTION
## Summary

- Implements the core scion-chat-thread component and all supporting chat UI components
- Shared markdown.ts utility with DOMPurify (AC7)
- Chat|Log toggle in Messages tab, gated on web.native_chat flag
- Flag off = byte-for-byte current behaviour (AC9)

## Test plan

- npm run typecheck passes
- npm run build passes
- No new npm dependencies