### PR TITLE
feat(web): add JWKS download button to federation admin page

### DIFF
--- a/web/src/components/pages/admin-federation.ts
+++ b/web/src/components/pages/admin-federation.ts
@@ -536,6 +536,27 @@ export class ScionPageAdminFederation extends LitElement {
     void this.save();
   }
 
+  // --- JWKS Download ---
+
+  private async downloadJWKS(): Promise<void> {
+    try {
+      const resp = await fetch('/.well-known/jwks.json');
+      if (!resp.ok) {
+        this.error = `Failed to download JWKS: ${resp.status} ${resp.statusText}`;
+        return;
+      }
+      const blob = await resp.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'scion-jwks.json';
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      this.error = 'Failed to download JWKS: could not connect to server';
+    }
+  }
+
   // --- Helpers for comma-separated array fields ---
 
   private arrayToCommaString(arr?: string[]): string {
@@ -592,6 +613,10 @@ export class ScionPageAdminFederation extends LitElement {
       <div class="section">
         <div class="section-header">
           <h3 class="section-title">Global Settings</h3>
+          <sl-button size="small" variant="default" @click=${() => { void this.downloadJWKS(); }}>
+            <sl-icon slot="prefix" name="download"></sl-icon>
+            Download JWKS
+          </sl-button>
         </div>
 
         <div class="form-field mb-1">

--- a/web/src/components/pages/admin-federation.ts
+++ b/web/src/components/pages/admin-federation.ts
@@ -49,6 +49,7 @@ export class ScionPageAdminFederation extends LitElement {
   @state() private error: string | null = null;
   @state() private successMessage: string | null = null;
   @state() private saving = false;
+  @state() private downloading = false;
 
   // Global federation settings
   @state() private enabled = false;
@@ -539,10 +540,11 @@ export class ScionPageAdminFederation extends LitElement {
   // --- JWKS Download ---
 
   private async downloadJWKS(): Promise<void> {
+    this.downloading = true;
     try {
-      const resp = await fetch('/.well-known/jwks.json');
+      const resp = await apiFetch('/.well-known/jwks.json');
       if (!resp.ok) {
-        this.error = `Failed to download JWKS: ${resp.status} ${resp.statusText}`;
+        this.error = await extractApiError(resp, 'Failed to download JWKS');
         return;
       }
       const blob = await resp.blob();
@@ -554,6 +556,8 @@ export class ScionPageAdminFederation extends LitElement {
       URL.revokeObjectURL(url);
     } catch {
       this.error = 'Failed to download JWKS: could not connect to server';
+    } finally {
+      this.downloading = false;
     }
   }
 
@@ -613,7 +617,7 @@ export class ScionPageAdminFederation extends LitElement {
       <div class="section">
         <div class="section-header">
           <h3 class="section-title">Global Settings</h3>
-          <sl-button size="small" variant="default" @click=${() => { void this.downloadJWKS(); }}>
+          <sl-button size="small" variant="default" ?loading=${this.downloading} @click=${() => { void this.downloadJWKS(); }}>
             <sl-icon slot="prefix" name="download"></sl-icon>
             Download JWKS
           </sl-button>

--- a/web/src/components/pages/admin-federation.ts
+++ b/web/src/components/pages/admin-federation.ts
@@ -541,6 +541,8 @@ export class ScionPageAdminFederation extends LitElement {
 
   private async downloadJWKS(): Promise<void> {
     this.downloading = true;
+    this.error = null;
+    this.successMessage = null;
     try {
       const resp = await apiFetch('/.well-known/jwks.json');
       if (!resp.ok) {
@@ -552,7 +554,9 @@ export class ScionPageAdminFederation extends LitElement {
       const a = document.createElement('a');
       a.href = url;
       a.download = 'scion-jwks.json';
+      document.body.appendChild(a);
       a.click();
+      document.body.removeChild(a);
       URL.revokeObjectURL(url);
     } catch {
       this.error = 'Failed to download JWKS: could not connect to server';


### PR DESCRIPTION
Adds a Download JWKS button to the Global Settings section of the federation admin page for out-of-band JWKS distribution when OIDC discovery is behind IAP.

Refs ptone/scion#930