### PR TITLE
feat(bridge): add JWKS/OIDC discovery proxy endpoints

### DIFF
--- a/extras/scion-a2a-bridge/go.mod
+++ b/extras/scion-a2a-bridge/go.mod
@@ -30,6 +30,7 @@ require (
 	cloud.google.com/go/logging v1.13.2 // indirect
 	cloud.google.com/go/longrunning v1.0.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
+	cloud.google.com/go/policytroubleshooter v1.11.7 // indirect
 	cloud.google.com/go/storage v1.59.1 // indirect
 	entgo.io/ent v0.14.5 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.34.0 // indirect

--- a/extras/scion-a2a-bridge/go.sum
+++ b/extras/scion-a2a-bridge/go.sum
@@ -20,6 +20,8 @@ cloud.google.com/go/longrunning v1.0.0 h1:lwzWEYD8+NkYV7dhexOz6kmlvajZA70+bW/xMh
 cloud.google.com/go/longrunning v1.0.0/go.mod h1:8nqFBPOO1U/XkhWl0I19AMZEphrHi73VNABIpKYaTwM=
 cloud.google.com/go/monitoring v1.24.3 h1:dde+gMNc0UhPZD1Azu6at2e79bfdztVDS5lvhOdsgaE=
 cloud.google.com/go/monitoring v1.24.3/go.mod h1:nYP6W0tm3N9H/bOw8am7t62YTzZY+zUeQ+Bi6+2eonI=
+cloud.google.com/go/policytroubleshooter v1.11.7 h1:Bbj1EiVh96u9mfO2p+JNoHrvvyC0Ms6zP+vxqQnsaG8=
+cloud.google.com/go/policytroubleshooter v1.11.7/go.mod h1:JP/aQ+bUkt4Gz6lQXBi/+A/6nyNRZ0Pvxui5Xl9ieyk=
 cloud.google.com/go/secretmanager v1.16.0 h1:19QT7ZsLJ8FSP1k+4esQvuCD7npMJml6hYzilxVyT+k=
 cloud.google.com/go/secretmanager v1.16.0/go.mod h1://C/e4I8D26SDTz1f3TQcddhcmiC3rMEl0S1Cakvs3Q=
 cloud.google.com/go/storage v1.59.1 h1:DXAZLcTimtiXdGqDSnebROVPd9QvRsFVVlptz02Wk58=

--- a/extras/scion-a2a-bridge/internal/bridge/bridge.go
+++ b/extras/scion-a2a-bridge/internal/bridge/bridge.go
@@ -85,6 +85,11 @@ type Bridge struct {
 	// oidcCache caches proxied OIDC discovery and JWKS responses from the hub.
 	oidcCache *oidcProxyCache
 
+	// oidcClientOnce ensures the shared OIDC HTTP client is created exactly once.
+	oidcClientOnce sync.Once
+	// oidcClient is the cached HTTP client for reaching the hub's OIDC endpoints.
+	oidcClient *http.Client
+
 	// agentCache caches lookupAgent results to avoid listing all agents per call.
 	agentCacheMu sync.RWMutex
 	agentCache   map[string]*agentCacheEntry

--- a/extras/scion-a2a-bridge/internal/bridge/bridge.go
+++ b/extras/scion-a2a-bridge/internal/bridge/bridge.go
@@ -82,6 +82,9 @@ type Bridge struct {
 	// nil in plugin/SQLite mode; polling remains the correctness floor.
 	notifier *Notifier
 
+	// oidcCache caches proxied OIDC discovery and JWKS responses from the hub.
+	oidcCache *oidcProxyCache
+
 	// agentCache caches lookupAgent results to avoid listing all agents per call.
 	agentCacheMu sync.RWMutex
 	agentCache   map[string]*agentCacheEntry
@@ -136,6 +139,7 @@ func New(store state.Store, hubClient hubclient.Client, minter *identity.TokenMi
 		push:           NewPushDispatcher(store, cfg, log, ctx),
 		activeTasks:    make(map[string]activeTaskEntry),
 		agentTasks:     make(map[string][]string),
+		oidcCache:      newOIDCProxyCache(oidcProxyCacheTTL),
 		agentCache:     make(map[string]*agentCacheEntry),
 		shutdownCtx:    ctx,
 		shutdownCancel: cancel,

--- a/extras/scion-a2a-bridge/internal/bridge/oidc_proxy.go
+++ b/extras/scion-a2a-bridge/internal/bridge/oidc_proxy.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -42,10 +43,13 @@ type oidcCacheEntry struct {
 }
 
 // oidcProxyCache provides a simple TTL cache for proxied OIDC responses.
+// A singleflight.Group deduplicates concurrent fetches for the same key,
+// preventing cache stampedes when the cache is empty or expired.
 type oidcProxyCache struct {
 	mu      sync.RWMutex
 	entries map[string]*oidcCacheEntry
 	ttl     time.Duration
+	flight  singleflight.Group
 }
 
 func newOIDCProxyCache(ttl time.Duration) *oidcProxyCache {
@@ -128,42 +132,75 @@ func (s *Server) handleJWKSProxy(w http.ResponseWriter, r *http.Request) {
 }
 
 // fetchCachedOIDC fetches an OIDC endpoint from the hub, using the cache
-// when available. The bridge's transport auth (IAP credentials) is applied
-// to reach hubs behind identity-aware proxies.
+// when available. Concurrent requests for the same cache key are deduplicated
+// via singleflight to prevent cache stampedes. The bridge's transport auth
+// (IAP credentials) is applied to reach hubs behind identity-aware proxies.
 func (s *Server) fetchCachedOIDC(ctx context.Context, cacheKey, hubURL string) ([]byte, error) {
-	if s.bridge.oidcCache != nil {
-		if cached := s.bridge.oidcCache.get(cacheKey); cached != nil {
+	cache := s.bridge.oidcCache
+
+	// Fast path: return from cache if present and not expired.
+	if cache != nil {
+		if cached := cache.get(cacheKey); cached != nil {
 			return cached, nil
 		}
 	}
 
-	client := s.bridge.oidcHTTPClient()
+	// fetchFromHub performs the actual HTTP request to the hub.
+	fetchFromHub := func() ([]byte, error) {
+		client := s.bridge.oidcHTTPClient()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, hubURL, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, hubURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("creating request for %s: %w", hubURL, err)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("GET %s: %w", hubURL, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("GET %s: status %d", hubURL, resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(io.LimitReader(resp.Body, oidcProxyMaxBody+1))
+		if err != nil {
+			return nil, fmt.Errorf("reading response from %s: %w", hubURL, err)
+		}
+		if int64(len(body)) > oidcProxyMaxBody {
+			return nil, fmt.Errorf("response from %s exceeded maximum size of %d bytes", hubURL, oidcProxyMaxBody)
+		}
+
+		return body, nil
+	}
+
+	// Without a cache, fetch directly.
+	if cache == nil {
+		return fetchFromHub()
+	}
+
+	// Use singleflight to deduplicate concurrent fetches for the same key.
+	// This prevents a thundering herd when the cache is empty or expired.
+	val, err, _ := cache.flight.Do(cacheKey, func() (interface{}, error) {
+		// Double-check after winning the singleflight race.
+		if cached := cache.get(cacheKey); cached != nil {
+			return cached, nil
+		}
+
+		body, err := fetchFromHub()
+		if err != nil {
+			return nil, err
+		}
+
+		cache.set(cacheKey, body)
+		return body, nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("creating request for %s: %w", hubURL, err)
+		return nil, err
 	}
 
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("GET %s: %w", hubURL, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET %s: status %d", hubURL, resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, oidcProxyMaxBody))
-	if err != nil {
-		return nil, fmt.Errorf("reading response from %s: %w", hubURL, err)
-	}
-
-	if s.bridge.oidcCache != nil {
-		s.bridge.oidcCache.set(cacheKey, body)
-	}
-
-	return body, nil
+	return val.([]byte), nil
 }
 
 // rewriteJWKSURI takes the raw OIDC discovery JSON and rewrites the jwks_uri
@@ -184,15 +221,19 @@ func rewriteJWKSURI(body []byte, bridgeExternalURL string) ([]byte, error) {
 	return rewritten, nil
 }
 
-// oidcHTTPClient returns an HTTP client configured with the bridge's transport
-// auth (IAP / Cloud Run invoker) for reaching the hub's OIDC endpoints.
+// oidcHTTPClient returns a shared HTTP client configured with the bridge's
+// transport auth (IAP / Cloud Run invoker) for reaching the hub's OIDC
+// endpoints. The client is created once and reused for connection pooling.
 func (b *Bridge) oidcHTTPClient() *http.Client {
-	transport := http.DefaultTransport
-	if b.transportSrc != nil {
-		transport = transportauth.Wrap(transport, b.transportSrc, b.transportMode)
-	}
-	return &http.Client{
-		Transport: transport,
-		Timeout:   10 * time.Second,
-	}
+	b.oidcClientOnce.Do(func() {
+		transport := http.DefaultTransport
+		if b.transportSrc != nil {
+			transport = transportauth.Wrap(transport, b.transportSrc, b.transportMode)
+		}
+		b.oidcClient = &http.Client{
+			Transport: transport,
+			Timeout:   10 * time.Second,
+		}
+	})
+	return b.oidcClient
 }

--- a/extras/scion-a2a-bridge/internal/bridge/oidc_proxy.go
+++ b/extras/scion-a2a-bridge/internal/bridge/oidc_proxy.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/transportauth"
+)
+
+const (
+	// oidcProxyCacheTTL is how long proxied OIDC responses are cached.
+	oidcProxyCacheTTL = 5 * time.Minute
+
+	// oidcProxyMaxBody is the maximum response body size from the hub.
+	oidcProxyMaxBody = 1 << 20 // 1 MB
+)
+
+// oidcCacheEntry holds a cached OIDC proxy response.
+type oidcCacheEntry struct {
+	body      []byte
+	fetchedAt time.Time
+}
+
+// oidcProxyCache provides a simple TTL cache for proxied OIDC responses.
+type oidcProxyCache struct {
+	mu      sync.RWMutex
+	entries map[string]*oidcCacheEntry
+	ttl     time.Duration
+}
+
+func newOIDCProxyCache(ttl time.Duration) *oidcProxyCache {
+	return &oidcProxyCache{
+		entries: make(map[string]*oidcCacheEntry),
+		ttl:     ttl,
+	}
+}
+
+// get returns the cached body for key, or nil if expired/missing.
+func (c *oidcProxyCache) get(key string) []byte {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.entries[key]
+	if !ok || time.Since(entry.fetchedAt) > c.ttl {
+		return nil
+	}
+	return entry.body
+}
+
+// set stores a response body in the cache.
+func (c *oidcProxyCache) set(key string, body []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = &oidcCacheEntry{
+		body:      body,
+		fetchedAt: time.Now(),
+	}
+}
+
+// handleOIDCDiscoveryProxy proxies the hub's /.well-known/openid-configuration
+// endpoint publicly. The jwks_uri field is rewritten to point to the bridge's
+// own /.well-known/jwks.json endpoint so federation partners can fetch the JWKS
+// without IAP credentials.
+func (s *Server) handleOIDCDiscoveryProxy(w http.ResponseWriter, r *http.Request) {
+	cfg := s.effectiveConfig()
+	hubEndpoint := strings.TrimRight(cfg.Hub.Endpoint, "/")
+	hubURL := hubEndpoint + "/.well-known/openid-configuration"
+
+	body, err := s.fetchCachedOIDC("openid-configuration", hubURL)
+	if err != nil {
+		s.log.Error("failed to fetch OIDC discovery from hub", "error", err)
+		http.Error(w, "failed to fetch OIDC discovery from hub", http.StatusBadGateway)
+		return
+	}
+
+	// Rewrite jwks_uri to point to the bridge's own JWKS proxy endpoint.
+	rewritten, err := rewriteJWKSURI(body, cfg.Bridge.ExternalURL)
+	if err != nil {
+		s.log.Error("failed to rewrite OIDC discovery document", "error", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	w.Write(rewritten)
+}
+
+// handleJWKSProxy proxies the hub's /.well-known/jwks.json endpoint publicly.
+func (s *Server) handleJWKSProxy(w http.ResponseWriter, r *http.Request) {
+	cfg := s.effectiveConfig()
+	hubEndpoint := strings.TrimRight(cfg.Hub.Endpoint, "/")
+	hubURL := hubEndpoint + "/.well-known/jwks.json"
+
+	body, err := s.fetchCachedOIDC("jwks", hubURL)
+	if err != nil {
+		s.log.Error("failed to fetch JWKS from hub", "error", err)
+		http.Error(w, "failed to fetch JWKS from hub", http.StatusBadGateway)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	w.Write(body)
+}
+
+// fetchCachedOIDC fetches an OIDC endpoint from the hub, using the cache
+// when available. The bridge's transport auth (IAP credentials) is applied
+// to reach hubs behind identity-aware proxies.
+func (s *Server) fetchCachedOIDC(cacheKey, hubURL string) ([]byte, error) {
+	if s.bridge.oidcCache != nil {
+		if cached := s.bridge.oidcCache.get(cacheKey); cached != nil {
+			return cached, nil
+		}
+	}
+
+	client := s.bridge.oidcHTTPClient()
+
+	resp, err := client.Get(hubURL)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", hubURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: status %d", hubURL, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, oidcProxyMaxBody))
+	if err != nil {
+		return nil, fmt.Errorf("reading response from %s: %w", hubURL, err)
+	}
+
+	if s.bridge.oidcCache != nil {
+		s.bridge.oidcCache.set(cacheKey, body)
+	}
+
+	return body, nil
+}
+
+// rewriteJWKSURI takes the raw OIDC discovery JSON and rewrites the jwks_uri
+// field to point to the bridge's own JWKS proxy endpoint.
+func rewriteJWKSURI(body []byte, bridgeExternalURL string) ([]byte, error) {
+	var doc map[string]interface{}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, fmt.Errorf("unmarshal OIDC discovery: %w", err)
+	}
+
+	bridgeBase := strings.TrimRight(bridgeExternalURL, "/")
+	doc["jwks_uri"] = bridgeBase + "/.well-known/jwks.json"
+
+	rewritten, err := json.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("marshal rewritten OIDC discovery: %w", err)
+	}
+	return rewritten, nil
+}
+
+// oidcHTTPClient returns an HTTP client configured with the bridge's transport
+// auth (IAP / Cloud Run invoker) for reaching the hub's OIDC endpoints.
+func (b *Bridge) oidcHTTPClient() *http.Client {
+	transport := http.DefaultTransport
+	if b.transportSrc != nil {
+		transport = transportauth.Wrap(transport, b.transportSrc, b.transportMode)
+	}
+	return &http.Client{
+		Transport: transport,
+		Timeout:   10 * time.Second,
+	}
+}

--- a/extras/scion-a2a-bridge/internal/bridge/oidc_proxy.go
+++ b/extras/scion-a2a-bridge/internal/bridge/oidc_proxy.go
@@ -15,6 +15,7 @@
 package bridge
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -84,7 +85,7 @@ func (s *Server) handleOIDCDiscoveryProxy(w http.ResponseWriter, r *http.Request
 	hubEndpoint := strings.TrimRight(cfg.Hub.Endpoint, "/")
 	hubURL := hubEndpoint + "/.well-known/openid-configuration"
 
-	body, err := s.fetchCachedOIDC("openid-configuration", hubURL)
+	body, err := s.fetchCachedOIDC(r.Context(), "openid-configuration", hubURL)
 	if err != nil {
 		s.log.Error("failed to fetch OIDC discovery from hub", "error", err)
 		http.Error(w, "failed to fetch OIDC discovery from hub", http.StatusBadGateway)
@@ -101,7 +102,9 @@ func (s *Server) handleOIDCDiscoveryProxy(w http.ResponseWriter, r *http.Request
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=300")
-	w.Write(rewritten)
+	if _, err := w.Write(rewritten); err != nil {
+		s.log.Debug("failed to write OIDC discovery response", "error", err)
+	}
 }
 
 // handleJWKSProxy proxies the hub's /.well-known/jwks.json endpoint publicly.
@@ -110,7 +113,7 @@ func (s *Server) handleJWKSProxy(w http.ResponseWriter, r *http.Request) {
 	hubEndpoint := strings.TrimRight(cfg.Hub.Endpoint, "/")
 	hubURL := hubEndpoint + "/.well-known/jwks.json"
 
-	body, err := s.fetchCachedOIDC("jwks", hubURL)
+	body, err := s.fetchCachedOIDC(r.Context(), "jwks", hubURL)
 	if err != nil {
 		s.log.Error("failed to fetch JWKS from hub", "error", err)
 		http.Error(w, "failed to fetch JWKS from hub", http.StatusBadGateway)
@@ -119,13 +122,15 @@ func (s *Server) handleJWKSProxy(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=300")
-	w.Write(body)
+	if _, err := w.Write(body); err != nil {
+		s.log.Debug("failed to write JWKS response", "error", err)
+	}
 }
 
 // fetchCachedOIDC fetches an OIDC endpoint from the hub, using the cache
 // when available. The bridge's transport auth (IAP credentials) is applied
 // to reach hubs behind identity-aware proxies.
-func (s *Server) fetchCachedOIDC(cacheKey, hubURL string) ([]byte, error) {
+func (s *Server) fetchCachedOIDC(ctx context.Context, cacheKey, hubURL string) ([]byte, error) {
 	if s.bridge.oidcCache != nil {
 		if cached := s.bridge.oidcCache.get(cacheKey); cached != nil {
 			return cached, nil
@@ -134,7 +139,12 @@ func (s *Server) fetchCachedOIDC(cacheKey, hubURL string) ([]byte, error) {
 
 	client := s.bridge.oidcHTTPClient()
 
-	resp, err := client.Get(hubURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, hubURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request for %s: %w", hubURL, err)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("GET %s: %w", hubURL, err)
 	}

--- a/extras/scion-a2a-bridge/internal/bridge/oidc_proxy_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/oidc_proxy_test.go
@@ -1,0 +1,410 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/a2aproject/a2a-go/v2/a2asrv/taskstore"
+
+	"github.com/GoogleCloudPlatform/scion/extras/scion-a2a-bridge/internal/state"
+)
+
+// fakeHubOIDC starts a fake hub server that serves OIDC discovery and JWKS.
+func fakeHubOIDC(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		doc := map[string]interface{}{
+			"issuer":   "https://hub.example.com",
+			"jwks_uri": "https://hub.example.com/.well-known/jwks.json",
+			"response_types_supported":            []string{"id_token"},
+			"subject_types_supported":             []string{"public"},
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		json.NewEncoder(w).Encode(doc)
+	})
+
+	mux.HandleFunc("GET /.well-known/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		jwks := map[string]interface{}{
+			"keys": []map[string]interface{}{
+				{
+					"kty": "RSA",
+					"kid": "test-key-1",
+					"use": "sig",
+					"n":   "test-modulus",
+					"e":   "AQAB",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "public, max-age=300")
+		json.NewEncoder(w).Encode(jwks)
+	})
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// newTestServerWithHub creates a test bridge server that proxies to a fake hub.
+func newTestServerWithHub(t *testing.T, hubURL string) (*Server, *httptest.Server) {
+	t.Helper()
+
+	dir := t.TempDir()
+	store, err := state.NewSQLite(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("state.New: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	cfg := &Config{
+		Bridge: BridgeConfig{
+			ExternalURL: "https://bridge.example.com",
+		},
+		Hub: HubConfig{
+			Endpoint: hubURL,
+			User:     "test@example.com",
+		},
+		Auth: AuthConfig{
+			Scheme: "none",
+		},
+		Projects: []ProjectConfig{
+			{Slug: "test-project", ExposedAgents: []string{"test-agent"}},
+		},
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := New(store, nil, nil, cfg, nil, log)
+
+	executor := NewScionExecutor(b, log)
+	routeAuth := RouteKeyAuthenticator()
+	innerStore := taskstore.NewInMemory(&taskstore.InMemoryStoreConfig{
+		Authenticator: routeAuth,
+	})
+	scopedStore := NewScopedTaskStore(innerStore)
+	sdkRequestHandler := a2asrv.NewHandler(
+		executor,
+		a2asrv.WithLogger(log),
+		a2asrv.WithCapabilityChecks(&a2a.AgentCapabilities{
+			Streaming:         true,
+			PushNotifications: false,
+		}),
+		a2asrv.WithTaskStore(scopedStore),
+	)
+	b.SetSDKRequestHandler(sdkRequestHandler)
+	sdkJSONRPCHandler := a2asrv.NewJSONRPCHandler(sdkRequestHandler)
+
+	srv := NewServer(b, cfg, nil, log, sdkJSONRPCHandler)
+
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	return srv, ts
+}
+
+func TestOIDCDiscoveryProxy(t *testing.T) {
+	hub := fakeHubOIDC(t)
+	_, ts := newTestServerWithHub(t, hub.URL)
+
+	resp, err := http.Get(ts.URL + "/.well-known/openid-configuration")
+	if err != nil {
+		t.Fatalf("GET /.well-known/openid-configuration: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != "public, max-age=300" {
+		t.Errorf("Cache-Control = %q, want %q", cc, "public, max-age=300")
+	}
+
+	var doc map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// Verify jwks_uri is rewritten to the bridge's endpoint.
+	wantJWKSURI := "https://bridge.example.com/.well-known/jwks.json"
+	if doc["jwks_uri"] != wantJWKSURI {
+		t.Errorf("jwks_uri = %q, want %q", doc["jwks_uri"], wantJWKSURI)
+	}
+
+	// Verify the original issuer is preserved.
+	if doc["issuer"] != "https://hub.example.com" {
+		t.Errorf("issuer = %q, want %q", doc["issuer"], "https://hub.example.com")
+	}
+}
+
+func TestJWKSProxy(t *testing.T) {
+	hub := fakeHubOIDC(t)
+	_, ts := newTestServerWithHub(t, hub.URL)
+
+	resp, err := http.Get(ts.URL + "/.well-known/jwks.json")
+	if err != nil {
+		t.Fatalf("GET /.well-known/jwks.json: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != "public, max-age=300" {
+		t.Errorf("Cache-Control = %q, want %q", cc, "public, max-age=300")
+	}
+
+	var jwks map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	keys, ok := jwks["keys"].([]interface{})
+	if !ok || len(keys) == 0 {
+		t.Fatal("expected non-empty keys array in JWKS response")
+	}
+
+	key, ok := keys[0].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected keys[0] to be an object")
+	}
+	if key["kid"] != "test-key-1" {
+		t.Errorf("kid = %q, want %q", key["kid"], "test-key-1")
+	}
+}
+
+func TestOIDCProxyCaching(t *testing.T) {
+	var fetchCount atomic.Int32
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"keys": []map[string]string{{"kid": "k1"}},
+		})
+	}))
+	t.Cleanup(hub.Close)
+
+	_, ts := newTestServerWithHub(t, hub.URL)
+
+	// First request should fetch from hub.
+	resp, err := http.Get(ts.URL + "/.well-known/jwks.json")
+	if err != nil {
+		t.Fatalf("first GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("first GET status = %d, want 200", resp.StatusCode)
+	}
+
+	// Second request should be served from cache.
+	resp, err = http.Get(ts.URL + "/.well-known/jwks.json")
+	if err != nil {
+		t.Fatalf("second GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("second GET status = %d, want 200", resp.StatusCode)
+	}
+
+	if count := fetchCount.Load(); count != 1 {
+		t.Errorf("hub was fetched %d times, want 1 (second should be cached)", count)
+	}
+}
+
+func TestOIDCProxyHubDown(t *testing.T) {
+	// Use a URL that can't be reached.
+	_, ts := newTestServerWithHub(t, "http://127.0.0.1:1")
+
+	resp, err := http.Get(ts.URL + "/.well-known/jwks.json")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 when hub is unreachable", resp.StatusCode)
+	}
+}
+
+func TestOIDCProxyHubReturnsError(t *testing.T) {
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(hub.Close)
+
+	_, ts := newTestServerWithHub(t, hub.URL)
+
+	resp, err := http.Get(ts.URL + "/.well-known/openid-configuration")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 when hub returns error", resp.StatusCode)
+	}
+}
+
+func TestOIDCProxyNoAuthRequired(t *testing.T) {
+	// Use a server with apiKey auth to verify the proxy endpoints bypass auth.
+	hub := fakeHubOIDC(t)
+
+	dir := t.TempDir()
+	store, err := state.NewSQLite(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("state.New: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	cfg := &Config{
+		Bridge: BridgeConfig{
+			ExternalURL: "https://bridge.example.com",
+		},
+		Hub: HubConfig{
+			Endpoint: hub.URL,
+			User:     "test@example.com",
+		},
+		Auth: AuthConfig{
+			Scheme: "apiKey",
+			APIKey: "secret-key",
+		},
+		Projects: []ProjectConfig{
+			{Slug: "test-project", ExposedAgents: []string{"test-agent"}},
+		},
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := New(store, nil, nil, cfg, nil, log)
+
+	executor := NewScionExecutor(b, log)
+	routeAuth := RouteKeyAuthenticator()
+	innerStore := taskstore.NewInMemory(&taskstore.InMemoryStoreConfig{
+		Authenticator: routeAuth,
+	})
+	scopedStore := NewScopedTaskStore(innerStore)
+	sdkRequestHandler := a2asrv.NewHandler(
+		executor,
+		a2asrv.WithLogger(log),
+		a2asrv.WithCapabilityChecks(&a2a.AgentCapabilities{
+			Streaming:         true,
+			PushNotifications: false,
+		}),
+		a2asrv.WithTaskStore(scopedStore),
+	)
+	b.SetSDKRequestHandler(sdkRequestHandler)
+	sdkJSONRPCHandler := a2asrv.NewJSONRPCHandler(sdkRequestHandler)
+
+	srv := NewServer(b, cfg, nil, log, sdkJSONRPCHandler)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	// Both OIDC proxy endpoints should be accessible without auth.
+	for _, path := range []string{
+		"/.well-known/openid-configuration",
+		"/.well-known/jwks.json",
+	} {
+		t.Run(path, func(t *testing.T) {
+			resp, err := http.Get(ts.URL + path)
+			if err != nil {
+				t.Fatalf("GET %s: %v", path, err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("GET %s without auth: status = %d, want 200", path, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestRewriteJWKSURI(t *testing.T) {
+	input := `{
+		"issuer": "https://hub.example.com",
+		"jwks_uri": "https://hub.example.com/.well-known/jwks.json",
+		"response_types_supported": ["id_token"]
+	}`
+
+	result, err := rewriteJWKSURI([]byte(input), "https://bridge.example.com")
+	if err != nil {
+		t.Fatalf("rewriteJWKSURI: %v", err)
+	}
+
+	var doc map[string]interface{}
+	if err := json.Unmarshal(result, &doc); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+
+	want := "https://bridge.example.com/.well-known/jwks.json"
+	if doc["jwks_uri"] != want {
+		t.Errorf("jwks_uri = %q, want %q", doc["jwks_uri"], want)
+	}
+
+	// Other fields should be preserved.
+	if doc["issuer"] != "https://hub.example.com" {
+		t.Errorf("issuer = %q, want preserved", doc["issuer"])
+	}
+}
+
+func TestRewriteJWKSURITrailingSlash(t *testing.T) {
+	input := `{"jwks_uri": "https://hub.example.com/.well-known/jwks.json"}`
+
+	result, err := rewriteJWKSURI([]byte(input), "https://bridge.example.com/")
+	if err != nil {
+		t.Fatalf("rewriteJWKSURI: %v", err)
+	}
+
+	var doc map[string]interface{}
+	json.Unmarshal(result, &doc)
+
+	want := "https://bridge.example.com/.well-known/jwks.json"
+	if doc["jwks_uri"] != want {
+		t.Errorf("jwks_uri = %q, want %q (trailing slash should be trimmed)", doc["jwks_uri"], want)
+	}
+}
+
+func TestOIDCProxyCacheTTL(t *testing.T) {
+	cache := newOIDCProxyCache(50 * time.Millisecond)
+
+	cache.set("key", []byte("value"))
+	if got := cache.get("key"); string(got) != "value" {
+		t.Errorf("cache.get = %q, want %q", got, "value")
+	}
+
+	// Wait for TTL to expire.
+	time.Sleep(60 * time.Millisecond)
+
+	if got := cache.get("key"); got != nil {
+		t.Errorf("cache.get after TTL = %q, want nil", got)
+	}
+}

--- a/extras/scion-a2a-bridge/internal/bridge/oidc_proxy_test.go
+++ b/extras/scion-a2a-bridge/internal/bridge/oidc_proxy_test.go
@@ -16,6 +16,7 @@ package bridge
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -39,10 +40,10 @@ func fakeHubOIDC(t *testing.T) *httptest.Server {
 
 	mux.HandleFunc("GET /.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		doc := map[string]interface{}{
-			"issuer":   "https://hub.example.com",
-			"jwks_uri": "https://hub.example.com/.well-known/jwks.json",
-			"response_types_supported":            []string{"id_token"},
-			"subject_types_supported":             []string{"public"},
+			"issuer":                                "https://hub.example.com",
+			"jwks_uri":                              "https://hub.example.com/.well-known/jwks.json",
+			"response_types_supported":              []string{"id_token"},
+			"subject_types_supported":               []string{"public"},
 			"id_token_signing_alg_values_supported": []string{"RS256"},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -390,6 +391,73 @@ func TestRewriteJWKSURITrailingSlash(t *testing.T) {
 	want := "https://bridge.example.com/.well-known/jwks.json"
 	if doc["jwks_uri"] != want {
 		t.Errorf("jwks_uri = %q, want %q (trailing slash should be trimmed)", doc["jwks_uri"], want)
+	}
+}
+
+func TestOIDCProxyOversizedBody(t *testing.T) {
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Write more than oidcProxyMaxBody (1 MB) bytes.
+		w.Write(make([]byte, 1<<20+1))
+	}))
+	t.Cleanup(hub.Close)
+
+	_, ts := newTestServerWithHub(t, hub.URL)
+
+	resp, err := http.Get(ts.URL + "/.well-known/jwks.json")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 when response exceeds max body size", resp.StatusCode)
+	}
+}
+
+func TestOIDCProxySingleflight(t *testing.T) {
+	var fetchCount atomic.Int32
+	// Add a small delay to ensure requests overlap.
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetchCount.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"keys": []map[string]string{{"kid": "k1"}},
+		})
+	}))
+	t.Cleanup(hub.Close)
+
+	_, ts := newTestServerWithHub(t, hub.URL)
+
+	// Launch multiple concurrent requests.
+	const n = 10
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			resp, err := http.Get(ts.URL + "/.well-known/jwks.json")
+			if err != nil {
+				errs <- err
+				return
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				errs <- fmt.Errorf("status = %d, want 200", resp.StatusCode)
+				return
+			}
+			errs <- nil
+		}()
+	}
+
+	for i := 0; i < n; i++ {
+		if err := <-errs; err != nil {
+			t.Errorf("request %d: %v", i, err)
+		}
+	}
+
+	// With singleflight, only 1 request should reach the hub.
+	if count := fetchCount.Load(); count != 1 {
+		t.Errorf("hub was fetched %d times, want 1 (singleflight should deduplicate)", count)
 	}
 }
 

--- a/extras/scion-a2a-bridge/internal/bridge/server.go
+++ b/extras/scion-a2a-bridge/internal/bridge/server.go
@@ -183,6 +183,10 @@ func (s *Server) Handler() http.Handler {
 	// Top-level well-known agent card (registry).
 	mux.HandleFunc("GET /.well-known/agent-card.json", s.handleWellKnownAgentCard)
 
+	// OIDC discovery proxy — publicly exposes the hub's IAP-protected OIDC endpoints.
+	mux.HandleFunc("GET /.well-known/openid-configuration", s.handleOIDCDiscoveryProxy)
+	mux.HandleFunc("GET /.well-known/jwks.json", s.handleJWKSProxy)
+
 	// Per-agent routes — the SDK handler handles JSON-RPC protocol.
 	mux.HandleFunc("GET /projects/{projectSlug}/agents/{agentSlug}/.well-known/agent-card.json", s.handleAgentCard)
 	mux.HandleFunc("POST /projects/{projectSlug}/agents/{agentSlug}/jsonrpc", s.handleJSONRPC)
@@ -391,7 +395,10 @@ func writeJSONRPCError(w http.ResponseWriter, id interface{}, code int, message 
 func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Public/operational endpoints skip auth.
-		if r.URL.Path == "/.well-known/agent-card.json" || r.URL.Path == "/healthz" || r.URL.Path == "/readyz" || r.URL.Path == "/metrics" {
+		if r.URL.Path == "/.well-known/agent-card.json" ||
+			r.URL.Path == "/.well-known/openid-configuration" ||
+			r.URL.Path == "/.well-known/jwks.json" ||
+			r.URL.Path == "/healthz" || r.URL.Path == "/readyz" || r.URL.Path == "/metrics" {
 			next.ServeHTTP(w, r)
 			return
 		}


### PR DESCRIPTION
Adds public proxy endpoints on the bridge for OIDC discovery and JWKS behind IAP. Uses bridge transport auth (IAP credentials) to fetch from hub, serves publicly. 5-minute in-memory cache, jwks_uri rewriting.

Refs ptone/scion#930