### PR TITLE
fix(hub): add durable workspace storage via NFS and safety gate for Cloud Run

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1544,6 +1544,7 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 		OIDCLogin:               cfg.OIDCLogin,
 		OIDCConfig:              cfg.OIDC,
 		Federation:              cfg.Federation,
+		WorkspaceStorageConfig:  cfg.WorkspaceStorage,
 	}
 
 	// In hosted mode every replica must share the same session secret for

--- a/pkg/config/hub_config.go
+++ b/pkg/config/hub_config.go
@@ -453,6 +453,11 @@ type GlobalConfig struct {
 	// OIDC Identity Provider settings
 	OIDC OIDCProviderConfig `json:"oidc,omitempty" yaml:"oidc,omitempty" koanf:"oidc"`
 
+	// WorkspaceStorage selects the workspace storage backend for hub-managed
+	// project workspaces. Nil or Backend=="" / "local" preserves the legacy
+	// node-local behavior. Populated from server.workspace_storage in settings.yaml.
+	WorkspaceStorage *V1WorkspaceStorageConfig `json:"-" yaml:"-" koanf:"-"`
+
 	// Federation settings for hub-hub authentication
 	Federation FederationConfig `json:"federation,omitempty" yaml:"federation,omitempty" koanf:"federation"`
 

--- a/pkg/config/settings_v1.go
+++ b/pkg/config/settings_v1.go
@@ -1607,9 +1607,10 @@ func ConvertV1ServerToGlobalConfig(v1 *V1ServerConfig) *GlobalConfig {
 		}
 	}
 
-	// Workspace storage NFS defaults (conditional on backend=nfs)
+	// Workspace storage — thread into GlobalConfig so the hub can read it.
 	if v1.WorkspaceStorage != nil {
 		v1.WorkspaceStorage.ApplyNFSDefaults()
+		gc.WorkspaceStorage = v1.WorkspaceStorage
 	}
 
 	// GitHub App

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -152,7 +152,7 @@ func (s *Server) populateAgentConfig(ctx context.Context, agent *store.Agent, pr
 	if project != nil && (project.GitRemote == "" || project.IsSharedWorkspace()) {
 		existingWorkspace := agent.AppliedConfig.Workspace
 		if existingWorkspace == "" {
-			workspacePath, err := hubManagedProjectPath(project.Slug)
+			workspacePath, err := s.hubManagedProjectPath(project.Slug)
 			if err == nil {
 				agent.AppliedConfig.Workspace = workspacePath
 			}

--- a/pkg/hub/handlers_health.go
+++ b/pkg/hub/handlers_health.go
@@ -17,6 +17,8 @@ package hub
 import (
 	"context"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
@@ -53,6 +55,9 @@ func (s *Server) GetHealthInfo(ctx context.Context) *HealthResponse {
 	} else {
 		checks["database"] = "healthy"
 	}
+
+	// Check NFS workspace storage when configured
+	s.checkWorkspaceStorageHealth(checks)
 
 	// Get stats
 	stats := &HealthStats{}
@@ -92,6 +97,41 @@ func (h *HealthResponse) HealthStatus() string {
 	return h.Status
 }
 
+// checkWorkspaceStorageHealth verifies that the configured workspace storage
+// backend is accessible. For NFS and Cloud Run volume backends, it stats the
+// mount point to confirm it is present. For local storage, no check is needed.
+func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
+	wsCfg := s.config.WorkspaceStorageConfig
+	if wsCfg == nil || wsCfg.Backend == "" || wsCfg.Backend == "local" {
+		return // Local storage — no health check needed
+	}
+
+	var mountPath string
+	switch wsCfg.Backend {
+	case "nfs":
+		if wsCfg.NFS != nil && len(wsCfg.NFS.Shares) > 0 {
+			share := wsCfg.NFS.Shares[0]
+			mountPath = filepath.Join(wsCfg.NFS.MountRoot, share.ID)
+		}
+	case "cloudrun-volume":
+		if wsCfg.CloudRunVolume != nil && wsCfg.CloudRunVolume.VolumeName != "" {
+			mountPath = filepath.Join("/mnt", wsCfg.CloudRunVolume.VolumeName)
+		}
+	}
+
+	if mountPath == "" {
+		checks["workspace_storage"] = "unhealthy: mount path not configured"
+		return
+	}
+
+	if _, err := os.Stat(mountPath); err != nil {
+		checks["workspace_storage"] = "unhealthy: mount not available"
+		return
+	}
+
+	checks["workspace_storage"] = "healthy"
+}
+
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		MethodNotAllowed(w)
@@ -115,6 +155,20 @@ func (s *Server) handleReadyz(w http.ResponseWriter, r *http.Request) {
 			"reason": "database not available",
 		})
 		return
+	}
+
+	// Check workspace storage health for readiness
+	wsCfg := s.config.WorkspaceStorageConfig
+	if wsCfg != nil && wsCfg.Backend != "" && wsCfg.Backend != "local" {
+		checks := make(map[string]string)
+		s.checkWorkspaceStorageHealth(checks)
+		if status, ok := checks["workspace_storage"]; ok && status != "healthy" {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+				"status": "not_ready",
+				"reason": "workspace storage not available",
+			})
+			return
+		}
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{

--- a/pkg/hub/handlers_health.go
+++ b/pkg/hub/handlers_health.go
@@ -124,12 +124,28 @@ func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 		return
 	}
 
-	if _, err := os.Stat(mountPath); err != nil {
-		checks["workspace_storage"] = "unhealthy: mount not available"
-		return
+	// Wrap os.Stat in a goroutine with a timeout to prevent blocking on a
+	// hung NFS mount. A stuck stat call would otherwise hang the health
+	// endpoint indefinitely, taking down readiness probes.
+	type statResult struct {
+		err error
 	}
+	ch := make(chan statResult, 1)
+	go func() {
+		_, err := os.Stat(mountPath)
+		ch <- statResult{err: err}
+	}()
 
-	checks["workspace_storage"] = "healthy"
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			checks["workspace_storage"] = "unhealthy: mount not available"
+			return
+		}
+		checks["workspace_storage"] = "healthy"
+	case <-time.After(2 * time.Second):
+		checks["workspace_storage"] = "unhealthy: mount check timed out"
+	}
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -705,8 +705,8 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 // legacy local path, so existing local deployments continue to work
 // when NFS is first configured.
 func (s *Server) hubManagedProjectPath(slug string) (string, error) {
-	if slug == "" {
-		return "", fmt.Errorf("project slug must not be empty")
+	if err := validateProjectSlug(slug); err != nil {
+		return "", err
 	}
 
 	wsCfg := s.config.WorkspaceStorageConfig
@@ -756,11 +756,23 @@ func hubManagedProjectPath(slug string) (string, error) {
 	return localProjectPath(slug)
 }
 
+// validateProjectSlug rejects empty slugs and slugs containing path-traversal
+// characters (/, \, ..) to prevent directory-traversal attacks.
+func validateProjectSlug(slug string) error {
+	if slug == "" {
+		return fmt.Errorf("project slug must not be empty")
+	}
+	if strings.Contains(slug, "/") || strings.Contains(slug, "\\") || strings.Contains(slug, "..") {
+		return fmt.Errorf("project slug contains invalid characters")
+	}
+	return nil
+}
+
 // localProjectPath returns the legacy local filesystem path for a hub-managed
 // project workspace under ~/.scion/projects/<slug>, with groves/<slug> fallback.
 func localProjectPath(slug string) (string, error) {
-	if slug == "" {
-		return "", fmt.Errorf("project slug must not be empty")
+	if err := validateProjectSlug(slug); err != nil {
+		return "", err
 	}
 	globalDir, err := config.GetGlobalDir()
 	if err != nil {
@@ -2511,7 +2523,8 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 		return
 	}
 
-	// For hub-native and shared-workspace projects, remove the filesystem directory.
+	// For hub-native and shared-workspace projects, remove the filesystem directory
+	// and clean up the per-project WebDAV lock store to prevent memory leaks.
 	if (project.GitRemote == "" || project.IsSharedWorkspace()) && project.Slug != "" {
 		if projectPath, err := s.hubManagedProjectPath(project.Slug); err == nil {
 			if err := util.RemoveAllSafe(projectPath); err != nil {
@@ -2520,6 +2533,7 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 			}
 		}
 	}
+	s.webdavLocks.Delete(id)
 
 	// Clean up the project-configs directory (~/.scion/project-configs/<slug>__<short-uuid>/).
 	// This stores external settings, templates, and agent homes for both

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -698,7 +698,67 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 // hubManagedProjectPath returns the filesystem path for a hub-managed project workspace.
 // It prefers projects/<slug> and falls back to groves/<slug> for backward compatibility
 // with workspaces created before the grove-to-project rename.
+//
+// When the server has a workspace storage config with backend "nfs" or
+// "cloudrun-volume", the NFS/volume-backed path is returned instead.
+// A backward-compatible fallback checks the NFS path first, then the
+// legacy local path, so existing local deployments continue to work
+// when NFS is first configured.
+func (s *Server) hubManagedProjectPath(slug string) (string, error) {
+	if slug == "" {
+		return "", fmt.Errorf("project slug must not be empty")
+	}
+
+	wsCfg := s.config.WorkspaceStorageConfig
+
+	// --- NFS backend ---
+	if wsCfg != nil && wsCfg.Backend == "nfs" && wsCfg.NFS != nil && len(wsCfg.NFS.Shares) > 0 {
+		share := wsCfg.NFS.Shares[0]
+		mountBase := filepath.Join(wsCfg.NFS.MountRoot, share.ID)
+		nfsPath := filepath.Join(mountBase, "hub-projects", slug)
+		if hasWorkspaceContent(nfsPath) {
+			return nfsPath, nil
+		}
+		// Fallback: check legacy local path for backward compatibility
+		if localPath, err := localProjectPath(slug); err == nil && hasWorkspaceContent(localPath) {
+			return localPath, nil
+		}
+		// Neither has content — return NFS path (new projects go to NFS)
+		return nfsPath, nil
+	}
+
+	// --- Cloud Run volume backend ---
+	if wsCfg != nil && wsCfg.Backend == "cloudrun-volume" && wsCfg.CloudRunVolume != nil {
+		subPathRoot := wsCfg.CloudRunVolume.SubPathRoot
+		if subPathRoot == "" {
+			subPathRoot = "projects"
+		}
+		crPath := filepath.Join("/mnt", wsCfg.CloudRunVolume.VolumeName, subPathRoot, "hub-projects", slug)
+		if hasWorkspaceContent(crPath) {
+			return crPath, nil
+		}
+		// Fallback: check legacy local path
+		if localPath, err := localProjectPath(slug); err == nil && hasWorkspaceContent(localPath) {
+			return localPath, nil
+		}
+		return crPath, nil
+	}
+
+	// --- Default: local ephemeral path (existing behavior) ---
+	return localProjectPath(slug)
+}
+
+// hubManagedProjectPath is the package-level backward-compatible wrapper used by
+// callers that don't have access to a Server (e.g. resolveHubProjectSharedDirPath).
+// It always returns the local path. Server-method callers should prefer
+// s.hubManagedProjectPath for durable-storage awareness.
 func hubManagedProjectPath(slug string) (string, error) {
+	return localProjectPath(slug)
+}
+
+// localProjectPath returns the legacy local filesystem path for a hub-managed
+// project workspace under ~/.scion/projects/<slug>, with groves/<slug> fallback.
+func localProjectPath(slug string) (string, error) {
 	if slug == "" {
 		return "", fmt.Errorf("project slug must not be empty")
 	}
@@ -714,7 +774,6 @@ func hubManagedProjectPath(slug string) (string, error) {
 	if hasWorkspaceContent(grovesPath) {
 		return grovesPath, nil
 	}
-	// Neither has content — return projects path (will be created on demand)
 	return projectsPath, nil
 }
 
@@ -741,7 +800,7 @@ func hasWorkspaceContent(dir string) bool {
 // hub connection settings. Unlike regular projects, hub-managed projects store
 // settings directly in the .scion directory (no split storage or marker files).
 func (s *Server) initHubManagedProject(project *store.Project) error {
-	workspacePath, err := hubManagedProjectPath(project.Slug)
+	workspacePath, err := s.hubManagedProjectPath(project.Slug)
 	if err != nil {
 		return err
 	}
@@ -791,7 +850,7 @@ func (s *Server) initHubManagedProject(project *store.Project) error {
 // seeds the .scion project structure on top. If the clone fails, the workspace
 // directory is cleaned up and an error is returned.
 func (s *Server) cloneSharedWorkspaceProject(ctx context.Context, project *store.Project) error {
-	workspacePath, err := hubManagedProjectPath(project.Slug)
+	workspacePath, err := s.hubManagedProjectPath(project.Slug)
 	if err != nil {
 		return err
 	}
@@ -967,7 +1026,7 @@ func (s *Server) syncWorkspaceOnStop(ctx context.Context, agent *store.Agent) {
 	}
 
 	// Download from GCS to Hub filesystem
-	workspacePath, err := hubManagedProjectPath(project.Slug)
+	workspacePath, err := s.hubManagedProjectPath(project.Slug)
 	if err != nil {
 		s.agentLifecycleLog.Warn("syncWorkspaceOnStop: failed to get project path", "agent_id", agent.ID, "error", err)
 		return
@@ -2318,7 +2377,7 @@ func (s *Server) migrateProjectSlug(ctx context.Context, project *store.Project,
 
 	// Migrate hub-managed project filesystem paths (best-effort).
 	// Derive newPath from oldPath's parent to preserve the directory type (groves/ vs projects/).
-	if oldPath, err := hubManagedProjectPath(oldSlug); err == nil {
+	if oldPath, err := s.hubManagedProjectPath(oldSlug); err == nil {
 		if _, statErr := os.Stat(oldPath); statErr == nil {
 			newPath := filepath.Join(filepath.Dir(oldPath), newSlug)
 			if _, statErr := os.Stat(newPath); os.IsNotExist(statErr) {
@@ -2454,7 +2513,7 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 
 	// For hub-native and shared-workspace projects, remove the filesystem directory.
 	if (project.GitRemote == "" || project.IsSharedWorkspace()) && project.Slug != "" {
-		if projectPath, err := hubManagedProjectPath(project.Slug); err == nil {
+		if projectPath, err := s.hubManagedProjectPath(project.Slug); err == nil {
 			if err := util.RemoveAllSafe(projectPath); err != nil {
 				s.projectsLogger().Warn("failed to remove hub-managed project directory",
 					"project_id", id, "slug", project.Slug, "path", projectPath, "error", err)

--- a/pkg/hub/project_cache.go
+++ b/pkg/hub/project_cache.go
@@ -215,7 +215,7 @@ func (s *Server) handleProjectCacheStatus(w http.ResponseWriter, r *http.Request
 	}
 
 	// Check if a cache exists on disk
-	cachePath, err := hubManagedProjectPath(project.Slug)
+	cachePath, err := s.hubManagedProjectPath(project.Slug)
 	if err != nil {
 		InternalError(w)
 		return
@@ -274,7 +274,7 @@ func (s *Server) handleProjectCacheNotify(w http.ResponseWriter, r *http.Request
 	}
 
 	// Download the latest workspace from GCS to local cache
-	cachePath, err := hubManagedProjectPath(project.Slug)
+	cachePath, err := s.hubManagedProjectPath(project.Slug)
 	if err != nil {
 		InternalError(w)
 		return
@@ -363,7 +363,7 @@ func (s *Server) refreshProjectCacheFromBroker(ctx context.Context, project *sto
 	}
 
 	// Download from GCS to local cache
-	cachePath, err := hubManagedProjectPath(project.Slug)
+	cachePath, err := s.hubManagedProjectPath(project.Slug)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve cache path: %w", err)
 	}

--- a/pkg/hub/project_cache.go
+++ b/pkg/hub/project_cache.go
@@ -458,8 +458,10 @@ func (s *Server) findConnectedProvider(ctx context.Context, project *store.Proje
 }
 
 // hasProjectCache returns true if the hub has a cached copy of the project workspace.
-func hasProjectCache(slug string) bool {
-	cachePath, err := hubManagedProjectPath(slug)
+// This is a Server method so it uses the workspace-storage-aware path resolution,
+// avoiding false "cache not populated" warnings when NFS is configured.
+func (s *Server) hasProjectCache(slug string) bool {
+	cachePath, err := s.hubManagedProjectPath(slug)
 	if err != nil {
 		return false
 	}

--- a/pkg/hub/project_cache_test.go
+++ b/pkg/hub/project_cache_test.go
@@ -296,8 +296,9 @@ func TestProjectCacheRefresh_MethodNotAllowed(t *testing.T) {
 // ============================================================================
 
 func TestHasProjectCache(t *testing.T) {
+	srv, _ := testServer(t)
 	// Non-existent slug should return false
-	assert.False(t, hasProjectCache("non-existent-slug-12345"))
+	assert.False(t, srv.hasProjectCache("non-existent-slug-12345"))
 }
 
 // ============================================================================

--- a/pkg/hub/project_webdav.go
+++ b/pkg/hub/project_webdav.go
@@ -89,9 +89,9 @@ func (s *Server) handleProjectWebDAV(w http.ResponseWriter, r *http.Request, pro
 	// Phase 0 safety gate: reject write operations on Cloud Run without durable storage.
 	if s.workspaceWriteBlocked() {
 		switch r.Method {
-		case "PUT", "DELETE", "MKCOL", "MOVE", "PROPPATCH":
+		case "PUT", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH":
 			writeError(w, http.StatusServiceUnavailable, "workspace_writes_unavailable",
-				"Workspace writes are not available in this deployment configuration. Configure durable workspace storage (NFS) to enable file editing.", nil)
+				errWorkspaceWritesUnavailable, nil)
 			return
 		}
 	}
@@ -99,7 +99,13 @@ func (s *Server) handleProjectWebDAV(w http.ResponseWriter, r *http.Request, pro
 	// Look up or create a per-project lock store so that WebDAV locks
 	// survive across HTTP requests within a single instance. Previously,
 	// NewMemLS() was called per-request, making locks completely ephemeral.
-	lockStore, _ := s.webdavLocks.LoadOrStore(projectID, webdav.NewMemLS())
+	// Use Load first to avoid allocating a new MemLS on every request.
+	var lockStore interface{}
+	if ls, ok := s.webdavLocks.Load(projectID); ok {
+		lockStore = ls
+	} else {
+		lockStore, _ = s.webdavLocks.LoadOrStore(projectID, webdav.NewMemLS())
+	}
 
 	handler := &webdav.Handler{
 		Prefix:     prefix,
@@ -196,7 +202,7 @@ func (s *Server) resolveProjectWebDAVPath(ctx context.Context, project *store.Pr
 
 	// If cache doesn't exist yet, return the path anyway (MkdirAll will create it).
 	// The client should trigger a cache/refresh to populate it.
-	if !hasProjectCache(project.Slug) {
+	if !s.hasProjectCache(project.Slug) {
 		slog.Debug("linked project cache not yet populated",
 			"project_id", project.ID, "slug", project.Slug)
 	}

--- a/pkg/hub/project_webdav.go
+++ b/pkg/hub/project_webdav.go
@@ -86,6 +86,16 @@ func (s *Server) handleProjectWebDAV(w http.ResponseWriter, r *http.Request, pro
 	}
 	prefix := r.URL.Path[:prefixEnd+len("/dav")]
 
+	// Phase 0 safety gate: reject write operations on Cloud Run without durable storage.
+	if s.workspaceWriteBlocked() {
+		switch r.Method {
+		case "PUT", "DELETE", "MKCOL", "MOVE", "PROPPATCH":
+			writeError(w, http.StatusServiceUnavailable, "workspace_writes_unavailable",
+				"Workspace writes are not available in this deployment configuration. Configure durable workspace storage (NFS) to enable file editing.", nil)
+			return
+		}
+	}
+
 	handler := &webdav.Handler{
 		Prefix:     prefix,
 		FileSystem: &filteredFS{root: webdav.Dir(workspacePath)},
@@ -136,7 +146,7 @@ func (s *Server) updateProjectSyncState(projectID, workspacePath string) {
 func (s *Server) resolveProjectWebDAVPath(ctx context.Context, project *store.Project) (string, error) {
 	// Hub-managed projects (no git remote) always have a managed workspace
 	if project.GitRemote == "" {
-		path, err := hubManagedProjectPath(project.Slug)
+		path, err := s.hubManagedProjectPath(project.Slug)
 		if err != nil {
 			return "", fmt.Errorf("failed to resolve project path")
 		}
@@ -145,7 +155,7 @@ func (s *Server) resolveProjectWebDAVPath(ctx context.Context, project *store.Pr
 
 	// Shared-workspace git projects have a managed workspace on the hub
 	if project.IsSharedWorkspace() {
-		path, err := hubManagedProjectPath(project.Slug)
+		path, err := s.hubManagedProjectPath(project.Slug)
 		if err != nil {
 			return "", fmt.Errorf("failed to resolve project path")
 		}
@@ -174,7 +184,7 @@ func (s *Server) resolveProjectWebDAVPath(ctx context.Context, project *store.Pr
 
 	// Remote linked project: serve from the hub's cached copy.
 	// The cache is populated via cache/refresh or cache/notify endpoints.
-	cachePath, err := hubManagedProjectPath(project.Slug)
+	cachePath, err := s.hubManagedProjectPath(project.Slug)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve project cache path")
 	}

--- a/pkg/hub/project_webdav.go
+++ b/pkg/hub/project_webdav.go
@@ -121,7 +121,7 @@ func (s *Server) handleProjectWebDAV(w http.ResponseWriter, r *http.Request, pro
 	handler.ServeHTTP(w, r)
 
 	// Update sync state after successful write operations
-	if r.Method == "PUT" || r.Method == "DELETE" || r.Method == "MKCOL" || r.Method == "MOVE" {
+	if r.Method == "PUT" || r.Method == "DELETE" || r.Method == "MKCOL" || r.Method == "MOVE" || r.Method == "COPY" {
 		go s.updateProjectSyncState(project.ID, workspacePath)
 	}
 }

--- a/pkg/hub/project_webdav.go
+++ b/pkg/hub/project_webdav.go
@@ -96,10 +96,15 @@ func (s *Server) handleProjectWebDAV(w http.ResponseWriter, r *http.Request, pro
 		}
 	}
 
+	// Look up or create a per-project lock store so that WebDAV locks
+	// survive across HTTP requests within a single instance. Previously,
+	// NewMemLS() was called per-request, making locks completely ephemeral.
+	lockStore, _ := s.webdavLocks.LoadOrStore(projectID, webdav.NewMemLS())
+
 	handler := &webdav.Handler{
 		Prefix:     prefix,
 		FileSystem: &filteredFS{root: webdav.Dir(workspacePath)},
-		LockSystem: webdav.NewMemLS(),
+		LockSystem: lockStore.(webdav.LockSystem),
 		Logger: func(r *http.Request, err error) {
 			if err != nil {
 				slog.Debug("webdav operation", "method", r.Method, "path", r.URL.Path, "error", err)

--- a/pkg/hub/project_workspace_handlers.go
+++ b/pkg/hub/project_workspace_handlers.go
@@ -54,19 +54,25 @@ const maxEditableFileSize = 1 * 1024 * 1024
 
 // workspaceWriteBlocked returns true when workspace writes should be rejected
 // with 503 Service Unavailable. This happens when the hub is running on Cloud
-// Run (K_SERVICE is set) and workspace storage backend is "local" (or empty),
-// meaning writes would go to ephemeral tmpfs and be silently lost on recycle.
+// Run (K_SERVICE is set) and no durable storage backend is configured.
+//
+// Uses an allowlist of known-durable backends rather than a blocklist, so that
+// an unrecognized backend value fails closed (blocked) rather than silently
+// writing to ephemeral storage.
 func (s *Server) workspaceWriteBlocked() bool {
 	// Not on Cloud Run → writes are fine (self-hosted with local disk)
 	if os.Getenv("K_SERVICE") == "" {
 		return false
 	}
-	// On Cloud Run with durable storage configured → writes are fine
+	// On Cloud Run — only allow writes if a known durable backend is configured
 	wsCfg := s.config.WorkspaceStorageConfig
-	if wsCfg != nil && wsCfg.Backend != "" && wsCfg.Backend != "local" {
-		return false
+	if wsCfg != nil {
+		switch wsCfg.Backend {
+		case "nfs", "cloudrun-volume", "gke-shared-volume":
+			return false // Known durable backend → writes allowed
+		}
 	}
-	// On Cloud Run with local/no backend → block writes
+	// No config, empty backend, "local", or unrecognized → block writes
 	return true
 }
 

--- a/pkg/hub/project_workspace_handlers.go
+++ b/pkg/hub/project_workspace_handlers.go
@@ -52,6 +52,15 @@ const maxUploadFileSize = 50 * 1024 * 1024
 // maxEditableFileSize is the maximum file size the editor will serve for inline editing (1MB).
 const maxEditableFileSize = 1 * 1024 * 1024
 
+// isCloudRunEnv checks K_SERVICE to determine if we're running on Cloud Run.
+// In production, K_SERVICE is set once at container startup and never changes,
+// so calling os.Getenv is effectively a cached lookup (the C library caches
+// the environment block). This avoids the complexity of sync.Once while
+// remaining test-friendly via t.Setenv.
+func isCloudRunEnv() bool {
+	return os.Getenv("K_SERVICE") != ""
+}
+
 // workspaceWriteBlocked returns true when workspace writes should be rejected
 // with 503 Service Unavailable. This happens when the hub is running on Cloud
 // Run (K_SERVICE is set) and no durable storage backend is configured.
@@ -61,7 +70,7 @@ const maxEditableFileSize = 1 * 1024 * 1024
 // writing to ephemeral storage.
 func (s *Server) workspaceWriteBlocked() bool {
 	// Not on Cloud Run → writes are fine (self-hosted with local disk)
-	if os.Getenv("K_SERVICE") == "" {
+	if !isCloudRunEnv() {
 		return false
 	}
 	// On Cloud Run — only allow writes if a known durable backend is configured
@@ -936,6 +945,14 @@ func validateWorkspaceFilePath(path string) error {
 func (s *Server) handleProjectWorkspacePull(w http.ResponseWriter, r *http.Request, projectID string) {
 	if r.Method != http.MethodPost {
 		MethodNotAllowed(w)
+		return
+	}
+
+	// Phase 0 safety gate: reject pull on Cloud Run without durable storage.
+	// Pull modifies the workspace filesystem, so it is a write operation.
+	if s.workspaceWriteBlocked() {
+		writeError(w, http.StatusServiceUnavailable, "workspace_writes_unavailable",
+			errWorkspaceWritesUnavailable, nil)
 		return
 	}
 

--- a/pkg/hub/project_workspace_handlers.go
+++ b/pkg/hub/project_workspace_handlers.go
@@ -39,6 +39,10 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
 )
 
+// errWorkspaceWritesUnavailable is the error message returned when workspace
+// writes are blocked because the deployment has no durable storage backend.
+const errWorkspaceWritesUnavailable = "Workspace writes are not available in this deployment configuration. Configure durable workspace storage (NFS) to enable file editing."
+
 // maxUploadTotalSize is the maximum total request body size for file uploads (100MB).
 const maxUploadTotalSize = 100 * 1024 * 1024
 
@@ -47,6 +51,24 @@ const maxUploadFileSize = 50 * 1024 * 1024
 
 // maxEditableFileSize is the maximum file size the editor will serve for inline editing (1MB).
 const maxEditableFileSize = 1 * 1024 * 1024
+
+// workspaceWriteBlocked returns true when workspace writes should be rejected
+// with 503 Service Unavailable. This happens when the hub is running on Cloud
+// Run (K_SERVICE is set) and workspace storage backend is "local" (or empty),
+// meaning writes would go to ephemeral tmpfs and be silently lost on recycle.
+func (s *Server) workspaceWriteBlocked() bool {
+	// Not on Cloud Run → writes are fine (self-hosted with local disk)
+	if os.Getenv("K_SERVICE") == "" {
+		return false
+	}
+	// On Cloud Run with durable storage configured → writes are fine
+	wsCfg := s.config.WorkspaceStorageConfig
+	if wsCfg != nil && wsCfg.Backend != "" && wsCfg.Backend != "local" {
+		return false
+	}
+	// On Cloud Run with local/no backend → block writes
+	return true
+}
 
 // ProjectWorkspaceFile represents a file in a project workspace.
 type ProjectWorkspaceFile struct {
@@ -282,6 +304,12 @@ func (s *Server) handleSharedDirFileList(w http.ResponseWriter, r *http.Request,
 
 // handleProjectWorkspaceUpload handles file uploads to a project workspace.
 func (s *Server) handleProjectWorkspaceUpload(w http.ResponseWriter, r *http.Request, workspacePath string) {
+	// Phase 0 safety gate: reject writes on Cloud Run without durable storage
+	if s.workspaceWriteBlocked() {
+		writeError(w, http.StatusServiceUnavailable, "workspace_writes_unavailable", errWorkspaceWritesUnavailable, nil)
+		return
+	}
+
 	// Apply total request body size limit
 	r.Body = http.MaxBytesReader(w, r.Body, maxUploadTotalSize)
 
@@ -623,6 +651,12 @@ type ProjectWorkspaceWriteRequest struct {
 // server checks that the file has not been modified since that time and returns
 // 409 Conflict if it has.
 func (s *Server) handleProjectWorkspaceWrite(w http.ResponseWriter, r *http.Request, workspacePath, filePath string) {
+	// Phase 0 safety gate: reject writes on Cloud Run without durable storage
+	if s.workspaceWriteBlocked() {
+		writeError(w, http.StatusServiceUnavailable, "workspace_writes_unavailable", errWorkspaceWritesUnavailable, nil)
+		return
+	}
+
 	// Validate the file path
 	if err := validateWorkspaceFilePath(filePath); err != nil {
 		BadRequest(w, fmt.Sprintf("Invalid file path %q: %s", filePath, err.Error()))
@@ -687,6 +721,12 @@ func (s *Server) handleProjectWorkspaceWrite(w http.ResponseWriter, r *http.Requ
 
 // handleProjectWorkspaceDelete deletes a file from a project workspace.
 func (s *Server) handleProjectWorkspaceDelete(w http.ResponseWriter, workspacePath, filePath string) {
+	// Phase 0 safety gate: reject writes on Cloud Run without durable storage
+	if s.workspaceWriteBlocked() {
+		writeError(w, http.StatusServiceUnavailable, "workspace_writes_unavailable", errWorkspaceWritesUnavailable, nil)
+		return
+	}
+
 	// Validate the file path
 	if err := validateWorkspaceFilePath(filePath); err != nil {
 		BadRequest(w, fmt.Sprintf("Invalid file path %q: %s", filePath, err.Error()))
@@ -906,7 +946,7 @@ func (s *Server) handleProjectWorkspacePull(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	workspacePath, err := hubManagedProjectPath(project.Slug)
+	workspacePath, err := s.hubManagedProjectPath(project.Slug)
 	if err != nil {
 		InternalError(w)
 		return

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -712,6 +712,10 @@ type Server struct {
 	statelessEmbeddedBroker bool
 	runtimeReloadFunc       func() bool        // Callback to reload the co-located broker runtime; returns true if swapped
 	workstation             bool               // True when running in workstation (non-production) mode
+	// webdavLocks stores per-project WebDAV lock systems keyed by project ID.
+	// This replaces the per-request webdav.NewMemLS() so that locks survive
+	// across HTTP requests within a single instance.
+	webdavLocks sync.Map // map[string]webdav.LockSystem
 	scheduler               *Scheduler         // Unified scheduler for recurring tasks
 	cleanupOnce             sync.Once          // Ensures CleanupResources runs only once
 	ctx                     context.Context    // Server-lifetime context; cancelled on Shutdown

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -261,6 +261,13 @@ type ServerConfig struct {
 	// Used by the federation authenticator to enforce HTTPS on issuer URLs
 	// in non-dev/non-workstation modes.
 	Mode string
+
+	// WorkspaceStorageConfig selects the workspace storage backend for
+	// hub-managed project workspaces. When Backend is "nfs" or
+	// "cloudrun-volume", hubManagedProjectPath returns a path on the
+	// configured durable mount instead of the node-local home directory.
+	// Nil or Backend=="" / "local" preserves the legacy ephemeral behavior.
+	WorkspaceStorageConfig *config.V1WorkspaceStorageConfig
 }
 
 // MaintenanceConfig holds configuration for routine maintenance operation executors.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -710,16 +710,16 @@ type Server struct {
 	// statelessEmbeddedBroker is true when the embedded broker identity is a
 	// replica-independent API adapter rather than a process-owned control channel.
 	statelessEmbeddedBroker bool
-	runtimeReloadFunc       func() bool        // Callback to reload the co-located broker runtime; returns true if swapped
-	workstation             bool               // True when running in workstation (non-production) mode
+	runtimeReloadFunc       func() bool // Callback to reload the co-located broker runtime; returns true if swapped
+	workstation             bool        // True when running in workstation (non-production) mode
 	// webdavLocks stores per-project WebDAV lock systems keyed by project ID.
 	// This replaces the per-request webdav.NewMemLS() so that locks survive
 	// across HTTP requests within a single instance.
-	webdavLocks sync.Map // map[string]webdav.LockSystem
-	scheduler               *Scheduler         // Unified scheduler for recurring tasks
-	cleanupOnce             sync.Once          // Ensures CleanupResources runs only once
-	ctx                     context.Context    // Server-lifetime context; cancelled on Shutdown
-	ctxCancel               context.CancelFunc // Cancels ctx
+	webdavLocks sync.Map           // map[string]webdav.LockSystem
+	scheduler   *Scheduler         // Unified scheduler for recurring tasks
+	cleanupOnce sync.Once          // Ensures CleanupResources runs only once
+	ctx         context.Context    // Server-lifetime context; cancelled on Shutdown
+	ctxCancel   context.CancelFunc // Cancels ctx
 
 	logQueryService  *LogQueryService         // Cloud Logging query service (nil = disabled)
 	metricsDashboard *MetricsDashboardService // Cloud Monitoring metrics dashboard (nil = disabled)

--- a/pkg/hub/workspace_handlers.go
+++ b/pkg/hub/workspace_handlers.go
@@ -691,7 +691,7 @@ func (s *Server) syncHubManagedWorkspaceBack(ctx context.Context, agent *store.A
 		return
 	}
 
-	workspacePath, err := hubManagedProjectPath(project.Slug)
+	workspacePath, err := s.hubManagedProjectPath(project.Slug)
 	if err != nil {
 		s.workspaceLog.Warn("syncHubManagedWorkspaceBack: failed to get project path", "error", err)
 		return

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -327,6 +327,157 @@ func TestPackageLevelHubManagedProjectPath_AlwaysLocal(t *testing.T) {
 }
 
 // ============================================================================
+// Phase 3: Health Check Tests
+// ============================================================================
+
+func TestHealthCheck_NoWorkspaceStorage(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, "/healthz", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp HealthResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	// No workspace_storage check when backend is local/unset
+	_, hasCheck := resp.Checks["workspace_storage"]
+	assert.False(t, hasCheck, "local backend should not have workspace_storage health check")
+}
+
+func TestHealthCheck_NFSHealthy(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Use a temp dir as the "NFS mount" so it actually exists
+	nfsMount := t.TempDir()
+	shareDir := filepath.Join(nfsMount, "test-share")
+	require.NoError(t, os.MkdirAll(shareDir, 0755))
+
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "nfs",
+		NFS: &config.V1NFSConfig{
+			MountRoot: nfsMount,
+			Shares:    []config.V1NFSShare{{ID: "test-share", Server: "10.0.0.2", Export: "/scion"}},
+		},
+	}
+
+	rec := doRequest(t, srv, http.MethodGet, "/healthz", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp HealthResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "healthy", resp.Checks["workspace_storage"])
+}
+
+func TestHealthCheck_NFSUnhealthy(t *testing.T) {
+	srv, _ := testServer(t)
+
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "nfs",
+		NFS: &config.V1NFSConfig{
+			MountRoot: "/nonexistent/nfs/mount",
+			Shares:    []config.V1NFSShare{{ID: "share1", Server: "10.0.0.2", Export: "/scion"}},
+		},
+	}
+
+	rec := doRequest(t, srv, http.MethodGet, "/healthz", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp HealthResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Contains(t, resp.Checks["workspace_storage"], "unhealthy")
+	assert.Equal(t, "degraded", resp.Status)
+}
+
+func TestReadiness_NFSUnavailable(t *testing.T) {
+	srv, _ := testServer(t)
+
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "nfs",
+		NFS: &config.V1NFSConfig{
+			MountRoot: "/nonexistent/nfs/mount",
+			Shares:    []config.V1NFSShare{{ID: "share1", Server: "10.0.0.2", Export: "/scion"}},
+		},
+	}
+
+	rec := doRequest(t, srv, http.MethodGet, "/readyz", nil)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "not_ready", resp["status"])
+	assert.Contains(t, resp["reason"], "workspace storage")
+}
+
+func TestReadiness_NFSAvailable(t *testing.T) {
+	srv, _ := testServer(t)
+
+	nfsMount := t.TempDir()
+	shareDir := filepath.Join(nfsMount, "test-share")
+	require.NoError(t, os.MkdirAll(shareDir, 0755))
+
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "nfs",
+		NFS: &config.V1NFSConfig{
+			MountRoot: nfsMount,
+			Shares:    []config.V1NFSShare{{ID: "test-share", Server: "10.0.0.2", Export: "/scion"}},
+		},
+	}
+
+	rec := doRequest(t, srv, http.MethodGet, "/readyz", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// ============================================================================
+// Integration Test: Write → Verify → Simulated Restart
+// ============================================================================
+
+func TestWorkspaceStorage_WriteVerifySurvivesRestart(t *testing.T) {
+	// Simulate durable storage with a temp directory that represents
+	// an NFS mount. Writes should persist across "restarts" (new Server instances
+	// pointing at the same storage).
+	nfsMount := t.TempDir()
+	shareDir := filepath.Join(nfsMount, "test-share")
+	require.NoError(t, os.MkdirAll(shareDir, 0755))
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	wsCfg := &config.V1WorkspaceStorageConfig{
+		Backend: "nfs",
+		NFS: &config.V1NFSConfig{
+			MountRoot: nfsMount,
+			Shares:    []config.V1NFSShare{{ID: "test-share", Server: "10.0.0.2", Export: "/scion"}},
+		},
+	}
+
+	// Verify path selection
+	srv, _ := testServer(t)
+	srv.config.WorkspaceStorageConfig = wsCfg
+
+	slug := "restart-test"
+	path, err := srv.hubManagedProjectPath(slug)
+	require.NoError(t, err)
+
+	// Write a file to the "NFS" path
+	require.NoError(t, os.MkdirAll(path, 0755))
+	testContent := []byte("this data should survive a restart")
+	require.NoError(t, os.WriteFile(filepath.Join(path, "persistent.txt"), testContent, 0644))
+
+	// "Restart" — create a new server instance with the same config
+	srv2, _ := testServer(t)
+	srv2.config.WorkspaceStorageConfig = wsCfg
+
+	// Verify the file is still accessible from the new instance
+	path2, err := srv2.hubManagedProjectPath(slug)
+	require.NoError(t, err)
+	assert.Equal(t, path, path2, "path should be the same across restarts")
+
+	data, err := os.ReadFile(filepath.Join(path2, "persistent.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, testContent, data, "file content should survive simulated restart")
+}
+
+// ============================================================================
 // WebDAV Safety Gate Tests
 // ============================================================================
 

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -1,0 +1,362 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Phase 0: Safety Gate Tests
+// ============================================================================
+
+func TestWorkspaceWriteBlocked_LocalBackendOnCloudRun(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Simulate Cloud Run environment
+	t.Setenv("K_SERVICE", "hub-service")
+
+	// No workspace storage config → local backend → blocked
+	assert.True(t, srv.workspaceWriteBlocked())
+}
+
+func TestWorkspaceWriteBlocked_LocalBackendExplicit(t *testing.T) {
+	srv, _ := testServer(t)
+	t.Setenv("K_SERVICE", "hub-service")
+
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "local",
+	}
+	assert.True(t, srv.workspaceWriteBlocked())
+}
+
+func TestWorkspaceWriteBlocked_NFSBackendOnCloudRun(t *testing.T) {
+	srv, _ := testServer(t)
+	t.Setenv("K_SERVICE", "hub-service")
+
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "nfs",
+		NFS: &config.V1NFSConfig{
+			MountRoot: "/mnt/nfs",
+			Shares:    []config.V1NFSShare{{ID: "share1", Server: "10.0.0.2", Export: "/scion"}},
+		},
+	}
+	assert.False(t, srv.workspaceWriteBlocked())
+}
+
+func TestWorkspaceWriteBlocked_CloudRunVolumeOnCloudRun(t *testing.T) {
+	srv, _ := testServer(t)
+	t.Setenv("K_SERVICE", "hub-service")
+
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "cloudrun-volume",
+		CloudRunVolume: &config.V1CloudRunVolumeConfig{
+			VolumeName: "workspace-vol",
+		},
+	}
+	assert.False(t, srv.workspaceWriteBlocked())
+}
+
+func TestWorkspaceWriteBlocked_NotOnCloudRun(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// K_SERVICE not set → not on Cloud Run → writes allowed
+	t.Setenv("K_SERVICE", "")
+	assert.False(t, srv.workspaceWriteBlocked())
+}
+
+func TestSafetyGate_Write503OnCloudRunLocalBackend(t *testing.T) {
+	srv, _ := testServer(t)
+	t.Setenv("K_SERVICE", "hub-service")
+
+	project, _ := createTestHubManagedProject(t, srv, "Gate Write Test")
+
+	// PUT (write) should return 503
+	rec := doRequest(t, srv, http.MethodPut,
+		fmt.Sprintf("/api/v1/projects/%s/workspace/files/test.txt", project.ID),
+		ProjectWorkspaceWriteRequest{Content: "hello"})
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Equal(t, "workspace_writes_unavailable", errResp.Error.Code)
+	assert.Contains(t, errResp.Error.Message, "Workspace writes are not available")
+}
+
+func TestSafetyGate_Upload503OnCloudRunLocalBackend(t *testing.T) {
+	srv, _ := testServer(t)
+	t.Setenv("K_SERVICE", "hub-service")
+
+	project, _ := createTestHubManagedProject(t, srv, "Gate Upload Test")
+
+	// POST (upload) should return 503
+	rec := doMultipartRequest(t, srv, http.MethodPost,
+		fmt.Sprintf("/api/v1/projects/%s/workspace/files", project.ID),
+		map[string][]byte{"test.txt": []byte("hello")})
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestSafetyGate_Delete503OnCloudRunLocalBackend(t *testing.T) {
+	srv, _ := testServer(t)
+	t.Setenv("K_SERVICE", "hub-service")
+
+	project, workspacePath := createTestHubManagedProject(t, srv, "Gate Delete Test")
+
+	// Create a file to delete
+	require.NoError(t, os.WriteFile(filepath.Join(workspacePath, "deleteme.txt"), []byte("bye"), 0644))
+
+	// DELETE should return 503
+	rec := doRequest(t, srv, http.MethodDelete,
+		fmt.Sprintf("/api/v1/projects/%s/workspace/files/deleteme.txt", project.ID), nil)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestSafetyGate_ReadAllowedOnCloudRunLocalBackend(t *testing.T) {
+	srv, _ := testServer(t)
+	t.Setenv("K_SERVICE", "hub-service")
+
+	project, _ := createTestHubManagedProject(t, srv, "Gate Read Test")
+
+	// GET (list) should still work
+	rec := doRequest(t, srv, http.MethodGet,
+		fmt.Sprintf("/api/v1/projects/%s/workspace/files", project.ID), nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestSafetyGate_WritesAllowedWithNFS(t *testing.T) {
+	srv, _ := testServer(t)
+	t.Setenv("K_SERVICE", "hub-service")
+
+	// Configure NFS backend — writes should be allowed
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "nfs",
+		NFS: &config.V1NFSConfig{
+			MountRoot: "/mnt/nfs",
+			Shares:    []config.V1NFSShare{{ID: "share1", Server: "10.0.0.2", Export: "/scion"}},
+		},
+	}
+
+	project, _ := createTestHubManagedProject(t, srv, "Gate NFS Test")
+
+	// PUT should not return 503 (it may fail for other reasons since NFS isn't actually mounted)
+	rec := doRequest(t, srv, http.MethodPut,
+		fmt.Sprintf("/api/v1/projects/%s/workspace/files/test.txt", project.ID),
+		ProjectWorkspaceWriteRequest{Content: "hello"})
+	assert.NotEqual(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// ============================================================================
+// Phase 1: NFS Path Integration Tests
+// ============================================================================
+
+func TestServerHubManagedProjectPath_LocalBackend(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	srv, _ := testServer(t)
+	// Default: no workspace storage config → local path
+	path, err := srv.hubManagedProjectPath("my-project")
+	require.NoError(t, err)
+
+	expected := filepath.Join(tmpHome, ".scion", "projects", "my-project")
+	assert.Equal(t, expected, path)
+}
+
+func TestServerHubManagedProjectPath_NFSBackend(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	srv, _ := testServer(t)
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "nfs",
+		NFS: &config.V1NFSConfig{
+			MountRoot: "/mnt/nfs",
+			Shares:    []config.V1NFSShare{{ID: "ws-share", Server: "10.0.0.2", Export: "/scion"}},
+		},
+	}
+
+	path, err := srv.hubManagedProjectPath("my-project")
+	require.NoError(t, err)
+
+	expected := filepath.Join("/mnt/nfs", "ws-share", "hub-projects", "my-project")
+	assert.Equal(t, expected, path)
+}
+
+func TestServerHubManagedProjectPath_CloudRunVolume(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	srv, _ := testServer(t)
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "cloudrun-volume",
+		CloudRunVolume: &config.V1CloudRunVolumeConfig{
+			VolumeName: "workspace-vol",
+		},
+	}
+
+	path, err := srv.hubManagedProjectPath("my-project")
+	require.NoError(t, err)
+
+	expected := filepath.Join("/mnt", "workspace-vol", "projects", "hub-projects", "my-project")
+	assert.Equal(t, expected, path)
+}
+
+func TestServerHubManagedProjectPath_CloudRunVolumeCustomSubPath(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	srv, _ := testServer(t)
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "cloudrun-volume",
+		CloudRunVolume: &config.V1CloudRunVolumeConfig{
+			VolumeName:  "workspace-vol",
+			SubPathRoot: "custom-root",
+		},
+	}
+
+	path, err := srv.hubManagedProjectPath("my-project")
+	require.NoError(t, err)
+
+	expected := filepath.Join("/mnt", "workspace-vol", "custom-root", "hub-projects", "my-project")
+	assert.Equal(t, expected, path)
+}
+
+func TestServerHubManagedProjectPath_NFSFallbackToLocal(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	slug := "fallback-project"
+	globalDir := filepath.Join(tmpHome, ".scion")
+
+	// Create content in the local path only (simulating existing deployment)
+	localDir := filepath.Join(globalDir, "projects", slug)
+	require.NoError(t, os.MkdirAll(localDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, "existing.txt"), []byte("data"), 0644))
+
+	srv, _ := testServer(t)
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "nfs",
+		NFS: &config.V1NFSConfig{
+			MountRoot: filepath.Join(tmpHome, "nfs-mount"),
+			Shares:    []config.V1NFSShare{{ID: "share1", Server: "10.0.0.2", Export: "/scion"}},
+		},
+	}
+
+	// NFS path has no content, local path does → should fall back to local
+	path, err := srv.hubManagedProjectPath(slug)
+	require.NoError(t, err)
+	assert.Equal(t, localDir, path)
+}
+
+func TestServerHubManagedProjectPath_NFSPrefersNFSWhenBothExist(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	slug := "both-exist"
+	globalDir := filepath.Join(tmpHome, ".scion")
+
+	// Create content in both local and NFS paths
+	localDir := filepath.Join(globalDir, "projects", slug)
+	require.NoError(t, os.MkdirAll(localDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, "local.txt"), []byte("local"), 0644))
+
+	nfsBase := filepath.Join(tmpHome, "nfs-mount", "share1")
+	nfsDir := filepath.Join(nfsBase, "hub-projects", slug)
+	require.NoError(t, os.MkdirAll(nfsDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(nfsDir, "nfs.txt"), []byte("nfs"), 0644))
+
+	srv, _ := testServer(t)
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "nfs",
+		NFS: &config.V1NFSConfig{
+			MountRoot: filepath.Join(tmpHome, "nfs-mount"),
+			Shares:    []config.V1NFSShare{{ID: "share1", Server: "10.0.0.2", Export: "/scion"}},
+		},
+	}
+
+	// When both have content, NFS takes precedence
+	path, err := srv.hubManagedProjectPath(slug)
+	require.NoError(t, err)
+	assert.Equal(t, nfsDir, path)
+}
+
+func TestServerHubManagedProjectPath_EmptySlugError(t *testing.T) {
+	srv, _ := testServer(t)
+
+	_, err := srv.hubManagedProjectPath("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "slug must not be empty")
+}
+
+// ============================================================================
+// Package-level hubManagedProjectPath backward compatibility
+// ============================================================================
+
+func TestPackageLevelHubManagedProjectPath_AlwaysLocal(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	path, err := hubManagedProjectPath("test-slug")
+	require.NoError(t, err)
+
+	expected := filepath.Join(tmpHome, ".scion", "projects", "test-slug")
+	assert.Equal(t, expected, path)
+}
+
+// ============================================================================
+// WebDAV Safety Gate Tests
+// ============================================================================
+
+func TestWebDAVSafetyGate_WriteMethodsBlocked(t *testing.T) {
+	srv, _ := testServer(t)
+	t.Setenv("K_SERVICE", "hub-service")
+
+	project, _ := createTestHubManagedProject(t, srv, "WebDAV Gate Test")
+
+	blockedMethods := []string{"PUT", "DELETE", "MKCOL", "MOVE"}
+	for _, method := range blockedMethods {
+		t.Run(method, func(t *testing.T) {
+			rec := doRequest(t, srv, method,
+				fmt.Sprintf("/api/v1/projects/%s/dav/test.txt", project.ID), nil)
+			assert.Equal(t, http.StatusServiceUnavailable, rec.Code,
+				"WebDAV %s should be blocked on Cloud Run with local backend", method)
+		})
+	}
+}
+
+func TestWebDAVSafetyGate_ReadMethodsAllowed(t *testing.T) {
+	srv, _ := testServer(t)
+	t.Setenv("K_SERVICE", "hub-service")
+
+	project, _ := createTestHubManagedProject(t, srv, "WebDAV Read Gate")
+
+	// PROPFIND (directory listing) should still work
+	rec := doRequest(t, srv, "PROPFIND",
+		fmt.Sprintf("/api/v1/projects/%s/dav/", project.ID), nil)
+	// PROPFIND returns 207 Multi-Status on success
+	assert.NotEqual(t, http.StatusServiceUnavailable, rec.Code,
+		"WebDAV PROPFIND should not be blocked on Cloud Run")
+}

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -347,6 +347,50 @@ func TestWebDAVSafetyGate_WriteMethodsBlocked(t *testing.T) {
 	}
 }
 
+// ============================================================================
+// Phase 2: WebDAV Lock Store Tests
+// ============================================================================
+
+func TestWebDAVLockStore_PerProject(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Create two projects
+	p1, _ := createTestHubManagedProject(t, srv, "Lock Project 1")
+	p2, _ := createTestHubManagedProject(t, srv, "Lock Project 2")
+
+	// Send PROPFIND requests to trigger lock store creation
+	doRequest(t, srv, "PROPFIND", fmt.Sprintf("/api/v1/projects/%s/dav/", p1.ID), nil)
+	doRequest(t, srv, "PROPFIND", fmt.Sprintf("/api/v1/projects/%s/dav/", p2.ID), nil)
+
+	// Both should now have lock stores, and they should be different instances
+	ls1, ok1 := srv.webdavLocks.Load(p1.ID)
+	ls2, ok2 := srv.webdavLocks.Load(p2.ID)
+	assert.True(t, ok1, "project 1 should have a lock store")
+	assert.True(t, ok2, "project 2 should have a lock store")
+	assert.NotNil(t, ls1, "project 1 lock store should not be nil")
+	assert.NotNil(t, ls2, "project 2 lock store should not be nil")
+	// Different projects should have independent lock stores
+	assert.True(t, ls1 != ls2, "different projects should have different lock stores")
+}
+
+func TestWebDAVLockStore_SameProjectSharesLocks(t *testing.T) {
+	srv, _ := testServer(t)
+
+	project, _ := createTestHubManagedProject(t, srv, "Lock Shared Project")
+
+	// First PROPFIND triggers lock store creation
+	doRequest(t, srv, "PROPFIND", fmt.Sprintf("/api/v1/projects/%s/dav/", project.ID), nil)
+	ls1, ok := srv.webdavLocks.Load(project.ID)
+	require.True(t, ok)
+
+	// Second request to same project should reuse the same lock store
+	doRequest(t, srv, "PROPFIND", fmt.Sprintf("/api/v1/projects/%s/dav/", project.ID), nil)
+	ls2, ok := srv.webdavLocks.Load(project.ID)
+	require.True(t, ok)
+
+	assert.Same(t, ls1, ls2, "same project should reuse the same lock store across requests")
+}
+
 func TestWebDAVSafetyGate_ReadMethodsAllowed(t *testing.T) {
 	srv, _ := testServer(t)
 	t.Setenv("K_SERVICE", "hub-service")

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -487,7 +487,7 @@ func TestWebDAVSafetyGate_WriteMethodsBlocked(t *testing.T) {
 
 	project, _ := createTestHubManagedProject(t, srv, "WebDAV Gate Test")
 
-	blockedMethods := []string{"PUT", "DELETE", "MKCOL", "MOVE"}
+	blockedMethods := []string{"PUT", "DELETE", "MKCOL", "MOVE", "COPY", "PROPPATCH"}
 	for _, method := range blockedMethods {
 		t.Run(method, func(t *testing.T) {
 			rec := doRequest(t, srv, method,


### PR DESCRIPTION
Adds NFS-backed workspace storage for hub-managed projects and a safety gate that returns 503 on write endpoints when running on Cloud Run without durable storage configured. Pivots hubManagedProjectPath() to return NFS-backed paths when workspace_storage.backend is nfs. Fixes WebDAV per-request lock store bug. Ref: ptone/scion#943.