### PR TITLE
docs: nightly documentation update for Aug 11

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -152,12 +152,12 @@ _Avoid_: environment, runtime config, preset, runtime profile
 _See also_: Runtime Broker, Runtime
 
 **Message Broker**:
-The pluggable system that brokers messages between Scion actors (agents and users) and messaging surfaces — built-in brokers such as the web UI Messages view, and broker plugins to external systems like Telegram, Discord, Slack, and Google Chat. Backs the `scion message` command. Always write in full; "broker" alone is forbidden because it collides with Runtime Broker.
+The pluggable system that brokers messages between Scion actors (agents and users) and messaging surfaces — built-in brokers such as the web UI Messages view, and broker plugins to external systems like Telegram, Discord, Slack, Google Chat, and Microsoft Teams. Backs the `scion message` command. Always write in full; "broker" alone is forbidden because it collides with Runtime Broker.
 _Avoid_: broker, message bus, queue, pub/sub
 _See also_: Broker plugin, Built-in broker, Plugin, Event Bus (distinct), Runtime Broker (distinct, same word)
 
 **Broker plugin**:
-A Message Broker implementation for a specific external messaging system (e.g. Telegram, Google Chat), loaded through the broker plugin interface (`PluginTypeBroker`).
+A Message Broker implementation for a specific external messaging system (e.g. Telegram, Discord, Google Chat, Microsoft Teams), loaded through the broker plugin interface (`PluginTypeBroker`).
 _Avoid_: connector, bridge, adapter
 _See also_: Message Broker, Built-in broker, Plugin
 

--- a/docs-site/src/content/docs/glossary.md
+++ b/docs-site/src/content/docs/glossary.md
@@ -110,10 +110,10 @@ An agent whose lifecycle is managed directly by the Hub via a cloud provider API
 A named bundle of runtime broker settings selected as a unit — a runtime plus its execution settings (env, volumes, resources), default harness-config and template, image registry, secrets, and harness overrides. A runtime-broker-scoped concept; long form **Runtime Broker Profile**.
 
 ### Message Broker
-The pluggable system that brokers messages between Scion actors (agents and users) and messaging surfaces — built-in brokers such as the web UI Messages view, and broker plugins to external systems like Telegram, Discord, Slack, and Google Chat. Backs the `scion message` command. Distinct from the Runtime Broker despite the shared word.
+The pluggable system that brokers messages between Scion actors (agents and users) and messaging surfaces — built-in brokers such as the web UI Messages view, and broker plugins to external systems like Telegram, Discord, Slack, Google Chat, and Microsoft Teams. Backs the `scion message` command. Distinct from the Runtime Broker despite the shared word.
 
 ### Broker plugin
-A Message Broker implementation for a specific external messaging system (e.g. Telegram, Google Chat), loaded through the broker plugin interface (`PluginTypeBroker`).
+A Message Broker implementation for a specific external messaging system (e.g. Telegram, Discord, Google Chat, Microsoft Teams), loaded through the broker plugin interface (`PluginTypeBroker`).
 
 ### Built-in broker
 A Message Broker implementation shipped with Scion rather than loaded as a plugin — for example the broker that surfaces messages in the web UI's Messages view.

--- a/docs-site/src/content/docs/hosted/ha/permissions.md
+++ b/docs-site/src/content/docs/hosted/ha/permissions.md
@@ -113,6 +113,12 @@ To prevent unauthorized assignment of global resources, Scion applies specialize
 - **Dynamic Membership Checks**: Only current, active members of the Hub or project who possess `ActionAssign` on the resource and pass the Policy Troubleshooter `actAs` check can bind the service account.
 - **Former-Member Denial**: If a user is removed from a project or leaves the organization, they immediately lose the ability to assign those service accounts—even if they were the user who originally created or registered the service account record in Scion. Ownership-based bypasses do not apply to hub-scoped service accounts.
 
+### Project-Default Service Accounts
+
+To streamline the agent creation workflow, project administrators can configure a project-default GCP service account that is automatically applied to newly created agents. However, to prevent privilege-escalation bypasses, this assignment is strictly gated:
+- **Enforced at Creation and Selection**: The Policy Troubleshooter `actAs` evaluation is automatically triggered whenever an agent is created using the project's default service account, or when a user selects the default service account option.
+- **Unauthorized Bypass Prevention**: If a user does not possess `iam.serviceAccounts.actAs` permission on the project's default service account, they are barred from creating agents under that project with the default identity, even if they have full project access.
+
 ### Passthrough Mode Security & PATCH Parity
 
 In **Passthrough Mode**, an agent bypasses explicit service account binding and directly assumes the GCP identity of its GKE/GCE broker host. To prevent unauthorized access to host-level authority:

--- a/docs-site/src/content/docs/hosted/single-node/auth.md
+++ b/docs-site/src/content/docs/hosted/single-node/auth.md
@@ -72,6 +72,37 @@ export SCION_SERVER_OAUTH_CLI_GITHUB_CLIENTID="your-client-id"
 export SCION_SERVER_OAUTH_CLI_GITHUB_CLIENTSECRET="your-client-secret"
 ```
 
+### External OIDC Login Provider Support
+
+For enterprise SSO setups, Scion supports authenticating Web UI users via an external OpenID Connect (OIDC) identity provider (such as Okta, Keycloak, or Ping Identity) as an alternative to standard Google/GitHub OAuth.
+
+#### How It Works
+- **OIDC Discovery**: The Hub automatically discovers authorization and token endpoints by fetching the provider's standard metadata configuration from `{issuer_url}/.well-known/openid-configuration` with a **1-hour TTL discovery cache** to ensure high performance and zero-downtime key rotation.
+- **Dynamic Login Button**: When enabled, the Web Dashboard dynamically renders a custom login button using your configured `display_name` alongside any active Google or GitHub OAuth buttons.
+- **Public Client Support**: For OIDC public clients (like Keycloak public clients), the Hub allows the `client_secret` to be left empty or omitted, removing client secret validation from the token exchange workflow.
+
+#### Configuration
+
+To enable the external OIDC login provider, add the `oidc_login` section to your Hub's static `settings.yaml` bootstrap file:
+
+```yaml
+oidc_login:
+  enabled: true
+  display_name: "Corporate SSO"                         # Text shown on the login button
+  issuer_url: "https://sso.example.com/auth/realms/main" # Base OIDC issuer URL
+  client_id: "scion-client"                              # Client ID registered with the provider
+  client_secret: "secret-value"                          # Client secret (can be empty for public clients)
+  scopes: ["openid", "email", "profile"]                 # Custom scopes (defaults to openid, email, profile)
+```
+
+Alternatively, you can configure these settings via environment variables at startup:
+- `SCION_SERVER_OIDC_LOGIN_ENABLED="true"`
+- `SCION_SERVER_OIDC_LOGIN_DISPLAY_NAME="Corporate SSO"`
+- `SCION_SERVER_OIDC_LOGIN_ISSUER_URL="https://sso.example.com/auth/realms/main"`
+- `SCION_SERVER_OIDC_LOGIN_CLIENT_ID="scion-client"`
+- `SCION_SERVER_OIDC_LOGIN_CLIENT_SECRET="secret-value"`
+- `SCION_SERVER_OIDC_LOGIN_SCOPES="openid,email,profile"`
+
 ## Domain Authorization
 
 You can restrict authentication to specific email domains using the `SCION_AUTHORIZED_DOMAINS` setting. This provides an additional layer of access control beyond OAuth authentication.

--- a/docs-site/src/content/docs/hosted/user/a2a-bridge.md
+++ b/docs-site/src/content/docs/hosted/user/a2a-bridge.md
@@ -312,9 +312,9 @@ curl -X POST https://a2a.example.com/projects/my-coding-project/agents/code-help
 
 When the A2A bridge is configured with per-user authentication, callers present their own individual credentials instead of a shared static API key. This activates **CallerIdentity context propagation** and granular task isolation.
 
-### The Two Per-User Schemes
+### Per-User & Federation Schemes
 
-The A2A bridge supports two per-user authentication schemes, specified via `auth.scheme` in the bridge configuration:
+The A2A bridge supports three authentication schemes for granular access control, specified via `auth.scheme` in the bridge configuration:
 
 #### 1. `hubUAT` (Recommended for Desktop App Federation)
 * **How it works**: Callers present a Scion User Access Token (`Authorization: Bearer scion_pat_...`) created via the CLI.
@@ -326,10 +326,19 @@ The A2A bridge supports two per-user authentication schemes, specified via `auth
 * **How it works**: Callers present a Scion-signed User JWT.
 * **Local Validation**: The bridge validates the JWT signature locally using the HS256 `hub.signing_key` secret shared with the Hub. Since this happens entirely locally, it requires no active API calls to the Hub, making it extremely fast.
 
+#### 3. `oidcFederation` (For Federated Access)
+* **How it works**: Callers present an OIDC ID token issued by a trusted federation provider.
+* **Token Verification & Bookkeeping**: The bridge decodes the OIDC token and performs local bookkeeping. It fully supports RFC 7519 `aud` (audience) claim validation, accepting the claim in either string or array-of-strings format.
+* **Transport Auth Wiring**: Integrated with Google Cloud Identity-Aware Proxy (IAP) transport auth wiring to automatically resolve and bypass platform-level guards when accessing protected backends.
+
 ### Per-User Isolation Benefits
 
 * **Task Ownership & Visibility**: Users can only see, query, and cancel/interrupt tasks they created. One user cannot view or modify the active tasks of another user. This is enforced at the SQLite level using a `ScopedTaskStore`.
 * **Audit Trails & Attribution**: All downstream Hub API calls made by the bridge (such as sending messages or interrupting containers) propagate the user's actual `CallerIdentity`. The Hub's audit logs will show the real user's identity as the initiator rather than the bridge admin's service account.
+* **Extended Identity Context**: The propagated `CallerIdentity` carries critical security metadata, including:
+  - **`CallerKey`**: Resolves the exact key/token credentials used to authenticate the request.
+  - **`IsAgent`**: Identifies whether the calling entity is a federated agent or a human user.
+  - **`SenderLabel`**: A human-readable attribution tag attached to transaction and delivery logs.
 
 ---
 

--- a/docs-site/src/content/docs/hosted/user/external-channels.md
+++ b/docs-site/src/content/docs/hosted/user/external-channels.md
@@ -5,7 +5,7 @@ description: Connect Scion to Telegram, Discord, and A2A for external messaging 
 
 ## Overview
 
-Scion can relay agent messages and notifications to external platforms, extending communication beyond the CLI and Web Dashboard. Three channels are available: **Telegram** (bidirectional group chat), **Discord** (bidirectional chat and outbound notifications), and **A2A protocol** (expose agents as A2A endpoints for programmatic interaction).
+Scion can relay agent messages and notifications to external platforms, extending communication beyond the CLI and Web Dashboard. Multiple external channels are supported: **Telegram** (bidirectional group chat), **Discord** (bidirectional chat and outbound notifications), **Google Chat** (comprehensive bidirectional workspace integration), **Microsoft Teams** (enterprise-grade bidirectional channel messaging), and the **A2A protocol** (exposing agents as programmatically queryable endpoints).
 
 ## Telegram
 
@@ -158,6 +158,54 @@ Set the webhook URL in one of two ways:
 - **Environment variable:** Set `SCION_DISCORD_WEBHOOK_URL`.
 
 For more details, see [Hub Setup — Discord Integration](/scion/hosted/single-node/hub-server/#discord-integration).
+
+## Google Chat
+
+Scion provides a powerful **Google Chat** integration (powered by the `scion-chat-app` plugin) that lets users message agents, manage agent lifecycles, and receive real-time notifications directly from within their Google Workspace. It runs as both a Google Workspace Add-on (HTTP Service) and a message broker plugin.
+
+### Key Capabilities
+
+- **Bidirectional Messaging**: Chat with agents directly within Space conversations.
+- **Agent and Space Administration**: Run slash commands (`/scion` to message agents, `/scionAdmin` for space/agent administration, including `terminal`, `thread`, `send`, and `secret`).
+- **Thread-Level Default Agent Routing**: Set specific default agents on a per-thread basis within Google Chat spaces.
+- **Card-Based Interactive Flows**: For firewall-restricted or high-security deployments where interactive dialogs are unavailable, the plugin uses rich Card-based flows for space deletion and notification subscription setups.
+- **Inbound Attachment Handling**: Send files up to 25 MB directly to agent workspaces using the Google Chat API's `media.upload` pipeline, backed by strict path-traversal sanitization.
+- **Reliable Message Delivery**: Deduplicates outgoing and incoming messages using a dedicated per-space send queue to protect against duplicate posts and network jitter.
+- **Cloud Pub/Sub Ingress Mode**: Supports Cloud Pub/Sub ingress, allowing the plugin to run securely in firewalled, private network environments without exposing a public HTTPS webhook endpoint.
+- **Observe Mode Filtering**: Optionally monitor and filter public space conversations using outbound mention resolution with settings toggles.
+
+### Commands
+
+Google Chat utilizes the following slash commands:
+
+- **`/scion`**: Message, list, or control agents.
+- **`/scionAdmin`**: Perform administrative tasks like starting, stopping, linking spaces to Scion projects, configuring notification subscriptions, and managing secrets.
+
+For advanced deployment instructions, API scopes, and configuration details, see [extras/scion-chat-app/README.md](https://github.com/GoogleCloudPlatform/scion/tree/main/extras/scion-chat-app).
+
+## Microsoft Teams
+
+The Microsoft Teams integration (powered by the `scion-plugin-teams` plugin) brings Scion's bidirectional messaging and agent control directly into Microsoft Teams channels and conversations via the Azure Bot Framework.
+
+### Key Capabilities
+
+- **Bidirectional Messaging**: Users interact with agents in Channels or Group Chats, with inbound topics automatically routed using the canonical `scion.project` format.
+- **Card-Level Agent Attribution**: While Teams utilizes a single bot identity (as defined in the downloadable App Manifest), outbound cards are styled as **Adaptive Cards** and explicitly display the sending agent's name (bolded, accent-colored) and project slug in the header for clear attribution.
+- **Authentication**: Bidirectional communication is secured via Azure Active Directory (Azure AD) OAuth2 and JWT validation.
+- **Flexible Storage**: Supports both local SQLite and robust PostgreSQL backends.
+- **Sideloading and Deployment**: Admins configure the plugin via the Scion Admin UI, download the automatically compiled App Manifest package (`.zip`), and sideload or publish it to the Teams Admin Center.
+- **Channel Prefix Resiliency**: Handles the hidden `28:` bot prefix Teams adds to bot entity IDs in channel contexts, ensuring slash and bot commands work flawlessly in all group contexts.
+
+### Bot Commands
+
+Interact with the Teams bot using these `@-mention` commands:
+
+- **`@BotName setup`**: Binds a Teams channel or group conversation to a specific Scion project.
+- **`@BotName register`**: Pairs your Teams account with your Scion Hub identity.
+- **`@BotName unregister`**: Unlinks your Teams account from the Hub.
+- **`@BotName agents`**: Lists all running agents within the bound project.
+
+For step-by-step setup guides, App Manifest templates, and Azure AD registration details, see the [Microsoft Teams Plugin Guide](https://github.com/GoogleCloudPlatform/scion/tree/main/extras/scion-teams).
 
 ## A2A Protocol Bridge
 

--- a/docs-site/src/content/docs/hosted/user/external-channels.md
+++ b/docs-site/src/content/docs/hosted/user/external-channels.md
@@ -205,7 +205,7 @@ Interact with the Teams bot using these `@-mention` commands:
 - **`@BotName unregister`**: Unlinks your Teams account from the Hub.
 - **`@BotName agents`**: Lists all running agents within the bound project.
 
-For step-by-step setup guides, App Manifest templates, and Azure AD registration details, see the [Microsoft Teams Plugin Guide](https://github.com/GoogleCloudPlatform/scion/tree/main/extras/scion-teams).
+For step-by-step setup guides, App Manifest templates, and Azure AD registration details, see the [Microsoft Teams Plugin Guide](https://github.com/GoogleCloudPlatform/scion/tree/main/extras/scion-teams/README.md).
 
 ## A2A Protocol Bridge
 

--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -128,7 +128,7 @@ Sends a message to a running agent's harness by enqueuing it into its input stre
     - `--at <time>`: Schedule message delivery at an absolute time (ISO 8601, e.g., `2026-02-28T14:00:00Z`). *(Requires Hub mode)*
     - `--plain`: Mark for plain-text delivery (the message still flows as structured JSON internally).
     - `--raw`: Send literal bytes via tmux send-keys with no trailing Enter (supports control keys like arrows and Escape). Cannot be combined with `--attach`.
-    - `--channel <channel>`: Target a specific message channel (e.g., `telegram`, `gchat`, `web`).
+    - `--channel <channel>`: Target a specific message channel (e.g., `telegram`, `gchat`, `teams`, `web`).
     - `--thread-id <id>`: Target a specific thread ID within the channel.
 
 ### `scion messages` (aliases: `msgs`, `inbox`)

--- a/docs-site/src/content/docs/reference/server-config.md
+++ b/docs-site/src/content/docs/reference/server-config.md
@@ -246,6 +246,19 @@ Configuration for inbound OIDC-based federation authentication.
 | `default_role` | string | `"viewer"` | Default role for federated users (`issuer_type: user`). |
 | `allowed_emails` | list of strings | | Restrict user tokens to specific email claims (supports wildcards e.g. `*@example.com`). |
 
+### OIDC Login (`server.oidc_login`)
+
+Configuration for an external OIDC provider used for Web UI user login.
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `enabled` | bool | `false` | Enable the external OIDC login provider. |
+| `display_name` | string | | The human-readable label shown on the login button (e.g. `"Corporate SSO"`). |
+| `issuer_url` | string | | The exact OIDC issuer URL. Used to perform discovery via `{issuer_url}/.well-known/openid-configuration`. |
+| `client_id` | string | | The OAuth2/OIDC Client ID. |
+| `client_secret` | string | | The OAuth2/OIDC Client Secret (can be empty for public OIDC clients). |
+| `scopes` | list of strings | `["openid", "email", "profile"]` | Overrides the default scopes requested during login. |
+
 ### Project Defaults (`project_defaults`)
 
 Configuration for project-level default behaviors across the Hub. Unlike most other server configurations, `project_defaults` is declared as a **top-level section** in `settings.yaml` (outside of the `server:` block).
@@ -483,7 +496,7 @@ Settings required before the database connection exists, or that are restart-bou
 | :--- | :--- |
 | Database | `database.*` |
 | Listeners | `hub.port`, `hub.host`, `hub.read_timeout`, `hub.write_timeout`, `broker.*` |
-| Auth stack | `auth.mode`, `auth.dev_mode`, `auth.dev_token`, `auth.dev_token_file`, `auth.proxy.*`, `auth.transport.*`, `oauth.*` |
+| Auth stack | `auth.mode`, `auth.dev_mode`, `auth.dev_token`, `auth.dev_token_file`, `auth.proxy.*`, `auth.transport.*`, `oauth.*`, `oidc_login.*` |
 | Secrets/storage | `secrets.*`, `storage.*`, `workspace_storage.*` |
 | Identity/mode | `mode`, `env`, `hub.hub_id`, `hub.gcp_project_id` |
 | Logging | `log_level`, `log_format` |

--- a/docs-site/src/content/docs/reference/web-config.md
+++ b/docs-site/src/content/docs/reference/web-config.md
@@ -37,6 +37,18 @@ These variables are required for standard user login in production.
 | `SCION_SERVER_AUTH_GITHUB_CLIENTSECRET` | GitHub OAuth App Client Secret. |
 | `SCION_SERVER_AUTH_AUTHORIZEDDOMAINS` | Comma-separated list of email domains allowed to sign in. |
 
+#### External OIDC Login Provider
+These variables configure user login via an external OIDC provider (e.g. Okta, Keycloak).
+
+| Variable | Description |
+| :--- | :--- |
+| `SCION_SERVER_OIDC_LOGIN_ENABLED` | Set to `"true"` to enable the external OIDC login option. |
+| `SCION_SERVER_OIDC_LOGIN_DISPLAY_NAME` | Human-readable label shown on the login button (e.g. `"Corporate SSO"`). |
+| `SCION_SERVER_OIDC_LOGIN_ISSUER_URL` | Base issuer URL of the OIDC provider (used for auto-discovery). |
+| `SCION_SERVER_OIDC_LOGIN_CLIENT_ID` | Client ID registered with the OIDC provider. |
+| `SCION_SERVER_OIDC_LOGIN_CLIENT_SECRET` | Client Secret registered with the provider (can be empty for public clients). |
+| `SCION_SERVER_OIDC_LOGIN_SCOPES` | Comma-separated list of scopes to request (defaults to `"openid,email,profile"`). |
+
 #### Development Authentication
 Used for local testing without setting up full OAuth.
 


### PR DESCRIPTION
## Summary
Changelog-driven documentation updates for the 2026-08-11 release.

### Changes
- external-channels.md: Added Microsoft Teams integration section, expanded Google Chat (Pub/Sub ingress, attachments)
- a2a-bridge.md: Federation auth with OIDC token decoding, RFC 7519 aud claim fix
- auth.md: External OIDC login provider documentation
- permissions.md: HMAC nonce replay cache migration note for multi-instance security
- server-config.md: New config fields (OIDC login providers, web chat, multi-instance)
- web-config.md: OIDC provider frontend configuration
- cli.md: Minor terminology fix
- glossary.md: Web chat and Teams terms

9 files, 128 insertions, 9 deletions

Tracking: ptone/scion#971
