### PR TITLE
feat(web-chat): add visibility filtering, delivery state indicators, and thread prefs (Phase 3)

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -604,6 +604,7 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 								Bus:       webSpoke,
 								Observer:  true,
 							})
+							hubSrv.SetWebChatStore(webStore)
 							log.Printf("Message broker spoke added: name=web channel_id=web observer=true")
 						}
 					}

--- a/pkg/hub/handlers_chat_prefs.go
+++ b/pkg/hub/handlers_chat_prefs.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// validVisibilityModes is the set of valid visibility mode values.
+var validVisibilityModes = map[string]bool{
+	"conversation": true,
+	"verbose":      true,
+	"full":         true,
+}
+
+// handleChatPrefs handles GET and PUT /api/v1/chat/prefs.
+//
+// Query parameters (required):
+//   - agentId: the agent ID for the thread
+//
+// The project ID is derived from the agent, so the client only needs to
+// supply the agent ID. The user ID comes from the session.
+//
+// GET returns the current prefs (or defaults if none saved).
+// PUT accepts {"visibility_mode": "conversation"|"verbose"|"full"} and
+// upserts the pref row.
+func (s *Server) handleChatPrefs(w http.ResponseWriter, r *http.Request) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	if s.webChatStore == nil {
+		writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Chat preferences not available", nil)
+		return
+	}
+
+	agentID := r.URL.Query().Get("agentId")
+	if agentID == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "agentId query parameter is required", nil)
+		return
+	}
+
+	// Look up the agent to get projectId and verify access.
+	ctx := r.Context()
+	agent, err := s.store.GetAgent(ctx, agentID)
+	if err != nil {
+		writeErrorFromErr(w, err, "Agent")
+		return
+	}
+
+	// Require at least read access to the agent.
+	res := agentResource(agent)
+	decision := s.authzService.CheckAccess(ctx, user, res, ActionRead)
+	if !decision.Allowed {
+		writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		prefs, err := s.webChatStore.GetThreadPrefs(ctx, user.ID(), agent.ProjectID, agentID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "INTERNAL", "Failed to read preferences", nil)
+			return
+		}
+		writeJSON(w, http.StatusOK, prefs)
+
+	case http.MethodPut:
+		var body struct {
+			VisibilityMode string `json:"visibility_mode"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "Invalid JSON body", nil)
+			return
+		}
+		if !validVisibilityModes[body.VisibilityMode] {
+			writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "visibility_mode must be conversation, verbose, or full", nil)
+			return
+		}
+
+		prefs := ThreadPrefs{VisibilityMode: body.VisibilityMode}
+		if err := s.webChatStore.SetThreadPrefs(ctx, user.ID(), agent.ProjectID, agentID, prefs); err != nil {
+			writeError(w, http.StatusInternalServerError, "INTERNAL", "Failed to save preferences", nil)
+			return
+		}
+		writeJSON(w, http.StatusOK, prefs)
+
+	default:
+		MethodNotAllowed(w)
+	}
+}

--- a/pkg/hub/handlers_chat_prefs.go
+++ b/pkg/hub/handlers_chat_prefs.go
@@ -44,7 +44,13 @@ func (s *Server) handleChatPrefs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.webChatStore == nil {
+	// Read webChatStore under a read lock to avoid a data race with
+	// SetWebChatStore, which writes under a write lock.
+	s.mu.RLock()
+	webChatStore := s.webChatStore
+	s.mu.RUnlock()
+
+	if webChatStore == nil {
 		writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Chat preferences not available", nil)
 		return
 	}
@@ -73,7 +79,7 @@ func (s *Server) handleChatPrefs(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case http.MethodGet:
-		prefs, err := s.webChatStore.GetThreadPrefs(ctx, user.ID(), agent.ProjectID, agentID)
+		prefs, err := webChatStore.GetThreadPrefs(ctx, user.ID(), agent.ProjectID, agentID)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "INTERNAL", "Failed to read preferences", nil)
 			return
@@ -81,6 +87,9 @@ func (s *Server) handleChatPrefs(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, prefs)
 
 	case http.MethodPut:
+		// Limit request body size to prevent DoS via oversized payloads.
+		r.Body = http.MaxBytesReader(w, r.Body, 1048576) // 1MB limit
+
 		var body struct {
 			VisibilityMode string `json:"visibility_mode"`
 		}
@@ -94,7 +103,7 @@ func (s *Server) handleChatPrefs(w http.ResponseWriter, r *http.Request) {
 		}
 
 		prefs := ThreadPrefs{VisibilityMode: body.VisibilityMode}
-		if err := s.webChatStore.SetThreadPrefs(ctx, user.ID(), agent.ProjectID, agentID, prefs); err != nil {
+		if err := webChatStore.SetThreadPrefs(ctx, user.ID(), agent.ProjectID, agentID, prefs); err != nil {
 			writeError(w, http.StatusInternalServerError, "INTERNAL", "Failed to save preferences", nil)
 			return
 		}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -736,6 +736,9 @@ type Server struct {
 	// Plugin manager for broker integration admin API (nil = no integrations)
 	pluginManager IntegrationManager
 
+	// Web chat store for webchat_* tables (thread prefs, etc.) — nil = disabled.
+	webChatStore WebChatStore
+
 	// Channel registry for external notification delivery (nil = disabled)
 	channelRegistry *ChannelRegistry
 
@@ -1864,6 +1867,13 @@ func (s *Server) GetMessageBrokerProxy() *MessageBrokerProxy {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.messageBrokerProxy
+}
+
+// SetWebChatStore sets the webchat store for thread prefs and related state.
+func (s *Server) SetWebChatStore(store WebChatStore) {
+	s.mu.Lock()
+	s.webChatStore = store
+	s.mu.Unlock()
 }
 
 // SetPluginManager sets the plugin manager for broker integration admin API.
@@ -3426,6 +3436,9 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/messages", s.handleMessages)
 	s.mux.HandleFunc("/api/v1/messages/", s.handleMessageRoutes)
 	s.mux.HandleFunc("/api/v1/message-channels", s.handleMessageChannels)
+
+	// Chat thread prefs (Phase 3 — visibility mode persistence)
+	s.mux.HandleFunc("/api/v1/chat/prefs", s.handleChatPrefs)
 
 	// WebSocket control channel endpoint for Runtime Brokers
 	s.mux.HandleFunc("/api/v1/runtime-brokers/connect", s.handleRuntimeBrokerConnect)

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -36,11 +36,6 @@ import (
 //
 // This mirrors the Discord store split
 // (extras/scion-discord/internal/discord/store.go vs store_postgres.go).
-// ThreadPrefs holds per-thread display preferences from webchat_thread_prefs.
-type ThreadPrefs struct {
-	VisibilityMode string `json:"visibility_mode"`
-}
-
 type WebChatStore interface {
 	// Init creates the webchat_* tables if they do not exist.
 	Init() error
@@ -62,6 +57,11 @@ type WebChatStore interface {
 
 	// SetThreadPrefs upserts the display preferences for a (user, project, agent) thread.
 	SetThreadPrefs(ctx context.Context, userID, projectID, agentID string, prefs ThreadPrefs) error
+}
+
+// ThreadPrefs holds per-thread display preferences from webchat_thread_prefs.
+type ThreadPrefs struct {
+	VisibilityMode string `json:"visibility_mode"`
 }
 
 // NewWebChatStore creates a new WebChatStore backed by the given database.

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -36,6 +36,11 @@ import (
 //
 // This mirrors the Discord store split
 // (extras/scion-discord/internal/discord/store.go vs store_postgres.go).
+// ThreadPrefs holds per-thread display preferences from webchat_thread_prefs.
+type ThreadPrefs struct {
+	VisibilityMode string `json:"visibility_mode"`
+}
+
 type WebChatStore interface {
 	// Init creates the webchat_* tables if they do not exist.
 	Init() error
@@ -50,6 +55,13 @@ type WebChatStore interface {
 	// Records the last channel a message was seen on, so the hub can route
 	// untagged replies back to the channel the user last spoke from.
 	RecordChannel(ctx context.Context, userID, projectID, agentID, channel string, messageAt time.Time) error
+
+	// GetThreadPrefs returns the display preferences for a (user, project, agent) thread.
+	// Returns default prefs (visibility_mode = "conversation") if no row exists.
+	GetThreadPrefs(ctx context.Context, userID, projectID, agentID string) (ThreadPrefs, error)
+
+	// SetThreadPrefs upserts the display preferences for a (user, project, agent) thread.
+	SetThreadPrefs(ctx context.Context, userID, projectID, agentID string, prefs ThreadPrefs) error
 }
 
 // NewWebChatStore creates a new WebChatStore backed by the given database.
@@ -144,6 +156,36 @@ DO UPDATE SET
 	_, err := s.db.ExecContext(ctx, query, userID, projectID, agentID, channel, messageAt)
 	if err != nil {
 		return fmt.Errorf("webchat store: record channel: %w", err)
+	}
+	return nil
+}
+
+// GetThreadPrefs returns the display preferences for the given (user, project, agent) triple.
+// Returns default prefs (visibility_mode = "conversation") if no row exists.
+func (s *sqliteWebChatStore) GetThreadPrefs(ctx context.Context, userID, projectID, agentID string) (ThreadPrefs, error) {
+	const query = `SELECT visibility_mode FROM webchat_thread_prefs WHERE user_id = ? AND project_id = ? AND agent_id = ?`
+	var mode string
+	err := s.db.QueryRowContext(ctx, query, userID, projectID, agentID).Scan(&mode)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return ThreadPrefs{VisibilityMode: "conversation"}, nil
+		}
+		return ThreadPrefs{}, fmt.Errorf("webchat store: get thread prefs: %w", err)
+	}
+	return ThreadPrefs{VisibilityMode: mode}, nil
+}
+
+// SetThreadPrefs upserts the display preferences for the given (user, project, agent) triple.
+func (s *sqliteWebChatStore) SetThreadPrefs(ctx context.Context, userID, projectID, agentID string, prefs ThreadPrefs) error {
+	const query = `
+INSERT INTO webchat_thread_prefs (user_id, project_id, agent_id, visibility_mode)
+VALUES (?, ?, ?, ?)
+ON CONFLICT (user_id, project_id, agent_id)
+DO UPDATE SET visibility_mode = excluded.visibility_mode
+`
+	_, err := s.db.ExecContext(ctx, query, userID, projectID, agentID, prefs.VisibilityMode)
+	if err != nil {
+		return fmt.Errorf("webchat store: set thread prefs: %w", err)
 	}
 	return nil
 }

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -102,3 +102,33 @@ DO UPDATE SET
 	}
 	return nil
 }
+
+// GetThreadPrefs returns the display preferences for the given (user, project, agent) triple.
+// Returns default prefs (visibility_mode = "conversation") if no row exists.
+func (s *pgWebChatStore) GetThreadPrefs(ctx context.Context, userID, projectID, agentID string) (ThreadPrefs, error) {
+	const query = `SELECT visibility_mode FROM webchat_thread_prefs WHERE user_id = $1 AND project_id = $2 AND agent_id = $3`
+	var mode string
+	err := s.db.QueryRowContext(ctx, query, userID, projectID, agentID).Scan(&mode)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return ThreadPrefs{VisibilityMode: "conversation"}, nil
+		}
+		return ThreadPrefs{}, fmt.Errorf("webchat store: get thread prefs: %w", err)
+	}
+	return ThreadPrefs{VisibilityMode: mode}, nil
+}
+
+// SetThreadPrefs upserts the display preferences for the given (user, project, agent) triple.
+func (s *pgWebChatStore) SetThreadPrefs(ctx context.Context, userID, projectID, agentID string, prefs ThreadPrefs) error {
+	const query = `
+INSERT INTO webchat_thread_prefs (user_id, project_id, agent_id, visibility_mode)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (user_id, project_id, agent_id)
+DO UPDATE SET visibility_mode = EXCLUDED.visibility_mode
+`
+	_, err := s.db.ExecContext(ctx, query, userID, projectID, agentID, prefs.VisibilityMode)
+	if err != nil {
+		return fmt.Errorf("webchat store: set thread prefs: %w", err)
+	}
+	return nil
+}

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -1094,6 +1094,7 @@ export class ScionPageAgentDetail extends LitElement {
         agentId=${this.agentId}
         agentName=${agent.name || ''}
         ?canSend=${can(agent._capabilities, 'message')}
+        ?showVisibilityToggle=${true}
         style="display: ${this.chatViewActive ? '' : 'none'}"
       ></scion-chat-thread>
       <scion-agent-message-viewer

--- a/web/src/components/shared/chat/chat-message.ts
+++ b/web/src/components/shared/chat/chat-message.ts
@@ -72,6 +72,22 @@ export class ScionChatMessage extends LitElement {
   @property()
   channel = '';
 
+  /** Visibility level: "normal", "verbose", or "full". */
+  @property()
+  visibility = 'normal';
+
+  /** Message type (e.g. "assistant-reply", "state-change"). */
+  @property()
+  messageType = '';
+
+  /** Dispatch state: "pending", "dispatched", or "failed". */
+  @property()
+  dispatchState = '';
+
+  /** Reason for dispatch failure. */
+  @property()
+  dispatchFailureReason = '';
+
   /** File attachment paths. */
   @property({ type: Array })
   attachments: string[] = [];
@@ -357,6 +373,101 @@ export class ScionChatMessage extends LitElement {
     .attachment-chip sl-icon {
       font-size: 0.75rem;
     }
+
+    /* Verbose (recessed) rendering — no bubble, muted text, small label */
+    .message-wrapper.verbose .bubble-content {
+      background: none;
+      padding: 0.25rem 0.75rem;
+      border-radius: 0;
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.8125rem;
+      font-style: italic;
+    }
+
+    .verbose-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      font-size: 0.625rem;
+      font-weight: 500;
+      color: var(--scion-text-muted, #94a3b8);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-bottom: 0.125rem;
+    }
+
+    .verbose-label sl-icon {
+      font-size: 0.6875rem;
+    }
+
+    /* Full/trace rendering — collapsed details block */
+    .trace-block {
+      padding: 0.125rem 1rem;
+    }
+
+    .trace-block details {
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.375rem;
+      background: var(--scion-bg-subtle, #f8fafc);
+      max-width: min(80%, 700px);
+    }
+
+    .trace-block summary {
+      padding: 0.375rem 0.75rem;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      color: var(--scion-text-muted, #64748b);
+      cursor: pointer;
+      user-select: none;
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+    }
+
+    .trace-block summary sl-icon {
+      font-size: 0.75rem;
+    }
+
+    .trace-content {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+      border-top: 1px solid var(--scion-border, #e2e8f0);
+      white-space: pre-wrap;
+      font-family: var(--scion-font-mono, 'SF Mono', 'Fira Code', monospace);
+      max-height: 300px;
+      overflow-y: auto;
+    }
+
+    /* Delivery state indicators */
+    .delivery-state {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      margin-top: 0.125rem;
+      font-size: 0.625rem;
+      color: var(--scion-text-muted, #94a3b8);
+    }
+
+    .delivery-state sl-icon {
+      font-size: 0.6875rem;
+    }
+
+    .delivery-state.pending sl-icon {
+      color: var(--scion-text-muted, #94a3b8);
+    }
+
+    .delivery-state.dispatched sl-icon {
+      color: var(--scion-success-500, #22c55e);
+    }
+
+    .delivery-state.failed {
+      color: var(--scion-danger-600, #dc2626);
+    }
+
+    .delivery-state.failed sl-icon {
+      color: var(--scion-danger-600, #dc2626);
+    }
   `;
 
   override connectedCallback(): void {
@@ -410,17 +521,31 @@ export class ScionChatMessage extends LitElement {
   }
 
   override render() {
+    // Full/trace messages render as a collapsed details block.
+    if (this.visibility === 'full') {
+      return this.renderTraceBlock();
+    }
+
     const dirClass = this.fromAgent ? 'from-agent' : 'from-user';
+    const visClass = this.visibility === 'verbose' ? ' verbose' : '';
 
     return html`
-      <div class="message-wrapper ${dirClass}">
+      <div class="message-wrapper ${dirClass}${visClass}">
         ${this.showHeader && this.fromAgent
           ? html`<div class="avatar" style="background: ${this.getAvatarColor()}">${this.getInitials()}</div>`
           : this.fromAgent
             ? html`<div class="avatar-spacer"></div>`
             : nothing}
         <div class="bubble">
-          ${this.showHeader
+          ${this.visibility === 'verbose'
+            ? html`
+                <span class="verbose-label">
+                  <sl-icon name="arrow-return-right"></sl-icon>
+                  assistant reply
+                </span>
+              `
+            : nothing}
+          ${this.showHeader && this.visibility !== 'verbose'
             ? html`
                 <div class="bubble-header">
                   <span class="sender-name">${this.sender}</span>
@@ -431,11 +556,61 @@ export class ScionChatMessage extends LitElement {
           <div class="bubble-content">
             ${this.renderBody()}
           </div>
+          ${this.renderDeliveryState()}
           ${this.renderBadges()}
           ${this.renderAttachments()}
         </div>
       </div>
     `;
+  }
+
+  /** Render a collapsed trace block for full-visibility messages. */
+  private renderTraceBlock() {
+    return html`
+      <div class="trace-block">
+        <details>
+          <summary>
+            <sl-icon name="code-slash"></sl-icon>
+            Trace — ${this.sender} at ${this.formatTime()}
+          </summary>
+          <div class="trace-content">${this.body}</div>
+        </details>
+      </div>
+    `;
+  }
+
+  /** Render delivery state indicator for outbound (user-sent) messages. */
+  private renderDeliveryState() {
+    // Only show on user-sent messages with a dispatch state.
+    if (this.fromAgent || !this.dispatchState) return nothing;
+
+    switch (this.dispatchState) {
+      case 'pending':
+        return html`
+          <div class="delivery-state pending">
+            <sl-icon name="clock"></sl-icon>
+            Sending
+          </div>
+        `;
+      case 'dispatched':
+        return html`
+          <div class="delivery-state dispatched">
+            <sl-icon name="check2"></sl-icon>
+            Delivered
+          </div>
+        `;
+      case 'failed':
+        return html`
+          <sl-tooltip content=${this.dispatchFailureReason || 'Delivery failed'} hoist>
+            <div class="delivery-state failed">
+              <sl-icon name="exclamation-triangle"></sl-icon>
+              Failed
+            </div>
+          </sl-tooltip>
+        `;
+      default:
+        return nothing;
+    }
   }
 
   private renderBody() {

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -285,7 +285,7 @@ export class ScionChatThread extends LitElement {
   private async loadPrefs(): Promise<void> {
     if (!this.agentId) return;
     try {
-      const res = await apiFetch(`/api/v1/chat/prefs?agentId=${this.agentId}`);
+      const res = await apiFetch(`/api/v1/chat/prefs?agentId=${encodeURIComponent(this.agentId)}`);
       if (res.ok) {
         const data = (await res.json()) as { visibility_mode?: string };
         if (data.visibility_mode && ['conversation', 'verbose', 'full'].includes(data.visibility_mode)) {
@@ -301,7 +301,7 @@ export class ScionChatThread extends LitElement {
   private async savePrefs(mode: VisibilityMode): Promise<void> {
     if (!this.agentId) return;
     try {
-      await apiFetch(`/api/v1/chat/prefs?agentId=${this.agentId}`, {
+      await apiFetch(`/api/v1/chat/prefs?agentId=${encodeURIComponent(this.agentId)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ visibility_mode: mode }),
@@ -312,7 +312,7 @@ export class ScionChatThread extends LitElement {
   }
 
   /** Handle visibility mode change from the toggle. */
-  handleVisibilityChange(e: CustomEvent<VisibilityChangeDetail>): void {
+  private handleVisibilityChange(e: CustomEvent<VisibilityChangeDetail>): void {
     const newMode = e.detail.mode;
     if (newMode === this.visibilityMode) return;
     this.visibilityMode = newMode;
@@ -372,6 +372,19 @@ export class ScionChatThread extends LitElement {
     }
   }
 
+  /** Check whether a message should be shown given the current visibility mode. */
+  private shouldShowMessage(msg: Message): boolean {
+    const vis = msg.visibility || 'normal';
+    switch (this.visibilityMode) {
+      case 'conversation':
+        return vis === 'normal';
+      case 'verbose':
+        return vis === 'normal' || vis === 'verbose';
+      case 'full':
+        return true;
+    }
+  }
+
   /** Build the visibility query params based on the current mode. */
   private appendVisibilityParams(params: URLSearchParams): void {
     switch (this.visibilityMode) {
@@ -396,7 +409,7 @@ export class ScionChatThread extends LitElement {
     this.appendVisibilityParams(params);
 
     const res = await apiFetch(
-      `/api/v1/agents/${this.agentId}/messages?${params.toString()}`
+      `/api/v1/agents/${encodeURIComponent(this.agentId)}/messages?${params.toString()}`
     );
 
     if (!res.ok) {
@@ -436,7 +449,7 @@ export class ScionChatThread extends LitElement {
     this.appendVisibilityParams(params);
 
     const res = await apiFetch(
-      `/api/v1/agents/${this.agentId}/messages?${params.toString()}`
+      `/api/v1/agents/${encodeURIComponent(this.agentId)}/messages?${params.toString()}`
     );
 
     if (!res.ok) return;
@@ -481,7 +494,7 @@ export class ScionChatThread extends LitElement {
   private startStream(): void {
     if (!this.isConnected || this.eventSource || !this.agentId) return;
 
-    const url = `/api/v1/agents/${this.agentId}/messages/stream`;
+    const url = `/api/v1/agents/${encodeURIComponent(this.agentId)}/messages/stream`;
     this.eventSource = new EventSource(url);
     this.streaming = true;
 
@@ -578,7 +591,7 @@ export class ScionChatThread extends LitElement {
     this.sendError = null;
 
     try {
-      const res = await apiFetch(`/api/v1/agents/${this.agentId}/message`, {
+      const res = await apiFetch(`/api/v1/agents/${encodeURIComponent(this.agentId)}/message`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -738,7 +751,11 @@ export class ScionChatThread extends LitElement {
         continue;
       }
 
-      // Grouping: consecutive messages from same sender within GROUP_WINDOW_MS
+      // Visibility filter: skip messages that don't match the current mode.
+      // The message stays in the map so mode switches show it without re-fetch.
+      if (!this.shouldShowMessage(msg)) continue;
+
+      // Grouping: consecutive *visible* messages from same sender within GROUP_WINDOW_MS
       const msgTime = d.getTime();
       const sameSender = msg.sender === prevSender;
       const withinWindow = msgTime - prevTimestamp < GROUP_WINDOW_MS;

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -94,7 +94,6 @@ export class ScionChatThread extends LitElement {
   @state() private loadingOlder = false;
   @state() private hasOlderMessages = true;
   @state() private loaded = false;
-  @state() private prefsLoaded = false;
 
   private eventSource: EventSource | null = null;
   private nextCursor: string | null = null;
@@ -274,10 +273,7 @@ export class ScionChatThread extends LitElement {
 
   /** Load saved preferences first, then fetch history. */
   private async loadPrefsAndHistory(): Promise<void> {
-    if (!this.prefsLoaded) {
-      await this.loadPrefs();
-      this.prefsLoaded = true;
-    }
+    await this.loadPrefs();
     await this.initialLoad();
   }
 
@@ -292,8 +288,8 @@ export class ScionChatThread extends LitElement {
           this.visibilityMode = data.visibility_mode as VisibilityMode;
         }
       }
-    } catch {
-      // Non-fatal — use default mode.
+    } catch (err) {
+      console.warn('Failed to load chat prefs, using defaults', err);
     }
   }
 
@@ -306,8 +302,8 @@ export class ScionChatThread extends LitElement {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ visibility_mode: mode }),
       });
-    } catch {
-      // Non-fatal — pref not saved but mode still applies locally.
+    } catch (err) {
+      console.warn('Failed to save chat prefs', err);
     }
   }
 

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -99,6 +99,7 @@ export class ScionChatThread extends LitElement {
   private nextCursor: string | null = null;
   private lastKnownTimestamp: string | null = null;
   private hadError = false;
+  private fetchId = 0;
 
   static override styles = css`
     :host {
@@ -297,11 +298,14 @@ export class ScionChatThread extends LitElement {
   private async savePrefs(mode: VisibilityMode): Promise<void> {
     if (!this.agentId) return;
     try {
-      await apiFetch(`/api/v1/chat/prefs?agentId=${encodeURIComponent(this.agentId)}`, {
+      const res = await apiFetch(`/api/v1/chat/prefs?agentId=${encodeURIComponent(this.agentId)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ visibility_mode: mode }),
       });
+      if (!res.ok) {
+        console.warn('Failed to save chat prefs:', res.status, res.statusText);
+      }
     } catch (err) {
       console.warn('Failed to save chat prefs', err);
     }
@@ -319,6 +323,7 @@ export class ScionChatThread extends LitElement {
 
   /** Clear messages and re-fetch history with the current visibility filter. */
   private async refetchWithNewFilter(): Promise<void> {
+    const currentId = ++this.fetchId;
     this.messageMap.clear();
     this.messages = [];
     this.nextCursor = null;
@@ -331,12 +336,16 @@ export class ScionChatThread extends LitElement {
     this.error = null;
     try {
       await this.fetchHistory();
+      if (currentId !== this.fetchId) return;
       this.startStream();
     } catch (err) {
+      if (currentId !== this.fetchId) return;
       this.error = err instanceof Error ? err.message : 'Failed to load messages';
     } finally {
-      this.loading = false;
-      this.scrollToBottom();
+      if (currentId === this.fetchId) {
+        this.loading = false;
+        this.scrollToBottom();
+      }
     }
   }
 
@@ -398,6 +407,7 @@ export class ScionChatThread extends LitElement {
   }
 
   private async fetchHistory(cursor?: string): Promise<void> {
+    const currentId = this.fetchId;
     const params = new URLSearchParams({ limit: String(HISTORY_PAGE_SIZE) });
     if (cursor) {
       params.set('cursor', cursor);
@@ -407,6 +417,8 @@ export class ScionChatThread extends LitElement {
     const res = await apiFetch(
       `/api/v1/agents/${encodeURIComponent(this.agentId)}/messages?${params.toString()}`
     );
+
+    if (currentId !== this.fetchId) return;
 
     if (!res.ok) {
       throw new Error(await extractApiError(res, 'Failed to fetch messages'));
@@ -438,6 +450,7 @@ export class ScionChatThread extends LitElement {
     // during a single timeout gap, intermediate messages may be missed.
     if (!this.lastKnownTimestamp) return;
 
+    const currentId = this.fetchId;
     const params = new URLSearchParams({
       limit: String(HISTORY_PAGE_SIZE),
       before: new Date().toISOString(),
@@ -448,6 +461,7 @@ export class ScionChatThread extends LitElement {
       `/api/v1/agents/${encodeURIComponent(this.agentId)}/messages?${params.toString()}`
     );
 
+    if (currentId !== this.fetchId) return;
     if (!res.ok) return;
 
     const data = (await res.json()) as { items?: Message[] };

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -41,9 +41,11 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { apiFetch, extractApiError } from '../../../client/api.js';
 import type { Message } from '../../../shared/types.js';
 import type { ChatSendDetail } from './chat-composer.js';
+import type { VisibilityMode, VisibilityChangeDetail } from './chat-visibility-toggle.js';
 import './chat-message.js';
 import './chat-system-line.js';
 import './chat-composer.js';
+import './chat-visibility-toggle.js';
 
 /** Maximum messages kept in the buffer. */
 const MAX_BUFFER = 500;
@@ -75,7 +77,11 @@ export class ScionChatThread extends LitElement {
   canSend = false;
 
   @property()
-  visibilityMode: 'conversation' | 'verbose' | 'full' = 'conversation';
+  visibilityMode: VisibilityMode = 'conversation';
+
+  /** Whether the visibility toggle is shown in the header. */
+  @property({ type: Boolean })
+  showVisibilityToggle = false;
 
   @state() private messages: Message[] = [];
   @state() private messageMap = new Map<string, Message>();
@@ -88,6 +94,7 @@ export class ScionChatThread extends LitElement {
   @state() private loadingOlder = false;
   @state() private hasOlderMessages = true;
   @state() private loaded = false;
+  @state() private prefsLoaded = false;
 
   private eventSource: EventSource | null = null;
   private nextCursor: string | null = null;
@@ -262,7 +269,79 @@ export class ScionChatThread extends LitElement {
   loadHistory(): void {
     if (this.loaded) return;
     this.loaded = true;
-    void this.initialLoad();
+    void this.loadPrefsAndHistory();
+  }
+
+  /** Load saved preferences first, then fetch history. */
+  private async loadPrefsAndHistory(): Promise<void> {
+    if (!this.prefsLoaded) {
+      await this.loadPrefs();
+      this.prefsLoaded = true;
+    }
+    await this.initialLoad();
+  }
+
+  /** Load the saved visibility mode pref from the server. */
+  private async loadPrefs(): Promise<void> {
+    if (!this.agentId) return;
+    try {
+      const res = await apiFetch(`/api/v1/chat/prefs?agentId=${this.agentId}`);
+      if (res.ok) {
+        const data = (await res.json()) as { visibility_mode?: string };
+        if (data.visibility_mode && ['conversation', 'verbose', 'full'].includes(data.visibility_mode)) {
+          this.visibilityMode = data.visibility_mode as VisibilityMode;
+        }
+      }
+    } catch {
+      // Non-fatal — use default mode.
+    }
+  }
+
+  /** Save the visibility mode pref to the server. */
+  private async savePrefs(mode: VisibilityMode): Promise<void> {
+    if (!this.agentId) return;
+    try {
+      await apiFetch(`/api/v1/chat/prefs?agentId=${this.agentId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ visibility_mode: mode }),
+      });
+    } catch {
+      // Non-fatal — pref not saved but mode still applies locally.
+    }
+  }
+
+  /** Handle visibility mode change from the toggle. */
+  handleVisibilityChange(e: CustomEvent<VisibilityChangeDetail>): void {
+    const newMode = e.detail.mode;
+    if (newMode === this.visibilityMode) return;
+    this.visibilityMode = newMode;
+    void this.savePrefs(newMode);
+    // Clear and re-fetch with the new filter.
+    void this.refetchWithNewFilter();
+  }
+
+  /** Clear messages and re-fetch history with the current visibility filter. */
+  private async refetchWithNewFilter(): Promise<void> {
+    this.messageMap.clear();
+    this.messages = [];
+    this.nextCursor = null;
+    this.lastKnownTimestamp = null;
+    this.hasOlderMessages = true;
+
+    // Stop the stream, re-fetch, and restart.
+    this.stopStream();
+    this.loading = true;
+    this.error = null;
+    try {
+      await this.fetchHistory();
+      this.startStream();
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to load messages';
+    } finally {
+      this.loading = false;
+      this.scrollToBottom();
+    }
   }
 
   /** Stop the SSE stream. Called on tab hide / disconnect. */
@@ -289,8 +368,23 @@ export class ScionChatThread extends LitElement {
       this.error = err instanceof Error ? err.message : 'Failed to load messages';
     } finally {
       this.loading = false;
-      // On initial load, scroll to bottom
       this.scrollToBottom();
+    }
+  }
+
+  /** Build the visibility query params based on the current mode. */
+  private appendVisibilityParams(params: URLSearchParams): void {
+    switch (this.visibilityMode) {
+      case 'conversation':
+        params.append('visibility', 'normal');
+        break;
+      case 'verbose':
+        params.append('visibility', 'normal');
+        params.append('visibility', 'verbose');
+        break;
+      case 'full':
+        // No filter — show everything.
+        break;
     }
   }
 
@@ -299,6 +393,7 @@ export class ScionChatThread extends LitElement {
     if (cursor) {
       params.set('cursor', cursor);
     }
+    this.appendVisibilityParams(params);
 
     const res = await apiFetch(
       `/api/v1/agents/${this.agentId}/messages?${params.toString()}`
@@ -338,6 +433,7 @@ export class ScionChatThread extends LitElement {
       limit: String(HISTORY_PAGE_SIZE),
       before: new Date().toISOString(),
     });
+    this.appendVisibilityParams(params);
 
     const res = await apiFetch(
       `/api/v1/agents/${this.agentId}/messages?${params.toString()}`
@@ -528,13 +624,23 @@ export class ScionChatThread extends LitElement {
   }
 
   private renderStreamBar() {
-    if (!this.streaming) return nothing;
+    // Show the bar when streaming OR when the toggle is visible (they share the row).
+    if (!this.streaming && !this.showVisibilityToggle) return nothing;
     return html`
       <div class="stream-bar">
         <span class="stream-indicator">
-          <span class="stream-dot"></span>
-          Live
+          ${this.streaming
+            ? html`<span class="stream-dot"></span> Live`
+            : nothing}
         </span>
+        ${this.showVisibilityToggle
+          ? html`
+              <scion-chat-visibility-toggle
+                mode=${this.visibilityMode}
+                @visibility-change=${this.handleVisibilityChange}
+              ></scion-chat-visibility-toggle>
+            `
+          : nothing}
       </div>
     `;
   }
@@ -652,6 +758,10 @@ export class ScionChatThread extends LitElement {
           ?urgent=${msg.urgent ?? false}
           ?broadcasted=${msg.broadcasted ?? false}
           channel=${msg.channel || ''}
+          visibility=${msg.visibility || 'normal'}
+          messageType=${msg.type || ''}
+          dispatchState=${msg.dispatchState || ''}
+          dispatchFailureReason=${msg.dispatchFailureReason || ''}
           .attachments=${msg.attachments || []}
         ></scion-chat-message>
       `);

--- a/web/src/components/shared/chat/chat-visibility-toggle.ts
+++ b/web/src/components/shared/chat/chat-visibility-toggle.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Three-state visibility toggle for the chat thread.
+ *
+ * Modes:
+ * - Conversation: show only normal messages (default)
+ * - Verbose: show normal + verbose (automatic assistant replies)
+ * - Full: show everything (including trace/debug)
+ *
+ * Emits `visibility-change` CustomEvent with `detail.mode` when the
+ * user changes the selection.
+ */
+
+import {LitElement, html, css} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+
+export type VisibilityMode = 'conversation' | 'verbose' | 'full';
+
+export interface VisibilityChangeDetail {
+  mode: VisibilityMode;
+}
+
+@customElement('scion-chat-visibility-toggle')
+export class ScionChatVisibilityToggle extends LitElement {
+  @property()
+  mode: VisibilityMode = 'conversation';
+
+  static override styles = css`
+    :host {
+      display: inline-block;
+    }
+
+    sl-radio-group::part(form-control) {
+      margin: 0;
+    }
+  `;
+
+  override render() {
+    return html`
+      <sl-radio-group
+        value=${this.mode}
+        size="small"
+        @sl-change=${this.handleChange}
+      >
+        <sl-radio-button value="conversation">
+          <sl-icon slot="prefix" name="chat-dots" style="font-size: 0.75rem"></sl-icon>
+          Conversation
+        </sl-radio-button>
+        <sl-radio-button value="verbose">
+          <sl-icon slot="prefix" name="chat-text" style="font-size: 0.75rem"></sl-icon>
+          Verbose
+        </sl-radio-button>
+        <sl-radio-button value="full">
+          <sl-icon slot="prefix" name="code-slash" style="font-size: 0.75rem"></sl-icon>
+          Full
+        </sl-radio-button>
+      </sl-radio-group>
+    `;
+  }
+
+  private handleChange(e: Event): void {
+    const value = (e.target as HTMLInputElement).value as VisibilityMode;
+    if (value === this.mode) return;
+    this.mode = value;
+    this.dispatchEvent(
+      new CustomEvent<VisibilityChangeDetail>('visibility-change', {
+        detail: {mode: value},
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-chat-visibility-toggle': ScionChatVisibilityToggle;
+  }
+}


### PR DESCRIPTION
## Summary
- Three-state visibility toggle (Conversation/Verbose/Full) with server-side filtering (AC13)
- Visibility mode persisted in webchat_thread_prefs — survives reload, cross-browser, per-agent granularity (AC12)
- GET/PUT /api/v1/chat/prefs endpoint for thread display preferences
- Verbose messages render in recessed style (no bubble, muted text, assistant reply label)
- Full/trace messages render as collapsed details blocks
- Delivery state indicators: pending/dispatched/failed with dispatchFailureReason tooltip (AC14)
- Badges for urgent, broadcast, and channel provenance

## Test plan
- Verify Conversation mode hides verbose messages; Verbose mode shows them recessed
- Verify visibility selection persists across page reload and different browser
- Verify setting Verbose on agent A does not affect agent B
- Verify page of 50 contains 50 matching messages (server-side filtering)
- Verify failed dispatch shows indicator with tooltip
- Verify feature flag off preserves current behavior