### PR TITLE
feat(web-chat): add @-mention autocomplete with server-side fan-out (Phase 4)

### DIFF
--- a/cmd/message.go
+++ b/cmd/message.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 	"text/tabwriter"
 	"time"
-	"unicode"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
@@ -909,57 +908,18 @@ func validateChannel(hubCtx *HubContext, channel string) error {
 	return fmt.Errorf("channel %q is not registered; available channels: %s", channel, strings.Join(available, ", "))
 }
 
-// extractMentions scans message text for @name tokens and returns a deduplicated
-// list of mentioned names (without the @ prefix). Trailing punctuation (except
-// underscores and hyphens) is stripped from each token.
+// extractMentions delegates to the shared messages.ExtractMentions.
 func extractMentions(text string) []string {
-	var mentions []string
-	seen := make(map[string]bool)
-	for _, word := range strings.Fields(text) {
-		if !strings.HasPrefix(word, "@") {
-			continue
-		}
-		name := strings.TrimPrefix(word, "@")
-		name = strings.TrimRightFunc(name, func(r rune) bool {
-			return unicode.IsPunct(r) && r != '_' && r != '-'
-		})
-		if name == "" {
-			continue
-		}
-		lower := strings.ToLower(name)
-		if !seen[lower] {
-			seen[lower] = true
-			mentions = append(mentions, name)
-		}
-	}
-	return mentions
+	return messages.ExtractMentions(text)
 }
 
-// parseCCFlag parses the --cc flag value into a slice of agent names.
-// Names are comma-separated and whitespace-trimmed.
+// parseCCFlag delegates to the shared messages.ParseCCFlag.
 func parseCCFlag(cc string) []string {
-	if cc == "" {
-		return nil
-	}
-	parts := strings.Split(cc, ",")
-	var names []string
-	seen := make(map[string]bool)
-	for _, p := range parts {
-		name := strings.TrimSpace(p)
-		if name == "" {
-			continue
-		}
-		lower := strings.ToLower(name)
-		if !seen[lower] {
-			seen[lower] = true
-			names = append(names, name)
-		}
-	}
-	return names
+	return messages.ParseCCFlag(cc)
 }
 
-// maxMentionRecipients caps the number of mention recipients to avoid spam.
-const maxMentionRecipients = 10
+// maxMentionRecipients is an alias for the shared constant.
+const maxMentionRecipients = messages.MaxMentionRecipients
 
 // sendMentionMessages resolves @mentions and --cc names against project agents
 // and sends TypeMention messages to each resolved agent. The primary recipient

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -395,6 +395,10 @@ type MessageRequest struct {
 
 	// Wake resumes a suspended agent before delivering the message.
 	Wake bool `json:"wake,omitempty"`
+
+	// Mentions lists agent slugs to receive mention notifications (max 10).
+	// The primary recipient is automatically excluded from mention fan-out.
+	Mentions []string `json:"mentions,omitempty"`
 }
 
 func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id string) {
@@ -655,13 +659,20 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		})
 		s.events.PublishAgentStatus(ctx, agent)
 
+		// Process @mentions for managed agents too.
+		var managedMentionResults []messages.MentionResult
+		if len(req.Mentions) > 0 && structuredMsg != nil {
+			managedMentionResults = s.processMentions(ctx, req.Mentions, agent, structuredMsg)
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(MessageDeliveryResponse{
-			MessageID:  persistedMsgID,
-			Status:     "delivered",
-			Agent:      agent.Slug,
-			AgentPhase: agent.Phase,
+			MessageID:      persistedMsgID,
+			Status:         "delivered",
+			Agent:          agent.Slug,
+			AgentPhase:     agent.Phase,
+			MentionResults: managedMentionResults,
 		})
 		return
 	}
@@ -729,22 +740,30 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		s.createNotifySubscription(ctx, agent.ID, agent.ProjectID, notifySubscriberType, notifySubscriberID, createdBy)
 	}
 
+	// Process @mentions: validate slugs, fan out mention messages to resolved agents.
+	var mentionResults []messages.MentionResult
+	if len(req.Mentions) > 0 && structuredMsg != nil {
+		mentionResults = s.processMentions(ctx, req.Mentions, agent, structuredMsg)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(MessageDeliveryResponse{
-		MessageID:  persistedMsgID,
-		Status:     "delivered",
-		Agent:      agent.Slug,
-		AgentPhase: agent.Phase,
+		MessageID:      persistedMsgID,
+		Status:         "delivered",
+		Agent:          agent.Slug,
+		AgentPhase:     agent.Phase,
+		MentionResults: mentionResults,
 	})
 }
 
 // MessageDeliveryResponse is the JSON response for a successful agent message delivery.
 type MessageDeliveryResponse struct {
-	MessageID  string `json:"message_id"`
-	Status     string `json:"status"`
-	Agent      string `json:"agent"`
-	AgentPhase string `json:"agent_phase"`
+	MessageID      string                   `json:"message_id"`
+	Status         string                   `json:"status"`
+	Agent          string                   `json:"agent"`
+	AgentPhase     string                   `json:"agent_phase"`
+	MentionResults []messages.MentionResult `json:"mention_results,omitempty"`
 }
 
 // GroupMessageRecipientResult represents the delivery status for one recipient in a group[] delivery.
@@ -1177,4 +1196,104 @@ func (s *Server) publishBroadcastDeliveryFailed(ctx context.Context, targetAgent
 		s.messageLog.Error("Failed to dispatch broadcast DELIVERY_FAILED notification",
 			"sender_id", msg.SenderID, "target_agent", targetAgent.Slug, "error", err)
 	}
+}
+
+// processMentions validates mention slugs against project agents, fans out
+// NewMention messages to each valid recipient, and returns per-slug results.
+// The primary recipient (the agent the message was sent to) is excluded.
+func (s *Server) processMentions(ctx context.Context, mentionSlugs []string, primaryAgent *store.Agent, originalMsg *messages.StructuredMessage) []messages.MentionResult {
+	if len(mentionSlugs) == 0 {
+		return nil
+	}
+
+	// List project agents for resolution.
+	agentList, err := s.store.ListAgents(ctx, store.AgentFilter{ProjectID: primaryAgent.ProjectID}, store.ListOptions{Limit: 200})
+	if err != nil {
+		s.messageLog.Error("Failed to list project agents for mention resolution", "error", err)
+		return nil
+	}
+
+	// Build the AgentInfo slice and a slug-to-agent map for dispatch.
+	agentInfos := make([]messages.AgentInfo, 0, len(agentList.Items))
+	agentBySlug := make(map[string]*store.Agent, len(agentList.Items))
+	for i := range agentList.Items {
+		a := &agentList.Items[i]
+		agentInfos = append(agentInfos, messages.AgentInfo{Slug: a.Slug, Name: a.Name})
+		agentBySlug[strings.ToLower(a.Slug)] = a
+	}
+
+	// Resolve mentions using the shared package.
+	results := messages.ResolveMentions(mentionSlugs, agentInfos, primaryAgent.Slug)
+
+	// Fan out mention messages for each delivered slug.
+	for i, r := range results {
+		if r.Status != "delivered" {
+			continue
+		}
+		mentionAgent, ok := agentBySlug[strings.ToLower(r.Slug)]
+		if !ok {
+			results[i].Status = "error"
+			results[i].Error = "agent resolved but not found for dispatch"
+			continue
+		}
+
+		mentionMsg := messages.NewMention(originalMsg.Sender, "agent:"+r.Slug, originalMsg.Msg, originalMsg.Recipient)
+		mentionMsg.SenderID = originalMsg.SenderID
+		mentionMsg.RecipientID = mentionAgent.ID
+		mentionMsg.Channel = originalMsg.Channel
+		mentionMsg.ThreadID = originalMsg.ThreadID
+
+		// Persist the mention message.
+		storeMsg := &store.Message{
+			ID:            api.NewUUID(),
+			ProjectID:     primaryAgent.ProjectID,
+			Sender:        mentionMsg.Sender,
+			SenderID:      mentionMsg.SenderID,
+			Recipient:     mentionMsg.Recipient,
+			RecipientID:   mentionMsg.RecipientID,
+			Msg:           mentionMsg.Msg,
+			Type:          mentionMsg.Type,
+			AgentID:       mentionAgent.ID,
+			Channel:       mentionMsg.Channel,
+			ThreadID:      mentionMsg.ThreadID,
+			DispatchState: store.MessageDispatchDispatched,
+			CreatedAt:     time.Now(),
+		}
+		if mentionMsg.Metadata != nil {
+			storeMsg.GroupID = mentionMsg.Metadata["group_id"]
+		}
+		if createErr := s.store.CreateMessage(ctx, storeMsg); createErr != nil {
+			s.messageLog.Error("Failed to persist mention message", "slug", r.Slug, "error", createErr)
+		}
+		s.events.PublishUserMessage(ctx, storeMsg)
+
+		// Dispatch to the mentioned agent's runtime.
+		dispatcher := s.GetDispatcher()
+		if dispatcher == nil {
+			results[i].Status = "error"
+			results[i].Error = "dispatch not available"
+			continue
+		}
+		if mentionAgent.RuntimeBrokerID == "" {
+			results[i].Status = "error"
+			results[i].Error = "agent has no runtime broker"
+			continue
+		}
+
+		dispatchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		if dispatchErr := dispatchWithBrokerRetry(dispatchCtx, dispatcher, mentionAgent, mentionMsg.Msg, false, mentionMsg); dispatchErr != nil {
+			cancel()
+			results[i].Status = "error"
+			results[i].Error = "dispatch failed: " + dispatchErr.Error()
+			if storeMsg.ID != "" {
+				if markErr := s.store.MarkMessageFailed(ctx, storeMsg.ID, dispatchErr.Error()); markErr != nil {
+					s.messageLog.Error("Failed to mark mention message as failed", "id", storeMsg.ID, "error", markErr)
+				}
+			}
+			continue
+		}
+		cancel()
+	}
+
+	return results
 }

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -465,6 +465,11 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		return
 	}
 
+	// Cap mentions to avoid oversized responses and wasted server resources (R1).
+	if len(req.Mentions) > messages.MaxMentionRecipients {
+		req.Mentions = req.Mentions[:messages.MaxMentionRecipients]
+	}
+
 	// Detect group[] recipient for multi-target fan-out.
 	if structuredMsg != nil && messages.IsGroupRecipient(structuredMsg.Recipient) {
 		s.handleGroupMessage(w, r, id, structuredMsg, plainMessage, req.Interrupt)
@@ -1225,11 +1230,24 @@ func (s *Server) processMentions(ctx context.Context, mentionSlugs []string, pri
 	// Resolve mentions using the shared package.
 	results := messages.ResolveMentions(mentionSlugs, agentInfos, primaryAgent.Slug)
 
+	// Aggregate timeout for all mention dispatches (O1): 30s total to avoid
+	// blocking the HTTP response for up to N × 10s in the worst case.
+	aggregateCtx, aggregateCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer aggregateCancel()
+
 	// Fan out mention messages for each delivered slug.
 	for i, r := range results {
 		if r.Status != "delivered" {
 			continue
 		}
+
+		// Check aggregate timeout before starting each dispatch.
+		if aggregateCtx.Err() != nil {
+			results[i].Status = "timeout"
+			results[i].Error = "aggregate mention dispatch timeout exceeded"
+			continue
+		}
+
 		mentionAgent, ok := agentBySlug[strings.ToLower(r.Slug)]
 		if !ok {
 			results[i].Status = "error"
@@ -1280,11 +1298,17 @@ func (s *Server) processMentions(ctx context.Context, mentionSlugs []string, pri
 			continue
 		}
 
-		dispatchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		// Per-dispatch timeout is the lesser of 10s or the remaining aggregate budget.
+		dispatchCtx, cancel := context.WithTimeout(aggregateCtx, 10*time.Second)
 		if dispatchErr := dispatchWithBrokerRetry(dispatchCtx, dispatcher, mentionAgent, mentionMsg.Msg, false, mentionMsg); dispatchErr != nil {
 			cancel()
-			results[i].Status = "error"
-			results[i].Error = "dispatch failed: " + dispatchErr.Error()
+			if aggregateCtx.Err() != nil {
+				results[i].Status = "timeout"
+				results[i].Error = "aggregate mention dispatch timeout exceeded"
+			} else {
+				results[i].Status = "error"
+				results[i].Error = "dispatch failed: " + dispatchErr.Error()
+			}
 			if storeMsg.ID != "" {
 				if markErr := s.store.MarkMessageFailed(ctx, storeMsg.ID, dispatchErr.Error()); markErr != nil {
 					s.messageLog.Error("Failed to mark mention message as failed", "id", storeMsg.ID, "error", markErr)

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -1280,8 +1280,11 @@ func (s *Server) processMentions(ctx context.Context, mentionSlugs []string, pri
 		if mentionMsg.Metadata != nil {
 			storeMsg.GroupID = mentionMsg.Metadata["group_id"]
 		}
+		var persisted bool
 		if createErr := s.store.CreateMessage(ctx, storeMsg); createErr != nil {
 			s.messageLog.Error("Failed to persist mention message", "slug", r.Slug, "error", createErr)
+		} else {
+			persisted = true
 		}
 		s.events.PublishUserMessage(ctx, storeMsg)
 
@@ -1309,7 +1312,7 @@ func (s *Server) processMentions(ctx context.Context, mentionSlugs []string, pri
 				results[i].Status = "error"
 				results[i].Error = "dispatch failed: " + dispatchErr.Error()
 			}
-			if storeMsg.ID != "" {
+			if persisted {
 				if markErr := s.store.MarkMessageFailed(ctx, storeMsg.ID, dispatchErr.Error()); markErr != nil {
 					s.messageLog.Error("Failed to mark mention message as failed", "id", storeMsg.ID, "error", markErr)
 				}

--- a/pkg/messages/mentions.go
+++ b/pkg/messages/mentions.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messages
+
+import (
+	"strings"
+	"unicode"
+)
+
+// MaxMentionRecipients caps the number of mention recipients to avoid spam.
+const MaxMentionRecipients = 10
+
+// MentionResult represents the outcome of a single mention fan-out attempt.
+type MentionResult struct {
+	Slug   string `json:"slug"`
+	Status string `json:"status"`          // "delivered", "not_found", "error"
+	Error  string `json:"error,omitempty"` // human-readable reason on failure
+}
+
+// ExtractMentions scans message text for @name tokens and returns a deduplicated
+// list of mentioned names (without the @ prefix). Trailing punctuation (except
+// underscores and hyphens) is stripped from each token.
+//
+// An @ preceded by a non-whitespace character (e.g. inside an email address like
+// user@example.com) is not treated as a mention trigger.
+func ExtractMentions(text string) []string {
+	var mentions []string
+	seen := make(map[string]bool)
+	for _, word := range strings.Fields(text) {
+		if !strings.HasPrefix(word, "@") {
+			continue
+		}
+		name := strings.TrimPrefix(word, "@")
+		name = strings.TrimRightFunc(name, func(r rune) bool {
+			return unicode.IsPunct(r) && r != '_' && r != '-'
+		})
+		if name == "" {
+			continue
+		}
+		lower := strings.ToLower(name)
+		if !seen[lower] {
+			seen[lower] = true
+			mentions = append(mentions, name)
+		}
+	}
+	return mentions
+}
+
+// ParseCCFlag parses a --cc flag value into a slice of agent names.
+// Names are comma-separated and whitespace-trimmed.
+func ParseCCFlag(cc string) []string {
+	if cc == "" {
+		return nil
+	}
+	parts := strings.Split(cc, ",")
+	var names []string
+	seen := make(map[string]bool)
+	for _, p := range parts {
+		name := strings.TrimSpace(p)
+		if name == "" {
+			continue
+		}
+		lower := strings.ToLower(name)
+		if !seen[lower] {
+			seen[lower] = true
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// AgentInfo holds the minimal agent data needed for mention resolution.
+type AgentInfo struct {
+	Slug string
+	Name string
+}
+
+// ResolveMentions validates mention slugs against a set of known agents,
+// deduplicates, excludes the primary recipient, and caps at MaxMentionRecipients.
+// It returns a MentionResult for each input slug.
+func ResolveMentions(mentionNames []string, knownAgents []AgentInfo, primaryRecipientSlug string) []MentionResult {
+	if len(mentionNames) == 0 {
+		return nil
+	}
+
+	// Build lookup map: lowercase slug -> original slug
+	lookup := make(map[string]string, len(knownAgents))
+	for _, a := range knownAgents {
+		lookup[strings.ToLower(a.Slug)] = a.Slug
+	}
+
+	primaryLower := strings.ToLower(strings.TrimPrefix(primaryRecipientSlug, "agent:"))
+
+	var results []MentionResult
+	seen := make(map[string]bool)
+	seen[primaryLower] = true // skip primary recipient
+	deliveredCount := 0
+
+	for _, name := range mentionNames {
+		lower := strings.ToLower(name)
+		if seen[lower] {
+			continue
+		}
+		seen[lower] = true
+
+		slug, ok := lookup[lower]
+		if !ok {
+			results = append(results, MentionResult{
+				Slug:   name,
+				Status: "not_found",
+				Error:  "no matching agent in this project",
+			})
+			continue
+		}
+
+		if deliveredCount >= MaxMentionRecipients {
+			results = append(results, MentionResult{
+				Slug:   slug,
+				Status: "error",
+				Error:  "mention recipient cap reached",
+			})
+			continue
+		}
+
+		results = append(results, MentionResult{
+			Slug:   slug,
+			Status: "delivered",
+		})
+		deliveredCount++
+	}
+
+	return results
+}
+
+// DeliveredSlugs returns only the slugs from results that were successfully delivered.
+func DeliveredSlugs(results []MentionResult) []string {
+	var slugs []string
+	for _, r := range results {
+		if r.Status == "delivered" {
+			slugs = append(slugs, r.Slug)
+		}
+	}
+	return slugs
+}

--- a/pkg/messages/mentions_test.go
+++ b/pkg/messages/mentions_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractMentions(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{name: "no mentions", text: "hello world", want: nil},
+		{name: "single mention", text: "hey @alice check this", want: []string{"alice"}},
+		{name: "multiple mentions", text: "hey @alice and @bob check this", want: []string{"alice", "bob"}},
+		{name: "mention at start", text: "@alice please review", want: []string{"alice"}},
+		{name: "mention at end", text: "please review @alice", want: []string{"alice"}},
+		{name: "duplicate mentions", text: "@alice hey @alice check this", want: []string{"alice"}},
+		{name: "case insensitive dedup", text: "@Alice hey @alice check this", want: []string{"Alice"}},
+		{name: "mention with trailing punctuation", text: "hey @alice, @bob! @charlie.", want: []string{"alice", "bob", "charlie"}},
+		{name: "mention with hyphen", text: "hey @my-agent check this", want: []string{"my-agent"}},
+		{name: "mention with underscore", text: "hey @my_agent check this", want: []string{"my_agent"}},
+		{name: "bare at sign", text: "hey @ what", want: nil},
+		{name: "email not mention", text: "send to user@example.com", want: nil},
+		{name: "mention followed by colon", text: "hey @alice: check this", want: []string{"alice"}},
+		{name: "mention in parentheses", text: "(cc @bob)", want: []string{"bob"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractMentions(tc.text)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseCCFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		cc   string
+		want []string
+	}{
+		{name: "empty", cc: "", want: nil},
+		{name: "single", cc: "alice", want: []string{"alice"}},
+		{name: "multiple", cc: "alice,bob,charlie", want: []string{"alice", "bob", "charlie"}},
+		{name: "whitespace trimmed", cc: " alice , bob ", want: []string{"alice", "bob"}},
+		{name: "empty entries", cc: "alice,,bob", want: []string{"alice", "bob"}},
+		{name: "duplicates", cc: "alice,bob,alice", want: []string{"alice", "bob"}},
+		{name: "case insensitive dedup", cc: "Alice,alice", want: []string{"Alice"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseCCFlag(tc.cc)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestResolveMentions(t *testing.T) {
+	agents := []AgentInfo{
+		{Slug: "alice", Name: "Alice Agent"},
+		{Slug: "bob", Name: "Bob Agent"},
+		{Slug: "charlie", Name: "Charlie Agent"},
+	}
+
+	t.Run("empty input", func(t *testing.T) {
+		results := ResolveMentions(nil, agents, "agent:primary")
+		assert.Nil(t, results)
+	})
+
+	t.Run("single valid mention", func(t *testing.T) {
+		results := ResolveMentions([]string{"alice"}, agents, "agent:primary")
+		assert.Len(t, results, 1)
+		assert.Equal(t, "alice", results[0].Slug)
+		assert.Equal(t, "delivered", results[0].Status)
+	})
+
+	t.Run("unknown mention", func(t *testing.T) {
+		results := ResolveMentions([]string{"nobody"}, agents, "agent:primary")
+		assert.Len(t, results, 1)
+		assert.Equal(t, "not_found", results[0].Status)
+	})
+
+	t.Run("primary recipient excluded", func(t *testing.T) {
+		results := ResolveMentions([]string{"alice", "bob"}, agents, "agent:alice")
+		assert.Len(t, results, 1)
+		assert.Equal(t, "bob", results[0].Slug)
+		assert.Equal(t, "delivered", results[0].Status)
+	})
+
+	t.Run("deduplication", func(t *testing.T) {
+		results := ResolveMentions([]string{"alice", "Alice"}, agents, "agent:primary")
+		assert.Len(t, results, 1)
+		assert.Equal(t, "alice", results[0].Slug)
+	})
+
+	t.Run("cap at max", func(t *testing.T) {
+		// Create many agents
+		manyAgents := make([]AgentInfo, 15)
+		names := make([]string, 15)
+		for i := range manyAgents {
+			slug := "agent-" + string(rune('a'+i))
+			manyAgents[i] = AgentInfo{Slug: slug, Name: slug}
+			names[i] = slug
+		}
+		results := ResolveMentions(names, manyAgents, "agent:primary")
+		delivered := DeliveredSlugs(results)
+		assert.Equal(t, MaxMentionRecipients, len(delivered))
+	})
+}
+
+func TestDeliveredSlugs(t *testing.T) {
+	results := []MentionResult{
+		{Slug: "alice", Status: "delivered"},
+		{Slug: "nobody", Status: "not_found"},
+		{Slug: "bob", Status: "delivered"},
+	}
+	slugs := DeliveredSlugs(results)
+	assert.Equal(t, []string{"alice", "bob"}, slugs)
+}

--- a/web/src/components/shared/chat/chat-composer.ts
+++ b/web/src/components/shared/chat/chat-composer.ts
@@ -21,7 +21,8 @@
  * - Character counter (rune-aware via Intl.Segmenter where available)
  * - 2000 character limit with visual feedback (AC10)
  * - Defaults to plain: false (design section 4.7)
- * - Sends via `chat-send` custom event: {text, plain, interrupt}
+ * - Sends via `chat-send` custom event: {text, plain, interrupt, mentions}
+ * - @-mention autocomplete integration (Phase 4)
  * - The composer knows nothing about the network
  * - Send on Enter (Shift+Enter for newline)
  * - Interrupt toggle
@@ -29,6 +30,9 @@
 
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import type { Agent } from '../../../shared/types.js';
+import type { MentionAcceptDetail } from './mention-autocomplete.js';
+import './mention-autocomplete.js';
 
 /** Maximum message length in rune count. */
 const MAX_MESSAGE_LENGTH = 2000;
@@ -39,6 +43,7 @@ export interface ChatSendDetail {
   plain: boolean;
   interrupt: boolean;
   onSuccess: () => void;
+  mentions: string[];
 }
 
 /**
@@ -63,10 +68,17 @@ export class ScionChatComposer extends LitElement {
   @property({ type: Boolean })
   disabled = false;
 
+  /** Agents available for @-mention (passed from parent). */
+  @property({ type: Array })
+  agents: Agent[] = [];
+
   @state() private text = '';
   @state() private plain = false;
   @state() private interrupt = false;
   @state() private runeCount = 0;
+
+  /** Set of accepted mention slugs. Filtered to those still present on send. */
+  private acceptedMentions = new Set<string>();
 
   static override styles = css`
     :host {
@@ -166,6 +178,10 @@ export class ScionChatComposer extends LitElement {
               @keydown=${this.handleKeydown}
               ?disabled=${this.disabled}
             ></sl-textarea>
+            <scion-mention-autocomplete
+              .agents=${this.agents}
+              @mention-accept=${this.handleMentionAccept}
+            ></scion-mention-autocomplete>
           </div>
           <sl-button
             class="send-btn"
@@ -213,13 +229,61 @@ export class ScionChatComposer extends LitElement {
     const target = e.target as HTMLInputElement;
     this.text = target.value;
     this.runeCount = countRunes(this.text);
+
+    // Feed the autocomplete component.
+    const autocomplete = this.shadowRoot?.querySelector(
+      'scion-mention-autocomplete'
+    ) as import('./mention-autocomplete.js').ScionMentionAutocomplete | null;
+    if (autocomplete) {
+      const textarea = this.getTextareaElement();
+      if (textarea) {
+        autocomplete.handleInput(this.text, textarea.selectionStart ?? this.text.length, textarea);
+      }
+    }
   }
 
   private handleKeydown(e: KeyboardEvent): void {
+    // Let the autocomplete handle keys first.
+    const autocomplete = this.shadowRoot?.querySelector(
+      'scion-mention-autocomplete'
+    ) as import('./mention-autocomplete.js').ScionMentionAutocomplete | null;
+    if (autocomplete?.handleKeydown(e)) {
+      return; // consumed by autocomplete
+    }
+
     if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
       e.preventDefault();
       this.handleSend();
     }
+  }
+
+  private handleMentionAccept(e: CustomEvent<MentionAcceptDetail>): void {
+    const { slug, triggerStart } = e.detail;
+    const textarea = this.getTextareaElement();
+    if (!textarea) return;
+
+    // Compute what to replace: from @-trigger to current cursor position.
+    const cursorPos = textarea.selectionStart ?? this.text.length;
+    const before = this.text.slice(0, triggerStart);
+    const after = this.text.slice(cursorPos);
+    const insertion = `@${slug} `;
+
+    this.text = before + insertion + after;
+    this.runeCount = countRunes(this.text);
+
+    // Track the accepted mention.
+    this.acceptedMentions.add(slug);
+
+    // Restore cursor position after the inserted text.
+    const newCursorPos = triggerStart + insertion.length;
+    this.updateComplete.then(() => {
+      const ta = this.getTextareaElement();
+      if (ta) {
+        ta.value = this.text;
+        ta.setSelectionRange(newCursorPos, newCursorPos);
+        ta.focus();
+      }
+    });
   }
 
   private handlePlainToggle(e: Event): void {
@@ -234,20 +298,40 @@ export class ScionChatComposer extends LitElement {
     const trimmed = this.text.trim();
     if (!trimmed || this.runeCount > MAX_MESSAGE_LENGTH || this.disabled) return;
 
+    // Filter accepted mentions to those still literally present in the text.
+    const mentions = [...this.acceptedMentions].filter((slug) =>
+      trimmed.includes(`@${slug}`)
+    );
+
     this.dispatchEvent(
       new CustomEvent<ChatSendDetail>('chat-send', {
         detail: {
           text: trimmed,
           plain: this.plain,
           interrupt: this.interrupt,
+          mentions,
           onSuccess: () => {
             this.text = '';
             this.runeCount = 0;
+            this.acceptedMentions.clear();
           },
         },
         bubbles: true,
         composed: true,
       })
+    );
+  }
+
+  /**
+   * Get the underlying HTMLTextAreaElement from the sl-textarea shadow DOM.
+   */
+  private getTextareaElement(): HTMLTextAreaElement | null {
+    const slTextarea = this.shadowRoot?.querySelector('sl-textarea');
+    if (!slTextarea) return null;
+    // Shoelace sl-textarea wraps a native <textarea> inside its shadow root.
+    return (
+      (slTextarea.shadowRoot?.querySelector('textarea') as HTMLTextAreaElement) ??
+      null
     );
   }
 }

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -39,13 +39,20 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { apiFetch, extractApiError } from '../../../client/api.js';
-import type { Message } from '../../../shared/types.js';
+import type { Agent, Message } from '../../../shared/types.js';
 import type { ChatSendDetail } from './chat-composer.js';
 import type { VisibilityMode, VisibilityChangeDetail } from './chat-visibility-toggle.js';
 import './chat-message.js';
 import './chat-system-line.js';
 import './chat-composer.js';
 import './chat-visibility-toggle.js';
+
+/** Result from server-side mention fan-out. */
+interface MentionResult {
+  slug: string;
+  status: string;
+  error?: string;
+}
 
 /** Maximum messages kept in the buffer. */
 const MAX_BUFFER = 500;
@@ -83,6 +90,10 @@ export class ScionChatThread extends LitElement {
   @property({ type: Boolean })
   showVisibilityToggle = false;
 
+  /** Agents available for @-mention in the composer. */
+  @property({ type: Array })
+  agents: Agent[] = [];
+
   @state() private messages: Message[] = [];
   @state() private messageMap = new Map<string, Message>();
   @state() private loading = false;
@@ -94,6 +105,8 @@ export class ScionChatThread extends LitElement {
   @state() private loadingOlder = false;
   @state() private hasOlderMessages = true;
   @state() private loaded = false;
+  /** Mention results from the last sent message (for "also notified" footer). */
+  @state() private lastMentionResults: MentionResult[] = [];
 
   private eventSource: EventSource | null = null;
   private nextCursor: string | null = null;
@@ -257,6 +270,18 @@ export class ScionChatThread extends LitElement {
       color: var(--scion-danger-600, #dc2626);
       background: var(--scion-danger-50, #fef2f2);
       border-top: 1px solid var(--scion-danger-200, #fecaca);
+    }
+
+    /* Mention results footer */
+    .mention-results {
+      padding: 0.25rem 1rem;
+      font-size: 0.6875rem;
+      color: var(--scion-text-muted, #64748b);
+      border-top: 1px solid var(--scion-border, #e2e8f0);
+    }
+
+    .mention-results .mention-slug {
+      font-weight: 600;
     }
   `;
 
@@ -594,25 +619,38 @@ export class ScionChatThread extends LitElement {
   // ---------------------------------------------------------------------------
 
   private async handleChatSend(e: CustomEvent<ChatSendDetail>): Promise<void> {
-    const { text, plain, interrupt, onSuccess } = e.detail;
+    const { text, plain, interrupt, mentions, onSuccess } = e.detail;
     if (!text || this.sending) return;
 
     this.sending = true;
     this.sendError = null;
+    this.lastMentionResults = [];
 
     try {
+      // Build the POST body, including mentions when present.
+      const body: Record<string, unknown> = {
+        structured_message: { msg: text, plain },
+        interrupt,
+      };
+      if (mentions && mentions.length > 0) {
+        body.mentions = mentions;
+      }
+
       const res = await apiFetch(`/api/v1/agents/${encodeURIComponent(this.agentId)}/message`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          structured_message: { msg: text, plain },
-          interrupt,
-        }),
+        body: JSON.stringify(body),
       });
 
       if (!res.ok) {
         this.sendError = await extractApiError(res, 'Failed to send message');
       } else {
+        const data = (await res.json()) as {
+          mention_results?: MentionResult[];
+        };
+        if (data?.mention_results && data.mention_results.length > 0) {
+          this.lastMentionResults = data.mention_results;
+        }
         onSuccess();
       }
     } catch (err) {
@@ -631,6 +669,7 @@ export class ScionChatThread extends LitElement {
       <div class="thread-container">
         ${this.renderStreamBar()}
         ${this.renderContent()}
+        ${this.renderMentionResults()}
         ${this.sendError
           ? html`<div class="send-error">${this.sendError}</div>`
           : nothing}
@@ -638,6 +677,7 @@ export class ScionChatThread extends LitElement {
           ? html`
               <scion-chat-composer
                 ?disabled=${this.sending}
+                .agents=${this.agents}
                 @chat-send=${this.handleChatSend}
               ></scion-chat-composer>
             `
@@ -798,6 +838,32 @@ export class ScionChatThread extends LitElement {
     }
 
     return rows;
+  }
+
+  /**
+   * Render a subtle "also notified: @slug" footer after a sent message
+   * when mention_results are present.
+   */
+  private renderMentionResults() {
+    if (this.lastMentionResults.length === 0) return nothing;
+
+    const delivered = this.lastMentionResults.filter(
+      (r) => r.status === 'delivered'
+    );
+    if (delivered.length === 0) return nothing;
+
+    const slugs = delivered.map(
+      (r) => html`<span class="mention-slug">@${r.slug}</span>`
+    );
+
+    return html`
+      <div class="mention-results">
+        Also notified: ${slugs.reduce(
+          (acc, s, i) => (i === 0 ? [s] : [...acc, ', ', s]),
+          [] as unknown[]
+        )}
+      </div>
+    `;
   }
 }
 

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -105,8 +105,8 @@ export class ScionChatThread extends LitElement {
   @state() private loadingOlder = false;
   @state() private hasOlderMessages = true;
   @state() private loaded = false;
-  /** Mention results from the last sent message (for "also notified" footer). */
-  @state() private lastMentionResults: MentionResult[] = [];
+  /** Mention results keyed by message ID (for "also notified" footer per message). */
+  @state() private mentionResultsByMessageId = new Map<string, MentionResult[]>();
 
   private eventSource: EventSource | null = null;
   private nextCursor: string | null = null;
@@ -624,7 +624,6 @@ export class ScionChatThread extends LitElement {
 
     this.sending = true;
     this.sendError = null;
-    this.lastMentionResults = [];
 
     try {
       // Build the POST body, including mentions when present.
@@ -646,10 +645,13 @@ export class ScionChatThread extends LitElement {
         this.sendError = await extractApiError(res, 'Failed to send message');
       } else {
         const data = (await res.json()) as {
+          message_id?: string;
           mention_results?: MentionResult[];
         };
-        if (data?.mention_results && data.mention_results.length > 0) {
-          this.lastMentionResults = data.mention_results;
+        if (data?.message_id && data?.mention_results && data.mention_results.length > 0) {
+          const updated = new Map(this.mentionResultsByMessageId);
+          updated.set(data.message_id, data.mention_results);
+          this.mentionResultsByMessageId = updated;
         }
         onSuccess();
       }
@@ -669,7 +671,6 @@ export class ScionChatThread extends LitElement {
       <div class="thread-container">
         ${this.renderStreamBar()}
         ${this.renderContent()}
-        ${this.renderMentionResults()}
         ${this.sendError
           ? html`<div class="send-error">${this.sendError}</div>`
           : nothing}
@@ -833,6 +834,25 @@ export class ScionChatThread extends LitElement {
         ></scion-chat-message>
       `);
 
+      // Render "also notified" footer under the specific message bubble (O3).
+      const msgMentionResults = this.mentionResultsByMessageId.get(msg.id);
+      if (msgMentionResults) {
+        const delivered = msgMentionResults.filter((r) => r.status === 'delivered');
+        if (delivered.length > 0) {
+          const slugs = delivered.map(
+            (r) => html`<span class="mention-slug">@${r.slug}</span>`
+          );
+          rows.push(html`
+            <div class="mention-results">
+              Also notified: ${slugs.reduce(
+                (acc, s, i) => (i === 0 ? [s] : [...acc, ', ', s]),
+                [] as unknown[]
+              )}
+            </div>
+          `);
+        }
+      }
+
       prevSender = msg.sender;
       prevTimestamp = msgTime;
     }
@@ -840,31 +860,6 @@ export class ScionChatThread extends LitElement {
     return rows;
   }
 
-  /**
-   * Render a subtle "also notified: @slug" footer after a sent message
-   * when mention_results are present.
-   */
-  private renderMentionResults() {
-    if (this.lastMentionResults.length === 0) return nothing;
-
-    const delivered = this.lastMentionResults.filter(
-      (r) => r.status === 'delivered'
-    );
-    if (delivered.length === 0) return nothing;
-
-    const slugs = delivered.map(
-      (r) => html`<span class="mention-slug">@${r.slug}</span>`
-    );
-
-    return html`
-      <div class="mention-results">
-        Also notified: ${slugs.reduce(
-          (acc, s, i) => (i === 0 ? [s] : [...acc, ', ', s]),
-          [] as unknown[]
-        )}
-      </div>
-    `;
-  }
 }
 
 declare global {

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -648,17 +648,21 @@ export class ScionChatThread extends LitElement {
       } else {
         // Only parse the JSON body when mentions were sent (O1 fix).
         if (mentions && mentions.length > 0) {
-          const contentType = res.headers.get('content-type');
-          if (contentType && contentType.includes('application/json')) {
-            const data = (await res.json()) as {
-              message_id?: string;
-              mention_results?: MentionResult[];
-            };
-            if (data?.message_id && data?.mention_results && data.mention_results.length > 0) {
-              const updated = new Map(this.mentionResultsByMessageId);
-              updated.set(data.message_id, data.mention_results);
-              this.mentionResultsByMessageId = updated;
+          try {
+            const contentType = res.headers.get('content-type');
+            if (contentType && contentType.includes('application/json')) {
+              const data = (await res.json()) as {
+                message_id?: string;
+                mention_results?: MentionResult[];
+              };
+              if (data?.message_id && data?.mention_results && data.mention_results.length > 0) {
+                const updated = new Map(this.mentionResultsByMessageId);
+                updated.set(data.message_id, data.mention_results);
+                this.mentionResultsByMessageId = updated;
+              }
             }
+          } catch (err) {
+            console.error('Failed to parse mention results response:', err);
           }
         }
         onSuccess();

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -511,6 +511,8 @@ export class ScionChatThread extends LitElement {
       const removed = sorted.splice(0, sorted.length - MAX_BUFFER);
       for (const msg of removed) {
         this.messageMap.delete(msg.id);
+        // Prune mention results for evicted messages (R1 fix).
+        this.mentionResultsByMessageId.delete(msg.id);
       }
     }
 
@@ -644,14 +646,20 @@ export class ScionChatThread extends LitElement {
       if (!res.ok) {
         this.sendError = await extractApiError(res, 'Failed to send message');
       } else {
-        const data = (await res.json()) as {
-          message_id?: string;
-          mention_results?: MentionResult[];
-        };
-        if (data?.message_id && data?.mention_results && data.mention_results.length > 0) {
-          const updated = new Map(this.mentionResultsByMessageId);
-          updated.set(data.message_id, data.mention_results);
-          this.mentionResultsByMessageId = updated;
+        // Only parse the JSON body when mentions were sent (O1 fix).
+        if (mentions && mentions.length > 0) {
+          const contentType = res.headers.get('content-type');
+          if (contentType && contentType.includes('application/json')) {
+            const data = (await res.json()) as {
+              message_id?: string;
+              mention_results?: MentionResult[];
+            };
+            if (data?.message_id && data?.mention_results && data.mention_results.length > 0) {
+              const updated = new Map(this.mentionResultsByMessageId);
+              updated.set(data.message_id, data.mention_results);
+              this.mentionResultsByMessageId = updated;
+            }
+          }
         }
         onSuccess();
       }

--- a/web/src/components/shared/chat/mention-autocomplete.ts
+++ b/web/src/components/shared/chat/mention-autocomplete.ts
@@ -1,0 +1,410 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Mention autocomplete dropdown component.
+ *
+ * Provides @-mention suggestions for agent names in the chat composer.
+ *
+ * Design decisions (from design doc §4.5):
+ * - Trigger: `@` at a word boundary (start of input or preceded by whitespace)
+ * - Source: stateManager.getAgents() — already cached, no network call
+ * - Matching: case-insensitive subsequence over slug and name; exact-prefix ranked first
+ * - Keys: Up/Down navigate, Enter/Tab accept, Esc dismiss
+ * - Insert: plain text `@<slug> ` — no chips, no hidden markup
+ * - Code fence guard: `@` inside fenced code blocks does NOT trigger (AC17)
+ * - Dropdown capped at 8 items
+ *
+ * Rejected approaches (design doc):
+ * - contenteditable with mention chips — too complex, breaks IME
+ * - New /mention-candidates endpoint — GET /agents already has everything
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import type { Agent } from '../../../shared/types.js';
+
+/** Maximum items shown in the dropdown. */
+const MAX_DROPDOWN_ITEMS = 8;
+
+/** Detail emitted when the user accepts a mention. */
+export interface MentionAcceptDetail {
+  slug: string;
+  /** The start index of the `@` trigger in the textarea value. */
+  triggerStart: number;
+  /** The end index of the query text (just past the last typed char). */
+  queryEnd: number;
+}
+
+@customElement('scion-mention-autocomplete')
+export class ScionMentionAutocomplete extends LitElement {
+  /** All agents available for mentioning. Set by the parent. */
+  @property({ type: Array })
+  agents: Agent[] = [];
+
+  /** Whether the autocomplete is currently active. */
+  @state() active = false;
+
+  /** Matched candidates (already filtered + ranked). */
+  @state() private candidates: Agent[] = [];
+
+  /** Index of the highlighted candidate. */
+  @state() private highlightIndex = 0;
+
+  /** Horizontal offset for the dropdown (pixels from left of host). */
+  @state() private dropdownLeft = 0;
+
+  /** Internal tracking of the trigger position. */
+  private triggerStart = -1;
+
+  static override styles = css`
+    :host {
+      display: block;
+      position: relative;
+    }
+
+    .dropdown {
+      position: absolute;
+      z-index: 100;
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.5rem;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+      max-width: 280px;
+      min-width: 200px;
+      overflow: hidden;
+    }
+
+    .dropdown-item {
+      display: flex;
+      flex-direction: column;
+      padding: 0.375rem 0.75rem;
+      cursor: pointer;
+      font-size: 0.8125rem;
+      transition: background 0.1s;
+    }
+
+    .dropdown-item:hover,
+    .dropdown-item.highlighted {
+      background: var(--scion-primary-50, #eff6ff);
+    }
+
+    .dropdown-item .slug {
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .dropdown-item .name {
+      font-size: 0.6875rem;
+      color: var(--scion-text-muted, #64748b);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .no-results {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+      font-style: italic;
+    }
+  `;
+
+  override render() {
+    if (!this.active || this.candidates.length === 0) return nothing;
+
+    return html`
+      <div
+        class="dropdown"
+        style="bottom: calc(100% + 4px); left: ${this.dropdownLeft}px;"
+        @mousedown=${this.handleMouseDown}
+      >
+        ${this.candidates.map(
+          (agent, i) => html`
+            <div
+              class="dropdown-item ${i === this.highlightIndex ? 'highlighted' : ''}"
+              data-index=${i}
+              @click=${() => this.acceptCandidate(i)}
+              @mouseenter=${() => { this.highlightIndex = i; }}
+            >
+              <span class="slug">@${agent.slug || agent.name}</span>
+              ${agent.slug && agent.name && agent.slug !== agent.name
+                ? html`<span class="name">${agent.name}</span>`
+                : nothing}
+            </div>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  /**
+   * Called by the parent composer on every input event.
+   * Determines whether to open/update/close the autocomplete.
+   *
+   * @param text Full textarea value
+   * @param cursorPos Current cursor position in the textarea
+   * @param textarea The textarea element (for caret measurement)
+   */
+  handleInput(text: string, cursorPos: number, textarea: HTMLTextAreaElement): void {
+    // Find the @ trigger working backwards from cursor.
+    const triggerInfo = this.findTrigger(text, cursorPos);
+
+    if (!triggerInfo) {
+      this.dismiss();
+      return;
+    }
+
+    this.triggerStart = triggerInfo.start;
+    const query = text.slice(triggerInfo.start + 1, cursorPos);
+
+    // Filter and rank agents.
+    const matched = this.matchAgents(query);
+
+    if (matched.length === 0) {
+      this.dismiss();
+      return;
+    }
+
+    this.candidates = matched;
+    this.highlightIndex = 0;
+    this.active = true;
+
+    // Position the dropdown near the caret.
+    this.positionDropdown(textarea, triggerInfo.start);
+  }
+
+  /**
+   * Called by the parent on keydown. Returns true if the event was consumed.
+   */
+  handleKeydown(e: KeyboardEvent): boolean {
+    if (!this.active) return false;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        this.highlightIndex = (this.highlightIndex + 1) % this.candidates.length;
+        return true;
+
+      case 'ArrowUp':
+        e.preventDefault();
+        this.highlightIndex =
+          (this.highlightIndex - 1 + this.candidates.length) % this.candidates.length;
+        return true;
+
+      case 'Enter':
+      case 'Tab':
+        e.preventDefault();
+        this.acceptCandidate(this.highlightIndex);
+        return true;
+
+      case 'Escape':
+        e.preventDefault();
+        this.dismiss();
+        return true;
+
+      default:
+        return false;
+    }
+  }
+
+  /** Dismiss the dropdown. */
+  dismiss(): void {
+    this.active = false;
+    this.candidates = [];
+    this.highlightIndex = 0;
+    this.triggerStart = -1;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Find the @ trigger position, working backwards from cursorPos.
+   * Returns null if no valid trigger is found.
+   *
+   * Rules:
+   * - The `@` must be at position 0 or preceded by whitespace (word boundary).
+   * - The `@` must NOT be inside a fenced code block (AC17).
+   */
+  private findTrigger(
+    text: string,
+    cursorPos: number
+  ): { start: number } | null {
+    // Walk backwards from cursor to find @.
+    for (let i = cursorPos - 1; i >= 0; i--) {
+      const ch = text[i];
+
+      // If we hit whitespace before finding @, no trigger.
+      if (/\s/.test(ch)) return null;
+
+      if (ch === '@') {
+        // Must be at word boundary: start of text or preceded by whitespace.
+        if (i > 0 && !/\s/.test(text[i - 1])) return null;
+
+        // Code fence guard (AC17): check if this @ is inside a fenced code block.
+        if (this.isInsideCodeFence(text, i)) return null;
+
+        return { start: i };
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Checks whether a position in the text is inside a fenced code block.
+   * Fences are triple backticks (```) on their own line.
+   */
+  private isInsideCodeFence(text: string, pos: number): boolean {
+    const before = text.slice(0, pos);
+    // Count triple-backtick fence markers (``` at the start of a line).
+    const fencePattern = /^```/gm;
+    let count = 0;
+    while (fencePattern.exec(before) !== null) {
+      count++;
+    }
+    // Inside a fence if count is odd (opened but not closed).
+    return count % 2 === 1;
+  }
+
+  /**
+   * Match agents against a query string using case-insensitive subsequence
+   * matching over slug and name. Exact-prefix matches ranked first.
+   */
+  private matchAgents(query: string): Agent[] {
+    if (query === '') {
+      // Show all agents when just @ is typed, capped at MAX_DROPDOWN_ITEMS.
+      return this.agents.slice(0, MAX_DROPDOWN_ITEMS);
+    }
+
+    const lowerQuery = query.toLowerCase();
+
+    const prefixMatches: Agent[] = [];
+    const subsequenceMatches: Agent[] = [];
+
+    for (const agent of this.agents) {
+      const slug = (agent.slug || agent.name || '').toLowerCase();
+      const name = (agent.name || '').toLowerCase();
+
+      // Check exact prefix match on slug or name.
+      if (slug.startsWith(lowerQuery) || name.startsWith(lowerQuery)) {
+        prefixMatches.push(agent);
+      } else if (
+        this.isSubsequence(lowerQuery, slug) ||
+        this.isSubsequence(lowerQuery, name)
+      ) {
+        subsequenceMatches.push(agent);
+      }
+    }
+
+    // Prefix matches first, then subsequence matches.
+    return [...prefixMatches, ...subsequenceMatches].slice(0, MAX_DROPDOWN_ITEMS);
+  }
+
+  /** Check if `sub` is a subsequence of `str`. */
+  private isSubsequence(sub: string, str: string): boolean {
+    let si = 0;
+    for (let i = 0; i < str.length && si < sub.length; i++) {
+      if (str[i] === sub[si]) si++;
+    }
+    return si === sub.length;
+  }
+
+  /** Dispatch the accept event and close the dropdown. */
+  private acceptCandidate(index: number): void {
+    const agent = this.candidates[index];
+    if (!agent) return;
+
+    const slug = agent.slug || agent.name;
+
+    this.dispatchEvent(
+      new CustomEvent<MentionAcceptDetail>('mention-accept', {
+        detail: {
+          slug,
+          triggerStart: this.triggerStart,
+          queryEnd: this.triggerStart + 1 + (slug.length > 0 ? slug.length : 0),
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+
+    this.dismiss();
+  }
+
+  /**
+   * Position the dropdown near the caret using a mirrored-div measurement.
+   * The dropdown is positioned relative to the host element.
+   */
+  private positionDropdown(textarea: HTMLTextAreaElement, triggerPos: number): void {
+    // Use a mirrored div to measure caret position.
+    const mirror = document.createElement('div');
+    const computed = window.getComputedStyle(textarea);
+
+    // Copy relevant styles to the mirror.
+    const stylesToCopy = [
+      'font-family', 'font-size', 'font-weight', 'line-height',
+      'letter-spacing', 'word-spacing', 'padding-top', 'padding-right',
+      'padding-bottom', 'padding-left', 'border-width', 'box-sizing',
+      'white-space', 'word-wrap', 'overflow-wrap',
+    ];
+
+    mirror.style.position = 'absolute';
+    mirror.style.visibility = 'hidden';
+    mirror.style.whiteSpace = 'pre-wrap';
+    mirror.style.wordWrap = 'break-word';
+    mirror.style.width = `${textarea.offsetWidth}px`;
+
+    for (const prop of stylesToCopy) {
+      mirror.style.setProperty(prop, computed.getPropertyValue(prop));
+    }
+
+    // Insert text up to the trigger, then a marker span.
+    const textBefore = textarea.value.slice(0, triggerPos);
+    mirror.textContent = textBefore;
+    const marker = document.createElement('span');
+    marker.textContent = '@';
+    mirror.appendChild(marker);
+
+    document.body.appendChild(mirror);
+
+    // Measure position relative to the host element.
+    const markerRect = marker.getBoundingClientRect();
+    const hostRect = this.getBoundingClientRect();
+
+    this.dropdownLeft = Math.max(
+      0,
+      markerRect.left - hostRect.left
+    );
+
+    // Clean up.
+    document.body.removeChild(mirror);
+  }
+
+  /**
+   * Prevent the textarea from losing focus when clicking the dropdown.
+   */
+  private handleMouseDown(e: Event): void {
+    e.preventDefault();
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-mention-autocomplete': ScionMentionAutocomplete;
+  }
+}

--- a/web/src/components/shared/chat/mention-autocomplete.ts
+++ b/web/src/components/shared/chat/mention-autocomplete.ts
@@ -45,8 +45,6 @@ export interface MentionAcceptDetail {
   slug: string;
   /** The start index of the `@` trigger in the textarea value. */
   triggerStart: number;
-  /** The end index of the query text (just past the last typed char). */
-  queryEnd: number;
 }
 
 @customElement('scion-mention-autocomplete')
@@ -336,7 +334,6 @@ export class ScionMentionAutocomplete extends LitElement {
         detail: {
           slug,
           triggerStart: this.triggerStart,
-          queryEnd: this.triggerStart + 1 + (slug.length > 0 ? slug.length : 0),
         },
         bubbles: true,
         composed: true,

--- a/web/src/components/shared/chat/mention-autocomplete.ts
+++ b/web/src/components/shared/chat/mention-autocomplete.ts
@@ -68,6 +68,15 @@ export class ScionMentionAutocomplete extends LitElement {
   /** Internal tracking of the trigger position. */
   private triggerStart = -1;
 
+  /** Cached mirror div for caret position measurement (O2 fix). */
+  private mirrorDiv: HTMLDivElement | null = null;
+
+  /** Cached marker span inside the mirror div. */
+  private mirrorMarker: HTMLSpanElement | null = null;
+
+  /** Last known textarea width used for the cached mirror div. */
+  private mirrorWidth = 0;
+
   static override styles = css`
     :host {
       display: block;
@@ -120,6 +129,21 @@ export class ScionMentionAutocomplete extends LitElement {
       font-style: italic;
     }
   `;
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.removeMirrorDiv();
+  }
+
+  /** Remove the cached mirror div from the DOM (cleanup). */
+  private removeMirrorDiv(): void {
+    if (this.mirrorDiv && this.mirrorDiv.parentNode) {
+      this.mirrorDiv.parentNode.removeChild(this.mirrorDiv);
+    }
+    this.mirrorDiv = null;
+    this.mirrorMarker = null;
+    this.mirrorWidth = 0;
+  }
 
   override render() {
     if (!this.active || this.candidates.length === 0) return nothing;
@@ -265,12 +289,14 @@ export class ScionMentionAutocomplete extends LitElement {
 
   /**
    * Checks whether a position in the text is inside a fenced code block.
-   * Fences are triple backticks (```) on their own line.
+   * Fences are exactly triple backticks (```) at the start of a line,
+   * optionally followed by a language tag — but NOT four or more backticks
+   * (which are inline constructs, not fence delimiters) (O3 fix).
    */
   private isInsideCodeFence(text: string, pos: number): boolean {
     const before = text.slice(0, pos);
-    // Count triple-backtick fence markers (``` at the start of a line).
-    const fencePattern = /^```/gm;
+    // Match exactly triple backticks at line start, not followed by another backtick.
+    const fencePattern = /^```(?!`)/gm;
     let count = 0;
     while (fencePattern.exec(before) !== null) {
       count++;
@@ -343,53 +369,64 @@ export class ScionMentionAutocomplete extends LitElement {
     this.dismiss();
   }
 
+  /** Styles copied from the textarea onto the mirror div. */
+  private static readonly MIRROR_STYLES = [
+    'font-family', 'font-size', 'font-weight', 'line-height',
+    'letter-spacing', 'word-spacing', 'padding-top', 'padding-right',
+    'padding-bottom', 'padding-left', 'border-width', 'box-sizing',
+    'white-space', 'word-wrap', 'overflow-wrap',
+  ] as const;
+
   /**
    * Position the dropdown near the caret using a mirrored-div measurement.
-   * The dropdown is positioned relative to the host element.
+   * The mirror div is cached and reused across keystrokes; it is only
+   * recreated when the textarea dimensions change (O2 fix).
    */
   private positionDropdown(textarea: HTMLTextAreaElement, triggerPos: number): void {
-    // Use a mirrored div to measure caret position.
-    const mirror = document.createElement('div');
-    const computed = window.getComputedStyle(textarea);
+    const currentWidth = textarea.offsetWidth;
 
-    // Copy relevant styles to the mirror.
-    const stylesToCopy = [
-      'font-family', 'font-size', 'font-weight', 'line-height',
-      'letter-spacing', 'word-spacing', 'padding-top', 'padding-right',
-      'padding-bottom', 'padding-left', 'border-width', 'box-sizing',
-      'white-space', 'word-wrap', 'overflow-wrap',
-    ];
+    // Create or recreate the mirror div if needed.
+    if (!this.mirrorDiv || !this.mirrorDiv.parentNode || this.mirrorWidth !== currentWidth) {
+      this.removeMirrorDiv();
 
-    mirror.style.position = 'absolute';
-    mirror.style.visibility = 'hidden';
-    mirror.style.whiteSpace = 'pre-wrap';
-    mirror.style.wordWrap = 'break-word';
-    mirror.style.width = `${textarea.offsetWidth}px`;
+      const mirror = document.createElement('div');
+      const computed = window.getComputedStyle(textarea);
 
-    for (const prop of stylesToCopy) {
-      mirror.style.setProperty(prop, computed.getPropertyValue(prop));
+      mirror.style.position = 'absolute';
+      mirror.style.visibility = 'hidden';
+      mirror.style.whiteSpace = 'pre-wrap';
+      mirror.style.wordWrap = 'break-word';
+      mirror.style.width = `${currentWidth}px`;
+
+      for (const prop of ScionMentionAutocomplete.MIRROR_STYLES) {
+        mirror.style.setProperty(prop, computed.getPropertyValue(prop));
+      }
+
+      const marker = document.createElement('span');
+      marker.textContent = '@';
+
+      mirror.appendChild(document.createTextNode(''));
+      mirror.appendChild(marker);
+
+      document.body.appendChild(mirror);
+
+      this.mirrorDiv = mirror;
+      this.mirrorMarker = marker;
+      this.mirrorWidth = currentWidth;
     }
 
-    // Insert text up to the trigger, then a marker span.
+    // Update the text content before the marker.
     const textBefore = textarea.value.slice(0, triggerPos);
-    mirror.textContent = textBefore;
-    const marker = document.createElement('span');
-    marker.textContent = '@';
-    mirror.appendChild(marker);
-
-    document.body.appendChild(mirror);
+    this.mirrorDiv.firstChild!.textContent = textBefore;
 
     // Measure position relative to the host element.
-    const markerRect = marker.getBoundingClientRect();
+    const markerRect = this.mirrorMarker!.getBoundingClientRect();
     const hostRect = this.getBoundingClientRect();
 
     this.dropdownLeft = Math.max(
       0,
       markerRect.left - hostRect.left
     );
-
-    // Clean up.
-    document.body.removeChild(mirror);
   }
 
   /**

--- a/web/src/components/shared/chat/mention-autocomplete.ts
+++ b/web/src/components/shared/chat/mention-autocomplete.ts
@@ -310,9 +310,10 @@ export class ScionMentionAutocomplete extends LitElement {
    * matching over slug and name. Exact-prefix matches ranked first.
    */
   private matchAgents(query: string): Agent[] {
+    const agents = this.agents || [];
     if (query === '') {
       // Show all agents when just @ is typed, capped at MAX_DROPDOWN_ITEMS.
-      return this.agents.slice(0, MAX_DROPDOWN_ITEMS);
+      return agents.slice(0, MAX_DROPDOWN_ITEMS);
     }
 
     const lowerQuery = query.toLowerCase();
@@ -320,7 +321,7 @@ export class ScionMentionAutocomplete extends LitElement {
     const prefixMatches: Agent[] = [];
     const subsequenceMatches: Agent[] = [];
 
-    for (const agent of this.agents) {
+    for (const agent of agents) {
       const slug = (agent.slug || agent.name || '').toLowerCase();
       const name = (agent.name || '').toLowerCase();
 


### PR DESCRIPTION
## Summary
- New shared Go package pkg/messages/mentions.go (ExtractMentions, ResolveMentions, MentionResult)
- Pure refactor of cmd/message.go to use shared package (CLI behavior unchanged)
- MessageRequest.Mentions field + server-side fan-out + mention_results in API response
- Input validation: mentions capped at MaxMentionRecipients (10), 30s aggregate timeout
- Client-side mention-autocomplete.ts: fuzzy match dropdown, keyboard nav, code fence guard
- Composer integration: mention tracking, filtered on send, scoped per-message footer
- New unit tests in pkg/messages/mentions_test.go

## Test plan
- Verify typing @rev opens dropdown with matching agents; keyboard nav works (AC15)
- Verify accepting inserts @reviewer and mentioned agent receives type:mention message
- Verify @notanagent sends with no fan-out, no error, literal text preserved (AC16)
- Verify @ inside fenced code block does not trigger mention (AC17)
- Verify existing scion message CLI mention behavior unchanged (AC18)
- Verify mentions capped at 10 server-side