### PR TITLE
feat(teams): fix setup card callback with Action.Execute and add default command

### DIFF
--- a/extras/scion-teams/internal/teams/callbacks.go
+++ b/extras/scion-teams/internal/teams/callbacks.go
@@ -38,6 +38,14 @@ func NewCallbackHandler(broker *TeamsBroker, log *slog.Logger) *CallbackHandler 
 	}
 }
 
+// getStore returns the broker's store under the broker mutex.
+func (h *CallbackHandler) getStore() Store {
+	h.broker.mu.Lock()
+	store := h.broker.store
+	h.broker.mu.Unlock()
+	return store
+}
+
 // HandleInvoke processes an invoke activity (Adaptive Card button click).
 // It reads the action field from activity.Value to dispatch to the correct handler.
 func (h *CallbackHandler) HandleInvoke(ctx context.Context, activity *Activity) (*InvokeResponse, error) {
@@ -109,7 +117,7 @@ func (h *CallbackHandler) handleAskResponse(ctx context.Context, activity *Activ
 		return h.respondWithUpdatedCard(activity, "Invalid response — missing request ID."), nil
 	}
 
-	store := h.broker.store
+	store := h.getStore()
 	if store == nil {
 		return h.respondWithUpdatedCard(activity, "Store not initialized."), nil
 	}
@@ -171,7 +179,7 @@ func (h *CallbackHandler) handleAskInput(ctx context.Context, activity *Activity
 		return h.respondWithUpdatedCard(activity, "Invalid request — missing request ID."), nil
 	}
 
-	store := h.broker.store
+	store := h.getStore()
 	if store == nil {
 		return h.respondWithUpdatedCard(activity, "Store not initialized."), nil
 	}
@@ -242,7 +250,7 @@ func (h *CallbackHandler) handleSetupConfirm(ctx context.Context, activity *Acti
 		return h.respondWithUpdatedCard(activity, "Invalid setup — missing project information."), nil
 	}
 
-	store := h.broker.store
+	store := h.getStore()
 	if store == nil {
 		return h.respondWithUpdatedCard(activity, "Store not initialized."), nil
 	}
@@ -310,7 +318,7 @@ func (h *CallbackHandler) deliverAskUserResponse(ctx context.Context, activity *
 	senderName := activity.From.Name
 
 	// Try to resolve Teams user to Scion identity.
-	store := h.broker.store
+	store := h.getStore()
 	if store != nil {
 		mapping, err := store.GetUserMapping(ctx, senderID)
 		if err == nil && mapping != nil && mapping.ScionEmail != "" {

--- a/extras/scion-teams/internal/teams/callbacks.go
+++ b/extras/scion-teams/internal/teams/callbacks.go
@@ -210,7 +210,7 @@ func (h *CallbackHandler) handleAskInput(ctx context.Context, activity *Activity
 			InputText{Type: "Input.Text", ID: "reply_text", IsMultiline: true, Placeholder: "Type your reply..."},
 		},
 		Actions: []CardAction{
-			ActionSubmit{Type: "Action.Submit", Title: "Send Reply", Style: "positive",
+			ActionExecute{Type: "Action.Execute", Title: "Send Reply", Style: "positive",
 				Data: map[string]interface{}{"action": "ask_response", "request_id": requestID, "choice": "custom"}},
 		},
 	}

--- a/extras/scion-teams/internal/teams/commands.go
+++ b/extras/scion-teams/internal/teams/commands.go
@@ -779,7 +779,30 @@ func (h *CommandHandler) handleDefault(ctx context.Context, activity *Activity, 
 		return h.sendReply(ctx, activity, "Default agent cleared for this channel.")
 	}
 
-	// Set default agent.
+	// Set default agent — validate it exists.
+	hubClient := h.broker.hubClient
+	if hubClient == nil {
+		return h.sendReply(ctx, activity, "Hub client not configured.")
+	}
+
+	agents, err := hubClient.ListAgents(ctx, link.ProjectID)
+	if err != nil {
+		h.log.Error("Failed to list agents for validation", "error", err)
+		return h.sendReply(ctx, activity, "Failed to validate agent. Please try again.")
+	}
+
+	var found bool
+	for _, a := range agents {
+		if strings.EqualFold(a.Slug, agentSlug) {
+			agentSlug = a.Slug // normalize to actual slug
+			found = true
+			break
+		}
+	}
+	if !found {
+		return h.sendReply(ctx, activity, fmt.Sprintf("Agent **%s** not found in project **%s**.", agentSlug, link.ProjectSlug))
+	}
+
 	link.DefaultAgent = agentSlug
 	if err := store.UpdateChannelLink(ctx, link); err != nil {
 		h.log.Error("Failed to set default agent", "error", err)

--- a/extras/scion-teams/internal/teams/commands.go
+++ b/extras/scion-teams/internal/teams/commands.go
@@ -105,6 +105,8 @@ func (h *CommandHandler) Handle(ctx context.Context, activity *Activity) (bool, 
 		return true, h.handleRegister(ctx, activity)
 	case "unregister":
 		return true, h.handleUnregister(ctx, activity)
+	case "default":
+		return true, h.handleDefault(ctx, activity, args)
 	case "help":
 		return true, h.handleHelp(ctx, activity)
 	default:
@@ -210,8 +212,8 @@ func (h *CommandHandler) handleSetup(ctx context.Context, activity *Activity, ar
 		if p.Name != "" && p.Name != p.Slug {
 			displayName = fmt.Sprintf("%s (%s)", p.Name, p.Slug)
 		}
-		card.Actions = append(card.Actions, ActionSubmit{
-			Type:  "Action.Submit",
+		card.Actions = append(card.Actions, ActionExecute{
+			Type:  "Action.Execute",
 			Title: displayName,
 			Data: map[string]string{
 				"action":       "setup_confirm",
@@ -742,6 +744,51 @@ func (h *CommandHandler) handleUnregister(ctx context.Context, activity *Activit
 			existing.ScionUserID, existing.ScionEmail))
 }
 
+// handleDefault sets or shows the default agent for the current channel.
+func (h *CommandHandler) handleDefault(ctx context.Context, activity *Activity, args []string) error {
+	store := h.getStore()
+	if store == nil {
+		return h.sendReply(ctx, activity, "Store not initialized.")
+	}
+
+	// Resolve channel link.
+	link, err := h.resolveChannelLink(ctx, activity)
+	if err != nil {
+		return nil // resolveChannelLink already sent reply
+	}
+
+	if len(args) == 0 {
+		// Show current default.
+		if link.DefaultAgent == "" {
+			return h.sendReply(ctx, activity,
+				fmt.Sprintf("No default agent set for this channel (project: **%s**). Use `default <agent-slug>` to set one.", link.ProjectSlug))
+		}
+		return h.sendReply(ctx, activity,
+			fmt.Sprintf("Default agent for this channel: **%s** (project: **%s**). Use `default clear` to remove.", link.DefaultAgent, link.ProjectSlug))
+	}
+
+	agentSlug := args[0]
+
+	if agentSlug == "clear" || agentSlug == "none" || agentSlug == "remove" {
+		// Clear default.
+		link.DefaultAgent = ""
+		if err := store.UpdateChannelLink(ctx, link); err != nil {
+			h.log.Error("Failed to clear default agent", "error", err)
+			return h.sendReply(ctx, activity, "Failed to clear default agent.")
+		}
+		return h.sendReply(ctx, activity, "Default agent cleared for this channel.")
+	}
+
+	// Set default agent.
+	link.DefaultAgent = agentSlug
+	if err := store.UpdateChannelLink(ctx, link); err != nil {
+		h.log.Error("Failed to set default agent", "error", err)
+		return h.sendReply(ctx, activity, "Failed to set default agent.")
+	}
+	return h.sendReply(ctx, activity,
+		fmt.Sprintf("Default agent set to **%s** for this channel.", agentSlug))
+}
+
 // handleHelp sends a card listing all available commands.
 func (h *CommandHandler) handleHelp(ctx context.Context, activity *Activity) error {
 	card := NewAdaptiveCard()
@@ -760,6 +807,7 @@ func (h *CommandHandler) handleHelp(ctx context.Context, activity *Activity) err
 		{"unlink", "Unlink this conversation from its project"},
 		{"agents", "List agents in the linked project"},
 		{"status [agent]", "Show project or agent status"},
+		{"default [agent]", "Set or show the default agent for this channel"},
 		{"register", "Link your Teams account to Scion"},
 		{"unregister", "Unlink your Teams account from Scion"},
 		{"help", "Show this help message"},

--- a/extras/scion-teams/internal/teams/types.go
+++ b/extras/scion-teams/internal/teams/types.go
@@ -286,6 +286,20 @@ type ActionSubmit struct {
 
 func (ActionSubmit) cardAction() {}
 
+// ActionExecute is a button that sends an invoke activity to the bot.
+// Unlike Action.Submit (which sends a message activity), Action.Execute
+// sends an invoke with name "adaptiveCard/action", allowing the bot to
+// return an updated card.
+type ActionExecute struct {
+	Type  string      `json:"type"` // "Action.Execute"
+	Title string      `json:"title,omitempty"`
+	Verb  string      `json:"verb,omitempty"`
+	Data  interface{} `json:"data,omitempty"`
+	Style string      `json:"style,omitempty"`
+}
+
+func (ActionExecute) cardAction() {}
+
 // ActionOpenURL opens a URL when clicked.
 type ActionOpenURL struct {
 	Type  string `json:"type"` // "Action.OpenUrl"


### PR DESCRIPTION
## Summary

- Fix setup card buttons by switching from Action.Submit to Action.Execute — Action.Submit sends a message activity that was silently dropped; Action.Execute sends the correct invoke activity that the callback handler processes
- Add ActionExecute type to types.go for Adaptive Card invoke-based interactions
- Add default command to set/show/clear the per-channel default agent (matching Discord integration)
- Add mutex-safe getStore() to CallbackHandler, replacing all direct store accesses

## Root Cause

Action.Submit in Adaptive Cards sends a regular message activity with data in activity.Value. The callback handler only processes invoke activities (type=invoke, name=adaptiveCard/action), which Action.Execute sends. The button click data was reaching the bot as a message, falling through command parsing (no text), and being silently dropped.

## Test plan

- [x] go test ./... -race passes
- [x] go build ./... clean
- [ ] Deploy and verify: click project button in setup card creates the channel link
- [ ] Verify default command: set, show, and clear default agent