### PR TITLE
feat(admin): add Runtimes & Profiles tab to admin settings UI

### DIFF
--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -397,6 +397,10 @@ const KOANF_KEY_LABELS: Record<string, string> = {
 
 const STATIC_LAYER1_KEYS: Set<string> = new Set(Object.keys(KOANF_KEY_LABELS));
 
+/** Safe own-property check that won't match inherited keys on user-controlled objects. */
+const hasOwn = (obj: Record<string, unknown>, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(obj, key);
+
 @customElement('scion-page-admin-server-config')
 export class ScionPageAdminServerConfig extends LitElement {
   @state() private loading = true;
@@ -562,6 +566,7 @@ export class ScionPageAdminServerConfig extends LitElement {
   @state() private runtimes: Record<string, V1RuntimeConfig> = {};
   @state() private profiles: Record<string, V1ProfileConfig> = {};
   @state() private harnessConfigsMap: Record<string, unknown> = {};
+  @state() private harnessConfigsRaw: Record<string, string> = {};
   @state() private newRuntimeName = '';
   @state() private newProfileName = '';
   @state() private newHarnessConfigName = '';
@@ -1540,6 +1545,16 @@ export class ScionPageAdminServerConfig extends LitElement {
     this.harnessConfigsMap = data.harness_configs
       ? (JSON.parse(JSON.stringify(data.harness_configs)) as Record<string, unknown>)
       : {};
+    // Initialize raw strings from parsed objects for textarea binding
+    const rawStrings: Record<string, string> = {};
+    for (const [k, v] of Object.entries(this.harnessConfigsMap)) {
+      try {
+        rawStrings[k] = JSON.stringify(v, null, 2);
+      } catch {
+        rawStrings[k] = String(v);
+      }
+    }
+    this.harnessConfigsRaw = rawStrings;
     this.harnessConfigErrors = {};
 
     // Settings-DB metadata (postgres mode only; absent in file/SQLite mode)
@@ -3378,14 +3393,14 @@ export class ScionPageAdminServerConfig extends LitElement {
                   size="small"
                   variant="default"
                   ?disabled=${!this.newRuntimeName.trim() ||
-                    this.newRuntimeName.trim() in this.runtimes}
+                    hasOwn(this.runtimes, this.newRuntimeName.trim())}
                   @click=${() => this.addRuntime()}
                 >
                   <sl-icon slot="prefix" name="plus-circle"></sl-icon>
                   Add Runtime
                 </sl-button>
               </div>
-              ${this.newRuntimeName.trim() in this.runtimes
+              ${hasOwn(this.runtimes, this.newRuntimeName.trim())
                 ? html`<small class="hint" style="color:var(--sl-color-danger-600);">A runtime named "${this.newRuntimeName.trim()}" already exists.</small>`
                 : nothing}
             `
@@ -3602,7 +3617,7 @@ export class ScionPageAdminServerConfig extends LitElement {
 
   private addRuntime(): void {
     const name = this.newRuntimeName.trim();
-    if (!name || name in this.runtimes) return;
+    if (!name || hasOwn(this.runtimes, name)) return;
     this.runtimes = { ...this.runtimes, [name]: { type: 'docker' } };
     this.newRuntimeName = '';
   }
@@ -3646,14 +3661,14 @@ export class ScionPageAdminServerConfig extends LitElement {
                   size="small"
                   variant="default"
                   ?disabled=${!this.newProfileName.trim() ||
-                    this.newProfileName.trim() in this.profiles}
+                    hasOwn(this.profiles, this.newProfileName.trim())}
                   @click=${() => this.addProfile()}
                 >
                   <sl-icon slot="prefix" name="plus-circle"></sl-icon>
                   Add Profile
                 </sl-button>
               </div>
-              ${this.newProfileName.trim() in this.profiles
+              ${hasOwn(this.profiles, this.newProfileName.trim())
                 ? html`<small class="hint" style="color:var(--sl-color-danger-600);">A profile named "${this.newProfileName.trim()}" already exists.</small>`
                 : nothing}
             `
@@ -3868,7 +3883,7 @@ export class ScionPageAdminServerConfig extends LitElement {
 
   private addProfile(): void {
     const name = this.newProfileName.trim();
-    if (!name || name in this.profiles) return;
+    if (!name || hasOwn(this.profiles, name)) return;
     const runtimeNames = Object.keys(this.runtimes);
     this.profiles = {
       ...this.profiles,
@@ -3913,14 +3928,14 @@ export class ScionPageAdminServerConfig extends LitElement {
                   size="small"
                   variant="default"
                   ?disabled=${!this.newHarnessConfigName.trim() ||
-                    this.newHarnessConfigName.trim() in this.harnessConfigsMap}
+                    hasOwn(this.harnessConfigsMap, this.newHarnessConfigName.trim())}
                   @click=${() => this.addHarnessConfig()}
                 >
                   <sl-icon slot="prefix" name="plus-circle"></sl-icon>
                   Add Harness Config
                 </sl-button>
               </div>
-              ${this.newHarnessConfigName.trim() in this.harnessConfigsMap
+              ${hasOwn(this.harnessConfigsMap, this.newHarnessConfigName.trim())
                 ? html`<small class="hint" style="color:var(--sl-color-danger-600);">A config named "${this.newHarnessConfigName.trim()}" already exists.</small>`
                 : nothing}
             `
@@ -3930,13 +3945,7 @@ export class ScionPageAdminServerConfig extends LitElement {
   }
 
   private renderHarnessConfigEntry(name: string, readOnly: boolean) {
-    const value = this.harnessConfigsMap[name];
-    let jsonStr: string;
-    try {
-      jsonStr = JSON.stringify(value, null, 2);
-    } catch {
-      jsonStr = String(value);
-    }
+    const rawStr = this.harnessConfigsRaw[name] ?? '';
     const jsonError = this.harnessConfigErrors[name];
     return html`
       <sl-card class="runtime-card">
@@ -3958,10 +3967,10 @@ export class ScionPageAdminServerConfig extends LitElement {
           <sl-textarea
             rows="8"
             resize="auto"
-            value=${jsonStr}
+            value=${rawStr}
             ?disabled=${readOnly}
             style="font-family: monospace; font-size: 0.8125rem;${jsonError ? ' --sl-input-border-color: var(--sl-color-danger-600);' : ''}"
-            @sl-change=${(e: Event) => {
+            @sl-input=${(e: Event) => {
               this.updateHarnessConfigJson(name, (e.target as HTMLTextAreaElement).value);
             }}
           ></sl-textarea>
@@ -3974,6 +3983,8 @@ export class ScionPageAdminServerConfig extends LitElement {
   }
 
   private updateHarnessConfigJson(name: string, jsonStr: string): void {
+    // Always store raw input so the textarea preserves the user's text
+    this.harnessConfigsRaw = { ...this.harnessConfigsRaw, [name]: jsonStr };
     try {
       const parsed: unknown = JSON.parse(jsonStr);
       const updated = { ...this.harnessConfigsMap };
@@ -3984,7 +3995,7 @@ export class ScionPageAdminServerConfig extends LitElement {
       delete errors[name];
       this.harnessConfigErrors = errors;
     } catch (e) {
-      // Store the error for display
+      // Store the error for display — parsed map keeps last valid value
       this.harnessConfigErrors = {
         ...this.harnessConfigErrors,
         [name]: e instanceof Error ? e.message : 'Invalid JSON',
@@ -3994,10 +4005,15 @@ export class ScionPageAdminServerConfig extends LitElement {
 
   private addHarnessConfig(): void {
     const name = this.newHarnessConfigName.trim();
-    if (!name || name in this.harnessConfigsMap) return;
+    if (!name || hasOwn(this.harnessConfigsMap, name)) return;
+    const defaultValue = { harness: 'claude-code' };
     this.harnessConfigsMap = {
       ...this.harnessConfigsMap,
-      [name]: { harness: 'claude-code' },
+      [name]: defaultValue,
+    };
+    this.harnessConfigsRaw = {
+      ...this.harnessConfigsRaw,
+      [name]: JSON.stringify(defaultValue, null, 2),
     };
     this.newHarnessConfigName = '';
   }
@@ -4006,8 +4022,11 @@ export class ScionPageAdminServerConfig extends LitElement {
     const updated = { ...this.harnessConfigsMap };
     delete updated[name];
     this.harnessConfigsMap = updated;
-    // Clear any associated validation error
-    if (name in this.harnessConfigErrors) {
+    // Clear raw string and any associated validation error
+    const raw = { ...this.harnessConfigsRaw };
+    delete raw[name];
+    this.harnessConfigsRaw = raw;
+    if (hasOwn(this.harnessConfigErrors, name)) {
       const errors = { ...this.harnessConfigErrors };
       delete errors[name];
       this.harnessConfigErrors = errors;

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -1540,6 +1540,7 @@ export class ScionPageAdminServerConfig extends LitElement {
     this.harnessConfigsMap = data.harness_configs
       ? (JSON.parse(JSON.stringify(data.harness_configs)) as Record<string, unknown>)
       : {};
+    this.harnessConfigErrors = {};
 
     // Settings-DB metadata (postgres mode only; absent in file/SQLite mode)
     this.settingsTier = data.settings_tier || 'file';
@@ -3545,7 +3546,13 @@ export class ScionPageAdminServerConfig extends LitElement {
     value: string,
   ): void {
     const updated = { ...this.runtimes };
-    updated[name] = { ...updated[name], [field]: value };
+    const rt = { ...updated[name] };
+    if (value) {
+      (rt as Record<string, unknown>)[field] = value;
+    } else {
+      delete (rt as Record<string, unknown>)[field];
+    }
+    updated[name] = rt;
     this.runtimes = updated;
   }
 
@@ -3562,7 +3569,17 @@ export class ScionPageAdminServerConfig extends LitElement {
   private updateRuntimeCloudRun(name: string, field: 'project' | 'region', value: string): void {
     const updated = { ...this.runtimes };
     const rt = { ...updated[name] };
-    rt.cloudrun = { ...(rt.cloudrun || {}), [field]: value };
+    const cr = { ...(rt.cloudrun || {}) };
+    if (value) {
+      cr[field] = value;
+    } else {
+      delete cr[field];
+    }
+    if (Object.keys(cr).length > 0) {
+      rt.cloudrun = cr;
+    } else {
+      delete rt.cloudrun;
+    }
     updated[name] = rt;
     this.runtimes = updated;
   }
@@ -3713,7 +3730,7 @@ export class ScionPageAdminServerConfig extends LitElement {
               placeholder="e.g. 500m"
               ?disabled=${readOnly}
               @sl-input=${(e: Event) => {
-                this.updateProfileResource(name, 'requests', 'cpu', (e.target as HTMLInputElement).value);
+                this.updateProfileResourceTier(name, 'requests', 'cpu', (e.target as HTMLInputElement).value);
               }}
             ></sl-input>
           </div>
@@ -3724,7 +3741,7 @@ export class ScionPageAdminServerConfig extends LitElement {
               placeholder="e.g. 512Mi"
               ?disabled=${readOnly}
               @sl-input=${(e: Event) => {
-                this.updateProfileResource(name, 'requests', 'memory', (e.target as HTMLInputElement).value);
+                this.updateProfileResourceTier(name, 'requests', 'memory', (e.target as HTMLInputElement).value);
               }}
             ></sl-input>
           </div>
@@ -3735,7 +3752,7 @@ export class ScionPageAdminServerConfig extends LitElement {
               placeholder="e.g. 2000m"
               ?disabled=${readOnly}
               @sl-input=${(e: Event) => {
-                this.updateProfileResource(name, 'limits', 'cpu', (e.target as HTMLInputElement).value);
+                this.updateProfileResourceTier(name, 'limits', 'cpu', (e.target as HTMLInputElement).value);
               }}
             ></sl-input>
           </div>
@@ -3746,7 +3763,7 @@ export class ScionPageAdminServerConfig extends LitElement {
               placeholder="e.g. 4Gi"
               ?disabled=${readOnly}
               @sl-input=${(e: Event) => {
-                this.updateProfileResource(name, 'limits', 'memory', (e.target as HTMLInputElement).value);
+                this.updateProfileResourceTier(name, 'limits', 'memory', (e.target as HTMLInputElement).value);
               }}
             ></sl-input>
           </div>
@@ -3757,7 +3774,7 @@ export class ScionPageAdminServerConfig extends LitElement {
               placeholder="e.g. 20Gi"
               ?disabled=${readOnly}
               @sl-input=${(e: Event) => {
-                this.updateProfileResource(name, 'disk', '', (e.target as HTMLInputElement).value);
+                this.updateProfileDisk(name, (e.target as HTMLInputElement).value);
               }}
             ></sl-input>
           </div>
@@ -3768,41 +3785,49 @@ export class ScionPageAdminServerConfig extends LitElement {
 
   private updateProfileField(name: string, field: string, value: string): void {
     const updated = { ...this.profiles };
-    updated[name] = { ...updated[name], [field]: value };
+    const profile = { ...updated[name] };
+    if (value) {
+      profile[field] = value;
+    } else {
+      delete profile[field];
+    }
+    updated[name] = profile;
     this.profiles = updated;
   }
 
-  private updateProfileResource(
+  /** Update a cpu or memory field within a profile's resource requests or limits. */
+  private updateProfileResourceTier(
     name: string,
-    tier: 'requests' | 'limits' | 'disk',
-    subField: 'cpu' | 'memory' | '',
+    tier: 'requests' | 'limits',
+    field: 'cpu' | 'memory',
     value: string,
   ): void {
     const updated = { ...this.profiles };
     const profile = { ...updated[name] };
-    if (tier === 'disk') {
-      const base: ResourceSpec = { ...(profile.resources || {}) };
-      if (value) {
-        base.disk = value;
-      } else {
-        delete base.disk;
-      }
-      profile.resources = base;
+    const existing: { cpu?: string; memory?: string } = {
+      ...(profile.resources?.[tier] || {}),
+    };
+    if (value) {
+      existing[field] = value;
     } else {
-      const key = subField as 'cpu' | 'memory';
-      const existing: { cpu?: string; memory?: string } = {
-        ...(profile.resources?.[tier] || {}),
-      };
-      if (value) {
-        existing[key] = value;
-      } else {
-        delete existing[key];
-      }
-      profile.resources = {
-        ...(profile.resources || {}),
-        [tier]: existing,
-      };
+      delete existing[field];
     }
+    profile.resources = { ...(profile.resources || {}), [tier]: existing };
+    updated[name] = profile;
+    this.profiles = updated;
+  }
+
+  /** Update a profile's disk resource field. */
+  private updateProfileDisk(name: string, value: string): void {
+    const updated = { ...this.profiles };
+    const profile = { ...updated[name] };
+    const base: ResourceSpec = { ...(profile.resources || {}) };
+    if (value) {
+      base.disk = value;
+    } else {
+      delete base.disk;
+    }
+    profile.resources = base;
     updated[name] = profile;
     this.profiles = updated;
   }

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -562,6 +562,10 @@ export class ScionPageAdminServerConfig extends LitElement {
   @state() private runtimes: Record<string, V1RuntimeConfig> = {};
   @state() private profiles: Record<string, V1ProfileConfig> = {};
   @state() private harnessConfigsMap: Record<string, unknown> = {};
+  @state() private newRuntimeName = '';
+  @state() private newProfileName = '';
+  @state() private newHarnessConfigName = '';
+  @state() private harnessConfigErrors: Record<string, string> = {};
 
   // Keep raw data for sections we don't fully edit
   private rawConfig: ServerConfigResponse | null = null;
@@ -671,6 +675,18 @@ export class ScionPageAdminServerConfig extends LitElement {
       padding: 0.75rem 1rem;
       border-bottom: 1px solid var(--scion-border, #e2e8f0);
       background: rgba(0, 0, 0, 0.02);
+    }
+
+    .add-entry-row {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+      margin-top: 0.5rem;
+    }
+
+    .add-entry-row sl-input {
+      flex: 1;
+      max-width: 20rem;
     }
 
     .form-grid {
@@ -1753,13 +1769,11 @@ export class ScionPageAdminServerConfig extends LitElement {
       };
     }
 
-    // Runtimes, profiles, harness_configs — send edited state
-    if (ok('runtimes') && Object.keys(this.runtimes).length > 0)
-      payload.runtimes = this.runtimes;
-    if (ok('harness_configs') && Object.keys(this.harnessConfigsMap).length > 0)
-      payload.harness_configs = this.harnessConfigsMap;
-    if (ok('profiles') && Object.keys(this.profiles).length > 0)
-      payload.profiles = this.profiles;
+    // Runtimes, profiles, harness_configs — always send edited state (including
+    // empty objects) so the backend can distinguish "no change" from "cleared".
+    if (ok('runtimes')) payload.runtimes = this.runtimes;
+    if (ok('harness_configs')) payload.harness_configs = this.harnessConfigsMap;
+    if (ok('profiles')) payload.profiles = this.profiles;
 
     return payload;
   }
@@ -1986,13 +2000,11 @@ export class ScionPageAdminServerConfig extends LitElement {
       };
     }
 
-    // Runtimes, profiles, harness_configs — send edited state
-    if (ok('runtimes') && Object.keys(this.runtimes).length > 0)
-      payload.runtimes = this.runtimes;
-    if (ok('harness_configs') && Object.keys(this.harnessConfigsMap).length > 0)
-      payload.harness_configs = this.harnessConfigsMap;
-    if (ok('profiles') && Object.keys(this.profiles).length > 0)
-      payload.profiles = this.profiles;
+    // Runtimes, profiles, harness_configs — always send edited state (including
+    // empty objects) so the backend can distinguish "no change" from "cleared".
+    if (ok('runtimes')) payload.runtimes = this.runtimes;
+    if (ok('harness_configs')) payload.harness_configs = this.harnessConfigsMap;
+    if (ok('profiles')) payload.profiles = this.profiles;
 
     return payload;
   }
@@ -3344,14 +3356,29 @@ export class ScionPageAdminServerConfig extends LitElement {
           : runtimeNames.map((name) => this.renderRuntimeEntry(name, !!runtimeReadOnly))}
         ${!runtimeReadOnly
           ? html`
-              <sl-button
-                size="small"
-                variant="default"
-                @click=${() => this.addRuntime()}
-              >
-                <sl-icon slot="prefix" name="plus-circle"></sl-icon>
-                Add Runtime
-              </sl-button>
+              <div class="add-entry-row">
+                <sl-input
+                  size="small"
+                  placeholder="Runtime name (e.g. docker, cloudrun-prod)"
+                  value=${this.newRuntimeName}
+                  @sl-input=${(e: Event) => {
+                    this.newRuntimeName = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>
+                <sl-button
+                  size="small"
+                  variant="default"
+                  ?disabled=${!this.newRuntimeName.trim() ||
+                    !!this.runtimes[this.newRuntimeName.trim()]}
+                  @click=${() => this.addRuntime()}
+                >
+                  <sl-icon slot="prefix" name="plus-circle"></sl-icon>
+                  Add Runtime
+                </sl-button>
+              </div>
+              ${this.runtimes[this.newRuntimeName.trim()]
+                ? html`<small class="hint" style="color:var(--sl-color-danger-600);">A runtime named "${this.newRuntimeName.trim()}" already exists.</small>`
+                : nothing}
             `
           : nothing}
       </div>
@@ -3441,6 +3468,32 @@ export class ScionPageAdminServerConfig extends LitElement {
                     }}
                   ></sl-input>
                 </div>
+                <div class="form-field">
+                  <sl-switch
+                    ?checked=${rt.gke || false}
+                    ?disabled=${readOnly}
+                    @sl-change=${(e: Event) => {
+                      this.updateRuntimeBool(name, 'gke', (e.target as HTMLInputElement).checked);
+                    }}
+                    >GKE cluster</sl-switch
+                  >
+                  <span class="hint">Enable GKE-specific features</span>
+                </div>
+                <div class="form-field">
+                  <sl-switch
+                    ?checked=${rt.list_all_namespaces || false}
+                    ?disabled=${readOnly}
+                    @sl-change=${(e: Event) => {
+                      this.updateRuntimeBool(
+                        name,
+                        'list_all_namespaces',
+                        (e.target as HTMLInputElement).checked,
+                      );
+                    }}
+                    >List all namespaces</sl-switch
+                  >
+                  <span class="hint">List agents across all namespaces</span>
+                </div>
               `
             : html`
                 <div class="form-field">
@@ -3488,6 +3541,16 @@ export class ScionPageAdminServerConfig extends LitElement {
     this.runtimes = updated;
   }
 
+  private updateRuntimeBool(
+    name: string,
+    field: 'gke' | 'list_all_namespaces',
+    value: boolean,
+  ): void {
+    const updated = { ...this.runtimes };
+    updated[name] = { ...updated[name], [field]: value };
+    this.runtimes = updated;
+  }
+
   private updateRuntimeCloudRun(name: string, field: 'project' | 'region', value: string): void {
     const updated = { ...this.runtimes };
     const rt = { ...updated[name] };
@@ -3497,13 +3560,10 @@ export class ScionPageAdminServerConfig extends LitElement {
   }
 
   private addRuntime(): void {
-    const baseName = 'new-runtime';
-    let name = baseName;
-    let i = 1;
-    while (this.runtimes[name]) {
-      name = `${baseName}-${i++}`;
-    }
+    const name = this.newRuntimeName.trim();
+    if (!name || this.runtimes[name]) return;
     this.runtimes = { ...this.runtimes, [name]: { type: 'docker' } };
+    this.newRuntimeName = '';
   }
 
   private removeRuntime(name: string): void {
@@ -3532,14 +3592,29 @@ export class ScionPageAdminServerConfig extends LitElement {
             )}
         ${!profileReadOnly
           ? html`
-              <sl-button
-                size="small"
-                variant="default"
-                @click=${() => this.addProfile()}
-              >
-                <sl-icon slot="prefix" name="plus-circle"></sl-icon>
-                Add Profile
-              </sl-button>
+              <div class="add-entry-row">
+                <sl-input
+                  size="small"
+                  placeholder="Profile name (e.g. default, production)"
+                  value=${this.newProfileName}
+                  @sl-input=${(e: Event) => {
+                    this.newProfileName = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>
+                <sl-button
+                  size="small"
+                  variant="default"
+                  ?disabled=${!this.newProfileName.trim() ||
+                    !!this.profiles[this.newProfileName.trim()]}
+                  @click=${() => this.addProfile()}
+                >
+                  <sl-icon slot="prefix" name="plus-circle"></sl-icon>
+                  Add Profile
+                </sl-button>
+              </div>
+              ${this.profiles[this.newProfileName.trim()]
+                ? html`<small class="hint" style="color:var(--sl-color-danger-600);">A profile named "${this.newProfileName.trim()}" already exists.</small>`
+                : nothing}
             `
           : nothing}
       </div>
@@ -3698,12 +3773,24 @@ export class ScionPageAdminServerConfig extends LitElement {
     const updated = { ...this.profiles };
     const profile = { ...updated[name] };
     if (tier === 'disk') {
-      profile.resources = { ...(profile.resources || {}), disk: value || undefined };
+      const base: ResourceSpec = { ...(profile.resources || {}) };
+      if (value) {
+        base.disk = value;
+      } else {
+        delete base.disk;
+      }
+      profile.resources = base;
     } else {
       const existing = profile.resources?.[tier] || {};
+      const tierObj = { ...existing };
+      if (value) {
+        tierObj[subField] = value;
+      } else {
+        delete tierObj[subField];
+      }
       profile.resources = {
         ...(profile.resources || {}),
-        [tier]: { ...existing, [subField]: value || undefined },
+        [tier]: tierObj,
       };
     }
     updated[name] = profile;
@@ -3711,17 +3798,14 @@ export class ScionPageAdminServerConfig extends LitElement {
   }
 
   private addProfile(): void {
-    const baseName = 'new-profile';
-    let name = baseName;
-    let i = 1;
-    while (this.profiles[name]) {
-      name = `${baseName}-${i++}`;
-    }
+    const name = this.newProfileName.trim();
+    if (!name || this.profiles[name]) return;
     const runtimeNames = Object.keys(this.runtimes);
     this.profiles = {
       ...this.profiles,
       [name]: { runtime: runtimeNames[0] || '' },
     };
+    this.newProfileName = '';
   }
 
   private removeProfile(name: string): void {
@@ -3747,14 +3831,29 @@ export class ScionPageAdminServerConfig extends LitElement {
           : configNames.map((name) => this.renderHarnessConfigEntry(name, !!hcReadOnly))}
         ${!hcReadOnly
           ? html`
-              <sl-button
-                size="small"
-                variant="default"
-                @click=${() => this.addHarnessConfig()}
-              >
-                <sl-icon slot="prefix" name="plus-circle"></sl-icon>
-                Add Harness Config
-              </sl-button>
+              <div class="add-entry-row">
+                <sl-input
+                  size="small"
+                  placeholder="Config name (e.g. claude-code, aider)"
+                  value=${this.newHarnessConfigName}
+                  @sl-input=${(e: Event) => {
+                    this.newHarnessConfigName = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>
+                <sl-button
+                  size="small"
+                  variant="default"
+                  ?disabled=${!this.newHarnessConfigName.trim() ||
+                    !!this.harnessConfigsMap[this.newHarnessConfigName.trim()]}
+                  @click=${() => this.addHarnessConfig()}
+                >
+                  <sl-icon slot="prefix" name="plus-circle"></sl-icon>
+                  Add Harness Config
+                </sl-button>
+              </div>
+              ${this.harnessConfigsMap[this.newHarnessConfigName.trim()]
+                ? html`<small class="hint" style="color:var(--sl-color-danger-600);">A config named "${this.newHarnessConfigName.trim()}" already exists.</small>`
+                : nothing}
             `
           : nothing}
       </div>
@@ -3769,6 +3868,7 @@ export class ScionPageAdminServerConfig extends LitElement {
     } catch {
       jsonStr = String(value);
     }
+    const jsonError = this.harnessConfigErrors[name];
     return html`
       <sl-card class="runtime-card">
         <div slot="header" style="display:flex;align-items:center;justify-content:space-between;">
@@ -3791,11 +3891,14 @@ export class ScionPageAdminServerConfig extends LitElement {
             resize="auto"
             value=${jsonStr}
             ?disabled=${readOnly}
-            style="font-family: monospace; font-size: 0.8125rem;"
+            style="font-family: monospace; font-size: 0.8125rem;${jsonError ? ' --sl-input-border-color: var(--sl-color-danger-600);' : ''}"
             @sl-change=${(e: Event) => {
               this.updateHarnessConfigJson(name, (e.target as HTMLTextAreaElement).value);
             }}
           ></sl-textarea>
+          ${jsonError
+            ? html`<small class="hint" style="color:var(--sl-color-danger-600);">Invalid JSON: ${jsonError}</small>`
+            : nothing}
         </div>
       </sl-card>
     `;
@@ -3807,23 +3910,27 @@ export class ScionPageAdminServerConfig extends LitElement {
       const updated = { ...this.harnessConfigsMap };
       updated[name] = parsed;
       this.harnessConfigsMap = updated;
-    } catch {
-      // Invalid JSON — don't update state; leave the textarea as-is until
-      // the user fixes it. A save attempt will send the last valid parse.
+      // Clear any previous error
+      const errors = { ...this.harnessConfigErrors };
+      delete errors[name];
+      this.harnessConfigErrors = errors;
+    } catch (e) {
+      // Store the error for display
+      this.harnessConfigErrors = {
+        ...this.harnessConfigErrors,
+        [name]: e instanceof Error ? e.message : 'Invalid JSON',
+      };
     }
   }
 
   private addHarnessConfig(): void {
-    const baseName = 'new-config';
-    let name = baseName;
-    let i = 1;
-    while (this.harnessConfigsMap[name]) {
-      name = `${baseName}-${i++}`;
-    }
+    const name = this.newHarnessConfigName.trim();
+    if (!name || this.harnessConfigsMap[name]) return;
     this.harnessConfigsMap = {
       ...this.harnessConfigsMap,
       [name]: { harness: 'claude-code' },
     };
+    this.newHarnessConfigName = '';
   }
 
   private removeHarnessConfig(name: string): void {

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -3767,7 +3767,7 @@ export class ScionPageAdminServerConfig extends LitElement {
   private updateProfileResource(
     name: string,
     tier: 'requests' | 'limits' | 'disk',
-    subField: string,
+    subField: 'cpu' | 'memory' | '',
     value: string,
   ): void {
     const updated = { ...this.profiles };
@@ -3781,16 +3781,18 @@ export class ScionPageAdminServerConfig extends LitElement {
       }
       profile.resources = base;
     } else {
-      const existing = profile.resources?.[tier] || {};
-      const tierObj = { ...existing };
+      const key = subField as 'cpu' | 'memory';
+      const existing: { cpu?: string; memory?: string } = {
+        ...(profile.resources?.[tier] || {}),
+      };
       if (value) {
-        tierObj[subField] = value;
+        existing[key] = value;
       } else {
-        delete tierObj[subField];
+        delete existing[key];
       }
       profile.resources = {
         ...(profile.resources || {}),
-        [tier]: tierObj,
+        [tier]: existing,
       };
     }
     updated[name] = profile;

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -175,12 +175,31 @@ interface V1TelemetryConfig {
   local?: V1TelemetryLocalConfig;
 }
 
+interface V1CloudRunConfig {
+  project?: string;
+  region?: string;
+}
+
 interface V1RuntimeConfig {
   type?: string;
   host?: string;
   context?: string;
   namespace?: string;
   sync?: string;
+  gke?: boolean;
+  list_all_namespaces?: boolean;
+  env?: Record<string, string>;
+  cloudrun?: V1CloudRunConfig;
+}
+
+interface V1ProfileConfig {
+  runtime?: string;
+  default_template?: string;
+  default_harness_config?: string;
+  image_registry?: string;
+  env?: Record<string, string>;
+  resources?: ResourceSpec;
+  [key: string]: unknown;
 }
 
 interface ResourceSpec {
@@ -370,6 +389,10 @@ const KOANF_KEY_LABELS: Record<string, string> = {
   'server.github_app.private_key_path': 'GitHub App Private Key Path',
   // notifications section
   'server.notification_channels': 'Notification Channels',
+  // runtimes / profiles / harness_configs section
+  runtimes: 'Runtimes',
+  profiles: 'Profiles',
+  harness_configs: 'Harness Configs',
 };
 
 const STATIC_LAYER1_KEYS: Set<string> = new Set(Object.keys(KOANF_KEY_LABELS));
@@ -535,6 +558,11 @@ export class ScionPageAdminServerConfig extends LitElement {
     projects?: { project_id: string; project_name: string; minted: number }[];
   } | null = null;
 
+  // Runtimes, Profiles & Harness Configs
+  @state() private runtimes: Record<string, V1RuntimeConfig> = {};
+  @state() private profiles: Record<string, V1ProfileConfig> = {};
+  @state() private harnessConfigsMap: Record<string, unknown> = {};
+
   // Keep raw data for sections we don't fully edit
   private rawConfig: ServerConfigResponse | null = null;
 
@@ -628,6 +656,21 @@ export class ScionPageAdminServerConfig extends LitElement {
       margin: 0 0 1rem 0;
       padding-bottom: 0.75rem;
       border-bottom: 1px solid var(--scion-border, #e2e8f0);
+    }
+
+    .runtime-card {
+      margin-bottom: 1rem;
+    }
+
+    .runtime-card::part(base) {
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius-lg, 0.75rem);
+    }
+
+    .runtime-card::part(header) {
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      background: rgba(0, 0, 0, 0.02);
     }
 
     .form-grid {
@@ -1473,7 +1516,14 @@ export class ScionPageAdminServerConfig extends LitElement {
       this.autoExposePortsEnabled = aep.enabled || false;
     }
 
-    // Runtimes, harness_configs, profiles preserved via rawConfig
+    // Runtimes, profiles, harness_configs — deep-copy into editable state
+    this.runtimes = data.runtimes ? JSON.parse(JSON.stringify(data.runtimes)) : {};
+    this.profiles = data.profiles
+      ? (JSON.parse(JSON.stringify(data.profiles)) as Record<string, V1ProfileConfig>)
+      : {};
+    this.harnessConfigsMap = data.harness_configs
+      ? (JSON.parse(JSON.stringify(data.harness_configs)) as Record<string, unknown>)
+      : {};
 
     // Settings-DB metadata (postgres mode only; absent in file/SQLite mode)
     this.settingsTier = data.settings_tier || 'file';
@@ -1703,10 +1753,13 @@ export class ScionPageAdminServerConfig extends LitElement {
       };
     }
 
-    // Preserve runtimes, harness_configs, profiles from raw config
-    if (this.rawConfig?.runtimes) payload.runtimes = this.rawConfig.runtimes;
-    if (this.rawConfig?.harness_configs) payload.harness_configs = this.rawConfig.harness_configs;
-    if (this.rawConfig?.profiles) payload.profiles = this.rawConfig.profiles;
+    // Runtimes, profiles, harness_configs — send edited state
+    if (ok('runtimes') && Object.keys(this.runtimes).length > 0)
+      payload.runtimes = this.runtimes;
+    if (ok('harness_configs') && Object.keys(this.harnessConfigsMap).length > 0)
+      payload.harness_configs = this.harnessConfigsMap;
+    if (ok('profiles') && Object.keys(this.profiles).length > 0)
+      payload.profiles = this.profiles;
 
     return payload;
   }
@@ -1933,10 +1986,13 @@ export class ScionPageAdminServerConfig extends LitElement {
       };
     }
 
-    // Preserve runtimes, harness_configs, profiles from raw config
-    if (this.rawConfig?.runtimes) payload.runtimes = this.rawConfig.runtimes;
-    if (this.rawConfig?.harness_configs) payload.harness_configs = this.rawConfig.harness_configs;
-    if (this.rawConfig?.profiles) payload.profiles = this.rawConfig.profiles;
+    // Runtimes, profiles, harness_configs — send edited state
+    if (ok('runtimes') && Object.keys(this.runtimes).length > 0)
+      payload.runtimes = this.runtimes;
+    if (ok('harness_configs') && Object.keys(this.harnessConfigsMap).length > 0)
+      payload.harness_configs = this.harnessConfigsMap;
+    if (ok('profiles') && Object.keys(this.profiles).length > 0)
+      payload.profiles = this.profiles;
 
     return payload;
   }
@@ -2450,6 +2506,9 @@ export class ScionPageAdminServerConfig extends LitElement {
           >Runtime Broker</sl-tab
         >
         <sl-tab slot="nav" panel="data" ?active=${this.activeTab === 'data'}>Data & Storage</sl-tab>
+        <sl-tab slot="nav" panel="runtimes-profiles" ?active=${this.activeTab === 'runtimes-profiles'}
+          >Runtimes & Profiles</sl-tab
+        >
         <sl-tab slot="nav" panel="auth" ?active=${this.activeTab === 'auth'}>Authentication</sl-tab>
         <sl-tab slot="nav" panel="telemetry" ?active=${this.activeTab === 'telemetry'}
           >Telemetry</sl-tab
@@ -2465,6 +2524,7 @@ export class ScionPageAdminServerConfig extends LitElement {
         <sl-tab-panel name="hub-server">${this.renderHubServerTab()}</sl-tab-panel>
         <sl-tab-panel name="broker">${this.renderBrokerTab()}</sl-tab-panel>
         <sl-tab-panel name="data">${this.renderDataTab()}</sl-tab-panel>
+        <sl-tab-panel name="runtimes-profiles">${this.renderRuntimesProfilesTab()}</sl-tab-panel>
         <sl-tab-panel name="auth">${this.renderAuthTab()}</sl-tab-panel>
         <sl-tab-panel name="telemetry">${this.renderTelemetryTab()}</sl-tab-panel>
         <sl-tab-panel name="github-app">${this.renderGitHubAppTab()}</sl-tab-panel>
@@ -3255,6 +3315,521 @@ export class ScionPageAdminServerConfig extends LitElement {
         </div>
       </div>
     `;
+  }
+
+  // ── Runtimes & Profiles tab ──
+
+  private renderRuntimesProfilesTab() {
+    return html`
+      ${this.renderRuntimesSection()}
+      ${this.renderProfilesSection()}
+      ${this.renderHarnessConfigsSection()}
+    `;
+  }
+
+  // ── Runtimes section ──
+
+  private renderRuntimesSection() {
+    const runtimeNames = Object.keys(this.runtimes);
+    const runtimeReadOnly = this.readOnlyReason('runtimes');
+    return html`
+      <div class="section">
+        ${this.renderSectionHeader('Runtimes', 'runtimes')}
+        ${this.renderSectionMeta('runtimes')}
+        ${runtimeReadOnly
+          ? html`${this.renderReadOnlyBadge(runtimeReadOnly)}`
+          : nothing}
+        ${runtimeNames.length === 0
+          ? html`<p class="hint">No runtimes configured.</p>`
+          : runtimeNames.map((name) => this.renderRuntimeEntry(name, !!runtimeReadOnly))}
+        ${!runtimeReadOnly
+          ? html`
+              <sl-button
+                size="small"
+                variant="default"
+                @click=${() => this.addRuntime()}
+              >
+                <sl-icon slot="prefix" name="plus-circle"></sl-icon>
+                Add Runtime
+              </sl-button>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderRuntimeEntry(name: string, readOnly: boolean) {
+    const rt = this.runtimes[name];
+    if (!rt) return nothing;
+    const isCloudRun = rt.type === 'cloudrun' || rt.type === 'cloudrun-instances';
+    return html`
+      <sl-card class="runtime-card">
+        <div slot="header" style="display:flex;align-items:center;justify-content:space-between;">
+          <strong>${name}</strong>
+          ${!readOnly
+            ? html`<sl-button
+                size="small"
+                variant="danger"
+                @click=${() => this.removeRuntime(name)}
+              >
+                <sl-icon slot="prefix" name="trash"></sl-icon>
+                Remove
+              </sl-button>`
+            : nothing}
+        </div>
+        <div class="form-grid">
+          <div class="form-field">
+            <label>Type</label>
+            <sl-select
+              value=${rt.type || ''}
+              ?disabled=${readOnly}
+              @sl-change=${(e: Event) => {
+                this.updateRuntimeField(name, 'type', (e.target as HTMLSelectElement).value);
+              }}
+            >
+              <sl-option value="docker">docker</sl-option>
+              <sl-option value="podman">podman</sl-option>
+              <sl-option value="kubernetes">kubernetes</sl-option>
+              <sl-option value="cloudrun">cloudrun</sl-option>
+              <sl-option value="cloudrun-instances">cloudrun-instances</sl-option>
+            </sl-select>
+          </div>
+          <div class="form-field">
+            <label>Sync</label>
+            <sl-input
+              value=${rt.sync || ''}
+              placeholder="e.g. mutagen"
+              ?disabled=${readOnly}
+              @sl-input=${(e: Event) => {
+                this.updateRuntimeField(name, 'sync', (e.target as HTMLInputElement).value);
+              }}
+            ></sl-input>
+          </div>
+          ${!isCloudRun
+            ? html`
+                <div class="form-field">
+                  <label>Host</label>
+                  <sl-input
+                    value=${rt.host || ''}
+                    ?disabled=${readOnly}
+                    @sl-input=${(e: Event) => {
+                      this.updateRuntimeField(name, 'host', (e.target as HTMLInputElement).value);
+                    }}
+                  ></sl-input>
+                </div>
+                <div class="form-field">
+                  <label>Context</label>
+                  <sl-input
+                    value=${rt.context || ''}
+                    ?disabled=${readOnly}
+                    @sl-input=${(e: Event) => {
+                      this.updateRuntimeField(name, 'context', (e.target as HTMLInputElement).value);
+                    }}
+                  ></sl-input>
+                </div>
+                <div class="form-field">
+                  <label>Namespace</label>
+                  <sl-input
+                    value=${rt.namespace || ''}
+                    ?disabled=${readOnly}
+                    @sl-input=${(e: Event) => {
+                      this.updateRuntimeField(
+                        name,
+                        'namespace',
+                        (e.target as HTMLInputElement).value,
+                      );
+                    }}
+                  ></sl-input>
+                </div>
+              `
+            : html`
+                <div class="form-field">
+                  <label>GCP Project</label>
+                  <sl-input
+                    value=${rt.cloudrun?.project || ''}
+                    ?disabled=${readOnly}
+                    @sl-input=${(e: Event) => {
+                      this.updateRuntimeCloudRun(
+                        name,
+                        'project',
+                        (e.target as HTMLInputElement).value,
+                      );
+                    }}
+                  ></sl-input>
+                </div>
+                <div class="form-field">
+                  <label>GCP Region</label>
+                  <sl-input
+                    value=${rt.cloudrun?.region || ''}
+                    placeholder="e.g. us-central1"
+                    ?disabled=${readOnly}
+                    @sl-input=${(e: Event) => {
+                      this.updateRuntimeCloudRun(
+                        name,
+                        'region',
+                        (e.target as HTMLInputElement).value,
+                      );
+                    }}
+                  ></sl-input>
+                </div>
+              `}
+        </div>
+      </sl-card>
+    `;
+  }
+
+  private updateRuntimeField(
+    name: string,
+    field: keyof V1RuntimeConfig,
+    value: string,
+  ): void {
+    const updated = { ...this.runtimes };
+    updated[name] = { ...updated[name], [field]: value };
+    this.runtimes = updated;
+  }
+
+  private updateRuntimeCloudRun(name: string, field: 'project' | 'region', value: string): void {
+    const updated = { ...this.runtimes };
+    const rt = { ...updated[name] };
+    rt.cloudrun = { ...(rt.cloudrun || {}), [field]: value };
+    updated[name] = rt;
+    this.runtimes = updated;
+  }
+
+  private addRuntime(): void {
+    const baseName = 'new-runtime';
+    let name = baseName;
+    let i = 1;
+    while (this.runtimes[name]) {
+      name = `${baseName}-${i++}`;
+    }
+    this.runtimes = { ...this.runtimes, [name]: { type: 'docker' } };
+  }
+
+  private removeRuntime(name: string): void {
+    const updated = { ...this.runtimes };
+    delete updated[name];
+    this.runtimes = updated;
+  }
+
+  // ── Profiles section ──
+
+  private renderProfilesSection() {
+    const profileNames = Object.keys(this.profiles);
+    const profileReadOnly = this.readOnlyReason('profiles');
+    const runtimeNames = Object.keys(this.runtimes);
+    return html`
+      <div class="section">
+        ${this.renderSectionHeader('Profiles', 'profiles')}
+        ${this.renderSectionMeta('profiles')}
+        ${profileReadOnly
+          ? html`${this.renderReadOnlyBadge(profileReadOnly)}`
+          : nothing}
+        ${profileNames.length === 0
+          ? html`<p class="hint">No profiles configured.</p>`
+          : profileNames.map((name) =>
+              this.renderProfileEntry(name, runtimeNames, !!profileReadOnly),
+            )}
+        ${!profileReadOnly
+          ? html`
+              <sl-button
+                size="small"
+                variant="default"
+                @click=${() => this.addProfile()}
+              >
+                <sl-icon slot="prefix" name="plus-circle"></sl-icon>
+                Add Profile
+              </sl-button>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderProfileEntry(name: string, runtimeNames: string[], readOnly: boolean) {
+    const profile = this.profiles[name];
+    if (!profile) return nothing;
+    return html`
+      <sl-card class="runtime-card">
+        <div slot="header" style="display:flex;align-items:center;justify-content:space-between;">
+          <strong>${name}</strong>
+          ${!readOnly
+            ? html`<sl-button
+                size="small"
+                variant="danger"
+                @click=${() => this.removeProfile(name)}
+              >
+                <sl-icon slot="prefix" name="trash"></sl-icon>
+                Remove
+              </sl-button>`
+            : nothing}
+        </div>
+        <div class="form-grid">
+          <div class="form-field">
+            <label>Runtime</label>
+            <span class="hint">Which named runtime this profile uses</span>
+            <sl-select
+              value=${profile.runtime || ''}
+              ?disabled=${readOnly}
+              @sl-change=${(e: Event) => {
+                this.updateProfileField(name, 'runtime', (e.target as HTMLSelectElement).value);
+              }}
+            >
+              ${runtimeNames.map(
+                (rt) => html`<sl-option value=${rt}>${rt}</sl-option>`,
+              )}
+            </sl-select>
+          </div>
+          <div class="form-field">
+            <label>Image Registry</label>
+            <sl-input
+              value=${profile.image_registry || ''}
+              placeholder="Override image registry"
+              ?disabled=${readOnly}
+              @sl-input=${(e: Event) => {
+                this.updateProfileField(
+                  name,
+                  'image_registry',
+                  (e.target as HTMLInputElement).value,
+                );
+              }}
+            ></sl-input>
+          </div>
+          <div class="form-field">
+            <label>Default Template</label>
+            <sl-input
+              value=${profile.default_template || ''}
+              ?disabled=${readOnly}
+              @sl-input=${(e: Event) => {
+                this.updateProfileField(
+                  name,
+                  'default_template',
+                  (e.target as HTMLInputElement).value,
+                );
+              }}
+            ></sl-input>
+          </div>
+          <div class="form-field">
+            <label>Default Harness Config</label>
+            <sl-input
+              value=${profile.default_harness_config || ''}
+              ?disabled=${readOnly}
+              @sl-input=${(e: Event) => {
+                this.updateProfileField(
+                  name,
+                  'default_harness_config',
+                  (e.target as HTMLInputElement).value,
+                );
+              }}
+            ></sl-input>
+          </div>
+          <div class="form-field">
+            <label>CPU Request</label>
+            <sl-input
+              value=${profile.resources?.requests?.cpu || ''}
+              placeholder="e.g. 500m"
+              ?disabled=${readOnly}
+              @sl-input=${(e: Event) => {
+                this.updateProfileResource(name, 'requests', 'cpu', (e.target as HTMLInputElement).value);
+              }}
+            ></sl-input>
+          </div>
+          <div class="form-field">
+            <label>Memory Request</label>
+            <sl-input
+              value=${profile.resources?.requests?.memory || ''}
+              placeholder="e.g. 512Mi"
+              ?disabled=${readOnly}
+              @sl-input=${(e: Event) => {
+                this.updateProfileResource(name, 'requests', 'memory', (e.target as HTMLInputElement).value);
+              }}
+            ></sl-input>
+          </div>
+          <div class="form-field">
+            <label>CPU Limit</label>
+            <sl-input
+              value=${profile.resources?.limits?.cpu || ''}
+              placeholder="e.g. 2000m"
+              ?disabled=${readOnly}
+              @sl-input=${(e: Event) => {
+                this.updateProfileResource(name, 'limits', 'cpu', (e.target as HTMLInputElement).value);
+              }}
+            ></sl-input>
+          </div>
+          <div class="form-field">
+            <label>Memory Limit</label>
+            <sl-input
+              value=${profile.resources?.limits?.memory || ''}
+              placeholder="e.g. 4Gi"
+              ?disabled=${readOnly}
+              @sl-input=${(e: Event) => {
+                this.updateProfileResource(name, 'limits', 'memory', (e.target as HTMLInputElement).value);
+              }}
+            ></sl-input>
+          </div>
+          <div class="form-field">
+            <label>Disk</label>
+            <sl-input
+              value=${profile.resources?.disk || ''}
+              placeholder="e.g. 20Gi"
+              ?disabled=${readOnly}
+              @sl-input=${(e: Event) => {
+                this.updateProfileResource(name, 'disk', '', (e.target as HTMLInputElement).value);
+              }}
+            ></sl-input>
+          </div>
+        </div>
+      </sl-card>
+    `;
+  }
+
+  private updateProfileField(name: string, field: string, value: string): void {
+    const updated = { ...this.profiles };
+    updated[name] = { ...updated[name], [field]: value };
+    this.profiles = updated;
+  }
+
+  private updateProfileResource(
+    name: string,
+    tier: 'requests' | 'limits' | 'disk',
+    subField: string,
+    value: string,
+  ): void {
+    const updated = { ...this.profiles };
+    const profile = { ...updated[name] };
+    if (tier === 'disk') {
+      profile.resources = { ...(profile.resources || {}), disk: value || undefined };
+    } else {
+      const existing = profile.resources?.[tier] || {};
+      profile.resources = {
+        ...(profile.resources || {}),
+        [tier]: { ...existing, [subField]: value || undefined },
+      };
+    }
+    updated[name] = profile;
+    this.profiles = updated;
+  }
+
+  private addProfile(): void {
+    const baseName = 'new-profile';
+    let name = baseName;
+    let i = 1;
+    while (this.profiles[name]) {
+      name = `${baseName}-${i++}`;
+    }
+    const runtimeNames = Object.keys(this.runtimes);
+    this.profiles = {
+      ...this.profiles,
+      [name]: { runtime: runtimeNames[0] || '' },
+    };
+  }
+
+  private removeProfile(name: string): void {
+    const updated = { ...this.profiles };
+    delete updated[name];
+    this.profiles = updated;
+  }
+
+  // ── Harness Configs section ──
+
+  private renderHarnessConfigsSection() {
+    const configNames = Object.keys(this.harnessConfigsMap);
+    const hcReadOnly = this.readOnlyReason('harness_configs');
+    return html`
+      <div class="section">
+        ${this.renderSectionHeader('Harness Configs', 'harness_configs')}
+        ${this.renderSectionMeta('harness_configs')}
+        ${hcReadOnly
+          ? html`${this.renderReadOnlyBadge(hcReadOnly)}`
+          : nothing}
+        ${configNames.length === 0
+          ? html`<p class="hint">No harness configs configured.</p>`
+          : configNames.map((name) => this.renderHarnessConfigEntry(name, !!hcReadOnly))}
+        ${!hcReadOnly
+          ? html`
+              <sl-button
+                size="small"
+                variant="default"
+                @click=${() => this.addHarnessConfig()}
+              >
+                <sl-icon slot="prefix" name="plus-circle"></sl-icon>
+                Add Harness Config
+              </sl-button>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderHarnessConfigEntry(name: string, readOnly: boolean) {
+    const value = this.harnessConfigsMap[name];
+    let jsonStr: string;
+    try {
+      jsonStr = JSON.stringify(value, null, 2);
+    } catch {
+      jsonStr = String(value);
+    }
+    return html`
+      <sl-card class="runtime-card">
+        <div slot="header" style="display:flex;align-items:center;justify-content:space-between;">
+          <strong>${name}</strong>
+          ${!readOnly
+            ? html`<sl-button
+                size="small"
+                variant="danger"
+                @click=${() => this.removeHarnessConfig(name)}
+              >
+                <sl-icon slot="prefix" name="trash"></sl-icon>
+                Remove
+              </sl-button>`
+            : nothing}
+        </div>
+        <div class="form-field full-width">
+          <label>Configuration (JSON)</label>
+          <sl-textarea
+            rows="8"
+            resize="auto"
+            value=${jsonStr}
+            ?disabled=${readOnly}
+            style="font-family: monospace; font-size: 0.8125rem;"
+            @sl-change=${(e: Event) => {
+              this.updateHarnessConfigJson(name, (e.target as HTMLTextAreaElement).value);
+            }}
+          ></sl-textarea>
+        </div>
+      </sl-card>
+    `;
+  }
+
+  private updateHarnessConfigJson(name: string, jsonStr: string): void {
+    try {
+      const parsed: unknown = JSON.parse(jsonStr);
+      const updated = { ...this.harnessConfigsMap };
+      updated[name] = parsed;
+      this.harnessConfigsMap = updated;
+    } catch {
+      // Invalid JSON — don't update state; leave the textarea as-is until
+      // the user fixes it. A save attempt will send the last valid parse.
+    }
+  }
+
+  private addHarnessConfig(): void {
+    const baseName = 'new-config';
+    let name = baseName;
+    let i = 1;
+    while (this.harnessConfigsMap[name]) {
+      name = `${baseName}-${i++}`;
+    }
+    this.harnessConfigsMap = {
+      ...this.harnessConfigsMap,
+      [name]: { harness: 'claude-code' },
+    };
+  }
+
+  private removeHarnessConfig(name: string): void {
+    const updated = { ...this.harnessConfigsMap };
+    delete updated[name];
+    this.harnessConfigsMap = updated;
   }
 
   private renderBrokerTab() {

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -3552,6 +3552,22 @@ export class ScionPageAdminServerConfig extends LitElement {
     } else {
       delete (rt as Record<string, unknown>)[field];
     }
+    // When switching type, clear fields that belong to the other type group
+    // so stale values don't persist in the payload.
+    if (field === 'type') {
+      const isCloudRun = value === 'cloudrun' || value === 'cloudrun-instances';
+      if (isCloudRun) {
+        // Switching to Cloud Run — clear container/k8s fields
+        delete rt.host;
+        delete rt.context;
+        delete rt.namespace;
+        delete rt.gke;
+        delete rt.list_all_namespaces;
+      } else {
+        // Switching away from Cloud Run — clear cloudrun sub-object
+        delete rt.cloudrun;
+      }
+    }
     updated[name] = rt;
     this.runtimes = updated;
   }
@@ -3812,22 +3828,40 @@ export class ScionPageAdminServerConfig extends LitElement {
     } else {
       delete existing[field];
     }
-    profile.resources = { ...(profile.resources || {}), [tier]: existing };
-    updated[name] = profile;
-    this.profiles = updated;
+    const res: ResourceSpec = { ...(profile.resources || {}) };
+    if (Object.keys(existing).length > 0) {
+      res[tier] = existing;
+    } else {
+      delete res[tier];
+    }
+    this.setProfileResources(updated, profile, name, res);
   }
 
   /** Update a profile's disk resource field. */
   private updateProfileDisk(name: string, value: string): void {
     const updated = { ...this.profiles };
     const profile = { ...updated[name] };
-    const base: ResourceSpec = { ...(profile.resources || {}) };
+    const res: ResourceSpec = { ...(profile.resources || {}) };
     if (value) {
-      base.disk = value;
+      res.disk = value;
     } else {
-      delete base.disk;
+      delete res.disk;
     }
-    profile.resources = base;
+    this.setProfileResources(updated, profile, name, res);
+  }
+
+  /** Assign resources to a profile, deleting the key if the object is empty. */
+  private setProfileResources(
+    updated: Record<string, V1ProfileConfig>,
+    profile: V1ProfileConfig,
+    name: string,
+    res: ResourceSpec,
+  ): void {
+    if (Object.keys(res).length > 0) {
+      profile.resources = res;
+    } else {
+      delete profile.resources;
+    }
     updated[name] = profile;
     this.profiles = updated;
   }

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -1590,6 +1590,10 @@ export class ScionPageAdminServerConfig extends LitElement {
       : this.harnessConfigSelection;
   }
 
+  private get hasHarnessConfigErrors(): boolean {
+    return Object.keys(this.harnessConfigErrors).length > 0;
+  }
+
   private readOnlyReason(koanfKey: string): 'bootstrap' | 'env' | null {
     if (this.settingsTier === 'db') {
       return this.layer1Keys.has(koanfKey) ? null : 'bootstrap';
@@ -2543,10 +2547,14 @@ export class ScionPageAdminServerConfig extends LitElement {
         <sl-tab-panel name="gcp-identity">${this.renderGCPIdentityTab()}</sl-tab-panel>
       </sl-tab-group>
 
+      ${this.hasHarnessConfigErrors
+        ? html`<div class="error" style="margin-bottom:0.75rem;">Cannot save: one or more harness config entries contain invalid JSON. Fix the errors on the Runtimes &amp; Profiles tab before saving.</div>`
+        : nothing}
       <div class="actions">
         <sl-button
           variant="primary"
           ?loading=${this.saving}
+          ?disabled=${this.hasHarnessConfigErrors}
           @click=${() => {
             void this.handleSave();
           }}
@@ -3369,14 +3377,14 @@ export class ScionPageAdminServerConfig extends LitElement {
                   size="small"
                   variant="default"
                   ?disabled=${!this.newRuntimeName.trim() ||
-                    !!this.runtimes[this.newRuntimeName.trim()]}
+                    this.newRuntimeName.trim() in this.runtimes}
                   @click=${() => this.addRuntime()}
                 >
                   <sl-icon slot="prefix" name="plus-circle"></sl-icon>
                   Add Runtime
                 </sl-button>
               </div>
-              ${this.runtimes[this.newRuntimeName.trim()]
+              ${this.newRuntimeName.trim() in this.runtimes
                 ? html`<small class="hint" style="color:var(--sl-color-danger-600);">A runtime named "${this.newRuntimeName.trim()}" already exists.</small>`
                 : nothing}
             `
@@ -3561,7 +3569,7 @@ export class ScionPageAdminServerConfig extends LitElement {
 
   private addRuntime(): void {
     const name = this.newRuntimeName.trim();
-    if (!name || this.runtimes[name]) return;
+    if (!name || name in this.runtimes) return;
     this.runtimes = { ...this.runtimes, [name]: { type: 'docker' } };
     this.newRuntimeName = '';
   }
@@ -3605,14 +3613,14 @@ export class ScionPageAdminServerConfig extends LitElement {
                   size="small"
                   variant="default"
                   ?disabled=${!this.newProfileName.trim() ||
-                    !!this.profiles[this.newProfileName.trim()]}
+                    this.newProfileName.trim() in this.profiles}
                   @click=${() => this.addProfile()}
                 >
                   <sl-icon slot="prefix" name="plus-circle"></sl-icon>
                   Add Profile
                 </sl-button>
               </div>
-              ${this.profiles[this.newProfileName.trim()]
+              ${this.newProfileName.trim() in this.profiles
                 ? html`<small class="hint" style="color:var(--sl-color-danger-600);">A profile named "${this.newProfileName.trim()}" already exists.</small>`
                 : nothing}
             `
@@ -3801,7 +3809,7 @@ export class ScionPageAdminServerConfig extends LitElement {
 
   private addProfile(): void {
     const name = this.newProfileName.trim();
-    if (!name || this.profiles[name]) return;
+    if (!name || name in this.profiles) return;
     const runtimeNames = Object.keys(this.runtimes);
     this.profiles = {
       ...this.profiles,
@@ -3846,14 +3854,14 @@ export class ScionPageAdminServerConfig extends LitElement {
                   size="small"
                   variant="default"
                   ?disabled=${!this.newHarnessConfigName.trim() ||
-                    !!this.harnessConfigsMap[this.newHarnessConfigName.trim()]}
+                    this.newHarnessConfigName.trim() in this.harnessConfigsMap}
                   @click=${() => this.addHarnessConfig()}
                 >
                   <sl-icon slot="prefix" name="plus-circle"></sl-icon>
                   Add Harness Config
                 </sl-button>
               </div>
-              ${this.harnessConfigsMap[this.newHarnessConfigName.trim()]
+              ${this.newHarnessConfigName.trim() in this.harnessConfigsMap
                 ? html`<small class="hint" style="color:var(--sl-color-danger-600);">A config named "${this.newHarnessConfigName.trim()}" already exists.</small>`
                 : nothing}
             `
@@ -3927,7 +3935,7 @@ export class ScionPageAdminServerConfig extends LitElement {
 
   private addHarnessConfig(): void {
     const name = this.newHarnessConfigName.trim();
-    if (!name || this.harnessConfigsMap[name]) return;
+    if (!name || name in this.harnessConfigsMap) return;
     this.harnessConfigsMap = {
       ...this.harnessConfigsMap,
       [name]: { harness: 'claude-code' },
@@ -3939,6 +3947,12 @@ export class ScionPageAdminServerConfig extends LitElement {
     const updated = { ...this.harnessConfigsMap };
     delete updated[name];
     this.harnessConfigsMap = updated;
+    // Clear any associated validation error
+    if (name in this.harnessConfigErrors) {
+      const errors = { ...this.harnessConfigErrors };
+      delete errors[name];
+      this.harnessConfigErrors = errors;
+    }
   }
 
   private renderBrokerTab() {


### PR DESCRIPTION
## Summary

- Adds a new **Runtimes & Profiles** tab to the admin server-config page with full CRUD editors for runtimes, profiles, and harness configs
- Replaces the `rawConfig` passthrough in both `buildLayer1Payload()` and `buildFilePayload()` with edited state, so changes made in the UI are actually saved
- Respects existing section metadata, read-only handling (bootstrap-locked / env-overridden), and Shoelace component patterns

### Runtimes section
- Editable list of named runtimes with type-aware fields (Docker/Podman/Kubernetes vs Cloud Run)
- Add/remove runtime entries

### Profiles section  
- Editable list with runtime reference, resource limits, image registry, and template overrides
- Add/remove profile entries

### Harness Configs section
- JSON textarea editor per entry for the loosely-typed schema
- Add/remove entries

Closes #934

## Test plan
- [x] `npm run build` passes
- [x] All 183 existing tests pass (`npm test`)
- [ ] Manual: navigate to Admin > Runtimes & Profiles tab — verify runtimes display correctly
- [ ] Manual: add/remove a runtime, save, reload — verify persistence
- [ ] Manual: edit profile fields and resource limits, save — verify correct payload
- [ ] Manual: edit harness config JSON textarea, save — verify valid JSON is sent
- [ ] Manual: verify read-only badges appear when sections are bootstrap-locked or env-overridden