### PR TITLE
feat(web-chat): add top-level chat mode as 4th ShellType (Phase 5)

### DIFF
--- a/pkg/hub/handlers_chat.go
+++ b/pkg/hub/handlers_chat.go
@@ -19,6 +19,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
 // handleChatThreads handles GET /api/v1/chat/threads.
@@ -63,7 +65,7 @@ func (s *Server) handleChatThreads(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Batch-fetch the last messages by ID.
+	// Batch-fetch the last messages by ID (design Section 5.3).
 	messageIDs := make([]string, 0, len(threads))
 	for _, t := range threads {
 		if t.LastMessageID != "" {
@@ -71,12 +73,13 @@ func (s *Server) handleChatThreads(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	messageMap := make(map[string]lastMessageInfo, len(messageIDs))
-	for _, id := range messageIDs {
-		msg, err := s.store.GetMessage(r.Context(), id)
-		if err != nil || msg == nil {
-			continue
-		}
+	rawMessages, err := s.store.GetMessagesByIDs(r.Context(), messageIDs)
+	if err != nil {
+		rawMessages = nil // degrade gracefully — previews will be empty
+	}
+
+	messageMap := make(map[string]lastMessageInfo, len(rawMessages))
+	for id, msg := range rawMessages {
 		messageMap[id] = lastMessageInfo{
 			Msg:       truncatePreview(msg.Msg, 120),
 			Sender:    msg.Sender,
@@ -85,22 +88,51 @@ func (s *Server) handleChatThreads(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Build response entries, joining with agent info from the store.
+	// Batch-fetch agents by ID. Collect all agent IDs from threads, then
+	// look them up in a single query instead of N individual GetAgent calls.
+	agentIDs := make([]string, 0, len(threads))
+	for _, t := range threads {
+		agentIDs = append(agentIDs, t.AgentID)
+	}
+
+	agentMap, err := s.store.GetAgentsByIDs(r.Context(), agentIDs)
+	if err != nil {
+		agentMap = nil // degrade gracefully — names will be empty
+	}
+
+	// For agents not found by ID (may be stored as slugs), try slug lookup.
+	// Collect missing IDs and batch-query by slug using GetAgentBySlug.
+	// This path handles the case where webchat_thread stores slugs instead
+	// of UUIDs (see webchannel.go O1 comment).
+	slugLookups := make([]string, 0)
+	for _, t := range threads {
+		if _, ok := agentMap[t.AgentID]; !ok {
+			slugLookups = append(slugLookups, t.AgentID)
+		}
+	}
+	slugAgentMap := make(map[string]*store.Agent)
+	for _, slug := range slugLookups {
+		agent, err := s.store.GetAgentBySlug(r.Context(), projectID, slug)
+		if err == nil && agent != nil {
+			slugAgentMap[slug] = agent
+		}
+	}
+
+	// Build response entries, joining with pre-fetched data.
 	entries := make([]chatThreadEntry, 0, len(threads))
 	for _, t := range threads {
 		entry := chatThreadEntry{
 			AgentID: t.AgentID,
 		}
 
-		// Try to enrich with agent metadata from the store.
-		// The agentID in webchat_thread may be a slug or UUID depending on
-		// how the thread was created (see webchannel.go O1 comment).
-		agent, err := s.store.GetAgent(r.Context(), t.AgentID)
-		if err != nil {
-			// Try by slug within the project
-			agent, err = s.store.GetAgentBySlug(r.Context(), projectID, t.AgentID)
-		}
-		if err == nil && agent != nil {
+		// Enrich with agent metadata from the batch-fetched maps.
+		if agent, ok := agentMap[t.AgentID]; ok {
+			entry.AgentID = agent.ID
+			entry.AgentSlug = agent.Slug
+			entry.AgentName = agent.Name
+			entry.Phase = agent.Phase
+			entry.Activity = agent.Activity
+		} else if agent, ok := slugAgentMap[t.AgentID]; ok {
 			entry.AgentID = agent.ID
 			entry.AgentSlug = agent.Slug
 			entry.AgentName = agent.Name

--- a/pkg/hub/handlers_chat.go
+++ b/pkg/hub/handlers_chat.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// handleChatThreads handles GET /api/v1/chat/threads.
+// Returns the thread rail for the authenticated user: a list of agents
+// they have conversed with, each with last-message preview and an
+// unread indicator. Reads from webchat_thread — no aggregate query
+// over the messages table (AC19a).
+func (s *Server) handleChatThreads(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	if s.webChatStore == nil {
+		writeJSON(w, http.StatusOK, chatThreadsResponse{Threads: []chatThreadEntry{}})
+		return
+	}
+
+	q := r.URL.Query()
+	projectID := q.Get("projectId")
+	if projectID == "" {
+		BadRequest(w, "projectId is required")
+		return
+	}
+
+	limit := 50 // default
+	if limitStr := q.Get("limit"); limitStr != "" {
+		if n, err := strconv.Atoi(limitStr); err == nil && n > 0 && n <= 200 {
+			limit = n
+		}
+	}
+
+	threads, err := s.webChatStore.GetThreads(r.Context(), user.ID(), projectID, limit)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to fetch threads"})
+		return
+	}
+
+	// Batch-fetch the last messages by ID.
+	messageIDs := make([]string, 0, len(threads))
+	for _, t := range threads {
+		if t.LastMessageID != "" {
+			messageIDs = append(messageIDs, t.LastMessageID)
+		}
+	}
+
+	messageMap := make(map[string]lastMessageInfo, len(messageIDs))
+	for _, id := range messageIDs {
+		msg, err := s.store.GetMessage(r.Context(), id)
+		if err != nil || msg == nil {
+			continue
+		}
+		messageMap[id] = lastMessageInfo{
+			Msg:       truncatePreview(msg.Msg, 120),
+			Sender:    msg.Sender,
+			CreatedAt: msg.CreatedAt,
+			Type:      msg.Type,
+		}
+	}
+
+	// Build response entries, joining with agent info from the store.
+	entries := make([]chatThreadEntry, 0, len(threads))
+	for _, t := range threads {
+		entry := chatThreadEntry{
+			AgentID: t.AgentID,
+		}
+
+		// Try to enrich with agent metadata from the store.
+		// The agentID in webchat_thread may be a slug or UUID depending on
+		// how the thread was created (see webchannel.go O1 comment).
+		agent, err := s.store.GetAgent(r.Context(), t.AgentID)
+		if err != nil {
+			// Try by slug within the project
+			agent, err = s.store.GetAgentBySlug(r.Context(), projectID, t.AgentID)
+		}
+		if err == nil && agent != nil {
+			entry.AgentID = agent.ID
+			entry.AgentSlug = agent.Slug
+			entry.AgentName = agent.Name
+			entry.Phase = agent.Phase
+			entry.Activity = agent.Activity
+		}
+
+		// Add last message preview
+		if info, ok := messageMap[t.LastMessageID]; ok {
+			entry.LastMessage = &info
+		}
+
+		// Compute unread: last_activity_at > last_read_at (AC19a — pure comparison, no count)
+		entry.HasUnread = t.LastReadAt == nil || t.LastActivityAt.After(*t.LastReadAt)
+
+		entries = append(entries, entry)
+	}
+
+	writeJSON(w, http.StatusOK, chatThreadsResponse{Threads: entries})
+}
+
+// handleChatThreadRoutes dispatches sub-routes under /api/v1/chat/threads/.
+// Currently handles POST /api/v1/chat/threads/{agentId}/read.
+func (s *Server) handleChatThreadRoutes(w http.ResponseWriter, r *http.Request) {
+	// Parse: /api/v1/chat/threads/{agentId}/read
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/chat/threads/")
+	parts := strings.SplitN(path, "/", 2)
+
+	if len(parts) < 2 || parts[1] != "read" {
+		http.NotFound(w, r)
+		return
+	}
+
+	agentID := parts[0]
+	if agentID == "" {
+		BadRequest(w, "agentId is required")
+		return
+	}
+
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	if s.webChatStore == nil {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		return
+	}
+
+	q := r.URL.Query()
+	projectID := q.Get("projectId")
+	if projectID == "" {
+		BadRequest(w, "projectId is required")
+		return
+	}
+
+	if err := s.webChatStore.MarkThreadRead(r.Context(), user.ID(), projectID, agentID); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to mark thread read"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// --- Response types ---
+
+type chatThreadsResponse struct {
+	Threads []chatThreadEntry `json:"threads"`
+}
+
+type chatThreadEntry struct {
+	AgentID     string           `json:"agentId"`
+	AgentSlug   string           `json:"agentSlug,omitempty"`
+	AgentName   string           `json:"agentName,omitempty"`
+	Phase       string           `json:"phase,omitempty"`
+	Activity    string           `json:"activity,omitempty"`
+	LastMessage *lastMessageInfo `json:"lastMessage,omitempty"`
+	HasUnread   bool             `json:"hasUnread"`
+}
+
+type lastMessageInfo struct {
+	Msg       string    `json:"msg"`
+	Sender    string    `json:"sender"`
+	CreatedAt time.Time `json:"createdAt"`
+	Type      string    `json:"type"`
+}
+
+// truncatePreview truncates a message to maxLen runes for rail preview.
+func truncatePreview(s string, maxLen int) string {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen]) + "..."
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -736,7 +736,7 @@ type Server struct {
 	// Plugin manager for broker integration admin API (nil = no integrations)
 	pluginManager IntegrationManager
 
-	// Web chat store for webchat_* tables (thread prefs, etc.) — nil = disabled.
+	// Web chat store for webchat_* tables (thread prefs, chat threads, etc.) — nil = disabled.
 	webChatStore WebChatStore
 
 	// Channel registry for external notification delivery (nil = disabled)
@@ -1869,7 +1869,7 @@ func (s *Server) GetMessageBrokerProxy() *MessageBrokerProxy {
 	return s.messageBrokerProxy
 }
 
-// SetWebChatStore sets the webchat store for thread prefs and related state.
+// SetWebChatStore sets the webchat store for thread prefs and chat threads API.
 func (s *Server) SetWebChatStore(store WebChatStore) {
 	s.mu.Lock()
 	s.webChatStore = store
@@ -3439,6 +3439,10 @@ func (s *Server) registerRoutes() {
 
 	// Chat thread prefs (Phase 3 — visibility mode persistence)
 	s.mux.HandleFunc("/api/v1/chat/prefs", s.handleChatPrefs)
+
+	// Chat thread endpoints (Phase 5 — thread rail)
+	s.mux.HandleFunc("/api/v1/chat/threads", s.handleChatThreads)
+	s.mux.HandleFunc("/api/v1/chat/threads/", s.handleChatThreadRoutes)
 
 	// WebSocket control channel endpoint for Runtime Brokers
 	s.mux.HandleFunc("/api/v1/runtime-brokers/connect", s.handleRuntimeBrokerConnect)

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -57,11 +57,29 @@ type WebChatStore interface {
 
 	// SetThreadPrefs upserts the display preferences for a (user, project, agent) thread.
 	SetThreadPrefs(ctx context.Context, userID, projectID, agentID string, prefs ThreadPrefs) error
+
+	// GetThreads returns thread watermarks for the given user and project,
+	// ordered by last_activity_at descending, limited to `limit` rows.
+	// This is the backing query for GET /api/v1/chat/threads.
+	GetThreads(ctx context.Context, userID, projectID string, limit int) ([]WebChatThread, error)
+
+	// MarkThreadRead advances the last_read_at watermark for the given
+	// (user, project, agent) thread to the current time.
+	MarkThreadRead(ctx context.Context, userID, projectID, agentID string) error
 }
 
 // ThreadPrefs holds per-thread display preferences from webchat_thread_prefs.
 type ThreadPrefs struct {
 	VisibilityMode string `json:"visibility_mode"`
+}
+
+// WebChatThread is a single row from the webchat_thread table,
+// returned by GetThreads.
+type WebChatThread struct {
+	AgentID        string
+	LastMessageID  string
+	LastActivityAt time.Time
+	LastReadAt     *time.Time // nil if never read
 }
 
 // NewWebChatStore creates a new WebChatStore backed by the given database.
@@ -186,6 +204,58 @@ DO UPDATE SET visibility_mode = excluded.visibility_mode
 	_, err := s.db.ExecContext(ctx, query, userID, projectID, agentID, prefs.VisibilityMode)
 	if err != nil {
 		return fmt.Errorf("webchat store: set thread prefs: %w", err)
+	}
+	return nil
+}
+
+// GetThreads returns thread watermarks for the given user and project.
+func (s *sqliteWebChatStore) GetThreads(ctx context.Context, userID, projectID string, limit int) ([]WebChatThread, error) {
+	const query = `
+SELECT agent_id, COALESCE(last_message_id, ''), COALESCE(last_activity_at, ''), last_read_at
+  FROM webchat_thread
+ WHERE user_id = ? AND project_id = ?
+ ORDER BY last_activity_at DESC
+ LIMIT ?
+`
+	rows, err := s.db.QueryContext(ctx, query, userID, projectID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("webchat store: get threads: %w", err)
+	}
+	defer rows.Close()
+
+	var threads []WebChatThread
+	for rows.Next() {
+		var t WebChatThread
+		var activityStr string
+		var readStr *string
+		if err := rows.Scan(&t.AgentID, &t.LastMessageID, &activityStr, &readStr); err != nil {
+			return nil, fmt.Errorf("webchat store: scan thread: %w", err)
+		}
+		if activityStr != "" {
+			if parsed, err := time.Parse(time.RFC3339Nano, activityStr); err == nil {
+				t.LastActivityAt = parsed
+			}
+		}
+		if readStr != nil && *readStr != "" {
+			if parsed, err := time.Parse(time.RFC3339Nano, *readStr); err == nil {
+				t.LastReadAt = &parsed
+			}
+		}
+		threads = append(threads, t)
+	}
+	return threads, rows.Err()
+}
+
+// MarkThreadRead advances the last_read_at watermark to now.
+func (s *sqliteWebChatStore) MarkThreadRead(ctx context.Context, userID, projectID, agentID string) error {
+	const query = `
+UPDATE webchat_thread
+   SET last_read_at = ?
+ WHERE user_id = ? AND project_id = ? AND agent_id = ?
+`
+	_, err := s.db.ExecContext(ctx, query, time.Now().UTC().Format(time.RFC3339Nano), userID, projectID, agentID)
+	if err != nil {
+		return fmt.Errorf("webchat store: mark thread read: %w", err)
 	}
 	return nil
 }

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -234,10 +234,18 @@ SELECT agent_id, COALESCE(last_message_id, ''), COALESCE(last_activity_at, ''), 
 		if activityStr != "" {
 			if parsed, err := time.Parse(time.RFC3339Nano, activityStr); err == nil {
 				t.LastActivityAt = parsed
+			} else if parsed, err := time.Parse("2006-01-02 15:04:05.999999999-07:00", activityStr); err == nil {
+				t.LastActivityAt = parsed
+			} else if parsed, err := time.Parse("2006-01-02 15:04:05.999999999", activityStr); err == nil {
+				t.LastActivityAt = parsed
 			}
 		}
 		if readStr != nil && *readStr != "" {
 			if parsed, err := time.Parse(time.RFC3339Nano, *readStr); err == nil {
+				t.LastReadAt = &parsed
+			} else if parsed, err := time.Parse("2006-01-02 15:04:05.999999999-07:00", *readStr); err == nil {
+				t.LastReadAt = &parsed
+			} else if parsed, err := time.Parse("2006-01-02 15:04:05.999999999", *readStr); err == nil {
 				t.LastReadAt = &parsed
 			}
 		}

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -221,7 +221,7 @@ SELECT agent_id, COALESCE(last_message_id, ''), COALESCE(last_activity_at, ''), 
 	if err != nil {
 		return nil, fmt.Errorf("webchat store: get threads: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var threads []WebChatThread
 	for rows.Next() {

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -146,7 +146,7 @@ SELECT agent_id, COALESCE(last_message_id, ''), last_activity_at, last_read_at
 	if err != nil {
 		return nil, fmt.Errorf("webchat store: get threads: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var threads []WebChatThread
 	for rows.Next() {

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -132,3 +132,49 @@ DO UPDATE SET visibility_mode = EXCLUDED.visibility_mode
 	}
 	return nil
 }
+
+// GetThreads returns thread watermarks for the given user and project.
+func (s *pgWebChatStore) GetThreads(ctx context.Context, userID, projectID string, limit int) ([]WebChatThread, error) {
+	const query = `
+SELECT agent_id, COALESCE(last_message_id, ''), last_activity_at, last_read_at
+  FROM webchat_thread
+ WHERE user_id = $1 AND project_id = $2
+ ORDER BY last_activity_at DESC
+ LIMIT $3
+`
+	rows, err := s.db.QueryContext(ctx, query, userID, projectID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("webchat store: get threads: %w", err)
+	}
+	defer rows.Close()
+
+	var threads []WebChatThread
+	for rows.Next() {
+		var t WebChatThread
+		var activityAt *time.Time
+		var readAt *time.Time
+		if err := rows.Scan(&t.AgentID, &t.LastMessageID, &activityAt, &readAt); err != nil {
+			return nil, fmt.Errorf("webchat store: scan thread: %w", err)
+		}
+		if activityAt != nil {
+			t.LastActivityAt = *activityAt
+		}
+		t.LastReadAt = readAt
+		threads = append(threads, t)
+	}
+	return threads, rows.Err()
+}
+
+// MarkThreadRead advances the last_read_at watermark to now.
+func (s *pgWebChatStore) MarkThreadRead(ctx context.Context, userID, projectID, agentID string) error {
+	const query = `
+UPDATE webchat_thread
+   SET last_read_at = NOW()
+ WHERE user_id = $1 AND project_id = $2 AND agent_id = $3
+`
+	_, err := s.db.ExecContext(ctx, query, userID, projectID, agentID)
+	if err != nil {
+		return fmt.Errorf("webchat store: mark thread read: %w", err)
+	}
+	return nil
+}

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -318,6 +318,42 @@ func (s *AgentStore) GetAgentBySlug(ctx context.Context, projectID, slug string)
 	return entAgentToStore(a), nil
 }
 
+// GetAgentsByIDs retrieves agents by a list of IDs.
+// Returns only agents that exist; missing IDs are silently skipped.
+func (s *AgentStore) GetAgentsByIDs(ctx context.Context, ids []string) (map[string]*store.Agent, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	uuids := make([]uuid.UUID, 0, len(ids))
+	for _, id := range ids {
+		uid, err := parseUUID(id)
+		if err != nil {
+			continue // skip invalid UUIDs
+		}
+		uuids = append(uuids, uid)
+	}
+
+	if len(uuids) == 0 {
+		return nil, nil
+	}
+
+	agents, err := s.client.Agent.Query().
+		Where(agent.IDIn(uuids...), agent.DeletedAtIsNil()).
+		All(ctx)
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	result := make(map[string]*store.Agent, len(agents))
+	for _, a := range agents {
+		sa := entAgentToStore(a)
+		result[sa.ID] = sa
+	}
+
+	return result, nil
+}
+
 // UpdateAgent updates an existing agent using optimistic locking on
 // state_version. The mutable field set mirrors the legacy SQLite store:
 // identity-adjacent operational fields are updated, while immutable lineage

--- a/pkg/store/entadapter/message_store.go
+++ b/pkg/store/entadapter/message_store.go
@@ -184,6 +184,42 @@ func (s *MessageStore) GetMessage(ctx context.Context, id string) (*store.Messag
 	return entMessageToStore(e), nil
 }
 
+// GetMessagesByIDs retrieves messages by a list of IDs.
+// Returns only messages that exist; missing IDs are silently skipped.
+func (s *MessageStore) GetMessagesByIDs(ctx context.Context, ids []string) (map[string]*store.Message, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	uuids := make([]uuid.UUID, 0, len(ids))
+	for _, id := range ids {
+		uid, err := parseUUID(id)
+		if err != nil {
+			continue // skip invalid UUIDs
+		}
+		uuids = append(uuids, uid)
+	}
+
+	if len(uuids) == 0 {
+		return nil, nil
+	}
+
+	msgs, err := s.client.Message.Query().
+		Where(message.IDIn(uuids...)).
+		All(ctx)
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	result := make(map[string]*store.Message, len(msgs))
+	for _, m := range msgs {
+		sm := entMessageToStore(m)
+		result[sm.ID] = sm
+	}
+
+	return result, nil
+}
+
 // encodeCursor produces a self-contained, opaque pagination cursor that embeds
 // both the created timestamp and the message ID. Format: base64(RFC3339Nano + "," + uuid).
 // This avoids a DB round-trip on decode and makes pagination resilient to message deletion.

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -150,6 +150,11 @@ type AgentStore interface {
 	// Returns ErrNotFound if the agent doesn't exist.
 	GetAgentBySlug(ctx context.Context, projectID, slug string) (*Agent, error)
 
+	// GetAgentsByIDs retrieves agents by a list of IDs.
+	// Returns only agents that exist; missing IDs are silently skipped.
+	// The returned map is keyed by agent ID.
+	GetAgentsByIDs(ctx context.Context, ids []string) (map[string]*Agent, error)
+
 	// UpdateAgent updates an existing agent.
 	// Uses optimistic locking via StateVersion.
 	// Returns ErrNotFound if agent doesn't exist.
@@ -1240,6 +1245,11 @@ type MessageStore interface {
 	// GetMessage returns a single message by ID.
 	// Returns ErrNotFound if the message doesn't exist.
 	GetMessage(ctx context.Context, id string) (*Message, error)
+
+	// GetMessagesByIDs retrieves messages by a list of IDs.
+	// Returns only messages that exist; missing IDs are silently skipped.
+	// The returned map is keyed by message ID.
+	GetMessagesByIDs(ctx context.Context, ids []string) (map[string]*Message, error)
 
 	// ListMessages returns messages matching the given filter.
 	// Results are ordered by created_at DESC.

--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -253,9 +253,15 @@ const ADMIN_ROUTES = new Set(['scion-page-settings', 'scion-page-admin-scheduler
 // Without this, unhandled errors in a long-lived surface (like chat mode)
 // silently fail. See design.md Section 4.1.
 // ---------------------------------------------------------------------------
-window.onerror = (message, source, lineno, colno, error) => {
-  console.error('[Scion] Unhandled error:', { message, source, lineno, colno, error });
-};
+window.addEventListener('error', (event) => {
+  console.error('[Scion] Unhandled error:', {
+    message: event.message,
+    source: event.filename,
+    lineno: event.lineno,
+    colno: event.colno,
+    error: event.error,
+  });
+});
 window.addEventListener('unhandledrejection', (event) => {
   console.error('[Scion] Unhandled promise rejection:', event.reason);
 });

--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -28,6 +28,7 @@ import type { PageData, User } from '../shared/types.js';
 import { stateManager } from './state.js';
 import { debugLog } from './debug-log.js';
 import { setDocumentTitle } from './page-title.js';
+import { isFeatureEnabled } from '../utils/feature-flags.js';
 
 /**
  * Strip the Vite base path prefix from a URL pathname so the client-side
@@ -426,6 +427,12 @@ async function renderRoute(path: string): Promise<void> {
     return;
   }
 
+  // Block /chat routes when the native_chat feature flag is disabled (O2).
+  if (CHAT_ROUTES.has(tag) && !isFeatureEnabled('web.native_chat')) {
+    navigateTo('/');
+    return;
+  }
+
   const shellType = getShellType(tag);
 
   // Lazy-load the page component module (and profile/chat shell if needed).
@@ -481,7 +488,13 @@ async function renderRoute(path: string): Promise<void> {
   } else {
     // Create the shell for the first time — clear any SSR-rendered content
     appContainer.innerHTML = '';
-    const shellTag = shellType === 'chat' ? 'scion-chat-shell' : shellType === 'profile' ? 'scion-profile-shell' : 'scion-app';
+    const SHELL_TAGS: Record<ShellType, string> = {
+      standalone: '', // handled above — standalone pages render without a shell
+      chat: 'scion-chat-shell',
+      profile: 'scion-profile-shell',
+      app: 'scion-app',
+    };
+    const shellTag = SHELL_TAGS[shellType] ?? 'scion-app';
     const shell = document.createElement(shellTag) as HTMLElement & {
       currentPath: string;
       user: User | null;

--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -221,6 +221,9 @@ const ROUTES: RouteConfig[] = [
   { pattern: /^\/agents\/[^/]+\/configure$/, tag: 'scion-page-agent-configure', load: () => import('../components/pages/agent-configure.js') },
   { pattern: /^\/agents\/[^/]+\/terminal$/, tag: 'scion-page-terminal', load: () => import('../components/pages/terminal.js') },
   { pattern: /^\/agents\/[^/]+$/, tag: 'scion-page-agent-detail', load: () => import('../components/pages/agent-detail.js') },
+  // Chat mode routes (Phase 5 — top-level chat)
+  { pattern: /^\/chat$/, tag: 'scion-page-chat', load: () => import('../components/pages/chat.js') },
+  { pattern: /^\/chat\/[^/]+$/, tag: 'scion-page-chat', load: () => import('../components/pages/chat.js') },
 ];
 
 /**
@@ -234,9 +237,27 @@ const STANDALONE_ROUTES = new Set(['scion-login-page', 'scion-page-invite', 'sci
 const PROFILE_ROUTES = new Set(['scion-page-profile-env-vars', 'scion-page-profile-secrets', 'scion-page-profile-settings', 'scion-page-profile-tokens', 'scion-page-profile-telegram', 'scion-page-profile-teams', 'scion-page-profile-discord', 'scion-page-profile-skills']);
 
 /**
+ * Routes that render inside the chat shell (Phase 5 — top-level chat mode).
+ * NOT standalone (chat has chrome, just different chrome from app shell).
+ */
+const CHAT_ROUTES = new Set(['scion-page-chat']);
+
+/**
  * Routes that require admin role. Non-admin users are redirected to dashboard.
  */
 const ADMIN_ROUTES = new Set(['scion-page-settings', 'scion-page-admin-scheduler', 'scion-page-admin-maintenance', 'scion-page-admin-users', 'scion-page-admin-groups', 'scion-page-admin-group-detail', 'scion-page-admin-server-config', 'scion-page-admin-federation', 'scion-page-admin-integrations', 'scion-page-admin-skill-registries', 'scion-page-admin-skill-registry-detail', 'scion-page-diagnostics', 'scion-page-health-dashboard']);
+
+// ---------------------------------------------------------------------------
+// Global error boundary — registered once so all shells share it.
+// Without this, unhandled errors in a long-lived surface (like chat mode)
+// silently fail. See design.md Section 4.1.
+// ---------------------------------------------------------------------------
+window.onerror = (message, source, lineno, colno, error) => {
+  console.error('[Scion] Unhandled error:', { message, source, lineno, colno, error });
+};
+window.addEventListener('unhandledrejection', (event) => {
+  console.error('[Scion] Unhandled promise rejection:', event.reason);
+});
 
 /**
  * Initialize the client-side application
@@ -354,11 +375,12 @@ function resolveRoute(path: string): RouteConfig {
 /**
  * Determines which shell type a route tag requires.
  */
-type ShellType = 'standalone' | 'profile' | 'app';
+type ShellType = 'standalone' | 'profile' | 'chat' | 'app';
 
 function getShellType(tag: string): ShellType {
   if (STANDALONE_ROUTES.has(tag)) return 'standalone';
   if (PROFILE_ROUTES.has(tag)) return 'profile';
+  if (CHAT_ROUTES.has(tag)) return 'chat';
   return 'app';
 }
 
@@ -406,7 +428,7 @@ async function renderRoute(path: string): Promise<void> {
 
   const shellType = getShellType(tag);
 
-  // Lazy-load the page component module (and profile shell if needed).
+  // Lazy-load the page component module (and profile/chat shell if needed).
   // The import registers the custom element as a side effect.
   const thisNav = ++navigationId;
   const loads: Promise<unknown>[] = [route.load()];
@@ -414,6 +436,11 @@ async function renderRoute(path: string): Promise<void> {
     loads.push(
       import('../components/profile/profile-shell.js'),
       import('../components/profile/profile-nav.js'),
+    );
+  }
+  if (shellType === 'chat' && !customElements.get('scion-chat-shell')) {
+    loads.push(
+      import('../components/chat/chat-shell.js'),
     );
   }
   await Promise.all(loads);
@@ -454,7 +481,7 @@ async function renderRoute(path: string): Promise<void> {
   } else {
     // Create the shell for the first time — clear any SSR-rendered content
     appContainer.innerHTML = '';
-    const shellTag = shellType === 'profile' ? 'scion-profile-shell' : 'scion-app';
+    const shellTag = shellType === 'chat' ? 'scion-chat-shell' : shellType === 'profile' ? 'scion-profile-shell' : 'scion-app';
     const shell = document.createElement(shellTag) as HTMLElement & {
       currentPath: string;
       user: User | null;

--- a/web/src/components/app-shell.ts
+++ b/web/src/components/app-shell.ts
@@ -33,6 +33,7 @@ import './shared/debug-panel.js';
 import type { User } from '../shared/types.js';
 import type { AccessDeniedDetail } from '../client/api.js';
 import { showToast } from '../utils/toast.js';
+import { performLogout } from '../utils/auth.js';
 import { setDocumentTitle, PAGE_TITLE_EVENT } from '../client/page-title.js';
 import type { PageTitleDetail } from '../client/page-title.js';
 
@@ -397,20 +398,10 @@ export class ScionApp extends LitElement {
 
   /**
    * Handle logout action.
-   * Uses the Vite BASE_URL to construct correct paths behind a reverse proxy.
+   * Delegates to shared performLogout() utility (design doc Section 4.1).
    */
   private handleLogout(): void {
-    const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
-    fetch(`${base}/auth/logout`, {
-      method: 'POST',
-      credentials: 'include',
-    })
-      .then(() => {
-        window.location.href = `${base}/auth/login`;
-      })
-      .catch((error) => {
-        console.error('Logout failed:', error);
-      });
+    performLogout();
   }
 }
 

--- a/web/src/components/app-shell.ts
+++ b/web/src/components/app-shell.ts
@@ -396,17 +396,17 @@ export class ScionApp extends LitElement {
   }
 
   /**
-   * Handle logout action
+   * Handle logout action.
+   * Uses the Vite BASE_URL to construct correct paths behind a reverse proxy.
    */
   private handleLogout(): void {
-    // POST to logout endpoint
-    fetch('/auth/logout', {
+    const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
+    fetch(`${base}/auth/logout`, {
       method: 'POST',
       credentials: 'include',
     })
       .then(() => {
-        // Redirect to login page
-        window.location.href = '/auth/login';
+        window.location.href = `${base}/auth/login`;
       })
       .catch((error) => {
         console.error('Logout failed:', error);

--- a/web/src/components/chat/chat-shell.ts
+++ b/web/src/components/chat/chat-shell.ts
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Chat Shell Component (4th ShellType)
+ *
+ * Layout shell for the top-level chat mode. Replaces the main nav sidebar
+ * with a thread rail and provides a slim header with project context.
+ * Modeled on profile-shell.ts.
+ *
+ * Key design decisions (from design.md Section 4.1):
+ * - NOT a second HTML entry point; a fourth ShellType in the existing SPA
+ * - Switching between app and chat mode does NOT reload the document (AC19c)
+ * - MUST re-register the scion:access-denied listener (AC19e)
+ * - Reuses showToast() and stateManager SSE connection (AC19f)
+ * - Dynamic document titles (agent name, unread count)
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import '../shared/header.js';
+import '../shared/debug-panel.js';
+
+import type { User } from '../../shared/types.js';
+import type { AccessDeniedDetail } from '../../client/api.js';
+import { showToast } from '../../utils/toast.js';
+import { setDocumentTitle, PAGE_TITLE_EVENT } from '../../client/page-title.js';
+import type { PageTitleDetail } from '../../client/page-title.js';
+
+@customElement('scion-chat-shell')
+export class ScionChatShell extends LitElement {
+  @property({ type: Object })
+  user: User | null = null;
+
+  @property({ type: String })
+  currentPath = '/chat';
+
+  /** Bound listener references for cleanup */
+  private _accessDeniedHandler = this.handleAccessDenied.bind(this);
+  private _pageTitleHandler = this.handlePageTitle.bind(this);
+
+  static override styles = css`
+    :host {
+      display: flex;
+      height: 100vh;
+      height: 100dvh;
+      background: var(--scion-bg, #f8fafc);
+    }
+
+    .main {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+    }
+
+    .content {
+      flex: 1;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+  `;
+
+  /**
+   * Re-register the scion:access-denied listener so 403 errors still
+   * raise a toast in chat mode. This is the most likely single defect
+   * if omitted (AC19e, design.md Section 4.1).
+   */
+  override connectedCallback(): void {
+    super.connectedCallback();
+    window.addEventListener('scion:access-denied', this._accessDeniedHandler as EventListener);
+    this.addEventListener(PAGE_TITLE_EVENT, this._pageTitleHandler as EventListener);
+    this.updateDocumentTitle();
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    window.removeEventListener('scion:access-denied', this._accessDeniedHandler as EventListener);
+    this.removeEventListener(PAGE_TITLE_EVENT, this._pageTitleHandler as EventListener);
+  }
+
+  override updated(changedProperties: Map<string, unknown>): void {
+    if (changedProperties.has('currentPath')) {
+      this.updateDocumentTitle();
+    }
+  }
+
+  /**
+   * Handle page-title events from the chat page component to set
+   * agent-specific titles (e.g. "agent-name - Chat - Scion").
+   */
+  private handlePageTitle(event: CustomEvent<PageTitleDetail>): void {
+    const segments = event.detail?.segments;
+    if (segments && segments.length > 0) {
+      setDocumentTitle(...segments);
+    }
+  }
+
+  private updateDocumentTitle(): void {
+    // Extract agent context from path for dynamic titles
+    const match = this.currentPath.match(/^\/chat\/([^/]+)/);
+    if (match) {
+      setDocumentTitle(decodeURIComponent(match[1]), 'Chat');
+    } else {
+      setDocumentTitle('Chat');
+    }
+  }
+
+  private handleAccessDenied(event: CustomEvent<AccessDeniedDetail>): void {
+    const detail = event.detail || {};
+    const action = detail.action || 'perform this action on';
+    const message = `You don't have permission to ${action} this resource.`;
+    showToast(message, 'warning');
+  }
+
+  override render() {
+    return html`
+      <main class="main">
+        <scion-header
+          .user=${this.user}
+          .currentPath=${this.currentPath}
+          .pageTitle=${'Chat'}
+          ?showMobileMenu=${false}
+          @logout=${(): void => this.handleLogout()}
+        ></scion-header>
+
+        <div class="content">
+          <slot></slot>
+        </div>
+      </main>
+
+      <scion-debug-panel></scion-debug-panel>
+    `;
+  }
+
+  /**
+   * Handle logout action.
+   * Uses the Vite BASE_URL to construct correct paths behind a reverse proxy.
+   */
+  private handleLogout(): void {
+    const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
+    fetch(`${base}/auth/logout`, {
+      method: 'POST',
+      credentials: 'include',
+    })
+      .then(() => {
+        window.location.href = `${base}/auth/login`;
+      })
+      .catch((error) => {
+        console.error('Logout failed:', error);
+      });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-chat-shell': ScionChatShell;
+  }
+}

--- a/web/src/components/chat/chat-shell.ts
+++ b/web/src/components/chat/chat-shell.ts
@@ -38,6 +38,7 @@ import '../shared/debug-panel.js';
 import type { User } from '../../shared/types.js';
 import type { AccessDeniedDetail } from '../../client/api.js';
 import { showToast } from '../../utils/toast.js';
+import { performLogout } from '../../utils/auth.js';
 import { setDocumentTitle, PAGE_TITLE_EVENT } from '../../client/page-title.js';
 import type { PageTitleDetail } from '../../client/page-title.js';
 
@@ -150,20 +151,10 @@ export class ScionChatShell extends LitElement {
 
   /**
    * Handle logout action.
-   * Uses the Vite BASE_URL to construct correct paths behind a reverse proxy.
+   * Delegates to shared performLogout() utility (design doc Section 4.1).
    */
   private handleLogout(): void {
-    const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
-    fetch(`${base}/auth/logout`, {
-      method: 'POST',
-      credentials: 'include',
-    })
-      .then(() => {
-        window.location.href = `${base}/auth/login`;
-      })
-      .catch((error) => {
-        console.error('Logout failed:', error);
-      });
+    performLogout();
   }
 }
 

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -74,6 +74,9 @@ export class ScionPageChat extends LitElement {
   /** Debounce timer for rail refresh to avoid rapid-fire reloads. */
   private _refreshTimer: ReturnType<typeof setTimeout> | null = null;
 
+  /** Cached project ID to avoid redundant /api/v1/projects?limit=1 fetches. */
+  private _cachedProjectId = '';
+
   static override styles = css`
     :host {
       display: flex;
@@ -353,10 +356,15 @@ export class ScionPageChat extends LitElement {
 
   /** Resolve the project ID from page context. */
   private async resolveProjectId(): Promise<string> {
+    if (this._cachedProjectId) return this._cachedProjectId;
+
     // Try to get from URL query param
     const url = new URL(window.location.href);
     const qProject = url.searchParams.get('projectId');
-    if (qProject) return qProject;
+    if (qProject) {
+      this._cachedProjectId = qProject;
+      return qProject;
+    }
 
     // Fall back to fetching the user's projects and using the first one
     try {
@@ -364,7 +372,8 @@ export class ScionPageChat extends LitElement {
       if (res.ok) {
         const data = (await res.json()) as { items?: { id: string }[] };
         if (data.items && data.items.length > 0) {
-          return data.items[0].id;
+          this._cachedProjectId = data.items[0].id;
+          return this._cachedProjectId;
         }
       }
     } catch {
@@ -540,6 +549,7 @@ export class ScionPageChat extends LitElement {
   /** Format a timestamp as a relative time string. */
   private formatRelativeTime(iso: string): string {
     const d = new Date(iso);
+    if (isNaN(d.getTime())) return '';
     const now = Date.now();
     const diffMs = now - d.getTime();
     const diffMin = Math.floor(diffMs / 60000);

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -31,9 +31,10 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-import type { PageData } from '../../shared/types.js';
+import type { PageData, Capabilities } from '../../shared/types.js';
+import { can } from '../../shared/types.js';
 import { apiFetch } from '../../client/api.js';
-import { navigateTo } from '../../client/main.js';
+import { navigateTo, stateManager } from '../../client/main.js';
 import { dispatchPageTitle } from '../../client/page-title.js';
 import '../shared/chat/chat-thread.js';
 
@@ -62,6 +63,16 @@ export class ScionPageChat extends LitElement {
   @state() private loadingThreads = false;
   @state() private selectedAgentId = '';
   @state() private selectedAgentName = '';
+  @state() private selectedAgentCanSend = false;
+
+  /** Cached agent capabilities keyed by agentId, fetched when a thread is selected. */
+  private agentCapabilities = new Map<string, Capabilities | undefined>();
+
+  /** Bound listener for SSE message events — used to refresh the thread rail. */
+  private _onUserMessage = this.handleUserMessage.bind(this);
+
+  /** Debounce timer for rail refresh to avoid rapid-fire reloads. */
+  private _refreshTimer: ReturnType<typeof setTimeout> | null = null;
 
   static override styles = css`
     :host {
@@ -252,12 +263,38 @@ export class ScionPageChat extends LitElement {
     super.connectedCallback();
     this.parseRoute();
     void this.loadThreads();
+
+    // Subscribe to SSE message events to refresh the thread rail (O5).
+    stateManager.addEventListener('user-message-created', this._onUserMessage);
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    stateManager.removeEventListener('user-message-created', this._onUserMessage);
+    if (this._refreshTimer) {
+      clearTimeout(this._refreshTimer);
+      this._refreshTimer = null;
+    }
   }
 
   override updated(changedProperties: Map<string, unknown>): void {
     if (changedProperties.has('pageData') && this.pageData) {
       this.parseRoute();
     }
+  }
+
+  /**
+   * Handle SSE user-message events — debounce and reload the thread rail.
+   * Uses a 2-second debounce to avoid rapid-fire reloads during bursts.
+   */
+  private handleUserMessage(): void {
+    if (this._refreshTimer) {
+      clearTimeout(this._refreshTimer);
+    }
+    this._refreshTimer = setTimeout(() => {
+      this._refreshTimer = null;
+      void this.loadThreads();
+    }, 2000);
   }
 
   /** Parse the current path to determine selected agent. */
@@ -271,8 +308,11 @@ export class ScionPageChat extends LitElement {
       // Update class for responsive layout
       if (newAgentId) {
         this.classList.add('thread-open');
+        // Fetch capabilities to gate the compose box (O3).
+        void this.fetchAgentCapabilities(newAgentId);
       } else {
         this.classList.remove('thread-open');
+        this.selectedAgentCanSend = false;
       }
     }
   }
@@ -345,6 +385,27 @@ export class ScionPageChat extends LitElement {
     }
   }
 
+  /** Fetch and cache agent capabilities to determine canSend. */
+  private async fetchAgentCapabilities(agentId: string): Promise<void> {
+    // Return cached value if available.
+    if (this.agentCapabilities.has(agentId)) {
+      this.selectedAgentCanSend = can(this.agentCapabilities.get(agentId), 'message');
+      return;
+    }
+
+    try {
+      const res = await apiFetch(`/api/v1/agents/${encodeURIComponent(agentId)}`);
+      if (res.ok) {
+        const agent = (await res.json()) as { _capabilities?: Capabilities };
+        this.agentCapabilities.set(agentId, agent._capabilities);
+        this.selectedAgentCanSend = can(agent._capabilities, 'message');
+      }
+    } catch {
+      // On failure, fail-closed: disable send.
+      this.selectedAgentCanSend = false;
+    }
+  }
+
   /** Mark a thread as read when opened. */
   private async markThreadRead(agentId: string): Promise<void> {
     const projectId = await this.resolveProjectId();
@@ -373,6 +434,9 @@ export class ScionPageChat extends LitElement {
     this.selectedAgentName = thread.agentName || thread.agentSlug || thread.agentId;
     this.classList.add('thread-open');
     dispatchPageTitle(this, this.selectedAgentName, 'Chat');
+
+    // Fetch capabilities to gate the compose box (O3).
+    void this.fetchAgentCapabilities(thread.agentId);
 
     // Mark as read (AC19b — server-side watermark)
     void this.markThreadRead(thread.agentId);
@@ -449,7 +513,7 @@ export class ScionPageChat extends LitElement {
       <scion-chat-thread
         agentId=${this.selectedAgentId}
         agentName=${this.selectedAgentName}
-        ?canSend=${true}
+        ?canSend=${this.selectedAgentCanSend}
       ></scion-chat-thread>
     `;
   }

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -1,0 +1,498 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Chat page component for the top-level chat mode (Phase 5).
+ *
+ * Renders inside `<scion-chat-shell>` and provides:
+ * - Thread rail listing agents with last-message preview and unread dot
+ * - Selecting a thread opens the existing `<scion-chat-thread>` component
+ * - `/chat` shows the rail with no thread selected
+ * - `/chat/:agentId` opens the thread for that agent
+ *
+ * The thread rail reads from `GET /api/v1/chat/threads` which queries
+ * the `webchat_thread` table — no aggregate query (AC19a).
+ * Unread is a boolean (hasUnread), not a count — a dot is what the rail renders.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+import type { PageData } from '../../shared/types.js';
+import { apiFetch } from '../../client/api.js';
+import { navigateTo } from '../../client/main.js';
+import { dispatchPageTitle } from '../../client/page-title.js';
+import '../shared/chat/chat-thread.js';
+
+/** Shape of a thread entry from GET /api/v1/chat/threads */
+interface ChatThread {
+  agentId: string;
+  agentSlug: string;
+  agentName: string;
+  phase: string;
+  activity: string;
+  lastMessage?: {
+    msg: string;
+    sender: string;
+    createdAt: string;
+    type: string;
+  };
+  hasUnread: boolean;
+}
+
+@customElement('scion-page-chat')
+export class ScionPageChat extends LitElement {
+  @property({ type: Object })
+  pageData: PageData | null = null;
+
+  @state() private threads: ChatThread[] = [];
+  @state() private loadingThreads = false;
+  @state() private selectedAgentId = '';
+  @state() private selectedAgentName = '';
+
+  static override styles = css`
+    :host {
+      display: flex;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    /* Thread rail (left sidebar) */
+    .thread-rail {
+      width: 300px;
+      min-width: 240px;
+      max-width: 360px;
+      border-right: 1px solid var(--scion-border, #e2e8f0);
+      background: var(--scion-surface, #ffffff);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .rail-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      font-weight: 600;
+      font-size: 0.875rem;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .rail-header a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--scion-primary, #3b82f6);
+      text-decoration: none;
+      cursor: pointer;
+    }
+
+    .rail-header a:hover {
+      text-decoration: underline;
+    }
+
+    .thread-list {
+      flex: 1;
+      overflow-y: auto;
+      padding: 0.25rem 0;
+    }
+
+    /* Individual thread item */
+    .thread-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.625rem;
+      padding: 0.625rem 1rem;
+      cursor: pointer;
+      transition: background 0.1s;
+      border-left: 3px solid transparent;
+      position: relative;
+    }
+
+    .thread-item:hover {
+      background: var(--scion-bg-subtle, #f1f5f9);
+    }
+
+    .thread-item.selected {
+      background: var(--scion-primary-50, #eff6ff);
+      border-left-color: var(--scion-primary, #3b82f6);
+    }
+
+    /* Agent avatar (color + initials) */
+    .agent-avatar {
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: #fff;
+      flex-shrink: 0;
+      text-transform: uppercase;
+    }
+
+    .thread-info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .thread-name {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      font-size: 0.8125rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .thread-name .unread-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--scion-primary, #3b82f6);
+      flex-shrink: 0;
+    }
+
+    .thread-preview {
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin-top: 0.125rem;
+    }
+
+    .thread-time {
+      font-size: 0.6875rem;
+      color: var(--scion-text-muted, #64748b);
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    /* Main content area (thread view or empty state) */
+    .thread-content {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      overflow: hidden;
+    }
+
+    .empty-state {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      color: var(--scion-text-muted, #64748b);
+      gap: 0.75rem;
+      padding: 2rem;
+    }
+
+    .empty-state sl-icon {
+      font-size: 2.5rem;
+      opacity: 0.3;
+    }
+
+    .empty-state .title {
+      font-size: 1rem;
+      font-weight: 500;
+    }
+
+    .empty-state .subtitle {
+      font-size: 0.875rem;
+    }
+
+    /* Loading state */
+    .loading-rail {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    /* Responsive: on mobile, hide the rail when a thread is selected */
+    @media (max-width: 768px) {
+      .thread-rail {
+        width: 100%;
+        max-width: none;
+      }
+
+      :host(.thread-open) .thread-rail {
+        display: none;
+      }
+
+      :host(:not(.thread-open)) .thread-content {
+        display: none;
+      }
+    }
+  `;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.parseRoute();
+    void this.loadThreads();
+  }
+
+  override updated(changedProperties: Map<string, unknown>): void {
+    if (changedProperties.has('pageData') && this.pageData) {
+      this.parseRoute();
+    }
+  }
+
+  /** Parse the current path to determine selected agent. */
+  private parseRoute(): void {
+    const path = this.pageData?.path || window.location.pathname;
+    const match = path.match(/\/chat\/([^/]+)/);
+    const newAgentId = match ? decodeURIComponent(match[1]) : '';
+
+    if (newAgentId !== this.selectedAgentId) {
+      this.selectedAgentId = newAgentId;
+      // Update class for responsive layout
+      if (newAgentId) {
+        this.classList.add('thread-open');
+      } else {
+        this.classList.remove('thread-open');
+      }
+    }
+  }
+
+  /** Load thread list from the API. */
+  private async loadThreads(): Promise<void> {
+    this.loadingThreads = true;
+
+    try {
+      // Use the first project the user has access to.
+      // The projectId must be determined from context. For now,
+      // look at the SSR page data or fetch the projects list.
+      const projectId = await this.resolveProjectId();
+      if (!projectId) {
+        this.loadingThreads = false;
+        return;
+      }
+
+      const res = await apiFetch(
+        `/api/v1/chat/threads?projectId=${encodeURIComponent(projectId)}&limit=50`
+      );
+
+      if (res.ok) {
+        const data = (await res.json()) as { threads: ChatThread[] };
+        this.threads = data.threads || [];
+
+        // If a thread is selected, try to find its name
+        if (this.selectedAgentId) {
+          this.resolveSelectedAgentName();
+        }
+      }
+    } catch {
+      // Silently fail — rail will show empty
+    } finally {
+      this.loadingThreads = false;
+    }
+  }
+
+  /** Resolve the project ID from page context. */
+  private async resolveProjectId(): Promise<string> {
+    // Try to get from URL query param
+    const url = new URL(window.location.href);
+    const qProject = url.searchParams.get('projectId');
+    if (qProject) return qProject;
+
+    // Fall back to fetching the user's projects and using the first one
+    try {
+      const res = await apiFetch('/api/v1/projects?limit=1');
+      if (res.ok) {
+        const data = (await res.json()) as { items?: { id: string }[] };
+        if (data.items && data.items.length > 0) {
+          return data.items[0].id;
+        }
+      }
+    } catch {
+      // ignore
+    }
+
+    return '';
+  }
+
+  /** Update selectedAgentName from the thread list or API. */
+  private resolveSelectedAgentName(): void {
+    const thread = this.threads.find(
+      (t) => t.agentId === this.selectedAgentId || t.agentSlug === this.selectedAgentId
+    );
+    if (thread) {
+      this.selectedAgentName = thread.agentName || thread.agentSlug || thread.agentId;
+      dispatchPageTitle(this, this.selectedAgentName, 'Chat');
+    }
+  }
+
+  /** Mark a thread as read when opened. */
+  private async markThreadRead(agentId: string): Promise<void> {
+    const projectId = await this.resolveProjectId();
+    if (!projectId) return;
+
+    try {
+      await apiFetch(
+        `/api/v1/chat/threads/${encodeURIComponent(agentId)}/read?projectId=${encodeURIComponent(projectId)}`,
+        { method: 'POST' }
+      );
+
+      // Clear the unread indicator locally
+      this.threads = this.threads.map((t) =>
+        t.agentId === agentId ? { ...t, hasUnread: false } : t
+      );
+    } catch {
+      // Non-critical — unread dot will persist until next load
+    }
+  }
+
+  /** Handle thread selection from the rail. */
+  private selectThread(thread: ChatThread): void {
+    const agentRef = thread.agentSlug || thread.agentId;
+    navigateTo(`/chat/${encodeURIComponent(agentRef)}`);
+    this.selectedAgentId = thread.agentId;
+    this.selectedAgentName = thread.agentName || thread.agentSlug || thread.agentId;
+    this.classList.add('thread-open');
+    dispatchPageTitle(this, this.selectedAgentName, 'Chat');
+
+    // Mark as read (AC19b — server-side watermark)
+    void this.markThreadRead(thread.agentId);
+  }
+
+  override render() {
+    return html`
+      <div class="thread-rail">
+        <div class="rail-header">
+          <span>Conversations</span>
+          <a href="/" @click=${(e: Event) => { e.preventDefault(); navigateTo('/'); }}>
+            <sl-icon name="arrow-left"></sl-icon>
+            App
+          </a>
+        </div>
+        <div class="thread-list">
+          ${this.loadingThreads
+            ? html`<div class="loading-rail"><sl-spinner></sl-spinner></div>`
+            : this.threads.length === 0
+              ? html`<div class="loading-rail" style="font-size: 0.8125rem">No conversations yet</div>`
+              : this.threads.map((t) => this.renderThreadItem(t))}
+        </div>
+      </div>
+
+      <div class="thread-content">
+        ${this.selectedAgentId
+          ? this.renderSelectedThread()
+          : html`
+              <div class="empty-state">
+                <sl-icon name="chat-dots"></sl-icon>
+                <span class="title">Select a conversation</span>
+                <span class="subtitle">Choose an agent from the left to start chatting</span>
+              </div>
+            `}
+      </div>
+    `;
+  }
+
+  private renderThreadItem(thread: ChatThread) {
+    const isSelected =
+      thread.agentId === this.selectedAgentId ||
+      thread.agentSlug === this.selectedAgentId;
+    const displayName = thread.agentName || thread.agentSlug || thread.agentId;
+    const avatarColor = this.hashColor(thread.agentSlug || thread.agentId);
+    const initials = this.getInitials(displayName);
+    const timeStr = thread.lastMessage?.createdAt
+      ? this.formatRelativeTime(thread.lastMessage.createdAt)
+      : '';
+
+    return html`
+      <div
+        class="thread-item ${isSelected ? 'selected' : ''}"
+        @click=${() => this.selectThread(thread)}
+      >
+        <div class="agent-avatar" style="background: ${avatarColor}">
+          ${initials}
+        </div>
+        <div class="thread-info">
+          <div class="thread-name">
+            <span>${displayName}</span>
+            ${thread.hasUnread ? html`<span class="unread-dot"></span>` : nothing}
+          </div>
+          ${thread.lastMessage
+            ? html`<div class="thread-preview">${thread.lastMessage.msg}</div>`
+            : nothing}
+        </div>
+        ${timeStr ? html`<span class="thread-time">${timeStr}</span>` : nothing}
+      </div>
+    `;
+  }
+
+  private renderSelectedThread() {
+    return html`
+      <scion-chat-thread
+        agentId=${this.selectedAgentId}
+        agentName=${this.selectedAgentName}
+        ?canSend=${true}
+      ></scion-chat-thread>
+    `;
+  }
+
+  /** Generate a deterministic color from a string (agent slug). */
+  private hashColor(str: string): string {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      hash = str.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    const hue = ((hash % 360) + 360) % 360;
+    return `hsl(${hue}, 55%, 48%)`;
+  }
+
+  /** Get 1-2 character initials from a name. */
+  private getInitials(name: string): string {
+    const parts = name.split(/[-_\s]+/).filter(Boolean);
+    if (parts.length >= 2) {
+      return (parts[0][0] + parts[1][0]).toUpperCase();
+    }
+    return (name.slice(0, 2) || '?').toUpperCase();
+  }
+
+  /** Format a timestamp as a relative time string. */
+  private formatRelativeTime(iso: string): string {
+    const d = new Date(iso);
+    const now = Date.now();
+    const diffMs = now - d.getTime();
+    const diffMin = Math.floor(diffMs / 60000);
+
+    if (diffMin < 1) return 'now';
+    if (diffMin < 60) return `${diffMin}m`;
+    const diffHrs = Math.floor(diffMin / 60);
+    if (diffHrs < 24) return `${diffHrs}h`;
+    const diffDays = Math.floor(diffHrs / 24);
+    if (diffDays < 7) return `${diffDays}d`;
+
+    return d.toLocaleDateString('en', { month: 'short', day: 'numeric' });
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-page-chat': ScionPageChat;
+  }
+}

--- a/web/src/components/profile/profile-shell.ts
+++ b/web/src/components/profile/profile-shell.ts
@@ -29,6 +29,7 @@ import '../shared/header.js';
 import '../shared/debug-panel.js';
 
 import type { User } from '../../shared/types.js';
+import { performLogout } from '../../utils/auth.js';
 import { setDocumentTitle } from '../../client/page-title.js';
 
 const PROFILE_TITLES: Record<string, string> = {
@@ -213,20 +214,10 @@ export class ScionProfileShell extends LitElement {
 
   /**
    * Handle logout action.
-   * Uses the Vite BASE_URL to construct correct paths behind a reverse proxy.
+   * Delegates to shared performLogout() utility (design doc Section 4.1).
    */
   private handleLogout(): void {
-    const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
-    fetch(`${base}/auth/logout`, {
-      method: 'POST',
-      credentials: 'include',
-    })
-      .then(() => {
-        window.location.href = `${base}/auth/login`;
-      })
-      .catch((error) => {
-        console.error('Logout failed:', error);
-      });
+    performLogout();
   }
 }
 

--- a/web/src/components/profile/profile-shell.ts
+++ b/web/src/components/profile/profile-shell.ts
@@ -211,13 +211,18 @@ export class ScionProfileShell extends LitElement {
     this._drawerOpen = false;
   }
 
+  /**
+   * Handle logout action.
+   * Uses the Vite BASE_URL to construct correct paths behind a reverse proxy.
+   */
   private handleLogout(): void {
-    fetch('/auth/logout', {
+    const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
+    fetch(`${base}/auth/logout`, {
       method: 'POST',
       credentials: 'include',
     })
       .then(() => {
-        window.location.href = '/auth/login';
+        window.location.href = `${base}/auth/login`;
       })
       .catch((error) => {
         console.error('Logout failed:', error);

--- a/web/src/utils/auth.ts
+++ b/web/src/utils/auth.ts
@@ -26,7 +26,7 @@
  * Uses the Vite BASE_URL to construct correct paths behind a reverse proxy.
  */
 export function performLogout(): void {
-  const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
+  const base = (import.meta.env?.BASE_URL || '/').replace(/\/$/, '');
   fetch(`${base}/auth/logout`, {
     method: 'POST',
     credentials: 'include',

--- a/web/src/utils/auth.ts
+++ b/web/src/utils/auth.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared authentication utilities.
+ *
+ * Extracted from the individual shell components so all shells use the same
+ * logout logic (design doc Section 4.1: "fix in place and share").
+ */
+
+/**
+ * Perform a logout by POSTing to the auth endpoint and redirecting to login.
+ * Uses the Vite BASE_URL to construct correct paths behind a reverse proxy.
+ */
+export function performLogout(): void {
+  const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
+  fetch(`${base}/auth/logout`, {
+    method: 'POST',
+    credentials: 'include',
+  })
+    .then(() => {
+      window.location.href = `${base}/auth/login`;
+    })
+    .catch((error) => {
+      console.error('Logout failed:', error);
+    });
+}

--- a/web/src/utils/feature-flags.ts
+++ b/web/src/utils/feature-flags.ts
@@ -31,6 +31,14 @@ declare global {
 }
 
 /**
+ * Feature flags that are ON by default (Phase 5+).
+ * These can still be disabled via server injection or localStorage override.
+ */
+const DEFAULT_ON_FLAGS = new Set([
+  'web.native_chat',
+]);
+
+/**
  * Check whether a feature flag is enabled.
  *
  * @param name - Dot-separated flag name (e.g. "web.native_chat")
@@ -54,6 +62,6 @@ export function isFeatureEnabled(name: string): boolean {
     }
   }
 
-  // Default: off
-  return false;
+  // Default: on for flags in DEFAULT_ON_FLAGS, off otherwise
+  return DEFAULT_ON_FLAGS.has(name);
 }


### PR DESCRIPTION
## Summary
- Chat ShellType with thread rail, unread dots, SSE refresh
- GET /api/v1/chat/threads (no aggregation), POST read watermark
- Batch queries, shared logout, global error handler
- Flag flipped ON, routes gated, canSend from capabilities
- No-reload mode switch, deep-link, access-denied toast

## Test plan
- AC19-AC20, AC19a-f per design doc