### PR TITLE
feat(web-chat): cross-channel coherence — broker inbound persistence + reply affinity (Phase 6)

### DIFF
--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -144,6 +144,21 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Reply affinity (Phase 6, AC22): when the agent sends an untagged reply
+	// (no explicit channel), check webchat_conversation_context for the
+	// (recipient, project, agent) triple. If a row exists, route to the
+	// channel the user last spoke from. If no row exists, leave channel
+	// empty so the message fans out to all spokes (today's default behavior).
+	if req.Channel == "" && recipientID != "" && s.webChatStore != nil {
+		if lastCh, err := s.webChatStore.GetLastChannel(ctx, recipientID, agent.ProjectID, agent.ID); err != nil {
+			s.messageLog.Error("Failed to look up reply affinity",
+				"recipient_id", recipientID, "agent_id", agent.ID, "error", err)
+			// Non-fatal: fall through to fan-out-to-all behavior.
+		} else if lastCh != "" {
+			req.Channel = lastCh
+		}
+	}
+
 	// Validate channel against registered channels.
 	// Fail closed: if broker proxy is unavailable, reject the message rather than
 	// silently skipping validation.

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -149,7 +149,7 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 	// (recipient, project, agent) triple. If a row exists, route to the
 	// channel the user last spoke from. If no row exists, leave channel
 	// empty so the message fans out to all spokes (today's default behavior).
-	if req.Channel == "" && recipientID != "" && s.webChatStore != nil {
+	if req.Channel == "" && recipientID != "" && s.webChatStore != nil && s.GetMessageBrokerProxy() != nil {
 		if lastCh, err := s.webChatStore.GetLastChannel(ctx, recipientID, agent.ProjectID, agent.ID); err != nil {
 			s.messageLog.Error("Failed to look up reply affinity",
 				"recipient_id", recipientID, "agent_id", agent.ID, "error", err)

--- a/pkg/hub/handlers_broker_inbound.go
+++ b/pkg/hub/handlers_broker_inbound.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -204,6 +205,62 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 		"sender", req.Message.Sender,
 		"type", req.Message.Type,
 	)
+
+	// F5 fix (Phase 6): Persist the inbound message and publish an SSE event
+	// so that messages from external channels (Discord, Telegram) appear in
+	// the web chat — both live and after a refresh. This mirrors the
+	// persistence + SSE pattern used by handleAgentMessage.
+	now := time.Now()
+	storeMsg := &store.Message{
+		ID:            api.NewUUID(),
+		ProjectID:     agent.ProjectID,
+		Sender:        req.Message.Sender,
+		SenderID:      req.Message.SenderID,
+		Recipient:     "agent:" + agent.Slug,
+		RecipientID:   agent.ID,
+		Msg:           req.Message.Msg,
+		Type:          req.Message.Type,
+		Urgent:        req.Message.Urgent,
+		AgentID:       agent.ID,
+		Channel:       req.Message.Channel,
+		ThreadID:      req.Message.ThreadID,
+		Visibility:    req.Message.Visibility,
+		DispatchState: store.MessageDispatchDispatched,
+		CreatedAt:     now,
+	}
+	if req.Message.Metadata != nil {
+		if gid, ok := req.Message.Metadata["group_id"]; ok {
+			storeMsg.GroupID = gid
+		}
+	}
+	if err := s.store.CreateMessage(r.Context(), storeMsg); err != nil {
+		log.Error("Failed to persist inbound broker message", "error", err)
+		// Non-fatal: the dispatch already succeeded, so the agent got the
+		// message. Failing the HTTP response here would mislead the caller
+		// into retrying — which would double-deliver.
+	} else {
+		s.events.PublishUserMessage(r.Context(), storeMsg)
+	}
+
+	// Record reply-affinity context so that the agent's next untagged reply
+	// can be routed back to the channel the user last spoke from (AC22).
+	// Only record for user-identity senders with a known channel.
+	if s.webChatStore != nil && req.Message.Channel != "" && strings.HasPrefix(req.Message.Sender, "user:") {
+		senderUserID := req.Message.SenderID
+		if senderUserID == "" {
+			// Try to resolve from the email we already validated above.
+			senderEmail := strings.TrimPrefix(req.Message.Sender, "user:")
+			if u, err := s.store.GetUserByEmail(r.Context(), senderEmail); err == nil {
+				senderUserID = u.ID
+			}
+		}
+		if senderUserID != "" {
+			if err := s.webChatStore.RecordChannel(r.Context(), senderUserID, agent.ProjectID, agent.ID, req.Message.Channel, now); err != nil {
+				log.Error("Failed to record conversation context for broker inbound",
+					"user_id", senderUserID, "agent_id", agent.ID, "channel", req.Message.Channel, "error", err)
+			}
+		}
+	}
 
 	// Log to dedicated message audit log
 	if s.dedicatedMessageLog != nil {

--- a/pkg/hub/handlers_broker_inbound.go
+++ b/pkg/hub/handlers_broker_inbound.go
@@ -211,6 +211,19 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 		"type", req.Message.Type,
 	)
 
+	// Resolve the sender's user ID before persisting the message. The
+	// upstream permission check already did a user lookup for "user:" senders,
+	// but req.Message.SenderID may still be empty if the originating plugin
+	// didn't populate it.  Resolving early guarantees that both the persisted
+	// storeMsg and the webChatStore calls below use a valid ID.
+	senderUserID := req.Message.SenderID
+	if senderUserID == "" && strings.HasPrefix(req.Message.Sender, "user:") {
+		senderEmail := strings.TrimPrefix(req.Message.Sender, "user:")
+		if u, err := s.store.GetUserByEmail(r.Context(), senderEmail); err == nil {
+			senderUserID = u.ID
+		}
+	}
+
 	// F5 fix (Phase 6): Persist the inbound message and publish an SSE event
 	// so that messages from external channels (Discord, Telegram) appear in
 	// the web chat — both live and after a refresh. This mirrors the
@@ -219,7 +232,7 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 		ID:            api.NewUUID(),
 		ProjectID:     agent.ProjectID,
 		Sender:        req.Message.Sender,
-		SenderID:      req.Message.SenderID,
+		SenderID:      senderUserID,
 		Recipient:     "agent:" + agent.Slug,
 		RecipientID:   agent.ID,
 		Msg:           req.Message.Msg,
@@ -251,14 +264,6 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 	// can be routed back to the channel the user last spoke from (AC22).
 	// Only record for user-identity senders with a known channel.
 	if s.webChatStore != nil && req.Message.Channel != "" && strings.HasPrefix(req.Message.Sender, "user:") {
-		senderUserID := req.Message.SenderID
-		if senderUserID == "" {
-			// Try to resolve from the email we already validated above.
-			senderEmail := strings.TrimPrefix(req.Message.Sender, "user:")
-			if u, err := s.store.GetUserByEmail(r.Context(), senderEmail); err == nil {
-				senderUserID = u.ID
-			}
-		}
 		if senderUserID != "" {
 			if err := s.webChatStore.RecordChannel(r.Context(), senderUserID, agent.ProjectID, agent.ID, req.Message.Channel, now); err != nil {
 				log.Error("Failed to record conversation context for broker inbound",

--- a/pkg/hub/handlers_broker_inbound.go
+++ b/pkg/hub/handlers_broker_inbound.go
@@ -184,6 +184,11 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Capture arrival time before dispatch so the persisted CreatedAt reflects
+	// when the hub received the message, not when dispatch completed (which can
+	// be up to 30s later under retry).
+	now := time.Now().UTC()
+
 	retryCtx, retryCancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer retryCancel()
 
@@ -210,7 +215,6 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 	// so that messages from external channels (Discord, Telegram) appear in
 	// the web chat — both live and after a refresh. This mirrors the
 	// persistence + SSE pattern used by handleAgentMessage.
-	now := time.Now()
 	storeMsg := &store.Message{
 		ID:            api.NewUUID(),
 		ProjectID:     agent.ProjectID,
@@ -225,6 +229,7 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 		Channel:       req.Message.Channel,
 		ThreadID:      req.Message.ThreadID,
 		Visibility:    req.Message.Visibility,
+		Broadcasted:   req.Message.Broadcasted,
 		DispatchState: store.MessageDispatchDispatched,
 		CreatedAt:     now,
 	}
@@ -258,6 +263,12 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 			if err := s.webChatStore.RecordChannel(r.Context(), senderUserID, agent.ProjectID, agent.ID, req.Message.Channel, now); err != nil {
 				log.Error("Failed to record conversation context for broker inbound",
 					"user_id", senderUserID, "agent_id", agent.ID, "channel", req.Message.Channel, "error", err)
+			}
+			// Update the thread watermark so the Phase 5 thread rail reflects
+			// inbound broker messages (last_activity_at / last_message_id).
+			if err := s.webChatStore.TouchThread(r.Context(), senderUserID, agent.ProjectID, agent.ID, storeMsg.ID, now); err != nil {
+				log.Error("Failed to update thread watermark for broker inbound",
+					"user_id", senderUserID, "agent_id", agent.ID, "error", err)
 			}
 		}
 	}

--- a/pkg/hub/webchannel.go
+++ b/pkg/hub/webchannel.go
@@ -146,12 +146,14 @@ func identityFromTopic(topic string, msg *messages.StructuredMessage) (userID, p
 		}
 	case projectcompat.TopicKindAgent:
 		// User → agent message: topic has the agent slug, recipient is the agent.
-		// NOTE(O1): agentID here is the slug from the topic, whereas for
-		// TopicKindUser above it is msg.SenderID (a UUID). This inconsistency
-		// must be normalized to a single identifier form before Phase 6 to
-		// avoid duplicate webchat_thread rows for the same conversation. See
-		// review nc-p1-rev-2 O1.
-		agentID = parsed.Actor
+		// Phase 6 fix (O1): prefer msg.RecipientID (UUID) over the slug from
+		// the topic so that both directions use the same identifier form
+		// and webchat_thread / webchat_conversation_context rows are not
+		// duplicated for the same conversation.
+		agentID = msg.RecipientID
+		if agentID == "" {
+			agentID = parsed.Actor // fallback to slug when RecipientID is absent
+		}
 		if strings.HasPrefix(msg.Sender, "user:") {
 			userID = msg.SenderID
 		}

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -51,6 +51,12 @@ type WebChatStore interface {
 	// untagged replies back to the channel the user last spoke from.
 	RecordChannel(ctx context.Context, userID, projectID, agentID, channel string, messageAt time.Time) error
 
+	// GetLastChannel returns the last channel recorded for (user, project, agent),
+	// or "" if no row exists. Used for reply affinity: when an agent sends an
+	// untagged reply, the hub checks here to route to the channel the user last
+	// spoke from.
+	GetLastChannel(ctx context.Context, userID, projectID, agentID string) (string, error)
+
 	// GetThreadPrefs returns the display preferences for a (user, project, agent) thread.
 	// Returns default prefs (visibility_mode = "conversation") if no row exists.
 	GetThreadPrefs(ctx context.Context, userID, projectID, agentID string) (ThreadPrefs, error)
@@ -158,6 +164,20 @@ DO UPDATE SET
 		return fmt.Errorf("webchat store: record channel: %w", err)
 	}
 	return nil
+}
+
+// GetLastChannel returns the last channel for (user, project, agent), or "" if no row exists.
+func (s *sqliteWebChatStore) GetLastChannel(ctx context.Context, userID, projectID, agentID string) (string, error) {
+	const query = `SELECT last_channel FROM webchat_conversation_context WHERE user_id = ? AND project_id = ? AND agent_id = ?`
+	var channel sql.NullString
+	err := s.db.QueryRowContext(ctx, query, userID, projectID, agentID).Scan(&channel)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil
+		}
+		return "", fmt.Errorf("webchat store: get last channel: %w", err)
+	}
+	return channel.String, nil
 }
 
 // GetThreadPrefs returns the display preferences for the given (user, project, agent) triple.

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -103,6 +103,20 @@ DO UPDATE SET
 	return nil
 }
 
+// GetLastChannel returns the last channel for (user, project, agent), or "" if no row exists.
+func (s *pgWebChatStore) GetLastChannel(ctx context.Context, userID, projectID, agentID string) (string, error) {
+	const query = `SELECT last_channel FROM webchat_conversation_context WHERE user_id = $1 AND project_id = $2 AND agent_id = $3`
+	var channel sql.NullString
+	err := s.db.QueryRowContext(ctx, query, userID, projectID, agentID).Scan(&channel)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil
+		}
+		return "", fmt.Errorf("webchat store: get last channel: %w", err)
+	}
+	return channel.String, nil
+}
+
 // GetThreadPrefs returns the display preferences for the given (user, project, agent) triple.
 // Returns default prefs (visibility_mode = "conversation") if no row exists.
 func (s *pgWebChatStore) GetThreadPrefs(ctx context.Context, userID, projectID, agentID string) (ThreadPrefs, error) {

--- a/pkg/hub/webchannel_test.go
+++ b/pkg/hub/webchannel_test.go
@@ -306,12 +306,14 @@ func TestWebChannelBus_Publish_AgentTopic(t *testing.T) {
 	err := bus.Publish(ctx, topic, msg)
 	require.NoError(t, err)
 
-	// For an agent topic, the agent slug comes from the topic, the user from SenderID.
+	// Phase 6 (O1 fix): for an agent topic, agentID is msg.RecipientID (UUID)
+	// when available, not the slug from the topic. This normalizes both
+	// directions to the same identifier form and prevents duplicate rows.
 	var userID, agentID string
 	err = db.QueryRow(`SELECT user_id, agent_id FROM webchat_thread`).Scan(&userID, &agentID)
 	require.NoError(t, err)
 	require.Equal(t, "alice-uuid", userID)
-	require.Equal(t, "coder", agentID)
+	require.Equal(t, "coder-uuid", agentID)
 }
 
 func TestWebChannelBus_Close(t *testing.T) {


### PR DESCRIPTION
## Summary
- F5 fix: broker inbound persists + publishes SSE (AC21)
- Reply affinity per (user, project, agent) (AC22)
- TouchThread for rail, Broadcasted propagation

## Test plan
- AC21: Discord msg appears in web chat live
- AC22: Per-conversation affinity, default fan-out preserved