### PR TITLE
fix(teams): normalize conversation IDs for channel link persistence and add default to manifest

### DIFF
--- a/extras/scion-teams/internal/teams/callbacks.go
+++ b/extras/scion-teams/internal/teams/callbacks.go
@@ -259,7 +259,11 @@ func (h *CallbackHandler) handleSetupConfirm(ctx context.Context, activity *Acti
 	convID := stripThreadSuffix(activity.Conversation.ID)
 
 	// Check if already linked.
-	existing, _ := store.GetChannelLink(ctx, convID)
+	existing, err := store.GetChannelLink(ctx, convID)
+	if err != nil {
+		h.log.Error("Failed to check existing channel link", "error", err)
+		return h.respondWithUpdatedCard(activity, "An error occurred while checking existing link."), nil
+	}
 	if existing != nil {
 		return h.respondWithUpdatedCard(activity,
 			fmt.Sprintf("This conversation is already linked to project **%s**.", existing.ProjectSlug)), nil

--- a/extras/scion-teams/internal/teams/callbacks.go
+++ b/extras/scion-teams/internal/teams/callbacks.go
@@ -255,8 +255,11 @@ func (h *CallbackHandler) handleSetupConfirm(ctx context.Context, activity *Acti
 		return h.respondWithUpdatedCard(activity, "Store not initialized."), nil
 	}
 
+	// Normalize conversation ID — strip thread suffix for consistent lookups.
+	convID := stripThreadSuffix(activity.Conversation.ID)
+
 	// Check if already linked.
-	existing, _ := store.GetChannelLink(ctx, activity.Conversation.ID)
+	existing, _ := store.GetChannelLink(ctx, convID)
 	if existing != nil {
 		return h.respondWithUpdatedCard(activity,
 			fmt.Sprintf("This conversation is already linked to project **%s**.", existing.ProjectSlug)), nil
@@ -282,7 +285,7 @@ func (h *CallbackHandler) handleSetupConfirm(ctx context.Context, activity *Acti
 	}
 
 	link := &ChannelLink{
-		ConversationID:     activity.Conversation.ID,
+		ConversationID:     convID,
 		TeamID:             teamID,
 		ProjectID:          projectID,
 		ProjectSlug:        projectSlug,

--- a/extras/scion-teams/internal/teams/commands.go
+++ b/extras/scion-teams/internal/teams/commands.go
@@ -117,7 +117,7 @@ func (h *CommandHandler) Handle(ctx context.Context, activity *Activity) (bool, 
 // handleSetup links a Teams conversation to a Scion project.
 // Usage: setup [project-slug]
 func (h *CommandHandler) handleSetup(ctx context.Context, activity *Activity, args []string) error {
-	conversationID := activity.Conversation.ID
+	conversationID := stripThreadSuffix(activity.Conversation.ID)
 
 	// Check if already linked.
 	store := h.getStore()
@@ -266,7 +266,7 @@ func (h *CommandHandler) completeSetup(ctx context.Context, activity *Activity, 
 	}
 
 	link := &ChannelLink{
-		ConversationID:     activity.Conversation.ID,
+		ConversationID:     stripThreadSuffix(activity.Conversation.ID),
 		TeamID:             teamID,
 		ProjectID:          projectID,
 		ProjectSlug:        projectSlug,
@@ -309,7 +309,7 @@ func (h *CommandHandler) handleUnlink(ctx context.Context, activity *Activity) e
 		return h.sendReply(ctx, activity, "Unlink failed: store not initialized.")
 	}
 
-	conversationID := activity.Conversation.ID
+	conversationID := stripThreadSuffix(activity.Conversation.ID)
 	link, err := store.GetChannelLink(ctx, conversationID)
 	if err != nil {
 		h.log.Warn("Error looking up channel link", "error", err)
@@ -866,7 +866,7 @@ func (h *CommandHandler) resolveChannelLink(ctx context.Context, activity *Activ
 		return nil, fmt.Errorf("store not initialized")
 	}
 
-	link, err := store.GetChannelLink(ctx, activity.Conversation.ID)
+	link, err := store.GetChannelLink(ctx, stripThreadSuffix(activity.Conversation.ID))
 	if err != nil {
 		h.log.Warn("Error looking up channel link", "error", err)
 		_ = h.sendReply(ctx, activity, "An error occurred. Please try again.")

--- a/extras/scion-teams/manifest/manifest.json.example
+++ b/extras/scion-teams/manifest/manifest.json.example
@@ -57,6 +57,10 @@
               "description": "Show project or agent status"
             },
             {
+              "title": "default",
+              "description": "Set or show the default agent for this channel"
+            },
+            {
               "title": "register",
               "description": "Link your Teams account to your Scion identity"
             },

--- a/pkg/hub/handlers_teams_manifest.go
+++ b/pkg/hub/handlers_teams_manifest.go
@@ -264,6 +264,7 @@ func buildTeamsManifest(appID string) teamsManifest {
 							{Title: "unlink", Description: "Unlink this channel from its project"},
 							{Title: "agents", Description: "List agents in the linked project"},
 							{Title: "status", Description: "Show project or agent status"},
+							{Title: "default", Description: "Set or show the default agent for this channel"},
 							{Title: "register", Description: "Link your Teams account to your Scion identity"},
 							{Title: "unregister", Description: "Unlink your Teams account from Scion"},
 							{Title: "help", Description: "Show available commands"},


### PR DESCRIPTION
## Summary

- Normalize conversation IDs via stripThreadSuffix() in all channel link storage and lookup operations (handleSetupConfirm, handleSetup, completeSetup, handleUnlink, resolveChannelLink)
- Add default command to the dynamic Teams manifest (buildTeamsManifest) and example manifest

## Root Cause

handleSetupConfirm stored the channel link with the raw activity.Conversation.ID, but handleMessage (inbound routing) and other commands looked it up using stripThreadSuffix(). When the invoke activity from an Adaptive Card button had a different conversation ID format, the link was stored under one key but looked up under another — resulting in channel not linked errors.

## Test plan

- [x] go test ./... -race passes (scion-teams)
- [x] go build ./pkg/hub/... clean (manifest change)
- [ ] Deploy, re-download manifest zip, re-upload to Teams Admin Center
- [ ] Verify setup card click persists channel link
- [ ] Verify status command shows linked project after setup
- [ ] Verify default command appears in Teams command picker