### PR TITLE
fix(antigravity): update model strings to current AGY CLI values

### DIFF
--- a/harnesses/antigravity/config.yaml
+++ b/harnesses/antigravity/config.yaml
@@ -31,10 +31,10 @@ env_template:
   SCION_AGENT_NAME: "{{ .AgentName }}"
 
 model_aliases:
-  small: "Gemini 3.5 Flash"
-  medium: "Gemini 3.5 Flash"
-  large: "Gemini 3.1 Pro"
-  extra-large: "Gemini 3.1 Pro"
+  small: "Gemini 3.1 Flash Lite"
+  medium: "Gemini 3.6 Flash (Medium)"
+  large: "Gemini 3.1 Pro (Low)"
+  extra-large: "Gemini 3.1 Pro (Low)"
 
 mcp:
   global_config_file: .gemini/config/mcp_config.json

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -31,8 +31,8 @@ assert scion_harness.INTERFACE_VERSION >= 2, (
 
 PROVISION_VERSION = "2026-07-09T01:00:00Z"
 
-FLASH_MODEL = "Gemini 3.5 Flash"
-PRO_MODEL = "Gemini 3.1 Pro"
+FLASH_MODEL = "Gemini 3.6 Flash (Medium)"
+PRO_MODEL = "Gemini 3.1 Pro (Low)"
 
 
 def _resolve_thinking_tier(level: int) -> str:


### PR DESCRIPTION
Update antigravity harness model strings to current AGY CLI model names. The previous strings (Gemini 3.5 Flash, Gemini 3.1 Pro) were invalid/stale.

Changes:
- provision.py: FLASH_MODEL -> "Gemini 3.6 Flash (Medium)", PRO_MODEL -> "Gemini 3.1 Pro (Low)"
- config.yaml model_aliases: small="Gemini 3.1 Flash Lite", medium="Gemini 3.6 Flash (Medium)", large/extra-large="Gemini 3.1 Pro (Low)"

Ref: ptone/scion#981
