### PR TITLE
fix(teams): bump manifest version to 1.1.0

### DIFF
--- a/extras/scion-teams/manifest/manifest.json.example
+++ b/extras/scion-teams/manifest/manifest.json.example
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.16/MicrosoftTeams.schema.json",
   "manifestVersion": "1.16",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "id": "<YOUR_APP_ID>",
   "developer": {
     "name": "Your Organization",

--- a/pkg/hub/handlers_teams_manifest.go
+++ b/pkg/hub/handlers_teams_manifest.go
@@ -229,7 +229,7 @@ func buildTeamsManifest(appID string) teamsManifest {
 	return teamsManifest{
 		Schema:          "https://developer.microsoft.com/json-schemas/teams/v1.16/MicrosoftTeams.schema.json",
 		ManifestVersion: "1.16",
-		Version:         "1.0.0",
+		Version:         "1.1.0",
 		ID:              appID,
 		Developer: teamsDevInfo{
 			Name:          "Scion",


### PR DESCRIPTION
## Summary

- Bump Teams app manifest version from 1.0.0 to 1.1.0
- Teams Admin Center rejects app updates when the version number hasn't changed

## Test plan

- [ ] Re-download manifest zip from admin UI, verify version is 1.1.0
- [ ] Upload to Teams Admin Center — should accept the update