### PR TITLE
fix(teams): correct inbound message Type, Channel, ThreadID, and Recipient fields

### DIFF
--- a/extras/scion-teams/internal/teams/activities.go
+++ b/extras/scion-teams/internal/teams/activities.go
@@ -80,7 +80,7 @@ func activityToStructuredMessage(activity *Activity, botID string) *messages.Str
 		Sender:    activity.From.Name,
 		SenderID:  senderID,
 		Msg:       text,
-		Type:      "chat",
+		Type:      messages.TypeInstruction,
 		Channel:   "", // Resolved later via channel links (Phase 3).
 		ThreadID:  resolveThreadID(activity),
 		Metadata:  metadata,

--- a/extras/scion-teams/internal/teams/activities_test.go
+++ b/extras/scion-teams/internal/teams/activities_test.go
@@ -52,7 +52,7 @@ func TestActivityToStructuredMessage_BasicFields(t *testing.T) {
 	assert.Equal(t, "Alice", msg.Sender)
 	assert.Equal(t, "aad-obj-123", msg.SenderID)
 	assert.Equal(t, "Hello from Teams!", msg.Msg)
-	assert.Equal(t, "chat", msg.Type)
+	assert.Equal(t, messages.TypeInstruction, msg.Type)
 
 	// Metadata checks.
 	assert.Equal(t, "conv-abc", msg.Metadata["teams_conversation_id"])

--- a/extras/scion-teams/internal/teams/broker.go
+++ b/extras/scion-teams/internal/teams/broker.go
@@ -809,8 +809,22 @@ func (b *TeamsBroker) handleMessage(ctx context.Context, activity *Activity) err
 		return nil
 	}
 
+	// Ensure Recipient is set when routing via the channel's default agent
+	// (no explicit @-mention).  This matches Discord's "agent:" + agentSlug.
+	if msg.Recipient == "" && agentSlug != "" {
+		msg.Recipient = "agent:" + agentSlug
+	}
+
 	// Populate Channel on the structured message so the hub can correlate.
-	msg.Channel = link.ProjectID
+	msg.Channel = "teams"
+
+	// Ensure ThreadID is set so the hub can route replies back to the
+	// correct Teams conversation.  resolveThreadID only sets it for
+	// thread replies (replyToId); for top-level messages we fall back to
+	// the normalized conversation ID, matching Discord's pattern.
+	if msg.ThreadID == "" {
+		msg.ThreadID = convID
+	}
 
 	topic := fmt.Sprintf("scion.project.%s.agent.%s.messages", link.ProjectID, agentSlug)
 	if err := b.hubClient.DeliverInbound(ctx, topic, msg); err != nil {

--- a/extras/scion-teams/internal/teams/broker.go
+++ b/extras/scion-teams/internal/teams/broker.go
@@ -736,30 +736,6 @@ func (b *TeamsBroker) handleMessage(ctx context.Context, activity *Activity) err
 		"conversation_id", activity.Conversation.ID,
 	)
 
-	// Update conversation context for routing replies back.
-	if msg.SenderID != "" && msg.Recipient != "" {
-		agentSlug := msg.Recipient
-		if strings.HasPrefix(agentSlug, "agent:") {
-			agentSlug = strings.TrimPrefix(agentSlug, "agent:")
-		}
-		projectID := msg.Channel
-		if projectID == "" && msg.Metadata != nil {
-			projectID = msg.Metadata["project_id"]
-		}
-		if projectID != "" {
-			// Fire-and-forget: error is logged inside SetConversationContext;
-			// a failure here should not block inbound message processing.
-			_ = b.SetConversationContext(&ConversationContext{
-				TeamsUserID:        msg.SenderID,
-				ProjectID:          projectID,
-				AgentSlug:          agentSlug,
-				LastConversationID: activity.Conversation.ID,
-				LastActivityID:     activity.ID,
-				LastMessageAt:      time.Now(),
-			})
-		}
-	}
-
 	if b.hubClient == nil {
 		b.log.Warn("Hub client not configured, message not delivered")
 		return nil
@@ -813,6 +789,20 @@ func (b *TeamsBroker) handleMessage(ctx context.Context, activity *Activity) err
 	// (no explicit @-mention).  This matches Discord's "agent:" + agentSlug.
 	if msg.Recipient == "" && agentSlug != "" {
 		msg.Recipient = "agent:" + agentSlug
+	}
+
+	// Update conversation context for routing replies back.
+	// Placed here (after link resolution) so link.ProjectID is available.
+	if msg.SenderID != "" {
+		ccSlug := agentSlug
+		_ = b.SetConversationContext(&ConversationContext{
+			TeamsUserID:        msg.SenderID,
+			ProjectID:          link.ProjectID,
+			AgentSlug:          ccSlug,
+			LastConversationID: activity.Conversation.ID,
+			LastActivityID:     activity.ID,
+			LastMessageAt:      time.Now(),
+		})
 	}
 
 	// Populate Channel on the structured message so the hub can correlate.


### PR DESCRIPTION
Fixes four bugs in the Teams inbound message path:

1. **Type** — was `"chat"`, now `messages.TypeInstruction` (`"instruction"`)
2. **Channel** — was set to project UUID, now `"teams"` (matches Discord pattern)
3. **ThreadID** — was empty for top-level channel messages, now falls back to normalized conversation ID
4. **Recipient** — was empty for default-agent routing, now set to `agent:<slug>`