### PR TITLE
fix(hub): resolve three eventbus fanout bugs

### DIFF
--- a/pkg/eventbus/fanout.go
+++ b/pkg/eventbus/fanout.go
@@ -29,6 +29,13 @@ const InProcessBusName = "inprocess"
 // NamedEventBus pairs an EventBus with a name and an observer flag.
 // Observer event buses are fire-and-forget: publish errors are logged but
 // not returned to the caller.
+//
+// Handler invocation contract: only the inprocess spoke invokes event
+// handlers. External spokes (plugin adapters, gRPC brokers) receive
+// subscription patterns so they can filter on the remote side, but they
+// discard the handler — inbound delivery happens via the hub API endpoint.
+// FanOutEventBus.Subscribe enforces this by passing nil to non-inprocess
+// spokes.
 type NamedEventBus struct {
 	Name     string
 	Bus      EventBus
@@ -66,7 +73,7 @@ func (f *FanOutEventBus) Publish(ctx context.Context, topic string, msg *message
 	copy(buses, f.buses)
 	f.mu.RUnlock()
 
-	if msg.Channel != "" {
+	if msg != nil && msg.Channel != "" {
 		if msg.Channel == InProcessBusName {
 			return fmt.Errorf("channel %q is reserved for internal use", InProcessBusName)
 		}
@@ -81,14 +88,12 @@ func (f *FanOutEventBus) Publish(ctx context.Context, topic string, msg *message
 			if channelKey == "" {
 				channelKey = buses[i].Name
 			}
-			if msg != nil && channelKey == msg.Channel {
+			if channelKey == msg.Channel {
 				target = &buses[i]
 			}
 		}
-		if target == nil {
-			return fmt.Errorf("no broker registered for channel %q", msg.Channel)
-		}
-
+		// Always publish to inproc first for persistence/SSE, even if the
+		// target channel spoke is missing.
 		var wg sync.WaitGroup
 		errs := make([]error, 2)
 		if inproc != nil {
@@ -100,19 +105,24 @@ func (f *FanOutEventBus) Publish(ctx context.Context, topic string, msg *message
 				}
 			}()
 		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if err := target.Bus.Publish(ctx, topic, msg); err != nil {
-				if target.Observer {
-					f.log.Error("channel publish failed (observer)",
-						"channel", msg.Channel, "topic", topic, "error", err)
-				} else {
-					errs[1] = fmt.Errorf("channel %q publish failed: %w", msg.Channel, err)
+		if target != nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := target.Bus.Publish(ctx, topic, msg); err != nil {
+					if target.Observer {
+						f.log.Error("channel publish failed (observer)",
+							"channel", msg.Channel, "topic", topic, "error", err)
+					} else {
+						errs[1] = fmt.Errorf("channel %q publish failed: %w", msg.Channel, err)
+					}
 				}
-			}
-		}()
+			}()
+		}
 		wg.Wait()
+		if target == nil {
+			return fmt.Errorf("no broker registered for channel %q", msg.Channel)
+		}
 		return errors.Join(errs...)
 	}
 
@@ -135,7 +145,11 @@ func (f *FanOutEventBus) Publish(ctx context.Context, topic string, msg *message
 	return errors.Join(errs...)
 }
 
-// Subscribe delegates to all child event buses.
+// Subscribe registers a handler for the given pattern across all spokes.
+// The handler is only installed on the inprocess spoke; external spokes
+// receive the pattern with a nil handler so they can set up remote-side
+// filtering without invoking callbacks locally. This prevents double
+// delivery and nil-handler panics on external spokes.
 func (f *FanOutEventBus) Subscribe(pattern string, handler EventHandler) (Subscription, error) {
 	f.mu.RLock()
 	buses := make([]NamedEventBus, len(f.buses))
@@ -144,7 +158,13 @@ func (f *FanOutEventBus) Subscribe(pattern string, handler EventHandler) (Subscr
 
 	subs := make([]Subscription, 0, len(buses))
 	for _, nb := range buses {
-		sub, err := nb.Bus.Subscribe(pattern, handler)
+		// Only the inprocess spoke invokes handlers. External spokes
+		// get the pattern for remote filtering but discard the handler.
+		h := handler
+		if nb.Name != InProcessBusName {
+			h = nil
+		}
+		sub, err := nb.Bus.Subscribe(pattern, h)
 		if err != nil {
 			f.log.Error("fan-out subscribe failed",
 				"bus", nb.Name, "pattern", pattern, "error", err)
@@ -253,7 +273,9 @@ func (f *FanOutEventBus) ReplaceSpoke(name string, newBus NamedEventBus) error {
 }
 
 // replaySubscriptions replays all existing subscriptions onto a spoke so it
-// receives the same event patterns as the other spokes.
+// receives the same event patterns as the other spokes. The handler is nil
+// because only the inprocess spoke invokes handlers — external spokes use
+// the pattern for remote-side filtering only.
 func (f *FanOutEventBus) replaySubscriptions(bus NamedEventBus) {
 	f.subMu.Lock()
 	subs := make([]string, len(f.subscriptions))

--- a/pkg/eventbus/fanout.go
+++ b/pkg/eventbus/fanout.go
@@ -121,7 +121,8 @@ func (f *FanOutEventBus) Publish(ctx context.Context, topic string, msg *message
 		}
 		wg.Wait()
 		if target == nil {
-			return fmt.Errorf("no broker registered for channel %q", msg.Channel)
+			errs[1] = fmt.Errorf("no broker registered for channel %q", msg.Channel)
+			return errors.Join(errs...)
 		}
 		return errors.Join(errs...)
 	}

--- a/pkg/eventbus/fanout.go
+++ b/pkg/eventbus/fanout.go
@@ -164,6 +164,8 @@ func (f *FanOutEventBus) Subscribe(pattern string, handler EventHandler) (Subscr
 		h := handler
 		if nb.Name != InProcessBusName {
 			h = nil
+		} else if h == nil {
+			continue
 		}
 		sub, err := nb.Bus.Subscribe(pattern, h)
 		if err != nil {
@@ -278,6 +280,9 @@ func (f *FanOutEventBus) ReplaceSpoke(name string, newBus NamedEventBus) error {
 // because only the inprocess spoke invokes handlers — external spokes use
 // the pattern for remote-side filtering only.
 func (f *FanOutEventBus) replaySubscriptions(bus NamedEventBus) {
+	if bus.Name == InProcessBusName {
+		return
+	}
 	f.subMu.Lock()
 	subs := make([]string, len(f.subscriptions))
 	copy(subs, f.subscriptions)

--- a/pkg/eventbus/fanout_test.go
+++ b/pkg/eventbus/fanout_test.go
@@ -318,10 +318,11 @@ func TestFanOutEventBus_ChannelRoutingUnmatchedChannel(t *testing.T) {
 		t.Fatalf("unexpected error message: %v", err)
 	}
 
-	// Unmatched channel fails fast — nothing is published.
+	// Even though the target channel is missing, inproc must still receive
+	// the message so it is persisted and streamed via SSE (bug #945 fix).
 	inproc.mu.Lock()
-	if len(inproc.published) != 0 {
-		t.Errorf("inprocess bus should not receive message on unmatched channel, got %d", len(inproc.published))
+	if len(inproc.published) != 1 {
+		t.Errorf("inprocess bus should receive message even on unmatched channel, got %d", len(inproc.published))
 	}
 	inproc.mu.Unlock()
 }
@@ -491,6 +492,128 @@ func TestFanOutEventBus_HasSpoke(t *testing.T) {
 	}
 	if fan.HasSpoke("") {
 		t.Error("expected HasSpoke('') = false")
+	}
+}
+
+// --- Bug fix tests ---
+
+func TestFanout_PublishNilMessageDoesNotPanic(t *testing.T) {
+	inproc := newStubEventBus()
+	external := newStubEventBus()
+
+	fan := NewFanOutEventBus([]NamedEventBus{
+		{Name: InProcessBusName, Bus: inproc},
+		{Name: "external", Bus: external},
+	}, slog.Default())
+
+	// A nil message must not panic (bug #946). The publish should fan out
+	// to all spokes because msg.Channel is effectively "".
+	if err := fan.Publish(context.Background(), "test.topic", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	inproc.mu.Lock()
+	if len(inproc.published) != 1 {
+		t.Errorf("inprocess bus: expected 1 message, got %d", len(inproc.published))
+	}
+	inproc.mu.Unlock()
+
+	external.mu.Lock()
+	if len(external.published) != 1 {
+		t.Errorf("external bus: expected 1 message, got %d", len(external.published))
+	}
+	external.mu.Unlock()
+}
+
+func TestFanout_ChannelMissingStillPersistsToInproc(t *testing.T) {
+	inproc := newStubEventBus()
+
+	fan := NewFanOutEventBus([]NamedEventBus{
+		{Name: InProcessBusName, Bus: inproc},
+	}, slog.Default())
+
+	msg := messages.NewInstruction("user:alice", "agent:bot", "hello")
+	msg.Channel = "nonexistent"
+
+	err := fan.Publish(context.Background(), "test.topic", msg)
+	if err == nil {
+		t.Fatal("expected error for missing channel spoke")
+	}
+	if !strings.Contains(err.Error(), "no broker registered for channel") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Bug #945: inproc must receive the message for persistence/SSE
+	// even when the target channel spoke is not registered.
+	inproc.mu.Lock()
+	if len(inproc.published) != 1 {
+		t.Errorf("inprocess bus should still receive message, got %d", len(inproc.published))
+	}
+	inproc.mu.Unlock()
+}
+
+func TestFanout_SubscribeOnlyInvokesHandlerOnInprocess(t *testing.T) {
+	inproc := newStubEventBus()
+	external := newStubEventBus()
+
+	// Track what handler each spoke received.
+	var inprocHandler, externalHandler EventHandler
+	inproc.subscribeFunc = func(pattern string, handler EventHandler) (Subscription, error) {
+		inprocHandler = handler
+		return &stubSubscription{}, nil
+	}
+	external.subscribeFunc = func(pattern string, handler EventHandler) (Subscription, error) {
+		externalHandler = handler
+		return &stubSubscription{}, nil
+	}
+
+	fan := NewFanOutEventBus([]NamedEventBus{
+		{Name: InProcessBusName, Bus: inproc},
+		{Name: "external", Bus: external},
+	}, slog.Default())
+
+	realHandler := func(_ context.Context, _ string, _ *messages.StructuredMessage) {}
+	if _, err := fan.Subscribe("test.>", realHandler); err != nil {
+		t.Fatalf("subscribe failed: %v", err)
+	}
+
+	// Bug #944: The inprocess spoke must receive the real handler.
+	if inprocHandler == nil {
+		t.Error("inprocess spoke should have received a non-nil handler")
+	}
+
+	// Bug #944: External spokes must receive nil (pattern-only subscription).
+	if externalHandler != nil {
+		t.Error("external spoke should have received a nil handler (pattern-only)")
+	}
+}
+
+func TestFanout_ReplaySubscriptionsPassesNilHandler(t *testing.T) {
+	inproc := newStubEventBus()
+	fan := NewFanOutEventBus([]NamedEventBus{
+		{Name: InProcessBusName, Bus: inproc},
+	}, slog.Default())
+
+	// Subscribe to establish a pattern.
+	if _, err := fan.Subscribe("events.>", func(_ context.Context, _ string, _ *messages.StructuredMessage) {}); err != nil {
+		t.Fatalf("subscribe failed: %v", err)
+	}
+
+	// Add a new external spoke and verify it gets nil handler via replay.
+	newBus := newStubEventBus()
+	var replayedHandler EventHandler
+	newBus.subscribeFunc = func(pattern string, handler EventHandler) (Subscription, error) {
+		replayedHandler = handler
+		return &stubSubscription{}, nil
+	}
+
+	if err := fan.AddSpoke(NamedEventBus{Name: "new-spoke", Bus: newBus}); err != nil {
+		t.Fatalf("AddSpoke failed: %v", err)
+	}
+
+	// replaySubscriptions should pass nil to external spokes.
+	if replayedHandler != nil {
+		t.Error("replayed subscription to external spoke should have nil handler")
 	}
 }
 


### PR DESCRIPTION
Fixes three related bugs in FanOutEventBus (pkg/eventbus/fanout.go), all discovered during native-chat architecture investigation:

1. **Nil message dereference (#946):** msg.Channel read before nil guard — added nil check
2. **Silent message loss (#945):** channel-targeted publish to missing spoke returned error before inproc publish, silently losing the message — restructured to always deliver to inproc first
3. **Handler contract violation (#944):** Subscribe fanned the same handler to every spoke, causing double delivery risk; replaySubscriptions passed nil handler, causing crash risk — Subscribe now only installs handler on inprocess spoke, matching replaySubscriptions behavior

Includes 4 new regression tests + 1 updated test. All 29 eventbus tests pass.

Fixes #944, #945, #946
Fork PR: https://github.com/ptone/scion/pull/988