### PR TITLE
fix(plugin): restart plugin process on hot-reconfigure to fix stale host callbacks

### DIFF
--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -78,6 +78,7 @@ type IntegrationManager interface {
 	GetDeploymentMode(pluginType, name string) plugin.DeploymentMode
 	ConfigureBroker(name string, extra map[string]string) error
 	ReplaceBrokerConfig(name string, cfg map[string]string) error
+	RestartBrokerPlugin(name string, cfg map[string]string) error
 	Reconnect(pluginType, name string) error
 	BrokerHealthCheck(name string) (status, message string, details map[string]string, err error)
 	BrokerInfo(name string) (version, channelID string, capabilities []string, err error)
@@ -663,20 +664,25 @@ func (s *Server) handleRestartIntegration(w http.ResponseWriter, r *http.Request
 	}
 	SettingsWriteMu.Unlock()
 
-	// reconfigureIntegration pushes new config to the running plugin process
-	// (via ReplaceBrokerConfig) without killing it, so the existing spoke's
-	// RPC connection remains valid — no refreshBrokerSpoke needed here.
-	// However the spoke may never have been added (e.g. first install before
-	// a full hub restart), so ensure it exists.
-	if err := s.reconfigureIntegration(r.Context(), mgr, name); err != nil {
+	// Resolve the latest config from file + secrets + hub wiring creds.
+	merged := s.resolveIntegrationMergedConfig(r.Context(), mgr, name)
+
+	// Full process restart: kill the old plugin process and start a new one
+	// with the resolved config. This ensures a fresh go-plugin handshake and
+	// new MuxBroker connections for host callbacks, fixing stale callback
+	// issues that arise when a plugin was initially started with incomplete
+	// config (e.g. first-time install before the user configures bot_token).
+	if err := mgr.RestartBrokerPlugin(name, merged); err != nil {
 		slog.Error("Failed to restart integration", "plugin", name, "error", err)
 		InternalError(w)
 		return
 	}
 
-	// Ensure the plugin is wired as a FanOut spoke — it may have been
-	// installed mid-session and never added at startup.
-	s.ensureBrokerSpoke(mgr, name)
+	// Replace the FanOut spoke with a fresh RPC connection to the restarted
+	// plugin process. The old spoke wraps a dead connection from the killed
+	// process. refreshBrokerSpoke replaces an existing spoke or adds a new
+	// one if none existed (e.g. first install before a full hub restart).
+	s.refreshBrokerSpoke(mgr, name)
 
 	// Post-restart validation: check that the plugin is wired into the FanOut.
 	warnings := s.validateIntegrationWiring(name)
@@ -1542,9 +1548,12 @@ func (s *Server) getPluginHubCreds(ctx context.Context, name string) map[string]
 	return creds
 }
 
-// reconfigureIntegration reloads config for a plugin and calls ConfigureBroker.
-// For self-managed plugins, it falls back to Reconnect on ConfigureBroker failure.
-func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationManager, name string) error {
+// resolveIntegrationMergedConfig builds the full merged config map for a plugin
+// by reading the config file, injecting secrets from the secret backend,
+// carrying over runtime keys, and applying hub wiring credentials. The returned
+// map is ready to be pushed to the plugin via ReplaceBrokerConfig or
+// RestartBrokerPlugin.
+func (s *Server) resolveIntegrationMergedConfig(ctx context.Context, mgr IntegrationManager, name string) map[string]string {
 	pluginCfg := mgr.GetPluginConfig("broker", name)
 
 	// Re-read config file if one is configured. Prefer the immutable
@@ -1565,7 +1574,7 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 	}
 	merged, err := config.ResolvePluginConfig(configFile, inlineToPass)
 	if err != nil {
-		slog.Error("Failed to resolve config for reconfigure", "plugin", name, "error", err)
+		slog.Error("Failed to resolve config for integration", "plugin", name, "error", err)
 		merged = make(map[string]string)
 	}
 
@@ -1609,6 +1618,15 @@ func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationMana
 	if configFile != "" {
 		merged["config_file"] = configFile
 	}
+
+	return merged
+}
+
+// reconfigureIntegration reloads config for a plugin and calls ReplaceBrokerConfig
+// to push new config to the running process without restarting it.
+// For self-managed plugins, it falls back to Reconnect on failure.
+func (s *Server) reconfigureIntegration(ctx context.Context, mgr IntegrationManager, name string) error {
+	merged := s.resolveIntegrationMergedConfig(ctx, mgr, name)
 
 	if err := mgr.ReplaceBrokerConfig(name, merged); err != nil {
 		if mgr.IsSelfManaged("broker", name) {

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -142,6 +142,15 @@ func (m *mockIntegrationManager) ReplaceBrokerConfig(name string, cfg map[string
 	return m.replaceConfigErr
 }
 
+func (m *mockIntegrationManager) RestartBrokerPlugin(name string, cfg map[string]string) error {
+	m.replaceConfigCalls = append(m.replaceConfigCalls, name)
+	m.lastReplacedConfig = make(map[string]string, len(cfg))
+	for k, v := range cfg {
+		m.lastReplacedConfig[k] = v
+	}
+	return m.replaceConfigErr
+}
+
 func (m *mockIntegrationManager) Reconnect(pluginType, name string) error {
 	m.reconnectCalls = append(m.reconnectCalls, name)
 	return m.reconnectErr

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -50,6 +50,7 @@ type mockIntegrationManager struct {
 	configureCalls     []string
 	replaceConfigCalls []string
 	lastReplacedConfig map[string]string
+	restartCalls       []string
 	reconnectCalls     []string
 	updateCalls        []string
 	installCalls       []string
@@ -143,11 +144,7 @@ func (m *mockIntegrationManager) ReplaceBrokerConfig(name string, cfg map[string
 }
 
 func (m *mockIntegrationManager) RestartBrokerPlugin(name string, cfg map[string]string) error {
-	m.replaceConfigCalls = append(m.replaceConfigCalls, name)
-	m.lastReplacedConfig = make(map[string]string, len(cfg))
-	for k, v := range cfg {
-		m.lastReplacedConfig[k] = v
-	}
+	m.restartCalls = append(m.restartCalls, name)
 	return m.replaceConfigErr
 }
 
@@ -502,8 +499,8 @@ func TestRestartIntegration_OK(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
 
-	if len(mgr.replaceConfigCalls) != 1 || mgr.replaceConfigCalls[0] != "telegram" {
-		t.Errorf("expected ReplaceBrokerConfig call for telegram, got %v", mgr.replaceConfigCalls)
+	if len(mgr.restartCalls) != 1 || mgr.restartCalls[0] != "telegram" {
+		t.Errorf("expected RestartBrokerPlugin call for telegram, got %v", mgr.restartCalls)
 	}
 }
 

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -517,7 +517,6 @@ func (m *Manager) RestartBrokerPlugin(name string, cfg map[string]string) error 
 
 	m.mu.RLock()
 	dp, ok := m.configs[key]
-	isSelf := m.selfManaged[key]
 	adapter, isGRPC := m.grpcAdapters[key]
 	m.mu.RUnlock()
 
@@ -531,16 +530,9 @@ func (m *Manager) RestartBrokerPlugin(name string, cfg map[string]string) error 
 	// Update the stored config so the new process starts with it.
 	dp.Config = cfg
 
-	if isSelf {
-		// Can't kill a self-managed process — update stored config and reconnect.
-		m.mu.Lock()
-		m.configs[key] = dp
-		m.mu.Unlock()
-		return m.loadPlugin(dp)
-	}
-
-	// Kill the old process and start a new one with updated config.
-	// loadPlugin handles killing the existing client and caching the new one.
+	// Kill the old process (or reconnect for self-managed) and start a new one
+	// with updated config. loadPlugin handles killing the existing client,
+	// caching the new one, and storing the config on success.
 	return m.loadPlugin(dp)
 }
 

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -515,24 +515,32 @@ func (m *Manager) ConfigureBroker(name string, extra map[string]string) error {
 func (m *Manager) RestartBrokerPlugin(name string, cfg map[string]string) error {
 	key := PluginTypeBroker + ":" + name
 
-	m.mu.RLock()
+	m.mu.Lock()
 	dp, ok := m.configs[key]
 	adapter, isGRPC := m.grpcAdapters[key]
-	m.mu.RUnlock()
-
 	if isGRPC {
+		m.mu.Unlock()
 		return adapter.Configure(cfg)
 	}
 	if !ok {
+		m.mu.Unlock()
 		return fmt.Errorf("broker plugin not loaded: %s", name)
 	}
+
+	// Kill the old process first to avoid port/database/resource conflicts
+	// when the new process starts up and runs its Configure phase.
+	if client, hasClient := m.clients[key]; hasClient {
+		if !m.selfManaged[key] {
+			client.Kill()
+		}
+		delete(m.clients, key)
+		delete(m.dispensed, key)
+	}
+	m.mu.Unlock()
 
 	// Update the stored config so the new process starts with it.
 	dp.Config = cfg
 
-	// Kill the old process (or reconnect for self-managed) and start a new one
-	// with updated config. loadPlugin handles killing the existing client,
-	// caching the new one, and storing the config on success.
 	return m.loadPlugin(dp)
 }
 

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -504,6 +504,46 @@ func (m *Manager) ConfigureBroker(name string, extra map[string]string) error {
 	return rpcClient.Configure(merged)
 }
 
+// RestartBrokerPlugin kills a running hub-managed broker plugin process and
+// relaunches it with the given config. This ensures a fresh go-plugin handshake
+// and new MuxBroker connections for host callbacks, fixing stale callback issues
+// that arise when a plugin was initially started with incomplete config (e.g.
+// first-time install before the user configures required fields like bot_token).
+//
+// For self-managed plugins, this performs a reconnect instead (the hub does not
+// own their process). For gRPC/HA adapters, it pushes the config directly.
+func (m *Manager) RestartBrokerPlugin(name string, cfg map[string]string) error {
+	key := PluginTypeBroker + ":" + name
+
+	m.mu.RLock()
+	dp, ok := m.configs[key]
+	isSelf := m.selfManaged[key]
+	adapter, isGRPC := m.grpcAdapters[key]
+	m.mu.RUnlock()
+
+	if isGRPC {
+		return adapter.Configure(cfg)
+	}
+	if !ok {
+		return fmt.Errorf("broker plugin not loaded: %s", name)
+	}
+
+	// Update the stored config so the new process starts with it.
+	dp.Config = cfg
+
+	if isSelf {
+		// Can't kill a self-managed process — update stored config and reconnect.
+		m.mu.Lock()
+		m.configs[key] = dp
+		m.mu.Unlock()
+		return m.loadPlugin(dp)
+	}
+
+	// Kill the old process and start a new one with updated config.
+	// loadPlugin handles killing the existing client and caching the new one.
+	return m.loadPlugin(dp)
+}
+
 // ReplaceBrokerConfig updates the stored config for a broker plugin and pushes
 // the exact cfg to the running plugin, with no underlay from boot-time config.
 func (m *Manager) ReplaceBrokerConfig(name string, cfg map[string]string) error {


### PR DESCRIPTION
When a broker plugin is installed for the first time while the hub is running, the initial go-plugin handshake establishes MuxBroker host callback connections with empty config. A subsequent hot-reconfigure (ReplaceBrokerConfig) pushes new config but the host callback connection from the initial start is stale, causing the plugin to fail to subscribe.

Fix: handleRestartIntegration now does a full plugin process restart (kill + relaunch via loadPlugin) instead of in-process config push, ensuring fresh go-plugin handshake and new MuxBroker connections. Also extracts config resolution into reusable resolveIntegrationMergedConfig helper.

Fixes #954
Fork PR: https://github.com/ptone/scion/pull/992