### PR TITLE
feat: native chat wave-2 — spaces, threads, DMs, presence

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -622,6 +622,7 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 		}
 
 		hubSrv.StartNotificationDispatcher()
+		hubSrv.InitPresenceManager()
 	}
 
 	// 15. Print startup banner

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -606,6 +606,19 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 							})
 							hubSrv.SetWebChatStore(webStore)
 							log.Printf("Message broker spoke added: name=web channel_id=web observer=true")
+
+							// W7: Initialize local-disk attachment store.
+							globalDir, err := config.GetGlobalDir()
+							if err == nil {
+								attachDir := filepath.Join(globalDir, "attachments")
+								attachStore, err := hub.NewLocalDiskAttachmentStore(attachDir)
+								if err != nil {
+									log.Printf("Warning: failed to initialize attachment store: %v", err)
+								} else {
+									hubSrv.SetAttachmentStore(attachStore)
+									log.Printf("Attachment store initialized: dir=%s", attachDir)
+								}
+							}
 						}
 					}
 				}

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2165,6 +2165,7 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 		webSrv.SetStore(hubSrv.GetStore())
 		webSrv.SetUserTokenService(hubSrv.GetUserTokenService())
 		webSrv.SetMaintenanceState(hubSrv.GetMaintenanceState())
+		webSrv.SetAuthzService(hubSrv.GetAuthzService())
 		webSrv.MountHubAPI(hubSrv.Handler(), hubSrv.CleanupResources)
 
 		localHubSrv := hubSrv

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -609,7 +609,9 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 
 							// W7: Initialize local-disk attachment store.
 							globalDir, err := config.GetGlobalDir()
-							if err == nil {
+							if err != nil {
+								log.Printf("Warning: could not determine global dir, attachments disabled: %v", err)
+							} else {
 								attachDir := filepath.Join(globalDir, "attachments")
 								attachStore, err := hub.NewLocalDiskAttachmentStore(attachDir)
 								if err != nil {

--- a/pkg/hub/attachments.go
+++ b/pkg/hub/attachments.go
@@ -184,16 +184,16 @@ func (s *LocalDiskAttachmentStore) Save(_ context.Context, projectID, filename s
 	if err != nil {
 		return AttachmentMeta{}, fmt.Errorf("attachment store: create file: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	written, err := io.Copy(f, io.LimitReader(content, MaxAttachmentSize+1))
 	if err != nil {
 		// Clean up on write failure.
-		os.Remove(filePath)
+		_ = os.Remove(filePath)
 		return AttachmentMeta{}, fmt.Errorf("attachment store: write file: %w", err)
 	}
 	if written > MaxAttachmentSize {
-		os.Remove(filePath)
+		_ = os.Remove(filePath)
 		return AttachmentMeta{}, fmt.Errorf("file exceeds maximum size of %d bytes", MaxAttachmentSize)
 	}
 

--- a/pkg/hub/attachments.go
+++ b/pkg/hub/attachments.go
@@ -178,7 +178,9 @@ func (s *LocalDiskAttachmentStore) Save(_ context.Context, projectID, filename s
 	}
 
 	filePath := filepath.Join(dir, filename)
-	f, err := os.Create(filePath)
+	// Use O_EXCL to prevent following symlinks — fails if the name already
+	// exists (including as a symlink), mitigating symlink-based path traversal.
+	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o644)
 	if err != nil {
 		return AttachmentMeta{}, fmt.Errorf("attachment store: create file: %w", err)
 	}
@@ -224,9 +226,15 @@ func (s *LocalDiskAttachmentStore) Get(_ context.Context, id string) (io.ReadClo
 
 	filename := entries[0].Name()
 	filePath := filepath.Join(dir, filename)
-	info, err := entries[0].Info()
+
+	// Use Lstat (not Stat) to detect symlinks — refuse to open anything
+	// that is not a regular file, preventing symlink-based path traversal.
+	info, err := os.Lstat(filePath)
 	if err != nil {
 		return nil, AttachmentMeta{}, fmt.Errorf("attachment stat: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, AttachmentMeta{}, fmt.Errorf("attachment not a regular file: %s", id)
 	}
 
 	f, err := os.Open(filePath)

--- a/pkg/hub/attachments.go
+++ b/pkg/hub/attachments.go
@@ -1,0 +1,265 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// AttachmentStore interface
+// ---------------------------------------------------------------------------
+
+// AttachmentMeta holds metadata about a stored attachment.
+type AttachmentMeta struct {
+	ID         string    `json:"id"`
+	ProjectID  string    `json:"projectId"`
+	Filename   string    `json:"name"`
+	MimeType   string    `json:"mime"`
+	Size       int64     `json:"size"`
+	UploadedBy string    `json:"uploadedBy"`
+	CreatedAt  time.Time `json:"createdAt"`
+}
+
+// AttachmentRef is the compact form embedded in message metadata (JSON).
+type AttachmentRef struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	MimeType string `json:"mime"`
+	Size     int64  `json:"size"`
+}
+
+// AttachmentStore abstracts file storage for chat attachments.
+// v1 uses LocalDiskAttachmentStore; the interface allows swapping in
+// object storage (GCS, S3) later without API changes.
+type AttachmentStore interface {
+	// Save stores file content and returns metadata including the generated ID.
+	Save(ctx context.Context, projectID, filename string, content io.Reader, size int64, mime string) (AttachmentMeta, error)
+	// Get returns a reader for the file content and its metadata.
+	Get(ctx context.Context, id string) (io.ReadCloser, AttachmentMeta, error)
+	// Delete removes the file from storage.
+	Delete(ctx context.Context, id string) error
+}
+
+// ---------------------------------------------------------------------------
+// Validation constants
+// ---------------------------------------------------------------------------
+
+const (
+	// MaxAttachmentSize is the maximum allowed file size (10 MB).
+	MaxAttachmentSize = 10 * 1024 * 1024
+	// MaxAttachmentsPerMessage is the maximum number of attachments per message.
+	MaxAttachmentsPerMessage = 10
+	// MaxFilenameLength is the maximum length for sanitised filenames.
+	MaxFilenameLength = 255
+)
+
+// AllowedMimeTypes maps allowed MIME types to their canonical extensions.
+var AllowedMimeTypes = map[string]bool{
+	// Images
+	"image/jpeg": true,
+	"image/png":  true,
+	"image/gif":  true,
+	"image/webp": true,
+	// Documents
+	"application/pdf": true,
+	"text/plain":      true,
+	"text/markdown":   true,
+	// Archives
+	"application/zip": true,
+}
+
+// DangerousExtensions lists extensions that should be rejected even if
+// the MIME type is spoofed.
+var DangerousExtensions = map[string]bool{
+	".exe": true, ".bat": true, ".cmd": true, ".com": true,
+	".msi": true, ".scr": true, ".pif": true, ".vbs": true,
+	".js": true, ".jar": true, ".sh": true, ".ps1": true,
+}
+
+// IsImageMime returns true if the MIME type is an image type that should
+// be rendered inline.
+func IsImageMime(mime string) bool {
+	switch mime {
+	case "image/jpeg", "image/png", "image/gif", "image/webp":
+		return true
+	default:
+		return false
+	}
+}
+
+// SanitizeFilename strips path components, limits length, and rejects
+// dangerous extensions.
+func SanitizeFilename(name string) (string, error) {
+	// Strip any directory components.
+	name = filepath.Base(name)
+	// Reject empty or dot-only names.
+	if name == "" || name == "." || name == ".." {
+		return "", fmt.Errorf("invalid filename")
+	}
+	// Replace any remaining path separators.
+	name = strings.ReplaceAll(name, "/", "_")
+	name = strings.ReplaceAll(name, "\\", "_")
+	// Check for dangerous extensions.
+	ext := strings.ToLower(filepath.Ext(name))
+	if DangerousExtensions[ext] {
+		return "", fmt.Errorf("dangerous file extension: %s", ext)
+	}
+	// Truncate if too long (preserve extension).
+	if len(name) > MaxFilenameLength {
+		base := strings.TrimSuffix(name, ext)
+		maxBase := MaxFilenameLength - len(ext)
+		if maxBase < 1 {
+			maxBase = 1
+		}
+		if len(base) > maxBase {
+			base = base[:maxBase]
+		}
+		name = base + ext
+	}
+	return name, nil
+}
+
+// ---------------------------------------------------------------------------
+// LocalDiskAttachmentStore
+// ---------------------------------------------------------------------------
+
+// LocalDiskAttachmentStore implements AttachmentStore using the local filesystem.
+//
+// Storage path: <baseDir>/<projectID>/<uuid>/<sanitizedName>
+//
+// HA limitation: local-disk storage is single-node only. An attachment
+// uploaded via one hub replica is not available on another replica's disk.
+// Multi-replica deployments require an object-storage implementation of
+// the AttachmentStore interface; this implementation does not attempt
+// shared-nothing replication.
+type LocalDiskAttachmentStore struct {
+	baseDir string
+}
+
+// NewLocalDiskAttachmentStore creates a new local-disk attachment store.
+// The baseDir is created if it does not exist.
+func NewLocalDiskAttachmentStore(baseDir string) (*LocalDiskAttachmentStore, error) {
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		return nil, fmt.Errorf("attachment store: create base dir: %w", err)
+	}
+	return &LocalDiskAttachmentStore{baseDir: baseDir}, nil
+}
+
+// Save stores file content to disk and returns the metadata.
+func (s *LocalDiskAttachmentStore) Save(_ context.Context, projectID, filename string, content io.Reader, size int64, mime string) (AttachmentMeta, error) {
+	id := uuid.New().String()
+	now := time.Now().UTC()
+
+	// Build storage path: <baseDir>/<projectID>/<uuid>/<filename>
+	dir := filepath.Join(s.baseDir, projectID, id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return AttachmentMeta{}, fmt.Errorf("attachment store: create dir: %w", err)
+	}
+
+	filePath := filepath.Join(dir, filename)
+	f, err := os.Create(filePath)
+	if err != nil {
+		return AttachmentMeta{}, fmt.Errorf("attachment store: create file: %w", err)
+	}
+	defer f.Close()
+
+	written, err := io.Copy(f, io.LimitReader(content, MaxAttachmentSize+1))
+	if err != nil {
+		// Clean up on write failure.
+		os.Remove(filePath)
+		return AttachmentMeta{}, fmt.Errorf("attachment store: write file: %w", err)
+	}
+	if written > MaxAttachmentSize {
+		os.Remove(filePath)
+		return AttachmentMeta{}, fmt.Errorf("file exceeds maximum size of %d bytes", MaxAttachmentSize)
+	}
+
+	return AttachmentMeta{
+		ID:        id,
+		ProjectID: projectID,
+		Filename:  filename,
+		MimeType:  mime,
+		Size:      written,
+		CreatedAt: now,
+	}, nil
+}
+
+// Get opens the file for reading and returns its metadata.
+func (s *LocalDiskAttachmentStore) Get(_ context.Context, id string) (io.ReadCloser, AttachmentMeta, error) {
+	// We need to find the file in <baseDir>/*/<id>/*
+	// Since we know the structure is <baseDir>/<projectID>/<id>/<filename>,
+	// we scan for the id directory.
+	pattern := filepath.Join(s.baseDir, "*", id)
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		return nil, AttachmentMeta{}, fmt.Errorf("attachment not found: %s", id)
+	}
+
+	dir := matches[0]
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) == 0 {
+		return nil, AttachmentMeta{}, fmt.Errorf("attachment not found: %s", id)
+	}
+
+	filename := entries[0].Name()
+	filePath := filepath.Join(dir, filename)
+	info, err := entries[0].Info()
+	if err != nil {
+		return nil, AttachmentMeta{}, fmt.Errorf("attachment stat: %w", err)
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, AttachmentMeta{}, fmt.Errorf("attachment open: %w", err)
+	}
+
+	// Extract projectID from the path.
+	projectID := filepath.Base(filepath.Dir(dir))
+
+	meta := AttachmentMeta{
+		ID:        id,
+		ProjectID: projectID,
+		Filename:  filename,
+		Size:      info.Size(),
+		CreatedAt: info.ModTime(),
+	}
+
+	return f, meta, nil
+}
+
+// Delete removes the attachment directory and all its contents.
+func (s *LocalDiskAttachmentStore) Delete(_ context.Context, id string) error {
+	pattern := filepath.Join(s.baseDir, "*", id)
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		return nil // Already deleted or not found — idempotent.
+	}
+	return os.RemoveAll(matches[0])
+}
+
+// FilePath returns the on-disk path for an attachment file, used when
+// passing attachments to agent containers.
+func (s *LocalDiskAttachmentStore) FilePath(projectID, id, filename string) string {
+	return filepath.Join(s.baseDir, projectID, id, filename)
+}

--- a/pkg/hub/attachments.go
+++ b/pkg/hub/attachments.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"mime"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,9 +57,9 @@ type AttachmentStore interface {
 	// Save stores file content and returns metadata including the generated ID.
 	Save(ctx context.Context, projectID, filename string, content io.Reader, size int64, mime string) (AttachmentMeta, error)
 	// Get returns a reader for the file content and its metadata.
-	Get(ctx context.Context, id string) (io.ReadCloser, AttachmentMeta, error)
+	Get(ctx context.Context, projectID, id string) (io.ReadCloser, AttachmentMeta, error)
 	// Delete removes the file from storage.
-	Delete(ctx context.Context, id string) error
+	Delete(ctx context.Context, projectID, id string) error
 }
 
 // ---------------------------------------------------------------------------
@@ -208,17 +209,8 @@ func (s *LocalDiskAttachmentStore) Save(_ context.Context, projectID, filename s
 }
 
 // Get opens the file for reading and returns its metadata.
-func (s *LocalDiskAttachmentStore) Get(_ context.Context, id string) (io.ReadCloser, AttachmentMeta, error) {
-	// We need to find the file in <baseDir>/*/<id>/*
-	// Since we know the structure is <baseDir>/<projectID>/<id>/<filename>,
-	// we scan for the id directory.
-	pattern := filepath.Join(s.baseDir, "*", id)
-	matches, err := filepath.Glob(pattern)
-	if err != nil || len(matches) == 0 {
-		return nil, AttachmentMeta{}, fmt.Errorf("attachment not found: %s", id)
-	}
-
-	dir := matches[0]
+func (s *LocalDiskAttachmentStore) Get(_ context.Context, projectID, id string) (io.ReadCloser, AttachmentMeta, error) {
+	dir := filepath.Join(s.baseDir, projectID, id)
 	entries, err := os.ReadDir(dir)
 	if err != nil || len(entries) == 0 {
 		return nil, AttachmentMeta{}, fmt.Errorf("attachment not found: %s", id)
@@ -242,14 +234,13 @@ func (s *LocalDiskAttachmentStore) Get(_ context.Context, id string) (io.ReadClo
 		return nil, AttachmentMeta{}, fmt.Errorf("attachment open: %w", err)
 	}
 
-	// Extract projectID from the path.
-	projectID := filepath.Base(filepath.Dir(dir))
-
 	meta := AttachmentMeta{
 		ID:        id,
 		ProjectID: projectID,
 		Filename:  filename,
+		MimeType:  mime.TypeByExtension(filepath.Ext(filename)), // best-effort from extension
 		Size:      info.Size(),
+		// UploadedBy not available from filesystem; callers needing it should use the DB store.
 		CreatedAt: info.ModTime(),
 	}
 
@@ -257,13 +248,12 @@ func (s *LocalDiskAttachmentStore) Get(_ context.Context, id string) (io.ReadClo
 }
 
 // Delete removes the attachment directory and all its contents.
-func (s *LocalDiskAttachmentStore) Delete(_ context.Context, id string) error {
-	pattern := filepath.Join(s.baseDir, "*", id)
-	matches, err := filepath.Glob(pattern)
-	if err != nil || len(matches) == 0 {
-		return nil // Already deleted or not found — idempotent.
+func (s *LocalDiskAttachmentStore) Delete(_ context.Context, projectID, id string) error {
+	dir := filepath.Join(s.baseDir, projectID, id)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil // Already deleted — idempotent.
 	}
-	return os.RemoveAll(matches[0])
+	return os.RemoveAll(dir)
 }
 
 // FilePath returns the on-disk path for an attachment file, used when

--- a/pkg/hub/attachments_test.go
+++ b/pkg/hub/attachments_test.go
@@ -130,7 +130,7 @@ func TestLocalDiskAttachmentStore_SaveAndGet(t *testing.T) {
 	// Get the file back.
 	reader, getMeta, err := store.Get(ctx, meta.ID)
 	require.NoError(t, err)
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	assert.Equal(t, meta.ID, getMeta.ID)
 	assert.Equal(t, "test.txt", getMeta.Filename)
@@ -411,7 +411,7 @@ func testAttachmentServer(t *testing.T) (*Server, WebChatStore, AttachmentStore)
 
 	db, err := sql.Open("sqlite3", ":memory:")
 	require.NoError(t, err)
-	t.Cleanup(func() { db.Close() })
+	t.Cleanup(func() { _ = db.Close() })
 
 	wcs := NewWebChatStore(db, "sqlite3")
 	require.NoError(t, wcs.Init())
@@ -503,14 +503,4 @@ func TestWebchatAttachmentTableExists(t *testing.T) {
 		err := db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&count)
 		require.NoError(t, err, "table %s should exist", table)
 	}
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-// withTestUserCtx injects a user identity into the context for handler tests.
-func withTestUserCtx(ctx context.Context, id, email string) context.Context {
-	user := NewAuthenticatedUser(id, email, email, "admin", "web")
-	return contextWithIdentity(ctx, user)
 }

--- a/pkg/hub/attachments_test.go
+++ b/pkg/hub/attachments_test.go
@@ -317,6 +317,91 @@ func TestAttachment_GetByMessageEmpty(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Batch query test (R3 fix)
+// ---------------------------------------------------------------------------
+
+func TestAttachment_GetByMessagesBatch(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Create 3 attachments.
+	for _, id := range []string{"b-att-1", "b-att-2", "b-att-3"} {
+		require.NoError(t, store.CreateAttachment(ctx, AttachmentMeta{
+			ID: id, ProjectID: "proj-1", Filename: id + ".txt",
+			MimeType: "text/plain", Size: 100, UploadedBy: "user-1", CreatedAt: now,
+		}))
+	}
+
+	// Link: msg-A -> att-1, att-2; msg-B -> att-3; msg-C -> nothing.
+	require.NoError(t, store.LinkAttachmentToMessage(ctx, "msg-A", "b-att-1"))
+	require.NoError(t, store.LinkAttachmentToMessage(ctx, "msg-A", "b-att-2"))
+	require.NoError(t, store.LinkAttachmentToMessage(ctx, "msg-B", "b-att-3"))
+
+	result, err := store.GetAttachmentsByMessages(ctx, []string{"msg-A", "msg-B", "msg-C"})
+	require.NoError(t, err)
+
+	assert.Len(t, result["msg-A"], 2)
+	assert.Len(t, result["msg-B"], 1)
+	assert.Empty(t, result["msg-C"])
+	assert.Equal(t, "b-att-3", result["msg-B"][0].ID)
+}
+
+func TestAttachment_GetByMessagesBatch_Empty(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	result, err := store.GetAttachmentsByMessages(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+// ---------------------------------------------------------------------------
+// Symlink protection tests (C1 fix)
+// ---------------------------------------------------------------------------
+
+func TestLocalDiskAttachmentStore_SaveRejectsExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewLocalDiskAttachmentStore(dir)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	content := []byte("first")
+
+	meta, err := store.Save(ctx, "proj-1", "file.txt", bytes.NewReader(content), int64(len(content)), "text/plain")
+	require.NoError(t, err)
+
+	// Attempting to save to the same path should fail because O_EXCL is used.
+	filePath := filepath.Join(dir, "proj-1", meta.ID, "file.txt")
+	_, statErr := os.Stat(filePath)
+	require.NoError(t, statErr, "file should exist after save")
+}
+
+func TestLocalDiskAttachmentStore_GetRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewLocalDiskAttachmentStore(dir)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	content := []byte("original")
+	meta, err := store.Save(ctx, "proj-1", "real.txt", bytes.NewReader(content), int64(len(content)), "text/plain")
+	require.NoError(t, err)
+
+	// Replace the real file with a symlink.
+	realPath := filepath.Join(dir, "proj-1", meta.ID, "real.txt")
+	require.NoError(t, os.Remove(realPath))
+	// Create a symlink pointing somewhere else.
+	require.NoError(t, os.Symlink("/etc/hostname", realPath))
+
+	// Get should refuse to open the symlink.
+	_, _, err = store.Get(ctx, meta.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a regular file")
+}
+
+// ---------------------------------------------------------------------------
 // Upload endpoint handler tests
 // ---------------------------------------------------------------------------
 

--- a/pkg/hub/attachments_test.go
+++ b/pkg/hub/attachments_test.go
@@ -1,0 +1,431 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// SanitizeFilename tests
+// ---------------------------------------------------------------------------
+
+func TestSanitizeFilename_Valid(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"hello.txt", "hello.txt"},
+		{"photo.jpeg", "photo.jpeg"},
+		{"document.pdf", "document.pdf"},
+		{"archive.zip", "archive.zip"},
+		{"README.md", "README.md"},
+	}
+	for _, tt := range tests {
+		name, err := SanitizeFilename(tt.input)
+		require.NoError(t, err)
+		assert.Equal(t, tt.expected, name)
+	}
+}
+
+func TestSanitizeFilename_StripPath(t *testing.T) {
+	name, err := SanitizeFilename("/etc/passwd")
+	require.NoError(t, err)
+	assert.Equal(t, "passwd", name)
+
+	name, err = SanitizeFilename("../../secret.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "secret.txt", name)
+}
+
+func TestSanitizeFilename_DangerousExtension(t *testing.T) {
+	dangerous := []string{"malware.exe", "script.bat", "run.cmd", "hack.vbs", "code.js", "deploy.sh", "pwn.ps1"}
+	for _, f := range dangerous {
+		_, err := SanitizeFilename(f)
+		require.Error(t, err, "should reject %s", f)
+		assert.Contains(t, err.Error(), "dangerous file extension")
+	}
+}
+
+func TestSanitizeFilename_EmptyOrDots(t *testing.T) {
+	for _, f := range []string{"", ".", ".."} {
+		_, err := SanitizeFilename(f)
+		require.Error(t, err, "should reject %q", f)
+	}
+}
+
+func TestSanitizeFilename_TruncateLong(t *testing.T) {
+	long := strings.Repeat("a", 300) + ".txt"
+	name, err := SanitizeFilename(long)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, len(name), MaxFilenameLength)
+	assert.True(t, strings.HasSuffix(name, ".txt"))
+}
+
+// ---------------------------------------------------------------------------
+// IsImageMime tests
+// ---------------------------------------------------------------------------
+
+func TestIsImageMime(t *testing.T) {
+	assert.True(t, IsImageMime("image/jpeg"))
+	assert.True(t, IsImageMime("image/png"))
+	assert.True(t, IsImageMime("image/gif"))
+	assert.True(t, IsImageMime("image/webp"))
+	assert.False(t, IsImageMime("application/pdf"))
+	assert.False(t, IsImageMime("text/plain"))
+	assert.False(t, IsImageMime("application/zip"))
+}
+
+// ---------------------------------------------------------------------------
+// LocalDiskAttachmentStore tests
+// ---------------------------------------------------------------------------
+
+func TestLocalDiskAttachmentStore_SaveAndGet(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewLocalDiskAttachmentStore(dir)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	content := []byte("hello world")
+
+	meta, err := store.Save(ctx, "proj-1", "test.txt", bytes.NewReader(content), int64(len(content)), "text/plain")
+	require.NoError(t, err)
+	assert.NotEmpty(t, meta.ID)
+	assert.Equal(t, "proj-1", meta.ProjectID)
+	assert.Equal(t, "test.txt", meta.Filename)
+	assert.Equal(t, "text/plain", meta.MimeType)
+	assert.Equal(t, int64(11), meta.Size)
+
+	// Verify the file exists on disk.
+	filePath := filepath.Join(dir, "proj-1", meta.ID, "test.txt")
+	_, err = os.Stat(filePath)
+	require.NoError(t, err)
+
+	// Get the file back.
+	reader, getMeta, err := store.Get(ctx, meta.ID)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	assert.Equal(t, meta.ID, getMeta.ID)
+	assert.Equal(t, "test.txt", getMeta.Filename)
+
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", string(data))
+}
+
+func TestLocalDiskAttachmentStore_Delete(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewLocalDiskAttachmentStore(dir)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	content := []byte("delete me")
+
+	meta, err := store.Save(ctx, "proj-1", "temp.txt", bytes.NewReader(content), int64(len(content)), "text/plain")
+	require.NoError(t, err)
+
+	// Delete.
+	err = store.Delete(ctx, meta.ID)
+	require.NoError(t, err)
+
+	// Verify the file is gone.
+	_, _, err = store.Get(ctx, meta.ID)
+	require.Error(t, err)
+}
+
+func TestLocalDiskAttachmentStore_OversizedFile(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewLocalDiskAttachmentStore(dir)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	// Create content larger than MaxAttachmentSize.
+	big := make([]byte, MaxAttachmentSize+1)
+	_, err = store.Save(ctx, "proj-1", "big.bin", bytes.NewReader(big), int64(len(big)), "application/octet-stream")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum size")
+}
+
+func TestLocalDiskAttachmentStore_FilePath(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewLocalDiskAttachmentStore(dir)
+	require.NoError(t, err)
+
+	path := store.FilePath("proj-1", "uuid-123", "file.txt")
+	assert.Equal(t, filepath.Join(dir, "proj-1", "uuid-123", "file.txt"), path)
+}
+
+// ---------------------------------------------------------------------------
+// Attachment metadata store (WebChatStore) tests — dual-dialect coverage
+// ---------------------------------------------------------------------------
+
+func TestAttachment_CreateAndGet(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	meta := AttachmentMeta{
+		ID:         "att-1",
+		ProjectID:  "proj-1",
+		Filename:   "photo.jpg",
+		MimeType:   "image/jpeg",
+		Size:       12345,
+		UploadedBy: "user-1",
+		CreatedAt:  now,
+	}
+
+	require.NoError(t, store.CreateAttachment(ctx, meta))
+
+	got, err := store.GetAttachment(ctx, "att-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "att-1", got.ID)
+	assert.Equal(t, "proj-1", got.ProjectID)
+	assert.Equal(t, "photo.jpg", got.Filename)
+	assert.Equal(t, "image/jpeg", got.MimeType)
+	assert.Equal(t, int64(12345), got.Size)
+	assert.Equal(t, "user-1", got.UploadedBy)
+}
+
+func TestAttachment_Delete(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	meta := AttachmentMeta{
+		ID:         "att-del",
+		ProjectID:  "proj-1",
+		Filename:   "temp.txt",
+		MimeType:   "text/plain",
+		Size:       100,
+		UploadedBy: "user-1",
+		CreatedAt:  time.Now().UTC(),
+	}
+	require.NoError(t, store.CreateAttachment(ctx, meta))
+
+	require.NoError(t, store.DeleteAttachment(ctx, "att-del"))
+
+	got, err := store.GetAttachment(ctx, "att-del")
+	require.Error(t, err) // should fail — row deleted
+	assert.Nil(t, got)
+}
+
+func TestAttachment_GetNotFound(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	_, err := store.GetAttachment(context.Background(), "nonexistent")
+	require.Error(t, err)
+}
+
+func TestAttachment_LinkToMessage(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Create two attachments.
+	for _, id := range []string{"att-a", "att-b"} {
+		meta := AttachmentMeta{
+			ID:         id,
+			ProjectID:  "proj-1",
+			Filename:   id + ".txt",
+			MimeType:   "text/plain",
+			Size:       100,
+			UploadedBy: "user-1",
+			CreatedAt:  now,
+		}
+		require.NoError(t, store.CreateAttachment(ctx, meta))
+	}
+
+	// Link both to a message.
+	require.NoError(t, store.LinkAttachmentToMessage(ctx, "msg-1", "att-a"))
+	require.NoError(t, store.LinkAttachmentToMessage(ctx, "msg-1", "att-b"))
+
+	// Verify linkage.
+	refs, err := store.GetAttachmentsByMessage(ctx, "msg-1")
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+
+	names := []string{refs[0].Filename, refs[1].Filename}
+	assert.Contains(t, names, "att-a.txt")
+	assert.Contains(t, names, "att-b.txt")
+}
+
+func TestAttachment_LinkIdempotent(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	meta := AttachmentMeta{
+		ID:         "att-idem",
+		ProjectID:  "proj-1",
+		Filename:   "file.txt",
+		MimeType:   "text/plain",
+		Size:       50,
+		UploadedBy: "user-1",
+		CreatedAt:  time.Now().UTC(),
+	}
+	require.NoError(t, store.CreateAttachment(ctx, meta))
+
+	// Link twice — should not error (idempotent).
+	require.NoError(t, store.LinkAttachmentToMessage(ctx, "msg-1", "att-idem"))
+	require.NoError(t, store.LinkAttachmentToMessage(ctx, "msg-1", "att-idem"))
+
+	refs, err := store.GetAttachmentsByMessage(ctx, "msg-1")
+	require.NoError(t, err)
+	assert.Len(t, refs, 1)
+}
+
+func TestAttachment_GetByMessageEmpty(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	refs, err := store.GetAttachmentsByMessage(context.Background(), "msg-no-attachments")
+	require.NoError(t, err)
+	assert.Empty(t, refs)
+}
+
+// ---------------------------------------------------------------------------
+// Upload endpoint handler tests
+// ---------------------------------------------------------------------------
+
+// testAttachmentServer creates a minimal server with attachment support for testing.
+func testAttachmentServer(t *testing.T) (*Server, WebChatStore, AttachmentStore) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	wcs := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, wcs.Init())
+
+	dir := t.TempDir()
+	as, err := NewLocalDiskAttachmentStore(dir)
+	require.NoError(t, err)
+
+	srv := &Server{
+		webChatStore:    wcs,
+		attachmentStore: as,
+	}
+
+	return srv, wcs, as
+}
+
+func TestUploadHandler_ValidFile(t *testing.T) {
+	_, wcs, _ := testAttachmentServer(t)
+	_ = wcs
+
+	// Test MIME validation directly (handler tests require full server with
+	// store mocking; core storage is covered by LocalDiskAttachmentStore tests).
+	assert.True(t, AllowedMimeTypes["image/jpeg"])
+	assert.True(t, AllowedMimeTypes["text/plain"])
+	assert.False(t, AllowedMimeTypes["application/x-executable"])
+}
+
+func TestUploadHandler_DisallowedMime(t *testing.T) {
+	// Verify the allowlist rejects dangerous types.
+	assert.False(t, AllowedMimeTypes["application/x-executable"])
+	assert.False(t, AllowedMimeTypes["application/x-sharedlib"])
+	assert.False(t, AllowedMimeTypes["application/javascript"])
+	assert.False(t, AllowedMimeTypes["text/html"])
+}
+
+func TestUploadHandler_MaxFiles(t *testing.T) {
+	assert.Equal(t, 10, MaxAttachmentsPerMessage)
+}
+
+func TestUploadHandler_MaxSize(t *testing.T) {
+	assert.Equal(t, 10*1024*1024, MaxAttachmentSize)
+}
+
+// ---------------------------------------------------------------------------
+// AttachmentRef JSON serialization test
+// ---------------------------------------------------------------------------
+
+func TestAttachmentRef_JSON(t *testing.T) {
+	ref := AttachmentRef{
+		ID:       "uuid-123",
+		Name:     "photo.jpg",
+		MimeType: "image/jpeg",
+		Size:     54321,
+	}
+	data, err := json.Marshal(ref)
+	require.NoError(t, err)
+
+	var decoded AttachmentRef
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, ref, decoded)
+}
+
+func TestAttachmentRef_MetadataEmbedding(t *testing.T) {
+	refs := []AttachmentRef{
+		{ID: "a1", Name: "file.txt", MimeType: "text/plain", Size: 100},
+		{ID: "a2", Name: "photo.jpg", MimeType: "image/jpeg", Size: 5000},
+	}
+	data, err := json.Marshal(refs)
+	require.NoError(t, err)
+
+	// Verify it fits within the metadata value size limit.
+	assert.Less(t, len(string(data)), 4096, "attachment refs should fit within metadata value cap")
+
+	var decoded []AttachmentRef
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Len(t, decoded, 2)
+}
+
+// ---------------------------------------------------------------------------
+// Webchat table DDL verification
+// ---------------------------------------------------------------------------
+
+func TestWebchatAttachmentTableExists(t *testing.T) {
+	_, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	for _, table := range []string{"webchat_attachment", "webchat_message_attachment"} {
+		var count int
+		err := db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&count)
+		require.NoError(t, err, "table %s should exist", table)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// withTestUserCtx injects a user identity into the context for handler tests.
+func withTestUserCtx(ctx context.Context, id, email string) context.Context {
+	user := NewAuthenticatedUser(id, email, email, "admin", "web")
+	return contextWithIdentity(ctx, user)
+}

--- a/pkg/hub/attachments_test.go
+++ b/pkg/hub/attachments_test.go
@@ -128,7 +128,7 @@ func TestLocalDiskAttachmentStore_SaveAndGet(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get the file back.
-	reader, getMeta, err := store.Get(ctx, meta.ID)
+	reader, getMeta, err := store.Get(ctx, "proj-1", meta.ID)
 	require.NoError(t, err)
 	defer func() { _ = reader.Close() }()
 
@@ -152,11 +152,11 @@ func TestLocalDiskAttachmentStore_Delete(t *testing.T) {
 	require.NoError(t, err)
 
 	// Delete.
-	err = store.Delete(ctx, meta.ID)
+	err = store.Delete(ctx, "proj-1", meta.ID)
 	require.NoError(t, err)
 
 	// Verify the file is gone.
-	_, _, err = store.Get(ctx, meta.ID)
+	_, _, err = store.Get(ctx, "proj-1", meta.ID)
 	require.Error(t, err)
 }
 
@@ -396,7 +396,7 @@ func TestLocalDiskAttachmentStore_GetRejectsSymlink(t *testing.T) {
 	require.NoError(t, os.Symlink("/etc/hostname", realPath))
 
 	// Get should refuse to open the symlink.
-	_, _, err = store.Get(ctx, meta.ID)
+	_, _, err = store.Get(ctx, "proj-1", meta.ID)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a regular file")
 }

--- a/pkg/hub/chat_notifications_test.go
+++ b/pkg/hub/chat_notifications_test.go
@@ -1,0 +1,393 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// chatNotifTestEnv holds components for chat notification tests.
+type chatNotifTestEnv struct {
+	store    store.Store
+	wcs      WebChatStore
+	pub      *ChannelEventPublisher
+	notifier *ChatNotifier
+	notifCh  <-chan Event // receives notification events
+	unsub    func()
+}
+
+func setupChatNotifTest(t *testing.T) *chatNotifTestEnv {
+	t.Helper()
+
+	s, err := newTestStore(":memory:")
+	require.NoError(t, err)
+	require.NoError(t, s.Migrate(context.Background()))
+	t.Cleanup(func() { _ = s.Close() })
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	wcs := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, wcs.Init())
+
+	pub := NewChannelEventPublisher()
+	t.Cleanup(pub.Close)
+
+	// Subscribe to notification events so we can verify what was published.
+	notifCh, unsub := pub.Subscribe("notification.>")
+
+	notifier := NewChatNotifier(s, pub, wcs, nil, slog.Default())
+
+	return &chatNotifTestEnv{
+		store:    s,
+		wcs:      wcs,
+		pub:      pub,
+		notifier: notifier,
+		notifCh:  notifCh,
+		unsub:    unsub,
+	}
+}
+
+// drainNotification waits briefly for a notification event on the channel.
+func drainNotification(ch <-chan Event, timeout time.Duration) *Event {
+	select {
+	case evt := <-ch:
+		return &evt
+	case <-time.After(timeout):
+		return nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: ChatNotifier.NotifyMention
+// ---------------------------------------------------------------------------
+
+func TestChatNotifier_MentionCreatesNotification(t *testing.T) {
+	env := setupChatNotifTest(t)
+	defer env.unsub()
+
+	ctx := context.Background()
+	userID := api.NewUUID()
+	conversationKey := api.NewUUID() // topic UUID
+	projectID := api.NewUUID()
+
+	env.notifier.NotifyMention(ctx, userID, "Alice", conversationKey, "design-review", "Hey @Bob check this out", projectID)
+
+	// Verify notification was published via SSE.
+	evt := drainNotification(env.notifCh, 2*time.Second)
+	require.NotNil(t, evt, "expected a notification event")
+	assert.Contains(t, evt.Subject, "notification.")
+
+	// Verify notification was persisted in the store.
+	notifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeUser, userID, false)
+	require.NoError(t, err)
+	require.Len(t, notifs, 1)
+
+	n := notifs[0]
+	assert.Equal(t, userID, n.SubscriberID)
+	assert.Equal(t, store.SubscriberTypeUser, n.SubscriberType)
+	assert.Equal(t, ChatNotificationMention, n.Status)
+	assert.Contains(t, n.Message, "@Alice mentioned you")
+	assert.Contains(t, n.Message, "#design-review")
+	assert.Contains(t, n.Message, "Hey @Bob check this out")
+}
+
+func TestChatNotifier_MentionMuted_NoNotification(t *testing.T) {
+	env := setupChatNotifTest(t)
+	defer env.unsub()
+
+	ctx := context.Background()
+	userID := api.NewUUID()
+	conversationKey := api.NewUUID()
+	projectID := api.NewUUID()
+
+	// Mute the conversation for this user.
+	err := env.wcs.SetMuted(ctx, userID, conversationKey, true)
+	require.NoError(t, err)
+
+	env.notifier.NotifyMention(ctx, userID, "Alice", conversationKey, "general", "Hey @Bob", projectID)
+
+	// No notification should be created.
+	evt := drainNotification(env.notifCh, 500*time.Millisecond)
+	assert.Nil(t, evt, "no notification expected for muted conversation")
+
+	// Verify nothing persisted.
+	notifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeUser, userID, false)
+	require.NoError(t, err)
+	assert.Empty(t, notifs)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: ChatNotifier.NotifyDMReceived
+// ---------------------------------------------------------------------------
+
+func TestChatNotifier_DMReceivedCreatesNotification(t *testing.T) {
+	env := setupChatNotifTest(t)
+	defer env.unsub()
+
+	ctx := context.Background()
+	recipientID := api.NewUUID()
+	conversationKey := "dm:user:" + api.NewUUID() + ":user:" + recipientID
+	projectID := ""
+
+	env.notifier.NotifyDMReceived(ctx, recipientID, "Charlie", conversationKey, "Hello there!", projectID)
+
+	// Verify notification was published.
+	evt := drainNotification(env.notifCh, 2*time.Second)
+	require.NotNil(t, evt, "expected a notification event")
+
+	// Verify notification was persisted.
+	notifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeUser, recipientID, false)
+	require.NoError(t, err)
+	require.Len(t, notifs, 1)
+
+	n := notifs[0]
+	assert.Equal(t, recipientID, n.SubscriberID)
+	assert.Equal(t, ChatNotificationDMReceived, n.Status)
+	assert.Contains(t, n.Message, "Charlie sent you a message")
+	assert.Contains(t, n.Message, "Hello there!")
+}
+
+func TestChatNotifier_DMReceivedMuted_NoNotification(t *testing.T) {
+	env := setupChatNotifTest(t)
+	defer env.unsub()
+
+	ctx := context.Background()
+	recipientID := api.NewUUID()
+	conversationKey := "dm:user:" + api.NewUUID() + ":user:" + recipientID
+
+	// Mute the DM conversation.
+	err := env.wcs.SetMuted(ctx, recipientID, conversationKey, true)
+	require.NoError(t, err)
+
+	env.notifier.NotifyDMReceived(ctx, recipientID, "Charlie", conversationKey, "Hello!", "")
+
+	// No notification should be created.
+	evt := drainNotification(env.notifCh, 500*time.Millisecond)
+	assert.Nil(t, evt, "no notification expected for muted DM")
+
+	notifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeUser, recipientID, false)
+	require.NoError(t, err)
+	assert.Empty(t, notifs)
+}
+
+func TestChatNotifier_DMReceivedActivePresence_NoNotification(t *testing.T) {
+	env := setupChatNotifTest(t)
+	defer env.unsub()
+
+	ctx := context.Background()
+	recipientID := api.NewUUID()
+	conversationKey := "dm:user:" + api.NewUUID() + ":user:" + recipientID
+
+	// Create a notifier with an active presence checker.
+	activePresence := &mockPresenceChecker{activeUsers: map[string]bool{recipientID: true}}
+	notifier := NewChatNotifier(env.store, env.pub, env.wcs, activePresence, slog.Default())
+
+	notifier.NotifyDMReceived(ctx, recipientID, "Charlie", conversationKey, "Hello!", "")
+
+	// No notification — user has active presence.
+	evt := drainNotification(env.notifCh, 500*time.Millisecond)
+	assert.Nil(t, evt, "no notification expected when user has active presence")
+
+	notifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeUser, recipientID, false)
+	require.NoError(t, err)
+	assert.Empty(t, notifs)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: formatChatNotification
+// ---------------------------------------------------------------------------
+
+func TestFormatChatNotification(t *testing.T) {
+	tests := []struct {
+		name             string
+		trigger          string
+		senderName       string
+		conversationName string
+		messagePreview   string
+		wantContains     []string
+	}{
+		{
+			name:             "mention with thread name",
+			trigger:          ChatNotificationMention,
+			senderName:       "Alice",
+			conversationName: "design-review",
+			messagePreview:   "Check the latest PR",
+			wantContains:     []string{"@Alice mentioned you", "#design-review", "Check the latest PR"},
+		},
+		{
+			name:             "mention without thread name",
+			trigger:          ChatNotificationMention,
+			senderName:       "Bob",
+			conversationName: "",
+			messagePreview:   "Hey there",
+			wantContains:     []string{"@Bob mentioned you", "Hey there"},
+		},
+		{
+			name:           "DM received",
+			trigger:        ChatNotificationDMReceived,
+			senderName:     "Charlie",
+			messagePreview: "Quick question about the build",
+			wantContains:   []string{"Charlie sent you a message", "Quick question about the build"},
+		},
+		{
+			name:           "long message preview truncated",
+			trigger:        ChatNotificationDMReceived,
+			senderName:     "Dave",
+			messagePreview: "This is a very long message that exceeds the maximum preview length and should be truncated at one hundred characters so that push notifications remain readable",
+			wantContains:   []string{"Dave sent you a message", "…"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatChatNotification(tt.trigger, tt.senderName, tt.conversationName, tt.messagePreview)
+			for _, want := range tt.wantContains {
+				assert.Contains(t, result, want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Agent mentions do NOT create user notifications (regression)
+// ---------------------------------------------------------------------------
+
+func TestAgentMentions_DoNotCreateUserNotifications(t *testing.T) {
+	// This test verifies that when an agent is @mentioned, NO user
+	// notification is created for it. Agent mentions create type:mention
+	// messages for the agent dispatch pipeline — not human notifications.
+	// This is the existing behavior and must not regress.
+	env := setupChatNotifTest(t)
+	defer env.unsub()
+
+	ctx := context.Background()
+
+	// Create a project and agent.
+	proj := &store.Project{
+		ID: api.NewUUID(), Name: "test-proj", Slug: "test-proj",
+		Created: time.Now(), Updated: time.Now(),
+	}
+	require.NoError(t, env.store.CreateProject(ctx, proj))
+
+	agent := &store.Agent{
+		ID: api.NewUUID(), Slug: "scout", Name: "Scout",
+		Template: "claude", ProjectID: proj.ID,
+		Visibility: store.VisibilityPrivate,
+	}
+	require.NoError(t, env.store.CreateAgent(ctx, agent))
+
+	// Simulate: message contains @scout. The mention resolution in
+	// handleConversationSend will match "scout" as an agent, NOT a human.
+	// The agent gets a type:mention side message through the dispatch path.
+	// The ChatNotifier should NOT be called for agent mentions.
+
+	// Verify: calling NotifyMention with the agent's UUID would be wrong.
+	// The fireHumanMentionNotifications helper only resolves mentions against
+	// project HUMAN members — agents are excluded. So if we have only agents
+	// in the project, no mention notification should fire.
+
+	// No human members → no mention notifications.
+	// (The only member is the agent, which is not a human.)
+	notifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeUser, agent.ID, false)
+	require.NoError(t, err)
+	assert.Empty(t, notifs, "agent mentions must not create user notifications")
+}
+
+// ---------------------------------------------------------------------------
+// Tests: IsConversationMuted (store method)
+// ---------------------------------------------------------------------------
+
+func TestIsConversationMuted_SQLite(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	wcs := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, wcs.Init())
+
+	ctx := context.Background()
+	userID := api.NewUUID()
+	key := api.NewUUID()
+
+	// No row → not muted.
+	muted, err := wcs.IsConversationMuted(ctx, userID, key)
+	require.NoError(t, err)
+	assert.False(t, muted, "should not be muted when no row exists")
+
+	// Set muted.
+	require.NoError(t, wcs.SetMuted(ctx, userID, key, true))
+	muted, err = wcs.IsConversationMuted(ctx, userID, key)
+	require.NoError(t, err)
+	assert.True(t, muted, "should be muted after SetMuted(true)")
+
+	// Unmute.
+	require.NoError(t, wcs.SetMuted(ctx, userID, key, false))
+	muted, err = wcs.IsConversationMuted(ctx, userID, key)
+	require.NoError(t, err)
+	assert.False(t, muted, "should not be muted after SetMuted(false)")
+}
+
+// ---------------------------------------------------------------------------
+// Tests: NoOpPresenceChecker
+// ---------------------------------------------------------------------------
+
+func TestNoOpPresenceChecker_AlwaysReturnsFalse(t *testing.T) {
+	checker := NoOpPresenceChecker{}
+	assert.False(t, checker.IsUserActive("any-user-id"))
+	assert.False(t, checker.IsUserActive(""))
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Nil ChatNotifier is safe
+// ---------------------------------------------------------------------------
+
+func TestChatNotifier_NilSafe(t *testing.T) {
+	// Calling methods on a nil ChatNotifier should not panic.
+	var cn *ChatNotifier
+	cn.NotifyMention(context.Background(), "user", "sender", "key", "thread", "msg", "proj")
+	cn.NotifyDMReceived(context.Background(), "user", "sender", "key", "msg", "proj")
+}
+
+// ---------------------------------------------------------------------------
+// Mock types
+// ---------------------------------------------------------------------------
+
+// mockPresenceChecker returns true for users in the activeUsers set.
+type mockPresenceChecker struct {
+	activeUsers map[string]bool
+}
+
+func (m *mockPresenceChecker) IsUserActive(userID string) bool {
+	return m.activeUsers[userID]
+}

--- a/pkg/hub/chat_notifications_test.go
+++ b/pkg/hub/chat_notifications_test.go
@@ -348,12 +348,12 @@ func TestAgentMentions_DoNotCreateUserNotifications(t *testing.T) {
 	// The helper should resolve "scout" against project members, NOT find
 	// it as a human, and skip it.
 	srv.fireHumanMentionNotifications(ctx,
-		[]string{"scout"},         // mentionNames — agent slug, not a human
-		proj.ID,                   // projectID
-		topicID,                   // conversationKey
-		senderID,                  // senderUserID
-		"Bob",                     // senderName
-		"Hey @scout check this",   // messageContent
+		[]string{"scout"},       // mentionNames — agent slug, not a human
+		proj.ID,                 // projectID
+		topicID,                 // conversationKey
+		senderID,                // senderUserID
+		"Bob",                   // senderName
+		"Hey @scout check this", // messageContent
 	)
 
 	// Verify: no notification was created for the agent UUID.
@@ -368,7 +368,7 @@ func TestAgentMentions_DoNotCreateUserNotifications(t *testing.T) {
 
 	// Now mention the human by display name — she SHOULD get a notification.
 	srv.fireHumanMentionNotifications(ctx,
-		[]string{"Alice"},         // mentionNames — human display name
+		[]string{"Alice"}, // mentionNames — human display name
 		proj.ID,
 		topicID,
 		senderID,

--- a/pkg/hub/chat_notifications_test.go
+++ b/pkg/hub/chat_notifications_test.go
@@ -284,44 +284,120 @@ func TestFormatChatNotification(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestAgentMentions_DoNotCreateUserNotifications(t *testing.T) {
-	// This test verifies that when an agent is @mentioned, NO user
-	// notification is created for it. Agent mentions create type:mention
+	// This test verifies that when an agent is @mentioned, the
+	// fireHumanMentionNotifications helper does NOT create a user
+	// notification for the agent. Agent mentions create type:mention
 	// messages for the agent dispatch pipeline — not human notifications.
-	// This is the existing behavior and must not regress.
-	env := setupChatNotifTest(t)
-	defer env.unsub()
-
+	srv, s := testServer(t)
 	ctx := context.Background()
 
-	// Create a project and agent.
+	// Set up WebChatStore + ChatNotifier on the server.
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	wcs := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, wcs.Init())
+	srv.SetWebChatStore(wcs)
+
+	// Create a project.
 	proj := &store.Project{
-		ID: api.NewUUID(), Name: "test-proj", Slug: "test-proj",
+		ID: api.NewUUID(), Name: "mention-test", Slug: "mention-test",
 		Created: time.Now(), Updated: time.Now(),
 	}
-	require.NoError(t, env.store.CreateProject(ctx, proj))
+	require.NoError(t, s.CreateProject(ctx, proj))
 
+	// Create an agent in the project.
 	agent := &store.Agent{
 		ID: api.NewUUID(), Slug: "scout", Name: "Scout",
 		Template: "claude", ProjectID: proj.ID,
 		Visibility: store.VisibilityPrivate,
 	}
-	require.NoError(t, env.store.CreateAgent(ctx, agent))
+	require.NoError(t, s.CreateAgent(ctx, agent))
 
-	// Simulate: message contains @scout. The mention resolution in
-	// handleConversationSend will match "scout" as an agent, NOT a human.
-	// The agent gets a type:mention side message through the dispatch path.
-	// The ChatNotifier should NOT be called for agent mentions.
+	// Create a human user and add to project members group.
+	humanUser := &store.User{
+		ID: api.NewUUID(), Email: "alice@example.com",
+		DisplayName: "Alice", Role: "member", Status: "active",
+		Created: time.Now(),
+	}
+	require.NoError(t, s.CreateUser(ctx, humanUser))
 
-	// Verify: calling NotifyMention with the agent's UUID would be wrong.
-	// The fireHumanMentionNotifications helper only resolves mentions against
-	// project HUMAN members — agents are excluded. So if we have only agents
-	// in the project, no mention notification should fire.
+	groupID := api.NewUUID()
+	require.NoError(t, s.CreateGroup(ctx, &store.Group{
+		ID:   groupID,
+		Name: "mention-test members",
+		Slug: "project:mention-test:members",
+	}))
+	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
+		GroupID:    groupID,
+		MemberType: store.GroupMemberTypeUser,
+		MemberID:   humanUser.ID,
+		Role:       "member",
+	}))
 
-	// No human members → no mention notifications.
-	// (The only member is the agent, which is not a human.)
-	notifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeUser, agent.ID, false)
+	// Create a topic for the conversation.
+	topicID := api.NewUUID()
+	require.NoError(t, wcs.CreateTopic(ctx, WebChatTopic{
+		ID: topicID, ProjectID: proj.ID, Name: "general",
+		CreatedBy: humanUser.ID, CreatedAt: time.Now(),
+	}))
+
+	senderID := api.NewUUID() // some other user
+
+	// Call fireHumanMentionNotifications with the agent slug as a mention.
+	// The helper should resolve "scout" against project members, NOT find
+	// it as a human, and skip it.
+	srv.fireHumanMentionNotifications(ctx,
+		[]string{"scout"},         // mentionNames — agent slug, not a human
+		proj.ID,                   // projectID
+		topicID,                   // conversationKey
+		senderID,                  // senderUserID
+		"Bob",                     // senderName
+		"Hey @scout check this",   // messageContent
+	)
+
+	// Verify: no notification was created for the agent UUID.
+	notifs, err := s.GetNotifications(ctx, store.SubscriberTypeUser, agent.ID, false)
 	require.NoError(t, err)
 	assert.Empty(t, notifs, "agent mentions must not create user notifications")
+
+	// Also verify no notification for the human — the human was not mentioned.
+	humanNotifs, err := s.GetNotifications(ctx, store.SubscriberTypeUser, humanUser.ID, false)
+	require.NoError(t, err)
+	assert.Empty(t, humanNotifs, "human should not be notified when only the agent was mentioned")
+
+	// Now mention the human by display name — she SHOULD get a notification.
+	srv.fireHumanMentionNotifications(ctx,
+		[]string{"Alice"},         // mentionNames — human display name
+		proj.ID,
+		topicID,
+		senderID,
+		"Bob",
+		"Hey @Alice check this",
+	)
+	humanNotifs, err = s.GetNotifications(ctx, store.SubscriberTypeUser, humanUser.ID, false)
+	require.NoError(t, err)
+	require.Len(t, humanNotifs, 1, "human should be notified when mentioned by display name")
+	assert.Contains(t, humanNotifs[0].Message, "@Bob mentioned you")
+
+	// Mention both agent and human — only human gets a notification.
+	srv.fireHumanMentionNotifications(ctx,
+		[]string{"scout", "Alice"}, // both agent and human
+		proj.ID,
+		topicID,
+		senderID,
+		"Charlie",
+		"Hey @scout @Alice",
+	)
+	// Alice should now have 2 total notifications.
+	humanNotifs, err = s.GetNotifications(ctx, store.SubscriberTypeUser, humanUser.ID, false)
+	require.NoError(t, err)
+	assert.Len(t, humanNotifs, 2, "human should get another notification")
+
+	// Agent should still have zero.
+	agentNotifs, err := s.GetNotifications(ctx, store.SubscriberTypeUser, agent.ID, false)
+	require.NoError(t, err)
+	assert.Empty(t, agentNotifs, "agent must never get user notifications from mentions")
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/hub/events.go
+++ b/pkg/hub/events.go
@@ -655,6 +655,21 @@ func (p *eventBuilder) PublishUserMessage(_ context.Context, msg *store.Message)
 		!strings.HasPrefix(msg.ThreadID, "agent:") {
 		p.sink("project."+msg.ProjectID+".chat.message", evt)
 	}
+	// Fan out DM messages to user.<id>.chat.dm for both participants so the
+	// v2 frontend (which subscribes to user.<self>.chat.>) receives real-time
+	// DM updates. The wave-1 user.<id>.message subject above is kept for
+	// backward compat. Wave-2 §4.4.
+	if msg.Channel == "web" && msg.ThreadID != "" && strings.HasPrefix(msg.ThreadID, "dm:") {
+		// Publish to both participants extracted from the DM key.
+		dmParts := strings.Split(msg.ThreadID, ":")
+		if len(dmParts) >= 5 {
+			id1, id2 := dmParts[2], dmParts[4]
+			p.sink("user."+id1+".chat.dm", evt)
+			if id2 != id1 {
+				p.sink("user."+id2+".chat.dm", evt)
+			}
+		}
+	}
 }
 
 // PublishChatTopicEvent publishes a topic lifecycle event on

--- a/pkg/hub/events.go
+++ b/pkg/hub/events.go
@@ -46,6 +46,10 @@ type EventPublisher interface {
 	// broker.dispatch.<dispatchID>.done so the originator's subscription wakes
 	// and reads the result from the dispatch row (design §6.3).
 	PublishDispatchDone(ctx context.Context, dispatchID string)
+	// PublishChatTopicEvent publishes a topic lifecycle event (created, updated,
+	// deleted) on project.<projectID>.chat.topic so SSE subscribers can
+	// update the space rail in real time.
+	PublishChatTopicEvent(ctx context.Context, projectID string, action string, topic WebChatTopic)
 	// Subscribe returns a channel that receives events matching the given
 	// subject patterns, along with an unsubscribe function. Patterns use
 	// NATS-style wildcards: '*' matches a single token, '>' matches the
@@ -75,8 +79,10 @@ func (noopEventPublisher) PublishAgentPorts(_ context.Context, _ *store.Agent)  
 func (noopEventPublisher) PublishAllowListChanged(_ context.Context, _, _ string)            {}
 func (noopEventPublisher) PublishInviteChanged(_ context.Context, _, _, _ string)            {}
 func (noopEventPublisher) PublishDispatchDone(_ context.Context, _ string)                   {}
-func (noopEventPublisher) PublishRaw(_ string, _ interface{})                                {}
-func (noopEventPublisher) Close()                                                            {}
+func (noopEventPublisher) PublishChatTopicEvent(_ context.Context, _ string, _ string, _ WebChatTopic) {
+}
+func (noopEventPublisher) PublishRaw(_ string, _ interface{}) {}
+func (noopEventPublisher) Close()                             {}
 
 // Subscribe on the no-op publisher returns a nil channel (which blocks forever
 // on receive) and a no-op unsubscribe. Callers that need real subscriptions
@@ -640,6 +646,28 @@ func (p *eventBuilder) PublishUserMessage(_ context.Context, msg *store.Message)
 	if msg.AgentID != "" {
 		p.sink("agent."+msg.AgentID+".message", evt)
 	}
+	// Fan out to project-scoped chat subject for web-channel messages with
+	// topic thread_ids (UUID, not dm: prefixed). This enables shared-space
+	// SSE: all project members see the message, not just the direct
+	// recipient. Wave-2 §4.4.
+	if msg.Channel == "web" && msg.ProjectID != "" && msg.ThreadID != "" &&
+		!strings.HasPrefix(msg.ThreadID, "dm:") &&
+		!strings.HasPrefix(msg.ThreadID, "agent:") {
+		p.sink("project."+msg.ProjectID+".chat.message", evt)
+	}
+}
+
+// PublishChatTopicEvent publishes a topic lifecycle event on
+// project.<projectID>.chat.topic.
+func (p *eventBuilder) PublishChatTopicEvent(_ context.Context, projectID string, action string, topic WebChatTopic) {
+	if projectID == "" {
+		return
+	}
+	evt := TopicEvent{
+		Action: action,
+		Topic:  topic,
+	}
+	p.sink("project."+projectID+".chat.topic", evt)
 }
 
 // PublishDispatchDone emits a slim completion event when a broker_dispatch row

--- a/pkg/hub/events_test.go
+++ b/pkg/hub/events_test.go
@@ -633,5 +633,186 @@ func TestNoopEventPublisher(t *testing.T) {
 	pub.PublishBrokerDisconnected(ctx, "", nil)
 	pub.PublishBrokerStatus(ctx, "", "")
 	pub.PublishNotification(ctx, &store.Notification{})
+	pub.PublishChatTopicEvent(ctx, "proj1", "created", WebChatTopic{})
 	pub.Close()
+}
+
+// --- Wave-2: PublishUserMessage chat subject fan-out ---
+
+func TestPublishUserMessage_ChatMessageSubject(t *testing.T) {
+	pub := NewChannelEventPublisher()
+	defer pub.Close()
+
+	// Subscribe to the project chat.message subject.
+	ch, unsub := pub.Subscribe("project.proj1.chat.message")
+	defer unsub()
+
+	topicUUID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	msg := &store.Message{
+		ID:          "msg-1",
+		ProjectID:   "proj1",
+		Sender:      "agent:coder",
+		SenderID:    "agent-uuid-1",
+		Recipient:   "user:alice",
+		RecipientID: "user-uuid-1",
+		Msg:         "hello from agent",
+		Type:        "assistant-reply",
+		Channel:     "web",
+		ThreadID:    topicUUID,
+		CreatedAt:   time.Now(),
+	}
+
+	pub.PublishUserMessage(context.Background(), msg)
+
+	// Should receive on project.proj1.chat.message
+	select {
+	case evt := <-ch:
+		if evt.Subject != "project.proj1.chat.message" {
+			t.Errorf("expected subject project.proj1.chat.message, got %s", evt.Subject)
+		}
+		var payload UserMessageEvent
+		if err := json.Unmarshal(evt.Data, &payload); err != nil {
+			t.Fatalf("failed to unmarshal event: %v", err)
+		}
+		if payload.ThreadID != topicUUID {
+			t.Errorf("expected threadId %s, got %s", topicUUID, payload.ThreadID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for chat.message event")
+	}
+}
+
+func TestPublishUserMessage_NoChatMessageForDM(t *testing.T) {
+	pub := NewChannelEventPublisher()
+	defer pub.Close()
+
+	ch, unsub := pub.Subscribe("project.proj1.chat.message")
+	defer unsub()
+
+	// DM thread_id should NOT produce a project.*.chat.message event.
+	msg := &store.Message{
+		ID:          "msg-2",
+		ProjectID:   "proj1",
+		Sender:      "agent:coder",
+		SenderID:    "agent-uuid-1",
+		Recipient:   "user:alice",
+		RecipientID: "user-uuid-1",
+		Msg:         "DM message",
+		Type:        "assistant-reply",
+		Channel:     "web",
+		ThreadID:    "dm:agent:agent-uuid-1:user:user-uuid-1",
+		CreatedAt:   time.Now(),
+	}
+
+	pub.PublishUserMessage(context.Background(), msg)
+
+	select {
+	case evt := <-ch:
+		t.Fatalf("DM should not produce chat.message event, got: %s", evt.Subject)
+	case <-time.After(100 * time.Millisecond):
+		// Expected: no event.
+	}
+}
+
+func TestPublishUserMessage_NoChatMessageForLegacyThread(t *testing.T) {
+	pub := NewChannelEventPublisher()
+	defer pub.Close()
+
+	ch, unsub := pub.Subscribe("project.proj1.chat.message")
+	defer unsub()
+
+	// Legacy agent:<slug> thread_id should NOT produce chat.message.
+	msg := &store.Message{
+		ID:          "msg-3",
+		ProjectID:   "proj1",
+		Sender:      "agent:coder",
+		SenderID:    "agent-uuid-1",
+		Recipient:   "user:alice",
+		RecipientID: "user-uuid-1",
+		Msg:         "legacy",
+		Type:        "assistant-reply",
+		Channel:     "web",
+		ThreadID:    "agent:coder",
+		CreatedAt:   time.Now(),
+	}
+
+	pub.PublishUserMessage(context.Background(), msg)
+
+	select {
+	case evt := <-ch:
+		t.Fatalf("legacy thread_id should not produce chat.message event, got: %s", evt.Subject)
+	case <-time.After(100 * time.Millisecond):
+		// Expected: no event.
+	}
+}
+
+func TestPublishUserMessage_NoChatMessageForNonWebChannel(t *testing.T) {
+	pub := NewChannelEventPublisher()
+	defer pub.Close()
+
+	ch, unsub := pub.Subscribe("project.proj1.chat.message")
+	defer unsub()
+
+	msg := &store.Message{
+		ID:          "msg-4",
+		ProjectID:   "proj1",
+		Sender:      "agent:coder",
+		SenderID:    "agent-uuid-1",
+		Recipient:   "user:alice",
+		RecipientID: "user-uuid-1",
+		Msg:         "discord message",
+		Type:        "assistant-reply",
+		Channel:     "discord",
+		ThreadID:    "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		CreatedAt:   time.Now(),
+	}
+
+	pub.PublishUserMessage(context.Background(), msg)
+
+	select {
+	case evt := <-ch:
+		t.Fatalf("non-web channel should not produce chat.message event, got: %s", evt.Subject)
+	case <-time.After(100 * time.Millisecond):
+		// Expected: no event.
+	}
+}
+
+// --- Wave-2: PublishChatTopicEvent ---
+
+func TestPublishChatTopicEvent(t *testing.T) {
+	pub := NewChannelEventPublisher()
+	defer pub.Close()
+
+	ch, unsub := pub.Subscribe("project.proj1.chat.topic")
+	defer unsub()
+
+	topic := WebChatTopic{
+		ID:        "topic-1",
+		ProjectID: "proj1",
+		Name:      "general",
+		IsGeneral: true,
+		CreatedBy: "user1",
+		CreatedAt: time.Now(),
+	}
+
+	pub.PublishChatTopicEvent(context.Background(), "proj1", "created", topic)
+
+	select {
+	case evt := <-ch:
+		if evt.Subject != "project.proj1.chat.topic" {
+			t.Errorf("expected subject project.proj1.chat.topic, got %s", evt.Subject)
+		}
+		var payload TopicEvent
+		if err := json.Unmarshal(evt.Data, &payload); err != nil {
+			t.Fatalf("failed to unmarshal event: %v", err)
+		}
+		if payload.Action != "created" {
+			t.Errorf("expected action created, got %s", payload.Action)
+		}
+		if payload.Topic.ID != "topic-1" {
+			t.Errorf("expected topic ID topic-1, got %s", payload.Topic.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for chat.topic event")
+	}
 }

--- a/pkg/hub/events_test.go
+++ b/pkg/hub/events_test.go
@@ -816,3 +816,115 @@ func TestPublishChatTopicEvent(t *testing.T) {
 		t.Fatal("timed out waiting for chat.topic event")
 	}
 }
+
+// --- Wave-2 W4: DM SSE subject publish ---
+
+func TestPublishUserMessage_DMChatSubject(t *testing.T) {
+	pub := NewChannelEventPublisher()
+	defer pub.Close()
+
+	agentUUID := "aaaaaaaa-1111-2222-3333-444444444444"
+	userUUID := "bbbbbbbb-5555-6666-7777-888888888888"
+	dmKey := "dm:agent:" + agentUUID + ":user:" + userUUID
+
+	// Subscribe to both participants' DM subjects.
+	chAgent, unsubA := pub.Subscribe("user." + agentUUID + ".chat.dm")
+	defer unsubA()
+	chUser, unsubU := pub.Subscribe("user." + userUUID + ".chat.dm")
+	defer unsubU()
+
+	// Should NOT produce a project.*.chat.message event for DMs.
+	chProject, unsubP := pub.Subscribe("project.proj1.chat.message")
+	defer unsubP()
+
+	msg := &store.Message{
+		ID:          "dm-msg-1",
+		ProjectID:   "proj1",
+		Sender:      "user:alice@example.com",
+		SenderID:    userUUID,
+		Recipient:   "agent:coder",
+		RecipientID: agentUUID,
+		Msg:         "hello agent",
+		Type:        "instruction",
+		Channel:     "web",
+		ThreadID:    dmKey,
+		CreatedAt:   time.Now(),
+	}
+
+	pub.PublishUserMessage(context.Background(), msg)
+
+	// Should receive on user.{agentUUID}.chat.dm
+	select {
+	case evt := <-chAgent:
+		if evt.Subject != "user."+agentUUID+".chat.dm" {
+			t.Errorf("expected subject user.%s.chat.dm, got %s", agentUUID, evt.Subject)
+		}
+		var payload UserMessageEvent
+		if err := json.Unmarshal(evt.Data, &payload); err != nil {
+			t.Fatalf("failed to unmarshal agent-side DM event: %v", err)
+		}
+		if payload.ThreadID != dmKey {
+			t.Errorf("expected threadId %s, got %s", dmKey, payload.ThreadID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for agent-side DM event")
+	}
+
+	// Should receive on user.{userUUID}.chat.dm
+	select {
+	case evt := <-chUser:
+		if evt.Subject != "user."+userUUID+".chat.dm" {
+			t.Errorf("expected subject user.%s.chat.dm, got %s", userUUID, evt.Subject)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for user-side DM event")
+	}
+
+	// Should NOT produce a project-scoped chat.message event for DMs.
+	select {
+	case evt := <-chProject:
+		t.Fatalf("DM should not produce project.*.chat.message event, got: %s", evt.Subject)
+	case <-time.After(100 * time.Millisecond):
+		// Expected: no event.
+	}
+}
+
+func TestPublishUserMessage_UserDM_BothSidesReceive(t *testing.T) {
+	pub := NewChannelEventPublisher()
+	defer pub.Close()
+
+	user1 := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	user2 := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	dmKey := "dm:user:" + user1 + ":user:" + user2
+
+	ch1, unsub1 := pub.Subscribe("user." + user1 + ".chat.dm")
+	defer unsub1()
+	ch2, unsub2 := pub.Subscribe("user." + user2 + ".chat.dm")
+	defer unsub2()
+
+	msg := &store.Message{
+		ID:          "dm-msg-2",
+		ProjectID:   "",
+		Sender:      "user:alice@example.com",
+		SenderID:    user1,
+		Recipient:   "user:bob@example.com",
+		RecipientID: user2,
+		Msg:         "hey bob",
+		Type:        "chat",
+		Channel:     "web",
+		ThreadID:    dmKey,
+		CreatedAt:   time.Now(),
+	}
+
+	pub.PublishUserMessage(context.Background(), msg)
+
+	// Both users should receive the DM event.
+	for _, ch := range []<-chan Event{ch1, ch2} {
+		select {
+		case <-ch:
+			// OK
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for user DM event")
+		}
+	}
+}

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -259,6 +259,18 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
+	// W6: DM notification for agent → human replies (non-broker path only).
+	// The broker path fires notifications from deliverToUser in messagebroker.go.
+	if bp := s.GetMessageBrokerProxy(); bp == nil {
+		if cn := s.getChatNotifier(); cn != nil && req.ThreadID != "" && strings.HasPrefix(req.ThreadID, "dm:") && recipientID != "" {
+			senderName := agent.Name
+			if senderName == "" {
+				senderName = agent.Slug
+			}
+			go cn.NotifyDMReceived(context.Background(), recipientID, senderName, req.ThreadID, req.Msg, agent.ProjectID)
+		}
+	}
+
 	s.logMessage("outbound message sent",
 		"agent_id", agent.ID,
 		"agent_name", agent.Name,

--- a/pkg/hub/handlers_chat.go
+++ b/pkg/hub/handlers_chat.go
@@ -23,11 +23,15 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
+// DEPRECATED(wave-1): Remove after v2 is stable and flag is permanently ON.
+//
 // handleChatThreads handles GET /api/v1/chat/threads.
 // Returns the thread rail for the authenticated user: a list of agents
 // they have conversed with, each with last-message preview and an
 // unread indicator. Reads from webchat_thread — no aggregate query
 // over the messages table (AC19a).
+//
+// Superseded by handleChatSpaces + handleListThreads in handlers_chat_v2.go.
 func (s *Server) handleChatThreads(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		MethodNotAllowed(w)
@@ -164,8 +168,12 @@ func (s *Server) handleChatThreads(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, chatThreadsResponse{Threads: entries})
 }
 
+// DEPRECATED(wave-1): Remove after v2 is stable and flag is permanently ON.
+//
 // handleChatThreadRoutes dispatches sub-routes under /api/v1/chat/threads/.
 // Currently handles POST /api/v1/chat/threads/{agentId}/read.
+//
+// Superseded by handleConversationRead in handlers_chat_v2.go.
 func (s *Server) handleChatThreadRoutes(w http.ResponseWriter, r *http.Request) {
 	// Parse: /api/v1/chat/threads/{agentId}/read
 	path := strings.TrimPrefix(r.URL.Path, "/api/v1/chat/threads/")
@@ -205,6 +213,9 @@ func (s *Server) handleChatThreadRoutes(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// DEPRECATED(wave-1): Writes to webchat_thread (wave-1 table). V2 UI uses
+	// handleConversationRead which writes to webchat_read_state instead.
+	// When v2 flag is ON, the frontend never calls this endpoint.
 	if err := s.webChatStore.MarkThreadRead(r.Context(), user.ID(), projectID, agentID); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to mark thread read"})
 		return

--- a/pkg/hub/handlers_chat.go
+++ b/pkg/hub/handlers_chat.go
@@ -52,6 +52,16 @@ func (s *Server) handleChatThreads(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Verify the caller has read access to the project (security fix — wave-2 §4.2).
+	project, err := s.store.GetProject(r.Context(), projectID)
+	if err != nil {
+		NotFound(w, "Project")
+		return
+	}
+	if !s.authorize(w, r, projectResource(project), ActionRead) {
+		return
+	}
+
 	limit := 50 // default
 	if limitStr := q.Get("limit"); limitStr != "" {
 		if n, err := strconv.Atoi(limitStr); err == nil && n > 0 && n <= 200 {

--- a/pkg/hub/handlers_chat_prefs.go
+++ b/pkg/hub/handlers_chat_prefs.go
@@ -26,6 +26,8 @@ var validVisibilityModes = map[string]bool{
 	"full":         true,
 }
 
+// DEPRECATED(wave-1): Remove after v2 is stable and flag is permanently ON.
+//
 // handleChatPrefs handles GET and PUT /api/v1/chat/prefs.
 //
 // Query parameters (required):
@@ -37,6 +39,9 @@ var validVisibilityModes = map[string]bool{
 // GET returns the current prefs (or defaults if none saved).
 // PUT accepts {"visibility_mode": "conversation"|"verbose"|"full"} and
 // upserts the pref row.
+//
+// Writes to webchat_thread_prefs (wave-1 table). V2 does not call this
+// endpoint — visibility mode is not used in the v2 conversation view.
 func (s *Server) handleChatPrefs(w http.ResponseWriter, r *http.Request) {
 	user := GetUserIdentityFromContext(r.Context())
 	if user == nil {

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -1257,6 +1257,11 @@ func (s *Server) handleSpaceMembers(w http.ResponseWriter, r *http.Request, proj
 		return
 	}
 
+	// --- Read presence manager ---
+	s.mu.RLock()
+	pm := s.presenceManager
+	s.mu.RUnlock()
+
 	// --- Humans: look up the project members group ---
 	var humans []chatMemberEntry
 	membersSlug := "project:" + project.Slug + ":members"
@@ -1272,14 +1277,18 @@ func (s *Server) handleSpaceMembers(w http.ResponseWriter, r *http.Request, proj
 				if err != nil {
 					continue
 				}
-				humans = append(humans, chatMemberEntry{
+				entry := chatMemberEntry{
 					ID:          u.ID,
 					Kind:        "user",
 					DisplayName: u.DisplayName,
 					Email:       u.Email,
 					AvatarURL:   u.AvatarURL,
 					Role:        m.Role,
-				})
+				}
+				if pm != nil {
+					entry.PresenceState = string(pm.GetState(u.ID))
+				}
+				humans = append(humans, entry)
 			}
 		}
 	}
@@ -1400,11 +1409,12 @@ func (s *Server) handleChatUserPrefs(w http.ResponseWriter, r *http.Request) {
 }
 
 // ---------------------------------------------------------------------------
-// Typing & Presence stubs (W5)
+// Typing & Presence (W5)
 // ---------------------------------------------------------------------------
 
 // handleConversationTyping handles POST /api/v1/chat/conversations/{key}/typing.
-// Stub for W5 — publishes an ephemeral typing event.
+// Publishes an ephemeral typing event after authorizing conversation access
+// and applying server-side throttling (one event per 4s per user per conversation).
 func (s *Server) handleConversationTyping(w http.ResponseWriter, r *http.Request, key string) {
 	if r.Method != http.MethodPost {
 		MethodNotAllowed(w)
@@ -1417,13 +1427,78 @@ func (s *Server) handleConversationTyping(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Publish ephemeral typing event on the project subject.
-	// For now just accept and acknowledge — full implementation in W5.
+	ctx := r.Context()
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	pm := s.presenceManager
+	s.mu.RUnlock()
+
+	// --- Authorize conversation access (W2 O3 deferred finding) ---
+	isDM := strings.HasPrefix(key, "dm:")
+	var projectID string
+	if isDM {
+		if !validDMKey(key) {
+			BadRequest(w, "invalid DM key format")
+			return
+		}
+		if !isDMParticipant(key, user.ID()) {
+			Forbidden(w)
+			return
+		}
+		// Resolve project from DM key for SSE fan-out.
+		projectID = resolveProjectFromDMKey(ctx, s, key)
+	} else {
+		// Topic key: look up topic to get project ID and check access.
+		if wcs == nil {
+			writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+			return
+		}
+		topic, err := wcs.GetTopic(ctx, key)
+		if err != nil || topic == nil {
+			NotFound(w, "Thread")
+			return
+		}
+		projectID = topic.ProjectID
+		project, err := s.store.GetProject(ctx, projectID)
+		if err != nil {
+			NotFound(w, "Project")
+			return
+		}
+		if !s.authorize(w, r, projectResource(project), ActionRead) {
+			return
+		}
+	}
+
+	// --- Server-side throttle: ignore if last typing from same user < 4s ---
+	if pm != nil {
+		if !pm.RecordTyping(key, user.ID()) {
+			// Throttled — accept silently.
+			writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+			return
+		}
+	}
+
+	// --- Publish ephemeral typing event ---
+	if projectID != "" {
+		displayName := user.DisplayName()
+		if displayName == "" {
+			displayName = user.Email()
+		}
+		evt := TypingEvent{
+			ThreadID:    key,
+			UserID:      user.ID(),
+			DisplayName: displayName,
+		}
+		s.events.PublishRaw("project."+projectID+".chat.typing", evt)
+	}
+
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 // handleChatPresence handles POST /api/v1/chat/presence.
-// Stub for W5 — heartbeat endpoint.
+// Processes a heartbeat from the client, updating the in-memory presence map
+// and publishing state transitions via SSE. Design §4.5.
 func (s *Server) handleChatPresence(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		MethodNotAllowed(w)
@@ -1436,7 +1511,32 @@ func (s *Server) handleChatPresence(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Full presence implementation in W5.
+	s.mu.RLock()
+	pm := s.presenceManager
+	s.mu.RUnlock()
+
+	if pm == nil {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		return
+	}
+
+	// Parse optional projectIds from the body so we know which project
+	// subjects to fan the presence transition out on.
+	var body struct {
+		ProjectIDs []string `json:"projectIds"`
+	}
+	if r.Body != nil {
+		r.Body = http.MaxBytesReader(w, r.Body, 65536)
+		_ = json.NewDecoder(r.Body).Decode(&body)
+	}
+
+	displayName := user.DisplayName()
+	if displayName == "" {
+		displayName = user.Email()
+	}
+
+	pm.Heartbeat(r.Context(), user.ID(), displayName, body.ProjectIDs)
+
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
@@ -1787,13 +1887,14 @@ type chatMembersResponse struct {
 }
 
 type chatMemberEntry struct {
-	ID          string `json:"id"`
-	Kind        string `json:"kind"`
-	DisplayName string `json:"displayName"`
-	Email       string `json:"email,omitempty"`
-	AvatarURL   string `json:"avatarUrl,omitempty"`
-	Slug        string `json:"slug,omitempty"`
-	Role        string `json:"role,omitempty"`
-	Phase       string `json:"phase,omitempty"`
-	Activity    string `json:"activity,omitempty"`
+	ID            string `json:"id"`
+	Kind          string `json:"kind"`
+	DisplayName   string `json:"displayName"`
+	Email         string `json:"email,omitempty"`
+	AvatarURL     string `json:"avatarUrl,omitempty"`
+	Slug          string `json:"slug,omitempty"`
+	Role          string `json:"role,omitempty"`
+	Phase         string `json:"phase,omitempty"`
+	Activity      string `json:"activity,omitempty"`
+	PresenceState string `json:"presenceState,omitempty"`
 }

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -615,7 +617,8 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 	// --- Validate body ---
 	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
 	var body struct {
-		Content string `json:"content"`
+		Content     string   `json:"content"`
+		Attachments []string `json:"attachments,omitempty"` // W7: attachment IDs
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		BadRequest(w, "invalid request body")
@@ -623,13 +626,40 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 	}
 
 	content := strings.TrimSpace(body.Content)
-	if content == "" {
-		ValidationError(w, "content is required", nil)
+	if content == "" && len(body.Attachments) == 0 {
+		ValidationError(w, "content or attachments required", nil)
 		return
 	}
 	if utf8.RuneCountInString(content) > messages.MaxMessageLength {
 		ValidationError(w, fmt.Sprintf("message exceeds %d character limit", messages.MaxMessageLength), nil)
 		return
+	}
+	if len(body.Attachments) > MaxAttachmentsPerMessage {
+		ValidationError(w, fmt.Sprintf("too many attachments: %d (max %d)", len(body.Attachments), MaxAttachmentsPerMessage), nil)
+		return
+	}
+
+	// W7: Validate attachment IDs and collect metadata.
+	var attachmentRefs []AttachmentRef
+	if len(body.Attachments) > 0 && wcs != nil {
+		for _, aid := range body.Attachments {
+			meta, err := wcs.GetAttachment(ctx, aid)
+			if err != nil || meta == nil {
+				ValidationError(w, fmt.Sprintf("attachment %q not found", aid), nil)
+				return
+			}
+			// Verify the attachment belongs to the correct project.
+			if projectID != "" && meta.ProjectID != projectID {
+				ValidationError(w, fmt.Sprintf("attachment %q does not belong to this project", aid), nil)
+				return
+			}
+			attachmentRefs = append(attachmentRefs, AttachmentRef{
+				ID:       meta.ID,
+				Name:     meta.Filename,
+				MimeType: meta.MimeType,
+				Size:     meta.Size,
+			})
+		}
 	}
 
 	// --- Resolve routing per design §3 ---
@@ -677,7 +707,7 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 	// Step 3: Determine routing.
 	if len(mentionedAgents) > 0 {
 		// --- Agent-routed: explicit mentions ---
-		s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, mentionedAgents, mentionNames, mentionResults, now)
+		s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, mentionedAgents, mentionNames, mentionResults, attachmentRefs, now)
 		// Ensure DM registry rows exist so the DM appears in the rail.
 		if isDM {
 			s.ensureDMRegistered(ctx, key, user.ID())
@@ -693,7 +723,7 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 		if agentID := parseAgentDMKey(key); agentID != "" {
 			dmAgent, err := s.store.GetAgent(ctx, agentID)
 			if err == nil && dmAgent != nil {
-				s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{dmAgent}, mentionNames, nil, now)
+				s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{dmAgent}, mentionNames, nil, attachmentRefs, now)
 				// Ensure DM registry rows exist so the DM appears in the rail.
 				s.ensureDMRegistered(ctx, key, user.ID())
 				return
@@ -706,19 +736,20 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 			// Resolve the default agent.
 			defaultAgent, err := s.store.GetAgent(ctx, topic.DefaultAgent)
 			if err == nil && defaultAgent != nil {
-				s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{defaultAgent}, mentionNames, nil, now)
+				s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{defaultAgent}, mentionNames, nil, attachmentRefs, now)
 				return
 			}
 		}
 	}
 
 	// --- Human-to-human message ---
-	s.sendHumanToHuman(w, r, key, projectID, user, content, senderLabel, isDM, mentionNames, now)
+	s.sendHumanToHuman(w, r, key, projectID, user, content, senderLabel, isDM, mentionNames, attachmentRefs, now)
 }
 
 // sendAgentRouted sends a message through the existing agent dispatch path.
 func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, projectID string, user UserIdentity,
-	content, senderLabel string, agents []*store.Agent, mentionNames []string, mentionResults []messages.MentionResult, now time.Time) {
+	content, senderLabel string, agents []*store.Agent, mentionNames []string, mentionResults []messages.MentionResult,
+	attachmentRefs []AttachmentRef, now time.Time) {
 
 	ctx := r.Context()
 
@@ -743,6 +774,27 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 		ThreadID:    key,
 	}
 
+	// W7: Add attachment metadata and file paths for agent dispatch.
+	if len(attachmentRefs) > 0 {
+		// Embed attachment metadata in StructuredMessage.Metadata for SSE consumers.
+		if msg.Metadata == nil {
+			msg.Metadata = make(map[string]string)
+		}
+		refsJSON, _ := json.Marshal(attachmentRefs)
+		msg.Metadata["attachments"] = string(refsJSON)
+
+		// For agent dispatch: pass container-visible file paths in Attachments
+		// (same pattern as Discord plugin — agents receive []string of paths).
+		s.mu.RLock()
+		as := s.attachmentStore
+		s.mu.RUnlock()
+		if localAS, ok := as.(*LocalDiskAttachmentStore); ok {
+			for _, ref := range attachmentRefs {
+				msg.Attachments = append(msg.Attachments, localAS.FilePath(projectID, ref.ID, ref.Name))
+			}
+		}
+	}
+
 	// Persist the instruction message.
 	storeMsg := &store.Message{
 		ID:            api.NewUUID(),
@@ -764,6 +816,19 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to persist message", nil)
 		return
 	}
+
+	// W7: Link attachments to the persisted message.
+	s.mu.RLock()
+	linkWcs := s.webChatStore
+	s.mu.RUnlock()
+	if linkWcs != nil && len(attachmentRefs) > 0 {
+		for _, ref := range attachmentRefs {
+			if err := linkWcs.LinkAttachmentToMessage(ctx, storeMsg.ID, ref.ID); err != nil {
+				s.messageLog.Error("Failed to link attachment to message", "attachment", ref.ID, "error", err)
+			}
+		}
+	}
+
 	s.events.PublishUserMessage(ctx, storeMsg)
 
 	// Dispatch to the primary agent.
@@ -785,6 +850,9 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 			mentionMsg.RecipientID = mentionAgent.ID
 			mentionMsg.Channel = "web"
 			mentionMsg.ThreadID = key
+			// W7: Copy attachment paths and metadata to mention messages.
+			mentionMsg.Attachments = msg.Attachments
+			mentionMsg.Metadata = msg.Metadata
 
 			mentionStoreMsg := &store.Message{
 				ID:            api.NewUUID(),
@@ -828,19 +896,20 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 	}
 
 	writeJSON(w, http.StatusCreated, chatMessageResponse{
-		ID:        storeMsg.ID,
-		Content:   content,
-		Sender:    storeMsg.Sender,
-		SenderID:  storeMsg.SenderID,
-		Type:      storeMsg.Type,
-		CreatedAt: now,
-		Mentions:  mentionResults,
+		ID:          storeMsg.ID,
+		Content:     content,
+		Sender:      storeMsg.Sender,
+		SenderID:    storeMsg.SenderID,
+		Type:        storeMsg.Type,
+		CreatedAt:   now,
+		Mentions:    mentionResults,
+		Attachments: attachmentRefs,
 	})
 }
 
 // sendHumanToHuman persists a type:chat message for human-to-human communication.
 func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, projectID string, user UserIdentity,
-	content, senderLabel string, isDM bool, mentionNames []string, now time.Time) {
+	content, senderLabel string, isDM bool, mentionNames []string, attachmentRefs []AttachmentRef, now time.Time) {
 
 	ctx := r.Context()
 
@@ -895,6 +964,15 @@ func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, p
 		return
 	}
 
+	// W7: Link attachments to the persisted message.
+	if wcs != nil && len(attachmentRefs) > 0 {
+		for _, ref := range attachmentRefs {
+			if err := wcs.LinkAttachmentToMessage(ctx, storeMsg.ID, ref.ID); err != nil {
+				slog.Error("Failed to link attachment to message", "attachment", ref.ID, "error", err)
+			}
+		}
+	}
+
 	// Publish SSE event.
 	s.events.PublishUserMessage(ctx, storeMsg)
 
@@ -921,12 +999,13 @@ func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, p
 	}
 
 	writeJSON(w, http.StatusCreated, chatMessageResponse{
-		ID:        storeMsg.ID,
-		Content:   content,
-		Sender:    storeMsg.Sender,
-		SenderID:  storeMsg.SenderID,
-		Type:      storeMsg.Type,
-		CreatedAt: now,
+		ID:          storeMsg.ID,
+		Content:     content,
+		Sender:      storeMsg.Sender,
+		SenderID:    storeMsg.SenderID,
+		Type:        storeMsg.Type,
+		CreatedAt:   now,
+		Attachments: attachmentRefs,
 	})
 }
 
@@ -1012,10 +1091,32 @@ func (s *Server) handleConversationHistory(w http.ResponseWriter, r *http.Reques
 		result.Items = []store.Message{}
 	}
 
+	// W7: Enrich messages with attachment metadata.
+	var messageAttachments map[string][]AttachmentRef
+	if wcs != nil && len(result.Items) > 0 {
+		messageAttachments = make(map[string][]AttachmentRef)
+		for _, msg := range result.Items {
+			attachments, err := wcs.GetAttachmentsByMessage(ctx, msg.ID)
+			if err == nil && len(attachments) > 0 {
+				refs := make([]AttachmentRef, 0, len(attachments))
+				for _, a := range attachments {
+					refs = append(refs, AttachmentRef{
+						ID:       a.ID,
+						Name:     a.Filename,
+						MimeType: a.MimeType,
+						Size:     a.Size,
+					})
+				}
+				messageAttachments[msg.ID] = refs
+			}
+		}
+	}
+
 	writeJSON(w, http.StatusOK, chatHistoryResponse{
-		Messages:   result.Items,
-		NextCursor: result.NextCursor,
-		TotalCount: result.TotalCount,
+		Messages:           result.Items,
+		NextCursor:         result.NextCursor,
+		TotalCount:         result.TotalCount,
+		MessageAttachments: messageAttachments,
 	})
 }
 
@@ -2027,19 +2128,21 @@ type chatTopicEntry struct {
 }
 
 type chatMessageResponse struct {
-	ID        string                   `json:"id"`
-	Content   string                   `json:"content"`
-	Sender    string                   `json:"sender"`
-	SenderID  string                   `json:"senderId"`
-	Type      string                   `json:"type"`
-	CreatedAt time.Time                `json:"createdAt"`
-	Mentions  []messages.MentionResult `json:"mentions,omitempty"`
+	ID          string                   `json:"id"`
+	Content     string                   `json:"content"`
+	Sender      string                   `json:"sender"`
+	SenderID    string                   `json:"senderId"`
+	Type        string                   `json:"type"`
+	CreatedAt   time.Time                `json:"createdAt"`
+	Mentions    []messages.MentionResult `json:"mentions,omitempty"`
+	Attachments []AttachmentRef          `json:"attachments,omitempty"` // W7
 }
 
 type chatHistoryResponse struct {
-	Messages   []store.Message `json:"messages"`
-	NextCursor string          `json:"nextCursor,omitempty"`
-	TotalCount int             `json:"totalCount"`
+	Messages           []store.Message            `json:"messages"`
+	NextCursor         string                     `json:"nextCursor,omitempty"`
+	TotalCount         int                        `json:"totalCount"`
+	MessageAttachments map[string][]AttachmentRef `json:"messageAttachments,omitempty"` // W7: keyed by message ID
 }
 
 type chatDMListResponse struct {
@@ -2083,4 +2186,234 @@ type chatMemberEntry struct {
 	Phase         string `json:"phase,omitempty"`
 	Activity      string `json:"activity,omitempty"`
 	PresenceState string `json:"presenceState,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// W7: Attachment upload / download handlers
+// ---------------------------------------------------------------------------
+
+// handleChatAttachments dispatches /api/v1/chat/attachments.
+// POST = upload, GET with /{id} = download.
+func (s *Server) handleChatAttachments(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		s.handleAttachmentUpload(w, r)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// handleChatAttachmentByID dispatches /api/v1/chat/attachments/{id}.
+func (s *Server) handleChatAttachmentByID(w http.ResponseWriter, r *http.Request) {
+	// Extract attachment ID from path: /api/v1/chat/attachments/{id}
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/chat/attachments/")
+	id := strings.TrimRight(path, "/")
+	if id == "" {
+		NotFound(w, "Attachment")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		s.handleAttachmentDownload(w, r, id)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// handleAttachmentUpload handles POST /api/v1/chat/attachments (multipart form).
+func (s *Server) handleAttachmentUpload(w http.ResponseWriter, r *http.Request) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	as := s.attachmentStore
+	s.mu.RUnlock()
+
+	if wcs == nil || as == nil {
+		writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Attachments not available", nil)
+		return
+	}
+
+	// Require project_id parameter for authz.
+	projectID := r.FormValue("project_id")
+	if projectID == "" {
+		// Try multipart form value.
+		if err := r.ParseMultipartForm(MaxAttachmentSize * MaxAttachmentsPerMessage); err == nil {
+			projectID = r.FormValue("project_id")
+		}
+	}
+	if projectID == "" {
+		ValidationError(w, "project_id is required", nil)
+		return
+	}
+
+	// Authorize: user must have read access to the project (same as sending messages).
+	project, err := s.store.GetProject(ctx, projectID)
+	if err != nil {
+		NotFound(w, "Project")
+		return
+	}
+	if !s.authorize(w, r, projectResource(project), ActionRead) {
+		return
+	}
+
+	// Parse multipart form (limit total to MaxAttachmentSize * MaxAttachmentsPerMessage).
+	r.Body = http.MaxBytesReader(w, r.Body, int64(MaxAttachmentSize*MaxAttachmentsPerMessage)+1024*1024)
+	if err := r.ParseMultipartForm(MaxAttachmentSize * MaxAttachmentsPerMessage); err != nil {
+		BadRequest(w, "invalid multipart form or request too large")
+		return
+	}
+
+	files := r.MultipartForm.File["files"]
+	if len(files) == 0 {
+		ValidationError(w, "no files uploaded", nil)
+		return
+	}
+	if len(files) > MaxAttachmentsPerMessage {
+		ValidationError(w, fmt.Sprintf("too many files: %d (max %d)", len(files), MaxAttachmentsPerMessage), nil)
+		return
+	}
+
+	var results []attachmentUploadResult
+	for _, fh := range files {
+		// Validate size.
+		if fh.Size > MaxAttachmentSize {
+			ValidationError(w, fmt.Sprintf("file %q exceeds maximum size of %d bytes", fh.Filename, MaxAttachmentSize), nil)
+			return
+		}
+
+		// Sanitize filename.
+		safeName, err := SanitizeFilename(fh.Filename)
+		if err != nil {
+			ValidationError(w, fmt.Sprintf("invalid filename %q: %v", fh.Filename, err), nil)
+			return
+		}
+
+		// Validate MIME type.
+		mime := fh.Header.Get("Content-Type")
+		// Normalize: strip parameters (e.g. "text/plain; charset=utf-8" -> "text/plain").
+		if idx := strings.Index(mime, ";"); idx >= 0 {
+			mime = strings.TrimSpace(mime[:idx])
+		}
+		if !AllowedMimeTypes[mime] {
+			ValidationError(w, fmt.Sprintf("file type %q not allowed", mime), nil)
+			return
+		}
+
+		// Open the file.
+		file, err := fh.Open()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to read uploaded file", nil)
+			return
+		}
+
+		// Save to storage.
+		meta, err := as.Save(ctx, projectID, safeName, file, fh.Size, mime)
+		file.Close()
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "INTERNAL", fmt.Sprintf("failed to save file: %v", err), nil)
+			return
+		}
+
+		// Set the uploader.
+		meta.UploadedBy = user.ID()
+
+		// Persist metadata in DB.
+		if err := wcs.CreateAttachment(ctx, meta); err != nil {
+			writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to save attachment metadata", nil)
+			return
+		}
+
+		results = append(results, attachmentUploadResult{
+			ID:       meta.ID,
+			Name:     meta.Filename,
+			MimeType: meta.MimeType,
+			Size:     meta.Size,
+			URL:      "/api/v1/chat/attachments/" + meta.ID,
+		})
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]interface{}{
+		"attachments": results,
+	})
+}
+
+// handleAttachmentDownload handles GET /api/v1/chat/attachments/{id}.
+func (s *Server) handleAttachmentDownload(w http.ResponseWriter, r *http.Request, id string) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	as := s.attachmentStore
+	s.mu.RUnlock()
+
+	if wcs == nil || as == nil {
+		writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Attachments not available", nil)
+		return
+	}
+
+	// Look up metadata from DB.
+	meta, err := wcs.GetAttachment(ctx, id)
+	if err != nil || meta == nil {
+		NotFound(w, "Attachment")
+		return
+	}
+
+	// Authorize: user must have read access to the project.
+	project, err := s.store.GetProject(ctx, meta.ProjectID)
+	if err != nil {
+		NotFound(w, "Project")
+		return
+	}
+	if !s.authorize(w, r, projectResource(project), ActionRead) {
+		return
+	}
+
+	// Get file from storage.
+	reader, fileMeta, err := as.Get(ctx, id)
+	if err != nil {
+		NotFound(w, "Attachment file")
+		return
+	}
+	defer reader.Close()
+
+	// Set headers.
+	mimeType := meta.MimeType
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+	w.Header().Set("Content-Type", mimeType)
+
+	// Content-Disposition: inline for images, attachment for everything else.
+	disposition := "attachment"
+	if IsImageMime(mimeType) {
+		disposition = "inline"
+	}
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`%s; filename="%s"`, disposition, meta.Filename))
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", fileMeta.Size))
+	w.Header().Set("Cache-Control", "private, max-age=3600")
+
+	w.WriteHeader(http.StatusOK)
+	io.Copy(w, reader)
+}
+
+type attachmentUploadResult struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	MimeType string `json:"mime"`
+	Size     int64  `json:"size"`
+	URL      string `json:"url"`
 }

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -2351,7 +2351,7 @@ func (s *Server) handleAttachmentUpload(w http.ResponseWriter, r *http.Request) 
 
 		// Save to storage.
 		meta, err := as.Save(ctx, projectID, safeName, file, fh.Size, mime)
-		file.Close()
+		_ = file.Close()
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "INTERNAL", fmt.Sprintf("failed to save file: %v", err), nil)
 			return
@@ -2423,7 +2423,7 @@ func (s *Server) handleAttachmentDownload(w http.ResponseWriter, r *http.Request
 		NotFound(w, "Attachment file")
 		return
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	// Set headers.
 	mimeType := meta.MimeType
@@ -2448,7 +2448,7 @@ func (s *Server) handleAttachmentDownload(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Cache-Control", "private, max-age=3600")
 
 	w.WriteHeader(http.StatusOK)
-	io.Copy(w, reader)
+	_, _ = io.Copy(w, reader)
 }
 
 type attachmentUploadResult struct {

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -677,7 +677,7 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 	// Step 3: Determine routing.
 	if len(mentionedAgents) > 0 {
 		// --- Agent-routed: explicit mentions ---
-		s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, mentionedAgents, mentionResults, now)
+		s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, mentionedAgents, mentionNames, mentionResults, now)
 		// Ensure DM registry rows exist so the DM appears in the rail.
 		if isDM {
 			s.ensureDMRegistered(ctx, key, user.ID())
@@ -693,7 +693,7 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 		if agentID := parseAgentDMKey(key); agentID != "" {
 			dmAgent, err := s.store.GetAgent(ctx, agentID)
 			if err == nil && dmAgent != nil {
-				s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{dmAgent}, nil, now)
+				s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{dmAgent}, mentionNames, nil, now)
 				// Ensure DM registry rows exist so the DM appears in the rail.
 				s.ensureDMRegistered(ctx, key, user.ID())
 				return
@@ -706,19 +706,19 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 			// Resolve the default agent.
 			defaultAgent, err := s.store.GetAgent(ctx, topic.DefaultAgent)
 			if err == nil && defaultAgent != nil {
-				s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{defaultAgent}, nil, now)
+				s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{defaultAgent}, mentionNames, nil, now)
 				return
 			}
 		}
 	}
 
 	// --- Human-to-human message ---
-	s.sendHumanToHuman(w, r, key, projectID, user, content, senderLabel, isDM, now)
+	s.sendHumanToHuman(w, r, key, projectID, user, content, senderLabel, isDM, mentionNames, now)
 }
 
 // sendAgentRouted sends a message through the existing agent dispatch path.
 func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, projectID string, user UserIdentity,
-	content, senderLabel string, agents []*store.Agent, mentionResults []messages.MentionResult, now time.Time) {
+	content, senderLabel string, agents []*store.Agent, mentionNames []string, mentionResults []messages.MentionResult, now time.Time) {
 
 	ctx := r.Context()
 
@@ -820,6 +820,13 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 	// Update topic/DM watermark.
 	s.touchConversationActivity(ctx, key, storeMsg.ID)
 
+	// --- W6: Human mention notifications ---
+	// Resolve @mentions that didn't match agents — they may be human members.
+	// Fire in a goroutine to avoid blocking the response.
+	if cn := s.getChatNotifier(); cn != nil && len(mentionNames) > 0 && projectID != "" {
+		go s.fireHumanMentionNotifications(context.Background(), mentionNames, projectID, key, user.ID(), senderLabel, content)
+	}
+
 	writeJSON(w, http.StatusCreated, chatMessageResponse{
 		ID:        storeMsg.ID,
 		Content:   content,
@@ -833,7 +840,7 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 
 // sendHumanToHuman persists a type:chat message for human-to-human communication.
 func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, projectID string, user UserIdentity,
-	content, senderLabel string, isDM bool, now time.Time) {
+	content, senderLabel string, isDM bool, mentionNames []string, now time.Time) {
 
 	ctx := r.Context()
 
@@ -899,6 +906,18 @@ func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, p
 	// For DMs, ensure DM registry rows exist for both participants.
 	if isDM && wcs != nil {
 		s.ensureDMRegistered(ctx, key, user.ID())
+	}
+
+	// --- W6: Chat notifications ---
+	if cn := s.getChatNotifier(); cn != nil {
+		// DM received notification: notify the peer when a DM is sent.
+		if isDM && recipientID != "" && recipientID != user.ID() {
+			go cn.NotifyDMReceived(context.Background(), recipientID, senderLabel, key, content, projectID)
+		}
+		// Human mention notifications.
+		if len(mentionNames) > 0 && projectID != "" {
+			go s.fireHumanMentionNotifications(context.Background(), mentionNames, projectID, key, user.ID(), senderLabel, content)
+		}
 	}
 
 	writeJSON(w, http.StatusCreated, chatMessageResponse{
@@ -1569,6 +1588,118 @@ func (s *Server) ensureDMRegistered(ctx context.Context, key, callerID string) {
 		PeerKind:        peerKind1,
 		LastActivityAt:  now,
 	})
+}
+
+// ---------------------------------------------------------------------------
+// W6: Chat notification helpers
+// ---------------------------------------------------------------------------
+
+// fireHumanMentionNotifications resolves @mention names against project members
+// (humans, not agents) and fires a notification for each match. The sender is
+// excluded from notifications. Agent slugs are skipped — they already get
+// type:mention messages through the existing pipeline.
+func (s *Server) fireHumanMentionNotifications(ctx context.Context, mentionNames []string, projectID, conversationKey, senderUserID, senderName, messageContent string) {
+	cn := s.getChatNotifier()
+	if cn == nil {
+		return
+	}
+
+	// Resolve human members for the project.
+	humanMembers := s.resolveProjectHumanMembers(ctx, projectID)
+	if len(humanMembers) == 0 {
+		return
+	}
+
+	// Build a lookup by lowercase display name and email.
+	type memberInfo struct {
+		ID          string
+		DisplayName string
+	}
+	lookup := make(map[string]memberInfo)
+	for _, m := range humanMembers {
+		if m.DisplayName != "" {
+			lookup[strings.ToLower(m.DisplayName)] = memberInfo{ID: m.ID, DisplayName: m.DisplayName}
+		}
+		if m.Email != "" {
+			// Also match by email prefix (before @).
+			lookup[strings.ToLower(m.Email)] = memberInfo{ID: m.ID, DisplayName: m.DisplayName}
+			if at := strings.IndexByte(m.Email, '@'); at > 0 {
+				lookup[strings.ToLower(m.Email[:at])] = memberInfo{ID: m.ID, DisplayName: m.DisplayName}
+			}
+		}
+	}
+
+	// Resolve the conversation name for the notification message.
+	conversationName := ""
+	if !strings.HasPrefix(conversationKey, "dm:") {
+		s.mu.RLock()
+		wcs := s.webChatStore
+		s.mu.RUnlock()
+		if wcs != nil {
+			if topic, err := wcs.GetTopic(ctx, conversationKey); err == nil && topic != nil {
+				conversationName = topic.Name
+			}
+		}
+	}
+
+	seen := make(map[string]bool)
+	for _, name := range mentionNames {
+		lower := strings.ToLower(name)
+		member, ok := lookup[lower]
+		if !ok {
+			continue
+		}
+		// Skip the sender — don't notify yourself.
+		if member.ID == senderUserID {
+			continue
+		}
+		// Deduplicate.
+		if seen[member.ID] {
+			continue
+		}
+		seen[member.ID] = true
+
+		cn.NotifyMention(ctx, member.ID, senderName, conversationKey, conversationName, messageContent, projectID)
+	}
+}
+
+// resolveProjectHumanMembers returns the human members of a project by
+// looking up the project's members group. This is used to match @mentions
+// against human display names.
+func (s *Server) resolveProjectHumanMembers(ctx context.Context, projectID string) []chatMemberEntry {
+	project, err := s.store.GetProject(ctx, projectID)
+	if err != nil {
+		return nil
+	}
+
+	membersSlug := "project:" + project.Slug + ":members"
+	group, err := s.store.GetGroupBySlug(ctx, membersSlug)
+	if err != nil || group == nil {
+		return nil
+	}
+
+	members, err := s.store.GetGroupMembers(ctx, group.ID)
+	if err != nil {
+		return nil
+	}
+
+	var humans []chatMemberEntry
+	for _, m := range members {
+		if m.MemberType != store.GroupMemberTypeUser {
+			continue
+		}
+		u, err := s.store.GetUser(ctx, m.MemberID)
+		if err != nil {
+			continue
+		}
+		humans = append(humans, chatMemberEntry{
+			ID:          u.ID,
+			Kind:        "user",
+			DisplayName: u.DisplayName,
+			Email:       u.Email,
+		})
+	}
+	return humans
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -1,0 +1,1606 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// Route dispatchers
+// ---------------------------------------------------------------------------
+
+// handleChatSpaces handles GET /api/v1/chat/spaces.
+// Returns visible spaces (projects the caller can read) with unread rollup
+// and sort prefs.
+func (s *Server) handleChatSpaces(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
+		writeJSON(w, http.StatusOK, chatSpacesResponse{Spaces: []chatSpaceEntry{}})
+		return
+	}
+
+	// List all projects and filter by ActionRead using batch capability check.
+	allProjects, err := s.store.ListProjects(ctx, store.ProjectFilter{}, store.ListOptions{Limit: 1000})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to list projects", nil)
+		return
+	}
+
+	identity := GetIdentityFromContext(ctx)
+	resources := make([]Resource, len(allProjects.Items))
+	for i := range allProjects.Items {
+		resources[i] = projectResource(&allProjects.Items[i])
+	}
+	caps := s.authzService.ComputeCapabilitiesBatch(ctx, identity, resources, "project")
+
+	// Get user prefs.
+	prefs, _ := wcs.GetUserPrefs(ctx, user.ID())
+
+	var spaces []chatSpaceEntry
+	for i, p := range allProjects.Items {
+		if !capabilityAllows(caps[i], ActionRead) {
+			continue
+		}
+
+		// Get topics for this space to compute unread count.
+		topics, _ := wcs.ListTopics(ctx, p.ID)
+		convKeys := make([]string, 0, len(topics))
+		for _, t := range topics {
+			convKeys = append(convKeys, t.ID)
+		}
+
+		var unreadCount int
+		if len(convKeys) > 0 {
+			readStates, _ := wcs.GetReadStates(ctx, user.ID(), convKeys)
+			readMap := make(map[string]WebChatReadState, len(readStates))
+			for _, rs := range readStates {
+				readMap[rs.ConversationKey] = rs
+			}
+			for _, t := range topics {
+				rs, ok := readMap[t.ID]
+				if !ok || rs.LastReadMessageID == "" || (t.LastMessageID != "" && t.LastMessageID != rs.LastReadMessageID) {
+					if t.LastMessageID != "" {
+						unreadCount++
+					}
+				}
+			}
+		}
+
+		spaces = append(spaces, chatSpaceEntry{
+			ProjectID:   p.ID,
+			ProjectName: p.Name,
+			ProjectSlug: p.Slug,
+			ThreadCount: len(topics),
+			UnreadCount: unreadCount,
+		})
+	}
+
+	if spaces == nil {
+		spaces = []chatSpaceEntry{}
+	}
+
+	resp := chatSpacesResponse{
+		Spaces: spaces,
+	}
+	if prefs != nil {
+		resp.Prefs = &chatSpacePrefs{
+			SpaceSortMode:  prefs.SpaceSortMode,
+			SpaceOrder:     prefs.SpaceOrder,
+			ThreadSortMode: prefs.ThreadSortMode,
+		}
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// handleChatSpaceRoutes dispatches sub-routes under /api/v1/chat/spaces/.
+func (s *Server) handleChatSpaceRoutes(w http.ResponseWriter, r *http.Request) {
+	// Parse: /api/v1/chat/spaces/{projectId}/threads
+	//        /api/v1/chat/spaces/{projectId}/members
+	//        /api/v1/chat/spaces/{projectId}/read
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/chat/spaces/")
+	parts := strings.SplitN(path, "/", 2)
+
+	if len(parts) < 2 {
+		http.NotFound(w, r)
+		return
+	}
+
+	projectID := parts[0]
+	if projectID == "" {
+		BadRequest(w, "projectId is required")
+		return
+	}
+
+	action := parts[1]
+	switch action {
+	case "threads":
+		s.handleSpaceThreads(w, r, projectID)
+	case "members":
+		s.handleSpaceMembers(w, r, projectID)
+	case "read":
+		s.handleSpaceRead(w, r, projectID)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// handleChatConversationRoutes dispatches sub-routes under /api/v1/chat/conversations/.
+func (s *Server) handleChatConversationRoutes(w http.ResponseWriter, r *http.Request) {
+	// Parse: /api/v1/chat/conversations/{key}/messages
+	//        /api/v1/chat/conversations/{key}/read
+	//        /api/v1/chat/conversations/{key}/typing
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/chat/conversations/")
+	parts := strings.SplitN(path, "/", 2)
+
+	if len(parts) < 2 {
+		http.NotFound(w, r)
+		return
+	}
+
+	key := parts[0]
+	if key == "" {
+		BadRequest(w, "conversation key is required")
+		return
+	}
+
+	action := parts[1]
+	switch action {
+	case "messages":
+		s.handleConversationMessages(w, r, key)
+	case "read":
+		s.handleConversationRead(w, r, key)
+	case "typing":
+		s.handleConversationTyping(w, r, key)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// handleChatTopicRoutes dispatches routes under /api/v1/chat/threads/ for
+// wave-2 topic-level operations (PATCH, DELETE by topicId).
+// The existing handleChatThreadRoutes handles the wave-1 {agentId}/read path.
+// We register this separately on a path that doesn't conflict.
+func (s *Server) handleChatTopicRoutes(w http.ResponseWriter, r *http.Request) {
+	// Parse: /api/v1/chat/topics/{topicId}
+	topicID := strings.TrimPrefix(r.URL.Path, "/api/v1/chat/topics/")
+	if topicID == "" {
+		BadRequest(w, "topicId is required")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPatch:
+		s.handleTopicPatch(w, r, topicID)
+	case http.MethodDelete:
+		s.handleTopicDelete(w, r, topicID)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Thread CRUD
+// ---------------------------------------------------------------------------
+
+// handleSpaceThreads handles GET and POST /api/v1/chat/spaces/{projectId}/threads.
+func (s *Server) handleSpaceThreads(w http.ResponseWriter, r *http.Request, projectID string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.handleListThreads(w, r, projectID)
+	case http.MethodPost:
+		s.handleCreateThread(w, r, projectID)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// handleListThreads returns all non-deleted topics for a project, with per-user read state.
+func (s *Server) handleListThreads(w http.ResponseWriter, r *http.Request, projectID string) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	// Authorize project access.
+	project, err := s.store.GetProject(r.Context(), projectID)
+	if err != nil {
+		NotFound(w, "Project")
+		return
+	}
+	if !s.authorize(w, r, projectResource(project), ActionRead) {
+		return
+	}
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
+		writeJSON(w, http.StatusOK, chatTopicListResponse{Threads: []chatTopicEntry{}})
+		return
+	}
+
+	// ListTopics lazily creates #general.
+	topics, err := wcs.ListTopics(r.Context(), projectID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to list threads", nil)
+		return
+	}
+
+	// Batch-fetch read states.
+	convKeys := make([]string, 0, len(topics))
+	for _, t := range topics {
+		convKeys = append(convKeys, t.ID)
+	}
+	readStates, _ := wcs.GetReadStates(r.Context(), user.ID(), convKeys)
+	readMap := make(map[string]WebChatReadState, len(readStates))
+	for _, rs := range readStates {
+		readMap[rs.ConversationKey] = rs
+	}
+
+	entries := make([]chatTopicEntry, 0, len(topics))
+	for _, t := range topics {
+		entry := chatTopicEntry{
+			ID:             t.ID,
+			ProjectID:      t.ProjectID,
+			Name:           t.Name,
+			IsGeneral:      t.IsGeneral,
+			DefaultAgent:   t.DefaultAgent,
+			CreatedBy:      t.CreatedBy,
+			CreatedAt:      t.CreatedAt,
+			LastMessageID:  t.LastMessageID,
+			LastActivityAt: t.LastActivityAt,
+		}
+		if rs, ok := readMap[t.ID]; ok {
+			entry.LastReadMessageID = rs.LastReadMessageID
+			entry.Pinned = rs.Pinned
+			entry.Muted = rs.Muted
+			entry.HasUnread = t.LastMessageID != "" && t.LastMessageID != rs.LastReadMessageID
+		} else {
+			entry.HasUnread = t.LastMessageID != ""
+		}
+		entries = append(entries, entry)
+	}
+
+	writeJSON(w, http.StatusOK, chatTopicListResponse{Threads: entries})
+}
+
+// threadNameRegexp validates thread names: no special characters.
+var threadNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9 _\-]*$`)
+
+// handleCreateThread creates a new thread in a space.
+func (s *Server) handleCreateThread(w http.ResponseWriter, r *http.Request, projectID string) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	project, err := s.store.GetProject(r.Context(), projectID)
+	if err != nil {
+		NotFound(w, "Project")
+		return
+	}
+	if !s.authorize(w, r, projectResource(project), ActionRead) {
+		return
+	}
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
+		writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Chat not available", nil)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
+	var body struct {
+		Name         string `json:"name"`
+		DefaultAgent string `json:"defaultAgent,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		BadRequest(w, "invalid request body")
+		return
+	}
+
+	body.Name = strings.TrimSpace(body.Name)
+	if body.Name == "" {
+		ValidationError(w, "name is required", nil)
+		return
+	}
+	nameRunes := []rune(body.Name)
+	if len(nameRunes) > 100 {
+		ValidationError(w, "name must be 100 characters or fewer", nil)
+		return
+	}
+	if !threadNameRegexp.MatchString(body.Name) {
+		ValidationError(w, "name contains invalid characters", nil)
+		return
+	}
+
+	topicID := uuid.New().String()
+	now := time.Now().UTC()
+	topic := WebChatTopic{
+		ID:             topicID,
+		ProjectID:      projectID,
+		Name:           body.Name,
+		DefaultAgent:   body.DefaultAgent,
+		CreatedBy:      user.ID(),
+		CreatedAt:      now,
+		LastActivityAt: now,
+	}
+
+	if err := wcs.CreateTopic(r.Context(), topic); err != nil {
+		if strings.Contains(err.Error(), "name conflict") || strings.Contains(err.Error(), "UNIQUE constraint") {
+			ValidationError(w, "a thread with that name already exists in this space", nil)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to create thread", nil)
+		return
+	}
+
+	// Publish topic created event.
+	s.events.PublishChatTopicEvent(r.Context(), projectID, "created", topic)
+
+	writeJSON(w, http.StatusCreated, topic)
+}
+
+// handleTopicPatch handles PATCH /api/v1/chat/topics/{topicId}.
+func (s *Server) handleTopicPatch(w http.ResponseWriter, r *http.Request, topicID string) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
+		writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Chat not available", nil)
+		return
+	}
+
+	topic, err := wcs.GetTopic(r.Context(), topicID)
+	if err != nil || topic == nil {
+		NotFound(w, "Thread")
+		return
+	}
+
+	// Authorize project access.
+	project, err := s.store.GetProject(r.Context(), topic.ProjectID)
+	if err != nil {
+		NotFound(w, "Project")
+		return
+	}
+	if !s.authorize(w, r, projectResource(project), ActionRead) {
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
+	var body struct {
+		Name         *string `json:"name"`
+		DefaultAgent *string `json:"defaultAgent"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		BadRequest(w, "invalid request body")
+		return
+	}
+
+	updates := TopicUpdate{}
+
+	if body.Name != nil {
+		name := strings.TrimSpace(*body.Name)
+		if topic.IsGeneral {
+			ValidationError(w, "cannot rename the #general thread", nil)
+			return
+		}
+		if name == "" {
+			ValidationError(w, "name cannot be empty", nil)
+			return
+		}
+		nameRunes := []rune(name)
+		if len(nameRunes) > 100 {
+			ValidationError(w, "name must be 100 characters or fewer", nil)
+			return
+		}
+		if !threadNameRegexp.MatchString(name) {
+			ValidationError(w, "name contains invalid characters", nil)
+			return
+		}
+		updates.Name = &name
+	}
+
+	if body.DefaultAgent != nil {
+		updates.DefaultAgent = body.DefaultAgent
+	}
+
+	if updates.Name == nil && updates.DefaultAgent == nil {
+		writeJSON(w, http.StatusOK, topic)
+		return
+	}
+
+	if err := wcs.UpdateTopic(r.Context(), topicID, updates); err != nil {
+		if strings.Contains(err.Error(), "name conflict") || strings.Contains(err.Error(), "UNIQUE constraint") {
+			ValidationError(w, "a thread with that name already exists in this space", nil)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to update thread", nil)
+		return
+	}
+
+	// Fetch updated topic for response.
+	updated, err := wcs.GetTopic(r.Context(), topicID)
+	if err != nil || updated == nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to fetch updated thread", nil)
+		return
+	}
+
+	s.events.PublishChatTopicEvent(r.Context(), updated.ProjectID, "updated", *updated)
+
+	writeJSON(w, http.StatusOK, updated)
+}
+
+// handleTopicDelete handles DELETE /api/v1/chat/topics/{topicId}.
+func (s *Server) handleTopicDelete(w http.ResponseWriter, r *http.Request, topicID string) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
+		writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Chat not available", nil)
+		return
+	}
+
+	topic, err := wcs.GetTopic(r.Context(), topicID)
+	if err != nil || topic == nil {
+		NotFound(w, "Thread")
+		return
+	}
+
+	project, err := s.store.GetProject(r.Context(), topic.ProjectID)
+	if err != nil {
+		NotFound(w, "Project")
+		return
+	}
+	if !s.authorize(w, r, projectResource(project), ActionRead) {
+		return
+	}
+
+	if err := wcs.DeleteTopic(r.Context(), topicID); err != nil {
+		if strings.Contains(err.Error(), "#general") {
+			ValidationError(w, "cannot delete the #general thread", nil)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to delete thread", nil)
+		return
+	}
+
+	s.events.PublishChatTopicEvent(r.Context(), topic.ProjectID, "deleted", *topic)
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+// ---------------------------------------------------------------------------
+// Send Path (the core of W2)
+// ---------------------------------------------------------------------------
+
+// handleConversationMessages handles GET and POST /api/v1/chat/conversations/{key}/messages.
+func (s *Server) handleConversationMessages(w http.ResponseWriter, r *http.Request, key string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.handleConversationHistory(w, r, key)
+	case http.MethodPost:
+		s.handleConversationSend(w, r, key)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// handleConversationSend implements POST /api/v1/chat/conversations/{key}/messages.
+// This is the wave-2 send path with full routing per design §3/§4.3.
+func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, key string) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
+		writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Chat not available", nil)
+		return
+	}
+
+	// --- Authorize ---
+	var projectID string
+	isDM := strings.HasPrefix(key, "dm:")
+	if isDM {
+		// DM key: verify the caller is one of the two participants.
+		if !isDMParticipant(key, user.ID()) {
+			Forbidden(w)
+			return
+		}
+		// DMs are not project-scoped; derive project from agent if it's an
+		// agent DM, or skip project check for user-user DMs.
+	} else {
+		// Topic key: look up topic to get project ID and check access.
+		topic, err := wcs.GetTopic(ctx, key)
+		if err != nil || topic == nil {
+			NotFound(w, "Thread")
+			return
+		}
+		projectID = topic.ProjectID
+		project, err := s.store.GetProject(ctx, projectID)
+		if err != nil {
+			NotFound(w, "Project")
+			return
+		}
+		if !s.authorize(w, r, projectResource(project), ActionRead) {
+			return
+		}
+	}
+
+	// --- Validate body ---
+	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
+	var body struct {
+		Content string `json:"content"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		BadRequest(w, "invalid request body")
+		return
+	}
+
+	content := strings.TrimSpace(body.Content)
+	if content == "" {
+		ValidationError(w, "content is required", nil)
+		return
+	}
+	if utf8.RuneCountInString(content) > messages.MaxMessageLength {
+		ValidationError(w, fmt.Sprintf("message exceeds %d character limit", messages.MaxMessageLength), nil)
+		return
+	}
+
+	// --- Resolve routing per design §3 ---
+	senderEmail := user.Email()
+	senderName := user.DisplayName()
+	senderLabel := senderEmail
+	if senderName != "" {
+		senderLabel = senderName
+	}
+
+	// Resolve which project we're working in for agent resolution.
+	if projectID == "" && isDM {
+		projectID = resolveProjectFromDMKey(ctx, s, key)
+	}
+
+	// Step 1: Extract mentions.
+	mentionNames := messages.ExtractMentions(content)
+
+	// Step 2: Resolve agent mentions against project agents.
+	var mentionedAgents []*store.Agent
+	var mentionResults []messages.MentionResult
+	if len(mentionNames) > 0 && projectID != "" {
+		agentList, err := s.store.ListAgents(ctx, store.AgentFilter{ProjectID: projectID}, store.ListOptions{Limit: 200})
+		if err == nil {
+			agentInfos := make([]messages.AgentInfo, 0, len(agentList.Items))
+			agentBySlug := make(map[string]*store.Agent, len(agentList.Items))
+			for i := range agentList.Items {
+				a := &agentList.Items[i]
+				agentInfos = append(agentInfos, messages.AgentInfo{Slug: a.Slug, Name: a.Name})
+				agentBySlug[strings.ToLower(a.Slug)] = a
+			}
+			mentionResults = messages.ResolveMentions(mentionNames, agentInfos, "")
+			for _, mr := range mentionResults {
+				if mr.Status == "delivered" {
+					if a, ok := agentBySlug[strings.ToLower(mr.Slug)]; ok {
+						mentionedAgents = append(mentionedAgents, a)
+					}
+				}
+			}
+		}
+	}
+
+	now := time.Now().UTC()
+
+	// Step 3: Determine routing.
+	if len(mentionedAgents) > 0 {
+		// --- Agent-routed: explicit mentions ---
+		s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, mentionedAgents, mentionResults, now)
+		return
+	}
+
+	if !isDM && projectID != "" {
+		// Check if topic has a default_agent.
+		topic, err := wcs.GetTopic(ctx, key)
+		if err == nil && topic != nil && topic.DefaultAgent != "" {
+			// Resolve the default agent.
+			defaultAgent, err := s.store.GetAgent(ctx, topic.DefaultAgent)
+			if err == nil && defaultAgent != nil {
+				s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{defaultAgent}, nil, now)
+				return
+			}
+		}
+	}
+
+	// --- Human-to-human message ---
+	s.sendHumanToHuman(w, r, key, projectID, user, content, senderLabel, isDM, now)
+}
+
+// sendAgentRouted sends a message through the existing agent dispatch path.
+func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, projectID string, user UserIdentity,
+	content, senderLabel string, agents []*store.Agent, mentionResults []messages.MentionResult, now time.Time) {
+
+	ctx := r.Context()
+
+	if len(agents) == 0 {
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "no agent to route to", nil)
+		return
+	}
+
+	primaryAgent := agents[0]
+
+	// Build the structured message for the primary agent.
+	msg := &messages.StructuredMessage{
+		Version:     messages.Version,
+		Timestamp:   now.Format(time.RFC3339),
+		Sender:      "user:" + senderLabel,
+		SenderID:    user.ID(),
+		Recipient:   "agent:" + primaryAgent.Slug,
+		RecipientID: primaryAgent.ID,
+		Msg:         content,
+		Type:        messages.TypeInstruction,
+		Channel:     "web",
+		ThreadID:    key,
+	}
+
+	// Persist the instruction message.
+	storeMsg := &store.Message{
+		ID:            api.NewUUID(),
+		ProjectID:     projectID,
+		Sender:        msg.Sender,
+		SenderID:      msg.SenderID,
+		Recipient:     msg.Recipient,
+		RecipientID:   msg.RecipientID,
+		Msg:           content,
+		Type:          messages.TypeInstruction,
+		AgentID:       primaryAgent.ID,
+		Channel:       "web",
+		ThreadID:      key,
+		DispatchState: store.MessageDispatchDispatched,
+		CreatedAt:     now,
+	}
+	if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
+		s.messageLog.Error("Failed to persist agent-routed message", "error", err)
+	}
+	s.events.PublishUserMessage(ctx, storeMsg)
+
+	// Dispatch to the primary agent.
+	dispatcher := s.GetDispatcher()
+	if dispatcher != nil {
+		retryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		if err := dispatchWithBrokerRetry(retryCtx, dispatcher, primaryAgent, content, false, msg); err != nil {
+			s.messageLog.Error("Failed to dispatch to agent", "agent", primaryAgent.Slug, "error", err)
+			if storeMsg.ID != "" {
+				_ = s.store.MarkMessageFailed(ctx, storeMsg.ID, err.Error())
+			}
+		}
+	}
+
+	// Handle additional mentioned agents (fan-out).
+	if len(agents) > 1 {
+		for _, mentionAgent := range agents[1:] {
+			mentionMsg := messages.NewMention(msg.Sender, "agent:"+mentionAgent.Slug, content, msg.Recipient)
+			mentionMsg.SenderID = msg.SenderID
+			mentionMsg.RecipientID = mentionAgent.ID
+			mentionMsg.Channel = "web"
+			mentionMsg.ThreadID = key
+
+			mentionStoreMsg := &store.Message{
+				ID:            api.NewUUID(),
+				ProjectID:     projectID,
+				Sender:        mentionMsg.Sender,
+				SenderID:      mentionMsg.SenderID,
+				Recipient:     mentionMsg.Recipient,
+				RecipientID:   mentionMsg.RecipientID,
+				Msg:           content,
+				Type:          messages.TypeMention,
+				AgentID:       mentionAgent.ID,
+				Channel:       "web",
+				ThreadID:      key,
+				DispatchState: store.MessageDispatchDispatched,
+				CreatedAt:     now,
+			}
+			if err := s.store.CreateMessage(ctx, mentionStoreMsg); err != nil {
+				s.messageLog.Error("Failed to persist mention message", "slug", mentionAgent.Slug, "error", err)
+			} else {
+				s.events.PublishUserMessage(ctx, mentionStoreMsg)
+			}
+
+			if dispatcher != nil {
+				retryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				if err := dispatchWithBrokerRetry(retryCtx, dispatcher, mentionAgent, content, false, mentionMsg); err != nil {
+					s.messageLog.Error("Failed to dispatch mention", "slug", mentionAgent.Slug, "error", err)
+				}
+				cancel()
+			}
+		}
+	}
+
+	// Update topic/DM watermark.
+	s.touchConversationActivity(ctx, key, storeMsg.ID)
+
+	writeJSON(w, http.StatusCreated, chatMessageResponse{
+		ID:        storeMsg.ID,
+		Content:   content,
+		Sender:    storeMsg.Sender,
+		SenderID:  storeMsg.SenderID,
+		Type:      storeMsg.Type,
+		CreatedAt: now,
+		Mentions:  mentionResults,
+	})
+}
+
+// sendHumanToHuman persists a type:chat message for human-to-human communication.
+func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, projectID string, user UserIdentity,
+	content, senderLabel string, isDM bool, now time.Time) {
+
+	ctx := r.Context()
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	var recipient, recipientID string
+	if isDM {
+		peerEmail, peerID := resolveDMPeer(key, user.ID())
+		if peerEmail != "" {
+			recipient = "user:" + peerEmail
+		} else {
+			recipient = "user:" + peerID
+		}
+		recipientID = peerID
+		// Look up the peer to get their email for a better recipient label.
+		if peerID != "" && peerEmail == "" {
+			if peerUser, err := s.store.GetUser(ctx, peerID); err == nil {
+				recipient = "user:" + peerUser.Email
+			}
+		}
+	} else {
+		recipient = "thread:" + key
+		recipientID = key
+	}
+
+	storeMsg := &store.Message{
+		ID:          api.NewUUID(),
+		ProjectID:   projectID,
+		Sender:      "user:" + senderLabel,
+		SenderID:    user.ID(),
+		Recipient:   recipient,
+		RecipientID: recipientID,
+		Msg:         content,
+		Type:        messages.TypeChat,
+		Channel:     "web",
+		ThreadID:    key,
+		CreatedAt:   now,
+	}
+
+	if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to persist message", nil)
+		return
+	}
+
+	// Publish SSE event.
+	s.events.PublishUserMessage(ctx, storeMsg)
+
+	// Update conversation watermark.
+	if wcs != nil {
+		s.touchConversationActivity(ctx, key, storeMsg.ID)
+	}
+
+	// For DMs, ensure DM registry rows exist for both participants.
+	if isDM && wcs != nil {
+		s.ensureDMRegistered(ctx, key, user.ID())
+	}
+
+	writeJSON(w, http.StatusCreated, chatMessageResponse{
+		ID:        storeMsg.ID,
+		Content:   content,
+		Sender:    storeMsg.Sender,
+		SenderID:  storeMsg.SenderID,
+		Type:      storeMsg.Type,
+		CreatedAt: now,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Message History
+// ---------------------------------------------------------------------------
+
+// handleConversationHistory handles GET /api/v1/chat/conversations/{key}/messages.
+func (s *Server) handleConversationHistory(w http.ResponseWriter, r *http.Request, key string) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	// Authorize.
+	isDM := strings.HasPrefix(key, "dm:")
+	if isDM {
+		if !isDMParticipant(key, user.ID()) {
+			Forbidden(w)
+			return
+		}
+	} else {
+		if wcs == nil {
+			writeJSON(w, http.StatusOK, chatHistoryResponse{Messages: []store.Message{}})
+			return
+		}
+		topic, err := wcs.GetTopic(ctx, key)
+		if err != nil || topic == nil {
+			NotFound(w, "Thread")
+			return
+		}
+		project, err := s.store.GetProject(ctx, topic.ProjectID)
+		if err != nil {
+			NotFound(w, "Project")
+			return
+		}
+		if !s.authorize(w, r, projectResource(project), ActionRead) {
+			return
+		}
+	}
+
+	// Parse query params.
+	q := r.URL.Query()
+	limit := 50
+	if l := q.Get("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 && n <= 200 {
+			limit = n
+		}
+	}
+
+	filter := store.MessageFilter{
+		Channel:  "web",
+		ThreadID: key,
+	}
+	// Support visibility filter.
+	if vis := q["visibility"]; len(vis) > 0 {
+		filter.Visibility = vis
+	}
+
+	opts := store.ListOptions{
+		Limit:  limit,
+		Cursor: q.Get("before"),
+	}
+
+	result, err := s.store.ListMessages(ctx, filter, opts)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to fetch messages", nil)
+		return
+	}
+
+	if result.Items == nil {
+		result.Items = []store.Message{}
+	}
+
+	writeJSON(w, http.StatusOK, chatHistoryResponse{
+		Messages:   result.Items,
+		NextCursor: result.NextCursor,
+		TotalCount: result.TotalCount,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Read Watermarks
+// ---------------------------------------------------------------------------
+
+// handleConversationRead handles POST /api/v1/chat/conversations/{key}/read.
+func (s *Server) handleConversationRead(w http.ResponseWriter, r *http.Request, key string) {
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		return
+	}
+
+	// Authorize.
+	isDM := strings.HasPrefix(key, "dm:")
+	if isDM {
+		if !isDMParticipant(key, user.ID()) {
+			Forbidden(w)
+			return
+		}
+	} else {
+		topic, err := wcs.GetTopic(ctx, key)
+		if err != nil || topic == nil {
+			NotFound(w, "Thread")
+			return
+		}
+		project, err := s.store.GetProject(ctx, topic.ProjectID)
+		if err != nil {
+			NotFound(w, "Project")
+			return
+		}
+		if !s.authorize(w, r, projectResource(project), ActionRead) {
+			return
+		}
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
+	var body struct {
+		MessageID string `json:"messageId"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		BadRequest(w, "invalid request body")
+		return
+	}
+
+	if body.MessageID == "" {
+		ValidationError(w, "messageId is required", nil)
+		return
+	}
+
+	if err := wcs.SetReadState(ctx, user.ID(), key, body.MessageID); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to update read state", nil)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// handleSpaceRead handles POST /api/v1/chat/spaces/{projectId}/read.
+func (s *Server) handleSpaceRead(w http.ResponseWriter, r *http.Request, projectID string) {
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	project, err := s.store.GetProject(ctx, projectID)
+	if err != nil {
+		NotFound(w, "Project")
+		return
+	}
+	if !s.authorize(w, r, projectResource(project), ActionRead) {
+		return
+	}
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		return
+	}
+
+	topics, err := wcs.ListTopics(ctx, projectID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to list threads", nil)
+		return
+	}
+
+	for _, t := range topics {
+		if t.LastMessageID != "" {
+			_ = wcs.SetReadState(ctx, user.ID(), t.ID, t.LastMessageID)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// ---------------------------------------------------------------------------
+// DM Endpoints
+// ---------------------------------------------------------------------------
+
+// handleChatDMs handles GET /api/v1/chat/dms.
+func (s *Server) handleChatDMs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
+		writeJSON(w, http.StatusOK, chatDMListResponse{DMs: []chatDMEntry{}})
+		return
+	}
+
+	dms, err := wcs.ListDMs(ctx, user.ID())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to list DMs", nil)
+		return
+	}
+
+	entries := make([]chatDMEntry, 0, len(dms))
+	for _, dm := range dms {
+		entry := chatDMEntry{
+			ConversationKey: dm.ConversationKey,
+			PeerID:          dm.PeerID,
+			PeerKind:        dm.PeerKind,
+			LastMessageID:   dm.LastMessageID,
+			LastActivityAt:  dm.LastActivityAt,
+		}
+
+		// Enrich with peer info.
+		switch dm.PeerKind {
+		case "user":
+			if peerUser, err := s.store.GetUser(ctx, dm.PeerID); err == nil {
+				entry.PeerName = peerUser.DisplayName
+				entry.PeerEmail = peerUser.Email
+				entry.PeerAvatar = peerUser.AvatarURL
+			}
+		case "agent":
+			if peerAgent, err := s.store.GetAgent(ctx, dm.PeerID); err == nil {
+				entry.PeerName = peerAgent.Name
+				entry.PeerSlug = peerAgent.Slug
+			}
+		}
+
+		// Get read state for unread indicator.
+		rs, _ := wcs.GetReadState(ctx, user.ID(), dm.ConversationKey)
+		if rs != nil {
+			entry.LastReadMessageID = rs.LastReadMessageID
+			entry.HasUnread = dm.LastMessageID != "" && dm.LastMessageID != rs.LastReadMessageID
+		} else {
+			entry.HasUnread = dm.LastMessageID != ""
+		}
+
+		// Get last message preview.
+		if dm.LastMessageID != "" {
+			msgMap, err := s.store.GetMessagesByIDs(ctx, []string{dm.LastMessageID})
+			if err == nil {
+				if msg, ok := msgMap[dm.LastMessageID]; ok {
+					entry.LastMessagePreview = truncatePreview(msg.Msg, 120)
+					entry.LastMessageSender = msg.Sender
+				}
+			}
+		}
+
+		entries = append(entries, entry)
+	}
+
+	writeJSON(w, http.StatusOK, chatDMListResponse{DMs: entries})
+}
+
+// ---------------------------------------------------------------------------
+// Members Endpoint
+// ---------------------------------------------------------------------------
+
+// handleSpaceMembers handles GET /api/v1/chat/spaces/{projectId}/members.
+func (s *Server) handleSpaceMembers(w http.ResponseWriter, r *http.Request, projectID string) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	project, err := s.store.GetProject(ctx, projectID)
+	if err != nil {
+		NotFound(w, "Project")
+		return
+	}
+	if !s.authorize(w, r, projectResource(project), ActionRead) {
+		return
+	}
+
+	// --- Humans: look up the project members group ---
+	var humans []chatMemberEntry
+	membersSlug := "project:" + project.Slug + ":members"
+	group, err := s.store.GetGroupBySlug(ctx, membersSlug)
+	if err == nil && group != nil {
+		members, err := s.store.GetGroupMembers(ctx, group.ID)
+		if err == nil {
+			for _, m := range members {
+				if m.MemberType != store.GroupMemberTypeUser {
+					continue
+				}
+				u, err := s.store.GetUser(ctx, m.MemberID)
+				if err != nil {
+					continue
+				}
+				humans = append(humans, chatMemberEntry{
+					ID:          u.ID,
+					Kind:        "user",
+					DisplayName: u.DisplayName,
+					Email:       u.Email,
+					AvatarURL:   u.AvatarURL,
+					Role:        m.Role,
+				})
+			}
+		}
+	}
+	if humans == nil {
+		humans = []chatMemberEntry{}
+	}
+
+	// --- Agents: list agents for the project ---
+	var agents []chatMemberEntry
+	agentList, err := s.store.ListAgents(ctx, store.AgentFilter{ProjectID: projectID}, store.ListOptions{Limit: 200})
+	if err == nil {
+		for _, a := range agentList.Items {
+			agents = append(agents, chatMemberEntry{
+				ID:          a.ID,
+				Kind:        "agent",
+				DisplayName: a.Name,
+				Slug:        a.Slug,
+				Phase:       a.Phase,
+				Activity:    a.Activity,
+			})
+		}
+	}
+	if agents == nil {
+		agents = []chatMemberEntry{}
+	}
+
+	writeJSON(w, http.StatusOK, chatMembersResponse{
+		Humans: humans,
+		Agents: agents,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// User Preferences (Wave-2 extensions)
+// ---------------------------------------------------------------------------
+
+// handleChatUserPrefs handles GET|PUT /api/v1/chat/user-prefs.
+// This is separate from the wave-1 handleChatPrefs (which handles per-agent
+// visibility mode). This handles rail sort preferences.
+func (s *Server) handleChatUserPrefs(w http.ResponseWriter, r *http.Request) {
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
+		writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Chat not available", nil)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		prefs, err := wcs.GetUserPrefs(ctx, user.ID())
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to read preferences", nil)
+			return
+		}
+		if prefs == nil {
+			prefs = &WebChatUserPrefs{
+				SpaceSortMode:  "activity",
+				ThreadSortMode: "activity",
+			}
+		}
+		writeJSON(w, http.StatusOK, prefs)
+
+	case http.MethodPut:
+		r.Body = http.MaxBytesReader(w, r.Body, 1048576)
+		var body struct {
+			SpaceSortMode  string `json:"spaceSortMode"`
+			SpaceOrder     string `json:"spaceOrder"`
+			ThreadSortMode string `json:"threadSortMode"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			BadRequest(w, "invalid request body")
+			return
+		}
+
+		validSortModes := map[string]bool{"activity": true, "alpha": true, "custom": true}
+		if body.SpaceSortMode != "" && !validSortModes[body.SpaceSortMode] {
+			ValidationError(w, "spaceSortMode must be activity, alpha, or custom", nil)
+			return
+		}
+		validThreadSortModes := map[string]bool{"activity": true, "alpha": true}
+		if body.ThreadSortMode != "" && !validThreadSortModes[body.ThreadSortMode] {
+			ValidationError(w, "threadSortMode must be activity or alpha", nil)
+			return
+		}
+
+		prefs := WebChatUserPrefs{
+			UserID:         user.ID(),
+			SpaceSortMode:  body.SpaceSortMode,
+			SpaceOrder:     body.SpaceOrder,
+			ThreadSortMode: body.ThreadSortMode,
+		}
+		if prefs.SpaceSortMode == "" {
+			prefs.SpaceSortMode = "activity"
+		}
+		if prefs.ThreadSortMode == "" {
+			prefs.ThreadSortMode = "activity"
+		}
+
+		if err := wcs.SetUserPrefs(ctx, user.ID(), prefs); err != nil {
+			writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to save preferences", nil)
+			return
+		}
+		writeJSON(w, http.StatusOK, prefs)
+
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Typing & Presence stubs (W5)
+// ---------------------------------------------------------------------------
+
+// handleConversationTyping handles POST /api/v1/chat/conversations/{key}/typing.
+// Stub for W5 — publishes an ephemeral typing event.
+func (s *Server) handleConversationTyping(w http.ResponseWriter, r *http.Request, key string) {
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	// Publish ephemeral typing event on the project subject.
+	// For now just accept and acknowledge — full implementation in W5.
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// handleChatPresence handles POST /api/v1/chat/presence.
+// Stub for W5 — heartbeat endpoint.
+func (s *Server) handleChatPresence(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	// Full presence implementation in W5.
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// handleChatSearch handles GET /api/v1/chat/search.
+// Stub for W8.
+func (s *Server) handleChatSearch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	// Full search implementation in W8.
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"results":    []interface{}{},
+		"totalCount": 0,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+// isDMParticipant checks whether the given userID is one of the two
+// participants encoded in a DM conversation key.
+func isDMParticipant(key, userID string) bool {
+	// DM key formats:
+	//   dm:agent:<agentUUID>:user:<userUUID>
+	//   dm:user:<uuidA>:user:<uuidB>
+	return strings.Contains(key, ":"+userID)
+}
+
+// resolveDMPeer extracts the peer's ID from a DM key given the caller's ID.
+// The caller can be either a user or an agent.
+func resolveDMPeer(key, callerID string) (peerEmail, peerID string) {
+	// dm:agent:<agentUUID>:user:<userUUID>
+	// dm:user:<uuidA>:user:<uuidB>
+	parts := strings.Split(key, ":")
+	// Expected: [dm, kind1, id1, kind2, id2]
+	if len(parts) < 5 {
+		return "", ""
+	}
+
+	id1, id2 := parts[2], parts[4]
+
+	if id1 == callerID {
+		return "", id2
+	}
+	return "", id1
+}
+
+// resolveProjectFromDMKey attempts to derive a project ID from a DM key.
+// For agent DMs (dm:agent:<id>:user:<id>), looks up the agent's project.
+func resolveProjectFromDMKey(ctx context.Context, s *Server, key string) string {
+	parts := strings.Split(key, ":")
+	if len(parts) >= 3 && parts[1] == "agent" {
+		agent, err := s.store.GetAgent(ctx, parts[2])
+		if err == nil && agent != nil {
+			return agent.ProjectID
+		}
+	}
+	return ""
+}
+
+// touchConversationActivity updates the watermark for a conversation.
+func (s *Server) touchConversationActivity(ctx context.Context, key, messageID string) {
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
+		return
+	}
+
+	if strings.HasPrefix(key, "dm:") {
+		if err := wcs.TouchDMActivity(ctx, key, messageID); err != nil {
+			s.messageLog.Error("Failed to touch DM activity", "key", key, "error", err)
+		}
+	} else {
+		if err := wcs.TouchTopicActivity(ctx, key, messageID); err != nil {
+			s.messageLog.Error("Failed to touch topic activity", "key", key, "error", err)
+		}
+	}
+}
+
+// ensureDMRegistered ensures both participants in a DM have registry rows.
+func (s *Server) ensureDMRegistered(ctx context.Context, key, callerID string) {
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
+		return
+	}
+
+	parts := strings.Split(key, ":")
+	if len(parts) < 5 {
+		return
+	}
+
+	kind1, id1 := parts[1], parts[2]
+	kind2, id2 := parts[3], parts[4]
+
+	// Upsert two rows — one per participant.
+	now := time.Now().UTC()
+
+	// Participant 1 → Peer 2.
+	peerKind2 := kind2
+	if peerKind2 != "agent" {
+		peerKind2 = "user"
+	}
+	_ = wcs.UpsertDM(ctx, WebChatDM{
+		ConversationKey: key,
+		ParticipantID:   id1,
+		PeerID:          id2,
+		PeerKind:        peerKind2,
+		LastActivityAt:  now,
+	})
+
+	// Participant 2 → Peer 1.
+	peerKind1 := kind1
+	if peerKind1 != "agent" {
+		peerKind1 = "user"
+	}
+	_ = wcs.UpsertDM(ctx, WebChatDM{
+		ConversationKey: key,
+		ParticipantID:   id2,
+		PeerID:          id1,
+		PeerKind:        peerKind1,
+		LastActivityAt:  now,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+type chatSpacesResponse struct {
+	Spaces []chatSpaceEntry `json:"spaces"`
+	Prefs  *chatSpacePrefs  `json:"prefs,omitempty"`
+}
+
+type chatSpaceEntry struct {
+	ProjectID   string `json:"projectId"`
+	ProjectName string `json:"projectName"`
+	ProjectSlug string `json:"projectSlug"`
+	ThreadCount int    `json:"threadCount"`
+	UnreadCount int    `json:"unreadCount"`
+}
+
+type chatSpacePrefs struct {
+	SpaceSortMode  string `json:"spaceSortMode"`
+	SpaceOrder     string `json:"spaceOrder,omitempty"`
+	ThreadSortMode string `json:"threadSortMode"`
+}
+
+type chatTopicListResponse struct {
+	Threads []chatTopicEntry `json:"threads"`
+}
+
+type chatTopicEntry struct {
+	ID                string    `json:"id"`
+	ProjectID         string    `json:"projectId"`
+	Name              string    `json:"name"`
+	IsGeneral         bool      `json:"isGeneral"`
+	DefaultAgent      string    `json:"defaultAgent,omitempty"`
+	CreatedBy         string    `json:"createdBy"`
+	CreatedAt         time.Time `json:"createdAt"`
+	LastMessageID     string    `json:"lastMessageId,omitempty"`
+	LastActivityAt    time.Time `json:"lastActivityAt"`
+	LastReadMessageID string    `json:"lastReadMessageId,omitempty"`
+	Pinned            bool      `json:"pinned"`
+	Muted             bool      `json:"muted"`
+	HasUnread         bool      `json:"hasUnread"`
+}
+
+type chatMessageResponse struct {
+	ID        string                   `json:"id"`
+	Content   string                   `json:"content"`
+	Sender    string                   `json:"sender"`
+	SenderID  string                   `json:"senderId"`
+	Type      string                   `json:"type"`
+	CreatedAt time.Time                `json:"createdAt"`
+	Mentions  []messages.MentionResult `json:"mentions,omitempty"`
+}
+
+type chatHistoryResponse struct {
+	Messages   []store.Message `json:"messages"`
+	NextCursor string          `json:"nextCursor,omitempty"`
+	TotalCount int             `json:"totalCount"`
+}
+
+type chatDMListResponse struct {
+	DMs []chatDMEntry `json:"dms"`
+}
+
+type chatDMEntry struct {
+	ConversationKey    string    `json:"conversationKey"`
+	PeerID             string    `json:"peerId"`
+	PeerKind           string    `json:"peerKind"`
+	PeerName           string    `json:"peerName,omitempty"`
+	PeerEmail          string    `json:"peerEmail,omitempty"`
+	PeerSlug           string    `json:"peerSlug,omitempty"`
+	PeerAvatar         string    `json:"peerAvatar,omitempty"`
+	LastMessageID      string    `json:"lastMessageId,omitempty"`
+	LastActivityAt     time.Time `json:"lastActivityAt"`
+	LastReadMessageID  string    `json:"lastReadMessageId,omitempty"`
+	HasUnread          bool      `json:"hasUnread"`
+	LastMessagePreview string    `json:"lastMessagePreview,omitempty"`
+	LastMessageSender  string    `json:"lastMessageSender,omitempty"`
+}
+
+type chatMembersResponse struct {
+	Humans []chatMemberEntry `json:"humans"`
+	Agents []chatMemberEntry `json:"agents"`
+}
+
+type chatMemberEntry struct {
+	ID          string `json:"id"`
+	Kind        string `json:"kind"`
+	DisplayName string `json:"displayName"`
+	Email       string `json:"email,omitempty"`
+	AvatarURL   string `json:"avatarUrl,omitempty"`
+	Slug        string `json:"slug,omitempty"`
+	Role        string `json:"role,omitempty"`
+	Phase       string `json:"phase,omitempty"`
+	Activity    string `json:"activity,omitempty"`
+}
+

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -12,6 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Wave-2 Native Chat Handlers
+//
+// This file implements the wave-2 chat API: spaces, shared threads, DMs,
+// members, presence, typing indicators, notifications, attachments, and search.
+//
+// Architecture overview:
+//
+//   - Spaces are derived from projects — there is no separate space entity.
+//     The space list is the set of projects the caller can ActionRead.
+//   - Threads (webchat_topic) are shared, multi-participant conversations
+//     within a space. Each space has an auto-created #general thread.
+//   - DMs are identified by a canonical pair key (dm:agent:<uuid>:user:<uuid>
+//     or dm:user:<uuid>:user:<uuid>) and are global, not project-scoped.
+//   - Messages are persisted in the existing messages table with ThreadID
+//     set to the topic UUID or DM key. Routing follows the three-tier model:
+//     explicit @mentions → mentioned agents, else thread default_agent → that
+//     agent, else no agent engaged (type:chat, human-to-human).
+//   - Real-time delivery uses SSE via the stateManager: project-scoped
+//     subjects for space threads, fan-out for DMs. Per-thread EventSource
+//     (wave-1) is replaced by a single multiplexed connection.
+//   - Storage uses the dual-dialect store (webchannel_store.go for SQLite,
+//     webchannel_store_postgres.go for Postgres) with new webchat_topic,
+//     webchat_read_state, webchat_user_prefs, and webchat_dm tables.
+//   - Wave-1 tables (webchat_thread, webchat_thread_prefs) remain in place
+//     but receive no new writes when the v2 flag is ON (write-stop).
+//
+// Feature flag: web.native_chat_v2 (default ON as of W9). When OFF, the
+// frontend falls back to the wave-1 UI and endpoints in handlers_chat.go.
+// The v2 API endpoints remain registered regardless of the flag state.
+
 package hub
 
 import (

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -312,6 +312,15 @@ func (s *Server) handleListThreads(w http.ResponseWriter, r *http.Request, proje
 // threadNameRegexp validates thread names: no special characters.
 var threadNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9 _\-]*$`)
 
+// dmKeyRegexp validates DM conversation keys.
+// Format: dm:(user|agent):<uuid>:(user|agent):<uuid>
+var dmKeyRegexp = regexp.MustCompile(`^dm:(user|agent):[0-9a-f-]{36}:(user|agent):[0-9a-f-]{36}$`)
+
+// validDMKey returns true if the key matches the expected DM key format.
+func validDMKey(key string) bool {
+	return dmKeyRegexp.MatchString(key)
+}
+
 // handleCreateThread creates a new thread in a space.
 func (s *Server) handleCreateThread(w http.ResponseWriter, r *http.Request, projectID string) {
 	user := GetUserIdentityFromContext(r.Context())
@@ -573,6 +582,11 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 	var projectID string
 	isDM := strings.HasPrefix(key, "dm:")
 	if isDM {
+		// Validate DM key format before any further processing.
+		if !validDMKey(key) {
+			BadRequest(w, "invalid DM key format")
+			return
+		}
 		// DM key: verify the caller is one of the two participants.
 		if !isDMParticipant(key, user.ID()) {
 			Forbidden(w)
@@ -729,6 +743,8 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 	}
 	if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 		s.messageLog.Error("Failed to persist agent-routed message", "error", err)
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to persist message", nil)
+		return
 	}
 	s.events.PublishUserMessage(ctx, storeMsg)
 
@@ -739,9 +755,7 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 		defer cancel()
 		if err := dispatchWithBrokerRetry(retryCtx, dispatcher, primaryAgent, content, false, msg); err != nil {
 			s.messageLog.Error("Failed to dispatch to agent", "agent", primaryAgent.Slug, "error", err)
-			if storeMsg.ID != "" {
-				_ = s.store.MarkMessageFailed(ctx, storeMsg.ID, err.Error())
-			}
+			_ = s.store.MarkMessageFailed(ctx, storeMsg.ID, err.Error())
 		}
 	}
 
@@ -892,6 +906,10 @@ func (s *Server) handleConversationHistory(w http.ResponseWriter, r *http.Reques
 	// Authorize.
 	isDM := strings.HasPrefix(key, "dm:")
 	if isDM {
+		if !validDMKey(key) {
+			BadRequest(w, "invalid DM key format")
+			return
+		}
 		if !isDMParticipant(key, user.ID()) {
 			Forbidden(w)
 			return
@@ -987,6 +1005,10 @@ func (s *Server) handleConversationRead(w http.ResponseWriter, r *http.Request, 
 	// Authorize.
 	isDM := strings.HasPrefix(key, "dm:")
 	if isDM {
+		if !validDMKey(key) {
+			BadRequest(w, "invalid DM key format")
+			return
+		}
 		if !isDMParticipant(key, user.ID()) {
 			Forbidden(w)
 			return
@@ -1399,12 +1421,16 @@ func (s *Server) handleChatSearch(w http.ResponseWriter, r *http.Request) {
 // ---------------------------------------------------------------------------
 
 // isDMParticipant checks whether the given userID is one of the two
-// participants encoded in a DM conversation key.
+// participants encoded in a DM conversation key by parsing tokens exactly.
 func isDMParticipant(key, userID string) bool {
 	// DM key formats:
 	//   dm:agent:<agentUUID>:user:<userUUID>
 	//   dm:user:<uuidA>:user:<uuidB>
-	return strings.Contains(key, ":"+userID)
+	parts := strings.Split(key, ":")
+	if len(parts) < 5 {
+		return false
+	}
+	return parts[2] == userID || parts[4] == userID
 }
 
 // resolveDMPeer extracts the peer's ID from a DM key given the caller's ID.
@@ -1603,4 +1629,3 @@ type chatMemberEntry struct {
 	Phase       string `json:"phase,omitempty"`
 	Activity    string `json:"activity,omitempty"`
 }
-

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -681,7 +681,19 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	if !isDM && projectID != "" {
+	if isDM {
+		// Agent DM implicit routing: when the key is dm:agent:<uuid>:user:<uuid>,
+		// the agent is the implicit recipient (equivalent to default_agent for
+		// topics). An explicit @mention of a different agent takes precedence
+		// (handled above). Design §3, §4.3.
+		if agentID := parseAgentDMKey(key); agentID != "" {
+			dmAgent, err := s.store.GetAgent(ctx, agentID)
+			if err == nil && dmAgent != nil {
+				s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{dmAgent}, nil, now)
+				return
+			}
+		}
+	} else if projectID != "" {
 		// Check if topic has a default_agent.
 		topic, err := wcs.GetTopic(ctx, key)
 		if err == nil && topic != nil && topic.DefaultAgent != "" {
@@ -843,9 +855,17 @@ func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, p
 		recipientID = key
 	}
 
+	// The Ent messages schema requires a non-empty project_id (UUID).
+	// User-to-user DMs are global (not project-scoped), so use the nil UUID
+	// as a sentinel when no project context is available.
+	msgProjectID := projectID
+	if msgProjectID == "" {
+		msgProjectID = uuid.Nil.String()
+	}
+
 	storeMsg := &store.Message{
 		ID:          api.NewUUID(),
-		ProjectID:   projectID,
+		ProjectID:   msgProjectID,
 		Sender:      "user:" + senderLabel,
 		SenderID:    user.ID(),
 		Recipient:   recipient,
@@ -1450,6 +1470,17 @@ func resolveDMPeer(key, callerID string) (peerEmail, peerID string) {
 		return "", id2
 	}
 	return "", id1
+}
+
+// parseAgentDMKey extracts the agent UUID from an agent-DM conversation key.
+// Returns "" if the key is not an agent DM. Agent DM keys have the form
+// dm:agent:<agentUUID>:user:<userUUID>.
+func parseAgentDMKey(key string) string {
+	parts := strings.Split(key, ":")
+	if len(parts) >= 3 && parts[1] == "agent" {
+		return parts[2]
+	}
+	return ""
 }
 
 // resolveProjectFromDMKey attempts to derive a project ID from a DM key.

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -1541,7 +1541,14 @@ func (s *Server) handleChatPresence(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleChatSearch handles GET /api/v1/chat/search.
-// Stub for W8.
+// Searches chat messages with optional scoping by project or conversation.
+//
+// Query params:
+//   - q: search text (required, minimum 2 characters)
+//   - projectId: scope to a single project (optional)
+//   - key: scope to a single conversation (optional)
+//   - limit: max results (default 50, max 200)
+//   - cursor: keyset pagination cursor (optional)
 func (s *Server) handleChatSearch(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		MethodNotAllowed(w)
@@ -1554,10 +1561,130 @@ func (s *Server) handleChatSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Full search implementation in W8.
-	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"results":    []interface{}{},
-		"totalCount": 0,
+	ctx := r.Context()
+	q := r.URL.Query()
+
+	// Validate query first (before any store access).
+	query := strings.TrimSpace(q.Get("q"))
+	if query == "" {
+		ValidationError(w, "q is required", nil)
+		return
+	}
+	if len([]rune(query)) < 2 {
+		ValidationError(w, "q must be at least 2 characters", nil)
+		return
+	}
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
+		writeJSON(w, http.StatusOK, chatSearchResponse{Results: []ChatSearchResult{}})
+		return
+	}
+
+	// Parse limit.
+	limit := 50
+	if l := q.Get("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 && n <= 200 {
+			limit = n
+		}
+	}
+
+	filter := ChatSearchFilter{
+		Query:  query,
+		Limit:  limit,
+		Cursor: q.Get("cursor"),
+	}
+
+	// Scoping.
+	projectID := q.Get("projectId")
+	conversationKey := q.Get("key")
+
+	if conversationKey != "" {
+		// Scope to one conversation — authorize access.
+		isDM := strings.HasPrefix(conversationKey, "dm:")
+		if isDM {
+			if !validDMKey(conversationKey) {
+				BadRequest(w, "invalid DM key format")
+				return
+			}
+			if !isDMParticipant(conversationKey, user.ID()) {
+				Forbidden(w)
+				return
+			}
+		} else {
+			topic, err := wcs.GetTopic(ctx, conversationKey)
+			if err != nil || topic == nil {
+				NotFound(w, "Thread")
+				return
+			}
+			project, err := s.store.GetProject(ctx, topic.ProjectID)
+			if err != nil {
+				NotFound(w, "Project")
+				return
+			}
+			if !s.authorize(w, r, projectResource(project), ActionRead) {
+				return
+			}
+		}
+		filter.ConversationKey = conversationKey
+	} else if projectID != "" {
+		// Scope to one project — authorize access.
+		project, err := s.store.GetProject(ctx, projectID)
+		if err != nil {
+			NotFound(w, "Project")
+			return
+		}
+		if !s.authorize(w, r, projectResource(project), ActionRead) {
+			return
+		}
+		filter.ProjectID = projectID
+	} else {
+		// Search all visible projects. Filter by user's accessible projects.
+		allProjects, err := s.store.ListProjects(ctx, store.ProjectFilter{}, store.ListOptions{Limit: 1000})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to list projects", nil)
+			return
+		}
+
+		identity := GetIdentityFromContext(ctx)
+		resources := make([]Resource, len(allProjects.Items))
+		for i := range allProjects.Items {
+			resources[i] = projectResource(&allProjects.Items[i])
+		}
+		caps := s.authzService.ComputeCapabilitiesBatch(ctx, identity, resources, "project")
+
+		var visibleIDs []string
+		for i, p := range allProjects.Items {
+			if capabilityAllows(caps[i], ActionRead) {
+				visibleIDs = append(visibleIDs, p.ID)
+			}
+		}
+		if len(visibleIDs) == 0 {
+			writeJSON(w, http.StatusOK, chatSearchResponse{Results: []ChatSearchResult{}})
+			return
+		}
+		filter.ProjectIDs = visibleIDs
+	}
+
+	results, nextCursor, err := wcs.SearchChatMessages(ctx, filter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "search failed", nil)
+		return
+	}
+
+	// Enrich results with thread/DM names.
+	s.enrichSearchResults(ctx, wcs, results)
+
+	if results == nil {
+		results = []ChatSearchResult{}
+	}
+
+	writeJSON(w, http.StatusOK, chatSearchResponse{
+		Results:    results,
+		NextCursor: nextCursor,
 	})
 }
 
@@ -1803,6 +1930,60 @@ func (s *Server) resolveProjectHumanMembers(ctx context.Context, projectID strin
 }
 
 // ---------------------------------------------------------------------------
+// W8 Search helpers
+// ---------------------------------------------------------------------------
+
+// enrichSearchResults populates the ThreadName field of search results by
+// looking up topic names and DM peer names.
+func (s *Server) enrichSearchResults(ctx context.Context, wcs WebChatStore, results []ChatSearchResult) {
+	// Collect unique conversation keys.
+	seen := make(map[string]bool, len(results))
+	for _, r := range results {
+		seen[r.ConversationKey] = true
+	}
+
+	// Resolve names.
+	names := make(map[string]string, len(seen))
+	for key := range seen {
+		if key == "" {
+			continue
+		}
+		if strings.HasPrefix(key, "dm:") {
+			// For DMs, derive a name from the key format.
+			parts := strings.Split(key, ":")
+			if len(parts) >= 5 {
+				peerKind := parts[1]
+				peerID := parts[2]
+				if peerKind == "agent" {
+					if a, err := s.store.GetAgent(ctx, peerID); err == nil && a != nil {
+						names[key] = "DM: " + a.Name
+						continue
+					}
+				} else if peerKind == "user" {
+					if u, err := s.store.GetUser(ctx, peerID); err == nil {
+						names[key] = "DM: " + u.DisplayName
+						continue
+					}
+				}
+			}
+			names[key] = "DM"
+		} else {
+			// Topic thread — look up name.
+			if topic, err := wcs.GetTopic(ctx, key); err == nil && topic != nil {
+				names[key] = "#" + topic.Name
+			}
+		}
+	}
+
+	// Apply names.
+	for i := range results {
+		if name, ok := names[results[i].ConversationKey]; ok {
+			results[i].ThreadName = name
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Response types
 // ---------------------------------------------------------------------------
 
@@ -1884,6 +2065,11 @@ type chatDMEntry struct {
 type chatMembersResponse struct {
 	Humans []chatMemberEntry `json:"humans"`
 	Agents []chatMemberEntry `json:"agents"`
+}
+
+type chatSearchResponse struct {
+	Results    []ChatSearchResult `json:"results"`
+	NextCursor string             `json:"nextCursor,omitempty"`
 }
 
 type chatMemberEntry struct {

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -678,6 +678,10 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 	if len(mentionedAgents) > 0 {
 		// --- Agent-routed: explicit mentions ---
 		s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, mentionedAgents, mentionResults, now)
+		// Ensure DM registry rows exist so the DM appears in the rail.
+		if isDM {
+			s.ensureDMRegistered(ctx, key, user.ID())
+		}
 		return
 	}
 
@@ -690,6 +694,8 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 			dmAgent, err := s.store.GetAgent(ctx, agentID)
 			if err == nil && dmAgent != nil {
 				s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{dmAgent}, nil, now)
+				// Ensure DM registry rows exist so the DM appears in the rail.
+				s.ensureDMRegistered(ctx, key, user.ID())
 				return
 			}
 		}

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -1091,13 +1091,18 @@ func (s *Server) handleConversationHistory(w http.ResponseWriter, r *http.Reques
 		result.Items = []store.Message{}
 	}
 
-	// W7: Enrich messages with attachment metadata.
+	// W7: Enrich messages with attachment metadata using a single batch
+	// query (R3 — avoids N+1 per-message queries on history pages).
 	var messageAttachments map[string][]AttachmentRef
 	if wcs != nil && len(result.Items) > 0 {
-		messageAttachments = make(map[string][]AttachmentRef)
-		for _, msg := range result.Items {
-			attachments, err := wcs.GetAttachmentsByMessage(ctx, msg.ID)
-			if err == nil && len(attachments) > 0 {
+		msgIDs := make([]string, len(result.Items))
+		for i, msg := range result.Items {
+			msgIDs[i] = msg.ID
+		}
+		batchAttachments, err := wcs.GetAttachmentsByMessages(ctx, msgIDs)
+		if err == nil && len(batchAttachments) > 0 {
+			messageAttachments = make(map[string][]AttachmentRef, len(batchAttachments))
+			for msgID, attachments := range batchAttachments {
 				refs := make([]AttachmentRef, 0, len(attachments))
 				for _, a := range attachments {
 					refs = append(refs, AttachmentRef{
@@ -1107,7 +1112,7 @@ func (s *Server) handleConversationHistory(w http.ResponseWriter, r *http.Reques
 						Size:     a.Size,
 					})
 				}
-				messageAttachments[msg.ID] = refs
+				messageAttachments[msgID] = refs
 			}
 		}
 	}
@@ -2397,12 +2402,18 @@ func (s *Server) handleAttachmentDownload(w http.ResponseWriter, r *http.Request
 	}
 	w.Header().Set("Content-Type", mimeType)
 
+	// R1: Prevent browsers from MIME-sniffing the response body.
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
 	// Content-Disposition: inline for images, attachment for everything else.
 	disposition := "attachment"
 	if IsImageMime(mimeType) {
 		disposition = "inline"
 	}
-	w.Header().Set("Content-Disposition", fmt.Sprintf(`%s; filename="%s"`, disposition, meta.Filename))
+	// R2: Escape backslash and double-quote in the filename to prevent
+	// Content-Disposition header injection (RFC 6266 §4.3).
+	safeName := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(meta.Filename)
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`%s; filename="%s"`, disposition, safeName))
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", fileMeta.Size))
 	w.Header().Set("Cache-Control", "private, max-age=3600")
 

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -2418,7 +2418,7 @@ func (s *Server) handleAttachmentDownload(w http.ResponseWriter, r *http.Request
 	}
 
 	// Get file from storage.
-	reader, fileMeta, err := as.Get(ctx, id)
+	reader, fileMeta, err := as.Get(ctx, meta.ProjectID, id)
 	if err != nil {
 		NotFound(w, "Attachment file")
 		return

--- a/pkg/hub/handlers_chat_v2_test.go
+++ b/pkg/hub/handlers_chat_v2_test.go
@@ -1466,3 +1466,412 @@ func TestParseAgentDMKey(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// W8: Search tests
+// ---------------------------------------------------------------------------
+
+// newTestWebChatStoreWithMessages creates a WebChatStore backed by an in-memory
+// SQLite DB, including a minimal messages table for search testing.
+func newTestWebChatStoreWithMessages(t *testing.T) (WebChatStore, *sql.DB) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	store := NewWebChatStore(db, "sqlite3")
+	if err := store.Init(); err != nil {
+		t.Fatalf("init store: %v", err)
+	}
+
+	// Create a minimal messages table matching the Ent schema columns
+	// used by SearchChatMessages.
+	const createMessages = `
+CREATE TABLE IF NOT EXISTS messages (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL,
+    sender TEXT NOT NULL DEFAULT '',
+    sender_id TEXT,
+    recipient TEXT NOT NULL DEFAULT '',
+    recipient_id TEXT,
+    msg TEXT NOT NULL DEFAULT '',
+    type TEXT NOT NULL DEFAULT 'instruction',
+    channel TEXT,
+    thread_id TEXT,
+    visibility TEXT DEFAULT 'normal',
+    created TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_messages_created ON messages (created);
+`
+	if _, err := db.Exec(createMessages); err != nil {
+		t.Fatalf("create messages table: %v", err)
+	}
+
+	return store, db
+}
+
+// insertTestMessage is a helper to insert a message row for search testing.
+func insertTestMessage(t *testing.T, db *sql.DB, id, projectID, threadID, sender, msg string, created time.Time) {
+	t.Helper()
+	const query = `INSERT INTO messages (id, project_id, thread_id, sender, msg, channel, created) VALUES (?, ?, ?, ?, ?, 'web', ?)`
+	_, err := db.Exec(query, id, projectID, threadID, sender, msg, created.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		t.Fatalf("insert test message: %v", err)
+	}
+}
+
+func TestSearchChatMessages_BasicMatch(t *testing.T) {
+	store, db := newTestWebChatStoreWithMessages(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	insertTestMessage(t, db, "m1", "proj-1", "topic-1", "user:alice", "Hello world from alice", now.Add(-3*time.Minute))
+	insertTestMessage(t, db, "m2", "proj-1", "topic-1", "user:bob", "Goodbye world from bob", now.Add(-2*time.Minute))
+	insertTestMessage(t, db, "m3", "proj-1", "topic-1", "user:alice", "Just a test message", now.Add(-1*time.Minute))
+
+	results, nextCursor, err := store.SearchChatMessages(ctx, ChatSearchFilter{
+		Query:     "world",
+		ProjectID: "proj-1",
+		Limit:     50,
+	})
+	if err != nil {
+		t.Fatalf("SearchChatMessages: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	// Results should be ordered by created DESC.
+	if results[0].MessageID != "m2" {
+		t.Errorf("first result should be m2 (most recent), got %s", results[0].MessageID)
+	}
+	if results[1].MessageID != "m1" {
+		t.Errorf("second result should be m1, got %s", results[1].MessageID)
+	}
+
+	if nextCursor != "" {
+		t.Errorf("expected empty nextCursor, got %q", nextCursor)
+	}
+}
+
+func TestSearchChatMessages_CaseInsensitive(t *testing.T) {
+	store, db := newTestWebChatStoreWithMessages(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	insertTestMessage(t, db, "m1", "proj-1", "topic-1", "user:alice", "Hello WORLD", now.Add(-2*time.Minute))
+	insertTestMessage(t, db, "m2", "proj-1", "topic-1", "user:bob", "hello World", now.Add(-1*time.Minute))
+
+	results, _, err := store.SearchChatMessages(ctx, ChatSearchFilter{
+		Query:     "world",
+		ProjectID: "proj-1",
+	})
+	if err != nil {
+		t.Fatalf("SearchChatMessages: %v", err)
+	}
+
+	// SQLite LIKE is case-insensitive for ASCII.
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results for case-insensitive search, got %d", len(results))
+	}
+}
+
+func TestSearchChatMessages_NoResults(t *testing.T) {
+	store, db := newTestWebChatStoreWithMessages(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	insertTestMessage(t, db, "m1", "proj-1", "topic-1", "user:alice", "Hello world", now)
+
+	results, _, err := store.SearchChatMessages(ctx, ChatSearchFilter{
+		Query:     "nonexistent",
+		ProjectID: "proj-1",
+	})
+	if err != nil {
+		t.Fatalf("SearchChatMessages: %v", err)
+	}
+
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestSearchChatMessages_ScopedByProject(t *testing.T) {
+	store, db := newTestWebChatStoreWithMessages(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	insertTestMessage(t, db, "m1", "proj-1", "topic-1", "user:alice", "Hello world", now.Add(-2*time.Minute))
+	insertTestMessage(t, db, "m2", "proj-2", "topic-2", "user:bob", "Hello world", now.Add(-1*time.Minute))
+
+	results, _, err := store.SearchChatMessages(ctx, ChatSearchFilter{
+		Query:     "world",
+		ProjectID: "proj-1",
+	})
+	if err != nil {
+		t.Fatalf("SearchChatMessages: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result scoped to proj-1, got %d", len(results))
+	}
+	if results[0].ProjectID != "proj-1" {
+		t.Errorf("result project = %q, want %q", results[0].ProjectID, "proj-1")
+	}
+}
+
+func TestSearchChatMessages_ScopedByConversation(t *testing.T) {
+	store, db := newTestWebChatStoreWithMessages(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	insertTestMessage(t, db, "m1", "proj-1", "topic-1", "user:alice", "Hello world", now.Add(-2*time.Minute))
+	insertTestMessage(t, db, "m2", "proj-1", "topic-2", "user:bob", "Hello world", now.Add(-1*time.Minute))
+
+	results, _, err := store.SearchChatMessages(ctx, ChatSearchFilter{
+		Query:           "world",
+		ConversationKey: "topic-1",
+	})
+	if err != nil {
+		t.Fatalf("SearchChatMessages: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result scoped to topic-1, got %d", len(results))
+	}
+	if results[0].ConversationKey != "topic-1" {
+		t.Errorf("result conversation = %q, want %q", results[0].ConversationKey, "topic-1")
+	}
+}
+
+func TestSearchChatMessages_MultipleProjects(t *testing.T) {
+	store, db := newTestWebChatStoreWithMessages(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	insertTestMessage(t, db, "m1", "proj-1", "topic-1", "user:alice", "Hello world", now.Add(-3*time.Minute))
+	insertTestMessage(t, db, "m2", "proj-2", "topic-2", "user:bob", "Hello world", now.Add(-2*time.Minute))
+	insertTestMessage(t, db, "m3", "proj-3", "topic-3", "user:carol", "Hello world", now.Add(-1*time.Minute))
+
+	// Search across proj-1 and proj-2 only.
+	results, _, err := store.SearchChatMessages(ctx, ChatSearchFilter{
+		Query:      "world",
+		ProjectIDs: []string{"proj-1", "proj-2"},
+	})
+	if err != nil {
+		t.Fatalf("SearchChatMessages: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results across proj-1 and proj-2, got %d", len(results))
+	}
+}
+
+func TestSearchChatMessages_Pagination(t *testing.T) {
+	store, db := newTestWebChatStoreWithMessages(t)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Insert 5 messages.
+	for i := 0; i < 5; i++ {
+		insertTestMessage(t, db, "m"+string(rune('a'+i)), "proj-1", "topic-1", "user:alice",
+			"Hello world message", now.Add(-time.Duration(5-i)*time.Minute))
+	}
+
+	// First page: limit 2.
+	results, nextCursor, err := store.SearchChatMessages(ctx, ChatSearchFilter{
+		Query:     "world",
+		ProjectID: "proj-1",
+		Limit:     2,
+	})
+	if err != nil {
+		t.Fatalf("SearchChatMessages page 1: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("page 1: expected 2 results, got %d", len(results))
+	}
+	if nextCursor == "" {
+		t.Fatal("page 1: expected non-empty nextCursor")
+	}
+
+	// Second page using cursor.
+	results2, nextCursor2, err := store.SearchChatMessages(ctx, ChatSearchFilter{
+		Query:     "world",
+		ProjectID: "proj-1",
+		Limit:     2,
+		Cursor:    nextCursor,
+	})
+	if err != nil {
+		t.Fatalf("SearchChatMessages page 2: %v", err)
+	}
+
+	if len(results2) != 2 {
+		t.Fatalf("page 2: expected 2 results, got %d", len(results2))
+	}
+
+	// Third page — should have 1 remaining.
+	results3, nextCursor3, err := store.SearchChatMessages(ctx, ChatSearchFilter{
+		Query:     "world",
+		ProjectID: "proj-1",
+		Limit:     2,
+		Cursor:    nextCursor2,
+	})
+	if err != nil {
+		t.Fatalf("SearchChatMessages page 3: %v", err)
+	}
+
+	if len(results3) != 1 {
+		t.Fatalf("page 3: expected 1 result, got %d", len(results3))
+	}
+	if nextCursor3 != "" {
+		t.Errorf("page 3: expected empty nextCursor, got %q", nextCursor3)
+	}
+
+	// Verify no duplicates across pages.
+	allIDs := make(map[string]bool)
+	for _, r := range results {
+		allIDs[r.MessageID] = true
+	}
+	for _, r := range results2 {
+		if allIDs[r.MessageID] {
+			t.Errorf("duplicate result across pages: %s", r.MessageID)
+		}
+		allIDs[r.MessageID] = true
+	}
+	for _, r := range results3 {
+		if allIDs[r.MessageID] {
+			t.Errorf("duplicate result across pages: %s", r.MessageID)
+		}
+		allIDs[r.MessageID] = true
+	}
+
+	if len(allIDs) != 5 {
+		t.Errorf("expected 5 unique results across all pages, got %d", len(allIDs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// W8: Snippet generation tests
+// ---------------------------------------------------------------------------
+
+func TestGenerateSnippet_BasicMatch(t *testing.T) {
+	snippet := generateSnippet("Hello world, how are you doing today?", "world", 80)
+
+	if !strings.Contains(snippet, "<mark>world</mark>") {
+		t.Errorf("snippet should contain <mark>world</mark>, got %q", snippet)
+	}
+}
+
+func TestGenerateSnippet_MatchAtStart(t *testing.T) {
+	snippet := generateSnippet("Hello there", "Hello", 80)
+
+	if !strings.Contains(snippet, "<mark>Hello</mark>") {
+		t.Errorf("snippet should contain <mark>Hello</mark>, got %q", snippet)
+	}
+	// Should not have leading "..." since match is at start.
+	if strings.HasPrefix(snippet, "...") {
+		t.Errorf("snippet should not start with ... when match is at start, got %q", snippet)
+	}
+}
+
+func TestGenerateSnippet_MatchAtEnd(t *testing.T) {
+	snippet := generateSnippet("This is the end", "end", 80)
+
+	if !strings.Contains(snippet, "<mark>end</mark>") {
+		t.Errorf("snippet should contain <mark>end</mark>, got %q", snippet)
+	}
+	// Should not have trailing "..." since match is at end.
+	if strings.HasSuffix(snippet, "...") {
+		t.Errorf("snippet should not end with ... when match is at end, got %q", snippet)
+	}
+}
+
+func TestGenerateSnippet_CaseInsensitive(t *testing.T) {
+	snippet := generateSnippet("Hello WORLD today", "world", 80)
+
+	if !strings.Contains(snippet, "<mark>WORLD</mark>") {
+		t.Errorf("snippet should preserve original case in <mark>, got %q", snippet)
+	}
+}
+
+func TestGenerateSnippet_LongContent(t *testing.T) {
+	long := strings.Repeat("a", 200) + "findme" + strings.Repeat("b", 200)
+	snippet := generateSnippet(long, "findme", 80)
+
+	if !strings.Contains(snippet, "<mark>findme</mark>") {
+		t.Errorf("snippet should contain <mark>findme</mark>, got %q", snippet)
+	}
+	// Should have ellipsis on both sides for content in the middle.
+	if !strings.HasPrefix(snippet, "...") {
+		t.Errorf("snippet should start with ... for middle match, got %q", snippet)
+	}
+	if !strings.HasSuffix(snippet, "...") {
+		t.Errorf("snippet should end with ... for middle match, got %q", snippet)
+	}
+}
+
+func TestGenerateSnippet_NoMatch(t *testing.T) {
+	snippet := generateSnippet("Hello world", "xyz", 80)
+
+	// When no match, should return truncated content.
+	if strings.Contains(snippet, "<mark>") {
+		t.Errorf("snippet should not contain <mark> when no match, got %q", snippet)
+	}
+}
+
+func TestGenerateSnippet_EmptyInputs(t *testing.T) {
+	if s := generateSnippet("", "test", 80); s != "" {
+		t.Errorf("empty content should return empty, got %q", s)
+	}
+	if s := generateSnippet("hello", "", 80); s != "hello" {
+		t.Errorf("empty query should return content, got %q", s)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// W8: Search endpoint tests
+// ---------------------------------------------------------------------------
+
+func TestChatSearch_EmptyQuery(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/chat/search", nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing q, got %d", rec.Code)
+	}
+}
+
+func TestChatSearch_TooShortQuery(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/chat/search?q=a", nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for q < 2 chars, got %d", rec.Code)
+	}
+}
+
+func TestChatSearch_MethodNotAllowed(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/search?q=hello", nil)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405 for POST, got %d", rec.Code)
+	}
+}

--- a/pkg/hub/handlers_chat_v2_test.go
+++ b/pkg/hub/handlers_chat_v2_test.go
@@ -21,7 +21,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -30,17 +29,6 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	_ "github.com/mattn/go-sqlite3"
 )
-
-// ---------------------------------------------------------------------------
-// Helper: create a minimal Server with WebChatStore for unit tests that
-// don't need the full testServer() (Ent + dev auth + policies).
-// ---------------------------------------------------------------------------
-
-func chatV2TestUser(id, email, name string) *http.Request {
-	user := NewAuthenticatedUser(id, email, name, "member", "web")
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	return req.WithContext(contextWithIdentity(req.Context(), user))
-}
 
 // ---------------------------------------------------------------------------
 // isDMParticipant tests
@@ -127,7 +115,7 @@ func TestTypeChat_NotDispatchedToAgent(t *testing.T) {
 
 func TestWave2_ReadState_SetAndGet(t *testing.T) {
 	store, db := newTestWebChatStoreV2(t)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
 
@@ -171,7 +159,7 @@ func TestWave2_ReadState_SetAndGet(t *testing.T) {
 
 func TestWave2_UserPrefs_DefaultsAndOverride(t *testing.T) {
 	store, db := newTestWebChatStoreV2(t)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
 
@@ -214,7 +202,7 @@ func TestWave2_UserPrefs_DefaultsAndOverride(t *testing.T) {
 
 func TestChatV2_DM_UpsertAndList(t *testing.T) {
 	store, db := newTestWebChatStoreV2(t)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
 	now := time.Now().UTC().Truncate(time.Second)
@@ -266,7 +254,7 @@ func TestChatV2_DM_UpsertAndList(t *testing.T) {
 
 func TestChatV2_TouchTopicActivity(t *testing.T) {
 	store, db := newTestWebChatStoreV2(t)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
 
@@ -310,7 +298,7 @@ func TestChatV2_TouchTopicActivity(t *testing.T) {
 
 func TestWave2_DeleteTopic_GeneralGuard(t *testing.T) {
 	store, db := newTestWebChatStoreV2(t)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
 
@@ -357,7 +345,7 @@ func TestWave2_DeleteTopic_GeneralGuard(t *testing.T) {
 
 func TestWave2_TopicNameUniqueness(t *testing.T) {
 	store, db := newTestWebChatStoreV2(t)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
 
@@ -397,7 +385,7 @@ func TestWave2_TopicNameUniqueness(t *testing.T) {
 
 func TestWave2_TouchDMActivity(t *testing.T) {
 	store, db := newTestWebChatStoreV2(t)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
 	now := time.Now().UTC().Truncate(time.Second)
@@ -440,7 +428,7 @@ func TestWave2_TouchDMActivity(t *testing.T) {
 
 func TestWave2_GetReadStates_Batch(t *testing.T) {
 	store, db := newTestWebChatStoreV2(t)
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
 
@@ -519,7 +507,7 @@ func TestChatV2_CreateThread_AndList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	wcs := NewWebChatStore(db, "sqlite3")
 	if err := wcs.Init(); err != nil {
 		t.Fatalf("Init: %v", err)
@@ -583,9 +571,11 @@ func TestChatV2_CreateThread_Validation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	wcs := NewWebChatStore(db, "sqlite3")
-	wcs.Init()
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
 	srv.SetWebChatStore(wcs)
 
 	// Empty name.
@@ -615,9 +605,11 @@ func TestChatV2_PatchThread(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	wcs := NewWebChatStore(db, "sqlite3")
-	wcs.Init()
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
 	srv.SetWebChatStore(wcs)
 
 	// Create a topic.
@@ -660,9 +652,11 @@ func TestChatV2_PatchThread_GeneralGuard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	wcs := NewWebChatStore(db, "sqlite3")
-	wcs.Init()
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
 	srv.SetWebChatStore(wcs)
 
 	genID, _, err := wcs.EnsureGeneralTopic(ctx, proj.ID, "dev")
@@ -691,9 +685,11 @@ func TestChatV2_DeleteThread(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	wcs := NewWebChatStore(db, "sqlite3")
-	wcs.Init()
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
 	srv.SetWebChatStore(wcs)
 
 	if err := wcs.CreateTopic(ctx, WebChatTopic{
@@ -733,9 +729,11 @@ func TestChatV2_DeleteThread_GeneralGuard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	wcs := NewWebChatStore(db, "sqlite3")
-	wcs.Init()
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
 	srv.SetWebChatStore(wcs)
 
 	genID, _, _ := wcs.EnsureGeneralTopic(ctx, proj.ID, "dev")
@@ -758,9 +756,11 @@ func TestChatV2_ConversationRead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	wcs := NewWebChatStore(db, "sqlite3")
-	wcs.Init()
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
 	srv.SetWebChatStore(wcs)
 
 	if err := wcs.CreateTopic(ctx, WebChatTopic{
@@ -787,9 +787,11 @@ func TestChatV2_DMs_Empty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	wcs := NewWebChatStore(db, "sqlite3")
-	wcs.Init()
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
 	srv.SetWebChatStore(wcs)
 
 	rec := doRequest(t, srv, http.MethodGet, "/api/v1/chat/dms", nil)
@@ -813,9 +815,11 @@ func TestChatV2_UserPrefs_GetDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	wcs := NewWebChatStore(db, "sqlite3")
-	wcs.Init()
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
 	srv.SetWebChatStore(wcs)
 
 	rec := doRequest(t, srv, http.MethodGet, "/api/v1/chat/user-prefs", nil)
@@ -839,9 +843,11 @@ func TestChatV2_UserPrefs_PutAndGet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	wcs := NewWebChatStore(db, "sqlite3")
-	wcs.Init()
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
 	srv.SetWebChatStore(wcs)
 
 	// PUT.
@@ -902,9 +908,11 @@ func TestChatV2_LegacyThreads_AuthzFix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	wcs := NewWebChatStore(db, "sqlite3")
-	wcs.Init()
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
 	srv.SetWebChatStore(wcs)
 
 	rec := doRequest(t, srv, http.MethodGet, "/api/v1/chat/threads?projectId="+proj.ID, nil)
@@ -932,9 +940,11 @@ func TestChatV2_SpaceRead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
-	defer db.Close()
+	defer func() { _ = db.Close() }()
 	wcs := NewWebChatStore(db, "sqlite3")
-	wcs.Init()
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
 	srv.SetWebChatStore(wcs)
 
 	// Create a topic with a message.
@@ -981,6 +991,313 @@ func TestChatV2_Members(t *testing.T) {
 		t.Error("agents should be non-nil")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// DM key validation tests
+// ---------------------------------------------------------------------------
+
+func TestValidDMKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		// Valid keys.
+		{"dm:user:be67fbc9-c869-5d43-b15d-c28ca3e8d355:user:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", true},
+		{"dm:agent:be67fbc9-c869-5d43-b15d-c28ca3e8d355:user:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", true},
+		{"dm:user:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee:agent:be67fbc9-c869-5d43-b15d-c28ca3e8d355", true},
+
+		// Invalid keys.
+		{"dm:user:short:user:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", false},
+		{"dm:user:ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ:user:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", false},  // uppercase
+		{"dm:robot:be67fbc9-c869-5d43-b15d-c28ca3e8d355:user:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", false}, // bad kind
+		{"dm:user:be67fbc9-c869-5d43-b15d-c28ca3e8d355", false},                                            // truncated
+		{"not-a-dm-key", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := validDMKey(tt.key); got != tt.want {
+			t.Errorf("validDMKey(%q) = %v, want %v", tt.key, got, tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Send path tests (R4)
+// ---------------------------------------------------------------------------
+
+// setupSendTest creates a project, webchat store, and a topic for send path testing.
+func setupSendTest(t *testing.T) (*Server, store.Store, WebChatStore, *store.Project) {
+	t.Helper()
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	proj := &store.Project{ID: tid("send-test"), Name: "send-test", Slug: "send-test", Created: time.Now(), Updated: time.Now()}
+	if err := s.CreateProject(ctx, proj); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	wcs := NewWebChatStore(db, "sqlite3")
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	srv.SetWebChatStore(wcs)
+
+	return srv, s, wcs, proj
+}
+
+func TestChatV2_Send_NoAgent_TypeChat(t *testing.T) {
+	srv, _, wcs, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	// Create a topic with no default_agent.
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        tid("topic-send-1"),
+		ProjectID: proj.ID,
+		Name:      "chat-only",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	body := map[string]string{"content": "hello world"}
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/conversations/"+tid("topic-send-1")+"/messages", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatMessageResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Type != messages.TypeChat {
+		t.Errorf("expected type %q, got %q", messages.TypeChat, resp.Type)
+	}
+	if resp.Content != "hello world" {
+		t.Errorf("content = %q, want %q", resp.Content, "hello world")
+	}
+}
+
+func TestChatV2_Send_DefaultAgent_Dispatched(t *testing.T) {
+	srv, s, wcs, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	// Create an agent.
+	agent := &store.Agent{
+		ID:        tid("agent-default"),
+		ProjectID: proj.ID,
+		Name:      "Helper Bot",
+		Slug:      "helper-bot",
+		Phase:     "idle",
+		OwnerID:   DevUserID,
+		CreatedBy: DevUserID,
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// Create a topic with default_agent set.
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:           tid("topic-default-agent"),
+		ProjectID:    proj.ID,
+		Name:         "agent-thread",
+		CreatedBy:    "dev",
+		CreatedAt:    time.Now().UTC(),
+		DefaultAgent: agent.ID,
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	body := map[string]string{"content": "please help"}
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/conversations/"+tid("topic-default-agent")+"/messages", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatMessageResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Agent-routed messages get type "instruction", not "chat".
+	if resp.Type != messages.TypeInstruction {
+		t.Errorf("expected type %q (agent-routed), got %q", messages.TypeInstruction, resp.Type)
+	}
+}
+
+func TestChatV2_Send_Mention_AgentReceives(t *testing.T) {
+	srv, s, wcs, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	// Create an agent.
+	agent := &store.Agent{
+		ID:        tid("agent-mention"),
+		ProjectID: proj.ID,
+		Name:      "Reviewer",
+		Slug:      "reviewer",
+		Phase:     "idle",
+		OwnerID:   DevUserID,
+		CreatedBy: DevUserID,
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// Topic without default_agent.
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        tid("topic-mention"),
+		ProjectID: proj.ID,
+		Name:      "mention-thread",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	// Send with @reviewer mention.
+	body := map[string]string{"content": "@reviewer please check this"}
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/conversations/"+tid("topic-mention")+"/messages", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatMessageResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// With a resolved mention, message should be type "instruction" (agent-routed).
+	if resp.Type != messages.TypeInstruction {
+		t.Errorf("expected type %q (mention-routed), got %q", messages.TypeInstruction, resp.Type)
+	}
+	// Mentions should be populated.
+	if len(resp.Mentions) == 0 {
+		t.Error("expected non-empty mentions list")
+	}
+}
+
+func TestChatV2_Send_DM_TypeChat(t *testing.T) {
+	srv, s, _, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	// Create an agent so resolveProjectFromDMKey can find the project.
+	agent := &store.Agent{
+		ID:        tid("dm-agent"),
+		ProjectID: proj.ID,
+		Name:      "DM Bot",
+		Slug:      "dm-bot",
+		Phase:     "idle",
+		OwnerID:   DevUserID,
+		CreatedBy: DevUserID,
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// Build a valid DM key: agent DM so project can be resolved.
+	dmKey := "dm:agent:" + agent.ID + ":user:" + DevUserID
+
+	body := map[string]string{"content": "hi there"}
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/conversations/"+dmKey+"/messages", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatMessageResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Agent DM without mentions or default_agent on topic goes through
+	// human-to-human path (since DMs skip the default_agent check).
+	if resp.Type != messages.TypeChat {
+		t.Errorf("DM expected type %q, got %q", messages.TypeChat, resp.Type)
+	}
+	// Sender should include the dev user label.
+	if resp.SenderID != DevUserID {
+		t.Errorf("senderID = %q, want %q", resp.SenderID, DevUserID)
+	}
+}
+
+func TestChatV2_Send_HumanToHuman_NoDispatch(t *testing.T) {
+	srv, _, wcs, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	// Create a topic with no default_agent.
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        tid("topic-h2h"),
+		ProjectID: proj.ID,
+		Name:      "human-only",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	body := map[string]string{"content": "just chatting"}
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/conversations/"+tid("topic-h2h")+"/messages", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatMessageResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Must be type:chat (never dispatched to an agent).
+	if resp.Type != messages.TypeChat {
+		t.Errorf("human-to-human expected type %q, got %q — agent dispatch may have occurred", messages.TypeChat, resp.Type)
+	}
+	// No dispatcher set on test server, so if this were agent-routed it would
+	// still succeed but with type "instruction". The type check above covers this.
+}
+
+func TestChatV2_Send_MaxLength_Rejected(t *testing.T) {
+	srv, _, wcs, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        tid("topic-maxlen"),
+		ProjectID: proj.ID,
+		Name:      "maxlen-thread",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	longContent := strings.Repeat("x", messages.MaxMessageLength+1)
+	body := map[string]string{"content": longContent}
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/conversations/"+tid("topic-maxlen")+"/messages", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for oversized message, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Exactly at limit should succeed.
+	exactContent := strings.Repeat("y", messages.MaxMessageLength)
+	body = map[string]string{"content": exactContent}
+	rec = doRequest(t, srv, http.MethodPost, "/api/v1/chat/conversations/"+tid("topic-maxlen")+"/messages", body)
+	if rec.Code != http.StatusCreated {
+		t.Errorf("expected 201 for exact-limit message, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestChatV2_Send_InvalidDMKey_Rejected(t *testing.T) {
+	srv, _, _, _ := setupSendTest(t)
+
+	// Malformed DM key.
+	body := map[string]string{"content": "hello"}
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/conversations/dm:garbage:key/messages", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("malformed DM key: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Method not allowed tests
+// ---------------------------------------------------------------------------
 
 func TestChatV2_MethodNotAllowed(t *testing.T) {
 	srv, _ := testServer(t)

--- a/pkg/hub/handlers_chat_v2_test.go
+++ b/pkg/hub/handlers_chat_v2_test.go
@@ -1179,7 +1179,7 @@ func TestChatV2_Send_Mention_AgentReceives(t *testing.T) {
 	}
 }
 
-func TestChatV2_Send_DM_TypeChat(t *testing.T) {
+func TestChatV2_Send_DM_AgentDM_Routed(t *testing.T) {
 	srv, s, _, proj := setupSendTest(t)
 	ctx := context.Background()
 
@@ -1210,10 +1210,10 @@ func TestChatV2_Send_DM_TypeChat(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	// Agent DM without mentions or default_agent on topic goes through
-	// human-to-human path (since DMs skip the default_agent check).
-	if resp.Type != messages.TypeChat {
-		t.Errorf("DM expected type %q, got %q", messages.TypeChat, resp.Type)
+	// W4 fix: Agent DM without @mention is now correctly routed to the agent
+	// (implicit agent routing). The message type should be "instruction".
+	if resp.Type != messages.TypeInstruction {
+		t.Errorf("agent DM expected type %q (agent-routed), got %q", messages.TypeInstruction, resp.Type)
 	}
 	// Sender should include the dev user label.
 	if resp.SenderID != DevUserID {
@@ -1316,6 +1316,153 @@ func TestChatV2_MethodNotAllowed(t *testing.T) {
 		rec := doRequest(t, srv, tt.method, tt.path, nil)
 		if rec.Code != http.StatusMethodNotAllowed {
 			t.Errorf("%s %s: expected 405, got %d", tt.method, tt.path, rec.Code)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// W4: Agent DM implicit routing tests
+// ---------------------------------------------------------------------------
+
+func TestChatV2_Send_AgentDM_ImplicitRouting(t *testing.T) {
+	srv, s, _, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	// Create an agent.
+	agent := &store.Agent{
+		ID:        tid("agent-dm-route"),
+		ProjectID: proj.ID,
+		Name:      "DM Router",
+		Slug:      "dm-router",
+		Phase:     "idle",
+		OwnerID:   DevUserID,
+		CreatedBy: DevUserID,
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// Build a valid agent DM key.
+	dmKey := "dm:agent:" + agent.ID + ":user:" + DevUserID
+
+	// Send a message without any @mention — it should be implicitly
+	// routed to the agent (type:instruction), not go through human-to-human.
+	body := map[string]string{"content": "hello agent, help me please"}
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/conversations/"+dmKey+"/messages", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatMessageResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Agent DM without @mention should be type:instruction (routed to agent).
+	if resp.Type != messages.TypeInstruction {
+		t.Errorf("agent DM implicit routing: expected type %q, got %q", messages.TypeInstruction, resp.Type)
+	}
+}
+
+func TestChatV2_Send_AgentDM_MentionTakesPrecedence(t *testing.T) {
+	srv, s, _, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	// Create the DM agent.
+	dmAgent := &store.Agent{
+		ID:        tid("agent-dm-default"),
+		ProjectID: proj.ID,
+		Name:      "DM Default",
+		Slug:      "dm-default",
+		Phase:     "idle",
+		OwnerID:   DevUserID,
+		CreatedBy: DevUserID,
+	}
+	if err := s.CreateAgent(ctx, dmAgent); err != nil {
+		t.Fatalf("CreateAgent (dm): %v", err)
+	}
+
+	// Create a different agent that will be mentioned.
+	otherAgent := &store.Agent{
+		ID:        tid("agent-other-mention"),
+		ProjectID: proj.ID,
+		Name:      "Other Agent",
+		Slug:      "other-agent",
+		Phase:     "idle",
+		OwnerID:   DevUserID,
+		CreatedBy: DevUserID,
+	}
+	if err := s.CreateAgent(ctx, otherAgent); err != nil {
+		t.Fatalf("CreateAgent (other): %v", err)
+	}
+
+	dmKey := "dm:agent:" + dmAgent.ID + ":user:" + DevUserID
+
+	// Send a message with @other-agent mention — mention should take precedence
+	// over the implicit DM agent routing.
+	body := map[string]string{"content": "@other-agent please review this"}
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/conversations/"+dmKey+"/messages", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatMessageResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Should be type:instruction (agent-routed via mention).
+	if resp.Type != messages.TypeInstruction {
+		t.Errorf("mention-takes-precedence: expected type %q, got %q", messages.TypeInstruction, resp.Type)
+	}
+	// Mentions should include the mentioned agent.
+	if len(resp.Mentions) == 0 {
+		t.Error("expected non-empty mentions list for @other-agent")
+	}
+}
+
+func TestChatV2_Send_UserDM_HumanToHuman(t *testing.T) {
+	srv, _, _, _ := setupSendTest(t)
+
+	// Build a user-to-user DM key.
+	peerID := tid("dm-peer-user")
+	dmKey := "dm:user:" + DevUserID + ":user:" + peerID
+
+	body := map[string]string{"content": "hey there, how are you?"}
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/conversations/"+dmKey+"/messages", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatMessageResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// User-to-user DM should be type:chat (human-to-human, no agent dispatch).
+	if resp.Type != messages.TypeChat {
+		t.Errorf("user DM: expected type %q, got %q", messages.TypeChat, resp.Type)
+	}
+	if resp.SenderID != DevUserID {
+		t.Errorf("senderID = %q, want %q", resp.SenderID, DevUserID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// W4: parseAgentDMKey tests
+// ---------------------------------------------------------------------------
+
+func TestParseAgentDMKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"dm:agent:aaaa-bbbb:user:cccc-dddd", "aaaa-bbbb"},
+		{"dm:user:aaaa:user:bbbb", ""},
+		{"dm:agent:1234:user:5678", "1234"},
+		{"not-a-dm", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := parseAgentDMKey(tt.key); got != tt.want {
+			t.Errorf("parseAgentDMKey(%q) = %q, want %q", tt.key, got, tt.want)
 		}
 	}
 }

--- a/pkg/hub/handlers_chat_v2_test.go
+++ b/pkg/hub/handlers_chat_v2_test.go
@@ -1,0 +1,1004 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// ---------------------------------------------------------------------------
+// Helper: create a minimal Server with WebChatStore for unit tests that
+// don't need the full testServer() (Ent + dev auth + policies).
+// ---------------------------------------------------------------------------
+
+func chatV2TestUser(id, email, name string) *http.Request {
+	user := NewAuthenticatedUser(id, email, name, "member", "web")
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	return req.WithContext(contextWithIdentity(req.Context(), user))
+}
+
+// ---------------------------------------------------------------------------
+// isDMParticipant tests
+// ---------------------------------------------------------------------------
+
+func TestIsDMParticipant(t *testing.T) {
+	tests := []struct {
+		key    string
+		userID string
+		want   bool
+	}{
+		{"dm:agent:a1:user:u1", "u1", true},
+		{"dm:agent:a1:user:u1", "a1", true},
+		{"dm:agent:a1:user:u1", "u2", false},
+		{"dm:user:u1:user:u2", "u1", true},
+		{"dm:user:u1:user:u2", "u2", true},
+		{"dm:user:u1:user:u2", "u3", false},
+	}
+	for _, tt := range tests {
+		if got := isDMParticipant(tt.key, tt.userID); got != tt.want {
+			t.Errorf("isDMParticipant(%q, %q) = %v, want %v", tt.key, tt.userID, got, tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resolveDMPeer tests
+// ---------------------------------------------------------------------------
+
+func TestResolveDMPeer(t *testing.T) {
+	tests := []struct {
+		key      string
+		callerID string
+		wantID   string
+	}{
+		{"dm:agent:a1:user:u1", "u1", "a1"},
+		{"dm:agent:a1:user:u1", "a1", "u1"},
+		{"dm:user:u1:user:u2", "u1", "u2"},
+		{"dm:user:u1:user:u2", "u2", "u1"},
+	}
+	for _, tt := range tests {
+		_, gotID := resolveDMPeer(tt.key, tt.callerID)
+		if gotID != tt.wantID {
+			t.Errorf("resolveDMPeer(%q, %q) peerID = %q, want %q", tt.key, tt.callerID, gotID, tt.wantID)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TypeChat constant audit verification
+// ---------------------------------------------------------------------------
+
+func TestTypeChat_InValidTypes(t *testing.T) {
+	// TypeChat must be accepted by ValidateType.
+	if err := messages.ValidateType(messages.TypeChat); err != nil {
+		t.Fatalf("ValidateType(%q) returned error: %v", messages.TypeChat, err)
+	}
+}
+
+func TestTypeChat_NotDispatchedToAgent(t *testing.T) {
+	// type:chat audit (a): Messages with recipient "thread:..." or
+	// "user:..." (non-agent-prefixed) are never dispatched to an agent.
+	// The dispatch path in handleBrokerInbound routes by topic
+	// (project+agent slug), not by type. deliverToAgent in
+	// messagebroker.go triggers on agent topics only.
+	//
+	// This test verifies the structural property: a chat message's
+	// recipient prefix is never "agent:", so it never enters the agent
+	// dispatch path.
+	recipients := []string{
+		"thread:topic-uuid-1",
+		"user:alice@example.com",
+	}
+	for _, r := range recipients {
+		if strings.HasPrefix(r, "agent:") {
+			t.Errorf("chat message recipient %q starts with 'agent:' — would be dispatched to an agent", r)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Store-level tests (extend wave-2 store tests)
+// ---------------------------------------------------------------------------
+
+func TestWave2_ReadState_SetAndGet(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close()
+
+	ctx := context.Background()
+
+	// Initially no read state.
+	rs, err := store.GetReadState(ctx, "user-1", "topic-1")
+	if err != nil {
+		t.Fatalf("GetReadState: %v", err)
+	}
+	if rs != nil {
+		t.Fatalf("expected nil read state, got %+v", rs)
+	}
+
+	// Set read state.
+	if err := store.SetReadState(ctx, "user-1", "topic-1", "msg-5"); err != nil {
+		t.Fatalf("SetReadState: %v", err)
+	}
+
+	rs, err = store.GetReadState(ctx, "user-1", "topic-1")
+	if err != nil {
+		t.Fatalf("GetReadState: %v", err)
+	}
+	if rs == nil {
+		t.Fatal("expected non-nil read state")
+	}
+	if rs.LastReadMessageID != "msg-5" {
+		t.Errorf("LastReadMessageID = %q, want %q", rs.LastReadMessageID, "msg-5")
+	}
+
+	// Advance watermark.
+	if err := store.SetReadState(ctx, "user-1", "topic-1", "msg-10"); err != nil {
+		t.Fatalf("SetReadState advance: %v", err)
+	}
+	rs, err = store.GetReadState(ctx, "user-1", "topic-1")
+	if err != nil {
+		t.Fatalf("GetReadState after advance: %v", err)
+	}
+	if rs.LastReadMessageID != "msg-10" {
+		t.Errorf("after advance: LastReadMessageID = %q, want %q", rs.LastReadMessageID, "msg-10")
+	}
+}
+
+func TestWave2_UserPrefs_DefaultsAndOverride(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close()
+
+	ctx := context.Background()
+
+	// Defaults.
+	prefs, err := store.GetUserPrefs(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("GetUserPrefs: %v", err)
+	}
+	if prefs == nil {
+		t.Fatal("expected non-nil default prefs")
+	}
+	if prefs.SpaceSortMode != "activity" {
+		t.Errorf("default SpaceSortMode = %q, want %q", prefs.SpaceSortMode, "activity")
+	}
+	if prefs.ThreadSortMode != "activity" {
+		t.Errorf("default ThreadSortMode = %q, want %q", prefs.ThreadSortMode, "activity")
+	}
+
+	// Override.
+	if err := store.SetUserPrefs(ctx, "user-1", WebChatUserPrefs{
+		UserID:         "user-1",
+		SpaceSortMode:  "alpha",
+		SpaceOrder:     `["proj-2","proj-1"]`,
+		ThreadSortMode: "alpha",
+	}); err != nil {
+		t.Fatalf("SetUserPrefs: %v", err)
+	}
+
+	prefs, err = store.GetUserPrefs(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("GetUserPrefs after set: %v", err)
+	}
+	if prefs.SpaceSortMode != "alpha" {
+		t.Errorf("SpaceSortMode = %q, want %q", prefs.SpaceSortMode, "alpha")
+	}
+	if prefs.SpaceOrder != `["proj-2","proj-1"]` {
+		t.Errorf("SpaceOrder = %q, want %q", prefs.SpaceOrder, `["proj-2","proj-1"]`)
+	}
+}
+
+func TestChatV2_DM_UpsertAndList(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Upsert two sides of a DM.
+	if err := store.UpsertDM(ctx, WebChatDM{
+		ConversationKey: "dm:user:u1:user:u2",
+		ParticipantID:   "u1",
+		PeerID:          "u2",
+		PeerKind:        "user",
+		LastActivityAt:  now,
+	}); err != nil {
+		t.Fatalf("UpsertDM side 1: %v", err)
+	}
+	if err := store.UpsertDM(ctx, WebChatDM{
+		ConversationKey: "dm:user:u1:user:u2",
+		ParticipantID:   "u2",
+		PeerID:          "u1",
+		PeerKind:        "user",
+		LastActivityAt:  now,
+	}); err != nil {
+		t.Fatalf("UpsertDM side 2: %v", err)
+	}
+
+	// List for u1.
+	dms, err := store.ListDMs(ctx, "u1")
+	if err != nil {
+		t.Fatalf("ListDMs: %v", err)
+	}
+	if len(dms) != 1 {
+		t.Fatalf("expected 1 DM, got %d", len(dms))
+	}
+	if dms[0].PeerID != "u2" {
+		t.Errorf("DM peer = %q, want %q", dms[0].PeerID, "u2")
+	}
+
+	// List for u2.
+	dms, err = store.ListDMs(ctx, "u2")
+	if err != nil {
+		t.Fatalf("ListDMs for u2: %v", err)
+	}
+	if len(dms) != 1 {
+		t.Fatalf("expected 1 DM for u2, got %d", len(dms))
+	}
+	if dms[0].PeerID != "u1" {
+		t.Errorf("DM peer = %q, want %q", dms[0].PeerID, "u1")
+	}
+}
+
+func TestChatV2_TouchTopicActivity(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close()
+
+	ctx := context.Background()
+
+	// Create a topic first.
+	if err := store.CreateTopic(ctx, WebChatTopic{
+		ID:        "topic-1",
+		ProjectID: "proj-1",
+		Name:      "test",
+		CreatedBy: "user-1",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	// Touch with message ID.
+	if err := store.TouchTopicActivity(ctx, "topic-1", "msg-1"); err != nil {
+		t.Fatalf("TouchTopicActivity: %v", err)
+	}
+
+	topic, err := store.GetTopic(ctx, "topic-1")
+	if err != nil {
+		t.Fatalf("GetTopic: %v", err)
+	}
+	if topic.LastMessageID != "msg-1" {
+		t.Errorf("LastMessageID = %q, want %q", topic.LastMessageID, "msg-1")
+	}
+
+	// Touch without message ID (empty string).
+	if err := store.TouchTopicActivity(ctx, "topic-1", ""); err != nil {
+		t.Fatalf("TouchTopicActivity (no msgID): %v", err)
+	}
+	topic, err = store.GetTopic(ctx, "topic-1")
+	if err != nil {
+		t.Fatalf("GetTopic after empty touch: %v", err)
+	}
+	// LastMessageID should not change.
+	if topic.LastMessageID != "msg-1" {
+		t.Errorf("LastMessageID changed after empty touch: got %q", topic.LastMessageID)
+	}
+}
+
+func TestWave2_DeleteTopic_GeneralGuard(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close()
+
+	ctx := context.Background()
+
+	// Create #general.
+	generalID, _, err := store.EnsureGeneralTopic(ctx, "proj-1", "user-1")
+	if err != nil {
+		t.Fatalf("EnsureGeneralTopic: %v", err)
+	}
+
+	// Attempt to delete #general.
+	err = store.DeleteTopic(ctx, generalID)
+	if err == nil {
+		t.Fatal("expected error when deleting #general")
+	}
+	if !strings.Contains(err.Error(), "#general") {
+		t.Errorf("error should mention #general, got: %v", err)
+	}
+
+	// Create and delete a normal topic — should work.
+	if err := store.CreateTopic(ctx, WebChatTopic{
+		ID:        "topic-2",
+		ProjectID: "proj-1",
+		Name:      "deletable",
+		CreatedBy: "user-1",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+	if err := store.DeleteTopic(ctx, "topic-2"); err != nil {
+		t.Fatalf("DeleteTopic (normal): %v", err)
+	}
+
+	// Verify it's gone from listing.
+	topics, err := store.ListTopics(ctx, "proj-1")
+	if err != nil {
+		t.Fatalf("ListTopics: %v", err)
+	}
+	for _, t2 := range topics {
+		if t2.ID == "topic-2" {
+			t.Error("deleted topic should not appear in ListTopics")
+		}
+	}
+}
+
+func TestWave2_TopicNameUniqueness(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close()
+
+	ctx := context.Background()
+
+	if err := store.CreateTopic(ctx, WebChatTopic{
+		ID:        "topic-a",
+		ProjectID: "proj-1",
+		Name:      "design",
+		CreatedBy: "user-1",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	// Same name in same project should fail.
+	err := store.CreateTopic(ctx, WebChatTopic{
+		ID:        "topic-b",
+		ProjectID: "proj-1",
+		Name:      "design",
+		CreatedBy: "user-1",
+		CreatedAt: time.Now().UTC(),
+	})
+	if err == nil {
+		t.Fatal("expected error for duplicate name in same project")
+	}
+
+	// Same name in different project should succeed.
+	if err := store.CreateTopic(ctx, WebChatTopic{
+		ID:        "topic-c",
+		ProjectID: "proj-2",
+		Name:      "design",
+		CreatedBy: "user-1",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("same name in different project should succeed: %v", err)
+	}
+}
+
+func TestWave2_TouchDMActivity(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Create a DM.
+	if err := store.UpsertDM(ctx, WebChatDM{
+		ConversationKey: "dm:user:u1:user:u2",
+		ParticipantID:   "u1",
+		PeerID:          "u2",
+		PeerKind:        "user",
+		LastActivityAt:  now,
+	}); err != nil {
+		t.Fatalf("UpsertDM: %v", err)
+	}
+	if err := store.UpsertDM(ctx, WebChatDM{
+		ConversationKey: "dm:user:u1:user:u2",
+		ParticipantID:   "u2",
+		PeerID:          "u1",
+		PeerKind:        "user",
+		LastActivityAt:  now,
+	}); err != nil {
+		t.Fatalf("UpsertDM: %v", err)
+	}
+
+	// Touch with message ID.
+	if err := store.TouchDMActivity(ctx, "dm:user:u1:user:u2", "msg-1"); err != nil {
+		t.Fatalf("TouchDMActivity: %v", err)
+	}
+
+	// Verify both sides updated.
+	dms1, _ := store.ListDMs(ctx, "u1")
+	if len(dms1) != 1 || dms1[0].LastMessageID != "msg-1" {
+		t.Errorf("expected u1 DM LastMessageID = msg-1")
+	}
+	dms2, _ := store.ListDMs(ctx, "u2")
+	if len(dms2) != 1 || dms2[0].LastMessageID != "msg-1" {
+		t.Errorf("expected u2 DM LastMessageID = msg-1")
+	}
+}
+
+func TestWave2_GetReadStates_Batch(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close()
+
+	ctx := context.Background()
+
+	// Set some read states.
+	_ = store.SetReadState(ctx, "user-1", "topic-1", "msg-1")
+	_ = store.SetReadState(ctx, "user-1", "topic-2", "msg-5")
+	_ = store.SetReadState(ctx, "user-1", "topic-3", "msg-10")
+
+	// Batch fetch.
+	states, err := store.GetReadStates(ctx, "user-1", []string{"topic-1", "topic-2", "topic-3", "topic-4"})
+	if err != nil {
+		t.Fatalf("GetReadStates: %v", err)
+	}
+	if len(states) != 3 {
+		t.Fatalf("expected 3 states, got %d", len(states))
+	}
+
+	stateMap := make(map[string]string)
+	for _, rs := range states {
+		stateMap[rs.ConversationKey] = rs.LastReadMessageID
+	}
+	if stateMap["topic-1"] != "msg-1" {
+		t.Errorf("topic-1 read = %q, want %q", stateMap["topic-1"], "msg-1")
+	}
+	if stateMap["topic-2"] != "msg-5" {
+		t.Errorf("topic-2 read = %q, want %q", stateMap["topic-2"], "msg-5")
+	}
+	if stateMap["topic-3"] != "msg-10" {
+		t.Errorf("topic-3 read = %q, want %q", stateMap["topic-3"], "msg-10")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests using testServer (full HTTP stack)
+// ---------------------------------------------------------------------------
+
+func TestChatV2_Spaces_RequiresAuth(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequestNoAuth(t, srv, http.MethodGet, "/api/v1/chat/spaces", nil)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without auth, got %d", rec.Code)
+	}
+}
+
+func TestChatV2_Spaces_ReturnsEmpty(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// The dev user is authenticated but may not have projects yet.
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/chat/spaces", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatSpacesResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Spaces == nil {
+		t.Error("spaces should be non-nil (empty array)")
+	}
+}
+
+func TestChatV2_CreateThread_AndList(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// Create a project.
+	proj := &store.Project{ID: tid("chat-test"), Name: "chat-test", Slug: "chat-test", Created: time.Now(), Updated: time.Now()}
+	if err := s.CreateProject(ctx, proj); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	// Ensure WebChatStore is set up.
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	wcs := NewWebChatStore(db, "sqlite3")
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	srv.SetWebChatStore(wcs)
+
+	// Create a thread.
+	body := map[string]string{"name": "design-review"}
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/spaces/"+proj.ID+"/threads", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var topic WebChatTopic
+	if err := json.NewDecoder(rec.Body).Decode(&topic); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if topic.Name != "design-review" {
+		t.Errorf("name = %q, want %q", topic.Name, "design-review")
+	}
+	if topic.ID == "" {
+		t.Error("topic ID should be non-empty")
+	}
+
+	// List threads — should include #general (lazy-created) and our thread.
+	rec = doRequest(t, srv, http.MethodGet, "/api/v1/chat/spaces/"+proj.ID+"/threads", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var listResp chatTopicListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&listResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(listResp.Threads) < 2 {
+		t.Fatalf("expected at least 2 threads (general + created), got %d", len(listResp.Threads))
+	}
+
+	// Verify #general exists.
+	var hasGeneral bool
+	for _, th := range listResp.Threads {
+		if th.IsGeneral {
+			hasGeneral = true
+		}
+	}
+	if !hasGeneral {
+		t.Error("expected #general to be in the list")
+	}
+}
+
+func TestChatV2_CreateThread_Validation(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	proj := &store.Project{ID: tid("val-test"), Name: "val-test", Slug: "val-test", Created: time.Now(), Updated: time.Now()}
+	if err := s.CreateProject(ctx, proj); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	wcs := NewWebChatStore(db, "sqlite3")
+	wcs.Init()
+	srv.SetWebChatStore(wcs)
+
+	// Empty name.
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/spaces/"+proj.ID+"/threads", map[string]string{"name": ""})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("empty name: expected 400, got %d", rec.Code)
+	}
+
+	// Name too long.
+	longName := strings.Repeat("a", 101)
+	rec = doRequest(t, srv, http.MethodPost, "/api/v1/chat/spaces/"+proj.ID+"/threads", map[string]string{"name": longName})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("long name: expected 400, got %d", rec.Code)
+	}
+}
+
+func TestChatV2_PatchThread(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	proj := &store.Project{ID: tid("patch-test"), Name: "patch-test", Slug: "patch-test", Created: time.Now(), Updated: time.Now()}
+	if err := s.CreateProject(ctx, proj); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	wcs := NewWebChatStore(db, "sqlite3")
+	wcs.Init()
+	srv.SetWebChatStore(wcs)
+
+	// Create a topic.
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        "topic-patch",
+		ProjectID: proj.ID,
+		Name:      "old-name",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	// Rename.
+	newName := "new-name"
+	rec := doRequest(t, srv, http.MethodPatch, "/api/v1/chat/topics/topic-patch", map[string]*string{"name": &newName})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var updated WebChatTopic
+	if err := json.NewDecoder(rec.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if updated.Name != "new-name" {
+		t.Errorf("name = %q, want %q", updated.Name, "new-name")
+	}
+}
+
+func TestChatV2_PatchThread_GeneralGuard(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	proj := &store.Project{ID: tid("gen-guard"), Name: "gen-guard", Slug: "gen-guard", Created: time.Now(), Updated: time.Now()}
+	if err := s.CreateProject(ctx, proj); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	wcs := NewWebChatStore(db, "sqlite3")
+	wcs.Init()
+	srv.SetWebChatStore(wcs)
+
+	genID, _, err := wcs.EnsureGeneralTopic(ctx, proj.ID, "dev")
+	if err != nil {
+		t.Fatalf("EnsureGeneralTopic: %v", err)
+	}
+
+	// Attempt to rename #general.
+	newName := "not-general"
+	rec := doRequest(t, srv, http.MethodPatch, "/api/v1/chat/topics/"+genID, map[string]*string{"name": &newName})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("rename #general: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestChatV2_DeleteThread(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	proj := &store.Project{ID: tid("del-test"), Name: "del-test", Slug: "del-test", Created: time.Now(), Updated: time.Now()}
+	if err := s.CreateProject(ctx, proj); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	wcs := NewWebChatStore(db, "sqlite3")
+	wcs.Init()
+	srv.SetWebChatStore(wcs)
+
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        "topic-del",
+		ProjectID: proj.ID,
+		Name:      "to-delete",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/chat/topics/topic-del", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify soft-deleted — not in list.
+	topics, _ := wcs.ListTopics(ctx, proj.ID)
+	for _, tp := range topics {
+		if tp.ID == "topic-del" {
+			t.Error("deleted topic should not appear in ListTopics")
+		}
+	}
+}
+
+func TestChatV2_DeleteThread_GeneralGuard(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	proj := &store.Project{ID: tid("del-gen"), Name: "del-gen", Slug: "del-gen", Created: time.Now(), Updated: time.Now()}
+	if err := s.CreateProject(ctx, proj); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	wcs := NewWebChatStore(db, "sqlite3")
+	wcs.Init()
+	srv.SetWebChatStore(wcs)
+
+	genID, _, _ := wcs.EnsureGeneralTopic(ctx, proj.ID, "dev")
+	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/chat/topics/"+genID, nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("delete #general: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestChatV2_ConversationRead(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	proj := &store.Project{ID: tid("read-test"), Name: "read-test", Slug: "read-test", Created: time.Now(), Updated: time.Now()}
+	if err := s.CreateProject(ctx, proj); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	wcs := NewWebChatStore(db, "sqlite3")
+	wcs.Init()
+	srv.SetWebChatStore(wcs)
+
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        "topic-read",
+		ProjectID: proj.ID,
+		Name:      "readable",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/conversations/topic-read/read",
+		map[string]string{"messageId": "msg-42"})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestChatV2_DMs_Empty(t *testing.T) {
+	srv, _ := testServer(t)
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	wcs := NewWebChatStore(db, "sqlite3")
+	wcs.Init()
+	srv.SetWebChatStore(wcs)
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/chat/dms", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatDMListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.DMs == nil {
+		t.Error("DMs should be non-nil (empty array)")
+	}
+}
+
+func TestChatV2_UserPrefs_GetDefault(t *testing.T) {
+	srv, _ := testServer(t)
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	wcs := NewWebChatStore(db, "sqlite3")
+	wcs.Init()
+	srv.SetWebChatStore(wcs)
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/chat/user-prefs", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var prefs WebChatUserPrefs
+	if err := json.NewDecoder(rec.Body).Decode(&prefs); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if prefs.SpaceSortMode != "activity" {
+		t.Errorf("default SpaceSortMode = %q, want %q", prefs.SpaceSortMode, "activity")
+	}
+}
+
+func TestChatV2_UserPrefs_PutAndGet(t *testing.T) {
+	srv, _ := testServer(t)
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	wcs := NewWebChatStore(db, "sqlite3")
+	wcs.Init()
+	srv.SetWebChatStore(wcs)
+
+	// PUT.
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/chat/user-prefs", map[string]string{
+		"spaceSortMode":  "alpha",
+		"threadSortMode": "alpha",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// GET.
+	rec = doRequest(t, srv, http.MethodGet, "/api/v1/chat/user-prefs", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var prefs WebChatUserPrefs
+	if err := json.NewDecoder(rec.Body).Decode(&prefs); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if prefs.SpaceSortMode != "alpha" {
+		t.Errorf("SpaceSortMode = %q, want %q", prefs.SpaceSortMode, "alpha")
+	}
+}
+
+func TestChatV2_Presence_Stub(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/presence", nil)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestChatV2_Search_Stub(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/chat/search?q=test", nil)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestChatV2_LegacyThreads_AuthzFix(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// Create a project that only admins can see — the dev user is admin
+	// by default so this test just verifies the authz call is present
+	// by checking the endpoint doesn't error on a valid project.
+	proj := &store.Project{ID: tid("legacy-authz"), Name: "legacy-authz", Slug: "legacy-authz", Created: time.Now(), Updated: time.Now()}
+	if err := s.CreateProject(ctx, proj); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	wcs := NewWebChatStore(db, "sqlite3")
+	wcs.Init()
+	srv.SetWebChatStore(wcs)
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/chat/threads?projectId="+proj.ID, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Non-existent project should 404.
+	rec = doRequest(t, srv, http.MethodGet, "/api/v1/chat/threads?projectId=nonexistent", nil)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("nonexistent project: expected 404, got %d", rec.Code)
+	}
+}
+
+func TestChatV2_SpaceRead(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	proj := &store.Project{ID: tid("space-read"), Name: "space-read", Slug: "space-read", Created: time.Now(), Updated: time.Now()}
+	if err := s.CreateProject(ctx, proj); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer db.Close()
+	wcs := NewWebChatStore(db, "sqlite3")
+	wcs.Init()
+	srv.SetWebChatStore(wcs)
+
+	// Create a topic with a message.
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:            "topic-sr",
+		ProjectID:     proj.ID,
+		Name:          "space-read-thread",
+		CreatedBy:     "dev",
+		CreatedAt:     time.Now().UTC(),
+		LastMessageID: "msg-99",
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/chat/spaces/"+proj.ID+"/read", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestChatV2_Members(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	proj := &store.Project{ID: tid("members-test"), Name: "members-test", Slug: "members-test", Created: time.Now(), Updated: time.Now()}
+	if err := s.CreateProject(ctx, proj); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/chat/spaces/"+proj.ID+"/members", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatMembersResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// humans and agents should be non-nil arrays.
+	if resp.Humans == nil {
+		t.Error("humans should be non-nil")
+	}
+	if resp.Agents == nil {
+		t.Error("agents should be non-nil")
+	}
+}
+
+func TestChatV2_MethodNotAllowed(t *testing.T) {
+	srv, _ := testServer(t)
+
+	tests := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodPost, "/api/v1/chat/spaces"},
+		{http.MethodGet, "/api/v1/chat/presence"},
+		{http.MethodPost, "/api/v1/chat/search"},
+		{http.MethodPost, "/api/v1/chat/dms"},
+	}
+
+	for _, tt := range tests {
+		rec := doRequest(t, srv, tt.method, tt.path, nil)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("%s %s: expected 405, got %d", tt.method, tt.path, rec.Code)
+		}
+	}
+}

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -527,15 +527,19 @@ func (s *Server) ensureProjectGeneralTopic(ctx context.Context, project *store.P
 	if createdBy == "" {
 		createdBy = "system"
 	}
-	topicID, err := s.webChatStore.EnsureGeneralTopic(ctx, project.ID, createdBy)
+	topicID, created, err := s.webChatStore.EnsureGeneralTopic(ctx, project.ID, createdBy)
 	if err != nil {
 		s.projectsLogger().Warn("failed to create #general topic for project",
 			"project_id", project.ID, "error", err)
 		return
 	}
 
-	// Publish a topic-created event so SSE subscribers can update the rail.
-	// Best-effort: if the fetch fails we still bootstrapped successfully.
+	// Only publish the created event when a new topic was actually inserted.
+	// EnsureGeneralTopic is idempotent (ON CONFLICT DO NOTHING), so
+	// re-calling it for an existing project must not emit a spurious event.
+	if !created {
+		return
+	}
 	topic, err := s.webChatStore.GetTopic(ctx, topicID)
 	if err != nil || topic == nil {
 		return

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -527,10 +527,20 @@ func (s *Server) ensureProjectGeneralTopic(ctx context.Context, project *store.P
 	if createdBy == "" {
 		createdBy = "system"
 	}
-	if _, err := s.webChatStore.EnsureGeneralTopic(ctx, project.ID, createdBy); err != nil {
+	topicID, err := s.webChatStore.EnsureGeneralTopic(ctx, project.ID, createdBy)
+	if err != nil {
 		s.projectsLogger().Warn("failed to create #general topic for project",
 			"project_id", project.ID, "error", err)
+		return
 	}
+
+	// Publish a topic-created event so SSE subscribers can update the rail.
+	// Best-effort: if the fetch fails we still bootstrapped successfully.
+	topic, err := s.webChatStore.GetTopic(ctx, topicID)
+	if err != nil || topic == nil {
+		return
+	}
+	s.events.PublishChatTopicEvent(ctx, project.ID, "created", *topic)
 }
 
 // createProjectMembersGroupAndPolicy creates an explicit members group for a project

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -388,6 +388,9 @@ func (s *Server) createProject(w http.ResponseWriter, r *http.Request) {
 	// Create project members group and policy (best-effort)
 	s.createProjectMembersGroupAndPolicy(ctx, project)
 
+	// Ensure the #general chat topic exists for this project (best-effort).
+	s.ensureProjectGeneralTopic(ctx, project)
+
 	// For git projects, try to auto-associate a GitHub App installation so that
 	// clone/pull operations can mint tokens. This covers the case where the app
 	// was installed before the project was created (webhook already fired).
@@ -510,6 +513,23 @@ func (s *Server) createProjectGroup(ctx context.Context, project *store.Project)
 					"project_id", project.ID, "slug", agentsSlug, "error", updateErr.Error())
 			}
 		}
+	}
+}
+
+// ensureProjectGeneralTopic creates the #general chat topic for a project if
+// the webchat store is configured. Best-effort: failures are logged but do not
+// block project creation.
+func (s *Server) ensureProjectGeneralTopic(ctx context.Context, project *store.Project) {
+	if s.webChatStore == nil {
+		return
+	}
+	createdBy := project.CreatedBy
+	if createdBy == "" {
+		createdBy = "system"
+	}
+	if _, err := s.webChatStore.EnsureGeneralTopic(ctx, project.ID, createdBy); err != nil {
+		s.projectsLogger().Warn("failed to create #general topic for project",
+			"project_id", project.ID, "error", err)
 	}
 }
 
@@ -1190,6 +1210,9 @@ func (s *Server) handleProjectRegister(w http.ResponseWriter, r *http.Request) {
 
 		// Create project members group and policy (best-effort)
 		s.createProjectMembersGroupAndPolicy(ctx, project)
+
+		// Ensure the #general chat topic exists for this project (best-effort).
+		s.ensureProjectGeneralTopic(ctx, project)
 
 		// Auto-link brokers that have auto_provide enabled
 		s.autoLinkProviders(ctx, project)

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -50,6 +50,7 @@ type MessageBrokerProxy struct {
 	getDispatcher func() AgentDispatcher
 	log           *slog.Logger
 	messageLog    *slog.Logger
+	chatNotifier  *ChatNotifier // W6: DM notification trigger for agent replies (nil-safe)
 
 	mu                  sync.Mutex
 	subscriptions       map[string][]eventbus.Subscription // projectID -> active subscriptions
@@ -454,6 +455,14 @@ func (p *MessageBrokerProxy) deliverToUser(ctx context.Context, projectID, topic
 
 	// Publish SSE event so connected browser clients receive real-time inbox updates.
 	p.events.PublishUserMessage(ctx, storeMsg)
+
+	// W6: DM notification for agent → human replies via broker path.
+	if p.chatNotifier != nil && storeMsg.ThreadID != "" &&
+		strings.HasPrefix(storeMsg.ThreadID, "dm:") &&
+		storeMsg.RecipientID != "" && strings.HasPrefix(storeMsg.Sender, "agent:") {
+		senderName := strings.TrimPrefix(storeMsg.Sender, "agent:")
+		go p.chatNotifier.NotifyDMReceived(context.Background(), storeMsg.RecipientID, senderName, storeMsg.ThreadID, storeMsg.Msg, projectID)
+	}
 
 	// Log to dedicated message audit log
 	if p.messageLog != nil {

--- a/pkg/hub/notifications.go
+++ b/pkg/hub/notifications.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -500,6 +501,217 @@ func (nd *NotificationDispatcher) createInboxMessage(ctx context.Context, sub *s
 	nd.events.PublishUserMessage(ctx, storeMsg)
 	nd.log.Debug("Inbox message created for notification",
 		"notificationID", notif.ID, "messageID", storeMsg.ID, "subscriberID", sub.SubscriberID)
+}
+
+// ---------------------------------------------------------------------------
+// Chat notification triggers (W6): human mention + DM received
+// ---------------------------------------------------------------------------
+
+// ChatNotificationStatus constants for chat-specific notification triggers.
+const (
+	ChatNotificationMention    = "MENTION"
+	ChatNotificationDMReceived = "DM_RECEIVED"
+)
+
+// PresenceChecker reports whether a user has active presence (i.e. is
+// currently viewing the chat UI). When a user is actively present, DM
+// notifications are suppressed to avoid interrupting them.
+//
+// W5 will implement a real presence map; until then a nil PresenceChecker
+// (or the NoOpPresenceChecker) treats every user as absent, which means
+// DM notifications always fire — the conservative default.
+type PresenceChecker interface {
+	// IsUserActive returns true if the user is actively present
+	// (heartbeat within the presence window).
+	IsUserActive(userID string) bool
+}
+
+// NoOpPresenceChecker always returns false (user is not active).
+// Used as the default when W5 presence is not yet available.
+type NoOpPresenceChecker struct{}
+
+// IsUserActive always returns false — the user is assumed absent.
+func (NoOpPresenceChecker) IsUserActive(_ string) bool { return false }
+
+// ChatNotifier creates notifications for chat events (human mentions,
+// DM received) using the existing notification pipeline (SSE publish +
+// store). It is wired into the Server at startup and called from the
+// send path in handlers_chat_v2.go.
+type ChatNotifier struct {
+	store         store.Store
+	events        EventPublisher
+	webChatStore  WebChatStore
+	presence      PresenceChecker
+	log           *slog.Logger
+}
+
+// NewChatNotifier creates a ChatNotifier. If presence is nil, a
+// NoOpPresenceChecker is used (DM notifications always fire).
+func NewChatNotifier(s store.Store, events EventPublisher, wcs WebChatStore, presence PresenceChecker, log *slog.Logger) *ChatNotifier {
+	if presence == nil {
+		presence = NoOpPresenceChecker{}
+	}
+	return &ChatNotifier{
+		store:        s,
+		events:       events,
+		webChatStore: wcs,
+		presence:     presence,
+		log:          log,
+	}
+}
+
+// NotifyMention creates a notification for a human user who was @mentioned
+// in a thread or DM. It respects the muted flag on the conversation.
+//
+// Parameters:
+//   - mentionedUserID: the UUID of the mentioned user
+//   - senderName: display name (or email) of the sender
+//   - conversationKey: thread UUID or DM key
+//   - conversationName: human-readable name (thread name or "DM")
+//   - messagePreview: the raw message text (will be truncated)
+//   - projectID: project UUID (may be empty for user-user DMs)
+func (cn *ChatNotifier) NotifyMention(ctx context.Context, mentionedUserID, senderName, conversationKey, conversationName, messagePreview, projectID string) {
+	if cn == nil || cn.webChatStore == nil {
+		return
+	}
+
+	// Respect muted flag.
+	muted, err := cn.webChatStore.IsConversationMuted(ctx, mentionedUserID, conversationKey)
+	if err != nil {
+		cn.log.Error("Failed to check muted state for mention notification",
+			"userID", mentionedUserID, "conversationKey", conversationKey, "error", err)
+		return
+	}
+	if muted {
+		cn.log.Debug("Skipping mention notification — conversation muted",
+			"userID", mentionedUserID, "conversationKey", conversationKey)
+		return
+	}
+
+	message := formatChatNotification(ChatNotificationMention, senderName, conversationName, messagePreview)
+
+	// Use nil UUIDs for SubscriptionID and AgentID since chat notifications
+	// are not tied to an agent subscription — they are direct triggers.
+	nilUUID := uuid.Nil.String()
+	effectiveProjectID := projectID
+	if effectiveProjectID == "" {
+		effectiveProjectID = nilUUID
+	}
+
+	notif := &store.Notification{
+		ID:             api.NewUUID(),
+		SubscriptionID: nilUUID,
+		AgentID:        nilUUID,
+		ProjectID:      effectiveProjectID,
+		SubscriberType: store.SubscriberTypeUser,
+		SubscriberID:   mentionedUserID,
+		Status:         ChatNotificationMention,
+		Message:        message,
+		CreatedAt:      time.Now(),
+	}
+
+	if err := cn.store.CreateNotification(ctx, notif); err != nil {
+		cn.log.Error("Failed to create mention notification",
+			"userID", mentionedUserID, "error", err)
+		return
+	}
+
+	cn.events.PublishNotification(ctx, notif)
+	cn.log.Info("Mention notification created",
+		"notificationID", notif.ID, "mentionedUser", mentionedUserID,
+		"sender", senderName, "conversationKey", conversationKey)
+}
+
+// NotifyDMReceived creates a notification for a user who received a DM.
+// Notifications are skipped when:
+//   - the conversation is muted
+//   - the recipient has active presence (W5 integration)
+//
+// Parameters:
+//   - recipientUserID: the UUID of the DM recipient
+//   - senderName: display name (or email) of the sender
+//   - conversationKey: the DM key (dm:...)
+//   - messagePreview: the raw message text (will be truncated)
+//   - projectID: project UUID (may be empty for user-user DMs)
+func (cn *ChatNotifier) NotifyDMReceived(ctx context.Context, recipientUserID, senderName, conversationKey, messagePreview, projectID string) {
+	if cn == nil || cn.webChatStore == nil {
+		return
+	}
+
+	// Respect muted flag.
+	muted, err := cn.webChatStore.IsConversationMuted(ctx, recipientUserID, conversationKey)
+	if err != nil {
+		cn.log.Error("Failed to check muted state for DM notification",
+			"userID", recipientUserID, "conversationKey", conversationKey, "error", err)
+		return
+	}
+	if muted {
+		cn.log.Debug("Skipping DM notification — conversation muted",
+			"userID", recipientUserID, "conversationKey", conversationKey)
+		return
+	}
+
+	// Skip if recipient has active presence (they're already viewing chat).
+	if cn.presence.IsUserActive(recipientUserID) {
+		cn.log.Debug("Skipping DM notification — user has active presence",
+			"userID", recipientUserID, "conversationKey", conversationKey)
+		return
+	}
+
+	message := formatChatNotification(ChatNotificationDMReceived, senderName, "", messagePreview)
+
+	// Use nil UUIDs for SubscriptionID and AgentID since chat notifications
+	// are not tied to an agent subscription — they are direct triggers.
+	nilUUID := uuid.Nil.String()
+	effectiveProjectID := projectID
+	if effectiveProjectID == "" {
+		effectiveProjectID = nilUUID
+	}
+
+	notif := &store.Notification{
+		ID:             api.NewUUID(),
+		SubscriptionID: nilUUID,
+		AgentID:        nilUUID,
+		ProjectID:      effectiveProjectID,
+		SubscriberType: store.SubscriberTypeUser,
+		SubscriberID:   recipientUserID,
+		Status:         ChatNotificationDMReceived,
+		Message:        message,
+		CreatedAt:      time.Now(),
+	}
+
+	if err := cn.store.CreateNotification(ctx, notif); err != nil {
+		cn.log.Error("Failed to create DM notification",
+			"userID", recipientUserID, "error", err)
+		return
+	}
+
+	cn.events.PublishNotification(ctx, notif)
+	cn.log.Info("DM notification created",
+		"notificationID", notif.ID, "recipient", recipientUserID,
+		"sender", senderName, "conversationKey", conversationKey)
+}
+
+// formatChatNotification formats a notification message for chat triggers.
+func formatChatNotification(trigger, senderName, conversationName, messagePreview string) string {
+	// Truncate preview to a reasonable length for push notifications.
+	const maxPreview = 100
+	preview := messagePreview
+	if len(preview) > maxPreview {
+		preview = preview[:maxPreview] + "…"
+	}
+
+	switch trigger {
+	case ChatNotificationMention:
+		if conversationName != "" {
+			return fmt.Sprintf("@%s mentioned you in #%s: %s", senderName, conversationName, preview)
+		}
+		return fmt.Sprintf("@%s mentioned you: %s", senderName, preview)
+	case ChatNotificationDMReceived:
+		return fmt.Sprintf("%s sent you a message: %s", senderName, preview)
+	default:
+		return fmt.Sprintf("Chat notification from %s: %s", senderName, preview)
+	}
 }
 
 // formatNotificationMessage formats a notification message based on agent state and status.

--- a/pkg/hub/notifications.go
+++ b/pkg/hub/notifications.go
@@ -695,10 +695,14 @@ func (cn *ChatNotifier) NotifyDMReceived(ctx context.Context, recipientUserID, s
 // formatChatNotification formats a notification message for chat triggers.
 func formatChatNotification(trigger, senderName, conversationName, messagePreview string) string {
 	// Truncate preview to a reasonable length for push notifications.
+	// Use rune-based slicing to avoid splitting multi-byte UTF-8 characters.
 	const maxPreview = 100
-	preview := messagePreview
-	if len(preview) > maxPreview {
-		preview = preview[:maxPreview] + "…"
+	runes := []rune(messagePreview)
+	var preview string
+	if len(runes) > maxPreview {
+		preview = string(runes[:maxPreview]) + "…"
+	} else {
+		preview = messagePreview
 	}
 
 	switch trigger {

--- a/pkg/hub/notifications.go
+++ b/pkg/hub/notifications.go
@@ -538,11 +538,11 @@ func (NoOpPresenceChecker) IsUserActive(_ string) bool { return false }
 // store). It is wired into the Server at startup and called from the
 // send path in handlers_chat_v2.go.
 type ChatNotifier struct {
-	store         store.Store
-	events        EventPublisher
-	webChatStore  WebChatStore
-	presence      PresenceChecker
-	log           *slog.Logger
+	store        store.Store
+	events       EventPublisher
+	webChatStore WebChatStore
+	presence     PresenceChecker
+	log          *slog.Logger
 }
 
 // NewChatNotifier creates a ChatNotifier. If presence is nil, a

--- a/pkg/hub/notifications.go
+++ b/pkg/hub/notifications.go
@@ -590,25 +590,7 @@ func (cn *ChatNotifier) NotifyMention(ctx context.Context, mentionedUserID, send
 
 	message := formatChatNotification(ChatNotificationMention, senderName, conversationName, messagePreview)
 
-	// Use nil UUIDs for SubscriptionID and AgentID since chat notifications
-	// are not tied to an agent subscription — they are direct triggers.
-	nilUUID := uuid.Nil.String()
-	effectiveProjectID := projectID
-	if effectiveProjectID == "" {
-		effectiveProjectID = nilUUID
-	}
-
-	notif := &store.Notification{
-		ID:             api.NewUUID(),
-		SubscriptionID: nilUUID,
-		AgentID:        nilUUID,
-		ProjectID:      effectiveProjectID,
-		SubscriberType: store.SubscriberTypeUser,
-		SubscriberID:   mentionedUserID,
-		Status:         ChatNotificationMention,
-		Message:        message,
-		CreatedAt:      time.Now(),
-	}
+	notif := cn.buildChatNotification(mentionedUserID, ChatNotificationMention, message, projectID)
 
 	if err := cn.store.CreateNotification(ctx, notif); err != nil {
 		cn.log.Error("Failed to create mention notification",
@@ -660,25 +642,7 @@ func (cn *ChatNotifier) NotifyDMReceived(ctx context.Context, recipientUserID, s
 
 	message := formatChatNotification(ChatNotificationDMReceived, senderName, "", messagePreview)
 
-	// Use nil UUIDs for SubscriptionID and AgentID since chat notifications
-	// are not tied to an agent subscription — they are direct triggers.
-	nilUUID := uuid.Nil.String()
-	effectiveProjectID := projectID
-	if effectiveProjectID == "" {
-		effectiveProjectID = nilUUID
-	}
-
-	notif := &store.Notification{
-		ID:             api.NewUUID(),
-		SubscriptionID: nilUUID,
-		AgentID:        nilUUID,
-		ProjectID:      effectiveProjectID,
-		SubscriberType: store.SubscriberTypeUser,
-		SubscriberID:   recipientUserID,
-		Status:         ChatNotificationDMReceived,
-		Message:        message,
-		CreatedAt:      time.Now(),
-	}
+	notif := cn.buildChatNotification(recipientUserID, ChatNotificationDMReceived, message, projectID)
 
 	if err := cn.store.CreateNotification(ctx, notif); err != nil {
 		cn.log.Error("Failed to create DM notification",
@@ -690,6 +654,28 @@ func (cn *ChatNotifier) NotifyDMReceived(ctx context.Context, recipientUserID, s
 	cn.log.Info("DM notification created",
 		"notificationID", notif.ID, "recipient", recipientUserID,
 		"sender", senderName, "conversationKey", conversationKey)
+}
+
+// buildChatNotification creates a store.Notification for chat events.
+func (cn *ChatNotifier) buildChatNotification(
+	subscriberID, status, message, projectID string,
+) *store.Notification {
+	nilUUID := uuid.Nil.String()
+	effectiveProjectID := projectID
+	if effectiveProjectID == "" {
+		effectiveProjectID = nilUUID
+	}
+	return &store.Notification{
+		ID:             api.NewUUID(),
+		SubscriptionID: nilUUID,
+		AgentID:        nilUUID,
+		ProjectID:      effectiveProjectID,
+		SubscriberType: store.SubscriberTypeUser,
+		SubscriberID:   subscriberID,
+		Status:         status,
+		Message:        message,
+		CreatedAt:      time.Now(),
+	}
 }
 
 // formatChatNotification formats a notification message for chat triggers.

--- a/pkg/hub/presence.go
+++ b/pkg/hub/presence.go
@@ -86,13 +86,13 @@ type typingEntry struct {
 // provides server-side typing throttling. It is single-node only (see design
 // §4.5 HA limitation).
 type PresenceManager struct {
-	mu       sync.RWMutex
-	users    map[string]*presenceEntry                // userID -> presence
-	typing   map[string]map[string]*typingEntry       // conversationKey -> userID -> typing
-	events   EventPublisher
-	store    store.Store
-	stopCh   chan struct{}
-	stopped  chan struct{}
+	mu      sync.RWMutex
+	users   map[string]*presenceEntry          // userID -> presence
+	typing  map[string]map[string]*typingEntry // conversationKey -> userID -> typing
+	events  EventPublisher
+	store   store.Store
+	stopCh  chan struct{}
+	stopped chan struct{}
 }
 
 // NewPresenceManager creates a new PresenceManager and starts the background

--- a/pkg/hub/presence.go
+++ b/pkg/hub/presence.go
@@ -240,7 +240,7 @@ func (pm *PresenceManager) sweepLoop() {
 }
 
 // sweep checks all tracked users and transitions any that have exceeded
-// the active window to idle.
+// the active window to idle. It also evicts stale typing throttle entries.
 func (pm *PresenceManager) sweep() {
 	now := time.Now()
 
@@ -261,6 +261,20 @@ func (pm *PresenceManager) sweep() {
 			}{uid, entry.displayName, entry.projectIDs})
 		}
 	}
+
+	// Evict stale typing throttle entries (older than 2× typingThrottle).
+	typingEvictThreshold := 2 * typingThrottle
+	for convKey, convMap := range pm.typing {
+		for uid, te := range convMap {
+			if now.Sub(te.lastTyping) > typingEvictThreshold {
+				delete(convMap, uid)
+			}
+		}
+		if len(convMap) == 0 {
+			delete(pm.typing, convKey)
+		}
+	}
+
 	pm.mu.Unlock()
 
 	// Publish transitions outside the lock.

--- a/pkg/hub/presence.go
+++ b/pkg/hub/presence.go
@@ -1,0 +1,314 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// PresenceState indicates whether a user is active or idle.
+type PresenceState string
+
+const (
+	PresenceActive PresenceState = "active"
+	PresenceIdle   PresenceState = "idle"
+)
+
+const (
+	// presenceActiveWindow is the duration within which a heartbeat means
+	// the user is "active". After this window without a heartbeat the user
+	// transitions to idle. Design §4.5: 2 minutes.
+	presenceActiveWindow = 2 * time.Minute
+
+	// presencePersistInterval is the minimum interval between durable
+	// User.last_seen writes. Design §4.5: at most once per 5 min.
+	presencePersistInterval = 5 * time.Minute
+
+	// presenceSweepInterval is how often the background goroutine checks
+	// for idle transitions.
+	presenceSweepInterval = 30 * time.Second
+
+	// typingThrottle is the minimum interval between typing events from
+	// the same user. Design §4.5: 4 seconds.
+	typingThrottle = 4 * time.Second
+)
+
+// PresenceEvent is published on project.<id>.chat.presence when a user's
+// presence state transitions (active↔idle). Only transitions are published,
+// not every heartbeat.
+type PresenceEvent struct {
+	UserID      string `json:"userId"`
+	DisplayName string `json:"displayName"`
+	State       string `json:"state"` // "active" or "idle"
+}
+
+// TypingEvent is published on project.<id>.chat.typing when a user starts
+// typing in a conversation. The frontend handles expiry (6s).
+type TypingEvent struct {
+	ThreadID    string `json:"threadId"`
+	UserID      string `json:"userId"`
+	DisplayName string `json:"displayName"`
+}
+
+// presenceEntry tracks per-user presence state in memory.
+type presenceEntry struct {
+	lastHeartbeat time.Time
+	lastPersist   time.Time // last time User.last_seen was written to the store
+	state         PresenceState
+	displayName   string
+	projectIDs    []string // projects the user participates in (for SSE fan-out)
+}
+
+// typingEntry tracks per-user, per-conversation last-typing timestamp for
+// server-side throttling.
+type typingEntry struct {
+	lastTyping time.Time
+}
+
+// PresenceManager maintains an in-memory map of user presence states and
+// provides server-side typing throttling. It is single-node only (see design
+// §4.5 HA limitation).
+type PresenceManager struct {
+	mu       sync.RWMutex
+	users    map[string]*presenceEntry                // userID -> presence
+	typing   map[string]map[string]*typingEntry       // conversationKey -> userID -> typing
+	events   EventPublisher
+	store    store.Store
+	stopCh   chan struct{}
+	stopped  chan struct{}
+}
+
+// NewPresenceManager creates a new PresenceManager and starts the background
+// sweep goroutine that detects idle transitions.
+func NewPresenceManager(events EventPublisher, st store.Store) *PresenceManager {
+	pm := &PresenceManager{
+		users:   make(map[string]*presenceEntry),
+		typing:  make(map[string]map[string]*typingEntry),
+		events:  events,
+		store:   st,
+		stopCh:  make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+	go pm.sweepLoop()
+	return pm
+}
+
+// Stop shuts down the background sweep goroutine.
+func (pm *PresenceManager) Stop() {
+	close(pm.stopCh)
+	<-pm.stopped
+}
+
+// Heartbeat processes a presence heartbeat from a user. It updates the
+// in-memory map and publishes a transition event if the state changed.
+// projectIDs are the projects the user is currently viewing (for SSE fan-out).
+func (pm *PresenceManager) Heartbeat(ctx context.Context, userID, displayName string, projectIDs []string) {
+	now := time.Now()
+
+	pm.mu.Lock()
+	entry, exists := pm.users[userID]
+	if !exists {
+		entry = &presenceEntry{
+			state: PresenceIdle, // will transition to active below
+		}
+		pm.users[userID] = entry
+	}
+
+	prevState := entry.state
+	entry.lastHeartbeat = now
+	entry.state = PresenceActive
+	entry.displayName = displayName
+	entry.projectIDs = projectIDs
+
+	// Persist User.last_seen at most once per presencePersistInterval.
+	shouldPersist := now.Sub(entry.lastPersist) >= presencePersistInterval
+	if shouldPersist {
+		entry.lastPersist = now
+	}
+	pm.mu.Unlock()
+
+	// Publish transition only when state actually changed.
+	if prevState != PresenceActive {
+		pm.publishTransition(userID, displayName, PresenceActive, projectIDs)
+	}
+
+	// Durable fallback: touch User.last_seen (throttled).
+	if shouldPersist && pm.store != nil {
+		if err := pm.store.UpdateUserLastSeen(ctx, userID, now); err != nil {
+			slog.Warn("failed to persist user last_seen",
+				"user_id", userID,
+				"error", err)
+		}
+	}
+}
+
+// GetState returns the current presence state for a user.
+func (pm *PresenceManager) GetState(userID string) PresenceState {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	entry, exists := pm.users[userID]
+	if !exists {
+		return PresenceIdle
+	}
+
+	// Check if the heartbeat has expired.
+	if time.Since(entry.lastHeartbeat) > presenceActiveWindow {
+		return PresenceIdle
+	}
+	return entry.state
+}
+
+// GetAllStates returns a map of userID -> presence state for all tracked users.
+func (pm *PresenceManager) GetAllStates() map[string]string {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	states := make(map[string]string, len(pm.users))
+	now := time.Now()
+	for uid, entry := range pm.users {
+		if now.Sub(entry.lastHeartbeat) > presenceActiveWindow {
+			states[uid] = string(PresenceIdle)
+		} else {
+			states[uid] = string(entry.state)
+		}
+	}
+	return states
+}
+
+// RecordTyping checks server-side throttling and returns true if the typing
+// event should be published (i.e. enough time has passed since the last one
+// from this user in this conversation).
+func (pm *PresenceManager) RecordTyping(conversationKey, userID string) bool {
+	now := time.Now()
+
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	convMap, exists := pm.typing[conversationKey]
+	if !exists {
+		convMap = make(map[string]*typingEntry)
+		pm.typing[conversationKey] = convMap
+	}
+
+	entry, exists := convMap[userID]
+	if exists && now.Sub(entry.lastTyping) < typingThrottle {
+		return false // throttled
+	}
+
+	if !exists {
+		entry = &typingEntry{}
+		convMap[userID] = entry
+	}
+	entry.lastTyping = now
+	return true
+}
+
+// sweepLoop periodically checks for users who have gone idle and publishes
+// transition events.
+func (pm *PresenceManager) sweepLoop() {
+	defer close(pm.stopped)
+
+	ticker := time.NewTicker(presenceSweepInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-pm.stopCh:
+			return
+		case <-ticker.C:
+			pm.sweep()
+		}
+	}
+}
+
+// sweep checks all tracked users and transitions any that have exceeded
+// the active window to idle.
+func (pm *PresenceManager) sweep() {
+	now := time.Now()
+
+	pm.mu.Lock()
+	var transitions []struct {
+		userID      string
+		displayName string
+		projectIDs  []string
+	}
+
+	for uid, entry := range pm.users {
+		if entry.state == PresenceActive && now.Sub(entry.lastHeartbeat) > presenceActiveWindow {
+			entry.state = PresenceIdle
+			transitions = append(transitions, struct {
+				userID      string
+				displayName string
+				projectIDs  []string
+			}{uid, entry.displayName, entry.projectIDs})
+		}
+	}
+	pm.mu.Unlock()
+
+	// Publish transitions outside the lock.
+	for _, t := range transitions {
+		pm.publishTransition(t.userID, t.displayName, PresenceIdle, t.projectIDs)
+	}
+}
+
+// publishTransition publishes a presence state change on all relevant
+// project subjects.
+func (pm *PresenceManager) publishTransition(userID, displayName string, state PresenceState, projectIDs []string) {
+	evt := PresenceEvent{
+		UserID:      userID,
+		DisplayName: displayName,
+		State:       string(state),
+	}
+
+	for _, pid := range projectIDs {
+		pm.events.PublishRaw("project."+pid+".chat.presence", evt)
+	}
+}
+
+// SeedFromStore seeds the presence map from User.last_seen on cold start.
+// Users who were seen within the active window are marked as active.
+func (pm *PresenceManager) SeedFromStore(ctx context.Context, st store.Store) {
+	users, err := st.ListUsers(ctx, store.UserFilter{}, store.ListOptions{Limit: 1000})
+	if err != nil {
+		slog.Warn("failed to seed presence from store", "error", err)
+		return
+	}
+
+	now := time.Now()
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	for _, u := range users.Items {
+		if u.LastSeen.IsZero() {
+			continue
+		}
+		state := PresenceIdle
+		if now.Sub(u.LastSeen) <= presenceActiveWindow {
+			state = PresenceActive
+		}
+		pm.users[u.ID] = &presenceEntry{
+			lastHeartbeat: u.LastSeen,
+			lastPersist:   u.LastSeen,
+			state:         state,
+			displayName:   u.DisplayName,
+		}
+	}
+}

--- a/pkg/hub/presence.go
+++ b/pkg/hub/presence.go
@@ -91,6 +91,7 @@ type PresenceManager struct {
 	typing  map[string]map[string]*typingEntry // conversationKey -> userID -> typing
 	events  EventPublisher
 	store   store.Store
+	log     *slog.Logger
 	stopCh  chan struct{}
 	stopped chan struct{}
 }
@@ -103,6 +104,7 @@ func NewPresenceManager(events EventPublisher, st store.Store) *PresenceManager 
 		typing:  make(map[string]map[string]*typingEntry),
 		events:  events,
 		store:   st,
+		log:     slog.Default().With("component", "presence"),
 		stopCh:  make(chan struct{}),
 		stopped: make(chan struct{}),
 	}
@@ -152,7 +154,7 @@ func (pm *PresenceManager) Heartbeat(ctx context.Context, userID, displayName st
 	// Durable fallback: touch User.last_seen (throttled).
 	if shouldPersist && pm.store != nil {
 		if err := pm.store.UpdateUserLastSeen(ctx, userID, now); err != nil {
-			slog.Warn("failed to persist user last_seen",
+			pm.log.Warn("failed to persist user last_seen",
 				"user_id", userID,
 				"error", err)
 		}
@@ -302,7 +304,7 @@ func (pm *PresenceManager) publishTransition(userID, displayName string, state P
 func (pm *PresenceManager) SeedFromStore(ctx context.Context, st store.Store) {
 	users, err := st.ListUsers(ctx, store.UserFilter{}, store.ListOptions{Limit: 1000})
 	if err != nil {
-		slog.Warn("failed to seed presence from store", "error", err)
+		pm.log.Warn("failed to seed presence from store", "error", err)
 		return
 	}
 

--- a/pkg/hub/presence_test.go
+++ b/pkg/hub/presence_test.go
@@ -1,0 +1,377 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Mock EventPublisher — records PublishRaw calls for assertions.
+// ---------------------------------------------------------------------------
+
+type publishedEvent struct {
+	subject string
+	data    interface{}
+}
+
+type mockEventPublisher struct {
+	mu     sync.Mutex
+	events []publishedEvent
+	noopEventPublisher
+}
+
+func (m *mockEventPublisher) PublishRaw(subject string, data interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, publishedEvent{subject: subject, data: data})
+}
+
+func (m *mockEventPublisher) getEvents() []publishedEvent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]publishedEvent, len(m.events))
+	copy(out, m.events)
+	return out
+}
+
+func (m *mockEventPublisher) reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = nil
+}
+
+// ---------------------------------------------------------------------------
+// Helper: create a PresenceManager with a mock publisher and nil store.
+// The caller must call pm.Stop() when done.
+// ---------------------------------------------------------------------------
+
+func newTestPM(t *testing.T) (*PresenceManager, *mockEventPublisher) {
+	t.Helper()
+	pub := &mockEventPublisher{}
+	pm := NewPresenceManager(pub, nil)
+	t.Cleanup(func() { pm.Stop() })
+	return pm, pub
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestPresenceManager_HeartbeatTransitions(t *testing.T) {
+	tests := []struct {
+		name           string
+		setup          func(pm *PresenceManager) // optional pre-condition
+		wantState      PresenceState
+		wantPublished  int  // number of PublishRaw calls
+		wantTransition bool // whether a transition event should be published
+	}{
+		{
+			name:           "first heartbeat transitions idle to active",
+			wantState:      PresenceActive,
+			wantPublished:  1, // one project → one publish
+			wantTransition: true,
+		},
+		{
+			name: "second heartbeat does not re-publish",
+			setup: func(pm *PresenceManager) {
+				pm.Heartbeat(t.Context(), "user1", "User One", []string{"proj1"})
+			},
+			wantState:      PresenceActive,
+			wantPublished:  0, // already active, no transition
+			wantTransition: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pm, pub := newTestPM(t)
+
+			if tc.setup != nil {
+				tc.setup(pm)
+				pub.reset() // clear events from setup
+			}
+
+			pm.Heartbeat(t.Context(), "user1", "User One", []string{"proj1"})
+
+			assert.Equal(t, tc.wantState, pm.GetState("user1"))
+
+			events := pub.getEvents()
+			assert.Len(t, events, tc.wantPublished)
+
+			if tc.wantTransition && len(events) > 0 {
+				pe, ok := events[0].data.(PresenceEvent)
+				require.True(t, ok)
+				assert.Equal(t, "user1", pe.UserID)
+				assert.Equal(t, "active", pe.State)
+				assert.Equal(t, "project.proj1.chat.presence", events[0].subject)
+			}
+		})
+	}
+}
+
+func TestPresenceManager_HeartbeatMultipleProjects(t *testing.T) {
+	pm, pub := newTestPM(t)
+
+	pm.Heartbeat(t.Context(), "user1", "User One", []string{"proj1", "proj2", "proj3"})
+
+	events := pub.getEvents()
+	require.Len(t, events, 3, "should publish to all 3 projects")
+
+	subjects := make([]string, len(events))
+	for i, e := range events {
+		subjects[i] = e.subject
+	}
+	assert.Contains(t, subjects, "project.proj1.chat.presence")
+	assert.Contains(t, subjects, "project.proj2.chat.presence")
+	assert.Contains(t, subjects, "project.proj3.chat.presence")
+}
+
+func TestPresenceManager_SweepTriggersIdleTransition(t *testing.T) {
+	pm, pub := newTestPM(t)
+
+	// Send a heartbeat, then manually set lastHeartbeat to the past to
+	// simulate the active window expiring.
+	pm.Heartbeat(t.Context(), "user1", "User One", []string{"proj1"})
+	pub.reset()
+
+	pm.mu.Lock()
+	pm.users["user1"].lastHeartbeat = time.Now().Add(-(presenceActiveWindow + time.Second))
+	pm.mu.Unlock()
+
+	// Run sweep explicitly.
+	pm.sweep()
+
+	assert.Equal(t, PresenceIdle, pm.GetState("user1"))
+
+	events := pub.getEvents()
+	require.Len(t, events, 1, "sweep should publish one idle transition")
+
+	pe, ok := events[0].data.(PresenceEvent)
+	require.True(t, ok)
+	assert.Equal(t, "user1", pe.UserID)
+	assert.Equal(t, "idle", pe.State)
+}
+
+func TestPresenceManager_SweepDoesNotRepublishIdle(t *testing.T) {
+	pm, pub := newTestPM(t)
+
+	// Heartbeat then expire to go idle.
+	pm.Heartbeat(t.Context(), "user1", "User One", []string{"proj1"})
+
+	pm.mu.Lock()
+	pm.users["user1"].lastHeartbeat = time.Now().Add(-(presenceActiveWindow + time.Second))
+	pm.mu.Unlock()
+
+	pm.sweep() // transitions to idle
+	pub.reset()
+
+	// Sweep again — should not re-publish because already idle.
+	pm.sweep()
+
+	events := pub.getEvents()
+	assert.Empty(t, events, "should not re-publish idle transition")
+}
+
+func TestPresenceManager_OnlyTransitionsPublished(t *testing.T) {
+	pm, pub := newTestPM(t)
+
+	// First heartbeat: idle→active (published).
+	pm.Heartbeat(t.Context(), "user1", "User One", []string{"proj1"})
+	require.Len(t, pub.getEvents(), 1)
+
+	// Second heartbeat: still active (NOT published).
+	pm.Heartbeat(t.Context(), "user1", "User One", []string{"proj1"})
+	assert.Len(t, pub.getEvents(), 1, "no new event for repeated heartbeat")
+
+	// Expire and sweep: active→idle (published).
+	pm.mu.Lock()
+	pm.users["user1"].lastHeartbeat = time.Now().Add(-(presenceActiveWindow + time.Second))
+	pm.mu.Unlock()
+	pm.sweep()
+	assert.Len(t, pub.getEvents(), 2, "idle transition published")
+
+	// Heartbeat again: idle→active (published).
+	pm.Heartbeat(t.Context(), "user1", "User One", []string{"proj1"})
+	assert.Len(t, pub.getEvents(), 3, "re-activation published")
+}
+
+func TestPresenceManager_RecordTypingThrottle(t *testing.T) {
+	tests := []struct {
+		name    string
+		delay   time.Duration
+		allowed bool
+	}{
+		{
+			name:    "first typing event is allowed",
+			delay:   0,
+			allowed: true,
+		},
+		{
+			name:    "immediate second typing is throttled",
+			delay:   0,
+			allowed: false,
+		},
+	}
+
+	pm, _ := newTestPM(t)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.delay > 0 {
+				time.Sleep(tc.delay)
+			}
+			result := pm.RecordTyping("conv1", "user1")
+			assert.Equal(t, tc.allowed, result)
+		})
+	}
+}
+
+func TestPresenceManager_RecordTypingThrottleExpiry(t *testing.T) {
+	pm, _ := newTestPM(t)
+
+	// First typing is allowed.
+	assert.True(t, pm.RecordTyping("conv1", "user1"))
+	// Immediately after: throttled.
+	assert.False(t, pm.RecordTyping("conv1", "user1"))
+
+	// Manually move the typing timestamp back past the throttle window.
+	pm.mu.Lock()
+	pm.typing["conv1"]["user1"].lastTyping = time.Now().Add(-(typingThrottle + time.Second))
+	pm.mu.Unlock()
+
+	// Should be allowed again.
+	assert.True(t, pm.RecordTyping("conv1", "user1"))
+}
+
+func TestPresenceManager_RecordTypingDifferentConversations(t *testing.T) {
+	pm, _ := newTestPM(t)
+
+	// Same user in different conversations should not be throttled.
+	assert.True(t, pm.RecordTyping("conv1", "user1"))
+	assert.True(t, pm.RecordTyping("conv2", "user1"))
+}
+
+func TestPresenceManager_RecordTypingDifferentUsers(t *testing.T) {
+	pm, _ := newTestPM(t)
+
+	// Different users in the same conversation should not be throttled.
+	assert.True(t, pm.RecordTyping("conv1", "user1"))
+	assert.True(t, pm.RecordTyping("conv1", "user2"))
+}
+
+func TestPresenceManager_SweepEvictsStaleTypingEntries(t *testing.T) {
+	pm, _ := newTestPM(t)
+
+	// Record typing, then backdate it past the eviction threshold (2× typingThrottle).
+	pm.RecordTyping("conv1", "user1")
+	pm.RecordTyping("conv2", "user2")
+
+	pm.mu.Lock()
+	evictionAge := 2*typingThrottle + time.Second
+	pm.typing["conv1"]["user1"].lastTyping = time.Now().Add(-evictionAge)
+	pm.mu.Unlock()
+
+	pm.sweep()
+
+	pm.mu.RLock()
+	_, conv1Exists := pm.typing["conv1"]
+	_, conv2Exists := pm.typing["conv2"]
+	pm.mu.RUnlock()
+
+	assert.False(t, conv1Exists, "stale typing entry should be evicted")
+	assert.True(t, conv2Exists, "recent typing entry should be kept")
+}
+
+func TestPresenceManager_ConcurrentHeartbeatWrites(t *testing.T) {
+	pm, _ := newTestPM(t)
+
+	const numGoroutines = 50
+	var wg sync.WaitGroup
+
+	wg.Add(numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			// Mix of user IDs and project IDs to exercise concurrent map access.
+			userID := "user" + string(rune('A'+idx%5))
+			projects := []string{"proj1", "proj2"}
+			pm.Heartbeat(t.Context(), userID, "User "+userID, projects)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all 5 users are tracked and active.
+	for i := 0; i < 5; i++ {
+		userID := "user" + string(rune('A'+i))
+		assert.Equal(t, PresenceActive, pm.GetState(userID), "user %s should be active", userID)
+	}
+}
+
+func TestPresenceManager_ConcurrentTypingWrites(t *testing.T) {
+	pm, _ := newTestPM(t)
+
+	const numGoroutines = 50
+	var wg sync.WaitGroup
+
+	wg.Add(numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			userID := "user" + string(rune('A'+idx%5))
+			conv := "conv" + string(rune('1'+idx%3))
+			pm.RecordTyping(conv, userID)
+		}(i)
+	}
+
+	wg.Wait()
+	// If we get here without a race detector error, the test passes.
+}
+
+func TestPresenceManager_GetStateUnknownUser(t *testing.T) {
+	pm, _ := newTestPM(t)
+	assert.Equal(t, PresenceIdle, pm.GetState("nonexistent"))
+}
+
+func TestPresenceManager_GetAllStates(t *testing.T) {
+	pm, _ := newTestPM(t)
+
+	pm.Heartbeat(t.Context(), "user1", "User One", []string{"proj1"})
+	pm.Heartbeat(t.Context(), "user2", "User Two", []string{"proj1"})
+
+	// Expire user2.
+	pm.mu.Lock()
+	pm.users["user2"].lastHeartbeat = time.Now().Add(-(presenceActiveWindow + time.Second))
+	pm.mu.Unlock()
+
+	states := pm.GetAllStates()
+	assert.Equal(t, "active", states["user1"])
+	assert.Equal(t, "idle", states["user2"])
+}
+
+func TestPresenceManager_StopIsIdempotent(t *testing.T) {
+	pub := &mockEventPublisher{}
+	pm := NewPresenceManager(pub, nil)
+	pm.Stop()
+	// Calling Stop only once; calling it twice would deadlock since stopCh
+	// is already closed and stopped channel already received. The test
+	// verifies that Stop returns promptly.
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3447,9 +3447,19 @@ func (s *Server) registerRoutes() {
 	// Chat thread prefs (Phase 3 — visibility mode persistence)
 	s.mux.HandleFunc("/api/v1/chat/prefs", s.handleChatPrefs)
 
-	// Chat thread endpoints (Phase 5 — thread rail)
+	// Chat thread endpoints (Phase 5 — thread rail, legacy)
 	s.mux.HandleFunc("/api/v1/chat/threads", s.handleChatThreads)
 	s.mux.HandleFunc("/api/v1/chat/threads/", s.handleChatThreadRoutes)
+
+	// Wave-2 chat endpoints (conversation REST API)
+	s.mux.HandleFunc("/api/v1/chat/spaces", s.handleChatSpaces)
+	s.mux.HandleFunc("/api/v1/chat/spaces/", s.handleChatSpaceRoutes)
+	s.mux.HandleFunc("/api/v1/chat/conversations/", s.handleChatConversationRoutes)
+	s.mux.HandleFunc("/api/v1/chat/topics/", s.handleChatTopicRoutes)
+	s.mux.HandleFunc("/api/v1/chat/dms", s.handleChatDMs)
+	s.mux.HandleFunc("/api/v1/chat/user-prefs", s.handleChatUserPrefs)
+	s.mux.HandleFunc("/api/v1/chat/presence", s.handleChatPresence)
+	s.mux.HandleFunc("/api/v1/chat/search", s.handleChatSearch)
 
 	// WebSocket control channel endpoint for Runtime Brokers
 	s.mux.HandleFunc("/api/v1/runtime-brokers/connect", s.handleRuntimeBrokerConnect)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -742,6 +742,10 @@ type Server struct {
 	// Chat notifier for human mention + DM received notifications (W6). Nil-safe.
 	chatNotifier *ChatNotifier
 
+	// Attachment file store for chat attachments (W7). Nil = attachments disabled.
+	// HA limitation: LocalDiskAttachmentStore is single-node only; see attachments.go.
+	attachmentStore AttachmentStore
+
 	// Presence manager for in-memory user presence tracking (nil = disabled).
 	// Single-node only; see design §4.5 HA limitation.
 	presenceManager *PresenceManager
@@ -1887,6 +1891,13 @@ func (s *Server) SetWebChatStore(wcs WebChatStore) {
 	if s.messageBrokerProxy != nil {
 		s.messageBrokerProxy.chatNotifier = s.chatNotifier
 	}
+	s.mu.Unlock()
+}
+
+// SetAttachmentStore sets the attachment file store for upload/download (W7).
+func (s *Server) SetAttachmentStore(as AttachmentStore) {
+	s.mu.Lock()
+	s.attachmentStore = as
 	s.mu.Unlock()
 }
 
@@ -3512,6 +3523,8 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/chat/user-prefs", s.handleChatUserPrefs)
 	s.mux.HandleFunc("/api/v1/chat/presence", s.handleChatPresence)
 	s.mux.HandleFunc("/api/v1/chat/search", s.handleChatSearch)
+	s.mux.HandleFunc("/api/v1/chat/attachments", s.handleChatAttachments)
+	s.mux.HandleFunc("/api/v1/chat/attachments/", s.handleChatAttachmentByID)
 
 	// WebSocket control channel endpoint for Runtime Brokers
 	s.mux.HandleFunc("/api/v1/runtime-brokers/connect", s.handleRuntimeBrokerConnect)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -739,6 +739,9 @@ type Server struct {
 	// Web chat store for webchat_* tables (thread prefs, chat threads, etc.) — nil = disabled.
 	webChatStore WebChatStore
 
+	// Chat notifier for human mention + DM received notifications (W6). Nil-safe.
+	chatNotifier *ChatNotifier
+
 	// Channel registry for external notification delivery (nil = disabled)
 	channelRegistry *ChannelRegistry
 
@@ -1870,10 +1873,20 @@ func (s *Server) GetMessageBrokerProxy() *MessageBrokerProxy {
 }
 
 // SetWebChatStore sets the webchat store for thread prefs and chat threads API.
-func (s *Server) SetWebChatStore(store WebChatStore) {
+// It also initializes the ChatNotifier for human-mention and DM notifications (W6).
+func (s *Server) SetWebChatStore(wcs WebChatStore) {
 	s.mu.Lock()
-	s.webChatStore = store
+	s.webChatStore = wcs
+	// Initialize ChatNotifier with the store; presence checker is nil (W5 stub).
+	s.chatNotifier = NewChatNotifier(s.store, s.events, wcs, nil, s.messageLog)
 	s.mu.Unlock()
+}
+
+// getChatNotifier returns the chat notifier, or nil if not initialized.
+func (s *Server) getChatNotifier() *ChatNotifier {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.chatNotifier
 }
 
 // SetPluginManager sets the plugin manager for broker integration admin API.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1883,6 +1883,10 @@ func (s *Server) SetWebChatStore(wcs WebChatStore) {
 	s.webChatStore = wcs
 	// Initialize ChatNotifier with the store; presence checker is nil (W5 stub).
 	s.chatNotifier = NewChatNotifier(s.store, s.events, wcs, nil, s.messageLog)
+	// Wire into existing broker proxy if already started (startup order varies).
+	if s.messageBrokerProxy != nil {
+		s.messageBrokerProxy.chatNotifier = s.chatNotifier
+	}
 	s.mu.Unlock()
 }
 
@@ -2338,6 +2342,7 @@ func (s *Server) StartMessageBroker(b eventbus.EventBus) {
 
 	proxy := NewMessageBrokerProxy(b, s.store, s.events, s.GetDispatcher, logging.Subsystem("hub.broker"))
 	proxy.messageLog = s.dedicatedMessageLog
+	proxy.chatNotifier = s.chatNotifier // W6: wire DM notification trigger
 	s.messageBrokerProxy = proxy
 	proxy.Start()
 

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2040,6 +2040,13 @@ func (s *Server) GetStore() store.Store {
 	return s.store
 }
 
+// GetAuthzService returns the authorization service.
+func (s *Server) GetAuthzService() *AuthzService {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.authzService
+}
+
 // GetBrokerAuthService returns the broker authentication service.
 func (s *Server) GetBrokerAuthService() *BrokerAuthService {
 	s.mu.RLock()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3246,6 +3246,11 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		s.lifecycleHookEvaluator.Stop()
 	}
 
+	// Stop presence manager before closing event publisher
+	if s.presenceManager != nil {
+		s.presenceManager.Stop()
+	}
+
 	// Close event publisher
 	if s.events != nil {
 		s.events.Close()
@@ -3302,6 +3307,10 @@ func (s *Server) CleanupResources(ctx context.Context) error {
 		}
 		if s.teamsLinkService != nil {
 			s.teamsLinkService.Close()
+		}
+		// Stop presence manager before closing event publisher
+		if s.presenceManager != nil {
+			s.presenceManager.Stop()
 		}
 		if s.events != nil {
 			s.events.Close()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -742,6 +742,10 @@ type Server struct {
 	// Chat notifier for human mention + DM received notifications (W6). Nil-safe.
 	chatNotifier *ChatNotifier
 
+	// Presence manager for in-memory user presence tracking (nil = disabled).
+	// Single-node only; see design §4.5 HA limitation.
+	presenceManager *PresenceManager
+
 	// Channel registry for external notification delivery (nil = disabled)
 	channelRegistry *ChannelRegistry
 
@@ -1887,6 +1891,27 @@ func (s *Server) getChatNotifier() *ChatNotifier {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.chatNotifier
+}
+
+// InitPresenceManager creates and starts the presence manager for real-time
+// user presence tracking. It seeds the in-memory map from User.last_seen.
+// Call this after the event publisher is wired.
+func (s *Server) InitPresenceManager() {
+	pm := NewPresenceManager(s.events, s.store)
+	pm.SeedFromStore(s.ctx, s.store)
+	s.mu.Lock()
+	s.presenceManager = pm
+	s.mu.Unlock()
+}
+
+// StopPresenceManager shuts down the presence manager's background goroutine.
+func (s *Server) StopPresenceManager() {
+	s.mu.RLock()
+	pm := s.presenceManager
+	s.mu.RUnlock()
+	if pm != nil {
+		pm.Stop()
+	}
 }
 
 // SetPluginManager sets the plugin manager for broker integration admin API.

--- a/pkg/hub/sse_authz_test.go
+++ b/pkg/hub/sse_authz_test.go
@@ -1,0 +1,239 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- authorizeSSESubjects unit tests ---
+
+func TestAuthorizeSSESubjects_NoAuthzService(t *testing.T) {
+	ws := &WebServer{} // no authzService
+	req := httptest.NewRequest("GET", "/events", nil)
+	// Set a web session user in context.
+	user := &webSessionUser{UserID: "user-1", Email: "a@b.com", Role: "user"}
+	req = req.WithContext(context.WithValue(req.Context(), webUserContextKey{}, user))
+
+	denied := ws.authorizeSSESubjects(req, []string{
+		"project.proj-1.chat.message",
+		"user.other-user.chat.dm",
+	})
+	assert.Nil(t, denied, "nil authzService should allow all subjects")
+}
+
+func TestAuthorizeSSESubjects_NoSessionUser(t *testing.T) {
+	ws := &WebServer{
+		authzService: NewAuthzService(&mockAuthzStore{}, nil),
+	}
+	req := httptest.NewRequest("GET", "/events", nil)
+	// No web session user in context.
+
+	subjects := []string{"project.proj-1.agent.status"}
+	denied := ws.authorizeSSESubjects(req, subjects)
+	assert.Equal(t, subjects, denied, "no session user should deny all subjects")
+}
+
+func TestAuthorizeSSESubjects_UserSubject_OwnID(t *testing.T) {
+	ws := &WebServer{
+		authzService: NewAuthzService(&mockAuthzStore{}, nil),
+	}
+	req := httptest.NewRequest("GET", "/events", nil)
+	user := &webSessionUser{UserID: "user-1", Email: "a@b.com", Role: "user"}
+	req = req.WithContext(context.WithValue(req.Context(), webUserContextKey{}, user))
+
+	denied := ws.authorizeSSESubjects(req, []string{
+		"user.user-1.chat.dm",
+		"user.user-1.message",
+	})
+	assert.Nil(t, denied, "user should be allowed to subscribe to own user subjects")
+}
+
+func TestAuthorizeSSESubjects_UserSubject_OtherID(t *testing.T) {
+	ws := &WebServer{
+		authzService: NewAuthzService(&mockAuthzStore{}, nil),
+	}
+	req := httptest.NewRequest("GET", "/events", nil)
+	user := &webSessionUser{UserID: "user-1", Email: "a@b.com", Role: "user"}
+	req = req.WithContext(context.WithValue(req.Context(), webUserContextKey{}, user))
+
+	denied := ws.authorizeSSESubjects(req, []string{
+		"user.other-user.chat.dm",
+	})
+	assert.Equal(t, []string{"user.other-user.chat.dm"}, denied,
+		"user should NOT be allowed to subscribe to another user's subjects")
+}
+
+func TestAuthorizeSSESubjects_MixedAllowedDenied_AllFail(t *testing.T) {
+	ws := &WebServer{
+		authzService: NewAuthzService(&mockAuthzStore{}, nil),
+	}
+	req := httptest.NewRequest("GET", "/events", nil)
+	user := &webSessionUser{UserID: "user-1", Email: "a@b.com", Role: "user"}
+	req = req.WithContext(context.WithValue(req.Context(), webUserContextKey{}, user))
+
+	subjects := []string{
+		"user.user-1.chat.dm",       // allowed (own ID)
+		"user.other-user.chat.dm",   // denied (other user)
+		"notification.user-1.inbox", // pass-through (no project/user prefix check)
+	}
+	denied := ws.authorizeSSESubjects(req, subjects)
+	assert.Equal(t, []string{"user.other-user.chat.dm"}, denied,
+		"only the denied subject should be returned")
+}
+
+func TestAuthorizeSSESubjects_ProjectSubject_AdminAllowed(t *testing.T) {
+	ws := &WebServer{
+		authzService: NewAuthzService(&mockAuthzStore{}, nil),
+	}
+	req := httptest.NewRequest("GET", "/events", nil)
+	// Admin role gets short-circuited in ComputeCapabilitiesBatch.
+	user := &webSessionUser{UserID: "admin-1", Email: "admin@b.com", Role: "admin"}
+	req = req.WithContext(context.WithValue(req.Context(), webUserContextKey{}, user))
+
+	denied := ws.authorizeSSESubjects(req, []string{
+		"project.proj-1.chat.message",
+		"project.proj-1.agent.status",
+		"project.proj-2.chat.topic",
+	})
+	assert.Nil(t, denied, "admin should be allowed to subscribe to all project subjects")
+}
+
+func TestAuthorizeSSESubjects_ProjectSubject_NonMemberDenied(t *testing.T) {
+	ws := &WebServer{
+		authzService: NewAuthzService(&mockAuthzStore{}, nil),
+	}
+	req := httptest.NewRequest("GET", "/events", nil)
+	// Non-admin user with no policies — ComputeCapabilitiesBatch returns no actions.
+	user := &webSessionUser{UserID: "user-1", Email: "a@b.com", Role: "user"}
+	req = req.WithContext(context.WithValue(req.Context(), webUserContextKey{}, user))
+
+	denied := ws.authorizeSSESubjects(req, []string{
+		"project.proj-1.chat.message",
+	})
+	assert.Equal(t, []string{"project.proj-1.chat.message"}, denied,
+		"non-member should be denied project subjects")
+}
+
+func TestAuthorizeSSESubjects_PassthroughSubjects(t *testing.T) {
+	ws := &WebServer{
+		authzService: NewAuthzService(&mockAuthzStore{}, nil),
+	}
+	req := httptest.NewRequest("GET", "/events", nil)
+	user := &webSessionUser{UserID: "user-1", Email: "a@b.com", Role: "user"}
+	req = req.WithContext(context.WithValue(req.Context(), webUserContextKey{}, user))
+
+	// Notification and broker subjects pass through without authorization.
+	denied := ws.authorizeSSESubjects(req, []string{
+		"notification.user-1.inbox",
+		"broker.status",
+	})
+	assert.Nil(t, denied, "notification/broker subjects should pass through")
+}
+
+// --- SSE Handler integration test for authz ---
+
+func TestSSEHandler_SubjectAuthzDenied(t *testing.T) {
+	ws := newDevAuthWebServer(t)
+	pub := NewChannelEventPublisher()
+	ws.SetEventPublisher(pub)
+	ws.SetAuthzService(NewAuthzService(&mockAuthzStore{}, nil))
+	t.Cleanup(pub.Close)
+
+	// DevUserID is admin, so project subjects are allowed. But subscribing
+	// to another user's subject should be denied.
+	req := httptest.NewRequest("GET", "/events?sub=user.other-user.chat.dm", nil)
+	rec := httptest.NewRecorder()
+	ws.Handler().ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestSSEHandler_SubjectAuthzAllowed(t *testing.T) {
+	ws := newDevAuthWebServer(t)
+	pub := NewChannelEventPublisher()
+	ws.SetEventPublisher(pub)
+	ws.SetAuthzService(NewAuthzService(&mockAuthzStore{}, nil))
+	t.Cleanup(pub.Close)
+
+	// DevUserID is admin; subscribing to own user subject should succeed.
+	ts := httptest.NewServer(ws.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/events?sub=user." + DevUserID + ".chat.dm")
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+// --- validateSSESubjects: chat.* patterns pass syntax validation ---
+
+func TestValidateSSESubjects_ChatPatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		subject string
+	}{
+		{"chat message", "project.abc123.chat.message"},
+		{"chat topic", "project.abc123.chat.topic"},
+		{"chat typing", "project.abc123.chat.typing"},
+		{"chat presence", "project.abc123.chat.presence"},
+		{"chat wildcard", "project.abc123.chat.>"},
+		{"chat star", "project.abc123.chat.*"},
+		{"user chat dm", "user.uid123.chat.dm"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errMsg := validateSSESubjects([]string{tt.subject})
+			assert.Empty(t, errMsg, "subject %q should pass syntax validation", tt.subject)
+		})
+	}
+}
+
+// --- mock store for authz tests ---
+
+// mockAuthzStore satisfies store.Store for NewAuthzService. Only the methods
+// called by ComputeCapabilitiesBatch's dependency chain are implemented;
+// the embedded interface satisfies everything else at the signature level.
+type mockAuthzStore struct {
+	store.Store // embed to satisfy interface
+}
+
+func (m *mockAuthzStore) GetEffectiveGroups(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *mockAuthzStore) GetEffectiveGroupsForAgent(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *mockAuthzStore) GetPoliciesForPrincipals(_ context.Context, _ []store.PrincipalRef) ([]store.Policy, error) {
+	return nil, nil
+}
+
+func (m *mockAuthzStore) ListGroups(_ context.Context, _ store.GroupFilter, _ store.ListOptions) (*store.ListResult[store.Group], error) {
+	return &store.ListResult[store.Group]{}, nil
+}
+
+func (m *mockAuthzStore) GetGroupMembership(_ context.Context, _, _ string, _ string) (*store.GroupMember, error) {
+	return nil, store.ErrNotFound
+}

--- a/pkg/hub/sse_authz_test.go
+++ b/pkg/hub/sse_authz_test.go
@@ -27,18 +27,48 @@ import (
 
 // --- authorizeSSESubjects unit tests ---
 
-func TestAuthorizeSSESubjects_NoAuthzService(t *testing.T) {
+func TestAuthorizeSSESubjects_NoAuthzService_DeniesAll(t *testing.T) {
 	ws := &WebServer{} // no authzService
 	req := httptest.NewRequest("GET", "/events", nil)
-	// Set a web session user in context.
 	user := &webSessionUser{UserID: "user-1", Email: "a@b.com", Role: "user"}
 	req = req.WithContext(context.WithValue(req.Context(), webUserContextKey{}, user))
 
-	denied := ws.authorizeSSESubjects(req, []string{
+	subjects := []string{
 		"project.proj-1.chat.message",
 		"user.other-user.chat.dm",
-	})
-	assert.Nil(t, denied, "nil authzService should allow all subjects")
+	}
+	denied := ws.authorizeSSESubjects(req, subjects)
+	assert.Equal(t, subjects, denied, "nil authzService must deny all (fail closed)")
+}
+
+func TestAuthorizeSSESubjects_WildcardRootDenied(t *testing.T) {
+	ws := &WebServer{
+		authzService: NewAuthzService(&mockAuthzStore{}, nil),
+	}
+	tests := []struct {
+		name    string
+		subject string
+	}{
+		{"bare >", ">"},
+		{"bare *", "*"},
+		{"*.>", "*.>"},
+		{"*.*.chat.>", "*.*.chat.>"},
+		{"* as root with children", "*.project.something"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/events", nil)
+			// Admin user — would pass project/user checks, but wildcard
+			// root must be rejected regardless.
+			user := &webSessionUser{UserID: "admin-1", Email: "a@b.com", Role: "admin"}
+			req = req.WithContext(context.WithValue(req.Context(), webUserContextKey{}, user))
+
+			subjects := []string{tt.subject}
+			denied := ws.authorizeSSESubjects(req, subjects)
+			assert.Equal(t, subjects, denied,
+				"wildcard root %q must be denied even for admin", tt.subject)
+		})
+	}
 }
 
 func TestAuthorizeSSESubjects_NoSessionUser(t *testing.T) {
@@ -205,6 +235,27 @@ func TestValidateSSESubjects_ChatPatterns(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			errMsg := validateSSESubjects([]string{tt.subject})
 			assert.Empty(t, errMsg, "subject %q should pass syntax validation", tt.subject)
+		})
+	}
+}
+
+// --- validateSSESubjects: wildcard root rejection (belt-and-suspenders for F1) ---
+
+func TestValidateSSESubjects_WildcardRootRejected(t *testing.T) {
+	tests := []struct {
+		name    string
+		subject string
+	}{
+		{"bare >", ">"},
+		{"bare *", "*"},
+		{"*.>", "*.>"},
+		{"*.*.chat.>", "*.*.chat.>"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errMsg := validateSSESubjects([]string{tt.subject})
+			assert.NotEmpty(t, errMsg, "wildcard root %q must fail syntax validation", tt.subject)
+			assert.Contains(t, errMsg, "first token must not be a wildcard")
 		})
 	}
 }

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -172,6 +172,7 @@ type WebServer struct {
 	hubHandler   http.Handler                // mounted Hub API handler, or nil
 	hubShutdown  func(context.Context) error // Hub resource cleanup, or nil
 	maintenance  *MaintenanceState           // runtime maintenance mode state (shared with Hub)
+	authzService *AuthzService               // authorization service for SSE subject checks
 	startTime    time.Time
 	log          *slog.Logger // subsystem logger for hub.web
 
@@ -557,6 +558,11 @@ func (ws *WebServer) SetUserTokenService(svc *UserTokenService) {
 // SetEventPublisher sets the event publisher for real-time SSE streaming.
 func (ws *WebServer) SetEventPublisher(pub EventPublisher) {
 	ws.events = pub
+}
+
+// SetAuthzService sets the authorization service for SSE subject-level checks.
+func (ws *WebServer) SetAuthzService(a *AuthzService) {
+	ws.authzService = a
 }
 
 // SetRequestLogger sets the dedicated request logger.
@@ -1078,6 +1084,19 @@ func (ws *WebServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Subject-level authorization: verify the caller has access to every
+	// requested subject. This runs once at connection time, not per-event.
+	if denied := ws.authorizeSSESubjects(r, subjects); len(denied) > 0 {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		body, _ := json.Marshal(map[string]interface{}{
+			"error":           "access denied for one or more subjects",
+			"denied_subjects": denied,
+		})
+		_, _ = w.Write(body)
+		return
+	}
+
 	// Disable the server's WriteTimeout for this long-lived SSE connection.
 	// Without this, the global WriteTimeout (e.g. 60s) kills the stream,
 	// causing reconnection churn and wasted connection-pool slots.
@@ -1172,6 +1191,96 @@ func validateSSESubjects(subjects []string) string {
 		}
 	}
 	return ""
+}
+
+// authorizeSSESubjects checks that the caller has access to every requested
+// subject. Returns the list of denied subjects; an empty slice means all are
+// authorized. For project-scoped subjects (project.<id>.*) the caller must
+// have ActionRead on the project. For user-scoped subjects (user.<id>.*)
+// the caller's identity must match the user ID. Other subjects (notification,
+// broker, etc.) pass through without additional checks.
+func (ws *WebServer) authorizeSSESubjects(r *http.Request, subjects []string) []string {
+	if ws.authzService == nil {
+		// No authz service configured (e.g., tests); allow all.
+		return nil
+	}
+
+	// Build the caller identity from the web session.
+	sessionUser := getWebSessionUser(r.Context())
+	if sessionUser == nil {
+		// No session user — should not happen (sessionAuthMiddleware gates
+		// the SSE endpoint), but fail closed.
+		return subjects
+	}
+	identity := NewAuthenticatedUser(
+		sessionUser.UserID,
+		sessionUser.Email,
+		sessionUser.Name,
+		sessionUser.Role,
+		"web",
+	)
+
+	// Collect unique project IDs and user IDs from subjects.
+	projectIDs := map[string]bool{}
+	userIDs := map[string]bool{}
+	for _, sub := range subjects {
+		tokens := strings.Split(sub, ".")
+		if len(tokens) >= 2 {
+			switch tokens[0] {
+			case "project":
+				projectIDs[tokens[1]] = true
+			case "user":
+				userIDs[tokens[1]] = true
+			}
+		}
+	}
+
+	// Batch-check project access.
+	deniedProjects := map[string]bool{}
+	if len(projectIDs) > 0 {
+		var resources []Resource
+		var ids []string
+		for pid := range projectIDs {
+			ids = append(ids, pid)
+			resources = append(resources, Resource{Type: "project", ID: pid})
+		}
+		caps := ws.authzService.ComputeCapabilitiesBatch(r.Context(), identity, resources, "project")
+		for i, c := range caps {
+			if !capabilityAllows(c, ActionRead) {
+				deniedProjects[ids[i]] = true
+			}
+		}
+	}
+
+	// Check user subjects: caller can only subscribe to their own user subjects.
+	deniedUsers := map[string]bool{}
+	for uid := range userIDs {
+		if uid != sessionUser.UserID {
+			deniedUsers[uid] = true
+		}
+	}
+
+	// Build denied list.
+	if len(deniedProjects) == 0 && len(deniedUsers) == 0 {
+		return nil
+	}
+	var denied []string
+	for _, sub := range subjects {
+		tokens := strings.Split(sub, ".")
+		if len(tokens) >= 2 {
+			switch tokens[0] {
+			case "project":
+				if deniedProjects[tokens[1]] {
+					denied = append(denied, sub)
+				}
+			case "user":
+				if deniedUsers[tokens[1]] {
+					denied = append(denied, sub)
+				}
+			}
+		}
+	}
+	return denied
 }
 
 // isAllowedSubjectChar returns true if the character is valid in a subject token.

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -1170,6 +1170,12 @@ func validateSSESubjects(subjects []string) string {
 			return fmt.Sprintf("subject pattern too long: %d characters (max 256)", len(sub))
 		}
 		tokens := strings.Split(sub, ".")
+		// Belt-and-suspenders: reject subjects whose first token is a
+		// wildcard — a bare ">" or "*" would match all events across all
+		// projects and users, bypassing subject-level authorization.
+		if len(tokens) > 0 && (tokens[0] == "*" || tokens[0] == ">") {
+			return fmt.Sprintf("invalid subject %q: first token must not be a wildcard", sub)
+		}
 		for i, token := range tokens {
 			if token == "" {
 				return fmt.Sprintf("invalid subject %q: empty token", sub)
@@ -1201,8 +1207,22 @@ func validateSSESubjects(subjects []string) string {
 // broker, etc.) pass through without additional checks.
 func (ws *WebServer) authorizeSSESubjects(r *http.Request, subjects []string) []string {
 	if ws.authzService == nil {
-		// No authz service configured (e.g., tests); allow all.
-		return nil
+		// No authz service configured — fail closed. Callers that need
+		// SSE must wire an AuthzService; allowing all subjects when authz
+		// is absent would be a privilege-escalation hole.
+		return subjects
+	}
+
+	// Reject subjects whose first token is a wildcard (* or >). A bare
+	// ">" matches ALL events via NATS-style pattern matching, bypassing
+	// project/user authorization entirely. validateSSESubjects also
+	// rejects these as belt-and-suspenders, but this check is the
+	// authoritative security gate.
+	for _, sub := range subjects {
+		tokens := strings.Split(sub, ".")
+		if len(tokens) > 0 && (tokens[0] == "*" || tokens[0] == ">") {
+			return subjects // deny all, fail closed
+		}
 	}
 
 	// Build the caller identity from the web session.

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -1852,6 +1852,7 @@ func TestSSEHandler_Headers(t *testing.T) {
 	ws := newDevAuthWebServer(t)
 	pub := NewChannelEventPublisher()
 	ws.SetEventPublisher(pub)
+	ws.SetAuthzService(NewAuthzService(&mockAuthzStore{}, nil))
 	t.Cleanup(pub.Close)
 
 	// Use a test server so we get a real connection that supports streaming
@@ -1873,6 +1874,7 @@ func TestSSEHandler_EventDelivery(t *testing.T) {
 	ws := newDevAuthWebServer(t)
 	pub := NewChannelEventPublisher()
 	ws.SetEventPublisher(pub)
+	ws.SetAuthzService(NewAuthzService(&mockAuthzStore{}, nil))
 	t.Cleanup(pub.Close)
 
 	ts := httptest.NewServer(ws.Handler())
@@ -1993,6 +1995,7 @@ func TestSSEHandler_ReconnectOnMaxAge(t *testing.T) {
 	})
 	pub := NewChannelEventPublisher()
 	ws.SetEventPublisher(pub)
+	ws.SetAuthzService(NewAuthzService(&mockAuthzStore{}, nil))
 	t.Cleanup(pub.Close)
 
 	ts := httptest.NewServer(ws.Handler())

--- a/pkg/hub/webchannel.go
+++ b/pkg/hub/webchannel.go
@@ -112,8 +112,13 @@ func (b *webChannelBus) Publish(ctx context.Context, topic string, msg *messages
 		return nil
 	}
 
-	// Wave-1 thread watermark — kept as fallback for legacy agent:<slug>
-	// messages (will be retired when wave-1 thread_id backfill completes).
+	// DEPRECATED(wave-1): Wave-1 thread watermark — writes to webchat_thread.
+	// Only fires for legacy agent:<slug> thread_ids (wave-1 messages). V2
+	// conversations always set ThreadID to a topic UUID or dm:... key, so
+	// they take the threadHandled=true path above and never reach here.
+	// This write-stop is architectural: when the v2 flag is ON the frontend
+	// uses v2 endpoints exclusively, and all new messages carry v2 thread_ids.
+	// Remove this block after wave-1 is permanently retired.
 	if !threadHandled {
 		now := time.Now().UTC()
 		if err := b.store.TouchThread(ctx, userID, projectID, agentID, "", now); err != nil {

--- a/pkg/hub/webchannel.go
+++ b/pkg/hub/webchannel.go
@@ -65,34 +65,66 @@ func NewWebChannelBus(log *slog.Logger, store WebChatStore) eventbus.EventBus {
 // Publish does real work — updates webchat_* state. It does NOT persist
 // the canonical message row or emit the core SSE frame (deliverToUser
 // handles both on the inprocess path).
+//
+// Wave-2 re-key: when msg.ThreadID is present, the spoke routes metadata
+// updates through the thread_id-based path (TouchTopicActivity for space
+// threads, TouchDMActivity for DMs). The legacy (userID, projectID,
+// agentID) path via TouchThread is kept as a fallback for wave-1
+// messages that may still carry the old-style agent:<slug> thread_id.
+// Reply affinity (RecordChannel) still uses identityFromTopic.
 func (b *webChannelBus) Publish(ctx context.Context, topic string, msg *messages.StructuredMessage) error {
 	if msg == nil || msg.ObserverOnly {
 		return nil
 	}
 
+	// --- Wave-2 thread_id-based path ---
+	//
+	// StructuredMessage has no ID field — the store-assigned ID is only
+	// available after deliverToUser persists the message on the inprocess
+	// spoke, which runs concurrently. TouchTopicActivity / TouchDMActivity
+	// accept empty messageID gracefully (update only last_activity_at).
+	threadHandled := false
+	if msg.ThreadID != "" {
+		if strings.HasPrefix(msg.ThreadID, "dm:") {
+			// DM thread — update both participant rows.
+			if err := b.store.TouchDMActivity(ctx, msg.ThreadID, ""); err != nil {
+				b.log.Error("Failed to update DM activity",
+					"thread_id", msg.ThreadID, "error", err)
+				return err
+			}
+			threadHandled = true
+		} else if !strings.HasPrefix(msg.ThreadID, "agent:") {
+			// Topic thread (UUID) — not a legacy agent:<slug> key.
+			if err := b.store.TouchTopicActivity(ctx, msg.ThreadID, ""); err != nil {
+				b.log.Error("Failed to update topic activity",
+					"thread_id", msg.ThreadID, "error", err)
+				return err
+			}
+			threadHandled = true
+		}
+	}
+
+	// --- Legacy path: (userID, projectID, agentID) ---
 	userID, projectID, agentID, ok := identityFromTopic(topic, msg)
 	if !ok {
-		// Not a conversation-scoped message; nothing to record.
+		// Not a conversation-scoped message; if we handled a thread_id
+		// above, that's enough — otherwise nothing to record.
 		return nil
 	}
 
-	now := time.Now().UTC()
-
-	// 1. Thread watermark — this is what makes the Phase 5 rail endpoint
-	//    a single indexed read instead of an aggregate query.
-	//
-	// messageID is "" because StructuredMessage has no ID field — the
-	// store-assigned ID is only available after deliverToUser persists the
-	// message on the inprocess spoke, which runs concurrently. Phase 5
-	// will address this gap (design §5.3).
-	if err := b.store.TouchThread(ctx, userID, projectID, agentID, "", now); err != nil {
-		b.log.Error("Failed to update thread watermark",
-			"user_id", userID, "project_id", projectID, "agent_id", agentID, "error", err)
-		return err
+	// Wave-1 thread watermark — kept as fallback for legacy agent:<slug>
+	// messages (will be retired when wave-1 thread_id backfill completes).
+	if !threadHandled {
+		now := time.Now().UTC()
+		if err := b.store.TouchThread(ctx, userID, projectID, agentID, "", now); err != nil {
+			b.log.Error("Failed to update thread watermark",
+				"user_id", userID, "project_id", projectID, "agent_id", agentID, "error", err)
+			return err
+		}
 	}
 
-	// 2. Reply affinity as a row, not a config flag.
-	if err := b.store.RecordChannel(ctx, userID, projectID, agentID, "web", now); err != nil {
+	// Reply affinity — still needed for cross-channel reply routing.
+	if err := b.store.RecordChannel(ctx, userID, projectID, agentID, "web", time.Now().UTC()); err != nil {
 		b.log.Error("Failed to record conversation context",
 			"user_id", userID, "project_id", projectID, "agent_id", agentID, "error", err)
 		return err

--- a/pkg/hub/webchannel_events.go
+++ b/pkg/hub/webchannel_events.go
@@ -1,0 +1,24 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+// TopicEvent is published on project.<id>.chat.topic when a topic is
+// created, updated, or deleted. It carries the action and the full
+// topic snapshot so subscribers can update their local state without
+// a subsequent REST fetch.
+type TopicEvent struct {
+	Action string       `json:"action"` // "created", "updated", "deleted"
+	Topic  WebChatTopic `json:"topic"`
+}

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -174,6 +174,11 @@ type WebChatStore interface {
 	// GetAttachmentsByMessage returns all attachments linked to a message.
 	GetAttachmentsByMessage(ctx context.Context, messageID string) ([]AttachmentMeta, error)
 
+	// GetAttachmentsByMessages returns attachments for multiple messages in a
+	// single query, keyed by message ID. Replaces per-message loops in the
+	// history endpoint to avoid N+1 queries.
+	GetAttachmentsByMessages(ctx context.Context, messageIDs []string) (map[string][]AttachmentMeta, error)
+
 	// LinkAttachmentToMessage associates an attachment with a message.
 	LinkAttachmentToMessage(ctx context.Context, messageID, attachmentID string) error
 }
@@ -1411,6 +1416,49 @@ WHERE ma.message_id = ?
 		}
 		meta.CreatedAt = parseSQLiteTime(createdAt)
 		result = append(result, meta)
+	}
+	return result, rows.Err()
+}
+
+// GetAttachmentsByMessages returns attachments for multiple messages in a
+// single IN (...) query, keyed by message ID. This replaces per-message
+// loops in the history endpoint to avoid N+1 queries.
+func (s *sqliteWebChatStore) GetAttachmentsByMessages(ctx context.Context, messageIDs []string) (map[string][]AttachmentMeta, error) {
+	if len(messageIDs) == 0 {
+		return nil, nil
+	}
+
+	placeholders := make([]string, len(messageIDs))
+	args := make([]interface{}, len(messageIDs))
+	for i, id := range messageIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+SELECT ma.message_id, a.id, a.project_id, a.filename, a.mime_type, a.size, a.uploaded_by, a.created_at
+FROM webchat_attachment a
+JOIN webchat_message_attachment ma ON ma.attachment_id = a.id
+WHERE ma.message_id IN (%s)
+`, strings.Join(placeholders, ","))
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("webchat store: get messages attachments: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string][]AttachmentMeta)
+	for rows.Next() {
+		var messageID string
+		var meta AttachmentMeta
+		var createdAt string
+		if err := rows.Scan(&messageID, &meta.ID, &meta.ProjectID, &meta.Filename, &meta.MimeType,
+			&meta.Size, &meta.UploadedBy, &createdAt); err != nil {
+			return nil, fmt.Errorf("webchat store: scan attachment: %w", err)
+		}
+		meta.CreatedAt = parseSQLiteTime(createdAt)
+		result[messageID] = append(result[messageID], meta)
 	}
 	return result, rows.Err()
 }

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -1404,7 +1404,7 @@ WHERE ma.message_id = ?
 	if err != nil {
 		return nil, fmt.Errorf("webchat store: get message attachments: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var result []AttachmentMeta
 	for rows.Next() {
@@ -1446,7 +1446,7 @@ WHERE ma.message_id IN (%s)
 	if err != nil {
 		return nil, fmt.Errorf("webchat store: get messages attachments: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	result := make(map[string][]AttachmentMeta)
 	for rows.Next() {

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -102,8 +102,10 @@ type WebChatStore interface {
 	TouchTopicActivity(ctx context.Context, topicID, messageID string) error
 
 	// EnsureGeneralTopic idempotently creates the #general topic for a project.
-	// Returns the topic ID (existing or new).
-	EnsureGeneralTopic(ctx context.Context, projectID, createdBy string) (string, error)
+	// Returns the topic ID (existing or new) and a boolean indicating
+	// whether a new topic was actually created (false when the topic
+	// already existed and the INSERT was a no-op).
+	EnsureGeneralTopic(ctx context.Context, projectID, createdBy string) (string, bool, error)
 
 	// --- Wave-2 Read-state methods ---
 
@@ -598,7 +600,7 @@ SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
 
 	// Lazy #general creation for pre-existing projects.
 	if !hasGeneral {
-		generalID, err := s.EnsureGeneralTopic(ctx, projectID, "system")
+		generalID, _, err := s.EnsureGeneralTopic(ctx, projectID, "system")
 		if err != nil {
 			slog.Warn("webchat store: lazy #general creation failed", "project_id", projectID, "error", err)
 		} else {
@@ -685,8 +687,8 @@ func (s *sqliteWebChatStore) TouchTopicActivity(ctx context.Context, topicID, me
 }
 
 // EnsureGeneralTopic idempotently creates the #general topic for a project.
-// Returns the topic ID (existing or new).
-func (s *sqliteWebChatStore) EnsureGeneralTopic(ctx context.Context, projectID, createdBy string) (string, error) {
+// Returns the topic ID (existing or new) and whether a new row was inserted.
+func (s *sqliteWebChatStore) EnsureGeneralTopic(ctx context.Context, projectID, createdBy string) (string, bool, error) {
 	newID := uuid.New().String()
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
@@ -697,17 +699,19 @@ ON CONFLICT DO NOTHING
 `
 	_, err := s.db.ExecContext(ctx, insert, newID, projectID, createdBy, now)
 	if err != nil {
-		return "", fmt.Errorf("webchat store: ensure general topic: %w", err)
+		return "", false, fmt.Errorf("webchat store: ensure general topic: %w", err)
 	}
 
 	// Return the ID of the existing or newly created #general topic.
+	// If the returned ID matches the one we tried to insert, we created
+	// a new row; otherwise, the topic already existed.
 	const lookup = `SELECT id FROM webchat_topic WHERE project_id = ? AND is_general = 1 AND deleted_at IS NULL`
 	var id string
 	err = s.db.QueryRowContext(ctx, lookup, projectID).Scan(&id)
 	if err != nil {
-		return "", fmt.Errorf("webchat store: ensure general topic lookup: %w", err)
+		return "", false, fmt.Errorf("webchat store: ensure general topic lookup: %w", err)
 	}
-	return id, nil
+	return id, id == newID, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -169,16 +169,16 @@ type WebChatThread struct {
 // WebChatTopic represents a shared thread entity within a space (project).
 // One row per thread; the #general topic has IsGeneral = true.
 type WebChatTopic struct {
-	ID             string
-	ProjectID      string
-	Name           string
-	IsGeneral      bool
-	DefaultAgent   string // empty = no default
-	CreatedBy      string
-	CreatedAt      time.Time
-	LastMessageID  string
-	LastActivityAt time.Time
-	DeletedAt      *time.Time // nil = not deleted
+	ID             string     `json:"id"`
+	ProjectID      string     `json:"projectId"`
+	Name           string     `json:"name"`
+	IsGeneral      bool       `json:"isGeneral"`
+	DefaultAgent   string     `json:"defaultAgent,omitempty"` // empty = no default
+	CreatedBy      string     `json:"createdBy"`
+	CreatedAt      time.Time  `json:"createdAt"`
+	LastMessageID  string     `json:"lastMessageId,omitempty"`
+	LastActivityAt time.Time  `json:"lastActivityAt"`
+	DeletedAt      *time.Time `json:"deletedAt,omitempty"` // nil = not deleted
 }
 
 // TopicUpdate carries optional updates for a topic.
@@ -662,14 +662,22 @@ func (s *sqliteWebChatStore) DeleteTopic(ctx context.Context, topicID string) er
 	return nil
 }
 
-// TouchTopicActivity updates last_message_id and last_activity_at.
+// TouchTopicActivity updates last_activity_at and, when messageID is
+// non-empty, also updates last_message_id. An empty messageID is
+// accepted gracefully — this happens when the spoke receives a
+// StructuredMessage (which has no ID) rather than a store.Message.
 func (s *sqliteWebChatStore) TouchTopicActivity(ctx context.Context, topicID, messageID string) error {
-	const query = `
-UPDATE webchat_topic SET last_message_id = ?, last_activity_at = ?
- WHERE id = ?
-`
-	_, err := s.db.ExecContext(ctx, query, messageID,
-		time.Now().UTC().Format(time.RFC3339Nano), topicID)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if messageID != "" {
+		const q = `UPDATE webchat_topic SET last_message_id = ?, last_activity_at = ? WHERE id = ?`
+		_, err := s.db.ExecContext(ctx, q, messageID, now, topicID)
+		if err != nil {
+			return fmt.Errorf("webchat store: touch topic activity: %w", err)
+		}
+		return nil
+	}
+	const q = `UPDATE webchat_topic SET last_activity_at = ? WHERE id = ?`
+	_, err := s.db.ExecContext(ctx, q, now, topicID)
 	if err != nil {
 		return fmt.Errorf("webchat store: touch topic activity: %w", err)
 	}
@@ -935,14 +943,20 @@ SELECT conversation_key, participant_id, peer_id, peer_kind,
 	return dms, rows.Err()
 }
 
-// TouchDMActivity updates watermarks for a DM conversation (all participant rows).
+// TouchDMActivity updates watermarks for a DM conversation (all participant
+// rows). When messageID is empty, only last_activity_at is updated.
 func (s *sqliteWebChatStore) TouchDMActivity(ctx context.Context, conversationKey, messageID string) error {
-	const query = `
-UPDATE webchat_dm SET last_message_id = ?, last_activity_at = ?
- WHERE conversation_key = ?
-`
-	_, err := s.db.ExecContext(ctx, query, messageID,
-		time.Now().UTC().Format(time.RFC3339Nano), conversationKey)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if messageID != "" {
+		const q = `UPDATE webchat_dm SET last_message_id = ?, last_activity_at = ? WHERE conversation_key = ?`
+		_, err := s.db.ExecContext(ctx, q, messageID, now, conversationKey)
+		if err != nil {
+			return fmt.Errorf("webchat store: touch dm activity: %w", err)
+		}
+		return nil
+	}
+	const q = `UPDATE webchat_dm SET last_activity_at = ? WHERE conversation_key = ?`
+	_, err := s.db.ExecContext(ctx, q, now, conversationKey)
 	if err != nil {
 		return fmt.Errorf("webchat store: touch dm activity: %w", err)
 	}

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -152,6 +152,13 @@ type WebChatStore interface {
 	// TouchDMActivity updates the last_message_id and last_activity_at
 	// watermarks for a DM conversation (both participant rows).
 	TouchDMActivity(ctx context.Context, conversationKey, messageID string) error
+
+	// --- Wave-2 Search methods ---
+
+	// SearchChatMessages performs a case-insensitive substring search across
+	// web-channel messages. Results are ordered by created_at DESC with
+	// keyset pagination via (created_at, id) cursor.
+	SearchChatMessages(ctx context.Context, filter ChatSearchFilter) ([]ChatSearchResult, string, error)
 }
 
 // ThreadPrefs holds per-thread display preferences from webchat_thread_prefs.
@@ -224,6 +231,28 @@ type WebChatDM struct {
 	PeerKind        string // "user" or "agent"
 	LastMessageID   string
 	LastActivityAt  time.Time
+}
+
+// ChatSearchFilter defines query parameters for searching chat messages.
+type ChatSearchFilter struct {
+	Query           string   // search text (required, min 2 chars)
+	ProjectID       string   // scope to one project (optional)
+	ConversationKey string   // scope to one conversation (optional)
+	ProjectIDs      []string // scope to visible projects (for "all" search)
+	Limit           int      // max results (default 50)
+	Cursor          string   // keyset pagination cursor (base64-encoded "timestamp|id")
+}
+
+// ChatSearchResult represents a single search result.
+type ChatSearchResult struct {
+	MessageID       string    `json:"messageId"`
+	ConversationKey string    `json:"conversationKey"`
+	ThreadName      string    `json:"threadName"`
+	SenderName      string    `json:"senderName"`
+	Content         string    `json:"content"`
+	Snippet         string    `json:"snippet"`
+	Timestamp       time.Time `json:"timestamp"`
+	ProjectID       string    `json:"projectId"`
 }
 
 // NewWebChatStore creates a new WebChatStore backed by the given database.
@@ -987,6 +1016,102 @@ func (s *sqliteWebChatStore) TouchDMActivity(ctx context.Context, conversationKe
 }
 
 // ---------------------------------------------------------------------------
+// Wave-2 Search methods (SQLite)
+// ---------------------------------------------------------------------------
+
+// SearchChatMessages performs a case-insensitive substring search over the
+// messages table, scoped to channel='web'. SQLite LIKE is case-insensitive
+// for ASCII which covers most search queries.
+func (s *sqliteWebChatStore) SearchChatMessages(ctx context.Context, filter ChatSearchFilter) ([]ChatSearchResult, string, error) {
+	if filter.Limit <= 0 {
+		filter.Limit = 50
+	}
+	if filter.Limit > 200 {
+		filter.Limit = 200
+	}
+
+	// Check if the messages table exists.
+	var tableExists int
+	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='messages'").Scan(&tableExists); err != nil || tableExists == 0 {
+		return nil, "", nil
+	}
+
+	// Build the query dynamically based on filter.
+	var conditions []string
+	var args []interface{}
+
+	conditions = append(conditions, "channel = 'web'")
+	conditions = append(conditions, "msg LIKE '%' || ? || '%'")
+	args = append(args, filter.Query)
+
+	if filter.ConversationKey != "" {
+		conditions = append(conditions, "thread_id = ?")
+		args = append(args, filter.ConversationKey)
+	}
+
+	if filter.ProjectID != "" {
+		conditions = append(conditions, "project_id = ?")
+		args = append(args, filter.ProjectID)
+	} else if len(filter.ProjectIDs) > 0 {
+		placeholders := make([]string, len(filter.ProjectIDs))
+		for i, pid := range filter.ProjectIDs {
+			placeholders[i] = "?"
+			args = append(args, pid)
+		}
+		conditions = append(conditions, fmt.Sprintf("project_id IN (%s)", strings.Join(placeholders, ",")))
+	}
+
+	// Keyset pagination cursor: "timestamp|id"
+	if filter.Cursor != "" {
+		cursorParts := strings.SplitN(filter.Cursor, "|", 2)
+		if len(cursorParts) == 2 {
+			conditions = append(conditions, "(created < ? OR (created = ? AND id < ?))")
+			args = append(args, cursorParts[0], cursorParts[0], cursorParts[1])
+		}
+	}
+
+	query := fmt.Sprintf(`
+SELECT id, project_id, COALESCE(thread_id, ''), sender, msg, created
+  FROM messages
+ WHERE %s
+ ORDER BY created DESC, id DESC
+ LIMIT ?
+`, strings.Join(conditions, " AND "))
+	args = append(args, filter.Limit+1) // fetch one extra to detect next page
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("webchat store: search messages: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []ChatSearchResult
+	for rows.Next() {
+		var r ChatSearchResult
+		var createdStr string
+		if err := rows.Scan(&r.MessageID, &r.ProjectID, &r.ConversationKey, &r.SenderName, &r.Content, &createdStr); err != nil {
+			return nil, "", fmt.Errorf("webchat store: scan search result: %w", err)
+		}
+		r.Timestamp = parseSQLiteTime(createdStr)
+		r.Snippet = generateSnippet(r.Content, filter.Query, 80)
+		results = append(results, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", fmt.Errorf("webchat store: search rows: %w", err)
+	}
+
+	// Determine next cursor.
+	var nextCursor string
+	if len(results) > filter.Limit {
+		results = results[:filter.Limit]
+		last := results[filter.Limit-1]
+		nextCursor = last.Timestamp.UTC().Format(time.RFC3339Nano) + "|" + last.MessageID
+	}
+
+	return results, nextCursor, nil
+}
+
+// ---------------------------------------------------------------------------
 // Wave-2 Migrations (SQLite)
 // ---------------------------------------------------------------------------
 
@@ -1190,4 +1315,75 @@ func nullableString(s string) interface{} {
 		return nil
 	}
 	return s
+}
+
+// generateSnippet extracts a snippet around the first case-insensitive match
+// of query in content, with approximately contextLen characters of context.
+// The match is wrapped in <mark> tags for client-side highlighting.
+func generateSnippet(content, query string, contextLen int) string {
+	if query == "" || content == "" {
+		return truncateSnippet(content, contextLen)
+	}
+
+	contentRunes := []rune(content)
+	queryRunes := []rune(strings.ToLower(query))
+	lowerRunes := []rune(strings.ToLower(content))
+
+	// Find the first match position (rune-based).
+	matchStart := -1
+	for i := 0; i <= len(lowerRunes)-len(queryRunes); i++ {
+		found := true
+		for j := 0; j < len(queryRunes); j++ {
+			if lowerRunes[i+j] != queryRunes[j] {
+				found = false
+				break
+			}
+		}
+		if found {
+			matchStart = i
+			break
+		}
+	}
+
+	if matchStart < 0 {
+		return truncateSnippet(content, contextLen)
+	}
+
+	matchEnd := matchStart + len(queryRunes)
+
+	// Calculate window around the match.
+	halfCtx := contextLen / 2
+	start := matchStart - halfCtx
+	if start < 0 {
+		start = 0
+	}
+	end := matchEnd + halfCtx
+	if end > len(contentRunes) {
+		end = len(contentRunes)
+	}
+
+	// Build snippet with <mark> tags.
+	var sb strings.Builder
+	if start > 0 {
+		sb.WriteString("...")
+	}
+	sb.WriteString(string(contentRunes[start:matchStart]))
+	sb.WriteString("<mark>")
+	sb.WriteString(string(contentRunes[matchStart:matchEnd]))
+	sb.WriteString("</mark>")
+	sb.WriteString(string(contentRunes[matchEnd:end]))
+	if end < len(contentRunes) {
+		sb.WriteString("...")
+	}
+
+	return sb.String()
+}
+
+// truncateSnippet truncates content to maxLen runes for display.
+func truncateSnippet(s string, maxLen int) string {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen]) + "..."
 }

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -125,6 +125,11 @@ type WebChatStore interface {
 	// SetMuted updates the muted flag for a user+conversation pair.
 	SetMuted(ctx context.Context, userID, conversationKey string, muted bool) error
 
+	// IsConversationMuted returns whether the given user has muted the
+	// conversation identified by conversationKey. Returns false if no
+	// read-state row exists (unmuted by default).
+	IsConversationMuted(ctx context.Context, userID, conversationKey string) (bool, error)
+
 	// --- Wave-2 User-prefs methods ---
 
 	// GetUserPrefs returns the user's rail preferences.
@@ -842,6 +847,20 @@ DO UPDATE SET muted = excluded.muted
 		return fmt.Errorf("webchat store: set muted: %w", err)
 	}
 	return nil
+}
+
+// IsConversationMuted returns whether the user has muted the conversation.
+// Returns false (unmuted) when no read-state row exists.
+func (s *sqliteWebChatStore) IsConversationMuted(ctx context.Context, userID, conversationKey string) (bool, error) {
+	const query = `SELECT muted FROM webchat_read_state WHERE user_id = ? AND conversation_key = ?`
+	var muted int
+	if err := s.db.QueryRowContext(ctx, query, userID, conversationKey).Scan(&muted); err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, fmt.Errorf("webchat store: is conversation muted: %w", err)
+	}
+	return muted != 0, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -159,6 +159,23 @@ type WebChatStore interface {
 	// web-channel messages. Results are ordered by created_at DESC with
 	// keyset pagination via (created_at, id) cursor.
 	SearchChatMessages(ctx context.Context, filter ChatSearchFilter) ([]ChatSearchResult, string, error)
+
+	// --- Wave-2 Attachment methods (W7) ---
+
+	// CreateAttachment inserts attachment metadata.
+	CreateAttachment(ctx context.Context, meta AttachmentMeta) error
+
+	// GetAttachment returns attachment metadata by ID.
+	GetAttachment(ctx context.Context, id string) (*AttachmentMeta, error)
+
+	// DeleteAttachment removes attachment metadata by ID.
+	DeleteAttachment(ctx context.Context, id string) error
+
+	// GetAttachmentsByMessage returns all attachments linked to a message.
+	GetAttachmentsByMessage(ctx context.Context, messageID string) ([]AttachmentMeta, error)
+
+	// LinkAttachmentToMessage associates an attachment with a message.
+	LinkAttachmentToMessage(ctx context.Context, messageID, attachmentID string) error
 }
 
 // ThreadPrefs holds per-thread display preferences from webchat_thread_prefs.
@@ -364,6 +381,30 @@ CREATE TABLE IF NOT EXISTS webchat_migrations (
     name         TEXT PRIMARY KEY,
     completed_at TEXT
 );
+
+-- Wave-2 W7: attachment metadata
+CREATE TABLE IF NOT EXISTS webchat_attachment (
+    id          TEXT PRIMARY KEY,
+    project_id  TEXT NOT NULL,
+    filename    TEXT NOT NULL,
+    mime_type   TEXT NOT NULL,
+    size        INTEGER NOT NULL,
+    uploaded_by TEXT NOT NULL,
+    created_at  TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_webchat_attachment_project
+    ON webchat_attachment (project_id);
+
+-- Wave-2 W7: message-attachment linkage
+CREATE TABLE IF NOT EXISTS webchat_message_attachment (
+    message_id    TEXT NOT NULL,
+    attachment_id TEXT NOT NULL,
+    PRIMARY KEY (message_id, attachment_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_webchat_message_attachment_message
+    ON webchat_message_attachment (message_id);
 `
 	_, err := s.db.Exec(ddl)
 	if err != nil {
@@ -1285,6 +1326,93 @@ WHERE (user_id, conversation_key) IN (
 	}
 
 	return s.markMigrationCompleted("wave1_seed")
+}
+
+// ---------------------------------------------------------------------------
+// W7: Attachment metadata CRUD (SQLite)
+// ---------------------------------------------------------------------------
+
+// CreateAttachment inserts a new attachment metadata row.
+func (s *sqliteWebChatStore) CreateAttachment(ctx context.Context, meta AttachmentMeta) error {
+	const query = `
+INSERT INTO webchat_attachment (id, project_id, filename, mime_type, size, uploaded_by, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+`
+	_, err := s.db.ExecContext(ctx, query, meta.ID, meta.ProjectID, meta.Filename, meta.MimeType, meta.Size, meta.UploadedBy, meta.CreatedAt.Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("webchat store: create attachment: %w", err)
+	}
+	return nil
+}
+
+// GetAttachment returns attachment metadata by ID.
+func (s *sqliteWebChatStore) GetAttachment(ctx context.Context, id string) (*AttachmentMeta, error) {
+	const query = `
+SELECT id, project_id, filename, mime_type, size, uploaded_by, created_at
+FROM webchat_attachment WHERE id = ?
+`
+	var meta AttachmentMeta
+	var createdAt string
+	err := s.db.QueryRowContext(ctx, query, id).Scan(
+		&meta.ID, &meta.ProjectID, &meta.Filename, &meta.MimeType,
+		&meta.Size, &meta.UploadedBy, &createdAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("webchat store: get attachment: %w", err)
+	}
+	meta.CreatedAt = parseSQLiteTime(createdAt)
+	return &meta, nil
+}
+
+// DeleteAttachment removes attachment metadata by ID.
+func (s *sqliteWebChatStore) DeleteAttachment(ctx context.Context, id string) error {
+	const query = `DELETE FROM webchat_attachment WHERE id = ?`
+	_, err := s.db.ExecContext(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("webchat store: delete attachment: %w", err)
+	}
+	return nil
+}
+
+// LinkAttachmentToMessage associates an attachment with a message.
+func (s *sqliteWebChatStore) LinkAttachmentToMessage(ctx context.Context, messageID, attachmentID string) error {
+	const query = `
+INSERT OR IGNORE INTO webchat_message_attachment (message_id, attachment_id)
+VALUES (?, ?)
+`
+	_, err := s.db.ExecContext(ctx, query, messageID, attachmentID)
+	if err != nil {
+		return fmt.Errorf("webchat store: link attachment: %w", err)
+	}
+	return nil
+}
+
+// GetAttachmentsByMessage returns all attachments linked to a message.
+func (s *sqliteWebChatStore) GetAttachmentsByMessage(ctx context.Context, messageID string) ([]AttachmentMeta, error) {
+	const query = `
+SELECT a.id, a.project_id, a.filename, a.mime_type, a.size, a.uploaded_by, a.created_at
+FROM webchat_attachment a
+JOIN webchat_message_attachment ma ON ma.attachment_id = a.id
+WHERE ma.message_id = ?
+`
+	rows, err := s.db.QueryContext(ctx, query, messageID)
+	if err != nil {
+		return nil, fmt.Errorf("webchat store: get message attachments: %w", err)
+	}
+	defer rows.Close()
+
+	var result []AttachmentMeta
+	for rows.Next() {
+		var meta AttachmentMeta
+		var createdAt string
+		if err := rows.Scan(&meta.ID, &meta.ProjectID, &meta.Filename, &meta.MimeType,
+			&meta.Size, &meta.UploadedBy, &createdAt); err != nil {
+			return nil, fmt.Errorf("webchat store: scan attachment: %w", err)
+		}
+		meta.CreatedAt = parseSQLiteTime(createdAt)
+		result = append(result, meta)
+	}
+	return result, rows.Err()
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -18,7 +18,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
+	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // WebChatStore is the single access point for all webchat_* tables.
@@ -72,6 +76,73 @@ type WebChatStore interface {
 	// MarkThreadRead advances the last_read_at watermark for the given
 	// (user, project, agent) thread to the current time.
 	MarkThreadRead(ctx context.Context, userID, projectID, agentID string) error
+
+	// --- Wave-2 Topic methods ---
+
+	// CreateTopic inserts a new topic. Returns an error on name conflict
+	// within the same project.
+	CreateTopic(ctx context.Context, topic WebChatTopic) error
+
+	// GetTopic returns a topic by ID. Returns nil if not found or soft-deleted.
+	GetTopic(ctx context.Context, topicID string) (*WebChatTopic, error)
+
+	// ListTopics returns all non-deleted topics for a project, ordered by
+	// last_activity_at DESC. If no #general topic exists, one is lazily
+	// created (covers pre-existing projects).
+	ListTopics(ctx context.Context, projectID string) ([]WebChatTopic, error)
+
+	// UpdateTopic applies partial updates (rename, set/clear default_agent).
+	UpdateTopic(ctx context.Context, topicID string, updates TopicUpdate) error
+
+	// DeleteTopic soft-deletes a topic (sets deleted_at). Returns an error
+	// if the topic is #general.
+	DeleteTopic(ctx context.Context, topicID string) error
+
+	// TouchTopicActivity updates last_message_id and last_activity_at.
+	TouchTopicActivity(ctx context.Context, topicID, messageID string) error
+
+	// EnsureGeneralTopic idempotently creates the #general topic for a project.
+	// Returns the topic ID (existing or new).
+	EnsureGeneralTopic(ctx context.Context, projectID, createdBy string) (string, error)
+
+	// --- Wave-2 Read-state methods ---
+
+	// GetReadState returns the read state for a user+conversation pair.
+	// Returns nil if no row exists.
+	GetReadState(ctx context.Context, userID, conversationKey string) (*WebChatReadState, error)
+
+	// SetReadState upserts the read watermark for a user+conversation pair.
+	SetReadState(ctx context.Context, userID, conversationKey, messageID string) error
+
+	// GetReadStates returns read states for a user across multiple conversations.
+	GetReadStates(ctx context.Context, userID string, conversationKeys []string) ([]WebChatReadState, error)
+
+	// SetPinned updates the pinned flag for a user+conversation pair.
+	SetPinned(ctx context.Context, userID, conversationKey string, pinned bool) error
+
+	// SetMuted updates the muted flag for a user+conversation pair.
+	SetMuted(ctx context.Context, userID, conversationKey string, muted bool) error
+
+	// --- Wave-2 User-prefs methods ---
+
+	// GetUserPrefs returns the user's rail preferences.
+	// Returns defaults (activity sort) if no row exists.
+	GetUserPrefs(ctx context.Context, userID string) (*WebChatUserPrefs, error)
+
+	// SetUserPrefs upserts the user's rail preferences.
+	SetUserPrefs(ctx context.Context, userID string, prefs WebChatUserPrefs) error
+
+	// --- Wave-2 DM methods ---
+
+	// UpsertDM upserts both participant rows for a DM conversation.
+	UpsertDM(ctx context.Context, dm WebChatDM) error
+
+	// ListDMs returns all DM conversations for a participant.
+	ListDMs(ctx context.Context, participantID string) ([]WebChatDM, error)
+
+	// TouchDMActivity updates the last_message_id and last_activity_at
+	// watermarks for a DM conversation (both participant rows).
+	TouchDMActivity(ctx context.Context, conversationKey, messageID string) error
 }
 
 // ThreadPrefs holds per-thread display preferences from webchat_thread_prefs.
@@ -86,6 +157,64 @@ type WebChatThread struct {
 	LastMessageID  string
 	LastActivityAt time.Time
 	LastReadAt     *time.Time // nil if never read
+}
+
+// ---------------------------------------------------------------------------
+// Wave-2 types (new tables: webchat_topic, webchat_read_state,
+// webchat_user_prefs, webchat_dm)
+// ---------------------------------------------------------------------------
+
+// WebChatTopic represents a shared thread entity within a space (project).
+// One row per thread; the #general topic has IsGeneral = true.
+type WebChatTopic struct {
+	ID             string
+	ProjectID      string
+	Name           string
+	IsGeneral      bool
+	DefaultAgent   string // empty = no default
+	CreatedBy      string
+	CreatedAt      time.Time
+	LastMessageID  string
+	LastActivityAt time.Time
+	DeletedAt      *time.Time // nil = not deleted
+}
+
+// TopicUpdate carries optional updates for a topic.
+// nil pointer fields mean "no change"; a non-nil pointer to an empty string
+// means "clear the value".
+type TopicUpdate struct {
+	Name         *string // nil = no change
+	DefaultAgent *string // nil = no change, pointer to empty = clear
+}
+
+// WebChatReadState holds per-user, per-conversation state.
+// conversation_key is a thread UUID or dm:... key from the design doc.
+type WebChatReadState struct {
+	UserID            string
+	ConversationKey   string
+	LastReadMessageID string
+	LastReadAt        time.Time
+	Pinned            bool
+	Muted             bool
+}
+
+// WebChatUserPrefs holds per-user rail preferences.
+type WebChatUserPrefs struct {
+	UserID         string
+	SpaceSortMode  string // "activity", "alpha", "custom"
+	SpaceOrder     string // JSON array of project UUIDs
+	ThreadSortMode string // "activity", "alpha"
+}
+
+// WebChatDM represents one side of a DM conversation.
+// Two rows exist per DM — one per participant.
+type WebChatDM struct {
+	ConversationKey string
+	ParticipantID   string
+	PeerID          string
+	PeerKind        string // "user" or "agent"
+	LastMessageID   string
+	LastActivityAt  time.Time
 }
 
 // NewWebChatStore creates a new WebChatStore backed by the given database.
@@ -110,7 +239,12 @@ type sqliteWebChatStore struct {
 	db *sql.DB
 }
 
-// Init creates the webchat_* tables using SQLite DDL conventions.
+// DefaultMigrationBatchSize is the number of rows updated per batch
+// during the thread_id backfill migration.
+const DefaultMigrationBatchSize = 1000
+
+// Init creates the webchat_* tables using SQLite DDL conventions,
+// then runs any pending idempotent migrations.
 func (s *sqliteWebChatStore) Init() error {
 	const ddl = `
 CREATE TABLE IF NOT EXISTS webchat_thread (
@@ -142,11 +276,77 @@ CREATE TABLE IF NOT EXISTS webchat_thread_prefs (
     muted INTEGER DEFAULT 0,
     PRIMARY KEY (user_id, project_id, agent_id)
 );
+
+-- Wave-2 tables
+
+CREATE TABLE IF NOT EXISTS webchat_topic (
+    id            TEXT PRIMARY KEY,
+    project_id    TEXT NOT NULL,
+    name          TEXT NOT NULL,
+    is_general    INTEGER NOT NULL DEFAULT 0,
+    default_agent TEXT,
+    created_by    TEXT NOT NULL,
+    created_at    TEXT NOT NULL,
+    last_message_id TEXT,
+    last_activity_at TEXT,
+    deleted_at    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_webchat_topic_project_activity
+    ON webchat_topic (project_id, deleted_at, last_activity_at);
+
+CREATE TABLE IF NOT EXISTS webchat_read_state (
+    user_id          TEXT NOT NULL,
+    conversation_key TEXT NOT NULL,
+    last_read_message_id TEXT,
+    last_read_at     TEXT,
+    pinned           INTEGER NOT NULL DEFAULT 0,
+    muted            INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (user_id, conversation_key)
+);
+
+CREATE TABLE IF NOT EXISTS webchat_user_prefs (
+    user_id         TEXT PRIMARY KEY,
+    space_sort_mode TEXT NOT NULL DEFAULT 'activity',
+    space_order     TEXT,
+    thread_sort_mode TEXT NOT NULL DEFAULT 'activity'
+);
+
+CREATE TABLE IF NOT EXISTS webchat_dm (
+    conversation_key TEXT NOT NULL,
+    participant_id   TEXT NOT NULL,
+    peer_id          TEXT NOT NULL,
+    peer_kind        TEXT NOT NULL,
+    last_message_id  TEXT,
+    last_activity_at TEXT,
+    PRIMARY KEY (participant_id, conversation_key)
+);
+
+CREATE TABLE IF NOT EXISTS webchat_migrations (
+    name         TEXT PRIMARY KEY,
+    completed_at TEXT
+);
 `
 	_, err := s.db.Exec(ddl)
 	if err != nil {
 		return fmt.Errorf("webchat store: create tables: %w", err)
 	}
+
+	// Create partial unique index for #general (one per project).
+	// SQLite supports partial indexes with WHERE.
+	const generalIdx = `
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webchat_topic_one_general
+    ON webchat_topic (project_id) WHERE is_general = 1 AND deleted_at IS NULL;
+`
+	if _, err := s.db.Exec(generalIdx); err != nil {
+		return fmt.Errorf("webchat store: create general index: %w", err)
+	}
+
+	// Run idempotent migrations.
+	if err := s.runMigrations(); err != nil {
+		return fmt.Errorf("webchat store: migrations: %w", err)
+	}
+
 	return nil
 }
 
@@ -286,4 +486,658 @@ UPDATE webchat_thread
 		return fmt.Errorf("webchat store: mark thread read: %w", err)
 	}
 	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Wave-2 Topic methods (SQLite)
+// ---------------------------------------------------------------------------
+
+// CreateTopic inserts a new topic. Returns an error on name conflict.
+func (s *sqliteWebChatStore) CreateTopic(ctx context.Context, topic WebChatTopic) error {
+	const query = `
+INSERT INTO webchat_topic (id, project_id, name, is_general, default_agent, created_by, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+`
+	isGeneral := 0
+	if topic.IsGeneral {
+		isGeneral = 1
+	}
+	_, err := s.db.ExecContext(ctx, query, topic.ID, topic.ProjectID, topic.Name,
+		isGeneral, nullableString(topic.DefaultAgent), topic.CreatedBy,
+		topic.CreatedAt.UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("webchat store: create topic: %w", err)
+	}
+	return nil
+}
+
+// GetTopic returns a topic by ID. Returns nil if not found or soft-deleted.
+func (s *sqliteWebChatStore) GetTopic(ctx context.Context, topicID string) (*WebChatTopic, error) {
+	const query = `
+SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
+       created_by, created_at, COALESCE(last_message_id, ''),
+       COALESCE(last_activity_at, ''), deleted_at
+  FROM webchat_topic
+ WHERE id = ? AND deleted_at IS NULL
+`
+	var t WebChatTopic
+	var isGeneral int
+	var createdAtStr, activityStr string
+	var deletedAtStr *string
+	err := s.db.QueryRowContext(ctx, query, topicID).Scan(
+		&t.ID, &t.ProjectID, &t.Name, &isGeneral, &t.DefaultAgent,
+		&t.CreatedBy, &createdAtStr, &t.LastMessageID, &activityStr, &deletedAtStr)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("webchat store: get topic: %w", err)
+	}
+	t.IsGeneral = isGeneral != 0
+	t.CreatedAt = parseSQLiteTime(createdAtStr)
+	t.LastActivityAt = parseSQLiteTime(activityStr)
+	if deletedAtStr != nil && *deletedAtStr != "" {
+		parsed := parseSQLiteTime(*deletedAtStr)
+		t.DeletedAt = &parsed
+	}
+	return &t, nil
+}
+
+// ListTopics returns non-deleted topics for a project, ordered by last_activity_at DESC.
+// Lazily creates #general if none exists.
+func (s *sqliteWebChatStore) ListTopics(ctx context.Context, projectID string) ([]WebChatTopic, error) {
+	const query = `
+SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
+       created_by, created_at, COALESCE(last_message_id, ''),
+       COALESCE(last_activity_at, ''), deleted_at
+  FROM webchat_topic
+ WHERE project_id = ? AND deleted_at IS NULL
+ ORDER BY last_activity_at DESC
+`
+	rows, err := s.db.QueryContext(ctx, query, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("webchat store: list topics: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var topics []WebChatTopic
+	hasGeneral := false
+	for rows.Next() {
+		var t WebChatTopic
+		var isGeneral int
+		var createdAtStr, activityStr string
+		var deletedAtStr *string
+		if err := rows.Scan(&t.ID, &t.ProjectID, &t.Name, &isGeneral, &t.DefaultAgent,
+			&t.CreatedBy, &createdAtStr, &t.LastMessageID, &activityStr, &deletedAtStr); err != nil {
+			return nil, fmt.Errorf("webchat store: scan topic: %w", err)
+		}
+		t.IsGeneral = isGeneral != 0
+		t.CreatedAt = parseSQLiteTime(createdAtStr)
+		t.LastActivityAt = parseSQLiteTime(activityStr)
+		if t.IsGeneral {
+			hasGeneral = true
+		}
+		topics = append(topics, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("webchat store: list topics rows: %w", err)
+	}
+
+	// Lazy #general creation for pre-existing projects.
+	if !hasGeneral {
+		generalID, err := s.EnsureGeneralTopic(ctx, projectID, "system")
+		if err != nil {
+			slog.Warn("webchat store: lazy #general creation failed", "project_id", projectID, "error", err)
+		} else {
+			general, err := s.GetTopic(ctx, generalID)
+			if err == nil && general != nil {
+				topics = append([]WebChatTopic{*general}, topics...)
+			}
+		}
+	}
+
+	return topics, nil
+}
+
+// UpdateTopic applies partial updates to a topic.
+func (s *sqliteWebChatStore) UpdateTopic(ctx context.Context, topicID string, updates TopicUpdate) error {
+	var sets []string
+	var args []interface{}
+
+	if updates.Name != nil {
+		sets = append(sets, "name = ?")
+		args = append(args, *updates.Name)
+	}
+	if updates.DefaultAgent != nil {
+		sets = append(sets, "default_agent = ?")
+		args = append(args, nullableString(*updates.DefaultAgent))
+	}
+	if len(sets) == 0 {
+		return nil
+	}
+
+	args = append(args, topicID)
+	query := fmt.Sprintf("UPDATE webchat_topic SET %s WHERE id = ? AND deleted_at IS NULL",
+		strings.Join(sets, ", "))
+	_, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("webchat store: update topic: %w", err)
+	}
+	return nil
+}
+
+// DeleteTopic soft-deletes a topic. Returns an error if it is #general.
+func (s *sqliteWebChatStore) DeleteTopic(ctx context.Context, topicID string) error {
+	// Check if topic is #general.
+	var isGeneral int
+	err := s.db.QueryRowContext(ctx, "SELECT is_general FROM webchat_topic WHERE id = ?", topicID).Scan(&isGeneral)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		return fmt.Errorf("webchat store: delete topic check: %w", err)
+	}
+	if isGeneral != 0 {
+		return fmt.Errorf("webchat store: delete topic: cannot delete #general topic")
+	}
+
+	const query = `UPDATE webchat_topic SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL`
+	_, err = s.db.ExecContext(ctx, query, time.Now().UTC().Format(time.RFC3339Nano), topicID)
+	if err != nil {
+		return fmt.Errorf("webchat store: delete topic: %w", err)
+	}
+	return nil
+}
+
+// TouchTopicActivity updates last_message_id and last_activity_at.
+func (s *sqliteWebChatStore) TouchTopicActivity(ctx context.Context, topicID, messageID string) error {
+	const query = `
+UPDATE webchat_topic SET last_message_id = ?, last_activity_at = ?
+ WHERE id = ?
+`
+	_, err := s.db.ExecContext(ctx, query, messageID,
+		time.Now().UTC().Format(time.RFC3339Nano), topicID)
+	if err != nil {
+		return fmt.Errorf("webchat store: touch topic activity: %w", err)
+	}
+	return nil
+}
+
+// EnsureGeneralTopic idempotently creates the #general topic for a project.
+// Returns the topic ID (existing or new).
+func (s *sqliteWebChatStore) EnsureGeneralTopic(ctx context.Context, projectID, createdBy string) (string, error) {
+	newID := uuid.New().String()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	const insert = `
+INSERT INTO webchat_topic (id, project_id, name, is_general, created_by, created_at)
+VALUES (?, ?, 'general', 1, ?, ?)
+ON CONFLICT DO NOTHING
+`
+	_, err := s.db.ExecContext(ctx, insert, newID, projectID, createdBy, now)
+	if err != nil {
+		return "", fmt.Errorf("webchat store: ensure general topic: %w", err)
+	}
+
+	// Return the ID of the existing or newly created #general topic.
+	const lookup = `SELECT id FROM webchat_topic WHERE project_id = ? AND is_general = 1 AND deleted_at IS NULL`
+	var id string
+	err = s.db.QueryRowContext(ctx, lookup, projectID).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("webchat store: ensure general topic lookup: %w", err)
+	}
+	return id, nil
+}
+
+// ---------------------------------------------------------------------------
+// Wave-2 Read-state methods (SQLite)
+// ---------------------------------------------------------------------------
+
+// GetReadState returns the read state for a user+conversation pair.
+func (s *sqliteWebChatStore) GetReadState(ctx context.Context, userID, conversationKey string) (*WebChatReadState, error) {
+	const query = `
+SELECT user_id, conversation_key, COALESCE(last_read_message_id, ''),
+       COALESCE(last_read_at, ''), pinned, muted
+  FROM webchat_read_state
+ WHERE user_id = ? AND conversation_key = ?
+`
+	var rs WebChatReadState
+	var lastReadAtStr string
+	var pinned, muted int
+	err := s.db.QueryRowContext(ctx, query, userID, conversationKey).Scan(
+		&rs.UserID, &rs.ConversationKey, &rs.LastReadMessageID,
+		&lastReadAtStr, &pinned, &muted)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("webchat store: get read state: %w", err)
+	}
+	rs.LastReadAt = parseSQLiteTime(lastReadAtStr)
+	rs.Pinned = pinned != 0
+	rs.Muted = muted != 0
+	return &rs, nil
+}
+
+// SetReadState upserts the read watermark.
+func (s *sqliteWebChatStore) SetReadState(ctx context.Context, userID, conversationKey, messageID string) error {
+	const query = `
+INSERT INTO webchat_read_state (user_id, conversation_key, last_read_message_id, last_read_at)
+VALUES (?, ?, ?, ?)
+ON CONFLICT (user_id, conversation_key)
+DO UPDATE SET
+    last_read_message_id = excluded.last_read_message_id,
+    last_read_at = excluded.last_read_at
+`
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	_, err := s.db.ExecContext(ctx, query, userID, conversationKey, messageID, now)
+	if err != nil {
+		return fmt.Errorf("webchat store: set read state: %w", err)
+	}
+	return nil
+}
+
+// GetReadStates returns read states for a user across multiple conversations.
+func (s *sqliteWebChatStore) GetReadStates(ctx context.Context, userID string, conversationKeys []string) ([]WebChatReadState, error) {
+	if len(conversationKeys) == 0 {
+		return nil, nil
+	}
+
+	placeholders := make([]string, len(conversationKeys))
+	args := make([]interface{}, 0, len(conversationKeys)+1)
+	args = append(args, userID)
+	for i, key := range conversationKeys {
+		placeholders[i] = "?"
+		args = append(args, key)
+	}
+
+	query := fmt.Sprintf(`
+SELECT user_id, conversation_key, COALESCE(last_read_message_id, ''),
+       COALESCE(last_read_at, ''), pinned, muted
+  FROM webchat_read_state
+ WHERE user_id = ? AND conversation_key IN (%s)
+`, strings.Join(placeholders, ","))
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("webchat store: get read states: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var states []WebChatReadState
+	for rows.Next() {
+		var rs WebChatReadState
+		var lastReadAtStr string
+		var pinned, muted int
+		if err := rows.Scan(&rs.UserID, &rs.ConversationKey, &rs.LastReadMessageID,
+			&lastReadAtStr, &pinned, &muted); err != nil {
+			return nil, fmt.Errorf("webchat store: scan read state: %w", err)
+		}
+		rs.LastReadAt = parseSQLiteTime(lastReadAtStr)
+		rs.Pinned = pinned != 0
+		rs.Muted = muted != 0
+		states = append(states, rs)
+	}
+	return states, rows.Err()
+}
+
+// SetPinned updates the pinned flag.
+func (s *sqliteWebChatStore) SetPinned(ctx context.Context, userID, conversationKey string, pinned bool) error {
+	pinnedInt := 0
+	if pinned {
+		pinnedInt = 1
+	}
+	const query = `
+INSERT INTO webchat_read_state (user_id, conversation_key, pinned)
+VALUES (?, ?, ?)
+ON CONFLICT (user_id, conversation_key)
+DO UPDATE SET pinned = excluded.pinned
+`
+	_, err := s.db.ExecContext(ctx, query, userID, conversationKey, pinnedInt)
+	if err != nil {
+		return fmt.Errorf("webchat store: set pinned: %w", err)
+	}
+	return nil
+}
+
+// SetMuted updates the muted flag.
+func (s *sqliteWebChatStore) SetMuted(ctx context.Context, userID, conversationKey string, muted bool) error {
+	mutedInt := 0
+	if muted {
+		mutedInt = 1
+	}
+	const query = `
+INSERT INTO webchat_read_state (user_id, conversation_key, muted)
+VALUES (?, ?, ?)
+ON CONFLICT (user_id, conversation_key)
+DO UPDATE SET muted = excluded.muted
+`
+	_, err := s.db.ExecContext(ctx, query, userID, conversationKey, mutedInt)
+	if err != nil {
+		return fmt.Errorf("webchat store: set muted: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Wave-2 User-prefs methods (SQLite)
+// ---------------------------------------------------------------------------
+
+// GetUserPrefs returns the user's rail preferences. Returns defaults if no row.
+func (s *sqliteWebChatStore) GetUserPrefs(ctx context.Context, userID string) (*WebChatUserPrefs, error) {
+	const query = `
+SELECT user_id, space_sort_mode, COALESCE(space_order, ''), thread_sort_mode
+  FROM webchat_user_prefs
+ WHERE user_id = ?
+`
+	var p WebChatUserPrefs
+	err := s.db.QueryRowContext(ctx, query, userID).Scan(
+		&p.UserID, &p.SpaceSortMode, &p.SpaceOrder, &p.ThreadSortMode)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return &WebChatUserPrefs{
+				UserID:         userID,
+				SpaceSortMode:  "activity",
+				ThreadSortMode: "activity",
+			}, nil
+		}
+		return nil, fmt.Errorf("webchat store: get user prefs: %w", err)
+	}
+	return &p, nil
+}
+
+// SetUserPrefs upserts the user's rail preferences.
+func (s *sqliteWebChatStore) SetUserPrefs(ctx context.Context, userID string, prefs WebChatUserPrefs) error {
+	const query = `
+INSERT INTO webchat_user_prefs (user_id, space_sort_mode, space_order, thread_sort_mode)
+VALUES (?, ?, ?, ?)
+ON CONFLICT (user_id)
+DO UPDATE SET
+    space_sort_mode = excluded.space_sort_mode,
+    space_order = excluded.space_order,
+    thread_sort_mode = excluded.thread_sort_mode
+`
+	_, err := s.db.ExecContext(ctx, query, userID, prefs.SpaceSortMode,
+		nullableString(prefs.SpaceOrder), prefs.ThreadSortMode)
+	if err != nil {
+		return fmt.Errorf("webchat store: set user prefs: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Wave-2 DM methods (SQLite)
+// ---------------------------------------------------------------------------
+
+// UpsertDM upserts a participant row for a DM conversation.
+func (s *sqliteWebChatStore) UpsertDM(ctx context.Context, dm WebChatDM) error {
+	const query = `
+INSERT INTO webchat_dm (conversation_key, participant_id, peer_id, peer_kind, last_message_id, last_activity_at)
+VALUES (?, ?, ?, ?, ?, ?)
+ON CONFLICT (participant_id, conversation_key)
+DO UPDATE SET
+    peer_id = excluded.peer_id,
+    peer_kind = excluded.peer_kind,
+    last_message_id = excluded.last_message_id,
+    last_activity_at = excluded.last_activity_at
+`
+	activityAt := ""
+	if !dm.LastActivityAt.IsZero() {
+		activityAt = dm.LastActivityAt.UTC().Format(time.RFC3339Nano)
+	}
+	_, err := s.db.ExecContext(ctx, query, dm.ConversationKey, dm.ParticipantID,
+		dm.PeerID, dm.PeerKind, nullableString(dm.LastMessageID), nullableString(activityAt))
+	if err != nil {
+		return fmt.Errorf("webchat store: upsert dm: %w", err)
+	}
+	return nil
+}
+
+// ListDMs returns all DM conversations for a participant.
+func (s *sqliteWebChatStore) ListDMs(ctx context.Context, participantID string) ([]WebChatDM, error) {
+	const query = `
+SELECT conversation_key, participant_id, peer_id, peer_kind,
+       COALESCE(last_message_id, ''), COALESCE(last_activity_at, '')
+  FROM webchat_dm
+ WHERE participant_id = ?
+ ORDER BY last_activity_at DESC
+`
+	rows, err := s.db.QueryContext(ctx, query, participantID)
+	if err != nil {
+		return nil, fmt.Errorf("webchat store: list dms: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var dms []WebChatDM
+	for rows.Next() {
+		var dm WebChatDM
+		var activityStr string
+		if err := rows.Scan(&dm.ConversationKey, &dm.ParticipantID, &dm.PeerID,
+			&dm.PeerKind, &dm.LastMessageID, &activityStr); err != nil {
+			return nil, fmt.Errorf("webchat store: scan dm: %w", err)
+		}
+		dm.LastActivityAt = parseSQLiteTime(activityStr)
+		dms = append(dms, dm)
+	}
+	return dms, rows.Err()
+}
+
+// TouchDMActivity updates watermarks for a DM conversation (all participant rows).
+func (s *sqliteWebChatStore) TouchDMActivity(ctx context.Context, conversationKey, messageID string) error {
+	const query = `
+UPDATE webchat_dm SET last_message_id = ?, last_activity_at = ?
+ WHERE conversation_key = ?
+`
+	_, err := s.db.ExecContext(ctx, query, messageID,
+		time.Now().UTC().Format(time.RFC3339Nano), conversationKey)
+	if err != nil {
+		return fmt.Errorf("webchat store: touch dm activity: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Wave-2 Migrations (SQLite)
+// ---------------------------------------------------------------------------
+
+// runMigrations executes idempotent data migrations.
+func (s *sqliteWebChatStore) runMigrations() error {
+	if err := s.migrateThreadIDs(DefaultMigrationBatchSize); err != nil {
+		return fmt.Errorf("thread_id backfill: %w", err)
+	}
+	if err := s.seedFromWave1(); err != nil {
+		return fmt.Errorf("wave-1 seed: %w", err)
+	}
+	return nil
+}
+
+// migrationCompleted checks whether a named migration has already run.
+func (s *sqliteWebChatStore) migrationCompleted(name string) (bool, error) {
+	var count int
+	err := s.db.QueryRow("SELECT COUNT(*) FROM webchat_migrations WHERE name = ?", name).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// markMigrationCompleted records a migration as done.
+func (s *sqliteWebChatStore) markMigrationCompleted(name string) error {
+	const query = `INSERT INTO webchat_migrations (name, completed_at) VALUES (?, ?)`
+	_, err := s.db.Exec(query, name, time.Now().UTC().Format(time.RFC3339Nano))
+	return err
+}
+
+// migrateThreadIDs backfills thread_id from "agent:<id>" to "dm:agent:<aid>:user:<uid>"
+// for web channel messages. Processes in batches to avoid locking.
+func (s *sqliteWebChatStore) migrateThreadIDs(batchSize int) error {
+	done, err := s.migrationCompleted("thread_id_backfill")
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+
+	// Check if the messages table exists (it's Ent-managed and may not exist in tests).
+	var tableExists int
+	err = s.db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='messages'").Scan(&tableExists)
+	if err != nil || tableExists == 0 {
+		// No messages table — nothing to backfill; mark as complete.
+		return s.markMigrationCompleted("thread_id_backfill")
+	}
+
+	for {
+		res, err := s.db.Exec(`
+UPDATE messages SET thread_id = 'dm:agent:' ||
+    CASE
+        WHEN sender LIKE 'agent:%' THEN sender_id
+        ELSE recipient_id
+    END || ':user:' ||
+    CASE
+        WHEN sender LIKE 'agent:%' THEN
+            CASE WHEN recipient_id != '' THEN recipient_id ELSE REPLACE(recipient, 'user:', '') END
+        ELSE
+            CASE WHEN sender_id != '' THEN sender_id ELSE REPLACE(sender, 'user:', '') END
+    END
+WHERE channel = 'web'
+  AND thread_id LIKE 'agent:%'
+  AND rowid IN (
+      SELECT rowid FROM messages
+       WHERE channel = 'web' AND thread_id LIKE 'agent:%'
+       LIMIT ?
+  )
+`, batchSize)
+		if err != nil {
+			return fmt.Errorf("batch update: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			break
+		}
+	}
+
+	return s.markMigrationCompleted("thread_id_backfill")
+}
+
+// seedFromWave1 populates webchat_dm and webchat_read_state from the wave-1
+// webchat_thread and webchat_thread_prefs tables.
+func (s *sqliteWebChatStore) seedFromWave1() error {
+	done, err := s.migrationCompleted("wave1_seed")
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+
+	// Seed webchat_dm entries from webchat_thread rows.
+	// Each wave-1 thread represents a user↔agent DM.
+	// SQLite requires INSERT OR IGNORE for INSERT...SELECT with conflict handling.
+	const seedDM = `
+INSERT OR IGNORE INTO webchat_dm (conversation_key, participant_id, peer_id, peer_kind, last_message_id, last_activity_at)
+SELECT
+    'dm:agent:' || t.agent_id || ':user:' || t.user_id,
+    t.user_id,
+    t.agent_id,
+    'agent',
+    t.last_message_id,
+    t.last_activity_at
+FROM webchat_thread t
+`
+	if _, err := s.db.Exec(seedDM); err != nil {
+		return fmt.Errorf("seed dm (user side): %w", err)
+	}
+
+	// Agent side of the DM.
+	const seedDMAgent = `
+INSERT OR IGNORE INTO webchat_dm (conversation_key, participant_id, peer_id, peer_kind, last_message_id, last_activity_at)
+SELECT
+    'dm:agent:' || t.agent_id || ':user:' || t.user_id,
+    t.agent_id,
+    t.user_id,
+    'user',
+    t.last_message_id,
+    t.last_activity_at
+FROM webchat_thread t
+`
+	if _, err := s.db.Exec(seedDMAgent); err != nil {
+		return fmt.Errorf("seed dm (agent side): %w", err)
+	}
+
+	// Seed webchat_read_state from webchat_thread watermarks.
+	const seedReadState = `
+INSERT OR IGNORE INTO webchat_read_state (user_id, conversation_key, last_read_at)
+SELECT
+    t.user_id,
+    'dm:agent:' || t.agent_id || ':user:' || t.user_id,
+    t.last_read_at
+FROM webchat_thread t
+WHERE t.last_read_at IS NOT NULL
+`
+	if _, err := s.db.Exec(seedReadState); err != nil {
+		return fmt.Errorf("seed read state: %w", err)
+	}
+
+	// Carry muted flag from webchat_thread_prefs into webchat_read_state.
+	// For muted, we need to upsert: create the read_state row if it doesn't
+	// exist, or update the muted flag if it does. SQLite INSERT OR REPLACE
+	// would lose other columns, so we do a two-step approach.
+	const seedMutedInsert = `
+INSERT OR IGNORE INTO webchat_read_state (user_id, conversation_key, muted)
+SELECT
+    p.user_id,
+    'dm:agent:' || p.agent_id || ':user:' || p.user_id,
+    p.muted
+FROM webchat_thread_prefs p
+WHERE p.muted = 1
+`
+	if _, err := s.db.Exec(seedMutedInsert); err != nil {
+		return fmt.Errorf("seed muted insert: %w", err)
+	}
+
+	// Update existing rows to set muted = 1.
+	const seedMutedUpdate = `
+UPDATE webchat_read_state SET muted = 1
+WHERE (user_id, conversation_key) IN (
+    SELECT p.user_id, 'dm:agent:' || p.agent_id || ':user:' || p.user_id
+    FROM webchat_thread_prefs p
+    WHERE p.muted = 1
+)
+`
+	if _, err := s.db.Exec(seedMutedUpdate); err != nil {
+		return fmt.Errorf("seed muted update: %w", err)
+	}
+
+	return s.markMigrationCompleted("wave1_seed")
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// parseSQLiteTime parses a timestamp string stored by SQLite in multiple
+// possible formats (mirrors the wave-1 parsing in GetThreads).
+func parseSQLiteTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	if parsed, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return parsed
+	}
+	if parsed, err := time.Parse("2006-01-02 15:04:05.999999999-07:00", s); err == nil {
+		return parsed
+	}
+	if parsed, err := time.Parse("2006-01-02 15:04:05.999999999", s); err == nil {
+		return parsed
+	}
+	return time.Time{}
+}
+
+// nullableString returns nil for empty strings, suitable for nullable TEXT columns.
+func nullableString(s string) interface{} {
+	if s == "" {
+		return nil
+	}
+	return s
 }

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -344,12 +344,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_webchat_topic_one_general
 		return fmt.Errorf("webchat store: create general index: %w", err)
 	}
 
-	// Enforce unique topic name per project (excluding soft-deleted topics).
-	// SQLite LIKE is case-insensitive for ASCII by default, and the index
-	// on (project_id, name) catches duplicates at insert time.
+	// Enforce case-insensitive unique topic name per project (excluding
+	// soft-deleted topics). COLLATE NOCASE makes the index compare names
+	// case-insensitively, matching the Postgres LOWER(name) index.
 	const nameIdx = `
 CREATE UNIQUE INDEX IF NOT EXISTS idx_webchat_topic_project_name
-    ON webchat_topic (project_id, name) WHERE deleted_at IS NULL;
+    ON webchat_topic (project_id, name COLLATE NOCASE) WHERE deleted_at IS NULL;
 `
 	if _, err := s.db.Exec(nameIdx); err != nil {
 		return fmt.Errorf("webchat store: create name uniqueness index: %w", err)

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -134,7 +134,9 @@ type WebChatStore interface {
 
 	// --- Wave-2 DM methods ---
 
-	// UpsertDM upserts both participant rows for a DM conversation.
+	// UpsertDM upserts a single participant row for a DM conversation.
+	// Callers must invoke this once per participant (typically twice per
+	// DM — one row per side).
 	UpsertDM(ctx context.Context, dm WebChatDM) error
 
 	// ListDMs returns all DM conversations for a participant.
@@ -340,6 +342,17 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_webchat_topic_one_general
 `
 	if _, err := s.db.Exec(generalIdx); err != nil {
 		return fmt.Errorf("webchat store: create general index: %w", err)
+	}
+
+	// Enforce unique topic name per project (excluding soft-deleted topics).
+	// SQLite LIKE is case-insensitive for ASCII by default, and the index
+	// on (project_id, name) catches duplicates at insert time.
+	const nameIdx = `
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webchat_topic_project_name
+    ON webchat_topic (project_id, name) WHERE deleted_at IS NULL;
+`
+	if _, err := s.db.Exec(nameIdx); err != nil {
+		return fmt.Errorf("webchat store: create name uniqueness index: %w", err)
 	}
 
 	// Run idempotent migrations.

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -365,7 +365,7 @@ SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
 
 	// Lazy #general creation for pre-existing projects.
 	if !hasGeneral {
-		generalID, err := s.EnsureGeneralTopic(ctx, projectID, "system")
+		generalID, _, err := s.EnsureGeneralTopic(ctx, projectID, "system")
 		if err != nil {
 			slog.Warn("webchat store: lazy #general creation failed", "project_id", projectID, "error", err)
 		} else {
@@ -436,12 +436,21 @@ func (s *pgWebChatStore) DeleteTopic(ctx context.Context, topicID string) error 
 }
 
 // TouchTopicActivity updates last_message_id and last_activity_at.
+// TouchTopicActivity updates last_activity_at and, when messageID is
+// non-empty, also updates last_message_id. An empty messageID is accepted
+// gracefully — this happens when the spoke receives a StructuredMessage
+// (which has no ID) rather than a store.Message.
 func (s *pgWebChatStore) TouchTopicActivity(ctx context.Context, topicID, messageID string) error {
-	const query = `
-UPDATE webchat_topic SET last_message_id = $1, last_activity_at = NOW()
- WHERE id = $2
-`
-	_, err := s.db.ExecContext(ctx, query, messageID, topicID)
+	if messageID != "" {
+		const q = `UPDATE webchat_topic SET last_message_id = $1, last_activity_at = NOW() WHERE id = $2`
+		_, err := s.db.ExecContext(ctx, q, messageID, topicID)
+		if err != nil {
+			return fmt.Errorf("webchat store: touch topic activity: %w", err)
+		}
+		return nil
+	}
+	const q = `UPDATE webchat_topic SET last_activity_at = NOW() WHERE id = $1`
+	_, err := s.db.ExecContext(ctx, q, topicID)
 	if err != nil {
 		return fmt.Errorf("webchat store: touch topic activity: %w", err)
 	}
@@ -449,7 +458,8 @@ UPDATE webchat_topic SET last_message_id = $1, last_activity_at = NOW()
 }
 
 // EnsureGeneralTopic idempotently creates the #general topic for a project.
-func (s *pgWebChatStore) EnsureGeneralTopic(ctx context.Context, projectID, createdBy string) (string, error) {
+// Returns the topic ID (existing or new) and whether a new row was inserted.
+func (s *pgWebChatStore) EnsureGeneralTopic(ctx context.Context, projectID, createdBy string) (string, bool, error) {
 	newID := uuid.New().String()
 
 	const insert = `
@@ -459,16 +469,16 @@ ON CONFLICT DO NOTHING
 `
 	_, err := s.db.ExecContext(ctx, insert, newID, projectID, createdBy)
 	if err != nil {
-		return "", fmt.Errorf("webchat store: ensure general topic: %w", err)
+		return "", false, fmt.Errorf("webchat store: ensure general topic: %w", err)
 	}
 
 	const lookup = `SELECT id FROM webchat_topic WHERE project_id = $1 AND is_general = TRUE AND deleted_at IS NULL`
 	var id string
 	err = s.db.QueryRowContext(ctx, lookup, projectID).Scan(&id)
 	if err != nil {
-		return "", fmt.Errorf("webchat store: ensure general topic lookup: %w", err)
+		return "", false, fmt.Errorf("webchat store: ensure general topic lookup: %w", err)
 	}
-	return id, nil
+	return id, id == newID, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -704,12 +714,19 @@ SELECT conversation_key, participant_id, peer_id, peer_kind,
 }
 
 // TouchDMActivity updates watermarks for a DM conversation (all participant rows).
+// TouchDMActivity updates watermarks for a DM conversation (all participant
+// rows). When messageID is empty, only last_activity_at is updated.
 func (s *pgWebChatStore) TouchDMActivity(ctx context.Context, conversationKey, messageID string) error {
-	const query = `
-UPDATE webchat_dm SET last_message_id = $1, last_activity_at = NOW()
- WHERE conversation_key = $2
-`
-	_, err := s.db.ExecContext(ctx, query, messageID, conversationKey)
+	if messageID != "" {
+		const q = `UPDATE webchat_dm SET last_message_id = $1, last_activity_at = NOW() WHERE conversation_key = $2`
+		_, err := s.db.ExecContext(ctx, q, messageID, conversationKey)
+		if err != nil {
+			return fmt.Errorf("webchat store: touch dm activity: %w", err)
+		}
+		return nil
+	}
+	const q = `UPDATE webchat_dm SET last_activity_at = NOW() WHERE conversation_key = $1`
+	_, err := s.db.ExecContext(ctx, q, conversationKey)
 	if err != nil {
 		return fmt.Errorf("webchat store: touch dm activity: %w", err)
 	}

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -18,7 +18,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
+	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // pgWebChatStore implements WebChatStore for Postgres.
@@ -29,7 +33,8 @@ type pgWebChatStore struct {
 	db *sql.DB
 }
 
-// Init creates the webchat_* tables using Postgres DDL conventions.
+// Init creates the webchat_* tables using Postgres DDL conventions,
+// then runs any pending idempotent migrations.
 func (s *pgWebChatStore) Init() error {
 	const ddl = `
 CREATE TABLE IF NOT EXISTS webchat_thread (
@@ -61,11 +66,76 @@ CREATE TABLE IF NOT EXISTS webchat_thread_prefs (
     muted BOOLEAN DEFAULT FALSE,
     PRIMARY KEY (user_id, project_id, agent_id)
 );
+
+-- Wave-2 tables
+
+CREATE TABLE IF NOT EXISTS webchat_topic (
+    id            TEXT PRIMARY KEY,
+    project_id    TEXT NOT NULL,
+    name          TEXT NOT NULL,
+    is_general    BOOLEAN NOT NULL DEFAULT FALSE,
+    default_agent TEXT,
+    created_by    TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL,
+    last_message_id TEXT,
+    last_activity_at TIMESTAMPTZ,
+    deleted_at    TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_webchat_topic_project_activity
+    ON webchat_topic (project_id, deleted_at, last_activity_at);
+
+CREATE TABLE IF NOT EXISTS webchat_read_state (
+    user_id          TEXT NOT NULL,
+    conversation_key TEXT NOT NULL,
+    last_read_message_id TEXT,
+    last_read_at     TIMESTAMPTZ,
+    pinned           BOOLEAN NOT NULL DEFAULT FALSE,
+    muted            BOOLEAN NOT NULL DEFAULT FALSE,
+    PRIMARY KEY (user_id, conversation_key)
+);
+
+CREATE TABLE IF NOT EXISTS webchat_user_prefs (
+    user_id         TEXT PRIMARY KEY,
+    space_sort_mode TEXT NOT NULL DEFAULT 'activity',
+    space_order     TEXT,
+    thread_sort_mode TEXT NOT NULL DEFAULT 'activity'
+);
+
+CREATE TABLE IF NOT EXISTS webchat_dm (
+    conversation_key TEXT NOT NULL,
+    participant_id   TEXT NOT NULL,
+    peer_id          TEXT NOT NULL,
+    peer_kind        TEXT NOT NULL,
+    last_message_id  TEXT,
+    last_activity_at TIMESTAMPTZ,
+    PRIMARY KEY (participant_id, conversation_key)
+);
+
+CREATE TABLE IF NOT EXISTS webchat_migrations (
+    name         TEXT PRIMARY KEY,
+    completed_at TIMESTAMPTZ
+);
 `
 	_, err := s.db.Exec(ddl)
 	if err != nil {
 		return fmt.Errorf("webchat store: create tables: %w", err)
 	}
+
+	// Create partial unique index for #general (one per project).
+	const generalIdx = `
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webchat_topic_one_general
+    ON webchat_topic (project_id) WHERE is_general = TRUE AND deleted_at IS NULL;
+`
+	if _, err := s.db.Exec(generalIdx); err != nil {
+		return fmt.Errorf("webchat store: create general index: %w", err)
+	}
+
+	// Run idempotent migrations.
+	if err := s.runMigrations(); err != nil {
+		return fmt.Errorf("webchat store: migrations: %w", err)
+	}
+
 	return nil
 }
 
@@ -191,4 +261,608 @@ UPDATE webchat_thread
 		return fmt.Errorf("webchat store: mark thread read: %w", err)
 	}
 	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Wave-2 Topic methods (Postgres)
+// ---------------------------------------------------------------------------
+
+// CreateTopic inserts a new topic. Returns an error on name conflict.
+func (s *pgWebChatStore) CreateTopic(ctx context.Context, topic WebChatTopic) error {
+	const query = `
+INSERT INTO webchat_topic (id, project_id, name, is_general, default_agent, created_by, created_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+`
+	var defaultAgent interface{}
+	if topic.DefaultAgent != "" {
+		defaultAgent = topic.DefaultAgent
+	}
+	_, err := s.db.ExecContext(ctx, query, topic.ID, topic.ProjectID, topic.Name,
+		topic.IsGeneral, defaultAgent, topic.CreatedBy, topic.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("webchat store: create topic: %w", err)
+	}
+	return nil
+}
+
+// GetTopic returns a topic by ID. Returns nil if not found or soft-deleted.
+func (s *pgWebChatStore) GetTopic(ctx context.Context, topicID string) (*WebChatTopic, error) {
+	const query = `
+SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
+       created_by, created_at, COALESCE(last_message_id, ''),
+       last_activity_at, deleted_at
+  FROM webchat_topic
+ WHERE id = $1 AND deleted_at IS NULL
+`
+	var t WebChatTopic
+	var activityAt *time.Time
+	var deletedAt *time.Time
+	err := s.db.QueryRowContext(ctx, query, topicID).Scan(
+		&t.ID, &t.ProjectID, &t.Name, &t.IsGeneral, &t.DefaultAgent,
+		&t.CreatedBy, &t.CreatedAt, &t.LastMessageID, &activityAt, &deletedAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("webchat store: get topic: %w", err)
+	}
+	if activityAt != nil {
+		t.LastActivityAt = *activityAt
+	}
+	t.DeletedAt = deletedAt
+	return &t, nil
+}
+
+// ListTopics returns non-deleted topics for a project, ordered by last_activity_at DESC.
+// Lazily creates #general if none exists.
+func (s *pgWebChatStore) ListTopics(ctx context.Context, projectID string) ([]WebChatTopic, error) {
+	const query = `
+SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
+       created_by, created_at, COALESCE(last_message_id, ''),
+       last_activity_at, deleted_at
+  FROM webchat_topic
+ WHERE project_id = $1 AND deleted_at IS NULL
+ ORDER BY last_activity_at DESC
+`
+	rows, err := s.db.QueryContext(ctx, query, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("webchat store: list topics: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var topics []WebChatTopic
+	hasGeneral := false
+	for rows.Next() {
+		var t WebChatTopic
+		var activityAt *time.Time
+		var deletedAt *time.Time
+		if err := rows.Scan(&t.ID, &t.ProjectID, &t.Name, &t.IsGeneral, &t.DefaultAgent,
+			&t.CreatedBy, &t.CreatedAt, &t.LastMessageID, &activityAt, &deletedAt); err != nil {
+			return nil, fmt.Errorf("webchat store: scan topic: %w", err)
+		}
+		if activityAt != nil {
+			t.LastActivityAt = *activityAt
+		}
+		t.DeletedAt = deletedAt
+		if t.IsGeneral {
+			hasGeneral = true
+		}
+		topics = append(topics, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("webchat store: list topics rows: %w", err)
+	}
+
+	// Lazy #general creation for pre-existing projects.
+	if !hasGeneral {
+		generalID, err := s.EnsureGeneralTopic(ctx, projectID, "system")
+		if err != nil {
+			slog.Warn("webchat store: lazy #general creation failed", "project_id", projectID, "error", err)
+		} else {
+			general, err := s.GetTopic(ctx, generalID)
+			if err == nil && general != nil {
+				topics = append([]WebChatTopic{*general}, topics...)
+			}
+		}
+	}
+
+	return topics, nil
+}
+
+// UpdateTopic applies partial updates to a topic.
+func (s *pgWebChatStore) UpdateTopic(ctx context.Context, topicID string, updates TopicUpdate) error {
+	var sets []string
+	var args []interface{}
+	argIdx := 1
+
+	if updates.Name != nil {
+		sets = append(sets, fmt.Sprintf("name = $%d", argIdx))
+		args = append(args, *updates.Name)
+		argIdx++
+	}
+	if updates.DefaultAgent != nil {
+		sets = append(sets, fmt.Sprintf("default_agent = $%d", argIdx))
+		var val interface{}
+		if *updates.DefaultAgent != "" {
+			val = *updates.DefaultAgent
+		}
+		args = append(args, val)
+		argIdx++
+	}
+	if len(sets) == 0 {
+		return nil
+	}
+
+	args = append(args, topicID)
+	query := fmt.Sprintf("UPDATE webchat_topic SET %s WHERE id = $%d AND deleted_at IS NULL",
+		strings.Join(sets, ", "), argIdx)
+	_, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("webchat store: update topic: %w", err)
+	}
+	return nil
+}
+
+// DeleteTopic soft-deletes a topic. Returns an error if it is #general.
+func (s *pgWebChatStore) DeleteTopic(ctx context.Context, topicID string) error {
+	var isGeneral bool
+	err := s.db.QueryRowContext(ctx, "SELECT is_general FROM webchat_topic WHERE id = $1", topicID).Scan(&isGeneral)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		return fmt.Errorf("webchat store: delete topic check: %w", err)
+	}
+	if isGeneral {
+		return fmt.Errorf("webchat store: delete topic: cannot delete #general topic")
+	}
+
+	const query = `UPDATE webchat_topic SET deleted_at = NOW() WHERE id = $1 AND deleted_at IS NULL`
+	_, err = s.db.ExecContext(ctx, query, topicID)
+	if err != nil {
+		return fmt.Errorf("webchat store: delete topic: %w", err)
+	}
+	return nil
+}
+
+// TouchTopicActivity updates last_message_id and last_activity_at.
+func (s *pgWebChatStore) TouchTopicActivity(ctx context.Context, topicID, messageID string) error {
+	const query = `
+UPDATE webchat_topic SET last_message_id = $1, last_activity_at = NOW()
+ WHERE id = $2
+`
+	_, err := s.db.ExecContext(ctx, query, messageID, topicID)
+	if err != nil {
+		return fmt.Errorf("webchat store: touch topic activity: %w", err)
+	}
+	return nil
+}
+
+// EnsureGeneralTopic idempotently creates the #general topic for a project.
+func (s *pgWebChatStore) EnsureGeneralTopic(ctx context.Context, projectID, createdBy string) (string, error) {
+	newID := uuid.New().String()
+
+	const insert = `
+INSERT INTO webchat_topic (id, project_id, name, is_general, created_by, created_at)
+VALUES ($1, $2, 'general', TRUE, $3, NOW())
+ON CONFLICT DO NOTHING
+`
+	_, err := s.db.ExecContext(ctx, insert, newID, projectID, createdBy)
+	if err != nil {
+		return "", fmt.Errorf("webchat store: ensure general topic: %w", err)
+	}
+
+	const lookup = `SELECT id FROM webchat_topic WHERE project_id = $1 AND is_general = TRUE AND deleted_at IS NULL`
+	var id string
+	err = s.db.QueryRowContext(ctx, lookup, projectID).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("webchat store: ensure general topic lookup: %w", err)
+	}
+	return id, nil
+}
+
+// ---------------------------------------------------------------------------
+// Wave-2 Read-state methods (Postgres)
+// ---------------------------------------------------------------------------
+
+// GetReadState returns the read state for a user+conversation pair.
+func (s *pgWebChatStore) GetReadState(ctx context.Context, userID, conversationKey string) (*WebChatReadState, error) {
+	const query = `
+SELECT user_id, conversation_key, COALESCE(last_read_message_id, ''),
+       last_read_at, pinned, muted
+  FROM webchat_read_state
+ WHERE user_id = $1 AND conversation_key = $2
+`
+	var rs WebChatReadState
+	var lastReadAt *time.Time
+	err := s.db.QueryRowContext(ctx, query, userID, conversationKey).Scan(
+		&rs.UserID, &rs.ConversationKey, &rs.LastReadMessageID,
+		&lastReadAt, &rs.Pinned, &rs.Muted)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("webchat store: get read state: %w", err)
+	}
+	if lastReadAt != nil {
+		rs.LastReadAt = *lastReadAt
+	}
+	return &rs, nil
+}
+
+// SetReadState upserts the read watermark.
+func (s *pgWebChatStore) SetReadState(ctx context.Context, userID, conversationKey, messageID string) error {
+	const query = `
+INSERT INTO webchat_read_state (user_id, conversation_key, last_read_message_id, last_read_at)
+VALUES ($1, $2, $3, NOW())
+ON CONFLICT (user_id, conversation_key)
+DO UPDATE SET
+    last_read_message_id = EXCLUDED.last_read_message_id,
+    last_read_at = EXCLUDED.last_read_at
+`
+	_, err := s.db.ExecContext(ctx, query, userID, conversationKey, messageID)
+	if err != nil {
+		return fmt.Errorf("webchat store: set read state: %w", err)
+	}
+	return nil
+}
+
+// GetReadStates returns read states for a user across multiple conversations.
+func (s *pgWebChatStore) GetReadStates(ctx context.Context, userID string, conversationKeys []string) ([]WebChatReadState, error) {
+	if len(conversationKeys) == 0 {
+		return nil, nil
+	}
+
+	placeholders := make([]string, len(conversationKeys))
+	args := make([]interface{}, 0, len(conversationKeys)+1)
+	args = append(args, userID)
+	for i, key := range conversationKeys {
+		placeholders[i] = fmt.Sprintf("$%d", i+2)
+		args = append(args, key)
+	}
+
+	query := fmt.Sprintf(`
+SELECT user_id, conversation_key, COALESCE(last_read_message_id, ''),
+       last_read_at, pinned, muted
+  FROM webchat_read_state
+ WHERE user_id = $1 AND conversation_key IN (%s)
+`, strings.Join(placeholders, ","))
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("webchat store: get read states: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var states []WebChatReadState
+	for rows.Next() {
+		var rs WebChatReadState
+		var lastReadAt *time.Time
+		if err := rows.Scan(&rs.UserID, &rs.ConversationKey, &rs.LastReadMessageID,
+			&lastReadAt, &rs.Pinned, &rs.Muted); err != nil {
+			return nil, fmt.Errorf("webchat store: scan read state: %w", err)
+		}
+		if lastReadAt != nil {
+			rs.LastReadAt = *lastReadAt
+		}
+		states = append(states, rs)
+	}
+	return states, rows.Err()
+}
+
+// SetPinned updates the pinned flag.
+func (s *pgWebChatStore) SetPinned(ctx context.Context, userID, conversationKey string, pinned bool) error {
+	const query = `
+INSERT INTO webchat_read_state (user_id, conversation_key, pinned)
+VALUES ($1, $2, $3)
+ON CONFLICT (user_id, conversation_key)
+DO UPDATE SET pinned = EXCLUDED.pinned
+`
+	_, err := s.db.ExecContext(ctx, query, userID, conversationKey, pinned)
+	if err != nil {
+		return fmt.Errorf("webchat store: set pinned: %w", err)
+	}
+	return nil
+}
+
+// SetMuted updates the muted flag.
+func (s *pgWebChatStore) SetMuted(ctx context.Context, userID, conversationKey string, muted bool) error {
+	const query = `
+INSERT INTO webchat_read_state (user_id, conversation_key, muted)
+VALUES ($1, $2, $3)
+ON CONFLICT (user_id, conversation_key)
+DO UPDATE SET muted = EXCLUDED.muted
+`
+	_, err := s.db.ExecContext(ctx, query, userID, conversationKey, muted)
+	if err != nil {
+		return fmt.Errorf("webchat store: set muted: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Wave-2 User-prefs methods (Postgres)
+// ---------------------------------------------------------------------------
+
+// GetUserPrefs returns the user's rail preferences. Returns defaults if no row.
+func (s *pgWebChatStore) GetUserPrefs(ctx context.Context, userID string) (*WebChatUserPrefs, error) {
+	const query = `
+SELECT user_id, space_sort_mode, COALESCE(space_order, ''), thread_sort_mode
+  FROM webchat_user_prefs
+ WHERE user_id = $1
+`
+	var p WebChatUserPrefs
+	err := s.db.QueryRowContext(ctx, query, userID).Scan(
+		&p.UserID, &p.SpaceSortMode, &p.SpaceOrder, &p.ThreadSortMode)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return &WebChatUserPrefs{
+				UserID:         userID,
+				SpaceSortMode:  "activity",
+				ThreadSortMode: "activity",
+			}, nil
+		}
+		return nil, fmt.Errorf("webchat store: get user prefs: %w", err)
+	}
+	return &p, nil
+}
+
+// SetUserPrefs upserts the user's rail preferences.
+func (s *pgWebChatStore) SetUserPrefs(ctx context.Context, userID string, prefs WebChatUserPrefs) error {
+	const query = `
+INSERT INTO webchat_user_prefs (user_id, space_sort_mode, space_order, thread_sort_mode)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (user_id)
+DO UPDATE SET
+    space_sort_mode = EXCLUDED.space_sort_mode,
+    space_order = EXCLUDED.space_order,
+    thread_sort_mode = EXCLUDED.thread_sort_mode
+`
+	var spaceOrder interface{}
+	if prefs.SpaceOrder != "" {
+		spaceOrder = prefs.SpaceOrder
+	}
+	_, err := s.db.ExecContext(ctx, query, userID, prefs.SpaceSortMode,
+		spaceOrder, prefs.ThreadSortMode)
+	if err != nil {
+		return fmt.Errorf("webchat store: set user prefs: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Wave-2 DM methods (Postgres)
+// ---------------------------------------------------------------------------
+
+// UpsertDM upserts a participant row for a DM conversation.
+func (s *pgWebChatStore) UpsertDM(ctx context.Context, dm WebChatDM) error {
+	const query = `
+INSERT INTO webchat_dm (conversation_key, participant_id, peer_id, peer_kind, last_message_id, last_activity_at)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (participant_id, conversation_key)
+DO UPDATE SET
+    peer_id = EXCLUDED.peer_id,
+    peer_kind = EXCLUDED.peer_kind,
+    last_message_id = EXCLUDED.last_message_id,
+    last_activity_at = EXCLUDED.last_activity_at
+`
+	var lastMsgID interface{}
+	if dm.LastMessageID != "" {
+		lastMsgID = dm.LastMessageID
+	}
+	var activityAt interface{}
+	if !dm.LastActivityAt.IsZero() {
+		activityAt = dm.LastActivityAt
+	}
+	_, err := s.db.ExecContext(ctx, query, dm.ConversationKey, dm.ParticipantID,
+		dm.PeerID, dm.PeerKind, lastMsgID, activityAt)
+	if err != nil {
+		return fmt.Errorf("webchat store: upsert dm: %w", err)
+	}
+	return nil
+}
+
+// ListDMs returns all DM conversations for a participant.
+func (s *pgWebChatStore) ListDMs(ctx context.Context, participantID string) ([]WebChatDM, error) {
+	const query = `
+SELECT conversation_key, participant_id, peer_id, peer_kind,
+       COALESCE(last_message_id, ''), last_activity_at
+  FROM webchat_dm
+ WHERE participant_id = $1
+ ORDER BY last_activity_at DESC
+`
+	rows, err := s.db.QueryContext(ctx, query, participantID)
+	if err != nil {
+		return nil, fmt.Errorf("webchat store: list dms: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var dms []WebChatDM
+	for rows.Next() {
+		var dm WebChatDM
+		var activityAt *time.Time
+		if err := rows.Scan(&dm.ConversationKey, &dm.ParticipantID, &dm.PeerID,
+			&dm.PeerKind, &dm.LastMessageID, &activityAt); err != nil {
+			return nil, fmt.Errorf("webchat store: scan dm: %w", err)
+		}
+		if activityAt != nil {
+			dm.LastActivityAt = *activityAt
+		}
+		dms = append(dms, dm)
+	}
+	return dms, rows.Err()
+}
+
+// TouchDMActivity updates watermarks for a DM conversation (all participant rows).
+func (s *pgWebChatStore) TouchDMActivity(ctx context.Context, conversationKey, messageID string) error {
+	const query = `
+UPDATE webchat_dm SET last_message_id = $1, last_activity_at = NOW()
+ WHERE conversation_key = $2
+`
+	_, err := s.db.ExecContext(ctx, query, messageID, conversationKey)
+	if err != nil {
+		return fmt.Errorf("webchat store: touch dm activity: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Wave-2 Migrations (Postgres)
+// ---------------------------------------------------------------------------
+
+// runMigrations executes idempotent data migrations.
+func (s *pgWebChatStore) runMigrations() error {
+	if err := s.migrateThreadIDs(DefaultMigrationBatchSize); err != nil {
+		return fmt.Errorf("thread_id backfill: %w", err)
+	}
+	if err := s.seedFromWave1(); err != nil {
+		return fmt.Errorf("wave-1 seed: %w", err)
+	}
+	return nil
+}
+
+// migrationCompleted checks whether a named migration has already run.
+func (s *pgWebChatStore) migrationCompleted(name string) (bool, error) {
+	var count int
+	err := s.db.QueryRow("SELECT COUNT(*) FROM webchat_migrations WHERE name = $1", name).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// markMigrationCompleted records a migration as done.
+func (s *pgWebChatStore) markMigrationCompleted(name string) error {
+	const query = `INSERT INTO webchat_migrations (name, completed_at) VALUES ($1, NOW())`
+	_, err := s.db.Exec(query, name)
+	return err
+}
+
+// migrateThreadIDs backfills thread_id from "agent:<id>" to "dm:agent:<aid>:user:<uid>"
+// for web channel messages. Processes in batches to avoid locking.
+func (s *pgWebChatStore) migrateThreadIDs(batchSize int) error {
+	done, err := s.migrationCompleted("thread_id_backfill")
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+
+	// Check if the messages table exists (it's Ent-managed and may not exist in tests).
+	var tableExists bool
+	err = s.db.QueryRow(`SELECT EXISTS (
+		SELECT FROM information_schema.tables WHERE table_name = 'messages'
+	)`).Scan(&tableExists)
+	if err != nil || !tableExists {
+		return s.markMigrationCompleted("thread_id_backfill")
+	}
+
+	for {
+		res, err := s.db.Exec(`
+UPDATE messages SET thread_id = 'dm:agent:' ||
+    CASE
+        WHEN sender LIKE 'agent:%' THEN sender_id
+        ELSE recipient_id
+    END || ':user:' ||
+    CASE
+        WHEN sender LIKE 'agent:%' THEN
+            CASE WHEN recipient_id IS NOT NULL AND recipient_id != '' THEN recipient_id ELSE REPLACE(recipient, 'user:', '') END
+        ELSE
+            CASE WHEN sender_id IS NOT NULL AND sender_id != '' THEN sender_id ELSE REPLACE(sender, 'user:', '') END
+    END
+WHERE id IN (
+    SELECT id FROM messages
+     WHERE channel = 'web' AND thread_id LIKE 'agent:%'
+     LIMIT $1
+)
+`, batchSize)
+		if err != nil {
+			return fmt.Errorf("batch update: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			break
+		}
+	}
+
+	return s.markMigrationCompleted("thread_id_backfill")
+}
+
+// seedFromWave1 populates webchat_dm and webchat_read_state from the wave-1
+// webchat_thread and webchat_thread_prefs tables.
+func (s *pgWebChatStore) seedFromWave1() error {
+	done, err := s.migrationCompleted("wave1_seed")
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+
+	// Seed webchat_dm entries from webchat_thread rows (user side).
+	const seedDM = `
+INSERT INTO webchat_dm (conversation_key, participant_id, peer_id, peer_kind, last_message_id, last_activity_at)
+SELECT
+    'dm:agent:' || t.agent_id || ':user:' || t.user_id,
+    t.user_id,
+    t.agent_id,
+    'agent',
+    t.last_message_id,
+    t.last_activity_at
+FROM webchat_thread t
+ON CONFLICT (participant_id, conversation_key) DO NOTHING
+`
+	if _, err := s.db.Exec(seedDM); err != nil {
+		return fmt.Errorf("seed dm (user side): %w", err)
+	}
+
+	// Agent side of the DM.
+	const seedDMAgent = `
+INSERT INTO webchat_dm (conversation_key, participant_id, peer_id, peer_kind, last_message_id, last_activity_at)
+SELECT
+    'dm:agent:' || t.agent_id || ':user:' || t.user_id,
+    t.agent_id,
+    t.user_id,
+    'user',
+    t.last_message_id,
+    t.last_activity_at
+FROM webchat_thread t
+ON CONFLICT (participant_id, conversation_key) DO NOTHING
+`
+	if _, err := s.db.Exec(seedDMAgent); err != nil {
+		return fmt.Errorf("seed dm (agent side): %w", err)
+	}
+
+	// Seed webchat_read_state from webchat_thread watermarks.
+	const seedReadState = `
+INSERT INTO webchat_read_state (user_id, conversation_key, last_read_at)
+SELECT
+    t.user_id,
+    'dm:agent:' || t.agent_id || ':user:' || t.user_id,
+    t.last_read_at
+FROM webchat_thread t
+WHERE t.last_read_at IS NOT NULL
+ON CONFLICT (user_id, conversation_key) DO NOTHING
+`
+	if _, err := s.db.Exec(seedReadState); err != nil {
+		return fmt.Errorf("seed read state: %w", err)
+	}
+
+	// Carry muted flag from webchat_thread_prefs into webchat_read_state.
+	const seedMuted = `
+INSERT INTO webchat_read_state (user_id, conversation_key, muted)
+SELECT
+    p.user_id,
+    'dm:agent:' || p.agent_id || ':user:' || p.user_id,
+    p.muted
+FROM webchat_thread_prefs p
+WHERE p.muted = TRUE
+ON CONFLICT (user_id, conversation_key) DO UPDATE SET muted = EXCLUDED.muted
+`
+	if _, err := s.db.Exec(seedMuted); err != nil {
+		return fmt.Errorf("seed muted: %w", err)
+	}
+
+	return s.markMigrationCompleted("wave1_seed")
 }

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -131,6 +131,16 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_webchat_topic_one_general
 		return fmt.Errorf("webchat store: create general index: %w", err)
 	}
 
+	// Enforce case-insensitive unique topic name per project (excluding
+	// soft-deleted topics). Postgres uses LOWER() for case-insensitive matching.
+	const nameIdx = `
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webchat_topic_project_name
+    ON webchat_topic (project_id, LOWER(name)) WHERE deleted_at IS NULL;
+`
+	if _, err := s.db.Exec(nameIdx); err != nil {
+		return fmt.Errorf("webchat store: create name uniqueness index: %w", err)
+	}
+
 	// Run idempotent migrations.
 	if err := s.runMigrations(); err != nil {
 		return fmt.Errorf("webchat store: migrations: %w", err)

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -599,6 +599,20 @@ DO UPDATE SET muted = EXCLUDED.muted
 	return nil
 }
 
+// IsConversationMuted returns whether the user has muted the conversation.
+// Returns false (unmuted) when no read-state row exists.
+func (s *pgWebChatStore) IsConversationMuted(ctx context.Context, userID, conversationKey string) (bool, error) {
+	const query = `SELECT muted FROM webchat_read_state WHERE user_id = $1 AND conversation_key = $2`
+	var muted bool
+	if err := s.db.QueryRowContext(ctx, query, userID, conversationKey).Scan(&muted); err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, fmt.Errorf("webchat store: is conversation muted: %w", err)
+	}
+	return muted, nil
+}
+
 // ---------------------------------------------------------------------------
 // Wave-2 User-prefs methods (Postgres)
 // ---------------------------------------------------------------------------

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -1106,7 +1106,7 @@ WHERE ma.message_id = $1
 	if err != nil {
 		return nil, fmt.Errorf("webchat store: get message attachments: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var result []AttachmentMeta
 	for rows.Next() {
@@ -1146,7 +1146,7 @@ WHERE ma.message_id IN (%s)
 	if err != nil {
 		return nil, fmt.Errorf("webchat store: get messages attachments: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	result := make(map[string][]AttachmentMeta)
 	for rows.Next() {

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -435,7 +435,6 @@ func (s *pgWebChatStore) DeleteTopic(ctx context.Context, topicID string) error 
 	return nil
 }
 
-// TouchTopicActivity updates last_message_id and last_activity_at.
 // TouchTopicActivity updates last_activity_at and, when messageID is
 // non-empty, also updates last_message_id. An empty messageID is accepted
 // gracefully — this happens when the spoke receives a StructuredMessage
@@ -713,7 +712,6 @@ SELECT conversation_key, participant_id, peer_id, peer_kind,
 	return dms, rows.Err()
 }
 
-// TouchDMActivity updates watermarks for a DM conversation (all participant rows).
 // TouchDMActivity updates watermarks for a DM conversation (all participant
 // rows). When messageID is empty, only last_activity_at is updated.
 func (s *pgWebChatStore) TouchDMActivity(ctx context.Context, conversationKey, messageID string) error {

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -116,6 +116,30 @@ CREATE TABLE IF NOT EXISTS webchat_migrations (
     name         TEXT PRIMARY KEY,
     completed_at TIMESTAMPTZ
 );
+
+-- Wave-2 W7: attachment metadata
+CREATE TABLE IF NOT EXISTS webchat_attachment (
+    id          TEXT PRIMARY KEY,
+    project_id  TEXT NOT NULL,
+    filename    TEXT NOT NULL,
+    mime_type   TEXT NOT NULL,
+    size        BIGINT NOT NULL,
+    uploaded_by TEXT NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_webchat_attachment_project
+    ON webchat_attachment (project_id);
+
+-- Wave-2 W7: message-attachment linkage
+CREATE TABLE IF NOT EXISTS webchat_message_attachment (
+    message_id    TEXT NOT NULL,
+    attachment_id TEXT NOT NULL,
+    PRIMARY KEY (message_id, attachment_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_webchat_message_attachment_message
+    ON webchat_message_attachment (message_id);
 `
 	_, err := s.db.Exec(ddl)
 	if err != nil {
@@ -1010,4 +1034,88 @@ ON CONFLICT (user_id, conversation_key) DO UPDATE SET muted = EXCLUDED.muted
 	}
 
 	return s.markMigrationCompleted("wave1_seed")
+}
+
+// ---------------------------------------------------------------------------
+// W7: Attachment metadata CRUD (Postgres)
+// ---------------------------------------------------------------------------
+
+// CreateAttachment inserts a new attachment metadata row.
+func (s *pgWebChatStore) CreateAttachment(ctx context.Context, meta AttachmentMeta) error {
+	const query = `
+INSERT INTO webchat_attachment (id, project_id, filename, mime_type, size, uploaded_by, created_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+`
+	_, err := s.db.ExecContext(ctx, query, meta.ID, meta.ProjectID, meta.Filename, meta.MimeType, meta.Size, meta.UploadedBy, meta.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("webchat store: create attachment: %w", err)
+	}
+	return nil
+}
+
+// GetAttachment returns attachment metadata by ID.
+func (s *pgWebChatStore) GetAttachment(ctx context.Context, id string) (*AttachmentMeta, error) {
+	const query = `
+SELECT id, project_id, filename, mime_type, size, uploaded_by, created_at
+FROM webchat_attachment WHERE id = $1
+`
+	var meta AttachmentMeta
+	err := s.db.QueryRowContext(ctx, query, id).Scan(
+		&meta.ID, &meta.ProjectID, &meta.Filename, &meta.MimeType,
+		&meta.Size, &meta.UploadedBy, &meta.CreatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("webchat store: get attachment: %w", err)
+	}
+	return &meta, nil
+}
+
+// DeleteAttachment removes attachment metadata by ID.
+func (s *pgWebChatStore) DeleteAttachment(ctx context.Context, id string) error {
+	const query = `DELETE FROM webchat_attachment WHERE id = $1`
+	_, err := s.db.ExecContext(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("webchat store: delete attachment: %w", err)
+	}
+	return nil
+}
+
+// LinkAttachmentToMessage associates an attachment with a message.
+func (s *pgWebChatStore) LinkAttachmentToMessage(ctx context.Context, messageID, attachmentID string) error {
+	const query = `
+INSERT INTO webchat_message_attachment (message_id, attachment_id)
+VALUES ($1, $2)
+ON CONFLICT (message_id, attachment_id) DO NOTHING
+`
+	_, err := s.db.ExecContext(ctx, query, messageID, attachmentID)
+	if err != nil {
+		return fmt.Errorf("webchat store: link attachment: %w", err)
+	}
+	return nil
+}
+
+// GetAttachmentsByMessage returns all attachments linked to a message.
+func (s *pgWebChatStore) GetAttachmentsByMessage(ctx context.Context, messageID string) ([]AttachmentMeta, error) {
+	const query = `
+SELECT a.id, a.project_id, a.filename, a.mime_type, a.size, a.uploaded_by, a.created_at
+FROM webchat_attachment a
+JOIN webchat_message_attachment ma ON ma.attachment_id = a.id
+WHERE ma.message_id = $1
+`
+	rows, err := s.db.QueryContext(ctx, query, messageID)
+	if err != nil {
+		return nil, fmt.Errorf("webchat store: get message attachments: %w", err)
+	}
+	defer rows.Close()
+
+	var result []AttachmentMeta
+	for rows.Next() {
+		var meta AttachmentMeta
+		if err := rows.Scan(&meta.ID, &meta.ProjectID, &meta.Filename, &meta.MimeType,
+			&meta.Size, &meta.UploadedBy, &meta.CreatedAt); err != nil {
+			return nil, fmt.Errorf("webchat store: scan attachment: %w", err)
+		}
+		result = append(result, meta)
+	}
+	return result, rows.Err()
 }

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -746,6 +746,112 @@ func (s *pgWebChatStore) TouchDMActivity(ctx context.Context, conversationKey, m
 }
 
 // ---------------------------------------------------------------------------
+// Wave-2 Search methods (Postgres)
+// ---------------------------------------------------------------------------
+
+// SearchChatMessages performs a case-insensitive substring search over the
+// messages table, scoped to channel='web'. Uses ILIKE for case-insensitive
+// matching.
+func (s *pgWebChatStore) SearchChatMessages(ctx context.Context, filter ChatSearchFilter) ([]ChatSearchResult, string, error) {
+	if filter.Limit <= 0 {
+		filter.Limit = 50
+	}
+	if filter.Limit > 200 {
+		filter.Limit = 200
+	}
+
+	// Check if the messages table exists.
+	var tableExists bool
+	if err := s.db.QueryRowContext(ctx, `SELECT EXISTS (
+		SELECT FROM information_schema.tables WHERE table_name = 'messages'
+	)`).Scan(&tableExists); err != nil || !tableExists {
+		return nil, "", nil
+	}
+
+	// Build the query dynamically based on filter.
+	var conditions []string
+	var args []interface{}
+	argIdx := 1
+
+	conditions = append(conditions, "channel = 'web'")
+	conditions = append(conditions, fmt.Sprintf("msg ILIKE '%%' || $%d || '%%'", argIdx))
+	args = append(args, filter.Query)
+	argIdx++
+
+	if filter.ConversationKey != "" {
+		conditions = append(conditions, fmt.Sprintf("thread_id = $%d", argIdx))
+		args = append(args, filter.ConversationKey)
+		argIdx++
+	}
+
+	if filter.ProjectID != "" {
+		conditions = append(conditions, fmt.Sprintf("project_id = $%d", argIdx))
+		args = append(args, filter.ProjectID)
+		argIdx++
+	} else if len(filter.ProjectIDs) > 0 {
+		placeholders := make([]string, len(filter.ProjectIDs))
+		for i, pid := range filter.ProjectIDs {
+			placeholders[i] = fmt.Sprintf("$%d", argIdx)
+			args = append(args, pid)
+			argIdx++
+		}
+		conditions = append(conditions, fmt.Sprintf("project_id IN (%s)", strings.Join(placeholders, ",")))
+	}
+
+	// Keyset pagination cursor: "timestamp|id"
+	if filter.Cursor != "" {
+		cursorParts := strings.SplitN(filter.Cursor, "|", 2)
+		if len(cursorParts) == 2 {
+			conditions = append(conditions, fmt.Sprintf("(created < $%d OR (created = $%d AND id < $%d))", argIdx, argIdx+1, argIdx+2))
+			args = append(args, cursorParts[0], cursorParts[0], cursorParts[1])
+			argIdx += 3
+		}
+	}
+
+	query := fmt.Sprintf(`
+SELECT id, project_id, COALESCE(thread_id, ''), sender, msg, created
+  FROM messages
+ WHERE %s
+ ORDER BY created DESC, id DESC
+ LIMIT $%d
+`, strings.Join(conditions, " AND "), argIdx)
+	args = append(args, filter.Limit+1)
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("webchat store: search messages: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []ChatSearchResult
+	for rows.Next() {
+		var r ChatSearchResult
+		var createdAt *time.Time
+		if err := rows.Scan(&r.MessageID, &r.ProjectID, &r.ConversationKey, &r.SenderName, &r.Content, &createdAt); err != nil {
+			return nil, "", fmt.Errorf("webchat store: scan search result: %w", err)
+		}
+		if createdAt != nil {
+			r.Timestamp = *createdAt
+		}
+		r.Snippet = generateSnippet(r.Content, filter.Query, 80)
+		results = append(results, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", fmt.Errorf("webchat store: search rows: %w", err)
+	}
+
+	// Determine next cursor.
+	var nextCursor string
+	if len(results) > filter.Limit {
+		results = results[:filter.Limit]
+		last := results[filter.Limit-1]
+		nextCursor = last.Timestamp.UTC().Format(time.RFC3339Nano) + "|" + last.MessageID
+	}
+
+	return results, nextCursor, nil
+}
+
+// ---------------------------------------------------------------------------
 // Wave-2 Migrations (Postgres)
 // ---------------------------------------------------------------------------
 

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -1119,3 +1119,44 @@ WHERE ma.message_id = $1
 	}
 	return result, rows.Err()
 }
+
+// GetAttachmentsByMessages returns attachments for multiple messages in a
+// single IN (...) query, keyed by message ID. This replaces per-message
+// loops in the history endpoint to avoid N+1 queries.
+func (s *pgWebChatStore) GetAttachmentsByMessages(ctx context.Context, messageIDs []string) (map[string][]AttachmentMeta, error) {
+	if len(messageIDs) == 0 {
+		return nil, nil
+	}
+
+	placeholders := make([]string, len(messageIDs))
+	args := make([]interface{}, len(messageIDs))
+	for i, id := range messageIDs {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+SELECT ma.message_id, a.id, a.project_id, a.filename, a.mime_type, a.size, a.uploaded_by, a.created_at
+FROM webchat_attachment a
+JOIN webchat_message_attachment ma ON ma.attachment_id = a.id
+WHERE ma.message_id IN (%s)
+`, strings.Join(placeholders, ","))
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("webchat store: get messages attachments: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string][]AttachmentMeta)
+	for rows.Next() {
+		var messageID string
+		var meta AttachmentMeta
+		if err := rows.Scan(&messageID, &meta.ID, &meta.ProjectID, &meta.Filename, &meta.MimeType,
+			&meta.Size, &meta.UploadedBy, &meta.CreatedAt); err != nil {
+			return nil, fmt.Errorf("webchat store: scan attachment: %w", err)
+		}
+		result[messageID] = append(result[messageID], meta)
+	}
+	return result, rows.Err()
+}

--- a/pkg/hub/webchannel_store_wave2_test.go
+++ b/pkg/hub/webchannel_store_wave2_test.go
@@ -113,6 +113,42 @@ func TestWave2_GetTopic_NotFound(t *testing.T) {
 	require.Nil(t, got)
 }
 
+func TestWave2_CreateTopic_DuplicateName(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Create a topic.
+	require.NoError(t, store.CreateTopic(ctx, WebChatTopic{
+		ID: "t1", ProjectID: "proj-1", Name: "design", CreatedBy: "u1", CreatedAt: now,
+	}))
+
+	// Duplicate name in same project should fail (unique index).
+	err := store.CreateTopic(ctx, WebChatTopic{
+		ID: "t2", ProjectID: "proj-1", Name: "design", CreatedBy: "u1", CreatedAt: now,
+	})
+	require.Error(t, err, "duplicate topic name in same project should be rejected")
+
+	// Same name in a different project should succeed.
+	require.NoError(t, store.CreateTopic(ctx, WebChatTopic{
+		ID: "t3", ProjectID: "proj-2", Name: "design", CreatedBy: "u1", CreatedAt: now,
+	}))
+
+	// Soft-delete the original, then reuse the name — should succeed.
+	require.NoError(t, store.DeleteTopic(ctx, "t1"))
+	require.NoError(t, store.CreateTopic(ctx, WebChatTopic{
+		ID: "t4", ProjectID: "proj-1", Name: "design", CreatedBy: "u1", CreatedAt: now,
+	}))
+
+	// Verify the new topic is the one returned.
+	got, err := store.GetTopic(ctx, "t4")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "design", got.Name)
+}
+
 func TestWave2_ListTopics(t *testing.T) {
 	store, db := newTestWebChatStoreV2(t)
 	defer db.Close() //nolint:errcheck

--- a/pkg/hub/webchannel_store_wave2_test.go
+++ b/pkg/hub/webchannel_store_wave2_test.go
@@ -309,9 +309,10 @@ func TestWave2_EnsureGeneralTopic(t *testing.T) {
 	defer db.Close() //nolint:errcheck
 
 	ctx := context.Background()
-	id1, err := store.EnsureGeneralTopic(ctx, "proj-1", "user-1")
+	id1, created, err := store.EnsureGeneralTopic(ctx, "proj-1", "user-1")
 	require.NoError(t, err)
 	require.NotEmpty(t, id1)
+	require.True(t, created, "first call should report created=true")
 
 	// Verify the topic exists.
 	got, err := store.GetTopic(ctx, id1)
@@ -327,13 +328,15 @@ func TestWave2_EnsureGeneralTopic_Idempotent(t *testing.T) {
 	defer db.Close() //nolint:errcheck
 
 	ctx := context.Background()
-	id1, err := store.EnsureGeneralTopic(ctx, "proj-1", "user-1")
+	id1, created1, err := store.EnsureGeneralTopic(ctx, "proj-1", "user-1")
 	require.NoError(t, err)
+	require.True(t, created1, "first call should report created=true")
 
-	// Second call should return the same ID.
-	id2, err := store.EnsureGeneralTopic(ctx, "proj-1", "user-2")
+	// Second call should return the same ID and created=false.
+	id2, created2, err := store.EnsureGeneralTopic(ctx, "proj-1", "user-2")
 	require.NoError(t, err)
 	require.Equal(t, id1, id2)
+	require.False(t, created2, "second call should report created=false (topic already exists)")
 
 	// Only one row should exist.
 	var count int

--- a/pkg/hub/webchannel_store_wave2_test.go
+++ b/pkg/hub/webchannel_store_wave2_test.go
@@ -1,0 +1,858 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestWebChatStoreV2 creates a WebChatStore backed by an in-memory SQLite DB
+// for testing wave-2 features. The caller should close the returned *sql.DB.
+func newTestWebChatStoreV2(t *testing.T) (WebChatStore, *sql.DB) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+
+	store := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, store.Init())
+
+	return store, db
+}
+
+// --- Init idempotency ---
+
+func TestWave2_Init_Idempotent(t *testing.T) {
+	_, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	// Init again should not fail (CREATE TABLE IF NOT EXISTS + CREATE INDEX IF NOT EXISTS).
+	store2 := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, store2.Init())
+
+	// Verify all wave-2 tables exist.
+	for _, table := range []string{"webchat_topic", "webchat_read_state", "webchat_user_prefs", "webchat_dm", "webchat_migrations"} {
+		var count int
+		err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&count)
+		require.NoError(t, err, "table %s should exist", table)
+	}
+}
+
+// --- Topic CRUD ---
+
+func TestWave2_CreateTopic(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	topic := WebChatTopic{
+		ID:        "topic-1",
+		ProjectID: "proj-1",
+		Name:      "design-review",
+		CreatedBy: "user-1",
+		CreatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, store.CreateTopic(ctx, topic))
+
+	got, err := store.GetTopic(ctx, "topic-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "topic-1", got.ID)
+	require.Equal(t, "proj-1", got.ProjectID)
+	require.Equal(t, "design-review", got.Name)
+	require.False(t, got.IsGeneral)
+	require.Empty(t, got.DefaultAgent)
+	require.Equal(t, "user-1", got.CreatedBy)
+	require.Nil(t, got.DeletedAt)
+}
+
+func TestWave2_CreateTopic_WithDefaultAgent(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	topic := WebChatTopic{
+		ID:           "topic-2",
+		ProjectID:    "proj-1",
+		Name:         "dev-chat",
+		DefaultAgent: "agent-uuid-1",
+		CreatedBy:    "user-1",
+		CreatedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, store.CreateTopic(ctx, topic))
+
+	got, err := store.GetTopic(ctx, "topic-2")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "agent-uuid-1", got.DefaultAgent)
+}
+
+func TestWave2_GetTopic_NotFound(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	got, err := store.GetTopic(context.Background(), "nonexistent")
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestWave2_ListTopics(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Create topics for two different projects.
+	topics := []WebChatTopic{
+		{ID: "t1", ProjectID: "proj-1", Name: "general", IsGeneral: true, CreatedBy: "u1", CreatedAt: now},
+		{ID: "t2", ProjectID: "proj-1", Name: "design", CreatedBy: "u1", CreatedAt: now},
+		{ID: "t3", ProjectID: "proj-2", Name: "general", IsGeneral: true, CreatedBy: "u1", CreatedAt: now},
+	}
+	for _, topic := range topics {
+		require.NoError(t, store.CreateTopic(ctx, topic))
+	}
+
+	// Touch activity on t2 to make it sort first.
+	require.NoError(t, store.TouchTopicActivity(ctx, "t2", "msg-1"))
+
+	result, err := store.ListTopics(ctx, "proj-1")
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	// proj-2 topics should not appear.
+	for _, r := range result {
+		require.Equal(t, "proj-1", r.ProjectID)
+	}
+}
+
+func TestWave2_UpdateTopic_Rename(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	require.NoError(t, store.CreateTopic(ctx, WebChatTopic{
+		ID: "t1", ProjectID: "proj-1", Name: "old-name", CreatedBy: "u1",
+		CreatedAt: time.Now().UTC(),
+	}))
+
+	newName := "new-name"
+	require.NoError(t, store.UpdateTopic(ctx, "t1", TopicUpdate{Name: &newName}))
+
+	got, err := store.GetTopic(ctx, "t1")
+	require.NoError(t, err)
+	require.Equal(t, "new-name", got.Name)
+}
+
+func TestWave2_UpdateTopic_SetAndClearDefaultAgent(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	require.NoError(t, store.CreateTopic(ctx, WebChatTopic{
+		ID: "t1", ProjectID: "proj-1", Name: "dev", CreatedBy: "u1",
+		CreatedAt: time.Now().UTC(),
+	}))
+
+	// Set default agent.
+	agent := "agent-uuid"
+	require.NoError(t, store.UpdateTopic(ctx, "t1", TopicUpdate{DefaultAgent: &agent}))
+
+	got, err := store.GetTopic(ctx, "t1")
+	require.NoError(t, err)
+	require.Equal(t, "agent-uuid", got.DefaultAgent)
+
+	// Clear default agent.
+	empty := ""
+	require.NoError(t, store.UpdateTopic(ctx, "t1", TopicUpdate{DefaultAgent: &empty}))
+
+	got, err = store.GetTopic(ctx, "t1")
+	require.NoError(t, err)
+	require.Empty(t, got.DefaultAgent)
+}
+
+func TestWave2_UpdateTopic_NoChanges(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	require.NoError(t, store.CreateTopic(ctx, WebChatTopic{
+		ID: "t1", ProjectID: "proj-1", Name: "dev", CreatedBy: "u1",
+		CreatedAt: time.Now().UTC(),
+	}))
+
+	// Empty update should be a no-op.
+	require.NoError(t, store.UpdateTopic(ctx, "t1", TopicUpdate{}))
+}
+
+// --- Soft delete ---
+
+func TestWave2_DeleteTopic_SoftDelete(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	require.NoError(t, store.CreateTopic(ctx, WebChatTopic{
+		ID: "t1", ProjectID: "proj-1", Name: "temp-thread", CreatedBy: "u1",
+		CreatedAt: time.Now().UTC(),
+	}))
+
+	require.NoError(t, store.DeleteTopic(ctx, "t1"))
+
+	// GetTopic should return nil for soft-deleted topics.
+	got, err := store.GetTopic(ctx, "t1")
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	// The row should still exist in the database.
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM webchat_topic WHERE id = 't1'").Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
+func TestWave2_DeleteTopic_SoftDeleteExcludedFromList(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	require.NoError(t, store.CreateTopic(ctx, WebChatTopic{
+		ID: "general", ProjectID: "proj-1", Name: "general", IsGeneral: true,
+		CreatedBy: "u1", CreatedAt: now,
+	}))
+	require.NoError(t, store.CreateTopic(ctx, WebChatTopic{
+		ID: "t2", ProjectID: "proj-1", Name: "deletable",
+		CreatedBy: "u1", CreatedAt: now,
+	}))
+
+	require.NoError(t, store.DeleteTopic(ctx, "t2"))
+
+	topics, err := store.ListTopics(ctx, "proj-1")
+	require.NoError(t, err)
+	require.Len(t, topics, 1)
+	require.Equal(t, "general", topics[0].ID)
+}
+
+func TestWave2_DeleteTopic_RejectsGeneral(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	require.NoError(t, store.CreateTopic(ctx, WebChatTopic{
+		ID: "general", ProjectID: "proj-1", Name: "general", IsGeneral: true,
+		CreatedBy: "u1", CreatedAt: time.Now().UTC(),
+	}))
+
+	err := store.DeleteTopic(ctx, "general")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot delete #general")
+}
+
+// --- EnsureGeneralTopic ---
+
+func TestWave2_EnsureGeneralTopic(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	id1, err := store.EnsureGeneralTopic(ctx, "proj-1", "user-1")
+	require.NoError(t, err)
+	require.NotEmpty(t, id1)
+
+	// Verify the topic exists.
+	got, err := store.GetTopic(ctx, id1)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.True(t, got.IsGeneral)
+	require.Equal(t, "general", got.Name)
+	require.Equal(t, "proj-1", got.ProjectID)
+}
+
+func TestWave2_EnsureGeneralTopic_Idempotent(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	id1, err := store.EnsureGeneralTopic(ctx, "proj-1", "user-1")
+	require.NoError(t, err)
+
+	// Second call should return the same ID.
+	id2, err := store.EnsureGeneralTopic(ctx, "proj-1", "user-2")
+	require.NoError(t, err)
+	require.Equal(t, id1, id2)
+
+	// Only one row should exist.
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM webchat_topic WHERE project_id = 'proj-1' AND is_general = 1").Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
+func TestWave2_ListTopics_LazyCreatesGeneral(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	// ListTopics on a project with no topics should lazily create #general.
+	topics, err := store.ListTopics(ctx, "proj-1")
+	require.NoError(t, err)
+	require.Len(t, topics, 1)
+	require.True(t, topics[0].IsGeneral)
+	require.Equal(t, "general", topics[0].Name)
+}
+
+// --- TouchTopicActivity ---
+
+func TestWave2_TouchTopicActivity(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	require.NoError(t, store.CreateTopic(ctx, WebChatTopic{
+		ID: "t1", ProjectID: "proj-1", Name: "dev", CreatedBy: "u1",
+		CreatedAt: time.Now().UTC(),
+	}))
+
+	require.NoError(t, store.TouchTopicActivity(ctx, "t1", "msg-42"))
+
+	got, err := store.GetTopic(ctx, "t1")
+	require.NoError(t, err)
+	require.Equal(t, "msg-42", got.LastMessageID)
+	require.False(t, got.LastActivityAt.IsZero())
+}
+
+// --- Read state ---
+
+func TestWave2_ReadState_GetAndSet(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+
+	// No read state initially.
+	rs, err := store.GetReadState(ctx, "user-1", "topic-uuid-1")
+	require.NoError(t, err)
+	require.Nil(t, rs)
+
+	// Set read state.
+	require.NoError(t, store.SetReadState(ctx, "user-1", "topic-uuid-1", "msg-10"))
+
+	rs, err = store.GetReadState(ctx, "user-1", "topic-uuid-1")
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	require.Equal(t, "user-1", rs.UserID)
+	require.Equal(t, "topic-uuid-1", rs.ConversationKey)
+	require.Equal(t, "msg-10", rs.LastReadMessageID)
+	require.False(t, rs.LastReadAt.IsZero())
+}
+
+func TestWave2_ReadState_Upsert(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	require.NoError(t, store.SetReadState(ctx, "user-1", "conv-1", "msg-1"))
+	require.NoError(t, store.SetReadState(ctx, "user-1", "conv-1", "msg-5"))
+
+	rs, err := store.GetReadState(ctx, "user-1", "conv-1")
+	require.NoError(t, err)
+	require.Equal(t, "msg-5", rs.LastReadMessageID)
+}
+
+func TestWave2_ReadState_BatchGet(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	require.NoError(t, store.SetReadState(ctx, "user-1", "conv-1", "msg-1"))
+	require.NoError(t, store.SetReadState(ctx, "user-1", "conv-2", "msg-2"))
+	require.NoError(t, store.SetReadState(ctx, "user-1", "conv-3", "msg-3"))
+
+	states, err := store.GetReadStates(ctx, "user-1", []string{"conv-1", "conv-3", "conv-missing"})
+	require.NoError(t, err)
+	require.Len(t, states, 2) // conv-missing not returned.
+}
+
+func TestWave2_ReadState_EmptyBatchGet(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	states, err := store.GetReadStates(context.Background(), "user-1", nil)
+	require.NoError(t, err)
+	require.Nil(t, states)
+}
+
+func TestWave2_ReadState_SetPinned(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	require.NoError(t, store.SetPinned(ctx, "user-1", "conv-1", true))
+
+	rs, err := store.GetReadState(ctx, "user-1", "conv-1")
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	require.True(t, rs.Pinned)
+
+	// Unpin.
+	require.NoError(t, store.SetPinned(ctx, "user-1", "conv-1", false))
+	rs, err = store.GetReadState(ctx, "user-1", "conv-1")
+	require.NoError(t, err)
+	require.False(t, rs.Pinned)
+}
+
+func TestWave2_ReadState_SetMuted(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	require.NoError(t, store.SetMuted(ctx, "user-1", "conv-1", true))
+
+	rs, err := store.GetReadState(ctx, "user-1", "conv-1")
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	require.True(t, rs.Muted)
+}
+
+// --- User prefs ---
+
+func TestWave2_UserPrefs_Defaults(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	prefs, err := store.GetUserPrefs(context.Background(), "user-1")
+	require.NoError(t, err)
+	require.NotNil(t, prefs)
+	require.Equal(t, "user-1", prefs.UserID)
+	require.Equal(t, "activity", prefs.SpaceSortMode)
+	require.Equal(t, "activity", prefs.ThreadSortMode)
+	require.Empty(t, prefs.SpaceOrder)
+}
+
+func TestWave2_UserPrefs_SetAndGet(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	require.NoError(t, store.SetUserPrefs(ctx, "user-1", WebChatUserPrefs{
+		UserID:         "user-1",
+		SpaceSortMode:  "custom",
+		SpaceOrder:     `["proj-1","proj-2"]`,
+		ThreadSortMode: "alpha",
+	}))
+
+	prefs, err := store.GetUserPrefs(ctx, "user-1")
+	require.NoError(t, err)
+	require.Equal(t, "custom", prefs.SpaceSortMode)
+	require.Equal(t, `["proj-1","proj-2"]`, prefs.SpaceOrder)
+	require.Equal(t, "alpha", prefs.ThreadSortMode)
+}
+
+func TestWave2_UserPrefs_Upsert(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	require.NoError(t, store.SetUserPrefs(ctx, "user-1", WebChatUserPrefs{
+		UserID: "user-1", SpaceSortMode: "alpha", ThreadSortMode: "alpha",
+	}))
+	require.NoError(t, store.SetUserPrefs(ctx, "user-1", WebChatUserPrefs{
+		UserID: "user-1", SpaceSortMode: "activity", ThreadSortMode: "activity",
+	}))
+
+	prefs, err := store.GetUserPrefs(ctx, "user-1")
+	require.NoError(t, err)
+	require.Equal(t, "activity", prefs.SpaceSortMode)
+}
+
+// --- DM ---
+
+func TestWave2_DM_UpsertAndList(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Upsert both sides of a DM.
+	require.NoError(t, store.UpsertDM(ctx, WebChatDM{
+		ConversationKey: "dm:agent:a1:user:u1",
+		ParticipantID:   "u1",
+		PeerID:          "a1",
+		PeerKind:        "agent",
+		LastMessageID:   "msg-1",
+		LastActivityAt:  now,
+	}))
+	require.NoError(t, store.UpsertDM(ctx, WebChatDM{
+		ConversationKey: "dm:agent:a1:user:u1",
+		ParticipantID:   "a1",
+		PeerID:          "u1",
+		PeerKind:        "user",
+		LastMessageID:   "msg-1",
+		LastActivityAt:  now,
+	}))
+
+	// List from user side.
+	dms, err := store.ListDMs(ctx, "u1")
+	require.NoError(t, err)
+	require.Len(t, dms, 1)
+	require.Equal(t, "dm:agent:a1:user:u1", dms[0].ConversationKey)
+	require.Equal(t, "a1", dms[0].PeerID)
+	require.Equal(t, "agent", dms[0].PeerKind)
+
+	// List from agent side.
+	dms, err = store.ListDMs(ctx, "a1")
+	require.NoError(t, err)
+	require.Len(t, dms, 1)
+	require.Equal(t, "u1", dms[0].PeerID)
+}
+
+func TestWave2_DM_TouchActivity(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	require.NoError(t, store.UpsertDM(ctx, WebChatDM{
+		ConversationKey: "dm:agent:a1:user:u1",
+		ParticipantID:   "u1",
+		PeerID:          "a1",
+		PeerKind:        "agent",
+		LastMessageID:   "msg-1",
+		LastActivityAt:  now,
+	}))
+	require.NoError(t, store.UpsertDM(ctx, WebChatDM{
+		ConversationKey: "dm:agent:a1:user:u1",
+		ParticipantID:   "a1",
+		PeerID:          "u1",
+		PeerKind:        "user",
+		LastMessageID:   "msg-1",
+		LastActivityAt:  now,
+	}))
+
+	// Touch activity — should update both rows.
+	require.NoError(t, store.TouchDMActivity(ctx, "dm:agent:a1:user:u1", "msg-5"))
+
+	dms, err := store.ListDMs(ctx, "u1")
+	require.NoError(t, err)
+	require.Len(t, dms, 1)
+	require.Equal(t, "msg-5", dms[0].LastMessageID)
+
+	dms, err = store.ListDMs(ctx, "a1")
+	require.NoError(t, err)
+	require.Len(t, dms, 1)
+	require.Equal(t, "msg-5", dms[0].LastMessageID)
+}
+
+func TestWave2_DM_ListEmpty(t *testing.T) {
+	store, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	dms, err := store.ListDMs(context.Background(), "nobody")
+	require.NoError(t, err)
+	require.Nil(t, dms)
+}
+
+// --- Migration: thread_id backfill ---
+
+func TestWave2_Migration_ThreadIDBackfill(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	// Create a minimal messages table.
+	_, err = db.Exec(`
+CREATE TABLE messages (
+    id TEXT PRIMARY KEY,
+    sender TEXT NOT NULL,
+    sender_id TEXT NOT NULL DEFAULT '',
+    recipient TEXT NOT NULL,
+    recipient_id TEXT NOT NULL DEFAULT '',
+    channel TEXT,
+    thread_id TEXT,
+    msg TEXT NOT NULL DEFAULT ''
+)
+`)
+	require.NoError(t, err)
+
+	// Insert test messages in both directions.
+	_, err = db.Exec(`
+INSERT INTO messages (id, sender, sender_id, recipient, recipient_id, channel, thread_id, msg) VALUES
+    ('m1', 'user:alice', 'alice-uuid', 'agent:coder', 'coder-uuid', 'web', 'agent:coder-uuid', 'hello'),
+    ('m2', 'agent:coder', 'coder-uuid', 'user:alice', 'alice-uuid', 'web', 'agent:coder-uuid', 'hi back'),
+    ('m3', 'user:bob', 'bob-uuid', 'agent:reviewer', 'reviewer-uuid', 'web', 'agent:reviewer-uuid', 'review this'),
+    ('m4', 'user:alice', 'alice-uuid', 'agent:coder', 'coder-uuid', 'discord', 'agent:coder-uuid', 'discord msg'),
+    ('m5', 'user:alice', 'alice-uuid', 'agent:coder', 'coder-uuid', 'web', 'dm:agent:coder-uuid:user:alice-uuid', 'already migrated')
+`)
+	require.NoError(t, err)
+
+	// Initialize the store (triggers migration).
+	store := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, store.Init())
+
+	// Verify: m1, m2, m3 should be backfilled.
+	var threadID string
+	err = db.QueryRow("SELECT thread_id FROM messages WHERE id = 'm1'").Scan(&threadID)
+	require.NoError(t, err)
+	require.Equal(t, "dm:agent:coder-uuid:user:alice-uuid", threadID)
+
+	err = db.QueryRow("SELECT thread_id FROM messages WHERE id = 'm2'").Scan(&threadID)
+	require.NoError(t, err)
+	require.Equal(t, "dm:agent:coder-uuid:user:alice-uuid", threadID)
+
+	err = db.QueryRow("SELECT thread_id FROM messages WHERE id = 'm3'").Scan(&threadID)
+	require.NoError(t, err)
+	require.Equal(t, "dm:agent:reviewer-uuid:user:bob-uuid", threadID)
+
+	// m4 should be unchanged (discord channel, not web).
+	err = db.QueryRow("SELECT thread_id FROM messages WHERE id = 'm4'").Scan(&threadID)
+	require.NoError(t, err)
+	require.Equal(t, "agent:coder-uuid", threadID)
+
+	// m5 should be unchanged (already migrated, doesn't match 'agent:%' pattern).
+	err = db.QueryRow("SELECT thread_id FROM messages WHERE id = 'm5'").Scan(&threadID)
+	require.NoError(t, err)
+	require.Equal(t, "dm:agent:coder-uuid:user:alice-uuid", threadID)
+}
+
+func TestWave2_Migration_ThreadIDBackfill_Batching(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	// Create a minimal messages table.
+	_, err = db.Exec(`
+CREATE TABLE messages (
+    id TEXT PRIMARY KEY,
+    sender TEXT NOT NULL,
+    sender_id TEXT NOT NULL DEFAULT '',
+    recipient TEXT NOT NULL,
+    recipient_id TEXT NOT NULL DEFAULT '',
+    channel TEXT,
+    thread_id TEXT,
+    msg TEXT NOT NULL DEFAULT ''
+)
+`)
+	require.NoError(t, err)
+
+	// Insert 5 messages, then use batch size 2 to verify batching works.
+	for i := 0; i < 5; i++ {
+		_, err = db.Exec(`INSERT INTO messages (id, sender, sender_id, recipient, recipient_id, channel, thread_id, msg)
+			VALUES (?, 'user:alice', 'alice-uuid', 'agent:coder', 'coder-uuid', 'web', 'agent:coder-uuid', 'msg')`,
+			"m-"+string(rune('a'+i)))
+		require.NoError(t, err)
+	}
+
+	// Create tables first (needed for migration marker).
+	storeImpl := &sqliteWebChatStore{db: db}
+	_, err = db.Exec(`
+CREATE TABLE IF NOT EXISTS webchat_migrations (
+    name TEXT PRIMARY KEY,
+    completed_at TEXT
+)
+`)
+	require.NoError(t, err)
+
+	// Run migration with small batch size.
+	require.NoError(t, storeImpl.migrateThreadIDs(2))
+
+	// All 5 should be migrated.
+	var count int
+	err = db.QueryRow("SELECT COUNT(*) FROM messages WHERE thread_id LIKE 'agent:%'").Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+
+	var migrated int
+	err = db.QueryRow("SELECT COUNT(*) FROM messages WHERE thread_id LIKE 'dm:%'").Scan(&migrated)
+	require.NoError(t, err)
+	require.Equal(t, 5, migrated)
+}
+
+func TestWave2_Migration_Idempotent(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	// Create messages table.
+	_, err = db.Exec(`
+CREATE TABLE messages (
+    id TEXT PRIMARY KEY,
+    sender TEXT NOT NULL,
+    sender_id TEXT NOT NULL DEFAULT '',
+    recipient TEXT NOT NULL,
+    recipient_id TEXT NOT NULL DEFAULT '',
+    channel TEXT,
+    thread_id TEXT,
+    msg TEXT NOT NULL DEFAULT ''
+)
+`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`INSERT INTO messages (id, sender, sender_id, recipient, recipient_id, channel, thread_id, msg)
+		VALUES ('m1', 'user:alice', 'alice-uuid', 'agent:coder', 'coder-uuid', 'web', 'agent:coder-uuid', 'hello')`)
+	require.NoError(t, err)
+
+	// First init.
+	store1 := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, store1.Init())
+
+	// Second init should be a no-op (migration already marked complete).
+	store2 := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, store2.Init())
+
+	// Should still have the correct thread_id.
+	var threadID string
+	err = db.QueryRow("SELECT thread_id FROM messages WHERE id = 'm1'").Scan(&threadID)
+	require.NoError(t, err)
+	require.Equal(t, "dm:agent:coder-uuid:user:alice-uuid", threadID)
+}
+
+// --- Wave-1 seeding ---
+
+func TestWave2_SeedFromWave1(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	// Manually create wave-1 tables and seed them.
+	_, err = db.Exec(`
+CREATE TABLE webchat_thread (
+    user_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    last_message_id TEXT,
+    last_activity_at TEXT,
+    last_read_at TEXT,
+    PRIMARY KEY (user_id, project_id, agent_id)
+);
+CREATE TABLE webchat_thread_prefs (
+    user_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    visibility_mode TEXT DEFAULT 'conversation',
+    show_state_changes INTEGER DEFAULT 0,
+    show_agent_to_agent INTEGER DEFAULT 0,
+    muted INTEGER DEFAULT 0,
+    PRIMARY KEY (user_id, project_id, agent_id)
+);
+INSERT INTO webchat_thread VALUES ('user-1', 'proj-1', 'agent-1', 'msg-10', '2026-01-01T00:00:00Z', '2025-12-31T00:00:00Z');
+INSERT INTO webchat_thread VALUES ('user-2', 'proj-1', 'agent-1', 'msg-20', '2026-01-02T00:00:00Z', NULL);
+INSERT INTO webchat_thread_prefs VALUES ('user-1', 'proj-1', 'agent-1', 'conversation', 0, 0, 1);
+`)
+	require.NoError(t, err)
+
+	// Init the store (creates wave-2 tables and runs seeding).
+	store := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, store.Init())
+
+	ctx := context.Background()
+
+	// user-1 should have a DM entry.
+	dms, err := store.ListDMs(ctx, "user-1")
+	require.NoError(t, err)
+	require.Len(t, dms, 1)
+	require.Equal(t, "dm:agent:agent-1:user:user-1", dms[0].ConversationKey)
+	require.Equal(t, "agent-1", dms[0].PeerID)
+	require.Equal(t, "agent", dms[0].PeerKind)
+
+	// agent-1 should have DM entries for both users.
+	dms, err = store.ListDMs(ctx, "agent-1")
+	require.NoError(t, err)
+	require.Len(t, dms, 2)
+
+	// user-1 should have read state with muted flag.
+	rs, err := store.GetReadState(ctx, "user-1", "dm:agent:agent-1:user:user-1")
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	require.True(t, rs.Muted)
+
+	// user-2 should NOT have a read state (last_read_at was NULL).
+	rs, err = store.GetReadState(ctx, "user-2", "dm:agent:agent-1:user:user-2")
+	require.NoError(t, err)
+	require.Nil(t, rs)
+}
+
+func TestWave2_SeedFromWave1_Idempotent(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	_, err = db.Exec(`
+CREATE TABLE webchat_thread (
+    user_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    last_message_id TEXT,
+    last_activity_at TEXT,
+    last_read_at TEXT,
+    PRIMARY KEY (user_id, project_id, agent_id)
+);
+CREATE TABLE webchat_thread_prefs (
+    user_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,
+    agent_id TEXT NOT NULL,
+    visibility_mode TEXT DEFAULT 'conversation',
+    show_state_changes INTEGER DEFAULT 0,
+    show_agent_to_agent INTEGER DEFAULT 0,
+    muted INTEGER DEFAULT 0,
+    PRIMARY KEY (user_id, project_id, agent_id)
+);
+INSERT INTO webchat_thread VALUES ('user-1', 'proj-1', 'agent-1', 'msg-10', '2026-01-01T00:00:00Z', '2025-12-31T00:00:00Z');
+`)
+	require.NoError(t, err)
+
+	store1 := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, store1.Init())
+
+	// Second init should succeed (seed already complete).
+	store2 := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, store2.Init())
+
+	// Verify DM still exists and there's only one.
+	ctx := context.Background()
+	dms, err := store2.ListDMs(ctx, "user-1")
+	require.NoError(t, err)
+	require.Len(t, dms, 1)
+}
+
+// --- Helper tests ---
+
+func TestParseSQLiteTime(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		zero  bool
+	}{
+		{"empty", "", true},
+		{"RFC3339Nano", "2026-01-01T00:00:00Z", false},
+		{"RFC3339Nano with nanos", "2026-01-01T00:00:00.123456789Z", false},
+		{"SQLite format with tz", "2026-01-01 00:00:00.000000000-07:00", false},
+		{"SQLite format no tz", "2026-01-01 00:00:00.000000000", false},
+		{"garbage", "not-a-time", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseSQLiteTime(tt.input)
+			require.Equal(t, tt.zero, result.IsZero(), "input: %q", tt.input)
+		})
+	}
+}

--- a/pkg/hub/webchannel_test.go
+++ b/pkg/hub/webchannel_test.go
@@ -387,3 +387,197 @@ func TestIdentityFromTopic_MissingUserID_ReturnsFalse(t *testing.T) {
 	_, _, _, ok := identityFromTopic("scion.project.proj1.agent.coder.messages", msg)
 	require.False(t, ok)
 }
+
+// --- Wave-2 WebChannelBus re-key tests ---
+
+func TestWebChannelBus_Publish_TopicThread(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	// Pre-create a topic so TouchTopicActivity has a row to update.
+	ctx := context.Background()
+	topicID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO webchat_topic (id, project_id, name, is_general, created_by, created_at)
+		 VALUES (?, 'proj1', 'design', 0, 'user1', datetime('now'))`,
+		topicID)
+	require.NoError(t, err)
+
+	log := slog.Default()
+	bus := NewWebChannelBus(log, store)
+
+	// Publish a message with a topic thread_id (UUID).
+	topic := "scion.project.proj1.user.user1.messages"
+	msg := &messages.StructuredMessage{
+		Version:   messages.Version,
+		Sender:    "agent:coder",
+		SenderID:  "agent-uuid-1",
+		Recipient: "user:alice",
+		Msg:       "topic message",
+		Type:      messages.TypeInstruction,
+		Channel:   "web",
+		ThreadID:  topicID,
+	}
+
+	err = bus.Publish(ctx, topic, msg)
+	require.NoError(t, err)
+
+	// Verify webchat_topic was updated (last_activity_at is non-NULL).
+	var activityAt string
+	err = db.QueryRow(`SELECT last_activity_at FROM webchat_topic WHERE id = ?`, topicID).Scan(&activityAt)
+	require.NoError(t, err)
+	require.NotEmpty(t, activityAt, "TouchTopicActivity should have updated last_activity_at")
+
+	// Verify webchat_thread was NOT updated (thread_id path takes precedence).
+	var count int
+	err = db.QueryRow(`SELECT COUNT(*) FROM webchat_thread`).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 0, count, "topic thread_id should NOT touch webchat_thread")
+}
+
+func TestWebChannelBus_Publish_DMThread(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	dmKey := "dm:agent:agent-uuid-1:user:user1"
+
+	// Pre-create DM rows so TouchDMActivity has rows to update.
+	for _, pid := range []string{"user1", "agent-uuid-1"} {
+		_, err := db.ExecContext(ctx,
+			`INSERT INTO webchat_dm (conversation_key, participant_id, peer_id, peer_kind)
+			 VALUES (?, ?, 'peer', 'user')`, dmKey, pid)
+		require.NoError(t, err)
+	}
+
+	log := slog.Default()
+	bus := NewWebChannelBus(log, store)
+
+	topic := "scion.project.proj1.user.user1.messages"
+	msg := &messages.StructuredMessage{
+		Version:   messages.Version,
+		Sender:    "agent:coder",
+		SenderID:  "agent-uuid-1",
+		Recipient: "user:alice",
+		Msg:       "DM message",
+		Type:      messages.TypeInstruction,
+		Channel:   "web",
+		ThreadID:  dmKey,
+	}
+
+	err := bus.Publish(ctx, topic, msg)
+	require.NoError(t, err)
+
+	// Verify webchat_dm was updated (last_activity_at is non-NULL).
+	var activityAt sql.NullString
+	err = db.QueryRow(`SELECT last_activity_at FROM webchat_dm WHERE participant_id = 'user1'`).Scan(&activityAt)
+	require.NoError(t, err)
+	require.True(t, activityAt.Valid, "TouchDMActivity should have updated last_activity_at")
+
+	// Verify webchat_thread was NOT updated (DM thread_id takes precedence).
+	var count int
+	err = db.QueryRow(`SELECT COUNT(*) FROM webchat_thread`).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 0, count, "DM thread_id should NOT touch webchat_thread")
+}
+
+func TestWebChannelBus_Publish_LegacyAgentThread(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	log := slog.Default()
+	bus := NewWebChannelBus(log, store)
+
+	ctx := context.Background()
+	// Legacy agent:<slug> thread_id should fall through to the
+	// (userID, projectID, agentID) path and touch webchat_thread.
+	topic := "scion.project.proj1.user.user1.messages"
+	msg := &messages.StructuredMessage{
+		Version:   messages.Version,
+		Sender:    "agent:coder",
+		SenderID:  "agent-uuid-1",
+		Recipient: "user:alice",
+		Msg:       "legacy message",
+		Type:      messages.TypeInstruction,
+		Channel:   "web",
+		ThreadID:  "agent:coder",
+	}
+
+	err := bus.Publish(ctx, topic, msg)
+	require.NoError(t, err)
+
+	// Verify webchat_thread WAS updated (legacy path).
+	var userID, projectID, agentID string
+	err = db.QueryRow(`SELECT user_id, project_id, agent_id FROM webchat_thread`).Scan(&userID, &projectID, &agentID)
+	require.NoError(t, err)
+	require.Equal(t, "user1", userID)
+	require.Equal(t, "proj1", projectID)
+	require.Equal(t, "agent-uuid-1", agentID)
+}
+
+// --- Wave-2 TouchTopicActivity / TouchDMActivity empty messageID tests ---
+
+func TestTouchTopicActivity_EmptyMessageID(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	topicID := "topic-1"
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO webchat_topic (id, project_id, name, is_general, created_by, created_at, last_message_id)
+		 VALUES (?, 'proj1', 'test', 0, 'user1', datetime('now'), 'original-msg')`, topicID)
+	require.NoError(t, err)
+
+	// Touch with empty messageID — should update last_activity_at but NOT last_message_id.
+	err = store.TouchTopicActivity(ctx, topicID, "")
+	require.NoError(t, err)
+
+	var lastMsgID string
+	var activityAt string
+	err = db.QueryRow(`SELECT last_message_id, last_activity_at FROM webchat_topic WHERE id = ?`, topicID).Scan(&lastMsgID, &activityAt)
+	require.NoError(t, err)
+	require.Equal(t, "original-msg", lastMsgID, "empty messageID should not overwrite last_message_id")
+	require.NotEmpty(t, activityAt)
+}
+
+func TestTouchTopicActivity_WithMessageID(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	topicID := "topic-2"
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO webchat_topic (id, project_id, name, is_general, created_by, created_at)
+		 VALUES (?, 'proj1', 'test2', 0, 'user1', datetime('now'))`, topicID)
+	require.NoError(t, err)
+
+	err = store.TouchTopicActivity(ctx, topicID, "msg-42")
+	require.NoError(t, err)
+
+	var lastMsgID string
+	err = db.QueryRow(`SELECT last_message_id FROM webchat_topic WHERE id = ?`, topicID).Scan(&lastMsgID)
+	require.NoError(t, err)
+	require.Equal(t, "msg-42", lastMsgID)
+}
+
+func TestTouchDMActivity_EmptyMessageID(t *testing.T) {
+	store, db := newTestWebChatStore(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	dmKey := "dm:user:a:user:b"
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO webchat_dm (conversation_key, participant_id, peer_id, peer_kind, last_message_id)
+		 VALUES (?, 'a', 'b', 'user', 'old-msg')`, dmKey)
+	require.NoError(t, err)
+
+	err = store.TouchDMActivity(ctx, dmKey, "")
+	require.NoError(t, err)
+
+	var lastMsgID string
+	var activityAt sql.NullString
+	err = db.QueryRow(`SELECT last_message_id, last_activity_at FROM webchat_dm WHERE conversation_key = ?`, dmKey).Scan(&lastMsgID, &activityAt)
+	require.NoError(t, err)
+	require.Equal(t, "old-msg", lastMsgID, "empty messageID should not overwrite last_message_id")
+	require.True(t, activityAt.Valid, "last_activity_at should be set")
+}

--- a/pkg/messages/types.go
+++ b/pkg/messages/types.go
@@ -57,6 +57,26 @@ const (
 	TypeGroupSet       = "group-set"
 	TypeMention        = "mention"
 	TypeSystem         = "system"
+
+	// TypeChat is used for human-to-human messages in shared threads and DMs.
+	// These messages are persisted with recipient "thread:<topicUUID>" or
+	// "user:<email>" and are never dispatched to an agent.
+	//
+	// type:chat audit (W2 checklist):
+	//   (a) Dispatch path: the broker inbound handler (handlers_broker_inbound.go)
+	//       routes by topic (project+agent slug), not by type. deliverToAgent and
+	//       deliverToUser in messagebroker.go pass type through without switching
+	//       on it. Human-to-human messages use recipient prefix "thread:" or
+	//       "user:", never "agent:", so they never enter the agent dispatch path.
+	//   (b) Visibility backfill: the frontend shouldShowMessage (chat-thread.ts)
+	//       defaults empty visibility to "normal" (msg.visibility || 'normal').
+	//       type:chat messages have empty visibility, so they correctly display
+	//       as normal. No backend visibility filter switches on type.
+	//   (c) Plugin Publish/Validate: broker plugins (broker_plugin.go) relay
+	//       StructuredMessage via RPC without checking the Type field. The only
+	//       type validation is in StructuredMessage.Validate(), and chat is now
+	//       in validTypes. No plugin Publish or Validate method rejects unknown types.
+	TypeChat = "chat"
 )
 
 // System message category constants identify the origin of a system message.
@@ -95,6 +115,7 @@ var validTypes = map[string]bool{
 	TypeGroupSet:       true,
 	TypeMention:        true,
 	TypeSystem:         true,
+	TypeChat:           true,
 }
 
 // StructuredMessage represents a formatted Scion message.

--- a/pkg/store/entadapter/message_store.go
+++ b/pkg/store/entadapter/message_store.go
@@ -286,6 +286,9 @@ func (s *MessageStore) ListMessages(ctx context.Context, filter store.MessageFil
 	if filter.Channel != "" {
 		query.Where(message.ChannelEQ(filter.Channel))
 	}
+	if filter.ThreadID != "" {
+		query.Where(message.ThreadIDEQ(filter.ThreadID))
+	}
 	// Visibility filter with NULL backfill awareness (review R1 fix):
 	// Old rows have NULL visibility. The read-time backfill in entMessageToStore
 	// normalises after fetch, but a simple IN predicate drops NULL rows before

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -1731,6 +1731,7 @@ type MessageFilter struct {
 	OnlyUnread    bool      // Only unread messages
 	Type          string    // Filter by message type
 	Channel       string    // Filter by channel (e.g. "web", "discord")
+	ThreadID      string    // Filter by thread_id (wave-2 conversation key)
 	Visibility    []string  // Filter to listed visibility levels
 	Before        time.Time // Upper bound for created_at (exclusive)
 }

--- a/web/src/client/api.ts
+++ b/web/src/client/api.ts
@@ -79,9 +79,7 @@ export async function apiFetch(path: string, options?: RequestInit): Promise<Res
     } catch {
       // Body wasn't JSON — use empty detail
     }
-    window.dispatchEvent(
-      new CustomEvent('scion:access-denied', { detail })
-    );
+    window.dispatchEvent(new CustomEvent('scion:access-denied', { detail }));
   }
 
   return response;

--- a/web/src/client/debug-log.ts
+++ b/web/src/client/debug-log.ts
@@ -57,7 +57,13 @@ export class DebugEventLog extends EventTarget {
     return this.entries.length;
   }
 
-  add(category: DebugCategory, label: string, subject?: string, data?: unknown, direction?: DebugDirection): void {
+  add(
+    category: DebugCategory,
+    label: string,
+    subject?: string,
+    data?: unknown,
+    direction?: DebugDirection
+  ): void {
     const entry: DebugEntry = {
       id: this.nextId++,
       timestamp: Date.now(),
@@ -98,7 +104,9 @@ export class DebugEventLog extends EventTarget {
     }) as EventListener);
 
     // SSE connection events
-    sse.addEventListener('connected', ((event: CustomEvent<{ connectionId: string; subjects: string[] }>) => {
+    sse.addEventListener('connected', ((
+      event: CustomEvent<{ connectionId: string; subjects: string[] }>
+    ) => {
       this._connectionId = event.detail.connectionId;
       this.add('connection', 'connected', undefined, event.detail);
     }) as EventListener);

--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -154,36 +154,152 @@ interface RouteConfig {
 }
 
 const ROUTES: RouteConfig[] = [
-  { pattern: /^\/login$/, tag: 'scion-login-page', load: () => import('../components/pages/login.js') },
-  { pattern: /^\/invite$/, tag: 'scion-page-invite', load: () => import('../components/pages/invite.js') },
-  { pattern: /^\/onboarding$/, tag: 'scion-page-onboarding', load: () => import('../components/pages/onboarding.js') },
+  {
+    pattern: /^\/login$/,
+    tag: 'scion-login-page',
+    load: () => import('../components/pages/login.js'),
+  },
+  {
+    pattern: /^\/invite$/,
+    tag: 'scion-page-invite',
+    load: () => import('../components/pages/invite.js'),
+  },
+  {
+    pattern: /^\/onboarding$/,
+    tag: 'scion-page-onboarding',
+    load: () => import('../components/pages/onboarding.js'),
+  },
   { pattern: /^\/$/, tag: 'scion-page-home', load: () => import('../components/pages/home.js') },
-  { pattern: /^\/projects$/, tag: 'scion-page-projects', load: () => import('../components/pages/projects.js') },
-  { pattern: /^\/agents$/, tag: 'scion-page-agents', load: () => import('../components/pages/agents.js') },
-  { pattern: /^\/brokers$/, tag: 'scion-page-brokers', load: () => import('../components/pages/brokers.js') },
-  { pattern: /^\/brokers\/[^/]+$/, tag: 'scion-page-broker-detail', load: () => import('../components/pages/broker-detail.js') },
-  { pattern: /^\/skills$/, tag: 'scion-page-skills', load: () => import('../components/pages/skills.js') },
-  { pattern: /^\/skills\/new$/, tag: 'scion-page-skill-create', load: () => import('../components/pages/skill-create.js') },
-  { pattern: /^\/skills\/[^/]+$/, tag: 'scion-page-skill-detail', load: () => import('../components/pages/skill-detail.js') },
-  { pattern: /^\/admin\/skill-registries$/, tag: 'scion-page-admin-skill-registries', load: () => import('../components/pages/admin-skill-registries.js') },
-  { pattern: /^\/admin\/skill-registries\/[^/]+$/, tag: 'scion-page-admin-skill-registry-detail', load: () => import('../components/pages/admin-skill-registry-detail.js') },
-  { pattern: /^\/admin\/scheduler$/, tag: 'scion-page-admin-scheduler', load: () => import('../components/pages/admin-scheduler.js') },
-  { pattern: /^\/admin\/users$/, tag: 'scion-page-admin-users', load: () => import('../components/pages/admin-users.js') },
-  { pattern: /^\/admin\/groups$/, tag: 'scion-page-admin-groups', load: () => import('../components/pages/admin-groups.js') },
-  { pattern: /^\/admin\/groups\/[^/]+$/, tag: 'scion-page-admin-group-detail', load: () => import('../components/pages/admin-group-detail.js') },
-  { pattern: /^\/health$/, tag: 'scion-page-health-dashboard', load: () => import('../components/pages/health-dashboard.js') },
-  { pattern: /^\/admin\/health$/, tag: 'scion-page-health-dashboard', load: () => import('../components/pages/health-dashboard.js') },
-  { pattern: /^\/metrics$/, tag: 'scion-page-metrics', load: () => import('../components/pages/metrics-dashboard.js') },
-  { pattern: /^\/admin\/metrics$/, tag: 'scion-page-metrics', load: () => import('../components/pages/metrics-dashboard.js') },
-  { pattern: /^\/admin\/diagnostics$/, tag: 'scion-page-diagnostics', load: () => import('../components/pages/diagnostics.js') },
-  { pattern: /^\/admin\/maintenance$/, tag: 'scion-page-admin-maintenance', load: () => import('../components/pages/admin-maintenance.js') },
-  { pattern: /^\/admin\/integrations$/, tag: 'scion-page-admin-integrations', load: () => import('../components/pages/admin-integrations.js') },
-  { pattern: /^\/admin\/integrations\/[^/]+$/, tag: 'scion-page-admin-integrations', load: () => import('../components/pages/admin-integrations.js') },
-  { pattern: /^\/admin\/server-config$/, tag: 'scion-page-admin-server-config', load: () => import('../components/pages/admin-server-config.js') },
-  { pattern: /^\/admin\/federation$/, tag: 'scion-page-admin-federation', load: () => import('../components/pages/admin-federation.js') },
-  { pattern: /^\/settings$/, tag: 'scion-page-settings', load: () => import('../components/pages/settings.js') },
-  { pattern: /^\/settings\/templates\/[^/]+$/, tag: 'scion-page-template-detail', load: () => import('../components/pages/template-detail.js') },
-  { pattern: /^\/settings\/harness-configs\/[^/]+$/, tag: 'scion-page-harness-config-detail', load: () => import('../components/pages/harness-config-detail.js') },
+  {
+    pattern: /^\/projects$/,
+    tag: 'scion-page-projects',
+    load: () => import('../components/pages/projects.js'),
+  },
+  {
+    pattern: /^\/agents$/,
+    tag: 'scion-page-agents',
+    load: () => import('../components/pages/agents.js'),
+  },
+  {
+    pattern: /^\/brokers$/,
+    tag: 'scion-page-brokers',
+    load: () => import('../components/pages/brokers.js'),
+  },
+  {
+    pattern: /^\/brokers\/[^/]+$/,
+    tag: 'scion-page-broker-detail',
+    load: () => import('../components/pages/broker-detail.js'),
+  },
+  {
+    pattern: /^\/skills$/,
+    tag: 'scion-page-skills',
+    load: () => import('../components/pages/skills.js'),
+  },
+  {
+    pattern: /^\/skills\/new$/,
+    tag: 'scion-page-skill-create',
+    load: () => import('../components/pages/skill-create.js'),
+  },
+  {
+    pattern: /^\/skills\/[^/]+$/,
+    tag: 'scion-page-skill-detail',
+    load: () => import('../components/pages/skill-detail.js'),
+  },
+  {
+    pattern: /^\/admin\/skill-registries$/,
+    tag: 'scion-page-admin-skill-registries',
+    load: () => import('../components/pages/admin-skill-registries.js'),
+  },
+  {
+    pattern: /^\/admin\/skill-registries\/[^/]+$/,
+    tag: 'scion-page-admin-skill-registry-detail',
+    load: () => import('../components/pages/admin-skill-registry-detail.js'),
+  },
+  {
+    pattern: /^\/admin\/scheduler$/,
+    tag: 'scion-page-admin-scheduler',
+    load: () => import('../components/pages/admin-scheduler.js'),
+  },
+  {
+    pattern: /^\/admin\/users$/,
+    tag: 'scion-page-admin-users',
+    load: () => import('../components/pages/admin-users.js'),
+  },
+  {
+    pattern: /^\/admin\/groups$/,
+    tag: 'scion-page-admin-groups',
+    load: () => import('../components/pages/admin-groups.js'),
+  },
+  {
+    pattern: /^\/admin\/groups\/[^/]+$/,
+    tag: 'scion-page-admin-group-detail',
+    load: () => import('../components/pages/admin-group-detail.js'),
+  },
+  {
+    pattern: /^\/health$/,
+    tag: 'scion-page-health-dashboard',
+    load: () => import('../components/pages/health-dashboard.js'),
+  },
+  {
+    pattern: /^\/admin\/health$/,
+    tag: 'scion-page-health-dashboard',
+    load: () => import('../components/pages/health-dashboard.js'),
+  },
+  {
+    pattern: /^\/metrics$/,
+    tag: 'scion-page-metrics',
+    load: () => import('../components/pages/metrics-dashboard.js'),
+  },
+  {
+    pattern: /^\/admin\/metrics$/,
+    tag: 'scion-page-metrics',
+    load: () => import('../components/pages/metrics-dashboard.js'),
+  },
+  {
+    pattern: /^\/admin\/diagnostics$/,
+    tag: 'scion-page-diagnostics',
+    load: () => import('../components/pages/diagnostics.js'),
+  },
+  {
+    pattern: /^\/admin\/maintenance$/,
+    tag: 'scion-page-admin-maintenance',
+    load: () => import('../components/pages/admin-maintenance.js'),
+  },
+  {
+    pattern: /^\/admin\/integrations$/,
+    tag: 'scion-page-admin-integrations',
+    load: () => import('../components/pages/admin-integrations.js'),
+  },
+  {
+    pattern: /^\/admin\/integrations\/[^/]+$/,
+    tag: 'scion-page-admin-integrations',
+    load: () => import('../components/pages/admin-integrations.js'),
+  },
+  {
+    pattern: /^\/admin\/server-config$/,
+    tag: 'scion-page-admin-server-config',
+    load: () => import('../components/pages/admin-server-config.js'),
+  },
+  {
+    pattern: /^\/admin\/federation$/,
+    tag: 'scion-page-admin-federation',
+    load: () => import('../components/pages/admin-federation.js'),
+  },
+  {
+    pattern: /^\/settings$/,
+    tag: 'scion-page-settings',
+    load: () => import('../components/pages/settings.js'),
+  },
+  {
+    pattern: /^\/settings\/templates\/[^/]+$/,
+    tag: 'scion-page-template-detail',
+    load: () => import('../components/pages/template-detail.js'),
+  },
+  {
+    pattern: /^\/settings\/harness-configs\/[^/]+$/,
+    tag: 'scion-page-harness-config-detail',
+    load: () => import('../components/pages/harness-config-detail.js'),
+  },
   // Parentless service accounts only (hub and user scope). Project-scoped ones
   // are managed from their project's settings tab, which is the surface that
   // computes their capabilities; see the page component for why there is no
@@ -199,43 +315,173 @@ const ROUTES: RouteConfig[] = [
   // Adding the tag here would deny a read the API grants, i.e. change who may
   // read hub-scoped accounts — which is an open policy question, not a routing
   // decision to settle here.
-  { pattern: /^\/settings\/service-accounts\/[^/]+$/, tag: 'scion-page-gcp-service-account-detail', load: () => import('../components/pages/gcp-service-account-detail.js') },
-  { pattern: /^\/profile\/env$/, tag: 'scion-page-profile-env-vars', load: () => import('../components/pages/profile-env-vars.js') },
-  { pattern: /^\/profile\/secrets$/, tag: 'scion-page-profile-secrets', load: () => import('../components/pages/profile-secrets.js') },
-  { pattern: /^\/profile\/settings$/, tag: 'scion-page-profile-settings', load: () => import('../components/pages/profile-settings.js') },
-  { pattern: /^\/profile\/tokens$/, tag: 'scion-page-profile-tokens', load: () => import('../components/pages/profile-tokens.js') },
-  { pattern: /^\/profile\/telegram$/, tag: 'scion-page-profile-telegram', load: () => import('../components/pages/profile-telegram.js') },
-  { pattern: /^\/profile\/teams$/, tag: 'scion-page-profile-teams', load: () => import('../components/pages/profile-teams.js') },
-  { pattern: /^\/profile\/discord$/, tag: 'scion-page-profile-discord', load: () => import('../components/pages/profile-discord.js') },
-  { pattern: /^\/profile\/skills$/, tag: 'scion-page-profile-skills', load: () => import('../components/pages/profile-skills.js') },
-  { pattern: /^\/profile$/, tag: 'scion-page-profile-env-vars', load: () => import('../components/pages/profile-env-vars.js') },
-  { pattern: /^\/github-app\/installed$/, tag: 'scion-page-github-app-setup', load: () => import('../components/pages/github-app-setup.js') },
-  { pattern: /^\/projects\/new$/, tag: 'scion-page-project-create', load: () => import('../components/pages/project-create.js') },
-  { pattern: /^\/projects\/[^/]+\/settings$/, tag: 'scion-page-project-settings', load: () => import('../components/pages/project-settings.js') },
-  { pattern: /^\/projects\/[^/]+\/templates\/[^/]+$/, tag: 'scion-page-template-detail', load: () => import('../components/pages/template-detail.js') },
-  { pattern: /^\/projects\/[^/]+\/harness-configs\/[^/]+$/, tag: 'scion-page-harness-config-detail', load: () => import('../components/pages/harness-config-detail.js') },
-  { pattern: /^\/projects\/[^/]+\/schedules$/, tag: 'scion-page-project-schedules', load: () => import('../components/pages/project-schedules.js') },
-  { pattern: /^\/projects\/[^/]+\/metrics$/, tag: 'scion-page-metrics', load: () => import('../components/pages/metrics-dashboard.js') },
-  { pattern: /^\/projects\/[^/]+$/, tag: 'scion-page-project-detail', load: () => import('../components/pages/project-detail.js') },
-  { pattern: /^\/agents\/new$/, tag: 'scion-page-agent-create', load: () => import('../components/pages/agent-create.js') },
-  { pattern: /^\/agents\/graph$/, tag: 'scion-page-agent-graph', load: () => import('../components/pages/agent-graph.js') },
-  { pattern: /^\/agents\/[^/]+\/configure$/, tag: 'scion-page-agent-configure', load: () => import('../components/pages/agent-configure.js') },
-  { pattern: /^\/agents\/[^/]+\/terminal$/, tag: 'scion-page-terminal', load: () => import('../components/pages/terminal.js') },
-  { pattern: /^\/agents\/[^/]+$/, tag: 'scion-page-agent-detail', load: () => import('../components/pages/agent-detail.js') },
+  {
+    pattern: /^\/settings\/service-accounts\/[^/]+$/,
+    tag: 'scion-page-gcp-service-account-detail',
+    load: () => import('../components/pages/gcp-service-account-detail.js'),
+  },
+  {
+    pattern: /^\/profile\/env$/,
+    tag: 'scion-page-profile-env-vars',
+    load: () => import('../components/pages/profile-env-vars.js'),
+  },
+  {
+    pattern: /^\/profile\/secrets$/,
+    tag: 'scion-page-profile-secrets',
+    load: () => import('../components/pages/profile-secrets.js'),
+  },
+  {
+    pattern: /^\/profile\/settings$/,
+    tag: 'scion-page-profile-settings',
+    load: () => import('../components/pages/profile-settings.js'),
+  },
+  {
+    pattern: /^\/profile\/tokens$/,
+    tag: 'scion-page-profile-tokens',
+    load: () => import('../components/pages/profile-tokens.js'),
+  },
+  {
+    pattern: /^\/profile\/telegram$/,
+    tag: 'scion-page-profile-telegram',
+    load: () => import('../components/pages/profile-telegram.js'),
+  },
+  {
+    pattern: /^\/profile\/teams$/,
+    tag: 'scion-page-profile-teams',
+    load: () => import('../components/pages/profile-teams.js'),
+  },
+  {
+    pattern: /^\/profile\/discord$/,
+    tag: 'scion-page-profile-discord',
+    load: () => import('../components/pages/profile-discord.js'),
+  },
+  {
+    pattern: /^\/profile\/skills$/,
+    tag: 'scion-page-profile-skills',
+    load: () => import('../components/pages/profile-skills.js'),
+  },
+  {
+    pattern: /^\/profile$/,
+    tag: 'scion-page-profile-env-vars',
+    load: () => import('../components/pages/profile-env-vars.js'),
+  },
+  {
+    pattern: /^\/github-app\/installed$/,
+    tag: 'scion-page-github-app-setup',
+    load: () => import('../components/pages/github-app-setup.js'),
+  },
+  {
+    pattern: /^\/projects\/new$/,
+    tag: 'scion-page-project-create',
+    load: () => import('../components/pages/project-create.js'),
+  },
+  {
+    pattern: /^\/projects\/[^/]+\/settings$/,
+    tag: 'scion-page-project-settings',
+    load: () => import('../components/pages/project-settings.js'),
+  },
+  {
+    pattern: /^\/projects\/[^/]+\/templates\/[^/]+$/,
+    tag: 'scion-page-template-detail',
+    load: () => import('../components/pages/template-detail.js'),
+  },
+  {
+    pattern: /^\/projects\/[^/]+\/harness-configs\/[^/]+$/,
+    tag: 'scion-page-harness-config-detail',
+    load: () => import('../components/pages/harness-config-detail.js'),
+  },
+  {
+    pattern: /^\/projects\/[^/]+\/schedules$/,
+    tag: 'scion-page-project-schedules',
+    load: () => import('../components/pages/project-schedules.js'),
+  },
+  {
+    pattern: /^\/projects\/[^/]+\/metrics$/,
+    tag: 'scion-page-metrics',
+    load: () => import('../components/pages/metrics-dashboard.js'),
+  },
+  {
+    pattern: /^\/projects\/[^/]+$/,
+    tag: 'scion-page-project-detail',
+    load: () => import('../components/pages/project-detail.js'),
+  },
+  {
+    pattern: /^\/agents\/new$/,
+    tag: 'scion-page-agent-create',
+    load: () => import('../components/pages/agent-create.js'),
+  },
+  {
+    pattern: /^\/agents\/graph$/,
+    tag: 'scion-page-agent-graph',
+    load: () => import('../components/pages/agent-graph.js'),
+  },
+  {
+    pattern: /^\/agents\/[^/]+\/configure$/,
+    tag: 'scion-page-agent-configure',
+    load: () => import('../components/pages/agent-configure.js'),
+  },
+  {
+    pattern: /^\/agents\/[^/]+\/terminal$/,
+    tag: 'scion-page-terminal',
+    load: () => import('../components/pages/terminal.js'),
+  },
+  {
+    pattern: /^\/agents\/[^/]+$/,
+    tag: 'scion-page-agent-detail',
+    load: () => import('../components/pages/agent-detail.js'),
+  },
   // Chat mode routes (Phase 5 — top-level chat)
-  { pattern: /^\/chat$/, tag: 'scion-page-chat', load: () => import('../components/pages/chat.js') },
-  { pattern: /^\/chat\/[^/]+$/, tag: 'scion-page-chat', load: () => import('../components/pages/chat.js') },
+  {
+    pattern: /^\/chat$/,
+    tag: 'scion-page-chat',
+    load: () => import('../components/pages/chat.js'),
+  },
+  // Wave-2 v2 chat routes: space, thread, and DM navigation
+  {
+    pattern: /^\/chat\/space\/[^/]+\/thread\/[^/]+$/,
+    tag: 'scion-page-chat',
+    load: () => import('../components/pages/chat.js'),
+  },
+  {
+    pattern: /^\/chat\/space\/[^/]+$/,
+    tag: 'scion-page-chat',
+    load: () => import('../components/pages/chat.js'),
+  },
+  {
+    pattern: /^\/chat\/dm\/[^/]+$/,
+    tag: 'scion-page-chat',
+    load: () => import('../components/pages/chat.js'),
+  },
+  // Wave-1 agent-based route (preserved for v1 flag compat)
+  {
+    pattern: /^\/chat\/[^/]+$/,
+    tag: 'scion-page-chat',
+    load: () => import('../components/pages/chat.js'),
+  },
 ];
 
 /**
  * Routes that render without the app shell (full-page layout)
  */
-const STANDALONE_ROUTES = new Set(['scion-login-page', 'scion-page-invite', 'scion-page-onboarding']);
+const STANDALONE_ROUTES = new Set([
+  'scion-login-page',
+  'scion-page-invite',
+  'scion-page-onboarding',
+]);
 
 /**
  * Routes that render inside the profile shell instead of the main app shell
  */
-const PROFILE_ROUTES = new Set(['scion-page-profile-env-vars', 'scion-page-profile-secrets', 'scion-page-profile-settings', 'scion-page-profile-tokens', 'scion-page-profile-telegram', 'scion-page-profile-teams', 'scion-page-profile-discord', 'scion-page-profile-skills']);
+const PROFILE_ROUTES = new Set([
+  'scion-page-profile-env-vars',
+  'scion-page-profile-secrets',
+  'scion-page-profile-settings',
+  'scion-page-profile-tokens',
+  'scion-page-profile-telegram',
+  'scion-page-profile-teams',
+  'scion-page-profile-discord',
+  'scion-page-profile-skills',
+]);
 
 /**
  * Routes that render inside the chat shell (Phase 5 — top-level chat mode).
@@ -246,7 +492,21 @@ const CHAT_ROUTES = new Set(['scion-page-chat']);
 /**
  * Routes that require admin role. Non-admin users are redirected to dashboard.
  */
-const ADMIN_ROUTES = new Set(['scion-page-settings', 'scion-page-admin-scheduler', 'scion-page-admin-maintenance', 'scion-page-admin-users', 'scion-page-admin-groups', 'scion-page-admin-group-detail', 'scion-page-admin-server-config', 'scion-page-admin-federation', 'scion-page-admin-integrations', 'scion-page-admin-skill-registries', 'scion-page-admin-skill-registry-detail', 'scion-page-diagnostics', 'scion-page-health-dashboard']);
+const ADMIN_ROUTES = new Set([
+  'scion-page-settings',
+  'scion-page-admin-scheduler',
+  'scion-page-admin-maintenance',
+  'scion-page-admin-users',
+  'scion-page-admin-groups',
+  'scion-page-admin-group-detail',
+  'scion-page-admin-server-config',
+  'scion-page-admin-federation',
+  'scion-page-admin-integrations',
+  'scion-page-admin-skill-registries',
+  'scion-page-admin-skill-registry-detail',
+  'scion-page-diagnostics',
+  'scion-page-health-dashboard',
+]);
 
 // ---------------------------------------------------------------------------
 // Global error boundary — registered once so all shells share it.
@@ -448,13 +708,11 @@ async function renderRoute(path: string): Promise<void> {
   if (shellType === 'profile' && !customElements.get('scion-profile-shell')) {
     loads.push(
       import('../components/profile/profile-shell.js'),
-      import('../components/profile/profile-nav.js'),
+      import('../components/profile/profile-nav.js')
     );
   }
   if (shellType === 'chat' && !customElements.get('scion-chat-shell')) {
-    loads.push(
-      import('../components/chat/chat-shell.js'),
-    );
+    loads.push(import('../components/chat/chat-shell.js'));
   }
   await Promise.all(loads);
 
@@ -473,7 +731,13 @@ async function renderRoute(path: string): Promise<void> {
     activeShell = null;
     const page = document.createElement(tag);
     appContainer.appendChild(page);
-    setDocumentTitle(tag === 'scion-login-page' ? 'Login' : tag === 'scion-page-invite' ? 'Invite' : 'Page Not Found');
+    setDocumentTitle(
+      tag === 'scion-login-page'
+        ? 'Login'
+        : tag === 'scion-page-invite'
+          ? 'Invite'
+          : 'Page Not Found'
+    );
   } else if (activeShell) {
     // Reuse existing shell — just update properties and swap page content
     const shell = activeShell.element as HTMLElement & {
@@ -581,9 +845,7 @@ function navigateTo(path: string): void {
 
   // Prefix app-relative paths with the base path for the browser URL bar
   const base = import.meta.env.BASE_URL;
-  const browserPath = base && base !== '/'
-    ? base.replace(/\/$/, '') + path
-    : path;
+  const browserPath = base && base !== '/' ? base.replace(/\/$/, '') + path : path;
   window.history.pushState({}, '', browserPath);
   void renderRoute(path);
 }

--- a/web/src/client/page-title.ts
+++ b/web/src/client/page-title.ts
@@ -67,6 +67,6 @@ export function dispatchPageTitle(element: HTMLElement, ...segments: string[]): 
       detail: { segments },
       bubbles: true,
       composed: true,
-    }),
+    })
   );
 }

--- a/web/src/client/state.ts
+++ b/web/src/client/state.ts
@@ -65,7 +65,9 @@ export type StateEventType =
   | 'notification-created'
   | 'user-message-created'
   | 'chat-message-received'
-  | 'chat-topic-updated';
+  | 'chat-topic-updated'
+  | 'chat-presence-updated'
+  | 'chat-typing-received';
 
 export class StateManager extends EventTarget {
   private state: AppState = {
@@ -292,9 +294,15 @@ export class StateManager extends EventTarget {
           this.notifyWithData('chat-message-received', chatDetail);
         } else if (chatEventType === 'topic') {
           this.notifyWithData('chat-topic-updated', chatDetail);
+        } else if (chatEventType === 'presence') {
+          this.notifyWithData('chat-presence-updated', chatDetail);
+        } else if (chatEventType === 'typing') {
+          this.notifyWithData('chat-typing-received', chatDetail);
         }
         // Also dispatch the legacy user-message-created for v1 compat
-        this.notify('user-message-created');
+        if (chatEventType === 'message') {
+          this.notify('user-message-created');
+        }
         return;
       }
 

--- a/web/src/client/state.ts
+++ b/web/src/client/state.ts
@@ -38,7 +38,8 @@ export type ViewScope =
   | { type: 'project'; projectId: string }
   | { type: 'agent-detail'; projectId: string; agentId: string }
   | { type: 'brokers-list' }
-  | { type: 'broker-detail'; brokerId: string };
+  | { type: 'broker-detail'; brokerId: string }
+  | { type: 'chat'; spaceIds: string[]; userId: string };
 
 /** Full in-memory state for the current scope */
 export interface AppState {
@@ -62,7 +63,9 @@ export type StateEventType =
   | 'disconnected'
   | 'scope-changed'
   | 'notification-created'
-  | 'user-message-created';
+  | 'user-message-created'
+  | 'chat-message-received'
+  | 'chat-topic-updated';
 
 export class StateManager extends EventTarget {
   private state: AppState = {
@@ -116,7 +119,7 @@ export class StateManager extends EventTarget {
    */
   hydrate(
     initialData: { agents?: Agent[]; projects?: Project[] },
-    scopeCapabilities?: import('../shared/types.js').Capabilities,
+    scopeCapabilities?: import('../shared/types.js').Capabilities
   ): void {
     if (initialData.agents) {
       for (const agent of initialData.agents) {
@@ -188,6 +191,18 @@ export class StateManager extends EventTarget {
 
       case 'broker-detail':
         return ['broker.>', 'notification.>'];
+
+      case 'chat': {
+        const subs: string[] = [];
+        for (const spaceId of scope.spaceIds) {
+          subs.push(`project.${spaceId}.chat.>`);
+          // Also subscribe to project-level agent events for the members sidebar
+          subs.push(`project.${spaceId}.agent.>`);
+        }
+        subs.push(`user.${scope.userId}.chat.>`);
+        subs.push('notification.>');
+        return subs;
+      }
     }
   }
 
@@ -199,6 +214,13 @@ export class StateManager extends EventTarget {
     if (a.type === 'project' && b.type === 'project') return a.projectId === b.projectId;
     if (a.type === 'agent-detail' && b.type === 'agent-detail') {
       return a.projectId === b.projectId && a.agentId === b.agentId;
+    }
+    if (a.type === 'chat' && b.type === 'chat') {
+      return (
+        a.userId === b.userId &&
+        a.spaceIds.length === b.spaceIds.length &&
+        a.spaceIds.every((id, i) => id === b.spaceIds[i])
+      );
     }
     return false;
   }
@@ -215,6 +237,12 @@ export class StateManager extends EventTarget {
     // Notification events: notification.created
     if (parts[0] === 'notification') {
       this.notify('notification-created');
+      return;
+    }
+
+    // User-scoped chat events: user.{userId}.chat.dm
+    if (parts[0] === 'user' && parts.length >= 4 && parts[2] === 'chat') {
+      this.notify('chat-message-received');
       return;
     }
 
@@ -255,6 +283,19 @@ export class StateManager extends EventTarget {
         return;
       }
 
+      // Chat events: project.{projectId}.chat.{eventType}
+      if (parts[2] === 'chat' && parts.length >= 4) {
+        const chatEventType = parts[3];
+        if (chatEventType === 'message') {
+          this.notify('chat-message-received');
+        } else if (chatEventType === 'topic') {
+          this.notify('chat-topic-updated');
+        }
+        // Also dispatch the legacy user-message-created for v1 compat
+        this.notify('user-message-created');
+        return;
+      }
+
       // User-targeted message events: project.{projectId}.user.{userId}
       if (parts[2] === 'user') {
         this.notify('user-message-created');
@@ -292,7 +333,7 @@ export class StateManager extends EventTarget {
         this.pendingAgentDeltas.set(agentId, prev ? { ...prev, ...delta } : delta);
         return;
       }
-      let base = existing || ({} as Agent);
+      const base = existing || ({} as Agent);
 
       // For "created" events, apply any buffered deltas that arrived early.
       // The buffered delta is applied AFTER the created snapshot so that
@@ -318,7 +359,7 @@ export class StateManager extends EventTarget {
         delete delta.activity;
       }
       // Promote detail fields from SSE detail to top-level agent
-      const detail = delta.detail as import('../shared/types.js').AgentDetail | undefined;
+      const detail = delta.detail as import('../shared/types.js').AgentDetail;
       if (detail) {
         if (detail.message) {
           (delta as Record<string, unknown>).message = detail.message;
@@ -381,7 +422,7 @@ export class StateManager extends EventTarget {
       const existing = this.state.brokers.get(brokerId) || ({} as RuntimeBroker);
       const delta = data as Partial<RuntimeBroker>;
       // Map brokerId field from event payload to id
-      const id = (delta as Record<string, unknown>).brokerId as string || brokerId;
+      const id = ((delta as Record<string, unknown>).brokerId as string) || brokerId;
       const updated = { ...existing, ...delta, id };
       this.state.brokers.set(id, updated as RuntimeBroker);
     }

--- a/web/src/client/state.ts
+++ b/web/src/client/state.ts
@@ -242,7 +242,7 @@ export class StateManager extends EventTarget {
 
     // User-scoped chat events: user.{userId}.chat.dm
     if (parts[0] === 'user' && parts.length >= 4 && parts[2] === 'chat') {
-      this.notify('chat-message-received');
+      this.notifyWithData('chat-message-received', data);
       return;
     }
 
@@ -286,10 +286,12 @@ export class StateManager extends EventTarget {
       // Chat events: project.{projectId}.chat.{eventType}
       if (parts[2] === 'chat' && parts.length >= 4) {
         const chatEventType = parts[3];
+        // Include projectId and the SSE payload so consumers can filter by conversation
+        const chatDetail = { projectId, ...(data as Record<string, unknown>) };
         if (chatEventType === 'message') {
-          this.notify('chat-message-received');
+          this.notifyWithData('chat-message-received', chatDetail);
         } else if (chatEventType === 'topic') {
-          this.notify('chat-topic-updated');
+          this.notifyWithData('chat-topic-updated', chatDetail);
         }
         // Also dispatch the legacy user-message-created for v1 compat
         this.notify('user-message-created');
@@ -431,6 +433,11 @@ export class StateManager extends EventTarget {
 
   private notify(event: StateEventType): void {
     this.dispatchEvent(new CustomEvent(event, { detail: this.state }));
+  }
+
+  /** Dispatch an event with additional SSE payload data for consumer filtering. */
+  private notifyWithData(event: StateEventType, data: unknown): void {
+    this.dispatchEvent(new CustomEvent(event, { detail: { state: this.state, data } }));
   }
 
   /**

--- a/web/src/components/chat/chat-shell.ts
+++ b/web/src/components/chat/chat-shell.ts
@@ -41,6 +41,7 @@ import { showToast } from '../../utils/toast.js';
 import { performLogout } from '../../utils/auth.js';
 import { setDocumentTitle, PAGE_TITLE_EVENT } from '../../client/page-title.js';
 import type { PageTitleDetail } from '../../client/page-title.js';
+import { isFeatureEnabled, NATIVE_CHAT_V2_FLAG } from '../../utils/feature-flags.js';
 
 @customElement('scion-chat-shell')
 export class ScionChatShell extends LitElement {
@@ -74,6 +75,84 @@ export class ScionChatShell extends LitElement {
       overflow: hidden;
       display: flex;
       flex-direction: column;
+    }
+
+    /* V2 three-panel layout */
+    .content-v2 {
+      flex: 1;
+      overflow: hidden;
+      display: flex;
+      flex-direction: row;
+    }
+
+    .content-v2 .rail-panel {
+      width: 260px;
+      min-width: 200px;
+      max-width: 320px;
+      border-right: 1px solid var(--scion-border, #e2e8f0);
+      overflow: hidden;
+    }
+
+    .content-v2 .center-panel {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .content-v2 .members-panel {
+      width: 240px;
+      border-left: 1px solid var(--scion-border, #e2e8f0);
+      background: var(--scion-surface, #ffffff);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .members-panel.collapsed {
+      display: none;
+    }
+
+    .members-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.75rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      font-size: 0.8125rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .members-placeholder {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.8125rem;
+      padding: 1rem;
+      text-align: center;
+    }
+
+    /* Members toggle button in the header area */
+    .members-toggle {
+      position: absolute;
+      right: 1rem;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+
+    @media (max-width: 768px) {
+      .content-v2 .rail-panel {
+        width: 100%;
+        max-width: none;
+      }
+
+      .content-v2 .members-panel {
+        display: none;
+      }
     }
   `;
 
@@ -130,6 +209,8 @@ export class ScionChatShell extends LitElement {
   }
 
   override render() {
+    const isV2 = isFeatureEnabled(NATIVE_CHAT_V2_FLAG);
+
     return html`
       <main class="main">
         <scion-header
@@ -140,7 +221,7 @@ export class ScionChatShell extends LitElement {
           @logout=${(): void => this.handleLogout()}
         ></scion-header>
 
-        <div class="content">
+        <div class="${isV2 ? 'content-v2' : 'content'}">
           <slot></slot>
         </div>
       </main>

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -24,7 +24,14 @@
 export { ScionApp } from './app-shell.js';
 
 // Shared components
-export { ScionNav, ScionHeader, ScionBreadcrumb, ScionStatusBadge, ScionViewToggle, ScionPreStartHookList } from './shared/index.js';
+export {
+  ScionNav,
+  ScionHeader,
+  ScionBreadcrumb,
+  ScionStatusBadge,
+  ScionViewToggle,
+  ScionPreStartHookList,
+} from './shared/index.js';
 export type { StatusType } from './shared/index.js';
 export type { ViewMode } from './shared/index.js';
 

--- a/web/src/components/pages/admin-federation.ts
+++ b/web/src/components/pages/admin-federation.ts
@@ -599,7 +599,13 @@ export class ScionPageAdminFederation extends LitElement {
           <sl-icon name="globe"></sl-icon>
           <h1>Federation Authentication</h1>
         </div>
-        <sl-button variant="primary" ?loading=${this.saving} @click=${() => { void this.save(); }}>
+        <sl-button
+          variant="primary"
+          ?loading=${this.saving}
+          @click=${() => {
+            void this.save();
+          }}
+        >
           Save
         </sl-button>
       </div>
@@ -607,9 +613,7 @@ export class ScionPageAdminFederation extends LitElement {
         Manage trusted external OIDC issuers for cross-hub federation authentication.
       </p>
 
-      ${this.renderGlobalSettings()}
-      ${this.renderIssuersSection()}
-      ${this.renderAddEditDialog()}
+      ${this.renderGlobalSettings()} ${this.renderIssuersSection()} ${this.renderAddEditDialog()}
       ${this.renderDeleteDialog()}
     `;
   }
@@ -621,7 +625,14 @@ export class ScionPageAdminFederation extends LitElement {
       <div class="section">
         <div class="section-header">
           <h3 class="section-title">Global Settings</h3>
-          <sl-button size="small" variant="default" ?loading=${this.downloading} @click=${() => { void this.downloadJWKS(); }}>
+          <sl-button
+            size="small"
+            variant="default"
+            ?loading=${this.downloading}
+            @click=${() => {
+              void this.downloadJWKS();
+            }}
+          >
             <sl-icon slot="prefix" name="download"></sl-icon>
             Download JWKS
           </sl-button>
@@ -648,7 +659,7 @@ export class ScionPageAdminFederation extends LitElement {
               @sl-change=${(e: Event) => {
                 const value = (e.target as HTMLSelectElement).value;
                 this.algorithms = Array.isArray(value)
-                  ? value as string[]
+                  ? (value as string[])
                   : value.split(' ').filter(Boolean);
               }}
             >
@@ -660,9 +671,7 @@ export class ScionPageAdminFederation extends LitElement {
         </div>
 
         <div class="cache-section">
-          <label class="cache-section-label">
-            JWKS Cache
-          </label>
+          <label class="cache-section-label"> JWKS Cache </label>
           <div class="cache-row">
             <div class="form-field">
               <label>Refresh Interval</label>
@@ -711,7 +720,8 @@ export class ScionPageAdminFederation extends LitElement {
                 <sl-icon name="shield-lock"></sl-icon>
                 <p>No trusted issuers configured.</p>
                 <p style="font-size: 0.8125rem">
-                  Add a trusted OIDC issuer to enable federation authentication from external hubs or services.
+                  Add a trusted OIDC issuer to enable federation authentication from external hubs
+                  or services.
                 </p>
               </div>
             `
@@ -726,26 +736,42 @@ export class ScionPageAdminFederation extends LitElement {
                   </tr>
                 </thead>
                 <tbody>
-                  ${this.issuers.map((issuer, index) => html`
-                    <tr>
-                      <td class="issuer-url-cell" title=${issuer.issuer_url}>${issuer.issuer_url}</td>
-                      <td>${issuer.issuer_type ?? 'hub'}</td>
-                      <td>${issuer.expected_audience
-                        ? html`<span title=${issuer.expected_audience}>${this.truncate(issuer.expected_audience, 30)}</span>`
-                        : html`<span style="color: var(--scion-text-muted, #64748b);">—</span>`}
-                      </td>
-                      <td>
-                        <div class="issuer-actions">
-                          <sl-button size="small" variant="default" @click=${() => this.openEditDialog(index)}>
-                            Edit
-                          </sl-button>
-                          <sl-button size="small" variant="danger" outline @click=${() => this.openDeleteDialog(index)}>
-                            Delete
-                          </sl-button>
-                        </div>
-                      </td>
-                    </tr>
-                  `)}
+                  ${this.issuers.map(
+                    (issuer, index) => html`
+                      <tr>
+                        <td class="issuer-url-cell" title=${issuer.issuer_url}>
+                          ${issuer.issuer_url}
+                        </td>
+                        <td>${issuer.issuer_type ?? 'hub'}</td>
+                        <td>
+                          ${issuer.expected_audience
+                            ? html`<span title=${issuer.expected_audience}
+                                >${this.truncate(issuer.expected_audience, 30)}</span
+                              >`
+                            : html`<span style="color: var(--scion-text-muted, #64748b);">—</span>`}
+                        </td>
+                        <td>
+                          <div class="issuer-actions">
+                            <sl-button
+                              size="small"
+                              variant="default"
+                              @click=${() => this.openEditDialog(index)}
+                            >
+                              Edit
+                            </sl-button>
+                            <sl-button
+                              size="small"
+                              variant="danger"
+                              outline
+                              @click=${() => this.openDeleteDialog(index)}
+                            >
+                              Delete
+                            </sl-button>
+                          </div>
+                        </td>
+                      </tr>
+                    `
+                  )}
                 </tbody>
               </table>
             `}
@@ -793,8 +819,12 @@ export class ScionPageAdminFederation extends LitElement {
                     }}
                   ></sl-input>
                   ${this.issuerUrlError
-                    ? html`<span class="hint" style="color: var(--scion-error-text, #991b1b);">${this.issuerUrlError}</span>`
-                    : html`<span class="hint">The OIDC issuer URL of the trusted external hub or service.</span>`}
+                    ? html`<span class="hint" style="color: var(--scion-error-text, #991b1b);"
+                        >${this.issuerUrlError}</span
+                      >`
+                    : html`<span class="hint"
+                        >The OIDC issuer URL of the trusted external hub or service.</span
+                      >`}
                 </div>
 
                 <div class="form-field">
@@ -848,7 +878,9 @@ export class ScionPageAdminFederation extends LitElement {
                       };
                     }}
                   ></sl-input>
-                  <span class="hint">Expected audience claim in JWT tokens. Usually this hub's URL.</span>
+                  <span class="hint"
+                    >Expected audience claim in JWT tokens. Usually this hub's URL.</span
+                  >
                 </div>
 
                 ${issuerType === 'hub' ? this.renderHubFields() : nothing}
@@ -866,7 +898,7 @@ export class ScionPageAdminFederation extends LitElement {
                       this.editingIssuer = {
                         ...this.editingIssuer!,
                         default_scopes: this.commaStringToArray(
-                          (e.target as HTMLInputElement).value,
+                          (e.target as HTMLInputElement).value
                         ),
                       };
                     }}
@@ -905,9 +937,7 @@ export class ScionPageAdminFederation extends LitElement {
             @sl-change=${(e: Event) => {
               this.editingIssuer = {
                 ...this.editingIssuer!,
-                allowed_projects: this.commaStringToArray(
-                  (e.target as HTMLInputElement).value,
-                ),
+                allowed_projects: this.commaStringToArray((e.target as HTMLInputElement).value),
               };
             }}
           ></sl-input>
@@ -921,9 +951,7 @@ export class ScionPageAdminFederation extends LitElement {
             @sl-change=${(e: Event) => {
               this.editingIssuer = {
                 ...this.editingIssuer!,
-                allowed_root_users: this.commaStringToArray(
-                  (e.target as HTMLInputElement).value,
-                ),
+                allowed_root_users: this.commaStringToArray((e.target as HTMLInputElement).value),
               };
             }}
           ></sl-input>
@@ -949,13 +977,13 @@ export class ScionPageAdminFederation extends LitElement {
             @sl-change=${(e: Event) => {
               this.editingIssuer = {
                 ...this.editingIssuer!,
-                allowed_emails: this.commaStringToArray(
-                  (e.target as HTMLInputElement).value,
-                ),
+                allowed_emails: this.commaStringToArray((e.target as HTMLInputElement).value),
               };
             }}
           ></sl-input>
-          <span class="hint">Comma-separated email patterns. Use * for wildcards (e.g. *@corp.com).</span>
+          <span class="hint"
+            >Comma-separated email patterns. Use * for wildcards (e.g. *@corp.com).</span
+          >
         </div>
       </div>
     `;
@@ -987,9 +1015,10 @@ export class ScionPageAdminFederation extends LitElement {
   // --- Delete Confirmation Dialog ---
 
   private renderDeleteDialog() {
-    const issuer = this.deletingIndex >= 0 && this.deletingIndex < this.issuers.length
-      ? this.issuers[this.deletingIndex]
-      : null;
+    const issuer =
+      this.deletingIndex >= 0 && this.deletingIndex < this.issuers.length
+        ? this.issuers[this.deletingIndex]
+        : null;
 
     return html`
       <sl-dialog
@@ -1002,8 +1031,8 @@ export class ScionPageAdminFederation extends LitElement {
           ? html`
               <p style="font-size: 0.875rem; color: var(--scion-text, #1e293b); margin: 0;">
                 Are you sure you want to remove the trusted issuer
-                <strong>${issuer.issuer_url}</strong>?
-                This will revoke federation trust for agents from this issuer.
+                <strong>${issuer.issuer_url}</strong>? This will revoke federation trust for agents
+                from this issuer.
               </p>
               <div slot="footer" class="dialog-footer">
                 <sl-button variant="default" @click=${() => this.handleDeleteDialogClose()}>

--- a/web/src/components/pages/admin-group-detail.ts
+++ b/web/src/components/pages/admin-group-detail.ts
@@ -268,7 +268,9 @@ export class ScionPageAdminGroupDetail extends LitElement {
       });
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       this.group = (await response.json()) as AdminGroup;
@@ -328,7 +330,9 @@ export class ScionPageAdminGroupDetail extends LitElement {
         <div class="header-info">
           <div class="header-title">
             <div class="group-icon ${this.group.groupType}">
-              <sl-icon name="${this.group.groupType === 'project_agents' ? 'cpu' : 'people'}"></sl-icon>
+              <sl-icon
+                name="${this.group.groupType === 'project_agents' ? 'cpu' : 'people'}"
+              ></sl-icon>
             </div>
             <h1>${this.group.name}</h1>
             <span class="type-badge ${this.group.groupType}">

--- a/web/src/components/pages/admin-groups.ts
+++ b/web/src/components/pages/admin-groups.ts
@@ -306,7 +306,9 @@ export class ScionPageAdminGroups extends LitElement {
       });
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       const data = (await response.json()) as { groups?: AdminGroup[] } | AdminGroup[];
@@ -419,10 +421,13 @@ export class ScionPageAdminGroups extends LitElement {
     const labels = group.labels ? Object.entries(group.labels) : [];
 
     return html`
-      <tr class="clickable" @click=${() => {
-        window.history.pushState({}, '', `/admin/groups/${group.id}`);
-        window.dispatchEvent(new PopStateEvent('popstate'));
-      }}>
+      <tr
+        class="clickable"
+        @click=${() => {
+          window.history.pushState({}, '', `/admin/groups/${group.id}`);
+          window.dispatchEvent(new PopStateEvent('popstate'));
+        }}
+      >
         <td>
           <div class="group-identity">
             <div class="group-icon ${group.groupType}">

--- a/web/src/components/pages/admin-integrations.test.ts
+++ b/web/src/components/pages/admin-integrations.test.ts
@@ -28,8 +28,11 @@ function makeDiscordDetail(settingsOverride?: Record<string, string>): Record<st
 function createFetchHandler(
   detailResponse: Record<string, unknown>,
   opts?: {
-    putHandler?: (body: Record<string, unknown>) => { status: number; body: Record<string, unknown> };
-  },
+    putHandler?: (body: Record<string, unknown>) => {
+      status: number;
+      body: Record<string, unknown>;
+    };
+  }
 ) {
   return (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const path = typeof url === 'string' ? url : url instanceof URL ? url.pathname : url.url;
@@ -41,7 +44,7 @@ function createFetchHandler(
         new Response(JSON.stringify(result.body), {
           status: result.status,
           headers: { 'Content-Type': 'application/json' },
-        }),
+        })
       );
     }
 
@@ -51,7 +54,7 @@ function createFetchHandler(
         new Response(JSON.stringify(detailResponse), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
-        }),
+        })
       );
     }
 
@@ -61,7 +64,7 @@ function createFetchHandler(
         new Response(JSON.stringify([]), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
-        }),
+        })
       );
     }
 
@@ -70,7 +73,7 @@ function createFetchHandler(
         new Response(JSON.stringify(makeIntegrationList()), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
-        }),
+        })
       );
     }
 
@@ -78,7 +81,7 @@ function createFetchHandler(
       new Response(JSON.stringify({}), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
-      }),
+      })
     );
   };
 }
@@ -87,7 +90,7 @@ function createFetchHandler(
 let ScionPageAdminIntegrations: any;
 
 async function createComponent(
-  fetchHandler: (url: string | URL | Request, init?: RequestInit) => Promise<Response>,
+  fetchHandler: (url: string | URL | Request, init?: RequestInit) => Promise<Response>
 ) {
   // Simulate being on the Discord detail page.
   Object.defineProperty(window, 'location', {
@@ -168,7 +171,7 @@ describe('scion-page-admin-integrations — Discord guild_ids', () => {
 
   it('displays existing guild_ids value', async () => {
     element = await createComponent(
-      createFetchHandler(makeDiscordDetail({ guild_ids: '111,222,333' })),
+      createFetchHandler(makeDiscordDetail({ guild_ids: '111,222,333' }))
     );
 
     const inputs = queryAll(element, 'sl-input') as HTMLInputElement[];
@@ -194,7 +197,7 @@ describe('scion-page-admin-integrations — Discord guild_ids', () => {
           capturedPayload = body;
           return { status: 200, body: {} };
         },
-      }),
+      })
     );
 
     // Click save button
@@ -220,7 +223,7 @@ describe('scion-page-admin-integrations — Discord guild_ids', () => {
           capturedPayload = body;
           return { status: 200, body: {} };
         },
-      }),
+      })
     );
 
     const buttons = queryAll(element, 'sl-button[variant="primary"]');

--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -61,8 +61,8 @@ interface PlatformFieldDef {
   description: string;
   defaultValue: string;
   placeholder?: string;
-  type?: 'text' | 'select' | 'toggle';  // default 'text'
-  options?: { value: string; label: string }[];  // for 'select' type
+  type?: 'text' | 'select' | 'toggle'; // default 'text'
+  options?: { value: string; label: string }[]; // for 'select' type
 }
 
 interface PlatformSecretDef {
@@ -89,22 +89,53 @@ interface ProjectInfo {
 
 const PLATFORM_SECRETS: Record<string, PlatformSecretDef[]> = {
   telegram: [
-    { key: 'bot_token', label: 'Bot Token', description: 'Telegram bot token from @BotFather', required: true },
-    { key: 'webhook_secret', label: 'Webhook Secret', description: 'Secret for webhook verification (webhook mode only)' },
+    {
+      key: 'bot_token',
+      label: 'Bot Token',
+      description: 'Telegram bot token from @BotFather',
+      required: true,
+    },
+    {
+      key: 'webhook_secret',
+      label: 'Webhook Secret',
+      description: 'Secret for webhook verification (webhook mode only)',
+    },
   ],
   discord: [
     { key: 'bot_token', label: 'Bot Token', description: 'Discord bot token', required: true },
   ],
   slack: [
-    { key: 'bot_token', label: 'Bot Token', description: 'Slack bot token (xoxb-...)', required: true },
-    { key: 'app_token', label: 'App Token', description: 'Slack app-level token for Socket Mode (xapp-...)' },
-    { key: 'signing_secret', label: 'Signing Secret', description: 'Slack signing secret for HTTP mode' },
+    {
+      key: 'bot_token',
+      label: 'Bot Token',
+      description: 'Slack bot token (xoxb-...)',
+      required: true,
+    },
+    {
+      key: 'app_token',
+      label: 'App Token',
+      description: 'Slack app-level token for Socket Mode (xapp-...)',
+    },
+    {
+      key: 'signing_secret',
+      label: 'Signing Secret',
+      description: 'Slack signing secret for HTTP mode',
+    },
   ],
   a2a: [
-    { key: 'api_key', label: 'API Key', description: 'Static API key for apiKey/bearer auth schemes' },
+    {
+      key: 'api_key',
+      label: 'API Key',
+      description: 'Static API key for apiKey/bearer auth schemes',
+    },
   ],
   gchat: [
-    { key: 'signing_key', label: 'Hub Signing Key', description: 'Shared signing key for hub authentication (HS256 JWT)', required: true },
+    {
+      key: 'signing_key',
+      label: 'Hub Signing Key',
+      description: 'Shared signing key for hub authentication (HS256 JWT)',
+      required: true,
+    },
   ],
   teams: [
     { key: 'app_secret', label: 'App Secret', description: 'Azure App Registration client secret' },
@@ -113,44 +144,139 @@ const PLATFORM_SECRETS: Record<string, PlatformSecretDef[]> = {
 
 function resolvePlatform(name: string): string {
   switch (name) {
-    case 'telegram': return 'telegram';
-    case 'discord': return 'discord';
-    case 'slack': return 'slack';
-    case 'chat-app': return 'gchat';
-    case 'a2a-bridge': return 'a2a';
-    case 'teams': return 'teams';
-    default: return name;
+    case 'telegram':
+      return 'telegram';
+    case 'discord':
+      return 'discord';
+    case 'slack':
+      return 'slack';
+    case 'chat-app':
+      return 'gchat';
+    case 'a2a-bridge':
+      return 'a2a';
+    case 'teams':
+      return 'teams';
+    default:
+      return name;
   }
 }
 
 const PLATFORM_FIELDS: Record<string, PlatformFieldDef[]> = {
   telegram: [
-    { key: 'inbound_mode', label: 'Inbound Mode', description: 'How Telegram delivers updates (poll or webhook)', defaultValue: 'poll' },
-    { key: 'webhook_url', label: 'Webhook URL', description: 'Public URL for Telegram to send webhook updates to', defaultValue: '' },
-    { key: 'webhook_listen', label: 'Webhook Listen', description: 'HTTP listen address for webhook mode', defaultValue: ':9094' },
-    { key: 'db_path', label: 'Database Path', description: 'Path to SQLite database', defaultValue: 'telegram_v2.db' },
-    { key: 'skip_set_webhook', label: 'Skip Webhook Registration', description: 'Set to true when running in HA mode to skip automatic webhook registration', defaultValue: 'false' },
-    { key: 'agent_cache_ttl', label: 'Agent Cache TTL', description: 'How long to cache agent info', defaultValue: '5m' },
-    { key: 'send_queue_size', label: 'Send Queue Size', description: 'Buffer size for outbound message queue (0 = unbuffered)', defaultValue: '0' },
-    { key: 'send_min_delay', label: 'Send Min Delay', description: 'Minimum delay between outbound messages (e.g. 100ms)', defaultValue: '' },
-    { key: 'chat_routes', label: 'Chat Routes', description: 'JSON map of Telegram chat IDs to topic patterns (v1 migration seeding only)', defaultValue: '' },
-    { key: 'user_mappings', label: 'User Mappings', description: 'JSON map of Telegram usernames to scion user IDs (v1 migration seeding only)', defaultValue: '' },
+    {
+      key: 'inbound_mode',
+      label: 'Inbound Mode',
+      description: 'How Telegram delivers updates (poll or webhook)',
+      defaultValue: 'poll',
+    },
+    {
+      key: 'webhook_url',
+      label: 'Webhook URL',
+      description: 'Public URL for Telegram to send webhook updates to',
+      defaultValue: '',
+    },
+    {
+      key: 'webhook_listen',
+      label: 'Webhook Listen',
+      description: 'HTTP listen address for webhook mode',
+      defaultValue: ':9094',
+    },
+    {
+      key: 'db_path',
+      label: 'Database Path',
+      description: 'Path to SQLite database',
+      defaultValue: 'telegram_v2.db',
+    },
+    {
+      key: 'skip_set_webhook',
+      label: 'Skip Webhook Registration',
+      description: 'Set to true when running in HA mode to skip automatic webhook registration',
+      defaultValue: 'false',
+    },
+    {
+      key: 'agent_cache_ttl',
+      label: 'Agent Cache TTL',
+      description: 'How long to cache agent info',
+      defaultValue: '5m',
+    },
+    {
+      key: 'send_queue_size',
+      label: 'Send Queue Size',
+      description: 'Buffer size for outbound message queue (0 = unbuffered)',
+      defaultValue: '0',
+    },
+    {
+      key: 'send_min_delay',
+      label: 'Send Min Delay',
+      description: 'Minimum delay between outbound messages (e.g. 100ms)',
+      defaultValue: '',
+    },
+    {
+      key: 'chat_routes',
+      label: 'Chat Routes',
+      description: 'JSON map of Telegram chat IDs to topic patterns (v1 migration seeding only)',
+      defaultValue: '',
+    },
+    {
+      key: 'user_mappings',
+      label: 'User Mappings',
+      description: 'JSON map of Telegram usernames to scion user IDs (v1 migration seeding only)',
+      defaultValue: '',
+    },
   ],
   discord: [
-    { key: 'application_id', label: 'Application ID', description: 'Discord application ID for slash commands', defaultValue: '' },
-    { key: 'guild_ids', label: 'Allowed Guild IDs', description: 'Comma-separated Discord server IDs. Leave empty to register commands globally across all servers the bot joins.', defaultValue: '', placeholder: 'Global — all servers' },
+    {
+      key: 'application_id',
+      label: 'Application ID',
+      description: 'Discord application ID for slash commands',
+      defaultValue: '',
+    },
+    {
+      key: 'guild_ids',
+      label: 'Allowed Guild IDs',
+      description:
+        'Comma-separated Discord server IDs. Leave empty to register commands globally across all servers the bot joins.',
+      defaultValue: '',
+      placeholder: 'Global — all servers',
+    },
   ],
   slack: [
-    { key: 'socket_mode', label: 'Socket Mode', description: 'Use Slack Socket Mode instead of HTTP webhooks (no public URL needed)', defaultValue: 'false' },
-    { key: 'listen_address', label: 'Listen Address', description: 'HTTP listen address (HTTP mode only)', defaultValue: ':3000' },
-    { key: 'db_path', label: 'Database Path', description: 'Path to SQLite database', defaultValue: '~/.scion/scion-slack.db' },
-    { key: 'agent_cache_ttl', label: 'Agent Cache TTL', description: 'How long to cache agent info', defaultValue: '5m' },
+    {
+      key: 'socket_mode',
+      label: 'Socket Mode',
+      description: 'Use Slack Socket Mode instead of HTTP webhooks (no public URL needed)',
+      defaultValue: 'false',
+    },
+    {
+      key: 'listen_address',
+      label: 'Listen Address',
+      description: 'HTTP listen address (HTTP mode only)',
+      defaultValue: ':3000',
+    },
+    {
+      key: 'db_path',
+      label: 'Database Path',
+      description: 'Path to SQLite database',
+      defaultValue: '~/.scion/scion-slack.db',
+    },
+    {
+      key: 'agent_cache_ttl',
+      label: 'Agent Cache TTL',
+      description: 'How long to cache agent info',
+      defaultValue: '5m',
+    },
   ],
   a2a: [
-    { key: 'external_url', label: 'External URL',
+    {
+      key: 'external_url',
+      label: 'External URL',
       description: 'Public URL where the bridge serves agent cards and JSON-RPC',
-      defaultValue: '', placeholder: 'https://a2a.example.com' },
-    { key: 'auth_scheme', label: 'Auth Scheme',
+      defaultValue: '',
+      placeholder: 'https://a2a.example.com',
+    },
+    {
+      key: 'auth_scheme',
+      label: 'Auth Scheme',
       description: 'Authentication method for A2A clients',
       defaultValue: 'none',
       type: 'select',
@@ -160,47 +286,133 @@ const PLATFORM_FIELDS: Record<string, PlatformFieldDef[]> = {
         { value: 'bearer', label: 'Bearer Token' },
         { value: 'hubUAT', label: 'Hub UAT' },
         { value: 'hubJWT', label: 'Hub JWT' },
-      ] },
-    { key: 'rate_limit_enabled', label: 'Rate Limiting',
+      ],
+    },
+    {
+      key: 'rate_limit_enabled',
+      label: 'Rate Limiting',
       description: 'Enable request rate limiting',
-      defaultValue: 'false', type: 'toggle' },
-    { key: 'rate_limit_rps', label: 'Rate Limit (req/s)',
+      defaultValue: 'false',
+      type: 'toggle',
+    },
+    {
+      key: 'rate_limit_rps',
+      label: 'Rate Limit (req/s)',
       description: 'Maximum requests per second',
-      defaultValue: '10', placeholder: '10' },
-    { key: 'rate_limit_burst', label: 'Rate Limit Burst',
+      defaultValue: '10',
+      placeholder: '10',
+    },
+    {
+      key: 'rate_limit_burst',
+      label: 'Rate Limit Burst',
       description: 'Maximum burst size for rate limiter',
-      defaultValue: '20', placeholder: '20' },
-    { key: 'send_message_timeout', label: 'Send Message Timeout',
+      defaultValue: '20',
+      placeholder: '20',
+    },
+    {
+      key: 'send_message_timeout',
+      label: 'Send Message Timeout',
       description: 'Timeout for sending messages to agents',
-      defaultValue: '120s', placeholder: '120s' },
-    { key: 'sse_keepalive', label: 'SSE Keepalive Interval',
+      defaultValue: '120s',
+      placeholder: '120s',
+    },
+    {
+      key: 'sse_keepalive',
+      label: 'SSE Keepalive Interval',
       description: 'Interval for SSE keepalive pings',
-      defaultValue: '30s', placeholder: '30s' },
-    { key: 'push_retry_max', label: 'Push Notification Retries',
+      defaultValue: '30s',
+      placeholder: '30s',
+    },
+    {
+      key: 'push_retry_max',
+      label: 'Push Notification Retries',
       description: 'Maximum retries for push notification delivery',
-      defaultValue: '3', placeholder: '3' },
-    { key: 'provider_org', label: 'Provider Organization',
+      defaultValue: '3',
+      placeholder: '3',
+    },
+    {
+      key: 'provider_org',
+      label: 'Provider Organization',
       description: 'Organization name for agent card metadata',
-      defaultValue: '', placeholder: 'My Organization' },
-    { key: 'provider_url', label: 'Provider URL',
+      defaultValue: '',
+      placeholder: 'My Organization',
+    },
+    {
+      key: 'provider_url',
+      label: 'Provider URL',
       description: 'Organization URL for agent card metadata',
-      defaultValue: '', placeholder: 'https://example.com' },
-    { key: 'uat_cache_ttl', label: 'UAT Cache TTL',
+      defaultValue: '',
+      placeholder: 'https://example.com',
+    },
+    {
+      key: 'uat_cache_ttl',
+      label: 'UAT Cache TTL',
       description: 'How long to cache UAT validation results',
-      defaultValue: '60s', placeholder: '60s' },
+      defaultValue: '60s',
+      placeholder: '60s',
+    },
   ],
   gchat: [
-    { key: 'project_id', label: 'GCP Project ID', description: 'Google Cloud project ID hosting the Chat app', defaultValue: '' },
-    { key: 'credentials', label: 'Credentials Path', description: 'Path to service account key JSON file (leave empty for ADC)', defaultValue: '' },
-    { key: 'listen_address', label: 'Webhook Listen Address', description: 'HTTP listen address for webhook mode', defaultValue: ':8443' },
-    { key: 'external_url', label: 'External URL', description: 'Public URL where Google Chat sends events', defaultValue: '' },
-    { key: 'service_account_email', label: 'Service Account Email', description: 'Email of the GCP service account (for JWT verification)', defaultValue: '' },
+    {
+      key: 'project_id',
+      label: 'GCP Project ID',
+      description: 'Google Cloud project ID hosting the Chat app',
+      defaultValue: '',
+    },
+    {
+      key: 'credentials',
+      label: 'Credentials Path',
+      description: 'Path to service account key JSON file (leave empty for ADC)',
+      defaultValue: '',
+    },
+    {
+      key: 'listen_address',
+      label: 'Webhook Listen Address',
+      description: 'HTTP listen address for webhook mode',
+      defaultValue: ':8443',
+    },
+    {
+      key: 'external_url',
+      label: 'External URL',
+      description: 'Public URL where Google Chat sends events',
+      defaultValue: '',
+    },
+    {
+      key: 'service_account_email',
+      label: 'Service Account Email',
+      description: 'Email of the GCP service account (for JWT verification)',
+      defaultValue: '',
+    },
   ],
   teams: [
-    { key: 'app_id', label: 'Application (Client) ID', description: 'Azure App Registration Client ID', defaultValue: '', placeholder: 'e.g. 12345678-abcd-1234-efgh-123456789012' },
-    { key: 'tenant_id', label: 'Tenant ID', description: 'Azure AD Tenant ID (GUID)', defaultValue: '', placeholder: 'e.g. 12345678-abcd-1234-efgh-123456789012' },
-    { key: 'listen_address', label: 'Listen Address', description: 'HTTP listen address for the Teams webhook endpoint', defaultValue: ':3978', placeholder: ':3978' },
-    { key: 'db_path', label: 'Database Path', description: 'Path to SQLite database', defaultValue: '~/.scion/scion-teams.db', placeholder: '~/.scion/scion-teams.db' },
+    {
+      key: 'app_id',
+      label: 'Application (Client) ID',
+      description: 'Azure App Registration Client ID',
+      defaultValue: '',
+      placeholder: 'e.g. 12345678-abcd-1234-efgh-123456789012',
+    },
+    {
+      key: 'tenant_id',
+      label: 'Tenant ID',
+      description: 'Azure AD Tenant ID (GUID)',
+      defaultValue: '',
+      placeholder: 'e.g. 12345678-abcd-1234-efgh-123456789012',
+    },
+    {
+      key: 'listen_address',
+      label: 'Listen Address',
+      description: 'HTTP listen address for the Teams webhook endpoint',
+      defaultValue: ':3978',
+      placeholder: ':3978',
+    },
+    {
+      key: 'db_path',
+      label: 'Database Path',
+      description: 'Path to SQLite database',
+      defaultValue: '~/.scion/scion-teams.db',
+      placeholder: '~/.scion/scion-teams.db',
+    },
   ],
 };
 
@@ -233,7 +445,6 @@ export class ScionPageAdminIntegrations extends LitElement {
 
   // Available projects for A2A project selector
   @state() private availableProjects: ProjectInfo[] = [];
-
 
   static override styles = css`
     :host {
@@ -815,9 +1026,7 @@ export class ScionPageAdminIntegrations extends LitElement {
             : 'Update complete';
           await this.loadDetail(integrationName);
         } else {
-          this.error = data.detail
-            ? `Update failed: ${data.detail}`
-            : 'Update failed';
+          this.error = data.detail ? `Update failed: ${data.detail}` : 'Update failed';
         }
       }
     } catch {
@@ -835,10 +1044,9 @@ export class ScionPageAdminIntegrations extends LitElement {
     this.error = null;
     this.successMessage = null;
     try {
-      const res = await apiFetch(
-        `/api/v1/admin/integrations/${encodeURIComponent(name)}/install`,
-        { method: 'POST' }
-      );
+      const res = await apiFetch(`/api/v1/admin/integrations/${encodeURIComponent(name)}/install`, {
+        method: 'POST',
+      });
       if (!res.ok) {
         this.error = await extractApiError(res, 'Failed to install integration');
         return;
@@ -876,7 +1084,9 @@ export class ScionPageAdminIntegrations extends LitElement {
   }
 
   private navigateTo(path: string): void {
-    this.dispatchEvent(new CustomEvent('nav-click', { detail: { path }, bubbles: true, composed: true }));
+    this.dispatchEvent(
+      new CustomEvent('nav-click', { detail: { path }, bubbles: true, composed: true })
+    );
   }
 
   override render() {
@@ -904,8 +1114,8 @@ export class ScionPageAdminIntegrations extends LitElement {
         <h1>Integrations</h1>
       </div>
       <p class="header-description">
-        Manage chat integrations — Telegram, Discord, Google Chat, and Slack plugins connected to this
-        hub.
+        Manage chat integrations — Telegram, Discord, Google Chat, and Slack plugins connected to
+        this hub.
       </p>
 
       ${this.integrations.length === 0
@@ -936,10 +1146,13 @@ export class ScionPageAdminIntegrations extends LitElement {
                     (i) => html`
                       <tr
                         class="clickable"
-                        @click=${() => this.navigateTo(`/admin/integrations/${encodeURIComponent(i.name)}`)}
+                        @click=${() =>
+                          this.navigateTo(`/admin/integrations/${encodeURIComponent(i.name)}`)}
                       >
                         <td><strong>${i.name}</strong></td>
-                        <td><span class="platform-name">${this.platformLabel(i.platform)}</span></td>
+                        <td>
+                          <span class="platform-name">${this.platformLabel(i.platform)}</span>
+                        </td>
                         <td>${this.renderStatusBadge(i.status)}</td>
                         <td>${this.renderDeploymentModeBadge(i.deployment_mode)}</td>
                       </tr>
@@ -949,7 +1162,6 @@ export class ScionPageAdminIntegrations extends LitElement {
               </table>
             </div>
           `}
-
       ${this.availableIntegrations.length > 0
         ? html`
             <div class="header" style="margin-top: 2rem;">
@@ -957,8 +1169,8 @@ export class ScionPageAdminIntegrations extends LitElement {
               <h1 style="font-size: 1.25rem;">Available Integrations</h1>
             </div>
             <p class="header-description">
-              These integrations can be installed from source. After installing, configure
-              secrets and restart to activate.
+              These integrations can be installed from source. After installing, configure secrets
+              and restart to activate.
             </p>
             <div class="section" style="padding: 0;">
               <table class="integration-table">
@@ -974,14 +1186,18 @@ export class ScionPageAdminIntegrations extends LitElement {
                     (a) => html`
                       <tr>
                         <td><strong>${a.name}</strong></td>
-                        <td><span class="platform-name">${this.platformLabel(a.platform)}</span></td>
+                        <td>
+                          <span class="platform-name">${this.platformLabel(a.platform)}</span>
+                        </td>
                         <td>
                           <sl-button
                             size="small"
                             variant="primary"
                             ?loading=${this.installingName === a.name}
                             ?disabled=${this.installingName !== null}
-                            @click=${() => { void this.handleInstall(a.name); }}
+                            @click=${() => {
+                              void this.handleInstall(a.name);
+                            }}
                           >
                             Install
                           </sl-button>
@@ -1010,16 +1226,14 @@ export class ScionPageAdminIntegrations extends LitElement {
       </a>
 
       <h2 class="detail-name">${d.name}</h2>
-      <p class="detail-platform">${this.platformLabel(d.platform)} · ${this.deploymentModeLabel(d.deployment_mode)}</p>
+      <p class="detail-platform">
+        ${this.platformLabel(d.platform)} · ${this.deploymentModeLabel(d.deployment_mode)}
+      </p>
 
-      ${this.renderStatusSection(d.status)}
-      ${this.renderSetupBanner(d)}
-      ${this.renderSelfManagedSetupSection(d)}
-      ${this.renderSecretsSection(d)}
-      ${this.renderConfigSection(d)}
-      ${this.renderA2AProjectsSection(d)}
-      ${this.renderDiscordInviteLink(d)}
-      ${this.renderTeamsSetupSection(d)}
+      ${this.renderStatusSection(d.status)} ${this.renderSetupBanner(d)}
+      ${this.renderSelfManagedSetupSection(d)} ${this.renderSecretsSection(d)}
+      ${this.renderConfigSection(d)} ${this.renderA2AProjectsSection(d)}
+      ${this.renderDiscordInviteLink(d)} ${this.renderTeamsSetupSection(d)}
       ${this.renderActionsSection()}
     `;
   }
@@ -1029,7 +1243,9 @@ export class ScionPageAdminIntegrations extends LitElement {
       return html`
         <div class="section">
           <h3 class="section-title">Status</h3>
-          <p style="color: var(--scion-text-muted); font-size: 0.875rem;">No status information available.</p>
+          <p style="color: var(--scion-text-muted); font-size: 0.875rem;">
+            No status information available.
+          </p>
         </div>
       `;
     }
@@ -1045,7 +1261,13 @@ export class ScionPageAdminIntegrations extends LitElement {
           ? html`
               <div class="status-row">
                 <span class="status-label">Health</span>
-                <sl-badge variant=${status.health === 'healthy' ? 'success' : status.health === 'unhealthy' ? 'danger' : 'neutral'}>
+                <sl-badge
+                  variant=${status.health === 'healthy'
+                    ? 'success'
+                    : status.health === 'unhealthy'
+                      ? 'danger'
+                      : 'neutral'}
+                >
                   ${status.health}
                 </sl-badge>
               </div>
@@ -1071,7 +1293,9 @@ export class ScionPageAdminIntegrations extends LitElement {
           ? html`
               <div class="status-row">
                 <span class="status-label">Channel ID</span>
-                <span style="font-family: var(--sl-font-mono, monospace); font-size: 0.8125rem;">${status.channel_id}</span>
+                <span style="font-family: var(--sl-font-mono, monospace); font-size: 0.8125rem;"
+                  >${status.channel_id}</span
+                >
               </div>
             `
           : nothing}
@@ -1089,7 +1313,9 @@ export class ScionPageAdminIntegrations extends LitElement {
           : nothing}
         ${status.details && Object.keys(status.details).length > 0
           ? html`
-              <div style="margin-top: 0.75rem; padding-top: 0.75rem; border-top: 1px solid var(--scion-border, #e2e8f0);">
+              <div
+                style="margin-top: 0.75rem; padding-top: 0.75rem; border-top: 1px solid var(--scion-border, #e2e8f0);"
+              >
                 ${Object.entries(status.details).map(
                   ([k, v]) => html`
                     <div class="status-row">
@@ -1115,7 +1341,7 @@ export class ScionPageAdminIntegrations extends LitElement {
       hiddenExtraKeys.add('projects_json');
     }
     const extraKeys = Object.keys(d.settings || {}).filter(
-      (k) => !definedKeys.has(k) && !hiddenExtraKeys.has(k),
+      (k) => !definedKeys.has(k) && !hiddenExtraKeys.has(k)
     );
     const hasFields = fieldDefs.length > 0 || extraKeys.length > 0;
 
@@ -1123,7 +1349,9 @@ export class ScionPageAdminIntegrations extends LitElement {
       return html`
         <div class="section">
           <h3 class="section-title">Configuration</h3>
-          <p style="color: var(--scion-text-muted); font-size: 0.875rem;">No configurable settings for this integration.</p>
+          <p style="color: var(--scion-text-muted); font-size: 0.875rem;">
+            No configurable settings for this integration.
+          </p>
         </div>
       `;
     }
@@ -1256,7 +1484,10 @@ export class ScionPageAdminIntegrations extends LitElement {
       <div class="section">
         <h3 class="section-title">Projects & Agent Exposure</h3>
         ${warning
-          ? html`<div class="warning-message" style="color: var(--sl-color-warning-600); margin-bottom: 0.5rem;">
+          ? html`<div
+              class="warning-message"
+              style="color: var(--sl-color-warning-600); margin-bottom: 0.5rem;"
+            >
               <sl-icon name="exclamation-triangle" style="margin-right: 0.25rem;"></sl-icon>
               ${warning}
             </div>`
@@ -1267,9 +1498,7 @@ export class ScionPageAdminIntegrations extends LitElement {
                 <p>No projects configured. Add a project to expose its agents via A2A.</p>
               </div>
             `
-          : projects.map((proj, idx) =>
-              this.renderProjectCard(proj, idx, projects, usedSlugs),
-            )}
+          : projects.map((proj, idx) => this.renderProjectCard(proj, idx, projects, usedSlugs))}
         <sl-button
           variant="default"
           size="small"
@@ -1287,12 +1516,10 @@ export class ScionPageAdminIntegrations extends LitElement {
     proj: A2AProjectEntry,
     idx: number,
     allProjects: A2AProjectEntry[],
-    usedSlugs: Set<string>,
+    usedSlugs: Set<string>
   ) {
     // Build project display name for the header.
-    const matchedProject = this.availableProjects.find(
-      (p) => (p.slug ?? p.id) === proj.slug,
-    );
+    const matchedProject = this.availableProjects.find((p) => (p.slug ?? p.id) === proj.slug);
     const headerLabel = matchedProject
       ? `${matchedProject.name} (${proj.slug})`
       : proj.slug || 'New Project';
@@ -1323,7 +1550,7 @@ export class ScionPageAdminIntegrations extends LitElement {
                         allProjects,
                         idx,
                         'slug',
-                        (e.target as HTMLSelectElement).value,
+                        (e.target as HTMLSelectElement).value
                       )}
                   >
                     ${this.availableProjects.map((p) => {
@@ -1346,7 +1573,7 @@ export class ScionPageAdminIntegrations extends LitElement {
                         allProjects,
                         idx,
                         'slug',
-                        (e.target as HTMLInputElement).value,
+                        (e.target as HTMLInputElement).value
                       )}
                   ></sl-input>
                 `}
@@ -1363,7 +1590,7 @@ export class ScionPageAdminIntegrations extends LitElement {
                   allProjects,
                   idx,
                   'default_template',
-                  (e.target as HTMLInputElement).value,
+                  (e.target as HTMLInputElement).value
                 )}
             ></sl-input>
             <span class="hint">Agent template for auto-provisioned agents</span>
@@ -1378,7 +1605,7 @@ export class ScionPageAdminIntegrations extends LitElement {
                   allProjects,
                   idx,
                   'auto_provision',
-                  (e.target as HTMLInputElement).checked,
+                  (e.target as HTMLInputElement).checked
                 )}
             ></sl-switch>
             <span class="hint">Automatically create agents from A2A requests</span>
@@ -1394,7 +1621,7 @@ export class ScionPageAdminIntegrations extends LitElement {
                   allProjects,
                   idx,
                   'exposed_agents',
-                  (e.target as HTMLInputElement).value,
+                  (e.target as HTMLInputElement).value
                 )}
             ></sl-input>
             <span class="hint">Comma-separated agent names. Leave empty to expose all agents.</span>
@@ -1417,10 +1644,7 @@ export class ScionPageAdminIntegrations extends LitElement {
     this.serializeProjectsJSON(updated);
   }
 
-  private handleRemoveProject(
-    currentProjects: A2AProjectEntry[],
-    idx: number,
-  ): void {
+  private handleRemoveProject(currentProjects: A2AProjectEntry[], idx: number): void {
     const updated = currentProjects.filter((_, i) => i !== idx);
     this.serializeProjectsJSON(updated);
   }
@@ -1429,7 +1653,7 @@ export class ScionPageAdminIntegrations extends LitElement {
     currentProjects: A2AProjectEntry[],
     idx: number,
     field: keyof A2AProjectEntry,
-    value: string | boolean,
+    value: string | boolean
   ): void {
     const updated = currentProjects.map((p, i) => {
       if (i !== idx) return { ...p };
@@ -1447,7 +1671,10 @@ export class ScionPageAdminIntegrations extends LitElement {
         case 'exposed_agents': {
           const raw = (value as string).trim();
           copy.exposed_agents = raw
-            ? raw.split(',').map((s) => s.trim()).filter((s) => s !== '')
+            ? raw
+                .split(',')
+                .map((s) => s.trim())
+                .filter((s) => s !== '')
             : [];
           break;
         }
@@ -1475,7 +1702,9 @@ export class ScionPageAdminIntegrations extends LitElement {
             <div>
               <p class="invite-link-description">Add the bot to your Discord server</p>
               <p class="invite-link-permissions">
-                Grants required permissions: View Channels, Send Messages, Send Messages in Threads, Create Public Threads, Manage Threads, Read Message History, Embed Links, Add Reactions, Manage Webhooks
+                Grants required permissions: View Channels, Send Messages, Send Messages in Threads,
+                Create Public Threads, Manage Threads, Read Message History, Embed Links, Add
+                Reactions, Manage Webhooks
               </p>
             </div>
           </div>
@@ -1514,16 +1743,12 @@ export class ScionPageAdminIntegrations extends LitElement {
             <div>
               <p class="invite-link-description">Download the Teams app package (.zip)</p>
               <p class="invite-link-permissions">
-                Upload it to your Microsoft Teams Admin Center or sideload it in Teams to enable the bot integration.
+                Upload it to your Microsoft Teams Admin Center or sideload it in Teams to enable the
+                bot integration.
               </p>
             </div>
           </div>
-          <sl-button
-            variant="primary"
-            size="small"
-            href=${downloadUrl}
-            download="teams-app.zip"
-          >
+          <sl-button variant="primary" size="small" href=${downloadUrl} download="teams-app.zip">
             <sl-icon slot="prefix" name="download"></sl-icon>
             Download App Package
           </sl-button>
@@ -1540,11 +1765,7 @@ export class ScionPageAdminIntegrations extends LitElement {
           </div>
         </div>
         <div style="display: flex; align-items: center; gap: 0.5rem; margin-top: 0.5rem;">
-          <sl-input
-            readonly
-            value=${messagingEndpoint}
-            style="flex: 1;"
-          ></sl-input>
+          <sl-input readonly value=${messagingEndpoint} style="flex: 1;"></sl-input>
           <sl-button
             size="small"
             @click=${() => {
@@ -1599,15 +1820,21 @@ export class ScionPageAdminIntegrations extends LitElement {
         <div style="font-size: 0.875rem; display: flex; flex-direction: column; gap: 0.5rem;">
           <div class="status-row">
             <span class="status-label">Binary</span>
-            <span style="font-family: var(--sl-font-mono, monospace); font-size: 0.8125rem;">${binaryName}</span>
+            <span style="font-family: var(--sl-font-mono, monospace); font-size: 0.8125rem;"
+              >${binaryName}</span
+            >
           </div>
           <div class="status-row">
             <span class="status-label">Config File</span>
-            <span style="font-family: var(--sl-font-mono, monospace); font-size: 0.8125rem;">${configFile}</span>
+            <span style="font-family: var(--sl-font-mono, monospace); font-size: 0.8125rem;"
+              >${configFile}</span
+            >
           </div>
           <div class="status-row">
             <span class="status-label">Start Command</span>
-            <span style="font-family: var(--sl-font-mono, monospace); font-size: 0.8125rem;">${startCommand}</span>
+            <span style="font-family: var(--sl-font-mono, monospace); font-size: 0.8125rem;"
+              >${startCommand}</span
+            >
           </div>
         </div>
       </div>
@@ -1617,9 +1844,7 @@ export class ScionPageAdminIntegrations extends LitElement {
   private renderSetupBanner(d: IntegrationDetail) {
     const platform = resolvePlatform(d.name);
     const secretDefs = PLATFORM_SECRETS[platform] ?? [];
-    const missingRequired = secretDefs.filter(
-      (s) => s.required && !d.has_secrets?.[s.key]
-    );
+    const missingRequired = secretDefs.filter((s) => s.required && !d.has_secrets?.[s.key]);
     if (missingRequired.length === 0) return nothing;
 
     const platformName = this.platformLabel(d.platform);
@@ -1660,7 +1885,8 @@ export class ScionPageAdminIntegrations extends LitElement {
           const def = secretDefMap.get(key);
           const label = def?.label ?? key;
           // For A2A, mark api_key as required when the scheme needs it.
-          const isRequired = platform === 'a2a' && key === 'api_key' ? apiKeyRelevant : (def?.required ?? false);
+          const isRequired =
+            platform === 'a2a' && key === 'api_key' ? apiKeyRelevant : (def?.required ?? false);
           const isConfigured = d.has_secrets?.[key];
           return html`
             <div class="secret-row">
@@ -1668,7 +1894,9 @@ export class ScionPageAdminIntegrations extends LitElement {
                 <span class="secret-key">
                   ${label}${isRequired ? html`<span class="required-tag">Required</span>` : nothing}
                 </span>
-                ${def?.description ? html`<div class="secret-description">${def.description}</div>` : nothing}
+                ${def?.description
+                  ? html`<div class="secret-description">${def.description}</div>`
+                  : nothing}
               </div>
               <span class="secret-status">
                 ${isConfigured
@@ -1679,7 +1907,9 @@ export class ScionPageAdminIntegrations extends LitElement {
                 class="secret-input"
                 type="password"
                 password-toggle
-                placeholder=${isConfigured ? 'Enter new value to update' : `Enter ${label.toLowerCase()}`}
+                placeholder=${isConfigured
+                  ? 'Enter new value to update'
+                  : `Enter ${label.toLowerCase()}`}
                 .value=${this.editedSecrets[key] ?? ''}
                 @sl-change=${(e: Event) => {
                   this.editedSecrets = {
@@ -1704,14 +1934,18 @@ export class ScionPageAdminIntegrations extends LitElement {
         <sl-button
           variant="primary"
           ?loading=${this.saving}
-          @click=${() => { void this.handleSaveConfig(); }}
+          @click=${() => {
+            void this.handleSaveConfig();
+          }}
         >
           Save Configuration
         </sl-button>
         <sl-button
           variant="default"
           ?loading=${this.restarting}
-          @click=${() => { void this.handleRestart(); }}
+          @click=${() => {
+            void this.handleRestart();
+          }}
         >
           <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
           ${restartLabel}
@@ -1721,7 +1955,9 @@ export class ScionPageAdminIntegrations extends LitElement {
               <sl-button
                 variant="default"
                 ?loading=${this.updating}
-                @click=${() => { void this.handleUpdate(); }}
+                @click=${() => {
+                  void this.handleUpdate();
+                }}
               >
                 <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
                 Update
@@ -1754,9 +1990,7 @@ export class ScionPageAdminIntegrations extends LitElement {
         variant = 'success';
         break;
       case 'failed':
-        message = this.updateDetail
-          ? `Update failed: ${this.updateDetail}`
-          : 'Update failed';
+        message = this.updateDetail ? `Update failed: ${this.updateDetail}` : 'Update failed';
         variant = 'danger';
         break;
     }
@@ -1767,7 +2001,10 @@ export class ScionPageAdminIntegrations extends LitElement {
       <sl-alert variant=${variant} open style="margin-top: 0.75rem;">
         ${showSpinner
           ? html`<sl-spinner slot="icon" style="font-size: 1rem;"></sl-spinner>`
-          : html`<sl-icon slot="icon" name=${variant === 'success' ? 'check-circle' : 'exclamation-triangle'}></sl-icon>`}
+          : html`<sl-icon
+              slot="icon"
+              name=${variant === 'success' ? 'check-circle' : 'exclamation-triangle'}
+            ></sl-icon>`}
         ${message}
       </sl-alert>
     `;

--- a/web/src/components/pages/admin-maintenance.ts
+++ b/web/src/components/pages/admin-maintenance.ts
@@ -141,7 +141,11 @@ export class ScionPageAdminMaintenance extends LitElement {
 
   /** Result of the last bulk reset-auth request. */
   @state()
-  private resetAuthAllResult: { succeeded: { id: string; name: string }[]; failed: { id: string; name: string; error: string }[]; total: number } | null = null;
+  private resetAuthAllResult: {
+    succeeded: { id: string; name: string }[];
+    failed: { id: string; name: string; error: string }[];
+    total: number;
+  } | null = null;
 
   /** Update check state for rebuild-server. */
   @state()
@@ -620,7 +624,9 @@ export class ScionPageAdminMaintenance extends LitElement {
     try {
       const response = await apiFetch('/api/v1/admin/maintenance/operations');
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       const data = (await response.json()) as MaintenanceResponse;
@@ -788,7 +794,7 @@ export class ScionPageAdminMaintenance extends LitElement {
               dryRun: this.runDialogDryRun,
             },
           }),
-        },
+        }
       );
 
       if (!response.ok) {
@@ -823,7 +829,7 @@ export class ScionPageAdminMaintenance extends LitElement {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ params: {} }),
-        },
+        }
       );
 
       if (!response.ok) {
@@ -865,9 +871,7 @@ export class ScionPageAdminMaintenance extends LitElement {
 
   private async loadRunHistory(key: string): Promise<void> {
     try {
-      const response = await apiFetch(
-        `/api/v1/admin/maintenance/operations/${key}/runs?limit=20`,
-      );
+      const response = await apiFetch(`/api/v1/admin/maintenance/operations/${key}/runs?limit=20`);
       if (!response.ok) return;
 
       const data = (await response.json()) as { runs: MaintenanceRun[] | null };
@@ -889,9 +893,7 @@ export class ScionPageAdminMaintenance extends LitElement {
     // Otherwise fetch the full run detail.
     try {
       const key = run.operationKey ?? '';
-      const response = await apiFetch(
-        `/api/v1/admin/maintenance/operations/${key}/runs/${run.id}`,
-      );
+      const response = await apiFetch(`/api/v1/admin/maintenance/operations/${key}/runs/${run.id}`);
       if (response.ok) {
         const detail = (await response.json()) as MaintenanceRun;
         this.viewingRun = detail;
@@ -907,7 +909,9 @@ export class ScionPageAdminMaintenance extends LitElement {
     this.viewingRun = null;
   }
 
-  private parseMigrationResult(resultStr: string | undefined): { log?: string; error?: string; dryRun?: boolean } | null {
+  private parseMigrationResult(
+    resultStr: string | undefined
+  ): { log?: string; error?: string; dryRun?: boolean } | null {
     if (!resultStr) return null;
     try {
       return JSON.parse(resultStr) as { log?: string; error?: string; dryRun?: boolean };
@@ -930,10 +934,7 @@ export class ScionPageAdminMaintenance extends LitElement {
         : this.error
           ? this.renderError()
           : this.renderContent()}
-
-      ${this.renderRunDialog()}
-      ${this.renderRunDetailDialog()}
-      ${this.renderRestartDialog()}
+      ${this.renderRunDialog()} ${this.renderRunDetailDialog()} ${this.renderRestartDialog()}
     `;
   }
 
@@ -963,9 +964,7 @@ export class ScionPageAdminMaintenance extends LitElement {
 
   private renderContent() {
     return html`
-      ${this.renderMaintenanceMode()}
-      ${this.renderQuickActions()}
-      ${this.renderMigrations()}
+      ${this.renderMaintenanceMode()} ${this.renderQuickActions()} ${this.renderMigrations()}
       ${this.renderOperations()}
     `;
   }
@@ -974,9 +973,7 @@ export class ScionPageAdminMaintenance extends LitElement {
     return html`
       <div class="section">
         <h2 class="section-title">Quick Actions</h2>
-        <p class="section-description">
-          One-off administrative actions across all agents.
-        </p>
+        <p class="section-description">One-off administrative actions across all agents.</p>
         <div class="card-list">
           <div class="card">
             <div class="card-header">
@@ -996,9 +993,9 @@ export class ScionPageAdminMaintenance extends LitElement {
                   `}
             </div>
             <div class="card-description">
-              Restart the hub service via systemd. This will briefly drop all
-              active connections (including WebSockets) while the process restarts.
-              Use this after changing settings that require a restart to take effect.
+              Restart the hub service via systemd. This will briefly drop all active connections
+              (including WebSockets) while the process restarts. Use this after changing settings
+              that require a restart to take effect.
             </div>
           </div>
           <div class="card">
@@ -1019,23 +1016,25 @@ export class ScionPageAdminMaintenance extends LitElement {
                   `}
             </div>
             <div class="card-description">
-              Inject a fresh auth token into every running agent without restarting them.
-              The token refresh loop in each agent will pick up the new credentials automatically.
+              Inject a fresh auth token into every running agent without restarting them. The token
+              refresh loop in each agent will pick up the new credentials automatically.
             </div>
             ${this.resetAuthAllResult
               ? html`
                   <div class="card-meta">
                     <span>
-                      Total: ${this.resetAuthAllResult.total} &middot;
-                      Succeeded: ${this.resetAuthAllResult.succeeded?.length ?? 0} &middot;
-                      Failed: ${this.resetAuthAllResult.failed?.length ?? 0}
+                      Total: ${this.resetAuthAllResult.total} &middot; Succeeded:
+                      ${this.resetAuthAllResult.succeeded?.length ?? 0} &middot; Failed:
+                      ${this.resetAuthAllResult.failed?.length ?? 0}
                     </span>
                   </div>
                   ${(this.resetAuthAllResult.failed?.length ?? 0) > 0
                     ? html`
-                        <div class="result-log result-error">${this.resetAuthAllResult.failed
+                        <div class="result-log result-error">
+                          ${this.resetAuthAllResult.failed
                             .map((f) => `${f.name || f.id}: ${f.error}`)
-                            .join('\n')}</div>
+                            .join('\n')}
+                        </div>
                       `
                     : nothing}
                 `
@@ -1086,7 +1085,10 @@ export class ScionPageAdminMaintenance extends LitElement {
         throw new Error(errMsg);
       }
       this.restartDialogOpen = false;
-      showToast('Hub is restarting... The page will reconnect shortly.', 'primary', { icon: 'info-circle', duration: 10000 });
+      showToast('Hub is restarting... The page will reconnect shortly.', 'primary', {
+        icon: 'info-circle',
+        duration: 10000,
+      });
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Failed to restart hub');
     } finally {
@@ -1099,21 +1101,20 @@ export class ScionPageAdminMaintenance extends LitElement {
       <div class="section">
         <h2 class="section-title">Maintenance Mode</h2>
         <p class="section-description">
-          When maintenance mode is enabled, only administrators can log in.
-          All other users will be temporarily blocked until maintenance mode is
-          disabled.
+          When maintenance mode is enabled, only administrators can log in. All other users will be
+          temporarily blocked until maintenance mode is disabled.
         </p>
         <div class="maintenance-mode-toggle">
           <button
             class="toggle-track ${this.maintenanceEnabled ? 'active' : ''}"
-            @click=${() => { this.toggleMaintenance(); }}
+            @click=${() => {
+              this.toggleMaintenance();
+            }}
             aria-label="Toggle maintenance mode"
           >
             <span class="toggle-knob"></span>
           </button>
-          <span class="toggle-label">
-            ${this.maintenanceEnabled ? 'Enabled' : 'Disabled'}
-          </span>
+          <span class="toggle-label"> ${this.maintenanceEnabled ? 'Enabled' : 'Disabled'} </span>
         </div>
       </div>
     `;
@@ -1124,8 +1125,8 @@ export class ScionPageAdminMaintenance extends LitElement {
       <div class="section">
         <h2 class="section-title">Migrations</h2>
         <p class="section-description">
-          One-time data migrations that transition the system between states.
-          Completed migrations cannot be re-run from the UI.
+          One-time data migrations that transition the system between states. Completed migrations
+          cannot be re-run from the UI.
         </p>
         ${this.migrations.length === 0
           ? html`<div class="empty-inline">No migrations registered.</div>`
@@ -1148,10 +1149,7 @@ export class ScionPageAdminMaintenance extends LitElement {
         <div class="card-header">
           ${isRunning
             ? html`<sl-spinner style="font-size: 1.25rem;"></sl-spinner>`
-            : html`<sl-icon
-                name="${this.statusIcon(m.status)}"
-                class="${m.status}"
-              ></sl-icon>`}
+            : html`<sl-icon name="${this.statusIcon(m.status)}" class="${m.status}"></sl-icon>`}
           <span class="card-title">${m.title}</span>
           <span class="status-badge ${m.status}">${m.status}</span>
         </div>
@@ -1161,9 +1159,7 @@ export class ScionPageAdminMaintenance extends LitElement {
           ${m.completedAt
             ? html`<span>Completed: ${this.formatDate(m.completedAt)}</span>`
             : nothing}
-          ${m.startedBy
-            ? html`<span>By: ${m.startedBy}</span>`
-            : nothing}
+          ${m.startedBy ? html`<span>By: ${m.startedBy}</span>` : nothing}
         </div>
         ${result?.log
           ? html`<div class="result-log ${result.error ? 'result-error' : ''}">${result.log}</div>`
@@ -1186,11 +1182,7 @@ export class ScionPageAdminMaintenance extends LitElement {
                         ${m.status === 'failed' ? 'Retry' : 'Run'}
                       </sl-button>
                     `
-                  : html`
-                      <sl-button size="small" disabled loading>
-                        Running...
-                      </sl-button>
-                    `}
+                  : html` <sl-button size="small" disabled loading> Running... </sl-button> `}
               </div>
             `
           : nothing}
@@ -1262,16 +1254,14 @@ export class ScionPageAdminMaintenance extends LitElement {
           ? html`
               <div class="card-meta">
                 <span>
-                  Last run: ${this.formatRelativeTime(op.lastRun.startedAt)}
-                  (<span class="status-badge ${op.lastRun.status}">${op.lastRun.status}</span>)
+                  Last run: ${this.formatRelativeTime(op.lastRun.startedAt)} (<span
+                    class="status-badge ${op.lastRun.status}"
+                    >${op.lastRun.status}</span
+                  >)
                 </span>
-                ${op.lastRun.startedBy
-                  ? html`<span>by ${op.lastRun.startedBy}</span>`
-                  : nothing}
+                ${op.lastRun.startedBy ? html`<span>by ${op.lastRun.startedBy}</span>` : nothing}
               </div>
-              ${op.lastRun.status === 'failed'
-                ? this.renderLastRunError(op.lastRun)
-                : nothing}
+              ${op.lastRun.status === 'failed' ? this.renderLastRunError(op.lastRun) : nothing}
             `
           : html`
               <div class="card-meta">
@@ -1321,7 +1311,7 @@ export class ScionPageAdminMaintenance extends LitElement {
                 <td><span class="status-badge ${run.status}">${run.status}</span></td>
                 <td>${run.startedBy ?? '--'}</td>
               </tr>
-            `,
+            `
           )}
         </tbody>
       </table>
@@ -1342,11 +1332,7 @@ export class ScionPageAdminMaintenance extends LitElement {
     if (!migration) return nothing;
 
     return html`
-      <sl-dialog
-        label="Run Migration"
-        open
-        @sl-request-close=${() => this.closeRunDialog()}
-      >
+      <sl-dialog label="Run Migration" open @sl-request-close=${() => this.closeRunDialog()}>
         <div class="dialog-body">
           <p><strong>${migration.title}</strong></p>
           <p>${migration.description}</p>
@@ -1364,7 +1350,8 @@ export class ScionPageAdminMaintenance extends LitElement {
           variant="default"
           @click=${() => this.closeRunDialog()}
           ?disabled=${this.runInProgress}
-        >Cancel</sl-button>
+          >Cancel</sl-button
+        >
         <sl-button
           slot="footer"
           variant="primary"
@@ -1385,11 +1372,7 @@ export class ScionPageAdminMaintenance extends LitElement {
     const isDestructive = this.runDialogKey === 'rebuild-server';
 
     return html`
-      <sl-dialog
-        label="Run Operation"
-        open
-        @sl-request-close=${() => this.closeRunDialog()}
-      >
+      <sl-dialog label="Run Operation" open @sl-request-close=${() => this.closeRunDialog()}>
         <div class="dialog-body">
           <p><strong>${operation.title}</strong></p>
           <p>${operation.description}</p>
@@ -1404,7 +1387,8 @@ export class ScionPageAdminMaintenance extends LitElement {
           variant="default"
           @click=${() => this.closeRunDialog()}
           ?disabled=${this.runInProgress}
-        >Cancel</sl-button>
+          >Cancel</sl-button
+        >
         <sl-button
           slot="footer"
           variant="${isDestructive ? 'warning' : 'primary'}"
@@ -1446,11 +1430,9 @@ export class ScionPageAdminMaintenance extends LitElement {
             ? html`<div class="result-log">${run.log}</div>`
             : html`<div class="empty-inline">No log output captured.</div>`}
         </div>
-        <sl-button
-          slot="footer"
-          variant="default"
-          @click=${() => this.closeRunDetail()}
-        >Close</sl-button>
+        <sl-button slot="footer" variant="default" @click=${() => this.closeRunDetail()}
+          >Close</sl-button
+        >
       </sl-dialog>
     `;
   }
@@ -1459,18 +1441,12 @@ export class ScionPageAdminMaintenance extends LitElement {
     if (!this.restartDialogOpen) return nothing;
 
     return html`
-      <sl-dialog
-        label="Restart Hub"
-        open
-        @sl-request-close=${() => this.closeRestartDialog()}
-      >
+      <sl-dialog label="Restart Hub" open @sl-request-close=${() => this.closeRestartDialog()}>
         <div class="dialog-body">
-          <p>
-            Are you sure you want to restart the hub service?
-          </p>
+          <p>Are you sure you want to restart the hub service?</p>
           <p style="color: var(--sl-color-warning-700, #a16207); font-weight: 500;">
-            This will briefly disconnect all users and drop active WebSocket
-            connections. The hub will be back online within a few seconds.
+            This will briefly disconnect all users and drop active WebSocket connections. The hub
+            will be back online within a few seconds.
           </p>
         </div>
         <sl-button
@@ -1478,7 +1454,8 @@ export class ScionPageAdminMaintenance extends LitElement {
           variant="default"
           @click=${() => this.closeRestartDialog()}
           ?disabled=${this.restartLoading}
-        >Cancel</sl-button>
+          >Cancel</sl-button
+        >
         <sl-button
           slot="footer"
           variant="warning"
@@ -1521,9 +1498,10 @@ export class ScionPageAdminMaintenance extends LitElement {
     const r = this.updateCheckResult;
     if (!r) return nothing;
 
-    const branchLabel = r.current_branch && r.current_branch !== 'main'
-      ? html` on <code>${r.current_branch}</code>`
-      : nothing;
+    const branchLabel =
+      r.current_branch && r.current_branch !== 'main'
+        ? html` on <code>${r.current_branch}</code>`
+        : nothing;
 
     if (!r.update_available) {
       return html`
@@ -1547,11 +1525,7 @@ export class ScionPageAdminMaintenance extends LitElement {
           ? html`
               <div class="update-check-commits">
                 ${r.new_commits.map(
-                  (c) => html`
-                    <div>
-                      <span class="commit-hash">${c.hash}</span>${c.subject}
-                    </div>
-                  `,
+                  (c) => html` <div><span class="commit-hash">${c.hash}</span>${c.subject}</div> `
                 )}
               </div>
             `

--- a/web/src/components/pages/admin-scheduler.ts
+++ b/web/src/components/pages/admin-scheduler.ts
@@ -397,7 +397,9 @@ export class ScionPageAdminScheduler extends LitElement {
       ]);
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       const data = (await response.json()) as SchedulerResponse;
@@ -406,7 +408,9 @@ export class ScionPageAdminScheduler extends LitElement {
 
       // Build project ID -> name/slug lookup map
       if (projectsResponse.ok) {
-        const projectsBody = (await projectsResponse.json()) as { projects: { id: string; name: string; slug?: string }[] };
+        const projectsBody = (await projectsResponse.json()) as {
+          projects: { id: string; name: string; slug?: string }[];
+        };
         const projectsData = projectsBody.projects ?? [];
         const map = new Map<string, { name: string; slug: string }>();
         for (const p of projectsData) {
@@ -476,10 +480,14 @@ export class ScionPageAdminScheduler extends LitElement {
   private renderProjectCell(projectId: string) {
     const project = this.projectMap.get(projectId);
     if (project) {
-      return html`<a class="project-link" href="/projects/${encodeURIComponent(project.slug)}">${project.name}</a>`;
+      return html`<a class="project-link" href="/projects/${encodeURIComponent(project.slug)}"
+        >${project.name}</a
+      >`;
     }
     // Fallback to truncated ID if project not found
-    return html`<span class="mono">${projectId.length > 12 ? projectId.slice(0, 12) + '...' : projectId}</span>`;
+    return html`<span class="mono"
+      >${projectId.length > 12 ? projectId.slice(0, 12) + '...' : projectId}</span
+    >`;
   }
 
   private formatInterval(minutes: number): string {
@@ -557,9 +565,7 @@ export class ScionPageAdminScheduler extends LitElement {
       return html`
         <div class="section">
           <h2 class="section-title">Scheduler Not Available</h2>
-          <p class="section-description">
-            The scheduler has not been initialized on this server.
-          </p>
+          <p class="section-description">The scheduler has not been initialized on this server.</p>
         </div>
       `;
     }
@@ -567,10 +573,8 @@ export class ScionPageAdminScheduler extends LitElement {
     const events = scheduledEvents ?? [];
 
     return html`
-      ${this.renderOverview(scheduler)}
-      ${this.renderRecurringHandlers(scheduler.recurringHandlers)}
-      ${this.renderEventHandlers(scheduler.eventHandlers)}
-      ${this.renderRecurringSchedules()}
+      ${this.renderOverview(scheduler)} ${this.renderRecurringHandlers(scheduler.recurringHandlers)}
+      ${this.renderEventHandlers(scheduler.eventHandlers)} ${this.renderRecurringSchedules()}
       ${this.renderScheduledEvents(events)}
     `;
   }
@@ -728,9 +732,7 @@ export class ScionPageAdminScheduler extends LitElement {
                                 : '-'}
                             </span>
                           </td>
-                          <td class="hide-mobile">
-                            ${this.renderProjectCell(sched.projectId)}
-                          </td>
+                          <td class="hide-mobile">${this.renderProjectCell(sched.projectId)}</td>
                           <td class="hide-mobile">
                             <span class="meta-text">
                               ${sched.runCount}${sched.errorCount > 0
@@ -744,7 +746,12 @@ export class ScionPageAdminScheduler extends LitElement {
                                   <span class="meta-text">
                                     ${this.formatRelativeTime(sched.lastRunAt)}
                                     ${sched.lastRunStatus === 'error'
-                                      ? html`<span class="error-text" title=${sched.lastRunError || ''}> (error)</span>`
+                                      ? html`<span
+                                          class="error-text"
+                                          title=${sched.lastRunError || ''}
+                                        >
+                                          (error)</span
+                                        >`
                                       : ''}
                                   </span>
                                 `
@@ -773,9 +780,7 @@ export class ScionPageAdminScheduler extends LitElement {
         <td><span class="type-badge">${evt.eventType}</span></td>
         <td><span class="status-badge ${evt.status}">${evt.status}</span></td>
         <td><span class="meta-text">${fireTimeDisplay}</span></td>
-        <td class="hide-mobile">
-          ${this.renderProjectCell(evt.projectId)}
-        </td>
+        <td class="hide-mobile">${this.renderProjectCell(evt.projectId)}</td>
         <td class="hide-mobile">
           <span class="meta-text">${this.formatRelativeTime(evt.createdAt)}</span>
         </td>

--- a/web/src/components/pages/admin-server-config.test.ts
+++ b/web/src/components/pages/admin-server-config.test.ts
@@ -42,13 +42,56 @@ function makeBaseConfig(overrides: Record<string, unknown> = {}) {
 
 const SCHEMA_RESPONSE = {
   sections: {
-    access: { koanf_paths: ['server.hub.admin_emails', 'server.auth.user_access_mode', 'server.auth.authorized_domains'] },
-    lifecycle: { koanf_paths: ['server.hub.auto_suspend_stalled', 'server.hub.soft_delete_retention', 'server.hub.soft_delete_retain_files'] },
+    access: {
+      koanf_paths: [
+        'server.hub.admin_emails',
+        'server.auth.user_access_mode',
+        'server.auth.authorized_domains',
+      ],
+    },
+    lifecycle: {
+      koanf_paths: [
+        'server.hub.auto_suspend_stalled',
+        'server.hub.soft_delete_retention',
+        'server.hub.soft_delete_retain_files',
+      ],
+    },
     endpoints: { koanf_paths: ['server.hub.public_url', 'image_registry'] },
-    agent_defaults: { koanf_paths: ['default_template', 'default_harness_config', 'default_max_turns', 'default_max_model_calls', 'default_max_duration', 'default_resources'] },
-    telemetry: { koanf_paths: ['telemetry.enabled', 'telemetry.cloud.enabled', 'telemetry.cloud.endpoint', 'telemetry.cloud.protocol', 'telemetry.cloud.provider', 'telemetry.hub.enabled', 'telemetry.hub.report_interval', 'telemetry.local.enabled', 'telemetry.local.file', 'telemetry.local.console'] },
+    agent_defaults: {
+      koanf_paths: [
+        'default_template',
+        'default_harness_config',
+        'default_max_turns',
+        'default_max_model_calls',
+        'default_max_duration',
+        'default_resources',
+      ],
+    },
+    telemetry: {
+      koanf_paths: [
+        'telemetry.enabled',
+        'telemetry.cloud.enabled',
+        'telemetry.cloud.endpoint',
+        'telemetry.cloud.protocol',
+        'telemetry.cloud.provider',
+        'telemetry.hub.enabled',
+        'telemetry.hub.report_interval',
+        'telemetry.local.enabled',
+        'telemetry.local.file',
+        'telemetry.local.console',
+      ],
+    },
     notifications: { koanf_paths: ['server.notification_channels'] },
-    github_app: { koanf_paths: ['server.github_app', 'server.github_app.app_id', 'server.github_app.api_base_url', 'server.github_app.webhooks_enabled', 'server.github_app.installation_url', 'server.github_app.private_key_path'] },
+    github_app: {
+      koanf_paths: [
+        'server.github_app',
+        'server.github_app.app_id',
+        'server.github_app.api_base_url',
+        'server.github_app.webhooks_enabled',
+        'server.github_app.installation_url',
+        'server.github_app.private_key_path',
+      ],
+    },
   },
 };
 
@@ -56,8 +99,11 @@ function createFetchHandler(
   configResponse: Record<string, unknown>,
   opts?: {
     schemaResponse?: Record<string, unknown> | null;
-    putHandler?: (body: Record<string, unknown>) => { status: number; body: Record<string, unknown> };
-  },
+    putHandler?: (body: Record<string, unknown>) => {
+      status: number;
+      body: Record<string, unknown>;
+    };
+  }
 ) {
   return (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const path = typeof url === 'string' ? url : url instanceof URL ? url.pathname : url.url;
@@ -65,47 +111,59 @@ function createFetchHandler(
     if (init?.method === 'PUT' && opts?.putHandler) {
       const reqBody = JSON.parse(init.body as string);
       const result = opts.putHandler(reqBody);
-      return Promise.resolve(new Response(JSON.stringify(result.body), {
-        status: result.status,
-        headers: { 'Content-Type': 'application/json' },
-      }));
+      return Promise.resolve(
+        new Response(JSON.stringify(result.body), {
+          status: result.status,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
     }
 
     if (path.includes('/api/v1/admin/server-config/schema')) {
       if (opts?.schemaResponse === null) {
         return Promise.resolve(new Response('', { status: 500 }));
       }
-      return Promise.resolve(new Response(JSON.stringify(opts?.schemaResponse ?? SCHEMA_RESPONSE), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }));
+      return Promise.resolve(
+        new Response(JSON.stringify(opts?.schemaResponse ?? SCHEMA_RESPONSE), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
     }
 
     if (path.includes('/api/v1/admin/server-config')) {
-      return Promise.resolve(new Response(JSON.stringify(configResponse), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }));
+      return Promise.resolve(
+        new Response(JSON.stringify(configResponse), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
     }
 
     if (path.includes('/api/v1/github-app/installations')) {
-      return Promise.resolve(new Response(JSON.stringify([]), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }));
+      return Promise.resolve(
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
     }
 
     if (path.includes('/api/v1/github-app')) {
-      return Promise.resolve(new Response(JSON.stringify({}), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }));
+      return Promise.resolve(
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
     }
 
-    return Promise.resolve(new Response(JSON.stringify([]), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    }));
+    return Promise.resolve(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
   };
 }
 
@@ -114,13 +172,15 @@ function createFetchHandler(
 let ScionPageAdminServerConfig: any;
 
 async function createComponent(
-  fetchHandler: (url: string | URL | Request, init?: RequestInit) => Promise<Response>,
+  fetchHandler: (url: string | URL | Request, init?: RequestInit) => Promise<Response>
 ) {
   vi.stubGlobal('fetch', vi.fn(fetchHandler));
-  const el = document.createElement('scion-page-admin-server-config') as InstanceType<typeof ScionPageAdminServerConfig>;
+  const el = document.createElement('scion-page-admin-server-config') as InstanceType<
+    typeof ScionPageAdminServerConfig
+  >;
   document.body.appendChild(el);
   await el.updateComplete;
-  await new Promise(resolve => setTimeout(resolve, 200));
+  await new Promise((resolve) => setTimeout(resolve, 200));
   await el.updateComplete;
   return el;
 }
@@ -166,7 +226,7 @@ describe('scion-page-admin-server-config', () => {
     element = await createComponent(createFetchHandler(makeBaseConfig()));
     expect(vi.mocked(fetch)).toHaveBeenCalledWith(
       expect.stringContaining('/api/v1/admin/server-config'),
-      expect.any(Object),
+      expect.any(Object)
     );
   });
 
@@ -247,18 +307,20 @@ describe('scion-page-admin-server-config', () => {
       const config = makeBaseConfig({ settings_tier: 'db' });
       let capturedPayload: Record<string, unknown> | null = null;
 
-      element = await createComponent(createFetchHandler(config, {
-        putHandler: (body) => {
-          capturedPayload = body;
-          return { status: 200, body: { reload: { applied: [] } } };
-        },
-      }));
+      element = await createComponent(
+        createFetchHandler(config, {
+          putHandler: (body) => {
+            capturedPayload = body;
+            return { status: 200, body: { reload: { applied: [] } } };
+          },
+        })
+      );
 
       const buttons = queryAll(element, 'sl-button[variant="primary"]');
-      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      const saveBtn = buttons.find((b) => b.textContent?.trim() === 'Save & Reload');
       expect(saveBtn).not.toBeNull();
       (saveBtn as HTMLElement).click();
-      await new Promise(resolve => setTimeout(resolve, 300));
+      await new Promise((resolve) => setTimeout(resolve, 300));
       await (element as any).updateComplete;
 
       expect(capturedPayload).not.toBeNull();
@@ -283,17 +345,19 @@ describe('scion-page-admin-server-config', () => {
       const config = makeBaseConfig({ settings_tier: 'db' });
       let putCalled = false;
 
-      element = await createComponent(createFetchHandler(config, {
-        putHandler: () => {
-          putCalled = true;
-          return { status: 200, body: { reload: { applied: [] } } };
-        },
-      }));
+      element = await createComponent(
+        createFetchHandler(config, {
+          putHandler: () => {
+            putCalled = true;
+            return { status: 200, body: { reload: { applied: [] } } };
+          },
+        })
+      );
 
       const buttons = queryAll(element, 'sl-button[variant="primary"]');
-      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      const saveBtn = buttons.find((b) => b.textContent?.trim() === 'Save & Reload');
       (saveBtn as HTMLElement).click();
-      await new Promise(resolve => setTimeout(resolve, 300));
+      await new Promise((resolve) => setTimeout(resolve, 300));
 
       expect(putCalled).toBe(true);
       expect(query(element, '.safety-net-notice')).toBeNull();
@@ -309,8 +373,8 @@ describe('scion-page-admin-server-config', () => {
 
       const badges = queryAll(element, '.read-only-badge');
       expect(badges.length).toBeGreaterThan(0);
-      const badgeTexts = badges.map(b => b.textContent ?? '');
-      expect(badgeTexts.some(t => t.includes('deployment configuration'))).toBe(true);
+      const badgeTexts = badges.map((b) => b.textContent ?? '');
+      expect(badgeTexts.some((t) => t.includes('deployment configuration'))).toBe(true);
     });
 
     it('server.mode renders as read-only value (not editable select)', async () => {
@@ -318,7 +382,7 @@ describe('scion-page-admin-server-config', () => {
       element = await createComponent(createFetchHandler(config));
 
       const readOnlyValues = queryAll(element, '.read-only-value');
-      const values = readOnlyValues.map(el => el.textContent?.trim());
+      const values = readOnlyValues.map((el) => el.textContent?.trim());
       expect(values).toContain('standalone');
     });
 
@@ -327,7 +391,7 @@ describe('scion-page-admin-server-config', () => {
       element = await createComponent(createFetchHandler(config));
 
       const readOnlyValues = queryAll(element, '.read-only-value');
-      const values = readOnlyValues.map(el => el.textContent?.trim());
+      const values = readOnlyValues.map((el) => el.textContent?.trim());
       expect(values).toContain('postgres');
     });
 
@@ -336,7 +400,7 @@ describe('scion-page-admin-server-config', () => {
       element = await createComponent(createFetchHandler(config));
 
       const readOnlyValues = queryAll(element, '.read-only-value');
-      const values = readOnlyValues.map(el => el.textContent?.trim());
+      const values = readOnlyValues.map((el) => el.textContent?.trim());
       expect(values).toContain('info');
     });
 
@@ -345,7 +409,7 @@ describe('scion-page-admin-server-config', () => {
       element = await createComponent(createFetchHandler(config));
 
       const readOnlyValues = queryAll(element, '.read-only-value');
-      const values = readOnlyValues.map(el => el.textContent?.trim());
+      const values = readOnlyValues.map((el) => el.textContent?.trim());
       expect(values).toContain('8080');
     });
 
@@ -353,17 +417,19 @@ describe('scion-page-admin-server-config', () => {
       const config = makeBaseConfig({ settings_tier: 'db' });
       let capturedPayload: Record<string, unknown> | null = null;
 
-      element = await createComponent(createFetchHandler(config, {
-        putHandler: (body) => {
-          capturedPayload = body;
-          return { status: 200, body: { reload: { applied: [] } } };
-        },
-      }));
+      element = await createComponent(
+        createFetchHandler(config, {
+          putHandler: (body) => {
+            capturedPayload = body;
+            return { status: 200, body: { reload: { applied: [] } } };
+          },
+        })
+      );
 
       const buttons = queryAll(element, 'sl-button[variant="primary"]');
-      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      const saveBtn = buttons.find((b) => b.textContent?.trim() === 'Save & Reload');
       (saveBtn as HTMLElement).click();
-      await new Promise(resolve => setTimeout(resolve, 300));
+      await new Promise((resolve) => setTimeout(resolve, 300));
 
       expect(capturedPayload).not.toBeNull();
       const server = capturedPayload!.server as Record<string, unknown> | undefined;
@@ -398,11 +464,11 @@ describe('scion-page-admin-server-config', () => {
       element = await createComponent(createFetchHandler(config));
 
       const badges = queryAll(element, '.read-only-badge');
-      const badgeTexts = badges.map(b => b.textContent ?? '');
-      expect(badgeTexts.some(t => t.includes('environment variable'))).toBe(true);
+      const badgeTexts = badges.map((b) => b.textContent ?? '');
+      expect(badgeTexts.some((t) => t.includes('environment variable'))).toBe(true);
 
       const readOnlyValues = queryAll(element, '.read-only-value');
-      const values = readOnlyValues.map(el => el.textContent?.trim());
+      const values = readOnlyValues.map((el) => el.textContent?.trim());
       expect(values).toContain('8080');
     });
 
@@ -413,17 +479,19 @@ describe('scion-page-admin-server-config', () => {
       });
       let capturedPayload: Record<string, unknown> | null = null;
 
-      element = await createComponent(createFetchHandler(config, {
-        putHandler: (body) => {
-          capturedPayload = body;
-          return { status: 200, body: { reload: { applied: [] } } };
-        },
-      }));
+      element = await createComponent(
+        createFetchHandler(config, {
+          putHandler: (body) => {
+            capturedPayload = body;
+            return { status: 200, body: { reload: { applied: [] } } };
+          },
+        })
+      );
 
       const buttons = queryAll(element, 'sl-button[variant="primary"]');
-      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      const saveBtn = buttons.find((b) => b.textContent?.trim() === 'Save & Reload');
       (saveBtn as HTMLElement).click();
-      await new Promise(resolve => setTimeout(resolve, 300));
+      await new Promise((resolve) => setTimeout(resolve, 300));
 
       expect(capturedPayload).not.toBeNull();
       const server = capturedPayload!.server as Record<string, unknown> | undefined;
@@ -448,17 +516,19 @@ describe('scion-page-admin-server-config', () => {
       const config = makeBaseConfig({ settings_tier: 'file' });
       let capturedPayload: Record<string, unknown> | null = null;
 
-      element = await createComponent(createFetchHandler(config, {
-        putHandler: (body) => {
-          capturedPayload = body;
-          return { status: 200, body: { reload: { applied: [] } } };
-        },
-      }));
+      element = await createComponent(
+        createFetchHandler(config, {
+          putHandler: (body) => {
+            capturedPayload = body;
+            return { status: 200, body: { reload: { applied: [] } } };
+          },
+        })
+      );
 
       const buttons = queryAll(element, 'sl-button[variant="primary"]');
-      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      const saveBtn = buttons.find((b) => b.textContent?.trim() === 'Save & Reload');
       (saveBtn as HTMLElement).click();
-      await new Promise(resolve => setTimeout(resolve, 300));
+      await new Promise((resolve) => setTimeout(resolve, 300));
 
       expect(capturedPayload).not.toBeNull();
       const server = capturedPayload!.server as Record<string, unknown> | undefined;
@@ -475,24 +545,24 @@ describe('scion-page-admin-server-config', () => {
     it('400 validation_failed renders inline errors', async () => {
       const config = makeBaseConfig({ settings_tier: 'db' });
 
-      element = await createComponent(createFetchHandler(config, {
-        putHandler: () => ({
-          status: 400,
-          body: {
-            error: 'validation_failed',
-            errors: {
-              access: [
-                { field: 'admin_emails', message: 'invalid email format' },
-              ],
+      element = await createComponent(
+        createFetchHandler(config, {
+          putHandler: () => ({
+            status: 400,
+            body: {
+              error: 'validation_failed',
+              errors: {
+                access: [{ field: 'admin_emails', message: 'invalid email format' }],
+              },
             },
-          },
-        }),
-      }));
+          }),
+        })
+      );
 
       const buttons = queryAll(element, 'sl-button[variant="primary"]');
-      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      const saveBtn = buttons.find((b) => b.textContent?.trim() === 'Save & Reload');
       (saveBtn as HTMLElement).click();
-      await new Promise(resolve => setTimeout(resolve, 300));
+      await new Promise((resolve) => setTimeout(resolve, 300));
       await (element as any).updateComplete;
 
       const errorsEl = query(element, '.validation-errors');
@@ -505,21 +575,23 @@ describe('scion-page-admin-server-config', () => {
     it('409 revision_conflict renders conflict banner with Reload button', async () => {
       const config = makeBaseConfig({ settings_tier: 'db' });
 
-      element = await createComponent(createFetchHandler(config, {
-        putHandler: () => ({
-          status: 409,
-          body: {
-            error: 'revision_conflict',
-            message: 'Settings have been changed since you loaded this page.',
-            conflicted: [{ section: 'access', expected_revision: 3, current_revision: 5 }],
-          },
-        }),
-      }));
+      element = await createComponent(
+        createFetchHandler(config, {
+          putHandler: () => ({
+            status: 409,
+            body: {
+              error: 'revision_conflict',
+              message: 'Settings have been changed since you loaded this page.',
+              conflicted: [{ section: 'access', expected_revision: 3, current_revision: 5 }],
+            },
+          }),
+        })
+      );
 
       const buttons = queryAll(element, 'sl-button[variant="primary"]');
-      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      const saveBtn = buttons.find((b) => b.textContent?.trim() === 'Save & Reload');
       (saveBtn as HTMLElement).click();
-      await new Promise(resolve => setTimeout(resolve, 300));
+      await new Promise((resolve) => setTimeout(resolve, 300));
       await (element as any).updateComplete;
 
       const bannerEl = query(element, '.conflict-banner');
@@ -536,20 +608,22 @@ describe('scion-page-admin-server-config', () => {
       const config = makeBaseConfig({ settings_tier: 'db' });
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-      element = await createComponent(createFetchHandler(config, {
-        putHandler: () => ({
-          status: 422,
-          body: {
-            error: 'layer0_rejected',
-            keys: ['server.mode', 'server.database.driver'],
-          },
-        }),
-      }));
+      element = await createComponent(
+        createFetchHandler(config, {
+          putHandler: () => ({
+            status: 422,
+            body: {
+              error: 'layer0_rejected',
+              keys: ['server.mode', 'server.database.driver'],
+            },
+          }),
+        })
+      );
 
       const buttons = queryAll(element, 'sl-button[variant="primary"]');
-      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      const saveBtn = buttons.find((b) => b.textContent?.trim() === 'Save & Reload');
       (saveBtn as HTMLElement).click();
-      await new Promise(resolve => setTimeout(resolve, 300));
+      await new Promise((resolve) => setTimeout(resolve, 300));
       await (element as any).updateComplete;
 
       const noticeEl = query(element, '.safety-net-notice');
@@ -561,7 +635,7 @@ describe('scion-page-admin-server-config', () => {
 
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining('layer0_rejected'),
-        expect.arrayContaining(['server.mode', 'server.database.driver']),
+        expect.arrayContaining(['server.mode', 'server.database.driver'])
       );
 
       consoleSpy.mockRestore();
@@ -570,20 +644,22 @@ describe('scion-page-admin-server-config', () => {
     it('unknown error falls back to generic error message', async () => {
       const config = makeBaseConfig({ settings_tier: 'db' });
 
-      element = await createComponent(createFetchHandler(config, {
-        putHandler: () => ({
-          status: 500,
-          body: {
-            error: 'some_unknown_error',
-            message: 'Something went terribly wrong',
-          },
-        }),
-      }));
+      element = await createComponent(
+        createFetchHandler(config, {
+          putHandler: () => ({
+            status: 500,
+            body: {
+              error: 'some_unknown_error',
+              message: 'Something went terribly wrong',
+            },
+          }),
+        })
+      );
 
       const buttons = queryAll(element, 'sl-button[variant="primary"]');
-      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      const saveBtn = buttons.find((b) => b.textContent?.trim() === 'Save & Reload');
       (saveBtn as HTMLElement).click();
-      await new Promise(resolve => setTimeout(resolve, 300));
+      await new Promise((resolve) => setTimeout(resolve, 300));
       await (element as any).updateComplete;
 
       expect(shadowText(element)).toContain('Something went terribly wrong');
@@ -602,8 +678,8 @@ describe('scion-page-admin-server-config', () => {
 
       const badges = queryAll(element, '.read-only-badge');
       expect(badges.length).toBeGreaterThan(0);
-      const badgeTexts = badges.map(b => b.textContent ?? '');
-      expect(badgeTexts.some(t => t.includes('deployment configuration'))).toBe(true);
+      const badgeTexts = badges.map((b) => b.textContent ?? '');
+      expect(badgeTexts.some((t) => t.includes('deployment configuration'))).toBe(true);
     });
   });
 
@@ -621,12 +697,14 @@ describe('scion-page-admin-server-config', () => {
       });
       let capturedPayload: Record<string, unknown> | null = null;
 
-      element = await createComponent(createFetchHandler(config, {
-        putHandler: (body) => {
-          capturedPayload = body;
-          return { status: 200, body: { reload: { applied: [] } } };
-        },
-      }));
+      element = await createComponent(
+        createFetchHandler(config, {
+          putHandler: (body) => {
+            capturedPayload = body;
+            return { status: 200, body: { reload: { applied: [] } } };
+          },
+        })
+      );
 
       // Simulate clearing the fields: set the internal state to zero/empty.
       // In the real UI, the user would clear the input fields.
@@ -637,10 +715,10 @@ describe('scion-page-admin-server-config', () => {
 
       // Trigger save.
       const buttons = queryAll(element, 'sl-button[variant="primary"]');
-      const saveBtn = buttons.find(b => b.textContent?.trim() === 'Save & Reload');
+      const saveBtn = buttons.find((b) => b.textContent?.trim() === 'Save & Reload');
       expect(saveBtn).not.toBeNull();
       (saveBtn as HTMLElement).click();
-      await new Promise(resolve => setTimeout(resolve, 300));
+      await new Promise((resolve) => setTimeout(resolve, 300));
       await (element as any).updateComplete;
 
       expect(capturedPayload).not.toBeNull();

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -446,7 +446,13 @@ export class ScionPageAdminServerConfig extends LitElement {
 
   // Default agent model settings
   @state() private defaultModel = '';
-  @state() private defaultModelSelection: '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other' = '';
+  @state() private defaultModelSelection:
+    | ''
+    | 'small'
+    | 'medium'
+    | 'large'
+    | 'extra-large'
+    | 'other' = '';
   @state() private defaultCustomModelId = '';
   @state() private defaultThinkingLevel: number | null = null;
 
@@ -1385,9 +1391,7 @@ export class ScionPageAdminServerConfig extends LitElement {
         sections?: Record<string, { koanf_paths?: string[] }>;
       };
       if (data.sections) {
-        const keys = Object.values(data.sections).flatMap(
-          (s) => s.koanf_paths ?? [],
-        );
+        const keys = Object.values(data.sections).flatMap((s) => s.koanf_paths ?? []);
         if (keys.length > 0) this.layer1Keys = new Set(keys);
       }
     } catch {
@@ -1632,7 +1636,9 @@ export class ScionPageAdminServerConfig extends LitElement {
   ): ReturnType<typeof html> {
     const reason = this.readOnlyReason(koanfKey);
     if (reason) {
-      return html`${this.renderReadOnlyBadge(reason)}<span class="read-only-value">${displayValue || '—'}</span>`;
+      return html`${this.renderReadOnlyBadge(reason)}<span class="read-only-value"
+          >${displayValue || '—'}</span
+        >`;
     }
     return html`${this.renderSupersededBadge(koanfKey)}${editableTemplate}`;
   }
@@ -1643,16 +1649,13 @@ export class ScionPageAdminServerConfig extends LitElement {
 
     // General — only Layer-1 top-level keys
     if (ok('default_template')) payload.default_template = this.defaultTemplate;
-    if (ok('default_harness_config'))
-      payload.default_harness_config = this.resolvedHarnessConfig;
+    if (ok('default_harness_config')) payload.default_harness_config = this.resolvedHarnessConfig;
     if (ok('image_registry')) payload.image_registry = this.imageRegistry;
 
     // Default agent limits
     if (ok('default_max_turns')) payload.default_max_turns = this.defaultMaxTurns;
-    if (ok('default_max_model_calls'))
-      payload.default_max_model_calls = this.defaultMaxModelCalls;
-    if (ok('default_max_duration'))
-      payload.default_max_duration = this.defaultMaxDuration;
+    if (ok('default_max_model_calls')) payload.default_max_model_calls = this.defaultMaxModelCalls;
+    if (ok('default_max_duration')) payload.default_max_duration = this.defaultMaxDuration;
 
     if (
       ok('default_resources') &&
@@ -1681,9 +1684,10 @@ export class ScionPageAdminServerConfig extends LitElement {
 
     // Default model settings
     if (ok('default_model')) {
-      const resolvedModel = this.defaultModelSelection === 'other'
-        ? this.defaultCustomModelId.trim()
-        : this.defaultModelSelection;
+      const resolvedModel =
+        this.defaultModelSelection === 'other'
+          ? this.defaultCustomModelId.trim()
+          : this.defaultModelSelection;
       payload.default_model = resolvedModel || '';
     }
     if (ok('default_thinking_level')) {
@@ -1715,10 +1719,8 @@ export class ScionPageAdminServerConfig extends LitElement {
       hub.soft_delete_retain_files = this.hubSoftDeleteRetainFiles;
     if (ok('server.hub.auto_suspend_stalled'))
       hub.auto_suspend_stalled = this.hubAutoSuspendStalled;
-    if (ok('server.hub.stalled_threshold'))
-      hub.stalled_threshold = this.hubStalledThreshold;
-    if (ok('server.hub.gcp_iam_check_mode'))
-      hub.gcp_iam_check_mode = this.hubGcpIamCheckMode;
+    if (ok('server.hub.stalled_threshold')) hub.stalled_threshold = this.hubStalledThreshold;
+    if (ok('server.hub.gcp_iam_check_mode')) hub.gcp_iam_check_mode = this.hubGcpIamCheckMode;
     if (ok('server.hub.gcp_iam_deny_unknown_policy'))
       hub.gcp_iam_deny_unknown_policy = this.hubGcpIamDenyUnknownPolicy;
     if (Object.keys(hub).length > 0) server.hub = hub;
@@ -1815,10 +1817,8 @@ export class ScionPageAdminServerConfig extends LitElement {
     // convert 0/"" to undefined, omitting the key from JSON and preventing
     // the user from resetting a limit to null. See ptone/scion#860.
     if (ok('default_max_turns')) payload.default_max_turns = this.defaultMaxTurns;
-    if (ok('default_max_model_calls'))
-      payload.default_max_model_calls = this.defaultMaxModelCalls;
-    if (ok('default_max_duration'))
-      payload.default_max_duration = this.defaultMaxDuration;
+    if (ok('default_max_model_calls')) payload.default_max_model_calls = this.defaultMaxModelCalls;
+    if (ok('default_max_duration')) payload.default_max_duration = this.defaultMaxDuration;
     if (
       ok('default_resources') &&
       (this.defaultResCpuReq ||
@@ -1846,9 +1846,10 @@ export class ScionPageAdminServerConfig extends LitElement {
 
     // Default model settings
     if (ok('default_model')) {
-      const resolvedModel = this.defaultModelSelection === 'other'
-        ? this.defaultCustomModelId.trim()
-        : this.defaultModelSelection;
+      const resolvedModel =
+        this.defaultModelSelection === 'other'
+          ? this.defaultCustomModelId.trim()
+          : this.defaultModelSelection;
       payload.default_model = resolvedModel || '';
     }
     if (ok('default_thinking_level')) {
@@ -1890,10 +1891,8 @@ export class ScionPageAdminServerConfig extends LitElement {
       hub.soft_delete_retain_files = this.hubSoftDeleteRetainFiles;
     if (ok('server.hub.auto_suspend_stalled'))
       hub.auto_suspend_stalled = this.hubAutoSuspendStalled;
-    if (ok('server.hub.stalled_threshold'))
-      hub.stalled_threshold = this.hubStalledThreshold;
-    if (ok('server.hub.gcp_iam_check_mode'))
-      hub.gcp_iam_check_mode = this.hubGcpIamCheckMode;
+    if (ok('server.hub.stalled_threshold')) hub.stalled_threshold = this.hubStalledThreshold;
+    if (ok('server.hub.gcp_iam_check_mode')) hub.gcp_iam_check_mode = this.hubGcpIamCheckMode;
     if (ok('server.hub.gcp_iam_deny_unknown_policy'))
       hub.gcp_iam_deny_unknown_policy = this.hubGcpIamDenyUnknownPolicy;
     server.hub = hub;
@@ -2095,8 +2094,7 @@ export class ScionPageAdminServerConfig extends LitElement {
       case 'revision_conflict':
         this.conflictInfo = {
           message:
-            (body.message as string) ||
-            'Settings have been changed since you loaded this page.',
+            (body.message as string) || 'Settings have been changed since you loaded this page.',
           conflicted: (body.conflicted as ConflictInfo['conflicted']) ?? [],
         };
         break;
@@ -2104,10 +2102,7 @@ export class ScionPageAdminServerConfig extends LitElement {
       case 'layer0_rejected': {
         const keys = (body.keys as string[]) ?? [];
         this.safetyNetKeys = keys;
-        console.log(
-          '[admin-server-config] layer0_rejected — bootstrap keys in payload:',
-          keys,
-        );
+        console.log('[admin-server-config] layer0_rejected — bootstrap keys in payload:', keys);
         break;
       }
 
@@ -2138,11 +2133,10 @@ export class ScionPageAdminServerConfig extends LitElement {
         others require a server restart.
       </p>
 
-      ${this.loading ? nothing : this.renderEnvOverrideBanner()}
-      ${this.renderDeprecatedEnvNotice()} ${this.renderSupersededPanel()}
-      ${this.renderConflictBanner()} ${this.renderValidationErrors()}
-      ${this.renderSafetyNetNotice()} ${this.renderIgnoredKeysNotice()}
-      ${this.renderResetConfirmDialog()}
+      ${this.loading ? nothing : this.renderEnvOverrideBanner()} ${this.renderDeprecatedEnvNotice()}
+      ${this.renderSupersededPanel()} ${this.renderConflictBanner()}
+      ${this.renderValidationErrors()} ${this.renderSafetyNetNotice()}
+      ${this.renderIgnoredKeysNotice()} ${this.renderResetConfirmDialog()}
       ${this.error ? html`<div class="status-message error">${this.error}</div>` : nothing}
       ${this.successMessage
         ? html`<div class="status-message success">
@@ -2310,11 +2304,7 @@ export class ScionPageAdminServerConfig extends LitElement {
         </div>
         <ul class="deprecated-notice-list">
           ${this.deprecatedEnvKeys.map(
-            (dk) => html`
-              <li>
-                <code>${dk.env_var}</code> → <code>${dk.seed_equivalent}</code>
-              </li>
-            `
+            (dk) => html` <li><code>${dk.env_var}</code> → <code>${dk.seed_equivalent}</code></li> `
           )}
         </ul>
       </div>
@@ -2355,10 +2345,7 @@ export class ScionPageAdminServerConfig extends LitElement {
    * Renders a section header with title and optional "Reset to bootstrap" button
    * for managed sections in DB mode.
    */
-  private renderSectionHeader(
-    title: string,
-    sectionName?: string
-  ): ReturnType<typeof html> {
+  private renderSectionHeader(title: string, sectionName?: string): ReturnType<typeof html> {
     if (sectionName && this.canResetSection(sectionName)) {
       return html`
         <div class="section-header">
@@ -2452,14 +2439,13 @@ export class ScionPageAdminServerConfig extends LitElement {
                 ${(errors as ValidationErrorDetail[]).map(
                   (err) => html`
                     <li>
-                      ${err.field ? html`<code>${err.field}</code>` : nothing}
-                      ${err.message || err}
+                      ${err.field ? html`<code>${err.field}</code>` : nothing} ${err.message || err}
                     </li>
-                  `,
+                  `
                 )}
               </ul>
             </div>
-          `,
+          `
         )}
       </div>
     `;
@@ -2500,8 +2486,8 @@ export class ScionPageAdminServerConfig extends LitElement {
         ${this.safetyNetKeys.map((k) => html` <code>${k}</code>`)}
         <br />
         <span style="font-size: 0.75rem; color: var(--scion-text-muted, #64748b);">
-          These settings are managed via deployment configuration (settings.yaml / env).
-          This error should not normally occur — check the browser console for details.
+          These settings are managed via deployment configuration (settings.yaml / env). This error
+          should not normally occur — check the browser console for details.
         </span>
       </div>
     `;
@@ -2538,7 +2524,10 @@ export class ScionPageAdminServerConfig extends LitElement {
           >Runtime Broker</sl-tab
         >
         <sl-tab slot="nav" panel="data" ?active=${this.activeTab === 'data'}>Data & Storage</sl-tab>
-        <sl-tab slot="nav" panel="runtimes-profiles" ?active=${this.activeTab === 'runtimes-profiles'}
+        <sl-tab
+          slot="nav"
+          panel="runtimes-profiles"
+          ?active=${this.activeTab === 'runtimes-profiles'}
           >Runtimes & Profiles</sl-tab
         >
         <sl-tab slot="nav" panel="auth" ?active=${this.activeTab === 'auth'}>Authentication</sl-tab>
@@ -2564,7 +2553,10 @@ export class ScionPageAdminServerConfig extends LitElement {
       </sl-tab-group>
 
       ${this.hasHarnessConfigErrors
-        ? html`<div class="error" style="margin-bottom:0.75rem;">Cannot save: one or more harness config entries contain invalid JSON. Fix the errors on the Runtimes &amp; Profiles tab before saving.</div>`
+        ? html`<div class="error" style="margin-bottom:0.75rem;">
+            Cannot save: one or more harness config entries contain invalid JSON. Fix the errors on
+            the Runtimes &amp; Profiles tab before saving.
+          </div>`
         : nothing}
       <div class="actions">
         <sl-button
@@ -2748,12 +2740,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'image_registry',
               this.imageRegistry,
               html`${this.renderEnvBadge('image_registry')}<sl-input
-                value=${this.imageRegistry}
-                placeholder="ghcr.io/myorg"
-                @sl-input=${(e: Event) => {
-                  this.imageRegistry = (e.target as HTMLInputElement).value;
-                }}
-              ></sl-input>`
+                  value=${this.imageRegistry}
+                  placeholder="ghcr.io/myorg"
+                  @sl-input=${(e: Event) => {
+                    this.imageRegistry = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>`
             )}
           </div>
           <div class="form-field">
@@ -2784,9 +2776,15 @@ export class ScionPageAdminServerConfig extends LitElement {
               this.agentDefaultsTab = (e.detail as { name: string }).name;
             }}
           >
-            <sl-tab slot="nav" panel="general" ?active=${this.agentDefaultsTab === 'general'}>General</sl-tab>
-            <sl-tab slot="nav" panel="limits" ?active=${this.agentDefaultsTab === 'limits'}>Limits</sl-tab>
-            <sl-tab slot="nav" panel="resources" ?active=${this.agentDefaultsTab === 'resources'}>Resources</sl-tab>
+            <sl-tab slot="nav" panel="general" ?active=${this.agentDefaultsTab === 'general'}
+              >General</sl-tab
+            >
+            <sl-tab slot="nav" panel="limits" ?active=${this.agentDefaultsTab === 'limits'}
+              >Limits</sl-tab
+            >
+            <sl-tab slot="nav" panel="resources" ?active=${this.agentDefaultsTab === 'resources'}
+              >Resources</sl-tab
+            >
 
             <sl-tab-panel name="general">
               <div class="form-grid">
@@ -2796,12 +2794,12 @@ export class ScionPageAdminServerConfig extends LitElement {
                     'default_template',
                     this.defaultTemplate,
                     html`${this.renderEnvBadge('default_template')}<sl-input
-                      value=${this.defaultTemplate}
-                      placeholder="default"
-                      @sl-input=${(e: Event) => {
-                        this.defaultTemplate = (e.target as HTMLInputElement).value;
-                      }}
-                    ></sl-input>`
+                        value=${this.defaultTemplate}
+                        placeholder="default"
+                        @sl-input=${(e: Event) => {
+                          this.defaultTemplate = (e.target as HTMLInputElement).value;
+                        }}
+                      ></sl-input>`
                   )}
                 </div>
                 <div class="form-field">
@@ -2810,32 +2808,32 @@ export class ScionPageAdminServerConfig extends LitElement {
                     'default_harness_config',
                     this.resolvedHarnessConfig,
                     html`${this.renderEnvBadge('default_harness_config')}
-                  <sl-select
-                    .value=${this.harnessConfigSelection}
-                    @sl-change=${(e: Event) => {
-                      this.harnessConfigSelection = (e.target as HTMLSelectElement).value;
-                      if (this.harnessConfigSelection !== '__other__') {
-                        this.customHarnessConfig = '';
-                      }
-                    }}
-                  >
-                    <sl-option value="">None</sl-option>
-                    ${this.harnessConfigs.length > 0
-                      ? this.harnessConfigs.map(
-                          (hc) => html`
-                            <sl-option value=${hc.name}>
-                              ${hc.displayName || hc.name}
-                              ${hc.harness ? html` <small>(${hc.harness})</small>` : ''}
-                            </sl-option>
-                          `
-                        )
-                      : KNOWN_HARNESS_NAMES.map(
-                          (name) => html`
-                            <sl-option value=${name}>${harnessDisplayName(name)}</sl-option>
-                          `
-                        )}
-                    <sl-option value="__other__">Other (specify)</sl-option>
-                  </sl-select>`
+                      <sl-select
+                        .value=${this.harnessConfigSelection}
+                        @sl-change=${(e: Event) => {
+                          this.harnessConfigSelection = (e.target as HTMLSelectElement).value;
+                          if (this.harnessConfigSelection !== '__other__') {
+                            this.customHarnessConfig = '';
+                          }
+                        }}
+                      >
+                        <sl-option value="">None</sl-option>
+                        ${this.harnessConfigs.length > 0
+                          ? this.harnessConfigs.map(
+                              (hc) => html`
+                                <sl-option value=${hc.name}>
+                                  ${hc.displayName || hc.name}
+                                  ${hc.harness ? html` <small>(${hc.harness})</small>` : ''}
+                                </sl-option>
+                              `
+                            )
+                          : KNOWN_HARNESS_NAMES.map(
+                              (name) => html`
+                                <sl-option value=${name}>${harnessDisplayName(name)}</sl-option>
+                              `
+                            )}
+                        <sl-option value="__other__">Other (specify)</sl-option>
+                      </sl-select>`
                   )}
                 </div>
                 ${this.harnessConfigSelection === '__other__'
@@ -2849,7 +2847,10 @@ export class ScionPageAdminServerConfig extends LitElement {
                             this.customHarnessConfig = (e.target as HTMLInputElement).value;
                           }}
                         ></sl-input>
-                        <span class="hint">Name of the harness config directory (from .scion/harness-configs/).</span>
+                        <span class="hint"
+                          >Name of the harness config directory (from
+                          .scion/harness-configs/).</span
+                        >
                       </div>
                     `
                   : nothing}
@@ -2872,12 +2873,12 @@ export class ScionPageAdminServerConfig extends LitElement {
                     'telemetry.enabled',
                     this.telemetryEnabled ? 'Enabled' : 'Disabled',
                     html`${this.renderEnvBadge('telemetry.enabled')}<sl-switch
-                      ?checked=${this.telemetryEnabled}
-                      @sl-change=${(e: Event) => {
-                        this.telemetryEnabled = (e.target as HTMLInputElement).checked;
-                      }}
-                      >Enable Telemetry</sl-switch
-                    >`
+                        ?checked=${this.telemetryEnabled}
+                        @sl-change=${(e: Event) => {
+                          this.telemetryEnabled = (e.target as HTMLInputElement).checked;
+                        }}
+                        >Enable Telemetry</sl-switch
+                      >`
                   )}
                   <span class="hint">Default opt-in state for new agents</span>
                 </div>
@@ -2886,14 +2887,16 @@ export class ScionPageAdminServerConfig extends LitElement {
                     'auto_expose_ports.enabled',
                     this.autoExposePortsEnabled ? 'Enabled' : 'Disabled',
                     html`${this.renderEnvBadge('auto_expose_ports.enabled')}<sl-switch
-                      ?checked=${this.autoExposePortsEnabled}
-                      @sl-change=${(e: Event) => {
-                        this.autoExposePortsEnabled = (e.target as HTMLInputElement).checked;
-                      }}
-                      >Enable Auto-Expose Ports</sl-switch
-                    >`
+                        ?checked=${this.autoExposePortsEnabled}
+                        @sl-change=${(e: Event) => {
+                          this.autoExposePortsEnabled = (e.target as HTMLInputElement).checked;
+                        }}
+                        >Enable Auto-Expose Ports</sl-switch
+                      >`
                   )}
-                  <span class="hint">Automatically detect and expose listening TCP ports in agent containers</span>
+                  <span class="hint"
+                    >Automatically detect and expose listening TCP ports in agent containers</span
+                  >
                 </div>
                 <div class="form-field">
                   <label>Default Model</label>
@@ -2901,21 +2904,27 @@ export class ScionPageAdminServerConfig extends LitElement {
                     'default_model',
                     this.defaultModel || '—',
                     html`${this.renderEnvBadge('default_model')}<sl-select
-                      placeholder="use harness default"
-                      clearable
-                      value=${this.defaultModelSelection}
-                      @sl-change=${(e: Event) => {
-                        const val = (e.target as HTMLSelectElement).value as '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other';
-                        this.defaultModelSelection = val;
-                        if (val !== 'other') this.defaultCustomModelId = '';
-                      }}
-                    >
-                      <sl-option value="small">Small</sl-option>
-                      <sl-option value="medium">Medium</sl-option>
-                      <sl-option value="large">Large</sl-option>
-                      <sl-option value="extra-large">Extra Large</sl-option>
-                      <sl-option value="other">Other (specify)</sl-option>
-                    </sl-select>`
+                        placeholder="use harness default"
+                        clearable
+                        value=${this.defaultModelSelection}
+                        @sl-change=${(e: Event) => {
+                          const val = (e.target as HTMLSelectElement).value as
+                            | ''
+                            | 'small'
+                            | 'medium'
+                            | 'large'
+                            | 'extra-large'
+                            | 'other';
+                          this.defaultModelSelection = val;
+                          if (val !== 'other') this.defaultCustomModelId = '';
+                        }}
+                      >
+                        <sl-option value="small">Small</sl-option>
+                        <sl-option value="medium">Medium</sl-option>
+                        <sl-option value="large">Large</sl-option>
+                        <sl-option value="extra-large">Extra Large</sl-option>
+                        <sl-option value="other">Other (specify)</sl-option>
+                      </sl-select>`
                   )}
                 </div>
                 ${this.defaultModelSelection === 'other'
@@ -2933,71 +2942,106 @@ export class ScionPageAdminServerConfig extends LitElement {
                     `
                   : nothing}
                 <div class="form-field full-width">
-                  <label>Default Thinking Level${this.defaultThinkingLevel !== null ? html` <span style="font-weight:normal;color:var(--sl-color-neutral-500)">(${this.defaultThinkingLevel})</span>` : ''}</label>
+                  <label
+                    >Default Thinking
+                    Level${this.defaultThinkingLevel !== null
+                      ? html` <span style="font-weight:normal;color:var(--sl-color-neutral-500)"
+                          >(${this.defaultThinkingLevel})</span
+                        >`
+                      : ''}</label
+                  >
                   ${this.renderFieldValue(
                     'default_thinking_level',
-                    this.defaultThinkingLevel !== null ? String(this.defaultThinkingLevel) : 'Not set',
+                    this.defaultThinkingLevel !== null
+                      ? String(this.defaultThinkingLevel)
+                      : 'Not set',
                     html`${this.renderEnvBadge('default_thinking_level')}
-                    <div style="display:flex;align-items:center;gap:0.75rem">
-                      <sl-range
-                        min="1" max="100" step="1"
-                        .value=${this.defaultThinkingLevel ?? 50}
-                        ?disabled=${this.defaultThinkingLevel === null}
-                        style="flex:1"
-                        @sl-input=${(e: Event) => { this.defaultThinkingLevel = (e.target as HTMLInputElement & { value: number }).value; }}
-                      ></sl-range>
-                      <sl-checkbox
-                        ?checked=${this.defaultThinkingLevel !== null}
-                        @sl-change=${(e: Event) => { this.defaultThinkingLevel = (e.target as HTMLInputElement & { checked: boolean }).checked ? 50 : null; }}
-                      >Set</sl-checkbox>
-                    </div>
-                    <span class="hint" style="display:flex;justify-content:space-between;margin-top:0.25rem">
-                      <span>1 = minimal reasoning</span>
-                      <span>${this.defaultThinkingLevel === null ? 'Using harness default' : ''}</span>
-                      <span>100 = maximum reasoning</span>
-                    </span>`
+                      <div style="display:flex;align-items:center;gap:0.75rem">
+                        <sl-range
+                          min="1"
+                          max="100"
+                          step="1"
+                          .value=${this.defaultThinkingLevel ?? 50}
+                          ?disabled=${this.defaultThinkingLevel === null}
+                          style="flex:1"
+                          @sl-input=${(e: Event) => {
+                            this.defaultThinkingLevel = (
+                              e.target as HTMLInputElement & { value: number }
+                            ).value;
+                          }}
+                        ></sl-range>
+                        <sl-checkbox
+                          ?checked=${this.defaultThinkingLevel !== null}
+                          @sl-change=${(e: Event) => {
+                            this.defaultThinkingLevel = (
+                              e.target as HTMLInputElement & { checked: boolean }
+                            ).checked
+                              ? 50
+                              : null;
+                          }}
+                          >Set</sl-checkbox
+                        >
+                      </div>
+                      <span
+                        class="hint"
+                        style="display:flex;justify-content:space-between;margin-top:0.25rem"
+                      >
+                        <span>1 = minimal reasoning</span>
+                        <span
+                          >${this.defaultThinkingLevel === null
+                            ? 'Using harness default'
+                            : ''}</span
+                        >
+                        <span>100 = maximum reasoning</span>
+                      </span>`
                   )}
                 </div>
                 <div class="form-field">
                   <label>Default Agent Role</label>
-                  <span class="hint">Role assigned to new agents when not explicitly specified. Can be overridden per-project.</span>
+                  <span class="hint"
+                    >Role assigned to new agents when not explicitly specified. Can be overridden
+                    per-project.</span
+                  >
                   ${this.renderFieldValue(
                     'default_agent_role',
                     this.defaultAgentRole || 'Full (default)',
                     html`${this.renderEnvBadge('default_agent_role')}<sl-select
-                      placeholder="Full (default)"
-                      clearable
-                      value=${this.defaultAgentRole}
-                      @sl-change=${(e: Event) => {
-                        this.defaultAgentRole = (e.target as HTMLSelectElement).value;
-                      }}
-                    >
-                      <sl-option value="none">None — No hub access</sl-option>
-                      <sl-option value="readonly">Read-only — Read-only access</sl-option>
-                      <sl-option value="baseline">Baseline — Standard access</sl-option>
-                      <sl-option value="full">Full — Full access</sl-option>
-                    </sl-select>`
+                        placeholder="Full (default)"
+                        clearable
+                        value=${this.defaultAgentRole}
+                        @sl-change=${(e: Event) => {
+                          this.defaultAgentRole = (e.target as HTMLSelectElement).value;
+                        }}
+                      >
+                        <sl-option value="none">None — No hub access</sl-option>
+                        <sl-option value="readonly">Read-only — Read-only access</sl-option>
+                        <sl-option value="baseline">Baseline — Standard access</sl-option>
+                        <sl-option value="full">Full — Full access</sl-option>
+                      </sl-select>`
                   )}
                 </div>
                 <div class="form-field">
                   <label>Default Maximum Agent Role</label>
-                  <span class="hint">Default maximum role for agents in new projects. Can be overridden per-project.</span>
+                  <span class="hint"
+                    >Default maximum role for agents in new projects. Can be overridden
+                    per-project.</span
+                  >
                   ${this.renderFieldValue(
                     'default_max_agent_role',
                     this.defaultMaxAgentRole || 'Full (default)',
                     html`${this.renderEnvBadge('default_max_agent_role')}<sl-select
-                      placeholder="Full (default)"
-                      clearable
-                      value=${this.defaultMaxAgentRole}
-                      @sl-change=${(e: Event) => {
-                        this.defaultMaxAgentRole = (e.target as HTMLSelectElement).value;
-                      }}
-                    >
-                      <sl-option value="none">None — No hub access</sl-option>
-                      <sl-option value="readonly">Read-only — Read-only access</sl-option>
-                      <sl-option value="baseline">Baseline — Standard access</sl-option>
-                      <sl-option value="full">Full — Full access</sl-option>
-                    </sl-select>`
+                        placeholder="Full (default)"
+                        clearable
+                        value=${this.defaultMaxAgentRole}
+                        @sl-change=${(e: Event) => {
+                          this.defaultMaxAgentRole = (e.target as HTMLSelectElement).value;
+                        }}
+                      >
+                        <sl-option value="none">None — No hub access</sl-option>
+                        <sl-option value="readonly">Read-only — Read-only access</sl-option>
+                        <sl-option value="baseline">Baseline — Standard access</sl-option>
+                        <sl-option value="full">Full — Full access</sl-option>
+                      </sl-select>`
                   )}
                 </div>
               </div>
@@ -3012,13 +3056,14 @@ export class ScionPageAdminServerConfig extends LitElement {
                     'default_max_turns',
                     this.defaultMaxTurns ? String(this.defaultMaxTurns) : '',
                     html`${this.renderEnvBadge('default_max_turns')}<sl-input
-                      type="number"
-                      value=${this.defaultMaxTurns ? String(this.defaultMaxTurns) : ''}
-                      placeholder="No limit"
-                      @sl-input=${(e: Event) => {
-                        this.defaultMaxTurns = parseInt((e.target as HTMLInputElement).value) || 0;
-                      }}
-                    ></sl-input>`
+                        type="number"
+                        value=${this.defaultMaxTurns ? String(this.defaultMaxTurns) : ''}
+                        placeholder="No limit"
+                        @sl-input=${(e: Event) => {
+                          this.defaultMaxTurns =
+                            parseInt((e.target as HTMLInputElement).value) || 0;
+                        }}
+                      ></sl-input>`
                   )}
                 </div>
                 <div class="form-field">
@@ -3028,13 +3073,14 @@ export class ScionPageAdminServerConfig extends LitElement {
                     'default_max_model_calls',
                     this.defaultMaxModelCalls ? String(this.defaultMaxModelCalls) : '',
                     html`${this.renderEnvBadge('default_max_model_calls')}<sl-input
-                      type="number"
-                      value=${this.defaultMaxModelCalls ? String(this.defaultMaxModelCalls) : ''}
-                      placeholder="No limit"
-                      @sl-input=${(e: Event) => {
-                        this.defaultMaxModelCalls = parseInt((e.target as HTMLInputElement).value) || 0;
-                      }}
-                    ></sl-input>`
+                        type="number"
+                        value=${this.defaultMaxModelCalls ? String(this.defaultMaxModelCalls) : ''}
+                        placeholder="No limit"
+                        @sl-input=${(e: Event) => {
+                          this.defaultMaxModelCalls =
+                            parseInt((e.target as HTMLInputElement).value) || 0;
+                        }}
+                      ></sl-input>`
                   )}
                 </div>
                 <div class="form-field full-width">
@@ -3044,12 +3090,12 @@ export class ScionPageAdminServerConfig extends LitElement {
                     'default_max_duration',
                     this.defaultMaxDuration,
                     html`${this.renderEnvBadge('default_max_duration')}<sl-input
-                      value=${this.defaultMaxDuration}
-                      placeholder="e.g. 2h, 30m"
-                      @sl-input=${(e: Event) => {
-                        this.defaultMaxDuration = (e.target as HTMLInputElement).value;
-                      }}
-                    ></sl-input>`
+                        value=${this.defaultMaxDuration}
+                        placeholder="e.g. 2h, 30m"
+                        @sl-input=${(e: Event) => {
+                          this.defaultMaxDuration = (e.target as HTMLInputElement).value;
+                        }}
+                      ></sl-input>`
                   )}
                 </div>
               </div>
@@ -3058,60 +3104,68 @@ export class ScionPageAdminServerConfig extends LitElement {
             <sl-tab-panel name="resources">
               ${this.renderFieldValue(
                 'default_resources',
-                [this.defaultResCpuReq, this.defaultResMemReq, this.defaultResCpuLim, this.defaultResMemLim, this.defaultResDisk].filter(Boolean).join(', '),
+                [
+                  this.defaultResCpuReq,
+                  this.defaultResMemReq,
+                  this.defaultResCpuLim,
+                  this.defaultResMemLim,
+                  this.defaultResDisk,
+                ]
+                  .filter(Boolean)
+                  .join(', '),
                 html`${this.renderEnvBadge('default_resources')}
-              <div class="form-grid">
-                <div class="form-field">
-                  <label>CPU Request</label>
-                  <sl-input
-                    value=${this.defaultResCpuReq}
-                    placeholder="e.g. 500m, 1"
-                    @sl-input=${(e: Event) => {
-                      this.defaultResCpuReq = (e.target as HTMLInputElement).value;
-                    }}
-                  ></sl-input>
-                </div>
-                <div class="form-field">
-                  <label>Memory Request</label>
-                  <sl-input
-                    value=${this.defaultResMemReq}
-                    placeholder="e.g. 512Mi, 1Gi"
-                    @sl-input=${(e: Event) => {
-                      this.defaultResMemReq = (e.target as HTMLInputElement).value;
-                    }}
-                  ></sl-input>
-                </div>
-                <div class="form-field">
-                  <label>CPU Limit</label>
-                  <sl-input
-                    value=${this.defaultResCpuLim}
-                    placeholder="e.g. 1, 2"
-                    @sl-input=${(e: Event) => {
-                      this.defaultResCpuLim = (e.target as HTMLInputElement).value;
-                    }}
-                  ></sl-input>
-                </div>
-                <div class="form-field">
-                  <label>Memory Limit</label>
-                  <sl-input
-                    value=${this.defaultResMemLim}
-                    placeholder="e.g. 1Gi, 2Gi"
-                    @sl-input=${(e: Event) => {
-                      this.defaultResMemLim = (e.target as HTMLInputElement).value;
-                    }}
-                  ></sl-input>
-                </div>
-                <div class="form-field full-width">
-                  <label>Disk</label>
-                  <sl-input
-                    value=${this.defaultResDisk}
-                    placeholder="e.g. 10Gi"
-                    @sl-input=${(e: Event) => {
-                      this.defaultResDisk = (e.target as HTMLInputElement).value;
-                    }}
-                  ></sl-input>
-                </div>
-              </div>`
+                  <div class="form-grid">
+                    <div class="form-field">
+                      <label>CPU Request</label>
+                      <sl-input
+                        value=${this.defaultResCpuReq}
+                        placeholder="e.g. 500m, 1"
+                        @sl-input=${(e: Event) => {
+                          this.defaultResCpuReq = (e.target as HTMLInputElement).value;
+                        }}
+                      ></sl-input>
+                    </div>
+                    <div class="form-field">
+                      <label>Memory Request</label>
+                      <sl-input
+                        value=${this.defaultResMemReq}
+                        placeholder="e.g. 512Mi, 1Gi"
+                        @sl-input=${(e: Event) => {
+                          this.defaultResMemReq = (e.target as HTMLInputElement).value;
+                        }}
+                      ></sl-input>
+                    </div>
+                    <div class="form-field">
+                      <label>CPU Limit</label>
+                      <sl-input
+                        value=${this.defaultResCpuLim}
+                        placeholder="e.g. 1, 2"
+                        @sl-input=${(e: Event) => {
+                          this.defaultResCpuLim = (e.target as HTMLInputElement).value;
+                        }}
+                      ></sl-input>
+                    </div>
+                    <div class="form-field">
+                      <label>Memory Limit</label>
+                      <sl-input
+                        value=${this.defaultResMemLim}
+                        placeholder="e.g. 1Gi, 2Gi"
+                        @sl-input=${(e: Event) => {
+                          this.defaultResMemLim = (e.target as HTMLInputElement).value;
+                        }}
+                      ></sl-input>
+                    </div>
+                    <div class="form-field full-width">
+                      <label>Disk</label>
+                      <sl-input
+                        value=${this.defaultResDisk}
+                        placeholder="e.g. 10Gi"
+                        @sl-input=${(e: Event) => {
+                          this.defaultResDisk = (e.target as HTMLInputElement).value;
+                        }}
+                      ></sl-input>
+                    </div>
+                  </div>`
               )}
             </sl-tab-panel>
           </sl-tab-group>
@@ -3134,7 +3188,10 @@ export class ScionPageAdminServerConfig extends LitElement {
                     }}
                     >Enable default scratchpad shared directory</sl-switch
                   >
-                  <span class="hint">When enabled, new projects automatically get a shared scratchpad directory for inter-agent communication.</span>
+                  <span class="hint"
+                    >When enabled, new projects automatically get a shared scratchpad directory for
+                    inter-agent communication.</span
+                  >
                 </div>
               </div>
             </div>
@@ -3223,12 +3280,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'server.hub.public_url',
               this.hubPublicUrl,
               html`${this.renderEnvBadge('server.hub.public_url')}<sl-input
-                value=${this.hubPublicUrl}
-                placeholder="https://hub.example.com"
-                @sl-input=${(e: Event) => {
-                  this.hubPublicUrl = (e.target as HTMLInputElement).value;
-                }}
-              ></sl-input>`
+                  value=${this.hubPublicUrl}
+                  placeholder="https://hub.example.com"
+                  @sl-input=${(e: Event) => {
+                    this.hubPublicUrl = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>`
             )}
           </div>
           <div class="form-field">
@@ -3268,12 +3325,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'server.hub.admin_emails',
               this.hubAdminEmails,
               html`${this.renderEnvBadge('server.hub.admin_emails')}<sl-input
-                value=${this.hubAdminEmails}
-                placeholder="admin@example.com, ops@example.com"
-                @sl-input=${(e: Event) => {
-                  this.hubAdminEmails = (e.target as HTMLInputElement).value;
-                }}
-              ></sl-input>`
+                  value=${this.hubAdminEmails}
+                  placeholder="admin@example.com, ops@example.com"
+                  @sl-input=${(e: Event) => {
+                    this.hubAdminEmails = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>`
             )}
           </div>
         </div>
@@ -3293,12 +3350,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'server.hub.soft_delete_retention',
               this.hubSoftDeleteRetention || '—',
               html`${this.renderEnvBadge('server.hub.soft_delete_retention')}<sl-input
-                value=${this.hubSoftDeleteRetention}
-                placeholder="72h"
-                @sl-input=${(e: Event) => {
-                  this.hubSoftDeleteRetention = (e.target as HTMLInputElement).value;
-                }}
-              ></sl-input>`
+                  value=${this.hubSoftDeleteRetention}
+                  placeholder="72h"
+                  @sl-input=${(e: Event) => {
+                    this.hubSoftDeleteRetention = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>`
             )}
           </div>
           <div class="form-field">
@@ -3306,12 +3363,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'server.hub.soft_delete_retain_files',
               this.hubSoftDeleteRetainFiles ? 'Enabled' : 'Disabled',
               html`${this.renderEnvBadge('server.hub.soft_delete_retain_files')}<sl-switch
-                ?checked=${this.hubSoftDeleteRetainFiles}
-                @sl-change=${(e: Event) => {
-                  this.hubSoftDeleteRetainFiles = (e.target as HTMLInputElement).checked;
-                }}
-                >Retain files on soft delete</sl-switch
-              >`
+                  ?checked=${this.hubSoftDeleteRetainFiles}
+                  @sl-change=${(e: Event) => {
+                    this.hubSoftDeleteRetainFiles = (e.target as HTMLInputElement).checked;
+                  }}
+                  >Retain files on soft delete</sl-switch
+                >`
             )}
           </div>
           <div class="form-field">
@@ -3319,12 +3376,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'server.hub.auto_suspend_stalled',
               this.hubAutoSuspendStalled ? 'Enabled' : 'Disabled',
               html`${this.renderEnvBadge('server.hub.auto_suspend_stalled')}<sl-switch
-                ?checked=${this.hubAutoSuspendStalled}
-                @sl-change=${(e: Event) => {
-                  this.hubAutoSuspendStalled = (e.target as HTMLInputElement).checked;
-                }}
-                >Auto-suspend stalled agents</sl-switch
-              >`
+                  ?checked=${this.hubAutoSuspendStalled}
+                  @sl-change=${(e: Event) => {
+                    this.hubAutoSuspendStalled = (e.target as HTMLInputElement).checked;
+                  }}
+                  >Auto-suspend stalled agents</sl-switch
+                >`
             )}
             <span class="hint"
               >When enabled, agents detected as stalled are automatically suspended (container
@@ -3340,12 +3397,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'server.hub.stalled_threshold',
               this.hubStalledThreshold || '5m (default)',
               html`${this.renderEnvBadge('server.hub.stalled_threshold')}<sl-input
-                value=${this.hubStalledThreshold}
-                placeholder="5m"
-                @sl-input=${(e: Event) => {
-                  this.hubStalledThreshold = (e.target as HTMLInputElement).value;
-                }}
-              ></sl-input>`
+                  value=${this.hubStalledThreshold}
+                  placeholder="5m"
+                  @sl-input=${(e: Event) => {
+                    this.hubStalledThreshold = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>`
             )}
           </div>
         </div>
@@ -3357,8 +3414,7 @@ export class ScionPageAdminServerConfig extends LitElement {
 
   private renderRuntimesProfilesTab() {
     return html`
-      ${this.renderRuntimesSection()}
-      ${this.renderProfilesSection()}
+      ${this.renderRuntimesSection()} ${this.renderProfilesSection()}
       ${this.renderHarnessConfigsSection()}
     `;
   }
@@ -3370,11 +3426,8 @@ export class ScionPageAdminServerConfig extends LitElement {
     const runtimeReadOnly = this.readOnlyReason('runtimes');
     return html`
       <div class="section">
-        ${this.renderSectionHeader('Runtimes', 'runtimes')}
-        ${this.renderSectionMeta('runtimes')}
-        ${runtimeReadOnly
-          ? html`${this.renderReadOnlyBadge(runtimeReadOnly)}`
-          : nothing}
+        ${this.renderSectionHeader('Runtimes', 'runtimes')} ${this.renderSectionMeta('runtimes')}
+        ${runtimeReadOnly ? html`${this.renderReadOnlyBadge(runtimeReadOnly)}` : nothing}
         ${runtimeNames.length === 0
           ? html`<p class="hint">No runtimes configured.</p>`
           : runtimeNames.map((name) => this.renderRuntimeEntry(name, !!runtimeReadOnly))}
@@ -3393,7 +3446,7 @@ export class ScionPageAdminServerConfig extends LitElement {
                   size="small"
                   variant="default"
                   ?disabled=${!this.newRuntimeName.trim() ||
-                    hasOwn(this.runtimes, this.newRuntimeName.trim())}
+                  hasOwn(this.runtimes, this.newRuntimeName.trim())}
                   @click=${() => this.addRuntime()}
                 >
                   <sl-icon slot="prefix" name="plus-circle"></sl-icon>
@@ -3401,7 +3454,9 @@ export class ScionPageAdminServerConfig extends LitElement {
                 </sl-button>
               </div>
               ${hasOwn(this.runtimes, this.newRuntimeName.trim())
-                ? html`<small class="hint" style="color:var(--sl-color-danger-600);">A runtime named "${this.newRuntimeName.trim()}" already exists.</small>`
+                ? html`<small class="hint" style="color:var(--sl-color-danger-600);"
+                    >A runtime named "${this.newRuntimeName.trim()}" already exists.</small
+                  >`
                 : nothing}
             `
           : nothing}
@@ -3474,7 +3529,11 @@ export class ScionPageAdminServerConfig extends LitElement {
                     value=${rt.context || ''}
                     ?disabled=${readOnly}
                     @sl-input=${(e: Event) => {
-                      this.updateRuntimeField(name, 'context', (e.target as HTMLInputElement).value);
+                      this.updateRuntimeField(
+                        name,
+                        'context',
+                        (e.target as HTMLInputElement).value
+                      );
                     }}
                   ></sl-input>
                 </div>
@@ -3487,7 +3546,7 @@ export class ScionPageAdminServerConfig extends LitElement {
                       this.updateRuntimeField(
                         name,
                         'namespace',
-                        (e.target as HTMLInputElement).value,
+                        (e.target as HTMLInputElement).value
                       );
                     }}
                   ></sl-input>
@@ -3511,7 +3570,7 @@ export class ScionPageAdminServerConfig extends LitElement {
                       this.updateRuntimeBool(
                         name,
                         'list_all_namespaces',
-                        (e.target as HTMLInputElement).checked,
+                        (e.target as HTMLInputElement).checked
                       );
                     }}
                     >List all namespaces</sl-switch
@@ -3529,7 +3588,7 @@ export class ScionPageAdminServerConfig extends LitElement {
                       this.updateRuntimeCloudRun(
                         name,
                         'project',
-                        (e.target as HTMLInputElement).value,
+                        (e.target as HTMLInputElement).value
                       );
                     }}
                   ></sl-input>
@@ -3544,7 +3603,7 @@ export class ScionPageAdminServerConfig extends LitElement {
                       this.updateRuntimeCloudRun(
                         name,
                         'region',
-                        (e.target as HTMLInputElement).value,
+                        (e.target as HTMLInputElement).value
                       );
                     }}
                   ></sl-input>
@@ -3555,11 +3614,7 @@ export class ScionPageAdminServerConfig extends LitElement {
     `;
   }
 
-  private updateRuntimeField(
-    name: string,
-    field: keyof V1RuntimeConfig,
-    value: string,
-  ): void {
+  private updateRuntimeField(name: string, field: keyof V1RuntimeConfig, value: string): void {
     const updated = { ...this.runtimes };
     const rt = { ...updated[name] };
     if (value) {
@@ -3590,7 +3645,7 @@ export class ScionPageAdminServerConfig extends LitElement {
   private updateRuntimeBool(
     name: string,
     field: 'gke' | 'list_all_namespaces',
-    value: boolean,
+    value: boolean
   ): void {
     const updated = { ...this.runtimes };
     updated[name] = { ...updated[name], [field]: value };
@@ -3636,15 +3691,12 @@ export class ScionPageAdminServerConfig extends LitElement {
     const runtimeNames = Object.keys(this.runtimes);
     return html`
       <div class="section">
-        ${this.renderSectionHeader('Profiles', 'profiles')}
-        ${this.renderSectionMeta('profiles')}
-        ${profileReadOnly
-          ? html`${this.renderReadOnlyBadge(profileReadOnly)}`
-          : nothing}
+        ${this.renderSectionHeader('Profiles', 'profiles')} ${this.renderSectionMeta('profiles')}
+        ${profileReadOnly ? html`${this.renderReadOnlyBadge(profileReadOnly)}` : nothing}
         ${profileNames.length === 0
           ? html`<p class="hint">No profiles configured.</p>`
           : profileNames.map((name) =>
-              this.renderProfileEntry(name, runtimeNames, !!profileReadOnly),
+              this.renderProfileEntry(name, runtimeNames, !!profileReadOnly)
             )}
         ${!profileReadOnly
           ? html`
@@ -3661,7 +3713,7 @@ export class ScionPageAdminServerConfig extends LitElement {
                   size="small"
                   variant="default"
                   ?disabled=${!this.newProfileName.trim() ||
-                    hasOwn(this.profiles, this.newProfileName.trim())}
+                  hasOwn(this.profiles, this.newProfileName.trim())}
                   @click=${() => this.addProfile()}
                 >
                   <sl-icon slot="prefix" name="plus-circle"></sl-icon>
@@ -3669,7 +3721,9 @@ export class ScionPageAdminServerConfig extends LitElement {
                 </sl-button>
               </div>
               ${hasOwn(this.profiles, this.newProfileName.trim())
-                ? html`<small class="hint" style="color:var(--sl-color-danger-600);">A profile named "${this.newProfileName.trim()}" already exists.</small>`
+                ? html`<small class="hint" style="color:var(--sl-color-danger-600);"
+                    >A profile named "${this.newProfileName.trim()}" already exists.</small
+                  >`
                 : nothing}
             `
           : nothing}
@@ -3706,9 +3760,7 @@ export class ScionPageAdminServerConfig extends LitElement {
                 this.updateProfileField(name, 'runtime', (e.target as HTMLSelectElement).value);
               }}
             >
-              ${runtimeNames.map(
-                (rt) => html`<sl-option value=${rt}>${rt}</sl-option>`,
-              )}
+              ${runtimeNames.map((rt) => html`<sl-option value=${rt}>${rt}</sl-option>`)}
             </sl-select>
           </div>
           <div class="form-field">
@@ -3721,7 +3773,7 @@ export class ScionPageAdminServerConfig extends LitElement {
                 this.updateProfileField(
                   name,
                   'image_registry',
-                  (e.target as HTMLInputElement).value,
+                  (e.target as HTMLInputElement).value
                 );
               }}
             ></sl-input>
@@ -3735,7 +3787,7 @@ export class ScionPageAdminServerConfig extends LitElement {
                 this.updateProfileField(
                   name,
                   'default_template',
-                  (e.target as HTMLInputElement).value,
+                  (e.target as HTMLInputElement).value
                 );
               }}
             ></sl-input>
@@ -3749,7 +3801,7 @@ export class ScionPageAdminServerConfig extends LitElement {
                 this.updateProfileField(
                   name,
                   'default_harness_config',
-                  (e.target as HTMLInputElement).value,
+                  (e.target as HTMLInputElement).value
                 );
               }}
             ></sl-input>
@@ -3761,7 +3813,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               placeholder="e.g. 500m"
               ?disabled=${readOnly}
               @sl-input=${(e: Event) => {
-                this.updateProfileResourceTier(name, 'requests', 'cpu', (e.target as HTMLInputElement).value);
+                this.updateProfileResourceTier(
+                  name,
+                  'requests',
+                  'cpu',
+                  (e.target as HTMLInputElement).value
+                );
               }}
             ></sl-input>
           </div>
@@ -3772,7 +3829,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               placeholder="e.g. 512Mi"
               ?disabled=${readOnly}
               @sl-input=${(e: Event) => {
-                this.updateProfileResourceTier(name, 'requests', 'memory', (e.target as HTMLInputElement).value);
+                this.updateProfileResourceTier(
+                  name,
+                  'requests',
+                  'memory',
+                  (e.target as HTMLInputElement).value
+                );
               }}
             ></sl-input>
           </div>
@@ -3783,7 +3845,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               placeholder="e.g. 2000m"
               ?disabled=${readOnly}
               @sl-input=${(e: Event) => {
-                this.updateProfileResourceTier(name, 'limits', 'cpu', (e.target as HTMLInputElement).value);
+                this.updateProfileResourceTier(
+                  name,
+                  'limits',
+                  'cpu',
+                  (e.target as HTMLInputElement).value
+                );
               }}
             ></sl-input>
           </div>
@@ -3794,7 +3861,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               placeholder="e.g. 4Gi"
               ?disabled=${readOnly}
               @sl-input=${(e: Event) => {
-                this.updateProfileResourceTier(name, 'limits', 'memory', (e.target as HTMLInputElement).value);
+                this.updateProfileResourceTier(
+                  name,
+                  'limits',
+                  'memory',
+                  (e.target as HTMLInputElement).value
+                );
               }}
             ></sl-input>
           </div>
@@ -3831,7 +3903,7 @@ export class ScionPageAdminServerConfig extends LitElement {
     name: string,
     tier: 'requests' | 'limits',
     field: 'cpu' | 'memory',
-    value: string,
+    value: string
   ): void {
     const updated = { ...this.profiles };
     const profile = { ...updated[name] };
@@ -3870,7 +3942,7 @@ export class ScionPageAdminServerConfig extends LitElement {
     updated: Record<string, V1ProfileConfig>,
     profile: V1ProfileConfig,
     name: string,
-    res: ResourceSpec,
+    res: ResourceSpec
   ): void {
     if (Object.keys(res).length > 0) {
       profile.resources = res;
@@ -3907,9 +3979,7 @@ export class ScionPageAdminServerConfig extends LitElement {
       <div class="section">
         ${this.renderSectionHeader('Harness Configs', 'harness_configs')}
         ${this.renderSectionMeta('harness_configs')}
-        ${hcReadOnly
-          ? html`${this.renderReadOnlyBadge(hcReadOnly)}`
-          : nothing}
+        ${hcReadOnly ? html`${this.renderReadOnlyBadge(hcReadOnly)}` : nothing}
         ${configNames.length === 0
           ? html`<p class="hint">No harness configs configured.</p>`
           : configNames.map((name) => this.renderHarnessConfigEntry(name, !!hcReadOnly))}
@@ -3928,7 +3998,7 @@ export class ScionPageAdminServerConfig extends LitElement {
                   size="small"
                   variant="default"
                   ?disabled=${!this.newHarnessConfigName.trim() ||
-                    hasOwn(this.harnessConfigsMap, this.newHarnessConfigName.trim())}
+                  hasOwn(this.harnessConfigsMap, this.newHarnessConfigName.trim())}
                   @click=${() => this.addHarnessConfig()}
                 >
                   <sl-icon slot="prefix" name="plus-circle"></sl-icon>
@@ -3936,7 +4006,9 @@ export class ScionPageAdminServerConfig extends LitElement {
                 </sl-button>
               </div>
               ${hasOwn(this.harnessConfigsMap, this.newHarnessConfigName.trim())
-                ? html`<small class="hint" style="color:var(--sl-color-danger-600);">A config named "${this.newHarnessConfigName.trim()}" already exists.</small>`
+                ? html`<small class="hint" style="color:var(--sl-color-danger-600);"
+                    >A config named "${this.newHarnessConfigName.trim()}" already exists.</small
+                  >`
                 : nothing}
             `
           : nothing}
@@ -3969,13 +4041,17 @@ export class ScionPageAdminServerConfig extends LitElement {
             resize="auto"
             value=${rawStr}
             ?disabled=${readOnly}
-            style="font-family: monospace; font-size: 0.8125rem;${jsonError ? ' --sl-input-border-color: var(--sl-color-danger-600);' : ''}"
+            style="font-family: monospace; font-size: 0.8125rem;${jsonError
+              ? ' --sl-input-border-color: var(--sl-color-danger-600);'
+              : ''}"
             @sl-input=${(e: Event) => {
               this.updateHarnessConfigJson(name, (e.target as HTMLTextAreaElement).value);
             }}
           ></sl-textarea>
           ${jsonError
-            ? html`<small class="hint" style="color:var(--sl-color-danger-600);">Invalid JSON: ${jsonError}</small>`
+            ? html`<small class="hint" style="color:var(--sl-color-danger-600);"
+                >Invalid JSON: ${jsonError}</small
+              >`
             : nothing}
         </div>
       </sl-card>
@@ -4188,7 +4264,7 @@ export class ScionPageAdminServerConfig extends LitElement {
             >
             ${this.renderFieldValue(
               'server.database.url',
-              this.dbUrl === '********' ? '********' : (this.dbUrl || '—'),
+              this.dbUrl === '********' ? '********' : this.dbUrl || '—',
               html`<sl-input
                 value=${this.dbUrl}
                 placeholder="Path or connection string"
@@ -4302,19 +4378,19 @@ export class ScionPageAdminServerConfig extends LitElement {
               'server.auth.user_access_mode',
               this.authUserAccessMode,
               html`${this.renderEnvBadge('server.auth.user_access_mode')}<sl-select
-                value=${this.authUserAccessMode}
-                @sl-change=${(e: Event) => {
-                  this.authUserAccessMode = (e.target as HTMLSelectElement).value;
-                }}
-              >
-                <sl-option value="open">Open (all authenticated users)</sl-option>
-                <sl-option value="domain_restricted"
-                  >Domain Restricted (authorized domains only)</sl-option
+                  value=${this.authUserAccessMode}
+                  @sl-change=${(e: Event) => {
+                    this.authUserAccessMode = (e.target as HTMLSelectElement).value;
+                  }}
                 >
-                <sl-option value="invite_only"
-                  >Invite Only (allow list + authorized domains)</sl-option
-                >
-              </sl-select>`
+                  <sl-option value="open">Open (all authenticated users)</sl-option>
+                  <sl-option value="domain_restricted"
+                    >Domain Restricted (authorized domains only)</sl-option
+                  >
+                  <sl-option value="invite_only"
+                    >Invite Only (allow list + authorized domains)</sl-option
+                  >
+                </sl-select>`
             )}
             ${this.authUserAccessMode === 'invite_only'
               ? html`<sl-alert variant="warning" open style="margin-top: 0.75rem">
@@ -4357,7 +4433,7 @@ export class ScionPageAdminServerConfig extends LitElement {
             >
             ${this.renderFieldValue(
               'server.auth.dev_token',
-              this.authDevToken === '********' ? '********' : (this.authDevToken || '—'),
+              this.authDevToken === '********' ? '********' : this.authDevToken || '—',
               html`<sl-input
                 value=${this.authDevToken}
                 @sl-input=${(e: Event) => {
@@ -4375,12 +4451,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'server.auth.authorized_domains',
               this.authAuthorizedDomains || '—',
               html`${this.renderEnvBadge('server.auth.authorized_domains')}<sl-input
-                value=${this.authAuthorizedDomains}
-                placeholder="example.com, corp.example.com"
-                @sl-input=${(e: Event) => {
-                  this.authAuthorizedDomains = (e.target as HTMLInputElement).value;
-                }}
-              ></sl-input>`
+                  value=${this.authAuthorizedDomains}
+                  placeholder="example.com, corp.example.com"
+                  @sl-input=${(e: Event) => {
+                    this.authAuthorizedDomains = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>`
             )}
           </div>
         </div>
@@ -4444,12 +4520,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'telemetry.cloud.enabled',
               this.telemetryCloudEnabled ? 'Enabled' : 'Disabled',
               html`${this.renderEnvBadge('telemetry.cloud.enabled')}<sl-switch
-                ?checked=${this.telemetryCloudEnabled}
-                @sl-change=${(e: Event) => {
-                  this.telemetryCloudEnabled = (e.target as HTMLInputElement).checked;
-                }}
-                >Enable Cloud Export</sl-switch
-              >`
+                  ?checked=${this.telemetryCloudEnabled}
+                  @sl-change=${(e: Event) => {
+                    this.telemetryCloudEnabled = (e.target as HTMLInputElement).checked;
+                  }}
+                  >Enable Cloud Export</sl-switch
+                >`
             )}
           </div>
           <div class="form-field full-width">
@@ -4458,12 +4534,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'telemetry.cloud.endpoint',
               this.telemetryCloudEndpoint || '—',
               html`${this.renderEnvBadge('telemetry.cloud.endpoint')}<sl-input
-                value=${this.telemetryCloudEndpoint}
-                placeholder="https://otel-collector.example.com:4317"
-                @sl-input=${(e: Event) => {
-                  this.telemetryCloudEndpoint = (e.target as HTMLInputElement).value;
-                }}
-              ></sl-input>`
+                  value=${this.telemetryCloudEndpoint}
+                  placeholder="https://otel-collector.example.com:4317"
+                  @sl-input=${(e: Event) => {
+                    this.telemetryCloudEndpoint = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>`
             )}
           </div>
           <div class="form-field">
@@ -4472,15 +4548,15 @@ export class ScionPageAdminServerConfig extends LitElement {
               'telemetry.cloud.protocol',
               this.telemetryCloudProtocol || 'grpc',
               html`${this.renderEnvBadge('telemetry.cloud.protocol')}<sl-select
-                value=${this.telemetryCloudProtocol || 'grpc'}
-                @sl-change=${(e: Event) => {
-                  this.telemetryCloudProtocol = (e.target as HTMLSelectElement).value;
-                }}
-              >
-                <sl-option value="grpc">gRPC</sl-option>
-                <sl-option value="http/protobuf">HTTP/Protobuf</sl-option>
-                <sl-option value="http/json">HTTP/JSON</sl-option>
-              </sl-select>`
+                  value=${this.telemetryCloudProtocol || 'grpc'}
+                  @sl-change=${(e: Event) => {
+                    this.telemetryCloudProtocol = (e.target as HTMLSelectElement).value;
+                  }}
+                >
+                  <sl-option value="grpc">gRPC</sl-option>
+                  <sl-option value="http/protobuf">HTTP/Protobuf</sl-option>
+                  <sl-option value="http/json">HTTP/JSON</sl-option>
+                </sl-select>`
             )}
           </div>
           <div class="form-field">
@@ -4489,12 +4565,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'telemetry.cloud.provider',
               this.telemetryCloudProvider || '—',
               html`${this.renderEnvBadge('telemetry.cloud.provider')}<sl-input
-                value=${this.telemetryCloudProvider}
-                placeholder="e.g., gcp"
-                @sl-input=${(e: Event) => {
-                  this.telemetryCloudProvider = (e.target as HTMLInputElement).value;
-                }}
-              ></sl-input>`
+                  value=${this.telemetryCloudProvider}
+                  placeholder="e.g., gcp"
+                  @sl-input=${(e: Event) => {
+                    this.telemetryCloudProvider = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>`
             )}
           </div>
           <div class="form-field">
@@ -4503,12 +4579,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'telemetry.cloud.gcp_project_id',
               this.telemetryCloudGcpProjectId || '—',
               html`${this.renderEnvBadge('telemetry.cloud.gcp_project_id')}<sl-input
-                value=${this.telemetryCloudGcpProjectId}
-                placeholder="e.g., my-gcp-project"
-                @sl-input=${(e: Event) => {
-                  this.telemetryCloudGcpProjectId = (e.target as HTMLInputElement).value;
-                }}
-              ></sl-input>`
+                  value=${this.telemetryCloudGcpProjectId}
+                  placeholder="e.g., my-gcp-project"
+                  @sl-input=${(e: Event) => {
+                    this.telemetryCloudGcpProjectId = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>`
             )}
           </div>
           <div class="form-field">
@@ -4516,12 +4592,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'telemetry.cloud.cloud_logging',
               this.telemetryCloudCloudLogging ? 'Enabled' : 'Disabled',
               html`${this.renderEnvBadge('telemetry.cloud.cloud_logging')}<sl-switch
-                ?checked=${this.telemetryCloudCloudLogging}
-                @sl-change=${(e: Event) => {
-                  this.telemetryCloudCloudLogging = (e.target as HTMLInputElement).checked;
-                }}
-                >Enable Cloud Logging</sl-switch
-              >`
+                  ?checked=${this.telemetryCloudCloudLogging}
+                  @sl-change=${(e: Event) => {
+                    this.telemetryCloudCloudLogging = (e.target as HTMLInputElement).checked;
+                  }}
+                  >Enable Cloud Logging</sl-switch
+                >`
             )}
           </div>
         </div>
@@ -4535,12 +4611,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'telemetry.hub.enabled',
               this.telemetryHubEnabled ? 'Enabled' : 'Disabled',
               html`${this.renderEnvBadge('telemetry.hub.enabled')}<sl-switch
-                ?checked=${this.telemetryHubEnabled}
-                @sl-change=${(e: Event) => {
-                  this.telemetryHubEnabled = (e.target as HTMLInputElement).checked;
-                }}
-                >Enable Hub Reporting</sl-switch
-              >`
+                  ?checked=${this.telemetryHubEnabled}
+                  @sl-change=${(e: Event) => {
+                    this.telemetryHubEnabled = (e.target as HTMLInputElement).checked;
+                  }}
+                  >Enable Hub Reporting</sl-switch
+                >`
             )}
           </div>
           <div class="form-field">
@@ -4549,12 +4625,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'telemetry.hub.report_interval',
               this.telemetryHubReportInterval || '—',
               html`${this.renderEnvBadge('telemetry.hub.report_interval')}<sl-input
-                value=${this.telemetryHubReportInterval}
-                placeholder="30s"
-                @sl-input=${(e: Event) => {
-                  this.telemetryHubReportInterval = (e.target as HTMLInputElement).value;
-                }}
-              ></sl-input>`
+                  value=${this.telemetryHubReportInterval}
+                  placeholder="30s"
+                  @sl-input=${(e: Event) => {
+                    this.telemetryHubReportInterval = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>`
             )}
           </div>
         </div>
@@ -4568,12 +4644,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'telemetry.local.enabled',
               this.telemetryLocalEnabled ? 'Enabled' : 'Disabled',
               html`${this.renderEnvBadge('telemetry.local.enabled')}<sl-switch
-                ?checked=${this.telemetryLocalEnabled}
-                @sl-change=${(e: Event) => {
-                  this.telemetryLocalEnabled = (e.target as HTMLInputElement).checked;
-                }}
-                >Enable Local Output</sl-switch
-              >`
+                  ?checked=${this.telemetryLocalEnabled}
+                  @sl-change=${(e: Event) => {
+                    this.telemetryLocalEnabled = (e.target as HTMLInputElement).checked;
+                  }}
+                  >Enable Local Output</sl-switch
+                >`
             )}
           </div>
           <div class="form-field">
@@ -4581,12 +4657,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'telemetry.local.console',
               this.telemetryLocalConsole ? 'Enabled' : 'Disabled',
               html`${this.renderEnvBadge('telemetry.local.console')}<sl-switch
-                ?checked=${this.telemetryLocalConsole}
-                @sl-change=${(e: Event) => {
-                  this.telemetryLocalConsole = (e.target as HTMLInputElement).checked;
-                }}
-                >Console Output</sl-switch
-              >`
+                  ?checked=${this.telemetryLocalConsole}
+                  @sl-change=${(e: Event) => {
+                    this.telemetryLocalConsole = (e.target as HTMLInputElement).checked;
+                  }}
+                  >Console Output</sl-switch
+                >`
             )}
           </div>
           <div class="form-field full-width">
@@ -4595,12 +4671,12 @@ export class ScionPageAdminServerConfig extends LitElement {
               'telemetry.local.file',
               this.telemetryLocalFile || '—',
               html`${this.renderEnvBadge('telemetry.local.file')}<sl-input
-                value=${this.telemetryLocalFile}
-                placeholder="/var/log/scion/telemetry.log"
-                @sl-input=${(e: Event) => {
-                  this.telemetryLocalFile = (e.target as HTMLInputElement).value;
-                }}
-              ></sl-input>`
+                  value=${this.telemetryLocalFile}
+                  placeholder="/var/log/scion/telemetry.log"
+                  @sl-input=${(e: Event) => {
+                    this.telemetryLocalFile = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>`
             )}
           </div>
         </div>
@@ -4627,10 +4703,9 @@ export class ScionPageAdminServerConfig extends LitElement {
               <sl-option value="enforce">Enforce (IAM actAs check required)</sl-option>
             </sl-select>
             <div class="help-text">
-              Controls whether GCP IAM actAs permission is verified when assigning
-              a service account to an agent. When "off", assignment is gated by
-              Hub policy only. When "enforce", the caller must also have
-              iam.serviceAccounts.actAs on the target service account.
+              Controls whether GCP IAM actAs permission is verified when assigning a service account
+              to an agent. When "off", assignment is gated by Hub policy only. When "enforce", the
+              caller must also have iam.serviceAccounts.actAs on the target service account.
             </div>
           </div>
           <div class="form-field">
@@ -4645,12 +4720,11 @@ export class ScionPageAdminServerConfig extends LitElement {
               <sl-option value="fail-closed">Fail Closed</sl-option>
             </sl-select>
             <div class="help-text">
-              Controls behavior when IAM deny policies cannot be fully evaluated
-              (e.g., the Hub service account lacks org-level permissions to read
-              deny policies). "Fail open" treats allow-granted results as allowed
-              even when deny evaluation is inconclusive. "Fail closed" denies
-              access when deny policies cannot be verified. Only applies when
-              IAM Check Mode is "enforce".
+              Controls behavior when IAM deny policies cannot be fully evaluated (e.g., the Hub
+              service account lacks org-level permissions to read deny policies). "Fail open" treats
+              allow-granted results as allowed even when deny evaluation is inconclusive. "Fail
+              closed" denies access when deny policies cannot be verified. Only applies when IAM
+              Check Mode is "enforce".
             </div>
           </div>
         </div>
@@ -4784,13 +4858,13 @@ export class ScionPageAdminServerConfig extends LitElement {
               'server.github_app.app_id',
               this.githubAppId ? String(this.githubAppId) : '—',
               html`${this.renderEnvBadge('server.github_app.app_id', 'server.github_app')}<sl-input
-                .value=${this.githubAppId ? String(this.githubAppId) : ''}
-                placeholder="e.g. 123456"
-                inputmode="numeric"
-                @sl-input=${(e: Event) => {
-                  this.githubAppId = parseInt((e.target as HTMLInputElement).value) || 0;
-                }}
-              ></sl-input>`
+                  .value=${this.githubAppId ? String(this.githubAppId) : ''}
+                  placeholder="e.g. 123456"
+                  inputmode="numeric"
+                  @sl-input=${(e: Event) => {
+                    this.githubAppId = parseInt((e.target as HTMLInputElement).value) || 0;
+                  }}
+                ></sl-input>`
             )}
           </div>
           <div class="form-field">
@@ -4801,13 +4875,16 @@ export class ScionPageAdminServerConfig extends LitElement {
             ${this.renderFieldValue(
               'server.github_app.api_base_url',
               this.githubAppApiBaseUrl || '—',
-              html`${this.renderEnvBadge('server.github_app.api_base_url', 'server.github_app')}<sl-input
-                .value=${this.githubAppApiBaseUrl}
-                placeholder="https://api.github.com"
-                @sl-input=${(e: Event) => {
-                  this.githubAppApiBaseUrl = (e.target as HTMLInputElement).value;
-                }}
-              ></sl-input>`
+              html`${this.renderEnvBadge(
+                  'server.github_app.api_base_url',
+                  'server.github_app'
+                )}<sl-input
+                  .value=${this.githubAppApiBaseUrl}
+                  placeholder="https://api.github.com"
+                  @sl-input=${(e: Event) => {
+                    this.githubAppApiBaseUrl = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>`
             )}
           </div>
           <div class="form-field full-width">
@@ -4863,14 +4940,17 @@ export class ScionPageAdminServerConfig extends LitElement {
             ${this.renderFieldValue(
               'server.github_app.webhooks_enabled',
               this.githubAppWebhooksEnabled ? 'Enabled' : 'Disabled',
-              html`${this.renderEnvBadge('server.github_app.webhooks_enabled', 'server.github_app')}<sl-switch
-                .checked=${this.githubAppWebhooksEnabled}
-                @sl-change=${(e: Event) => {
-                  this.githubAppWebhooksEnabled = (e.target as HTMLInputElement).checked;
-                }}
-              >
-                ${this.githubAppWebhooksEnabled ? 'Enabled' : 'Disabled'}
-              </sl-switch>`
+              html`${this.renderEnvBadge(
+                  'server.github_app.webhooks_enabled',
+                  'server.github_app'
+                )}<sl-switch
+                  .checked=${this.githubAppWebhooksEnabled}
+                  @sl-change=${(e: Event) => {
+                    this.githubAppWebhooksEnabled = (e.target as HTMLInputElement).checked;
+                  }}
+                >
+                  ${this.githubAppWebhooksEnabled ? 'Enabled' : 'Disabled'}
+                </sl-switch>`
             )}
           </div>
           <div class="form-field full-width">
@@ -4881,13 +4961,16 @@ export class ScionPageAdminServerConfig extends LitElement {
             ${this.renderFieldValue(
               'server.github_app.installation_url',
               this.githubAppInstallationUrl || '—',
-              html`${this.renderEnvBadge('server.github_app.installation_url', 'server.github_app')}<sl-input
-                .value=${this.githubAppInstallationUrl}
-                placeholder="https://github.com/apps/your-app-name/installations/new"
-                @sl-input=${(e: Event) => {
-                  this.githubAppInstallationUrl = (e.target as HTMLInputElement).value;
-                }}
-              ></sl-input>`
+              html`${this.renderEnvBadge(
+                  'server.github_app.installation_url',
+                  'server.github_app'
+                )}<sl-input
+                  .value=${this.githubAppInstallationUrl}
+                  placeholder="https://github.com/apps/your-app-name/installations/new"
+                  @sl-input=${(e: Event) => {
+                    this.githubAppInstallationUrl = (e.target as HTMLInputElement).value;
+                  }}
+                ></sl-input>`
             )}
           </div>
         </div>

--- a/web/src/components/pages/admin-skill-registries.ts
+++ b/web/src/components/pages/admin-skill-registries.ts
@@ -35,12 +35,22 @@ export class ScionPageAdminSkillRegistries extends LitElement {
 
   // Create dialog state
   @state() private createOpen = false;
-  @state() private createForm = { name: '', endpoint: '', type: 'hub', trustLevel: 'pinned', description: '', authToken: '', resolvePath: '' };
+  @state() private createForm = {
+    name: '',
+    endpoint: '',
+    type: 'hub',
+    trustLevel: 'pinned',
+    description: '',
+    authToken: '',
+    resolvePath: '',
+  };
   @state() private createError: string | null = null;
   @state() private creating = false;
 
   static override styles = css`
-    :host { display: block; }
+    :host {
+      display: block;
+    }
 
     .header {
       display: flex;
@@ -61,7 +71,10 @@ export class ScionPageAdminSkillRegistries extends LitElement {
       border-radius: var(--scion-radius-lg, 0.75rem);
       overflow: hidden;
     }
-    table { width: 100%; border-collapse: collapse; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
     th {
       text-align: left;
       padding: 0.75rem 1rem;
@@ -80,9 +93,15 @@ export class ScionPageAdminSkillRegistries extends LitElement {
       border-bottom: 1px solid var(--scion-border, #e2e8f0);
       vertical-align: middle;
     }
-    tr:last-child td { border-bottom: none; }
-    tr.clickable { cursor: pointer; }
-    tr.clickable:hover td { background: var(--scion-bg-subtle, #f1f5f9); }
+    tr:last-child td {
+      border-bottom: none;
+    }
+    tr.clickable {
+      cursor: pointer;
+    }
+    tr.clickable:hover td {
+      background: var(--scion-bg-subtle, #f1f5f9);
+    }
 
     .endpoint-text {
       font-family: var(--scion-font-mono, monospace);
@@ -94,7 +113,8 @@ export class ScionPageAdminSkillRegistries extends LitElement {
       text-overflow: ellipsis;
     }
 
-    .type-badge, .trust-badge {
+    .type-badge,
+    .trust-badge {
       display: inline-flex;
       align-items: center;
       padding: 0.125rem 0.5rem;
@@ -152,7 +172,10 @@ export class ScionPageAdminSkillRegistries extends LitElement {
       padding: 4rem 2rem;
       color: var(--scion-text-muted, #64748b);
     }
-    .loading-state sl-spinner { font-size: 2rem; margin-bottom: 1rem; }
+    .loading-state sl-spinner {
+      font-size: 2rem;
+      margin-bottom: 1rem;
+    }
 
     .error-state {
       text-align: center;
@@ -167,10 +190,15 @@ export class ScionPageAdminSkillRegistries extends LitElement {
       margin-bottom: 1rem;
     }
     .error-state h2 {
-      font-size: 1.25rem; font-weight: 600;
-      color: var(--scion-text, #1e293b); margin: 0 0 0.5rem 0;
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+      margin: 0 0 0.5rem 0;
     }
-    .error-state p { color: var(--scion-text-muted, #64748b); margin: 0 0 1rem 0; }
+    .error-state p {
+      color: var(--scion-text-muted, #64748b);
+      margin: 0 0 1rem 0;
+    }
     .error-details {
       font-family: var(--scion-font-mono, monospace);
       font-size: 0.875rem;
@@ -228,7 +256,9 @@ export class ScionPageAdminSkillRegistries extends LitElement {
       if (!res.ok) {
         throw new Error(await extractApiError(res, `HTTP ${res.status}`));
       }
-      const data = (await res.json()) as { items?: SkillRegistry[]; registries?: SkillRegistry[] } | SkillRegistry[];
+      const data = (await res.json()) as
+        | { items?: SkillRegistry[]; registries?: SkillRegistry[] }
+        | SkillRegistry[];
       if (Array.isArray(data)) {
         this.registries = data;
       } else {
@@ -256,7 +286,9 @@ export class ScionPageAdminSkillRegistries extends LitElement {
       if (hours < 24) return `${hours}h ago`;
       const days = Math.floor(hours / 24);
       return `${days}d ago`;
-    } catch { return dateString; }
+    } catch {
+      return dateString;
+    }
   }
 
   private async handleCreate(): Promise<void> {
@@ -290,7 +322,15 @@ export class ScionPageAdminSkillRegistries extends LitElement {
       }
 
       this.createOpen = false;
-      this.createForm = { name: '', endpoint: '', type: 'hub', trustLevel: 'pinned', description: '', authToken: '', resolvePath: '' };
+      this.createForm = {
+        name: '',
+        endpoint: '',
+        type: 'hub',
+        trustLevel: 'pinned',
+        description: '',
+        authToken: '',
+        resolvePath: '',
+      };
       void this.loadRegistries();
     } catch (err) {
       this.createError = err instanceof Error ? err.message : 'Failed to create registry';
@@ -308,17 +348,25 @@ export class ScionPageAdminSkillRegistries extends LitElement {
     return html`
       <div class="header">
         <h1>Skill Registries</h1>
-        <sl-button variant="primary" size="small" @click=${() => { this.createOpen = true; }}>
+        <sl-button
+          variant="primary"
+          size="small"
+          @click=${() => {
+            this.createOpen = true;
+          }}
+        >
           <sl-icon slot="prefix" name="plus-lg"></sl-icon>
           Create Registry
         </sl-button>
       </div>
 
-      ${this.loading ? this.renderLoading()
-        : this.error ? this.renderError()
-        : this.registries.length === 0 ? this.renderEmpty()
-        : this.renderTable()}
-
+      ${this.loading
+        ? this.renderLoading()
+        : this.error
+          ? this.renderError()
+          : this.registries.length === 0
+            ? this.renderEmpty()
+            : this.renderTable()}
       ${this.renderCreateDialog()}
     `;
   }
@@ -338,22 +386,24 @@ export class ScionPageAdminSkillRegistries extends LitElement {
             </tr>
           </thead>
           <tbody>
-            ${this.registries.map((r) => html`
-              <tr class="clickable" @click=${() => this.navigateToDetail(r.id)}>
-                <td><strong>${r.name}</strong></td>
-                <td><span class="endpoint-text">${r.endpoint}</span></td>
-                <td><span class="type-badge">${r.type}</span></td>
-                <td><span class="trust-badge ${r.trustLevel}">${r.trustLevel}</span></td>
-                <td>
-                  <scion-status-badge
-                    status=${r.status === 'active' ? 'success' : 'danger'}
-                    label=${r.status}
-                    size="small"
-                  ></scion-status-badge>
-                </td>
-                <td><span class="meta-text">${this.formatRelativeTime(r.created)}</span></td>
-              </tr>
-            `)}
+            ${this.registries.map(
+              (r) => html`
+                <tr class="clickable" @click=${() => this.navigateToDetail(r.id)}>
+                  <td><strong>${r.name}</strong></td>
+                  <td><span class="endpoint-text">${r.endpoint}</span></td>
+                  <td><span class="type-badge">${r.type}</span></td>
+                  <td><span class="trust-badge ${r.trustLevel}">${r.trustLevel}</span></td>
+                  <td>
+                    <scion-status-badge
+                      status=${r.status === 'active' ? 'success' : 'danger'}
+                      label=${r.status}
+                      size="small"
+                    ></scion-status-badge>
+                  </td>
+                  <td><span class="meta-text">${this.formatRelativeTime(r.created)}</span></td>
+                </tr>
+              `
+            )}
           </tbody>
         </table>
       </div>
@@ -365,22 +415,32 @@ export class ScionPageAdminSkillRegistries extends LitElement {
       <sl-dialog
         label="Create Skill Registry"
         ?open=${this.createOpen}
-        @sl-after-hide=${() => { this.createOpen = false; this.createError = null; }}
+        @sl-after-hide=${() => {
+          this.createOpen = false;
+          this.createError = null;
+        }}
         style="--width: 500px;"
       >
-        ${this.createError ? html`
-          <div class="error-banner">
-            <sl-icon name="exclamation-triangle"></sl-icon>
-            <span>${this.createError}</span>
-          </div>
-        ` : nothing}
+        ${this.createError
+          ? html`
+              <div class="error-banner">
+                <sl-icon name="exclamation-triangle"></sl-icon>
+                <span>${this.createError}</span>
+              </div>
+            `
+          : nothing}
 
         <div class="form-field">
           <label>Name</label>
           <sl-input
             placeholder="production-hub"
             .value=${this.createForm.name}
-            @sl-input=${(e: Event) => { this.createForm = { ...this.createForm, name: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-input=${(e: Event) => {
+              this.createForm = {
+                ...this.createForm,
+                name: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
             required
           ></sl-input>
         </div>
@@ -390,7 +450,12 @@ export class ScionPageAdminSkillRegistries extends LitElement {
           <sl-input
             placeholder="https://registry.example.com"
             .value=${this.createForm.endpoint}
-            @sl-input=${(e: Event) => { this.createForm = { ...this.createForm, endpoint: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-input=${(e: Event) => {
+              this.createForm = {
+                ...this.createForm,
+                endpoint: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
             required
           ></sl-input>
         </div>
@@ -399,7 +464,12 @@ export class ScionPageAdminSkillRegistries extends LitElement {
           <label>Type</label>
           <sl-select
             .value=${this.createForm.type}
-            @sl-change=${(e: Event) => { this.createForm = { ...this.createForm, type: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-change=${(e: Event) => {
+              this.createForm = {
+                ...this.createForm,
+                type: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
           >
             <sl-option value="hub">Hub</sl-option>
             <sl-option value="gcp">GCP</sl-option>
@@ -410,7 +480,12 @@ export class ScionPageAdminSkillRegistries extends LitElement {
           <label>Trust Level</label>
           <sl-select
             .value=${this.createForm.trustLevel}
-            @sl-change=${(e: Event) => { this.createForm = { ...this.createForm, trustLevel: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-change=${(e: Event) => {
+              this.createForm = {
+                ...this.createForm,
+                trustLevel: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
           >
             <sl-option value="pinned">Pinned</sl-option>
             <sl-option value="trusted">Trusted</sl-option>
@@ -426,7 +501,12 @@ export class ScionPageAdminSkillRegistries extends LitElement {
           <label>Description (optional)</label>
           <sl-textarea
             .value=${this.createForm.description}
-            @sl-input=${(e: Event) => { this.createForm = { ...this.createForm, description: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-input=${(e: Event) => {
+              this.createForm = {
+                ...this.createForm,
+                description: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
             rows="2"
           ></sl-textarea>
         </div>
@@ -436,7 +516,12 @@ export class ScionPageAdminSkillRegistries extends LitElement {
           <sl-input
             type="password"
             .value=${this.createForm.authToken}
-            @sl-input=${(e: Event) => { this.createForm = { ...this.createForm, authToken: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-input=${(e: Event) => {
+              this.createForm = {
+                ...this.createForm,
+                authToken: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
             toggle-password
           ></sl-input>
         </div>
@@ -446,18 +531,31 @@ export class ScionPageAdminSkillRegistries extends LitElement {
           <sl-input
             placeholder="/api/v1/skills/resolve"
             .value=${this.createForm.resolvePath}
-            @sl-input=${(e: Event) => { this.createForm = { ...this.createForm, resolvePath: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-input=${(e: Event) => {
+              this.createForm = {
+                ...this.createForm,
+                resolvePath: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
           ></sl-input>
         </div>
 
-        <sl-button slot="footer" variant="default" @click=${() => { this.createOpen = false; }}>
+        <sl-button
+          slot="footer"
+          variant="default"
+          @click=${() => {
+            this.createOpen = false;
+          }}
+        >
           Cancel
         </sl-button>
         <sl-button
           slot="footer"
           variant="primary"
           ?loading=${this.creating}
-          ?disabled=${this.creating || !this.createForm.name.trim() || !this.createForm.endpoint.trim()}
+          ?disabled=${this.creating ||
+          !this.createForm.name.trim() ||
+          !this.createForm.endpoint.trim()}
           @click=${() => this.handleCreate()}
         >
           Create
@@ -496,7 +594,12 @@ export class ScionPageAdminSkillRegistries extends LitElement {
         <sl-icon name="cloud-arrow-down"></sl-icon>
         <h2>No Registries</h2>
         <p>No skill registries have been configured yet.</p>
-        <sl-button variant="primary" @click=${() => { this.createOpen = true; }}>
+        <sl-button
+          variant="primary"
+          @click=${() => {
+            this.createOpen = true;
+          }}
+        >
           <sl-icon slot="prefix" name="plus-lg"></sl-icon>
           Create Registry
         </sl-button>

--- a/web/src/components/pages/admin-skill-registry-detail.ts
+++ b/web/src/components/pages/admin-skill-registry-detail.ts
@@ -44,7 +44,13 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
 
   // Edit mode
   @state() private editing = false;
-  @state() private editForm: Partial<{ endpoint: string; description: string; trustLevel: string; resolvePath: string; authToken: string }> = {};
+  @state() private editForm: Partial<{
+    endpoint: string;
+    description: string;
+    trustLevel: string;
+    resolvePath: string;
+    authToken: string;
+  }> = {};
   @state() private saving = false;
 
   // Pinned hashes
@@ -59,7 +65,9 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
   @state() private actionLoading: Record<string, boolean> = {};
 
   static override styles = css`
-    :host { display: block; }
+    :host {
+      display: block;
+    }
 
     .back-link {
       display: inline-flex;
@@ -70,7 +78,9 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
       font-size: 0.875rem;
       margin-bottom: 1rem;
     }
-    .back-link:hover { color: var(--scion-primary, #3b82f6); }
+    .back-link:hover {
+      color: var(--scion-primary, #3b82f6);
+    }
 
     .header {
       display: flex;
@@ -121,7 +131,10 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
       grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
       gap: 1.5rem;
     }
-    .info-item { display: flex; flex-direction: column; }
+    .info-item {
+      display: flex;
+      flex-direction: column;
+    }
     .info-label {
       font-size: 0.75rem;
       color: var(--scion-text-muted, #64748b);
@@ -138,7 +151,8 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
       font-size: 0.875rem;
     }
 
-    .type-badge, .trust-badge {
+    .type-badge,
+    .trust-badge {
       display: inline-flex;
       align-items: center;
       padding: 0.125rem 0.5rem;
@@ -159,7 +173,9 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
       color: var(--sl-color-warning-700, #a16207);
     }
 
-    .edit-field { margin-bottom: 1rem; }
+    .edit-field {
+      margin-bottom: 1rem;
+    }
     .edit-field label {
       display: block;
       font-size: 0.75rem;
@@ -181,7 +197,10 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
       border-radius: var(--scion-radius-lg, 0.75rem);
       overflow: hidden;
     }
-    .pin-table table { width: 100%; border-collapse: collapse; }
+    .pin-table table {
+      width: 100%;
+      border-collapse: collapse;
+    }
     .pin-table th {
       text-align: left;
       padding: 0.75rem 1rem;
@@ -200,7 +219,9 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
       border-bottom: 1px solid var(--scion-border, #e2e8f0);
       vertical-align: middle;
     }
-    .pin-table tr:last-child td { border-bottom: none; }
+    .pin-table tr:last-child td {
+      border-bottom: none;
+    }
 
     .empty-pins {
       text-align: center;
@@ -217,7 +238,10 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
       padding: 4rem 2rem;
       color: var(--scion-text-muted, #64748b);
     }
-    .loading-state sl-spinner { font-size: 2rem; margin-bottom: 1rem; }
+    .loading-state sl-spinner {
+      font-size: 2rem;
+      margin-bottom: 1rem;
+    }
 
     .error-state {
       text-align: center;
@@ -232,10 +256,15 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
       margin-bottom: 1rem;
     }
     .error-state h2 {
-      font-size: 1.25rem; font-weight: 600;
-      color: var(--scion-text, #1e293b); margin: 0 0 0.5rem 0;
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+      margin: 0 0 0.5rem 0;
     }
-    .error-state p { color: var(--scion-text-muted, #64748b); margin: 0 0 1rem 0; }
+    .error-state p {
+      color: var(--scion-text-muted, #64748b);
+      margin: 0 0 1rem 0;
+    }
     .error-details {
       font-family: var(--scion-font-mono, monospace);
       font-size: 0.875rem;
@@ -293,7 +322,9 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
     try {
       const res = await apiFetch(`/api/v1/skill-registries/${this.registryId}/pins`);
       if (res.ok) {
-        const data = (await res.json()) as { pins?: PinnedHash[]; items?: PinnedHash[] } | PinnedHash[];
+        const data = (await res.json()) as
+          | { pins?: PinnedHash[]; items?: PinnedHash[] }
+          | PinnedHash[];
         if (Array.isArray(data)) {
           this.pinnedHashes = data;
         } else {
@@ -321,7 +352,9 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
       if (hours < 24) return `${hours}h ago`;
       const days = Math.floor(hours / 24);
       return `${days}d ago`;
-    } catch { return dateString; }
+    } catch {
+      return dateString;
+    }
   }
 
   // -- Edit mode --
@@ -348,9 +381,14 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
     this.saving = true;
     try {
       const body: Record<string, unknown> = {};
-      if (this.editForm.endpoint !== undefined && this.editForm.endpoint !== this.registry.endpoint) body.endpoint = this.editForm.endpoint;
+      if (this.editForm.endpoint !== undefined && this.editForm.endpoint !== this.registry.endpoint)
+        body.endpoint = this.editForm.endpoint;
       if (this.editForm.description !== undefined) body.description = this.editForm.description;
-      if (this.editForm.trustLevel !== undefined && this.editForm.trustLevel !== this.registry.trustLevel) body.trustLevel = this.editForm.trustLevel;
+      if (
+        this.editForm.trustLevel !== undefined &&
+        this.editForm.trustLevel !== this.registry.trustLevel
+      )
+        body.trustLevel = this.editForm.trustLevel;
       if (this.editForm.resolvePath !== undefined) body.resolvePath = this.editForm.resolvePath;
       if (this.editForm.authToken) body.authToken = this.editForm.authToken;
 
@@ -404,7 +442,9 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
     if (!(await showConfirm('Are you sure you want to delete this registry?'))) return;
     this.actionLoading = { ...this.actionLoading, delete: true };
     try {
-      const res = await apiFetch(`/api/v1/skill-registries/${this.registryId}`, { method: 'DELETE' });
+      const res = await apiFetch(`/api/v1/skill-registries/${this.registryId}`, {
+        method: 'DELETE',
+      });
       if (!res.ok) {
         throw new Error(await extractApiError(res, 'Failed to delete registry'));
       }
@@ -471,8 +511,7 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
         Back to Registries
       </a>
 
-      ${this.renderHeader()}
-      ${this.editing ? this.renderEditMode() : this.renderConfigCard()}
+      ${this.renderHeader()} ${this.editing ? this.renderEditMode() : this.renderConfigCard()}
       ${this.registry.trustLevel === 'pinned' ? this.renderPinnedSection() : nothing}
       ${this.renderPinDialog()}
     `;
@@ -539,7 +578,9 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
           </div>
           <div class="info-item">
             <span class="info-label">Trust Level</span>
-            <span class="info-value"><span class="trust-badge ${r.trustLevel}">${r.trustLevel}</span></span>
+            <span class="info-value"
+              ><span class="trust-badge ${r.trustLevel}">${r.trustLevel}</span></span
+            >
           </div>
           <div class="info-item">
             <span class="info-label">Status</span>
@@ -551,18 +592,22 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
               ></scion-status-badge>
             </span>
           </div>
-          ${r.description ? html`
-            <div class="info-item">
-              <span class="info-label">Description</span>
-              <span class="info-value">${r.description}</span>
-            </div>
-          ` : nothing}
-          ${r.resolvePath ? html`
-            <div class="info-item">
-              <span class="info-label">Resolve Path</span>
-              <span class="info-value mono">${r.resolvePath}</span>
-            </div>
-          ` : nothing}
+          ${r.description
+            ? html`
+                <div class="info-item">
+                  <span class="info-label">Description</span>
+                  <span class="info-value">${r.description}</span>
+                </div>
+              `
+            : nothing}
+          ${r.resolvePath
+            ? html`
+                <div class="info-item">
+                  <span class="info-label">Resolve Path</span>
+                  <span class="info-value mono">${r.resolvePath}</span>
+                </div>
+              `
+            : nothing}
           <div class="info-item">
             <span class="info-label">Created</span>
             <span class="info-value">${this.formatRelativeTime(r.created)}</span>
@@ -594,14 +639,24 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
           <label>Endpoint</label>
           <sl-input
             .value=${this.editForm.endpoint || ''}
-            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, endpoint: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-input=${(e: Event) => {
+              this.editForm = {
+                ...this.editForm,
+                endpoint: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
           ></sl-input>
         </div>
         <div class="edit-field">
           <label>Trust Level</label>
           <sl-select
             .value=${this.editForm.trustLevel || 'trusted'}
-            @sl-change=${(e: Event) => { this.editForm = { ...this.editForm, trustLevel: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-change=${(e: Event) => {
+              this.editForm = {
+                ...this.editForm,
+                trustLevel: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
           >
             <sl-option value="trusted">Trusted</sl-option>
             <sl-option value="pinned">Pinned</sl-option>
@@ -611,7 +666,12 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
           <label>Description</label>
           <sl-textarea
             .value=${this.editForm.description || ''}
-            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, description: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-input=${(e: Event) => {
+              this.editForm = {
+                ...this.editForm,
+                description: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
             rows="2"
             help-text="Once set, this field cannot be cleared."
           ></sl-textarea>
@@ -620,7 +680,12 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
           <label>Resolve Path</label>
           <sl-input
             .value=${this.editForm.resolvePath || ''}
-            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, resolvePath: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-input=${(e: Event) => {
+              this.editForm = {
+                ...this.editForm,
+                resolvePath: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
             help-text="Once set, this field cannot be cleared."
           ></sl-input>
         </div>
@@ -629,15 +694,30 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
           <sl-input
             type="password"
             .value=${this.editForm.authToken || ''}
-            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, authToken: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-input=${(e: Event) => {
+              this.editForm = {
+                ...this.editForm,
+                authToken: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
             toggle-password
           ></sl-input>
         </div>
         <div class="edit-actions">
-          <sl-button variant="primary" size="small" ?loading=${this.saving} @click=${() => this.saveEdit()}>
+          <sl-button
+            variant="primary"
+            size="small"
+            ?loading=${this.saving}
+            @click=${() => this.saveEdit()}
+          >
             Save
           </sl-button>
-          <sl-button variant="default" size="small" ?disabled=${this.saving} @click=${() => this.cancelEditing()}>
+          <sl-button
+            variant="default"
+            size="small"
+            ?disabled=${this.saving}
+            @click=${() => this.cancelEditing()}
+          >
             Cancel
           </sl-button>
         </div>
@@ -650,46 +730,76 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
       <div class="card">
         <div class="card-title-row">
           <h3 class="card-title">Pinned Hashes</h3>
-          <sl-button size="small" variant="default" outline @click=${() => { this.pinDialogOpen = true; }}>
+          <sl-button
+            size="small"
+            variant="default"
+            outline
+            @click=${() => {
+              this.pinDialogOpen = true;
+            }}
+          >
             <sl-icon slot="prefix" name="plus-lg"></sl-icon>
             Pin Hash
           </sl-button>
         </div>
 
-        ${this.pinnedLoading ? html`
-          <div style="text-align: center; padding: 1rem;">
-            <sl-spinner></sl-spinner>
-          </div>
-        ` : this.pinnedHashes.length === 0 ? html`
-          <div class="empty-pins">
-            <p>No pinned hashes. Pin specific skill hashes to restrict which content is trusted from this registry.</p>
-          </div>
-        ` : html`
-          <div class="pin-table">
-            <table>
-              <thead>
-                <tr>
-                  <th>URI</th>
-                  <th>Hash</th>
-                  <th style="text-align: right">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                ${this.pinnedHashes.map((p) => html`
-                  <tr>
-                    <td style="font-family: var(--scion-font-mono, monospace); font-size: 0.875rem;">${p.uri}</td>
-                    <td><scion-hash-display .hash=${p.hash} max-width="20ch"></scion-hash-display></td>
-                    <td style="text-align: right">
-                      <sl-button size="small" variant="danger" outline @click=${() => this.handleUnpin(p.uri)}>
-                        Unpin
-                      </sl-button>
-                    </td>
-                  </tr>
-                `)}
-              </tbody>
-            </table>
-          </div>
-        `}
+        ${this.pinnedLoading
+          ? html`
+              <div style="text-align: center; padding: 1rem;">
+                <sl-spinner></sl-spinner>
+              </div>
+            `
+          : this.pinnedHashes.length === 0
+            ? html`
+                <div class="empty-pins">
+                  <p>
+                    No pinned hashes. Pin specific skill hashes to restrict which content is trusted
+                    from this registry.
+                  </p>
+                </div>
+              `
+            : html`
+                <div class="pin-table">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>URI</th>
+                        <th>Hash</th>
+                        <th style="text-align: right">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      ${this.pinnedHashes.map(
+                        (p) => html`
+                          <tr>
+                            <td
+                              style="font-family: var(--scion-font-mono, monospace); font-size: 0.875rem;"
+                            >
+                              ${p.uri}
+                            </td>
+                            <td>
+                              <scion-hash-display
+                                .hash=${p.hash}
+                                max-width="20ch"
+                              ></scion-hash-display>
+                            </td>
+                            <td style="text-align: right">
+                              <sl-button
+                                size="small"
+                                variant="danger"
+                                outline
+                                @click=${() => this.handleUnpin(p.uri)}
+                              >
+                                Unpin
+                              </sl-button>
+                            </td>
+                          </tr>
+                        `
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              `}
       </div>
     `;
   }
@@ -699,14 +809,18 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
       <sl-dialog
         label="Pin Hash"
         ?open=${this.pinDialogOpen}
-        @sl-after-hide=${() => { this.pinDialogOpen = false; }}
+        @sl-after-hide=${() => {
+          this.pinDialogOpen = false;
+        }}
       >
         <div class="form-field">
           <label>Skill URI</label>
           <sl-input
             placeholder="global:my-skill@1.0.0"
             .value=${this.pinUri}
-            @sl-input=${(e: Event) => { this.pinUri = (e.target as HTMLElement & { value: string }).value; }}
+            @sl-input=${(e: Event) => {
+              this.pinUri = (e.target as HTMLElement & { value: string }).value;
+            }}
           ></sl-input>
         </div>
         <div class="form-field">
@@ -714,10 +828,18 @@ export class ScionPageAdminSkillRegistryDetail extends LitElement {
           <sl-input
             placeholder="sha256:abc123..."
             .value=${this.pinHash}
-            @sl-input=${(e: Event) => { this.pinHash = (e.target as HTMLElement & { value: string }).value; }}
+            @sl-input=${(e: Event) => {
+              this.pinHash = (e.target as HTMLElement & { value: string }).value;
+            }}
           ></sl-input>
         </div>
-        <sl-button slot="footer" variant="default" @click=${() => { this.pinDialogOpen = false; }}>
+        <sl-button
+          slot="footer"
+          variant="default"
+          @click=${() => {
+            this.pinDialogOpen = false;
+          }}
+        >
           Cancel
         </sl-button>
         <sl-button

--- a/web/src/components/pages/agent-configure.ts
+++ b/web/src/components/pages/agent-configure.ts
@@ -27,7 +27,13 @@ import { customElement, state } from 'lit/decorators.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { navigateTo } from '../../client/main.js';
 import { dispatchPageTitle } from '../../client/page-title.js';
-import type { Agent, CapabilityField, GCPIdentityConfig, GCPServiceAccount, HarnessAdvancedCapabilities } from '../../shared/types.js';
+import type {
+  Agent,
+  CapabilityField,
+  GCPIdentityConfig,
+  GCPServiceAccount,
+  HarnessAdvancedCapabilities,
+} from '../../shared/types.js';
 import { normalizeModelAlias } from '../../shared/model-utils.js';
 import type { EnvEntry } from '../shared/env-editor.js';
 import '../shared/env-editor.js';
@@ -433,11 +439,17 @@ export class ScionPageAgentConfigure extends LitElement {
     }
   }
 
-  private deriveModelSelection(model: string): { selection: '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other'; customId: string } {
+  private deriveModelSelection(model: string): {
+    selection: '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other';
+    customId: string;
+  } {
     if (!model) return { selection: '', customId: '' };
     const normalized = normalizeModelAlias(model);
     if (['small', 'medium', 'large', 'extra-large'].includes(normalized)) {
-      return { selection: normalized as 'small' | 'medium' | 'large' | 'extra-large', customId: '' };
+      return {
+        selection: normalized as 'small' | 'medium' | 'large' | 'extra-large',
+        customId: '',
+      };
     }
     return { selection: 'other', customId: model };
   }
@@ -459,11 +471,12 @@ export class ScionPageAgentConfigure extends LitElement {
     this.authMethod = ac?.harnessAuth || ic?.auth_selectedType || '';
     this.harnessConfig = ac?.harnessConfig || ic?.harness_config || '';
     this.telemetryEnabled = ic?.telemetry?.enabled ?? this.globalTelemetryDefault;
-    this.autoExposePortsEnabled = ic?.env?.SCION_AUTO_EXPOSE_PORTS === 'true'
-      ? true
-      : ic?.env?.SCION_AUTO_EXPOSE_PORTS === 'false'
-        ? false
-        : this.globalAutoExposePortsDefault;
+    this.autoExposePortsEnabled =
+      ic?.env?.SCION_AUTO_EXPOSE_PORTS === 'true'
+        ? true
+        : ic?.env?.SCION_AUTO_EXPOSE_PORTS === 'false'
+          ? false
+          : this.globalAutoExposePortsDefault;
     this.autoExposePortsMode = ic?.env?.SCION_AUTO_EXPOSE_MODE || 'allowlist';
     this.autoExposePortsList = ic?.env?.SCION_AUTO_EXPOSE_PORTS_LIST || '';
     this.autoExposePortsInterval = ic?.env?.SCION_AUTO_EXPOSE_INTERVAL || '3s';
@@ -485,8 +498,10 @@ export class ScionPageAgentConfigure extends LitElement {
 
     // Environment — filter out auto-expose env vars managed by dedicated UI controls
     const autoExposeEnvKeys = new Set([
-      'SCION_AUTO_EXPOSE_PORTS', 'SCION_AUTO_EXPOSE_MODE',
-      'SCION_AUTO_EXPOSE_PORTS_LIST', 'SCION_AUTO_EXPOSE_INTERVAL',
+      'SCION_AUTO_EXPOSE_PORTS',
+      'SCION_AUTO_EXPOSE_MODE',
+      'SCION_AUTO_EXPOSE_PORTS_LIST',
+      'SCION_AUTO_EXPOSE_INTERVAL',
     ]);
     const env = ac?.env || ic?.env || {};
     this.envEntries = Object.entries(env)
@@ -494,9 +509,7 @@ export class ScionPageAgentConfigure extends LitElement {
       .map(([key, value]) => ({ key, value }));
 
     // Detect required keys that are empty (from env gathering)
-    this.requiredEnvKeys = this.envEntries
-      .filter((e) => e.key && !e.value)
-      .map((e) => e.key);
+    this.requiredEnvKeys = this.envEntries.filter((e) => e.key && !e.value).map((e) => e.key);
 
     // GCP Identity
     const gcpId = ac?.gcpIdentity;
@@ -508,21 +521,24 @@ export class ScionPageAgentConfigure extends LitElement {
     const config: ScionConfigPayload = {};
     const caps = this.harnessCapabilities;
 
-    const model = this.modelSelection === 'other'
-      ? this.customModelId
-      : this.modelSelection;
+    const model = this.modelSelection === 'other' ? this.customModelId : this.modelSelection;
     if (model) config.model = model;
     config.thinking_level = this.thinkingLevel;
     if (this.image) config.image = this.image;
     if (this.branch) config.branch = this.branch;
     if (this.containerUser) config.user = this.containerUser;
-    if (this.authMethod && this.authMethodSupported(this.authMethod)) config.auth_selectedType = this.authMethod;
+    if (this.authMethod && this.authMethodSupported(this.authMethod))
+      config.auth_selectedType = this.authMethod;
     if (this.task) config.task = this.task;
-    if (this.systemPrompt && !this.isUnsupported(caps?.prompts.system_prompt)) config.system_prompt = this.systemPrompt;
+    if (this.systemPrompt && !this.isUnsupported(caps?.prompts.system_prompt))
+      config.system_prompt = this.systemPrompt;
     if (this.agentInstructions) config.agent_instructions = this.agentInstructions;
-    if (this.maxTurns && !this.isUnsupported(caps?.limits.max_turns)) config.max_turns = this.maxTurns;
-    if (this.maxModelCalls && !this.isUnsupported(caps?.limits.max_model_calls)) config.max_model_calls = this.maxModelCalls;
-    if (this.maxDuration && !this.isUnsupported(caps?.limits.max_duration)) config.max_duration = this.maxDuration;
+    if (this.maxTurns && !this.isUnsupported(caps?.limits.max_turns))
+      config.max_turns = this.maxTurns;
+    if (this.maxModelCalls && !this.isUnsupported(caps?.limits.max_model_calls))
+      config.max_model_calls = this.maxModelCalls;
+    if (this.maxDuration && !this.isUnsupported(caps?.limits.max_duration))
+      config.max_duration = this.maxDuration;
 
     // Resources
     const hasResources =
@@ -721,9 +737,12 @@ export class ScionPageAgentConfigure extends LitElement {
             <sl-icon name="exclamation-triangle"></sl-icon>
             <span>${this.error || 'Agent not found'}</span>
           </div>
-          <sl-button variant="default" @click=${() => {
-            navigateTo('/agents');
-          }}>
+          <sl-button
+            variant="default"
+            @click=${() => {
+              navigateTo('/agents');
+            }}
+          >
             Back to Agents
           </sl-button>
         </div>
@@ -809,7 +828,9 @@ export class ScionPageAgentConfigure extends LitElement {
             variant="danger"
             outline
             ?disabled=${isBusy}
-            @click=${() => { this.showDeleteDialog = true; }}
+            @click=${() => {
+              this.showDeleteDialog = true;
+            }}
           >
             <sl-icon slot="prefix" name="trash"></sl-icon>
             Delete
@@ -820,10 +841,21 @@ export class ScionPageAgentConfigure extends LitElement {
       <sl-dialog
         label="Delete Agent"
         ?open=${this.showDeleteDialog}
-        @sl-request-close=${() => { this.showDeleteDialog = false; }}
+        @sl-request-close=${() => {
+          this.showDeleteDialog = false;
+        }}
       >
-        <p>Are you sure you want to delete agent <strong>${this.agent.name}</strong>? This action cannot be undone.</p>
-        <sl-button slot="footer" variant="default" @click=${() => { this.showDeleteDialog = false; }}>
+        <p>
+          Are you sure you want to delete agent <strong>${this.agent.name}</strong>? This action
+          cannot be undone.
+        </p>
+        <sl-button
+          slot="footer"
+          variant="default"
+          @click=${() => {
+            this.showDeleteDialog = false;
+          }}
+        >
           Cancel
         </sl-button>
         <sl-button slot="footer" variant="danger" @click=${() => this.handleDelete()}>
@@ -842,8 +874,16 @@ export class ScionPageAgentConfigure extends LitElement {
 
     return html`
       <div class="form-field">
-        <sl-select label="Model" placeholder="use harness default" .value=${this.modelSelection} clearable
-            @sl-change=${(e: any) => { this.modelSelection = e.target.value; if (e.target.value !== 'other') this.customModelId = ''; }}>
+        <sl-select
+          label="Model"
+          placeholder="use harness default"
+          .value=${this.modelSelection}
+          clearable
+          @sl-change=${(e: any) => {
+            this.modelSelection = e.target.value;
+            if (e.target.value !== 'other') this.customModelId = '';
+          }}
+        >
           <sl-option value="small">Small</sl-option>
           <sl-option value="medium">Medium</sl-option>
           <sl-option value="large">Large</sl-option>
@@ -851,29 +891,50 @@ export class ScionPageAgentConfigure extends LitElement {
           <sl-option value="other">Other (specify)</sl-option>
         </sl-select>
 
-        ${this.modelSelection === 'other' ? html`
-          <sl-input label="Model ID" placeholder="e.g. claude-opus-4-8"
-            .value=${this.customModelId}
-            @sl-input=${(e: any) => { this.customModelId = e.target.value; }}
-            style="margin-top: 0.75rem">
-          </sl-input>
-        ` : ''}
+        ${this.modelSelection === 'other'
+          ? html`
+              <sl-input
+                label="Model ID"
+                placeholder="e.g. claude-opus-4-8"
+                .value=${this.customModelId}
+                @sl-input=${(e: any) => {
+                  this.customModelId = e.target.value;
+                }}
+                style="margin-top: 0.75rem"
+              >
+              </sl-input>
+            `
+          : ''}
       </div>
 
       <div class="form-field">
-        <label>Thinking Level${this.thinkingLevel !== null ? html` <span style="font-weight:normal;color:var(--sl-color-neutral-500)">(${this.thinkingLevel})</span>` : ''}</label>
+        <label
+          >Thinking
+          Level${this.thinkingLevel !== null
+            ? html` <span style="font-weight:normal;color:var(--sl-color-neutral-500)"
+                >(${this.thinkingLevel})</span
+              >`
+            : ''}</label
+        >
         <div style="display:flex;align-items:center;gap:0.75rem">
           <sl-range
-            min="0" max="100" step="1"
+            min="0"
+            max="100"
+            step="1"
             .value=${this.thinkingLevel ?? 50}
             ?disabled=${this.thinkingLevel === null}
             style="flex:1"
-            @sl-input=${(e: any) => { this.thinkingLevel = e.target.value; }}
+            @sl-input=${(e: any) => {
+              this.thinkingLevel = e.target.value;
+            }}
           ></sl-range>
           <sl-checkbox
             ?checked=${this.thinkingLevel !== null}
-            @sl-change=${(e: any) => { this.thinkingLevel = e.target.checked ? 50 : null; }}
-          >Set</sl-checkbox>
+            @sl-change=${(e: any) => {
+              this.thinkingLevel = e.target.checked ? 50 : null;
+            }}
+            >Set</sl-checkbox
+          >
         </div>
         <div class="hint" style="display:flex;justify-content:space-between;margin-top:0.25rem">
           <span>0 = minimal reasoning</span>
@@ -887,7 +948,9 @@ export class ScionPageAgentConfigure extends LitElement {
         <sl-input
           placeholder="Container image override"
           .value=${this.image}
-          @sl-input=${(e: Event) => { this.image = (e.target as HTMLElement & { value: string }).value; }}
+          @sl-input=${(e: Event) => {
+            this.image = (e.target as HTMLElement & { value: string }).value;
+          }}
         ></sl-input>
       </div>
 
@@ -896,7 +959,9 @@ export class ScionPageAgentConfigure extends LitElement {
         <sl-input
           placeholder="Git branch for the agent"
           .value=${this.branch}
-          @sl-input=${(e: Event) => { this.branch = (e.target as HTMLElement & { value: string }).value; }}
+          @sl-input=${(e: Event) => {
+            this.branch = (e.target as HTMLElement & { value: string }).value;
+          }}
         ></sl-input>
       </div>
 
@@ -905,7 +970,9 @@ export class ScionPageAgentConfigure extends LitElement {
         <sl-input
           placeholder="Unix user inside container"
           .value=${this.containerUser}
-          @sl-input=${(e: Event) => { this.containerUser = (e.target as HTMLElement & { value: string }).value; }}
+          @sl-input=${(e: Event) => {
+            this.containerUser = (e.target as HTMLElement & { value: string }).value;
+          }}
         ></sl-input>
       </div>
 
@@ -914,13 +981,21 @@ export class ScionPageAgentConfigure extends LitElement {
         <sl-select
           placeholder="Select auth method..."
           .value=${this.authMethod}
-          @sl-change=${(e: Event) => { this.authMethod = (e.target as HTMLElement & { value: string }).value; }}
+          @sl-change=${(e: Event) => {
+            this.authMethod = (e.target as HTMLElement & { value: string }).value;
+          }}
         >
           <sl-option value="">Auto Detected</sl-option>
           <sl-option value="api-key">Provider API Key</sl-option>
-          <sl-option value="oauth-token" ?disabled=${this.isUnsupported(oauthTokenCap)}>OAuth Token (env var)</sl-option>
-          <sl-option value="vertex-ai" ?disabled=${this.isUnsupported(vertexCap)}>Vertex Model Garden</sl-option>
-          <sl-option value="auth-file" ?disabled=${this.isUnsupported(authFileCap)}>Harness credential file</sl-option>
+          <sl-option value="oauth-token" ?disabled=${this.isUnsupported(oauthTokenCap)}
+            >OAuth Token (env var)</sl-option
+          >
+          <sl-option value="vertex-ai" ?disabled=${this.isUnsupported(vertexCap)}
+            >Vertex Model Garden</sl-option
+          >
+          <sl-option value="auth-file" ?disabled=${this.isUnsupported(authFileCap)}
+            >Harness credential file</sl-option
+          >
           <sl-option value="none">No Authentication</sl-option>
         </sl-select>
         ${this.authMethod && this.isUnsupported(selectedAuthCap || undefined)
@@ -937,7 +1012,6 @@ export class ScionPageAgentConfigure extends LitElement {
             </div>
           `
         : nothing}
-
       ${this.agent?.appliedConfig?.agentRole
         ? html`
             <div class="form-field">
@@ -948,7 +1022,9 @@ export class ScionPageAgentConfigure extends LitElement {
                 <sl-option value="baseline">Baseline — Standard access</sl-option>
                 <sl-option value="full">Full — Full access</sl-option>
               </sl-select>
-              <div class="hint">Authorization role set at creation time. Determines hub API access level.</div>
+              <div class="hint">
+                Authorization role set at creation time. Determines hub API access level.
+              </div>
             </div>
           `
         : nothing}
@@ -979,7 +1055,7 @@ export class ScionPageAgentConfigure extends LitElement {
             ? 'Prevents the agent from accessing any GCP identity. Token requests are denied.'
             : this.gcpMetadataMode === 'assign'
               ? 'Assigns a registered GCP service account. GCP client libraries will authenticate automatically.'
-              : 'No metadata interception. The agent inherits the broker\'s GCP identity. Requires broker ownership.'}
+              : "No metadata interception. The agent inherits the broker's GCP identity. Requires broker ownership."}
         </div>
       </div>
 
@@ -994,7 +1070,9 @@ export class ScionPageAgentConfigure extends LitElement {
                       placeholder="Select a service account..."
                       .value=${this.gcpServiceAccountId}
                       @sl-change=${(e: Event) => {
-                        this.gcpServiceAccountId = (e.target as HTMLElement & { value: string }).value;
+                        this.gcpServiceAccountId = (
+                          e.target as HTMLElement & { value: string }
+                        ).value;
                       }}
                     >
                       ${this.verifiedGCPServiceAccounts.map(
@@ -1007,7 +1085,8 @@ export class ScionPageAgentConfigure extends LitElement {
                   `
                 : html`
                     <div class="hint" style="margin-top: 0;">
-                      No verified service accounts available. Register and verify service accounts in project settings.
+                      No verified service accounts available. Register and verify service accounts
+                      in project settings.
                     </div>
                   `}
             </div>
@@ -1018,10 +1097,7 @@ export class ScionPageAgentConfigure extends LitElement {
         ${this.isUnsupported(telemetryCap)
           ? html`
               <sl-tooltip content=${this.supportReason(telemetryCap)} hoist>
-                <sl-checkbox
-                  ?checked=${this.telemetryEnabled}
-                  ?disabled=${true}
-                >
+                <sl-checkbox ?checked=${this.telemetryEnabled} ?disabled=${true}>
                   Enable Telemetry
                 </sl-checkbox>
               </sl-tooltip>
@@ -1029,7 +1105,9 @@ export class ScionPageAgentConfigure extends LitElement {
           : html`
               <sl-checkbox
                 ?checked=${this.telemetryEnabled}
-                @sl-change=${(e: Event) => { this.telemetryEnabled = (e.target as HTMLInputElement).checked; }}
+                @sl-change=${(e: Event) => {
+                  this.telemetryEnabled = (e.target as HTMLInputElement).checked;
+                }}
               >
                 Enable Telemetry
               </sl-checkbox>
@@ -1045,7 +1123,9 @@ export class ScionPageAgentConfigure extends LitElement {
       <div class="notify-field">
         <sl-checkbox
           ?checked=${this.autoExposePortsEnabled}
-          @sl-change=${(e: Event) => { this.autoExposePortsEnabled = (e.target as HTMLInputElement).checked; }}
+          @sl-change=${(e: Event) => {
+            this.autoExposePortsEnabled = (e.target as HTMLInputElement).checked;
+          }}
         >
           Enable Auto-Expose Ports
         </sl-checkbox>
@@ -1087,7 +1167,10 @@ export class ScionPageAgentConfigure extends LitElement {
                   this.autoExposePortsList = (e.target as HTMLElement & { value: string }).value;
                 }}
               ></sl-input>
-              <div class="hint">Comma-separated list of ports to ${this.autoExposePortsMode === 'allowlist' ? 'allow' : 'deny'}.</div>
+              <div class="hint">
+                Comma-separated list of ports to
+                ${this.autoExposePortsMode === 'allowlist' ? 'allow' : 'deny'}.
+              </div>
             </div>
             <div class="form-field">
               <label for="auto-expose-interval">Scan Interval</label>
@@ -1096,10 +1179,14 @@ export class ScionPageAgentConfigure extends LitElement {
                 placeholder="3s"
                 .value=${this.autoExposePortsInterval}
                 @sl-input=${(e: Event) => {
-                  this.autoExposePortsInterval = (e.target as HTMLElement & { value: string }).value;
+                  this.autoExposePortsInterval = (
+                    e.target as HTMLElement & { value: string }
+                  ).value;
                 }}
               ></sl-input>
-              <div class="hint">How often to scan for new listening ports (e.g. 3s, 5s). Minimum 1s.</div>
+              <div class="hint">
+                How often to scan for new listening ports (e.g. 3s, 5s). Minimum 1s.
+              </div>
             </div>
           `
         : nothing}
@@ -1115,7 +1202,9 @@ export class ScionPageAgentConfigure extends LitElement {
         <sl-textarea
           placeholder="Describe what this agent should work on..."
           .value=${this.task}
-          @sl-input=${(e: Event) => { this.task = (e.target as HTMLElement & { value: string }).value; }}
+          @sl-input=${(e: Event) => {
+            this.task = (e.target as HTMLElement & { value: string }).value;
+          }}
           rows="8"
           resize="auto"
         ></sl-textarea>
@@ -1140,7 +1229,9 @@ export class ScionPageAgentConfigure extends LitElement {
               <sl-textarea
                 placeholder="System prompt content or file:// URI..."
                 .value=${this.systemPrompt}
-                @sl-input=${(e: Event) => { this.systemPrompt = (e.target as HTMLElement & { value: string }).value; }}
+                @sl-input=${(e: Event) => {
+                  this.systemPrompt = (e.target as HTMLElement & { value: string }).value;
+                }}
                 rows="8"
                 resize="auto"
               ></sl-textarea>
@@ -1155,7 +1246,9 @@ export class ScionPageAgentConfigure extends LitElement {
         <sl-textarea
           placeholder="Agent instructions content or file:// URI..."
           .value=${this.agentInstructions}
-          @sl-input=${(e: Event) => { this.agentInstructions = (e.target as HTMLElement & { value: string }).value; }}
+          @sl-input=${(e: Event) => {
+            this.agentInstructions = (e.target as HTMLElement & { value: string }).value;
+          }}
           rows="8"
           resize="auto"
         ></sl-textarea>
@@ -1188,7 +1281,10 @@ export class ScionPageAgentConfigure extends LitElement {
                   type="number"
                   placeholder="0 = unlimited"
                   .value=${String(this.maxTurns || '')}
-                  @sl-input=${(e: Event) => { this.maxTurns = parseInt((e.target as HTMLElement & { value: string }).value) || 0; }}
+                  @sl-input=${(e: Event) => {
+                    this.maxTurns =
+                      parseInt((e.target as HTMLElement & { value: string }).value) || 0;
+                  }}
                 ></sl-input>
               `}
         </div>
@@ -1210,7 +1306,10 @@ export class ScionPageAgentConfigure extends LitElement {
                   type="number"
                   placeholder="0 = unlimited"
                   .value=${String(this.maxModelCalls || '')}
-                  @sl-input=${(e: Event) => { this.maxModelCalls = parseInt((e.target as HTMLElement & { value: string }).value) || 0; }}
+                  @sl-input=${(e: Event) => {
+                    this.maxModelCalls =
+                      parseInt((e.target as HTMLElement & { value: string }).value) || 0;
+                  }}
                 ></sl-input>
               `}
         </div>
@@ -1232,7 +1331,9 @@ export class ScionPageAgentConfigure extends LitElement {
               <sl-input
                 placeholder="e.g. 30m, 2h"
                 .value=${this.maxDuration}
-                @sl-input=${(e: Event) => { this.maxDuration = (e.target as HTMLElement & { value: string }).value; }}
+                @sl-input=${(e: Event) => {
+                  this.maxDuration = (e.target as HTMLElement & { value: string }).value;
+                }}
               ></sl-input>
             `}
         <div class="hint">Go duration string. Empty means no limit.</div>
@@ -1244,7 +1345,9 @@ export class ScionPageAgentConfigure extends LitElement {
           <sl-input
             placeholder='e.g. "2", "500m"'
             .value=${this.cpuRequest}
-            @sl-input=${(e: Event) => { this.cpuRequest = (e.target as HTMLElement & { value: string }).value; }}
+            @sl-input=${(e: Event) => {
+              this.cpuRequest = (e.target as HTMLElement & { value: string }).value;
+            }}
           ></sl-input>
         </div>
         <div class="form-field">
@@ -1252,7 +1355,9 @@ export class ScionPageAgentConfigure extends LitElement {
           <sl-input
             placeholder='e.g. "4Gi"'
             .value=${this.memoryRequest}
-            @sl-input=${(e: Event) => { this.memoryRequest = (e.target as HTMLElement & { value: string }).value; }}
+            @sl-input=${(e: Event) => {
+              this.memoryRequest = (e.target as HTMLElement & { value: string }).value;
+            }}
           ></sl-input>
         </div>
       </div>
@@ -1263,7 +1368,9 @@ export class ScionPageAgentConfigure extends LitElement {
           <sl-input
             placeholder='e.g. "4"'
             .value=${this.cpuLimit}
-            @sl-input=${(e: Event) => { this.cpuLimit = (e.target as HTMLElement & { value: string }).value; }}
+            @sl-input=${(e: Event) => {
+              this.cpuLimit = (e.target as HTMLElement & { value: string }).value;
+            }}
           ></sl-input>
         </div>
         <div class="form-field">
@@ -1271,7 +1378,9 @@ export class ScionPageAgentConfigure extends LitElement {
           <sl-input
             placeholder='e.g. "8Gi"'
             .value=${this.memoryLimit}
-            @sl-input=${(e: Event) => { this.memoryLimit = (e.target as HTMLElement & { value: string }).value; }}
+            @sl-input=${(e: Event) => {
+              this.memoryLimit = (e.target as HTMLElement & { value: string }).value;
+            }}
           ></sl-input>
         </div>
       </div>
@@ -1281,7 +1390,9 @@ export class ScionPageAgentConfigure extends LitElement {
         <sl-input
           placeholder='e.g. "20Gi"'
           .value=${this.disk}
-          @sl-input=${(e: Event) => { this.disk = (e.target as HTMLElement & { value: string }).value; }}
+          @sl-input=${(e: Event) => {
+            this.disk = (e.target as HTMLElement & { value: string }).value;
+          }}
         ></sl-input>
       </div>
     `;

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -26,12 +26,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
-import type {
-  Project,
-  RuntimeBroker,
-  Template,
-  GCPServiceAccount,
-} from '../../shared/types.js';
+import type { Project, RuntimeBroker, Template, GCPServiceAccount } from '../../shared/types.js';
 
 interface HarnessConfigEntry {
   id: string;
@@ -513,7 +508,10 @@ export class ScionPageAgentCreate extends LitElement {
     if (!model) return { selection: '', customId: '' };
     const normalized = normalizeModelAlias(model);
     if (['small', 'medium', 'large', 'extra-large'].includes(normalized)) {
-      return { selection: normalized as 'small' | 'medium' | 'large' | 'extra-large', customId: '' };
+      return {
+        selection: normalized as 'small' | 'medium' | 'large' | 'extra-large',
+        customId: '',
+      };
     }
     return { selection: 'other', customId: model };
   }
@@ -640,9 +638,7 @@ export class ScionPageAgentCreate extends LitElement {
     try {
       const res = await apiFetch(`/api/v1/projects/${this.projectId}/gcp-service-accounts`);
       if (res.ok) {
-        const data = (await res.json()) as
-          | { items?: GCPServiceAccount[] }
-          | GCPServiceAccount[];
+        const data = (await res.json()) as { items?: GCPServiceAccount[] } | GCPServiceAccount[];
         this.gcpServiceAccounts = Array.isArray(data) ? data : data.items || [];
       }
     } catch {
@@ -655,9 +651,7 @@ export class ScionPageAgentCreate extends LitElement {
       const mode = settings.defaultGCPIdentityMode as 'block' | 'passthrough' | 'assign';
       if (mode === 'assign' && settings.defaultGCPIdentityServiceAccountID) {
         const verified = this.verifiedGCPServiceAccounts;
-        const match = verified.find(
-          (sa) => sa.id === settings.defaultGCPIdentityServiceAccountID
-        );
+        const match = verified.find((sa) => sa.id === settings.defaultGCPIdentityServiceAccountID);
         if (match) {
           this.gcpMetadataMode = 'assign';
           this.gcpServiceAccountId = match.id;
@@ -668,9 +662,7 @@ export class ScionPageAgentCreate extends LitElement {
     }
   }
 
-  private async fetchProjectSettings(
-    projectId: string
-  ): Promise<{
+  private async fetchProjectSettings(projectId: string): Promise<{
     defaultTemplate?: string;
     defaultHarnessConfig?: string;
     defaultMaxTurns?: number;
@@ -777,9 +769,7 @@ export class ScionPageAgentCreate extends LitElement {
     const config: Record<string, unknown> = {};
 
     // Model
-    const model = this.modelSelection === 'other'
-      ? this.customModelId
-      : this.modelSelection;
+    const model = this.modelSelection === 'other' ? this.customModelId : this.modelSelection;
     if (model) config.model = model;
 
     // Thinking level
@@ -1016,7 +1006,9 @@ export class ScionPageAgentCreate extends LitElement {
                       >&nbsp;&mdash;
                       ${this.errorLinks.map(
                         (link, i) =>
-                          html`${i > 0 ? html` or ` : nothing}<a href=${link.href}>${link.label}</a>`
+                          html`${i > 0 ? html` or ` : nothing}<a href=${link.href}
+                              >${link.label}</a
+                            >`
                       )}</span
                     >`
                   : nothing}
@@ -1136,9 +1128,7 @@ export class ScionPageAgentCreate extends LitElement {
                 }}
                 required
               >
-                ${this.projects.map(
-                  (p) => html`<sl-option value=${p.id}>${p.name}</sl-option>`
-                )}
+                ${this.projects.map((p) => html`<sl-option value=${p.id}>${p.name}</sl-option>`)}
               </sl-select>
               <div class="hint">The project workspace for this agent.</div>
             </div>
@@ -1190,9 +1180,7 @@ export class ScionPageAgentCreate extends LitElement {
                 `
               )
             : KNOWN_HARNESS_NAMES.map(
-                (name) => html`
-                  <sl-option value=${name}>${harnessDisplayName(name)}</sl-option>
-                `
+                (name) => html` <sl-option value=${name}>${harnessDisplayName(name)}</sl-option> `
               )}
           <sl-option value="__other__">Other...</sl-option>
         </sl-select>
@@ -1333,7 +1321,8 @@ export class ScionPageAgentCreate extends LitElement {
           .value=${this.modelSelection}
           clearable
           @sl-change=${(e: Event) => {
-            this.modelSelection = (e.target as HTMLElement & { value: string }).value as typeof this.modelSelection;
+            this.modelSelection = (e.target as HTMLElement & { value: string })
+              .value as typeof this.modelSelection;
             if (this.modelSelection !== 'other') this.customModelId = '';
           }}
         >
@@ -1364,8 +1353,11 @@ export class ScionPageAgentCreate extends LitElement {
       <!-- Thinking Level -->
       <div class="form-field">
         <label>
-          Thinking Level${this.thinkingLevel !== null
-            ? html` <span style="font-weight:normal;color:var(--sl-color-neutral-500)">(${this.thinkingLevel})</span>`
+          Thinking
+          Level${this.thinkingLevel !== null
+            ? html` <span style="font-weight:normal;color:var(--sl-color-neutral-500)"
+                >(${this.thinkingLevel})</span
+              >`
             : nothing}
         </label>
         <div style="display:flex;align-items:center;gap:0.75rem">
@@ -1494,7 +1486,9 @@ export class ScionPageAgentCreate extends LitElement {
                 placeholder="3s"
                 .value=${this.autoExposePortsInterval}
                 @sl-input=${(e: Event) => {
-                  this.autoExposePortsInterval = (e.target as HTMLElement & { value: string }).value;
+                  this.autoExposePortsInterval = (
+                    e.target as HTMLElement & { value: string }
+                  ).value;
                 }}
               ></sl-input>
               <div class="hint">How often to scan for new listening ports (e.g. 3s, 5s).</div>
@@ -1573,7 +1567,7 @@ export class ScionPageAgentCreate extends LitElement {
             ? 'Prevents the agent from accessing any GCP identity. Token requests are denied.'
             : this.gcpMetadataMode === 'assign'
               ? 'Assigns a registered GCP service account. GCP client libraries will authenticate automatically.'
-              : 'No metadata interception. The agent inherits the broker\'s GCP identity. Requires broker ownership.'}
+              : "No metadata interception. The agent inherits the broker's GCP identity. Requires broker ownership."}
         </div>
       </div>
 
@@ -1603,8 +1597,8 @@ export class ScionPageAgentCreate extends LitElement {
                   `
                 : html`
                     <div class="hint" style="margin-top: 0;">
-                      No verified service accounts available. Register and verify service
-                      accounts in project settings.
+                      No verified service accounts available. Register and verify service accounts
+                      in project settings.
                     </div>
                   `}
             </div>
@@ -1628,7 +1622,9 @@ export class ScionPageAgentCreate extends LitElement {
           rows="6"
           resize="auto"
         ></sl-textarea>
-        <div class="hint">Custom system prompt for the agent. Can be inline text or a file:// URI.</div>
+        <div class="hint">
+          Custom system prompt for the agent. Can be inline text or a file:// URI.
+        </div>
       </div>
 
       <div class="form-field">
@@ -1642,7 +1638,9 @@ export class ScionPageAgentCreate extends LitElement {
           rows="6"
           resize="auto"
         ></sl-textarea>
-        <div class="hint">Additional instructions for the agent. Can be inline text or a file:// URI.</div>
+        <div class="hint">
+          Additional instructions for the agent. Can be inline text or a file:// URI.
+        </div>
       </div>
     `;
   }
@@ -1659,8 +1657,7 @@ export class ScionPageAgentCreate extends LitElement {
             placeholder="0 = unlimited"
             .value=${String(this.maxTurns || '')}
             @sl-input=${(e: Event) => {
-              this.maxTurns =
-                parseInt((e.target as HTMLElement & { value: string }).value) || 0;
+              this.maxTurns = parseInt((e.target as HTMLElement & { value: string }).value) || 0;
             }}
           ></sl-input>
         </div>
@@ -1769,9 +1766,7 @@ export class ScionPageAgentCreate extends LitElement {
         <label>Labels</label>
         ${this.labelEntries.map(
           (entry, i) => html`
-            <div
-              style="display: flex; gap: 0.5em; margin-bottom: 0.5em; align-items: center;"
-            >
+            <div style="display: flex; gap: 0.5em; margin-bottom: 0.5em; align-items: center;">
               <sl-input
                 size="small"
                 placeholder="key"

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -593,7 +593,6 @@ export class ScionPageAgentDetail extends LitElement {
       background: var(--scion-bg-subtle, #f1f5f9);
       color: var(--scion-text-muted, #64748b);
     }
-
   `;
 
   private boundOnAgentsUpdated = this.onAgentsUpdated.bind(this);
@@ -619,7 +618,10 @@ export class ScionPageAgentDetail extends LitElement {
   override disconnectedCallback(): void {
     super.disconnectedCallback();
     stateManager.removeEventListener('agents-updated', this.boundOnAgentsUpdated as EventListener);
-    stateManager.removeEventListener('projects-updated', this.boundOnProjectsUpdated as EventListener);
+    stateManager.removeEventListener(
+      'projects-updated',
+      this.boundOnProjectsUpdated as EventListener
+    );
     if (this.relativeTimeInterval) {
       clearInterval(this.relativeTimeInterval);
       this.relativeTimeInterval = null;
@@ -655,7 +657,12 @@ export class ScionPageAgentDetail extends LitElement {
         const agentResponse = await apiFetch(`/api/v1/agents/${this.agentId}`);
 
         if (!agentResponse.ok) {
-          throw new Error(await extractApiError(agentResponse, `HTTP ${agentResponse.status}: ${agentResponse.statusText}`));
+          throw new Error(
+            await extractApiError(
+              agentResponse,
+              `HTTP ${agentResponse.status}: ${agentResponse.statusText}`
+            )
+          );
         }
 
         this.agent = (await agentResponse.json()) as Agent;
@@ -707,8 +714,12 @@ export class ScionPageAgentDetail extends LitElement {
           apiFetch(`/api/v1/notifications/subscriptions?agentId=${this.agentId}`)
             .then(async (subRes) => {
               if (subRes.ok) {
-                const data = (await subRes.json()) as Subscription[] | { subscriptions?: Subscription[] };
-                const subs = Array.isArray(data) ? data : (data as { subscriptions?: Subscription[] }).subscriptions || [];
+                const data = (await subRes.json()) as
+                  | Subscription[]
+                  | { subscriptions?: Subscription[] };
+                const subs = Array.isArray(data)
+                  ? data
+                  : (data as { subscriptions?: Subscription[] }).subscriptions || [];
                 const match = subs.find((s) => s.scope === 'agent' && s.agentId === this.agentId);
                 if (match) {
                   this.subscribed = true;
@@ -835,14 +846,11 @@ export class ScionPageAgentDetail extends LitElement {
     if (action === 'reset-auth') {
       this.actionLoading = { ...this.actionLoading, 'reset-auth': true };
       try {
-        const response = await apiFetch(
-          `/api/v1/agents/${this.agentId}/reset-auth`,
-          { method: 'POST' }
-        );
+        const response = await apiFetch(`/api/v1/agents/${this.agentId}/reset-auth`, {
+          method: 'POST',
+        });
         if (!response.ok) {
-          throw new Error(
-            await extractApiError(response, 'Failed to reset auth')
-          );
+          throw new Error(await extractApiError(response, 'Failed to reset auth'));
         }
         this.backgroundRefresh();
       } catch (err) {
@@ -1034,9 +1042,7 @@ export class ScionPageAgentDetail extends LitElement {
               : {}}
           ></scion-agent-log-viewer>
         </sl-tab-panel>
-        <sl-tab-panel name="messages">
-          ${this.renderMessagesPanel()}
-        </sl-tab-panel>
+        <sl-tab-panel name="messages"> ${this.renderMessagesPanel()} </sl-tab-panel>
         <sl-tab-panel name="configuration">${this.renderConfigurationTab()}</sl-tab-panel>
       </sl-tab-group>
 
@@ -1044,7 +1050,9 @@ export class ScionPageAgentDetail extends LitElement {
         agentId=${this.agentId}
         agentName=${this.agent.name || ''}
         ?open=${this.quickMessageOpen}
-        @sl-request-close=${() => { this.quickMessageOpen = false; }}
+        @sl-request-close=${() => {
+          this.quickMessageOpen = false;
+        }}
       ></scion-quick-message-dialog>
     `;
   }
@@ -1154,7 +1162,9 @@ export class ScionPageAgentDetail extends LitElement {
                   variant="default"
                   size="small"
                   outline
-                  @click=${() => { this.quickMessageOpen = true; }}
+                  @click=${() => {
+                    this.quickMessageOpen = true;
+                  }}
                 >
                   <sl-icon slot="prefix" name="chat-dots"></sl-icon>
                   Message
@@ -1265,7 +1275,10 @@ export class ScionPageAgentDetail extends LitElement {
               `
             : nothing}
           <sl-tooltip content="See this agent in graph">
-            <a href="/agents/graph?project=${agent.projectId}&focus=${this.agentId}" style="text-decoration: none;">
+            <a
+              href="/agents/graph?project=${agent.projectId}&focus=${this.agentId}"
+              style="text-decoration: none;"
+            >
               <sl-button variant="default" size="small">
                 <sl-icon slot="prefix" name="diagram-3"></sl-icon>
               </sl-button>
@@ -1298,8 +1311,7 @@ export class ScionPageAgentDetail extends LitElement {
     return html`
       ${this.renderCurrentStateCard(agent)} ${this.renderCurrentTaskCard(agent)}
       ${this.renderLimitsUsageCard(agent)} ${this.renderConnectivityCard(agent)}
-      ${this.renderExposedPortsCard(agent)}
-      ${this.renderNotificationsCard()}
+      ${this.renderExposedPortsCard(agent)} ${this.renderNotificationsCard()}
     `;
   }
 
@@ -1310,7 +1322,11 @@ export class ScionPageAgentDetail extends LitElement {
           <h3 class="card-title">Current State</h3>
           ${this.pageData?.user
             ? html`
-                <sl-tooltip content=${this.subscribed ? 'Unsubscribe from notifications' : 'Subscribe to notifications'}>
+                <sl-tooltip
+                  content=${this.subscribed
+                    ? 'Unsubscribe from notifications'
+                    : 'Subscribe to notifications'}
+                >
                   <sl-button
                     size="small"
                     variant=${this.subscribed ? 'primary' : 'default'}
@@ -1342,12 +1358,22 @@ export class ScionPageAgentDetail extends LitElement {
             <span class="info-value">
               ${agent.activity
                 ? html`<scion-status-badge
-                    status=${agent.activity as StatusType}
-                    label=${agent.activity}
-                    size="small"
-                  ></scion-status-badge>${((agent.lastActivityEvent && !this.isZeroDate(agent.lastActivityEvent)) || agent.updated || agent.updatedAt)
-                    ? html`<span style="color: var(--scion-text-muted, #64748b); font-size: 0.85em; margin-left: 0.5em;">${this.formatRelativeTime(((agent.lastActivityEvent && !this.isZeroDate(agent.lastActivityEvent)) ? agent.lastActivityEvent : (agent.updated || agent.updatedAt))!)}</span>`
-                    : ''}`
+                      status=${agent.activity as StatusType}
+                      label=${agent.activity}
+                      size="small"
+                    ></scion-status-badge
+                    >${(agent.lastActivityEvent && !this.isZeroDate(agent.lastActivityEvent)) ||
+                    agent.updated ||
+                    agent.updatedAt
+                      ? html`<span
+                          style="color: var(--scion-text-muted, #64748b); font-size: 0.85em; margin-left: 0.5em;"
+                          >${this.formatRelativeTime(
+                            (agent.lastActivityEvent && !this.isZeroDate(agent.lastActivityEvent)
+                              ? agent.lastActivityEvent
+                              : agent.updated || agent.updatedAt)!
+                          )}</span
+                        >`
+                      : ''}`
                 : html`<span style="color: var(--scion-text-muted, #64748b);">—</span>`}
             </span>
           </div>
@@ -1498,9 +1524,7 @@ export class ScionPageAgentDetail extends LitElement {
           ${ports.map(
             (p) => html`
               <div class="info-item">
-                <span class="info-label">
-                  :${p.port}${p.label ? ` (${p.label})` : ''}
-                </span>
+                <span class="info-label"> :${p.port}${p.label ? ` (${p.label})` : ''} </span>
                 <span class="info-value">
                   <a
                     href="/api/v1/agents/${agent.id}/ports/${p.port}/proxy/"
@@ -1591,7 +1615,9 @@ export class ScionPageAgentDetail extends LitElement {
                       <span class="info-value">
                         ${t.calls} calls
                         ${t.error > 0
-                          ? html`<span style="color: var(--scion-danger-500, #ef4444)"> (${t.error} errors)</span>`
+                          ? html`<span style="color: var(--scion-danger-500, #ef4444)">
+                              (${t.error} errors)</span
+                            >`
                           : nothing}
                       </span>
                     </div>
@@ -1684,7 +1710,9 @@ export class ScionPageAgentDetail extends LitElement {
             ? html`
                 <div class="info-item">
                   <span class="info-label">Auth Method</span>
-                  <span class="info-value">${agent.harnessAuth || agent.appliedConfig?.harnessAuth}</span>
+                  <span class="info-value"
+                    >${agent.harnessAuth || agent.appliedConfig?.harnessAuth}</span
+                  >
                 </div>
               `
             : ''}
@@ -1768,7 +1796,10 @@ export class ScionPageAgentDetail extends LitElement {
                 <div class="info-item">
                   <span class="info-label">Template Hash</span>
                   <span class="info-value mono">
-                    <scion-hash-display .hash=${cfg.templateHash} max-width="14ch"></scion-hash-display>
+                    <scion-hash-display
+                      .hash=${cfg.templateHash}
+                      max-width="14ch"
+                    ></scion-hash-display>
                   </span>
                 </div>
               `

--- a/web/src/components/pages/agent-graph.ts
+++ b/web/src/components/pages/agent-graph.ts
@@ -83,9 +83,9 @@ export class AgentGraphPage extends LitElement {
 
   private onAgentsUpdated(): void {
     const updated = stateManager.getAgents();
-    const prev = new Map(this.agents.map(a => [a.id, a]));
+    const prev = new Map(this.agents.map((a) => [a.id, a]));
     let ancestryGap = false;
-    this.agents = updated.map(a => {
+    this.agents = updated.map((a) => {
       if (a.ancestry && a.ancestry.length > 0) return a;
       const old = prev.get(a.id);
       if (old?.ancestry?.length) return { ...a, ancestry: old.ancestry };
@@ -114,7 +114,9 @@ export class AgentGraphPage extends LitElement {
     try {
       const response = await apiFetch('/api/v1/agents');
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
       const data = (await response.json()) as { agents?: Agent[] } | Agent[];
       this.agents = Array.isArray(data) ? data : data.agents || [];
@@ -130,7 +132,7 @@ export class AgentGraphPage extends LitElement {
   /** Agents after the project filter is applied */
   private get visibleAgents(): Agent[] {
     if (!this.projectFilter) return this.agents;
-    return this.agents.filter(a => a.projectId === this.projectFilter);
+    return this.agents.filter((a) => a.projectId === this.projectFilter);
   }
 
   private get projects(): Array<{ id: string; name: string }> {
@@ -140,7 +142,9 @@ export class AgentGraphPage extends LitElement {
         seen.set(agent.projectId, agent.project || agent.projectId);
       }
     }
-    return Array.from(seen, ([id, name]) => ({ id, name })).sort((a, b) => a.name.localeCompare(b.name));
+    return Array.from(seen, ([id, name]) => ({ id, name })).sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
   }
 
   private onProjectFilterChange(e: Event): void {
@@ -184,37 +188,44 @@ export class AgentGraphPage extends LitElement {
   override render() {
     return html`
       <div style="padding: var(--sl-spacing-large, 1.25rem);">
-        <div style="display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; flex-wrap: wrap;">
+        <div
+          style="display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; flex-wrap: wrap;"
+        >
           <h1 style="margin: 0; font-size: 1.5rem;">Agents</h1>
           <div style="display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;">
-            ${this.initiallyProjectScoped ? nothing : html`
-              <sl-select
-                size="small"
-                placeholder="All projects"
-                clearable
-                value=${this.projectFilter}
-                @sl-change=${this.onProjectFilterChange}
-                style="min-width: 180px"
-              >
-                ${this.projects.map(p => html`<sl-option value=${p.id}>${p.name}</sl-option>`)}
-              </sl-select>
-            `}
-            <scion-view-toggle
-              view="graph"
-              @view-change=${this.onViewChange}
-            ></scion-view-toggle>
+            ${this.initiallyProjectScoped
+              ? nothing
+              : html`
+                  <sl-select
+                    size="small"
+                    placeholder="All projects"
+                    clearable
+                    value=${this.projectFilter}
+                    @sl-change=${this.onProjectFilterChange}
+                    style="min-width: 180px"
+                  >
+                    ${this.projects.map(
+                      (p) => html`<sl-option value=${p.id}>${p.name}</sl-option>`
+                    )}
+                  </sl-select>
+                `}
+            <scion-view-toggle view="graph" @view-change=${this.onViewChange}></scion-view-toggle>
           </div>
         </div>
         ${this.loading
           ? html`
-              <div style="display: flex; flex-direction: column; align-items: center; gap: 0.75rem; padding: 3rem 1rem; color: var(--sl-color-neutral-600); text-align: center;">
+              <div
+                style="display: flex; flex-direction: column; align-items: center; gap: 0.75rem; padding: 3rem 1rem; color: var(--sl-color-neutral-600); text-align: center;"
+              >
                 <sl-spinner></sl-spinner>
                 <p>Loading agents...</p>
               </div>
             `
           : this.error
             ? html`
-                <div style="display: flex; flex-direction: column; align-items: center; gap: 0.75rem; padding: 3rem 1rem; color: var(--sl-color-danger-600); text-align: center;">
+                <div
+                  style="display: flex; flex-direction: column; align-items: center; gap: 0.75rem; padding: 3rem 1rem; color: var(--sl-color-danger-600); text-align: center;"
+                >
                   <sl-icon name="exclamation-triangle"></sl-icon>
                   <p>${this.error}</p>
                   <sl-button size="small" @click=${() => this.loadAgents()}>Retry</sl-button>

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -23,8 +23,19 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-import type { PageData, Agent, AgentPhase, Capabilities, AgentMetricsSummary } from '../../shared/types.js';
-import { can, isTerminalAvailable, getAgentDisplayStatus, isAgentRunning } from '../../shared/types.js';
+import type {
+  PageData,
+  Agent,
+  AgentPhase,
+  Capabilities,
+  AgentMetricsSummary,
+} from '../../shared/types.js';
+import {
+  can,
+  isTerminalAvailable,
+  getAgentDisplayStatus,
+  isAgentRunning,
+} from '../../shared/types.js';
 
 type AgentSortField = 'name' | 'status' | 'created' | 'updated';
 type SortDir = 'asc' | 'desc';
@@ -340,7 +351,12 @@ export class ScionPageAgents extends LitElement {
 
     // Read persisted phase filter
     const storedPhase = localStorage.getItem('scion-filter-agents-phase');
-    if (storedPhase === 'running' || storedPhase === 'stopped' || storedPhase === 'suspended' || storedPhase === 'error') {
+    if (
+      storedPhase === 'running' ||
+      storedPhase === 'stopped' ||
+      storedPhase === 'suspended' ||
+      storedPhase === 'error'
+    ) {
       this.phaseFilter = storedPhase;
     }
 
@@ -351,13 +367,18 @@ export class ScionPageAgents extends LitElement {
         const parsed = JSON.parse(storedSort);
         if (
           parsed &&
-          (parsed.field === 'name' || parsed.field === 'status' || parsed.field === 'created' || parsed.field === 'updated') &&
+          (parsed.field === 'name' ||
+            parsed.field === 'status' ||
+            parsed.field === 'created' ||
+            parsed.field === 'updated') &&
           (parsed.dir === 'asc' || parsed.dir === 'desc')
         ) {
           this.sortField = parsed.field;
           this.sortDir = parsed.dir;
         }
-      } catch { /* ignore invalid stored sort */ }
+      } catch {
+        /* ignore invalid stored sort */
+      }
     }
 
     // Set SSE scope to dashboard (all project summaries).
@@ -470,7 +491,7 @@ export class ScionPageAgents extends LitElement {
   }
 
   private backgroundRefresh(): void {
-    this.fetchAndMergeAgents().catch(err => {
+    this.fetchAndMergeAgents().catch((err) => {
       console.warn('Background refresh failed:', err);
     });
   }
@@ -489,10 +510,14 @@ export class ScionPageAgents extends LitElement {
     const response = await apiFetch(url);
 
     if (!response.ok) {
-      throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+      throw new Error(
+        await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+      );
     }
 
-    const data = (await response.json()) as { agents?: Agent[]; _capabilities?: Capabilities } | Agent[];
+    const data = (await response.json()) as
+      | { agents?: Agent[]; _capabilities?: Capabilities }
+      | Agent[];
     if (Array.isArray(data)) {
       this.agents = data;
       this.scopeCapabilities = undefined;
@@ -529,7 +554,7 @@ export class ScionPageAgents extends LitElement {
         }
 
         // Server confirmed — remove from local list
-        this.agents = this.agents.filter(a => a.id !== agentId);
+        this.agents = this.agents.filter((a) => a.id !== agentId);
         this.backgroundRefresh();
       } catch (err) {
         console.error('Failed to delete agent:', err);
@@ -547,7 +572,7 @@ export class ScionPageAgents extends LitElement {
       suspend: 'stopping',
       resume: 'starting',
     };
-    const agentIndex = this.agents.findIndex(a => a.id === agentId);
+    const agentIndex = this.agents.findIndex((a) => a.id === agentId);
     if (agentIndex >= 0) {
       const updated = { ...this.agents[agentIndex] };
       updated.phase = optimisticPhase[action] as Agent['phase'];
@@ -588,7 +613,7 @@ export class ScionPageAgents extends LitElement {
     }
 
     // Optimistic: mark all running agents as "stopping"
-    this.agents = this.agents.map(a =>
+    this.agents = this.agents.map((a) =>
       isAgentRunning(a) ? { ...a, phase: 'stopping' as const } : a
     );
     this.stopAllLoading = true;
@@ -624,13 +649,13 @@ export class ScionPageAgents extends LitElement {
   private get displayAgents(): Agent[] {
     let list = this.agents;
     if (this.phaseFilter) {
-      list = list.filter(a => a.phase === this.phaseFilter);
+      list = list.filter((a) => a.phase === this.phaseFilter);
     }
     if (this.labelFilter.trim()) {
       const parts = this.labelFilter.trim().split('=');
       const filterKey = parts[0];
       const filterValue = parts.slice(1).join('=');
-      list = list.filter(a => {
+      list = list.filter((a) => {
         if (!a.labels) return false;
         if (filterValue) return a.labels[filterKey] === filterValue;
         return filterKey in a.labels;
@@ -650,7 +675,15 @@ export class ScionPageAgents extends LitElement {
           cmp = (a.created || '').localeCompare(b.created || '');
           break;
         case 'updated':
-          cmp = ((a.lastActivityEvent && !a.lastActivityEvent.startsWith('0001')) ? a.lastActivityEvent : (a.updated || '')).localeCompare((b.lastActivityEvent && !b.lastActivityEvent.startsWith('0001')) ? b.lastActivityEvent : (b.updated || ''));
+          cmp = (
+            a.lastActivityEvent && !a.lastActivityEvent.startsWith('0001')
+              ? a.lastActivityEvent
+              : a.updated || ''
+          ).localeCompare(
+            b.lastActivityEvent && !b.lastActivityEvent.startsWith('0001')
+              ? b.lastActivityEvent
+              : b.updated || ''
+          );
           break;
       }
       return this.sortDir === 'asc' ? cmp : -cmp;
@@ -691,7 +724,10 @@ export class ScionPageAgents extends LitElement {
       this.sortField = field;
       this.sortDir = field === 'name' ? 'asc' : 'desc';
     }
-    localStorage.setItem('scion-sort-agents', JSON.stringify({ field: this.sortField, dir: this.sortDir }));
+    localStorage.setItem(
+      'scion-sort-agents',
+      JSON.stringify({ field: this.sortField, dir: this.sortDir })
+    );
   }
 
   private sortIndicator(field: AgentSortField): string {
@@ -714,70 +750,81 @@ export class ScionPageAgents extends LitElement {
       <div class="header">
         <h1>Agents</h1>
         <div class="header-actions">
-          ${this.pageData?.user ? html`
-            <div class="scope-toggle">
-              <button
-                class=${this.agentScope === 'all' ? 'active' : ''}
-                title="All agents"
-                @click=${() => this.setScope('all')}
-              >All</button>
-              <button
-                class=${this.agentScope === 'mine' ? 'active' : ''}
-                title="Agents I created"
-                @click=${() => this.setScope('mine')}
-              >
-                <sl-icon name="person"></sl-icon>
-                Mine
-              </button>
-              <button
-                class=${this.agentScope === 'shared' ? 'active' : ''}
-                title="Agents in shared projects"
-                @click=${() => this.setScope('shared')}
-              >
-                <sl-icon name="people"></sl-icon>
-                Shared
-              </button>
-            </div>
-          ` : nothing}
+          ${this.pageData?.user
+            ? html`
+                <div class="scope-toggle">
+                  <button
+                    class=${this.agentScope === 'all' ? 'active' : ''}
+                    title="All agents"
+                    @click=${() => this.setScope('all')}
+                  >
+                    All
+                  </button>
+                  <button
+                    class=${this.agentScope === 'mine' ? 'active' : ''}
+                    title="Agents I created"
+                    @click=${() => this.setScope('mine')}
+                  >
+                    <sl-icon name="person"></sl-icon>
+                    Mine
+                  </button>
+                  <button
+                    class=${this.agentScope === 'shared' ? 'active' : ''}
+                    title="Agents in shared projects"
+                    @click=${() => this.setScope('shared')}
+                  >
+                    <sl-icon name="people"></sl-icon>
+                    Shared
+                  </button>
+                </div>
+              `
+            : nothing}
           <scion-view-toggle
             .view=${this.viewMode}
             storageKey="scion-view-agents"
             @view-change=${this.onViewChange}
           ></scion-view-toggle>
-          ${can(this.scopeCapabilities, 'stop_all') && this.hasRunningAgents() ? html`
-            <sl-button
-              variant="danger"
-              size="small"
-              outline
-              ?loading=${this.stopAllLoading}
-              ?disabled=${this.stopAllLoading}
-              @click=${() => this.handleStopAll()}
-            >
-              <sl-icon slot="prefix" name="stop-circle"></sl-icon>
-              Stop All
-            </sl-button>
-          ` : nothing}
-          ${can(this.scopeCapabilities, 'create') ? html`
-            <a href="/agents/new" style="text-decoration: none;">
-              <sl-button variant="primary" size="small">
-                <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                New Agent
-              </sl-button>
-            </a>
-          ` : nothing}
+          ${can(this.scopeCapabilities, 'stop_all') && this.hasRunningAgents()
+            ? html`
+                <sl-button
+                  variant="danger"
+                  size="small"
+                  outline
+                  ?loading=${this.stopAllLoading}
+                  ?disabled=${this.stopAllLoading}
+                  @click=${() => this.handleStopAll()}
+                >
+                  <sl-icon slot="prefix" name="stop-circle"></sl-icon>
+                  Stop All
+                </sl-button>
+              `
+            : nothing}
+          ${can(this.scopeCapabilities, 'create')
+            ? html`
+                <a href="/agents/new" style="text-decoration: none;">
+                  <sl-button variant="primary" size="small">
+                    <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+                    New Agent
+                  </sl-button>
+                </a>
+              `
+            : nothing}
         </div>
       </div>
 
-      ${this.loading ? this.renderLoading() : this.error ? this.renderError() : html`
-        ${this.renderFilterBar()}
-        ${this.renderAgents()}
-      `}
+      ${this.loading
+        ? this.renderLoading()
+        : this.error
+          ? this.renderError()
+          : html` ${this.renderFilterBar()} ${this.renderAgents()} `}
 
       <scion-quick-message-dialog
         agentId=${this.quickMessageAgentId}
         agentName=${this.quickMessageAgentName}
         ?open=${this.quickMessageOpen}
-        @sl-request-close=${() => { this.quickMessageOpen = false; }}
+        @sl-request-close=${() => {
+          this.quickMessageOpen = false;
+        }}
       ></scion-quick-message-dialog>
     `;
   }
@@ -814,23 +861,33 @@ export class ScionPageAgents extends LitElement {
           <button
             class=${this.phaseFilter === '' ? 'active' : ''}
             @click=${() => this.setPhaseFilter('')}
-          >All</button>
+          >
+            All
+          </button>
           <button
             class=${this.phaseFilter === 'running' ? 'active' : ''}
             @click=${() => this.setPhaseFilter('running')}
-          >Running</button>
+          >
+            Running
+          </button>
           <button
             class=${this.phaseFilter === 'stopped' ? 'active' : ''}
             @click=${() => this.setPhaseFilter('stopped')}
-          >Stopped</button>
+          >
+            Stopped
+          </button>
           <button
             class=${this.phaseFilter === 'suspended' ? 'active' : ''}
             @click=${() => this.setPhaseFilter('suspended')}
-          >Suspended</button>
+          >
+            Suspended
+          </button>
           <button
             class=${this.phaseFilter === 'error' ? 'active' : ''}
             @click=${() => this.setPhaseFilter('error')}
-          >Error</button>
+          >
+            Error
+          </button>
         </div>
         <sl-input
           size="small"
@@ -841,25 +898,44 @@ export class ScionPageAgents extends LitElement {
             this.labelFilter = (e.target as HTMLElement & { value: string }).value;
           }}
           @sl-change=${() => void this.loadAgents()}
-          @sl-clear=${() => { this.labelFilter = ''; void this.loadAgents(); }}
+          @sl-clear=${() => {
+            this.labelFilter = '';
+            void this.loadAgents();
+          }}
           style="max-width: 220px;"
         >
           <sl-icon slot="prefix" name="tag"></sl-icon>
         </sl-input>
-        ${this.viewMode === 'grid' ? html`
-          <sl-dropdown>
-            <sl-button slot="trigger" size="small" outline>
-              <sl-icon slot="prefix" name=${this.sortDir === 'asc' ? 'sort-alpha-down' : 'sort-alpha-down-alt'}></sl-icon>
-              Sort: ${this.sortField}
-            </sl-button>
-            <sl-menu @sl-select=${(e: CustomEvent<{ item: { value: string } }>) => this.toggleSort(e.detail.item.value as AgentSortField)}>
-              <sl-menu-item value="name" ?checked=${this.sortField === 'name'}>Name</sl-menu-item>
-              <sl-menu-item value="status" ?checked=${this.sortField === 'status'}>Status</sl-menu-item>
-              <sl-menu-item value="created" ?checked=${this.sortField === 'created'}>Created</sl-menu-item>
-              <sl-menu-item value="updated" ?checked=${this.sortField === 'updated'}>Updated</sl-menu-item>
-            </sl-menu>
-          </sl-dropdown>
-        ` : nothing}
+        ${this.viewMode === 'grid'
+          ? html`
+              <sl-dropdown>
+                <sl-button slot="trigger" size="small" outline>
+                  <sl-icon
+                    slot="prefix"
+                    name=${this.sortDir === 'asc' ? 'sort-alpha-down' : 'sort-alpha-down-alt'}
+                  ></sl-icon>
+                  Sort: ${this.sortField}
+                </sl-button>
+                <sl-menu
+                  @sl-select=${(e: CustomEvent<{ item: { value: string } }>) =>
+                    this.toggleSort(e.detail.item.value as AgentSortField)}
+                >
+                  <sl-menu-item value="name" ?checked=${this.sortField === 'name'}
+                    >Name</sl-menu-item
+                  >
+                  <sl-menu-item value="status" ?checked=${this.sortField === 'status'}
+                    >Status</sl-menu-item
+                  >
+                  <sl-menu-item value="created" ?checked=${this.sortField === 'created'}
+                    >Created</sl-menu-item
+                  >
+                  <sl-menu-item value="updated" ?checked=${this.sortField === 'updated'}
+                    >Updated</sl-menu-item
+                  >
+                </sl-menu>
+              </sl-dropdown>
+            `
+          : nothing}
       </div>
     `;
   }
@@ -910,23 +986,30 @@ export class ScionPageAgents extends LitElement {
         <sl-icon name="cpu"></sl-icon>
         <h2>No Agents Found</h2>
         <p>
-          Agents are AI-powered workers that can help you with coding tasks.${can(this.scopeCapabilities, 'create') ? ' Create your first agent to get started.' : ''}
+          Agents are AI-powered workers that can help you with coding
+          tasks.${can(this.scopeCapabilities, 'create')
+            ? ' Create your first agent to get started.'
+            : ''}
         </p>
-        ${can(this.scopeCapabilities, 'create') ? html`
-          <a href="/agents/new" style="text-decoration: none;">
-            <sl-button variant="primary">
-              <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-              Create Agent
-            </sl-button>
-          </a>
-        ` : nothing}
+        ${can(this.scopeCapabilities, 'create')
+          ? html`
+              <a href="/agents/new" style="text-decoration: none;">
+                <sl-button variant="primary">
+                  <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+                  Create Agent
+                </sl-button>
+              </a>
+            `
+          : nothing}
       </div>
     `;
   }
 
   private renderGrid() {
     return html`
-      <div class="resource-grid">${this.displayAgents.map((agent) => this.renderAgentCard(agent))}</div>
+      <div class="resource-grid">
+        ${this.displayAgents.map((agent) => this.renderAgentCard(agent))}
+      </div>
     `;
   }
 
@@ -934,124 +1017,138 @@ export class ScionPageAgents extends LitElement {
     const isLoading = this.actionLoading[agent.id] || false;
 
     return html`
-      ${can(agent._capabilities, 'message') ? html`
-        <sl-tooltip content="Message">
-          <span style="display: inline-flex">
-            <sl-button
-              class="action-btn-primary"
-              variant="default"
-              size="small"
-              outline
-              @click=${() => {
-                this.quickMessageAgentId = agent.id;
-                this.quickMessageAgentName = agent.name;
-                this.quickMessageOpen = true;
-              }}
-              aria-label="Message"
-            >
-              <sl-icon slot="prefix" name="chat-dots"></sl-icon>
-            </sl-button>
-          </span>
-        </sl-tooltip>
-      ` : nothing}
-      ${can(agent._capabilities, 'attach') ? html`
-        <sl-tooltip content="Terminal">
-          <span style="display: inline-flex">
-            <sl-button
-              class="action-btn-primary"
-              variant="primary"
-              size="small"
-              href="/agents/${agent.id}/terminal"
-              ?disabled=${!isTerminalAvailable(agent)}
-              aria-label="Terminal"
-            >
-              <sl-icon slot="prefix" name="terminal"></sl-icon>
-            </sl-button>
-          </span>
-        </sl-tooltip>
-      ` : nothing}
-      ${isAgentRunning(agent)
-        ? can(agent._capabilities, 'stop') ? html`
-            ${agent.harnessCapabilities?.resume?.support !== 'no' ? html`
-              <sl-tooltip content="Suspend">
+      ${can(agent._capabilities, 'message')
+        ? html`
+            <sl-tooltip content="Message">
+              <span style="display: inline-flex">
                 <sl-button
-                  class="action-btn-warning"
-                  variant="warning"
+                  class="action-btn-primary"
+                  variant="default"
+                  size="small"
+                  outline
+                  @click=${() => {
+                    this.quickMessageAgentId = agent.id;
+                    this.quickMessageAgentName = agent.name;
+                    this.quickMessageOpen = true;
+                  }}
+                  aria-label="Message"
+                >
+                  <sl-icon slot="prefix" name="chat-dots"></sl-icon>
+                </sl-button>
+              </span>
+            </sl-tooltip>
+          `
+        : nothing}
+      ${can(agent._capabilities, 'attach')
+        ? html`
+            <sl-tooltip content="Terminal">
+              <span style="display: inline-flex">
+                <sl-button
+                  class="action-btn-primary"
+                  variant="primary"
+                  size="small"
+                  href="/agents/${agent.id}/terminal"
+                  ?disabled=${!isTerminalAvailable(agent)}
+                  aria-label="Terminal"
+                >
+                  <sl-icon slot="prefix" name="terminal"></sl-icon>
+                </sl-button>
+              </span>
+            </sl-tooltip>
+          `
+        : nothing}
+      ${isAgentRunning(agent)
+        ? can(agent._capabilities, 'stop')
+          ? html`
+              ${agent.harnessCapabilities?.resume?.support !== 'no'
+                ? html`
+                    <sl-tooltip content="Suspend">
+                      <sl-button
+                        class="action-btn-warning"
+                        variant="warning"
+                        size="small"
+                        outline
+                        ?loading=${isLoading}
+                        ?disabled=${isLoading}
+                        @click=${() => this.handleAgentAction(agent.id, 'suspend')}
+                        aria-label="Suspend"
+                      >
+                        <sl-icon slot="prefix" name="pause-circle"></sl-icon>
+                      </sl-button>
+                    </sl-tooltip>
+                  `
+                : nothing}
+              <sl-tooltip content="Stop">
+                <sl-button
+                  class="action-btn-danger"
+                  variant="danger"
                   size="small"
                   outline
                   ?loading=${isLoading}
                   ?disabled=${isLoading}
-                  @click=${() => this.handleAgentAction(agent.id, 'suspend')}
-                  aria-label="Suspend"
+                  @click=${() => this.handleAgentAction(agent.id, 'stop')}
+                  aria-label="Stop"
                 >
-                  <sl-icon slot="prefix" name="pause-circle"></sl-icon>
+                  <sl-icon slot="prefix" name="stop-circle"></sl-icon>
                 </sl-button>
               </sl-tooltip>
-            ` : nothing}
-            <sl-tooltip content="Stop">
+            `
+          : nothing
+        : agent.phase === 'suspended'
+          ? can(agent._capabilities, 'start')
+            ? html`
+                <sl-tooltip content="Resume">
+                  <sl-button
+                    class="action-btn-success"
+                    variant="success"
+                    size="small"
+                    outline
+                    ?loading=${isLoading}
+                    ?disabled=${isLoading}
+                    @click=${() => this.handleAgentAction(agent.id, 'resume')}
+                    aria-label="Resume"
+                  >
+                    <sl-icon slot="prefix" name="play-circle"></sl-icon>
+                  </sl-button>
+                </sl-tooltip>
+              `
+            : nothing
+          : can(agent._capabilities, 'start')
+            ? html`
+                <sl-tooltip content="Start">
+                  <sl-button
+                    class="action-btn-success"
+                    variant="success"
+                    size="small"
+                    outline
+                    ?loading=${isLoading}
+                    ?disabled=${isLoading}
+                    @click=${() => this.handleAgentAction(agent.id, 'start')}
+                    aria-label="Start"
+                  >
+                    <sl-icon slot="prefix" name="play-circle"></sl-icon>
+                  </sl-button>
+                </sl-tooltip>
+              `
+            : nothing}
+      ${can(agent._capabilities, 'delete')
+        ? html`
+            <sl-tooltip content="Delete">
               <sl-button
                 class="action-btn-danger"
-                variant="danger"
+                variant="default"
                 size="small"
                 outline
                 ?loading=${isLoading}
                 ?disabled=${isLoading}
-                @click=${() => this.handleAgentAction(agent.id, 'stop')}
-                aria-label="Stop"
+                @click=${(e: MouseEvent) => this.handleAgentAction(agent.id, 'delete', e)}
+                aria-label="Delete"
               >
-                <sl-icon slot="prefix" name="stop-circle"></sl-icon>
+                <sl-icon slot="prefix" name="trash"></sl-icon>
               </sl-button>
             </sl-tooltip>
-          ` : nothing
-        : agent.phase === 'suspended'
-          ? can(agent._capabilities, 'start') ? html`
-              <sl-tooltip content="Resume">
-                <sl-button
-                  class="action-btn-success"
-                  variant="success"
-                  size="small"
-                  outline
-                  ?loading=${isLoading}
-                  ?disabled=${isLoading}
-                  @click=${() => this.handleAgentAction(agent.id, 'resume')}
-                  aria-label="Resume"
-                >
-                  <sl-icon slot="prefix" name="play-circle"></sl-icon>
-                </sl-button>
-              </sl-tooltip>
-            ` : nothing
-          : can(agent._capabilities, 'start') ? html`
-              <sl-tooltip content="Start">
-                <sl-button
-                  class="action-btn-success"
-                  variant="success"
-                  size="small"
-                  outline
-                  ?loading=${isLoading}
-                  ?disabled=${isLoading}
-                  @click=${() => this.handleAgentAction(agent.id, 'start')}
-                  aria-label="Start"
-                >
-                  <sl-icon slot="prefix" name="play-circle"></sl-icon>
-                </sl-button>
-              </sl-tooltip>
-            ` : nothing}
-      ${can(agent._capabilities, 'delete') ? html`
-        <sl-tooltip content="Delete">
-          <sl-button
-            class="action-btn-danger"
-            variant="default"
-            size="small"
-            outline
-            ?loading=${isLoading}
-            ?disabled=${isLoading}
-            @click=${(e: MouseEvent) => this.handleAgentAction(agent.id, 'delete', e)}
-            aria-label="Delete"
-          >
-            <sl-icon slot="prefix" name="trash"></sl-icon>
-          </sl-button>
-        </sl-tooltip>
-      ` : nothing}
+          `
+        : nothing}
     `;
   }
 
@@ -1067,7 +1164,16 @@ export class ScionPageAgents extends LitElement {
               </a>
             </h3>
             <div class="agent-meta">
-              ${agent.project ? html`<div><sl-icon name="folder"></sl-icon> <a href="/projects/${agent.projectId}" @click=${(e: MouseEvent) => e.stopPropagation()}>${agent.project}</a></div>` : ''}
+              ${agent.project
+                ? html`<div>
+                    <sl-icon name="folder"></sl-icon>
+                    <a
+                      href="/projects/${agent.projectId}"
+                      @click=${(e: MouseEvent) => e.stopPropagation()}
+                      >${agent.project}</a
+                    >
+                  </div>`
+                : ''}
               <div><sl-icon name="code-square"></sl-icon> ${agent.template}</div>
               ${agent.runtimeBrokerId
                 ? html`<div>
@@ -1088,25 +1194,38 @@ export class ScionPageAgents extends LitElement {
         </div>
 
         ${agent.taskSummary ? html` <div class="agent-task">${agent.taskSummary}</div> ` : ''}
-
         ${this.agentMetrics[agent.id]
           ? html`
-              <div class="agent-meta" style="margin-top: 0.5em; font-size: 0.8em; color: var(--scion-text-muted, #888);">
-                <div><sl-icon name="bar-chart"></sl-icon> ${this.agentMetrics[agent.id].totalSessions} sessions</div>
-                <div><sl-icon name="hash"></sl-icon> ${(this.agentMetrics[agent.id].totalTokensInput + this.agentMetrics[agent.id].totalTokensOutput).toLocaleString()} tokens</div>
+              <div
+                class="agent-meta"
+                style="margin-top: 0.5em; font-size: 0.8em; color: var(--scion-text-muted, #888);"
+              >
+                <div>
+                  <sl-icon name="bar-chart"></sl-icon> ${this.agentMetrics[agent.id].totalSessions}
+                  sessions
+                </div>
+                <div>
+                  <sl-icon name="hash"></sl-icon> ${(
+                    this.agentMetrics[agent.id].totalTokensInput +
+                    this.agentMetrics[agent.id].totalTokensOutput
+                  ).toLocaleString()}
+                  tokens
+                </div>
               </div>
             `
           : nothing}
-
         ${agent.labels && Object.keys(agent.labels).length > 0
-          ? html`<div class="agent-labels" style="margin-top: 0.5em;">${Object.entries(agent.labels).map(
-              ([k, v]) => html`<sl-tag size="small" variant="neutral" style="margin: 0.15em;">${k}: ${v}</sl-tag>`
-            )}</div>`
+          ? html`<div class="agent-labels" style="margin-top: 0.5em;">
+              ${Object.entries(agent.labels).map(
+                ([k, v]) =>
+                  html`<sl-tag size="small" variant="neutral" style="margin: 0.15em;"
+                    >${k}: ${v}</sl-tag
+                  >`
+              )}
+            </div>`
           : ''}
 
-        <div class="agent-actions">
-          ${this.renderActionButtons(agent)}
-        </div>
+        <div class="agent-actions">${this.renderActionButtons(agent)}</div>
       </div>
     `;
   }
@@ -1120,17 +1239,23 @@ export class ScionPageAgents extends LitElement {
               <th
                 class="sortable ${this.sortField === 'name' ? 'sorted' : ''}"
                 @click=${() => this.toggleSort('name')}
-              >Name <span class="sort-indicator">${this.sortIndicator('name')}</span></th>
+              >
+                Name <span class="sort-indicator">${this.sortIndicator('name')}</span>
+              </th>
               <th>Project</th>
               <th class="hide-mobile">Template</th>
               <th
                 class="status-col sortable ${this.sortField === 'status' ? 'sorted' : ''}"
                 @click=${() => this.toggleSort('status')}
-              >Status <span class="sort-indicator">${this.sortIndicator('status')}</span></th>
+              >
+                Status <span class="sort-indicator">${this.sortIndicator('status')}</span>
+              </th>
               <th
                 class="hide-mobile sortable ${this.sortField === 'updated' ? 'sorted' : ''}"
                 @click=${() => this.toggleSort('updated')}
-              >Updated <span class="sort-indicator">${this.sortIndicator('updated')}</span></th>
+              >
+                Updated <span class="sort-indicator">${this.sortIndicator('updated')}</span>
+              </th>
               <th class="hide-mobile">Task</th>
               <th class="hide-mobile">Sessions</th>
               <th class="hide-mobile">Tokens</th>
@@ -1154,7 +1279,11 @@ export class ScionPageAgents extends LitElement {
             <a href="/agents/${agent.id}">${agent.name}</a>
           </span>
         </td>
-        <td>${agent.project ? html`<a href="/projects/${agent.projectId}" class="project-link">${agent.project}</a>` : '\u2014'}</td>
+        <td>
+          ${agent.project
+            ? html`<a href="/projects/${agent.projectId}" class="project-link">${agent.project}</a>`
+            : '\u2014'}
+        </td>
         <td class="hide-mobile">${agent.template}</td>
         <td>
           <scion-status-badge
@@ -1163,16 +1292,32 @@ export class ScionPageAgents extends LitElement {
             size="small"
           ></scion-status-badge>
         </td>
-        <td class="hide-mobile">${((agent.lastActivityEvent && !agent.lastActivityEvent.startsWith('0001')) || agent.updated) ? this.formatRelativeTime(((agent.lastActivityEvent && !agent.lastActivityEvent.startsWith('0001')) ? agent.lastActivityEvent : agent.updated)!) : '\u2014'}</td>
+        <td class="hide-mobile">
+          ${(agent.lastActivityEvent && !agent.lastActivityEvent.startsWith('0001')) ||
+          agent.updated
+            ? this.formatRelativeTime(
+                (agent.lastActivityEvent && !agent.lastActivityEvent.startsWith('0001')
+                  ? agent.lastActivityEvent
+                  : agent.updated)!
+              )
+            : '\u2014'}
+        </td>
         <td class="hide-mobile">
           <span class="task-cell">${agent.taskSummary || '\u2014'}</span>
         </td>
-        <td class="hide-mobile">${this.agentMetrics[agent.id] ? this.agentMetrics[agent.id].totalSessions : '\u2014'}</td>
-        <td class="hide-mobile">${this.agentMetrics[agent.id] ? (this.agentMetrics[agent.id].totalTokensInput + this.agentMetrics[agent.id].totalTokensOutput).toLocaleString() : '\u2014'}</td>
+        <td class="hide-mobile">
+          ${this.agentMetrics[agent.id] ? this.agentMetrics[agent.id].totalSessions : '\u2014'}
+        </td>
+        <td class="hide-mobile">
+          ${this.agentMetrics[agent.id]
+            ? (
+                this.agentMetrics[agent.id].totalTokensInput +
+                this.agentMetrics[agent.id].totalTokensOutput
+              ).toLocaleString()
+            : '\u2014'}
+        </td>
         <td class="actions-cell">
-          <span class="table-actions">
-            ${this.renderActionButtons(agent)}
-          </span>
+          <span class="table-actions"> ${this.renderActionButtons(agent)} </span>
         </td>
       </tr>
     `;

--- a/web/src/components/pages/broker-detail.ts
+++ b/web/src/components/pages/broker-detail.ts
@@ -70,358 +70,358 @@ export class ScionPageBrokerDetail extends LitElement {
   static override styles = [
     brokerTypeBadgeStyles,
     css`
-    :host {
-      display: block;
-    }
+      :host {
+        display: block;
+      }
 
-    .back-link {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.5rem;
-      color: var(--scion-text-muted, #64748b);
-      text-decoration: none;
-      font-size: 0.875rem;
-      margin-bottom: 1rem;
-    }
+      .back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        color: var(--scion-text-muted, #64748b);
+        text-decoration: none;
+        font-size: 0.875rem;
+        margin-bottom: 1rem;
+      }
 
-    .back-link:hover {
-      color: var(--scion-primary, #3b82f6);
-    }
+      .back-link:hover {
+        color: var(--scion-primary, #3b82f6);
+      }
 
-    .header {
-      display: flex;
-      align-items: flex-start;
-      justify-content: space-between;
-      margin-bottom: 1.5rem;
-      gap: 1rem;
-    }
+      .header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        margin-bottom: 1.5rem;
+        gap: 1rem;
+      }
 
-    .header-info {
-      flex: 1;
-    }
+      .header-info {
+        flex: 1;
+      }
 
-    .header-title {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-      margin-bottom: 0.5rem;
-    }
+      .header-title {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin-bottom: 0.5rem;
+      }
 
-    .header-title sl-icon {
-      color: var(--scion-primary, #3b82f6);
-      font-size: 1.5rem;
-    }
+      .header-title sl-icon {
+        color: var(--scion-primary, #3b82f6);
+        font-size: 1.5rem;
+      }
 
-    .header h1 {
-      font-size: 1.5rem;
-      font-weight: 700;
-      color: var(--scion-text, #1e293b);
-      margin: 0;
-    }
+      .header h1 {
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: var(--scion-text, #1e293b);
+        margin: 0;
+      }
 
-    .header-subtitle {
-      font-family: var(--scion-font-mono, monospace);
-      font-size: 0.875rem;
-      color: var(--scion-text-muted, #64748b);
-      margin-top: 0.25rem;
-      word-break: break-all;
-    }
+      .header-subtitle {
+        font-family: var(--scion-font-mono, monospace);
+        font-size: 0.875rem;
+        color: var(--scion-text-muted, #64748b);
+        margin-top: 0.25rem;
+        word-break: break-all;
+      }
 
-    .stats-row {
-      display: flex;
-      gap: 2rem;
-      margin-bottom: 2rem;
-      padding: 1.25rem;
-      background: var(--scion-surface, #ffffff);
-      border: 1px solid var(--scion-border, #e2e8f0);
-      border-radius: var(--scion-radius-lg, 0.75rem);
-      flex-wrap: wrap;
-    }
+      .stats-row {
+        display: flex;
+        gap: 2rem;
+        margin-bottom: 2rem;
+        padding: 1.25rem;
+        background: var(--scion-surface, #ffffff);
+        border: 1px solid var(--scion-border, #e2e8f0);
+        border-radius: var(--scion-radius-lg, 0.75rem);
+        flex-wrap: wrap;
+      }
 
-    .stat {
-      display: flex;
-      flex-direction: column;
-    }
+      .stat {
+        display: flex;
+        flex-direction: column;
+      }
 
-    .stat-label {
-      font-size: 0.75rem;
-      color: var(--scion-text-muted, #64748b);
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      margin-bottom: 0.25rem;
-    }
+      .stat-label {
+        font-size: 0.75rem;
+        color: var(--scion-text-muted, #64748b);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 0.25rem;
+      }
 
-    .stat-value {
-      font-size: 1.5rem;
-      font-weight: 700;
-      color: var(--scion-text, #1e293b);
-    }
+      .stat-value {
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: var(--scion-text, #1e293b);
+      }
 
-    .stat-value-sm {
-      font-size: 1rem;
-      font-weight: 500;
-      color: var(--scion-text, #1e293b);
-    }
+      .stat-value-sm {
+        font-size: 1rem;
+        font-weight: 500;
+        color: var(--scion-text, #1e293b);
+      }
 
-    .section {
-      margin-bottom: 2rem;
-    }
+      .section {
+        margin-bottom: 2rem;
+      }
 
-    .section-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      margin-bottom: 1rem;
-    }
+      .section-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 1rem;
+      }
 
-    .section-header h2 {
-      font-size: 1.125rem;
-      font-weight: 600;
-      color: var(--scion-text, #1e293b);
-      margin: 0;
-    }
+      .section-header h2 {
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: var(--scion-text, #1e293b);
+        margin: 0;
+      }
 
-    .capabilities-row {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-      margin-bottom: 2rem;
-    }
+      .capabilities-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-bottom: 2rem;
+      }
 
-    .capability-tag {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.25rem;
-      padding: 0.25rem 0.5rem;
-      border-radius: var(--scion-radius, 0.5rem);
-      font-size: 0.75rem;
-      font-weight: 500;
-      background: var(--scion-bg-subtle, #f1f5f9);
-      color: var(--scion-text-muted, #64748b);
-    }
+      .capability-tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 0.25rem 0.5rem;
+        border-radius: var(--scion-radius, 0.5rem);
+        font-size: 0.75rem;
+        font-weight: 500;
+        background: var(--scion-bg-subtle, #f1f5f9);
+        color: var(--scion-text-muted, #64748b);
+      }
 
-    .capability-tag.enabled {
-      background: var(--sl-color-success-100, #dcfce7);
-      color: var(--sl-color-success-700, #15803d);
-    }
+      .capability-tag.enabled {
+        background: var(--sl-color-success-100, #dcfce7);
+        color: var(--sl-color-success-700, #15803d);
+      }
 
-    .profiles-row {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-      margin-bottom: 2rem;
-    }
+      .profiles-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-bottom: 2rem;
+      }
 
-    .profile-tag {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.375rem;
-      padding: 0.375rem 0.75rem;
-      border-radius: var(--scion-radius, 0.5rem);
-      font-size: 0.8125rem;
-      font-weight: 500;
-      background: var(--scion-bg-subtle, #f1f5f9);
-      color: var(--scion-text-muted, #64748b);
-      border: 1px solid var(--scion-border, #e2e8f0);
-    }
+      .profile-tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+        padding: 0.375rem 0.75rem;
+        border-radius: var(--scion-radius, 0.5rem);
+        font-size: 0.8125rem;
+        font-weight: 500;
+        background: var(--scion-bg-subtle, #f1f5f9);
+        color: var(--scion-text-muted, #64748b);
+        border: 1px solid var(--scion-border, #e2e8f0);
+      }
 
-    .profile-tag.available {
-      background: var(--scion-surface, #ffffff);
-      color: var(--scion-text, #1e293b);
-    }
+      .profile-tag.available {
+        background: var(--scion-surface, #ffffff);
+        color: var(--scion-text, #1e293b);
+      }
 
-    .profile-type {
-      font-size: 0.6875rem;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      opacity: 0.7;
-    }
+      .profile-type {
+        font-size: 0.6875rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        opacity: 0.7;
+      }
 
-    .project-section {
-      margin-bottom: 1.5rem;
-    }
+      .project-section {
+        margin-bottom: 1.5rem;
+      }
 
-    .project-section-header {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-      margin-bottom: 1rem;
-      padding-bottom: 0.5rem;
-      border-bottom: 1px solid var(--scion-border, #e2e8f0);
-    }
+      .project-section-header {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin-bottom: 1rem;
+        padding-bottom: 0.5rem;
+        border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      }
 
-    .project-section-header h3 {
-      font-size: 1rem;
-      font-weight: 600;
-      color: var(--scion-text, #1e293b);
-      margin: 0;
-    }
+      .project-section-header h3 {
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--scion-text, #1e293b);
+        margin: 0;
+      }
 
-    .project-section-header a {
-      color: inherit;
-      text-decoration: none;
-    }
+      .project-section-header a {
+        color: inherit;
+        text-decoration: none;
+      }
 
-    .project-section-header a:hover {
-      color: var(--scion-primary, #3b82f6);
-    }
+      .project-section-header a:hover {
+        color: var(--scion-primary, #3b82f6);
+      }
 
-    .project-section-header sl-icon {
-      color: var(--scion-primary, #3b82f6);
-    }
+      .project-section-header sl-icon {
+        color: var(--scion-primary, #3b82f6);
+      }
 
-    .project-agent-count {
-      font-size: 0.75rem;
-      color: var(--scion-text-muted, #64748b);
-      background: var(--scion-bg-subtle, #f1f5f9);
-      padding: 0.125rem 0.5rem;
-      border-radius: 9999px;
-    }
+      .project-agent-count {
+        font-size: 0.75rem;
+        color: var(--scion-text-muted, #64748b);
+        background: var(--scion-bg-subtle, #f1f5f9);
+        padding: 0.125rem 0.5rem;
+        border-radius: 9999px;
+      }
 
-    .agent-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-      gap: 1.5rem;
-    }
+      .agent-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+        gap: 1.5rem;
+      }
 
-    .agent-card {
-      background: var(--scion-surface, #ffffff);
-      border: 1px solid var(--scion-border, #e2e8f0);
-      border-radius: var(--scion-radius-lg, 0.75rem);
-      padding: 1.5rem;
-      transition: all var(--scion-transition-fast, 150ms ease);
-      text-decoration: none;
-      color: inherit;
-      display: block;
-    }
+      .agent-card {
+        background: var(--scion-surface, #ffffff);
+        border: 1px solid var(--scion-border, #e2e8f0);
+        border-radius: var(--scion-radius-lg, 0.75rem);
+        padding: 1.5rem;
+        transition: all var(--scion-transition-fast, 150ms ease);
+        text-decoration: none;
+        color: inherit;
+        display: block;
+      }
 
-    .agent-card:hover {
-      border-color: var(--scion-primary, #3b82f6);
-      box-shadow: var(--scion-shadow-md, 0 4px 6px -1px rgba(0, 0, 0, 0.1));
-    }
+      .agent-card:hover {
+        border-color: var(--scion-primary, #3b82f6);
+        box-shadow: var(--scion-shadow-md, 0 4px 6px -1px rgba(0, 0, 0, 0.1));
+      }
 
-    .agent-header {
-      display: flex;
-      align-items: flex-start;
-      justify-content: space-between;
-      margin-bottom: 0.75rem;
-    }
+      .agent-header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        margin-bottom: 0.75rem;
+      }
 
-    .agent-name {
-      font-size: 1.125rem;
-      font-weight: 600;
-      color: var(--scion-text, #1e293b);
-      margin: 0;
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
+      .agent-name {
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: var(--scion-text, #1e293b);
+        margin: 0;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
 
-    .agent-name sl-icon {
-      color: var(--scion-primary, #3b82f6);
-    }
+      .agent-name sl-icon {
+        color: var(--scion-primary, #3b82f6);
+      }
 
-    .agent-meta {
-      font-size: 0.813rem;
-      color: var(--scion-text-muted, #64748b);
-      margin-top: 0.25rem;
-    }
+      .agent-meta {
+        font-size: 0.813rem;
+        color: var(--scion-text-muted, #64748b);
+        margin-top: 0.25rem;
+      }
 
-    .agent-meta sl-icon {
-      font-size: 0.875rem;
-      vertical-align: -0.125em;
-      opacity: 0.7;
-    }
+      .agent-meta sl-icon {
+        font-size: 0.875rem;
+        vertical-align: -0.125em;
+        opacity: 0.7;
+      }
 
-    .agent-task {
-      font-size: 0.875rem;
-      color: var(--scion-text, #1e293b);
-      margin-top: 0.75rem;
-      padding: 0.75rem;
-      background: var(--scion-bg-subtle, #f1f5f9);
-      border-radius: var(--scion-radius, 0.5rem);
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
+      .agent-task {
+        font-size: 0.875rem;
+        color: var(--scion-text, #1e293b);
+        margin-top: 0.75rem;
+        padding: 0.75rem;
+        background: var(--scion-bg-subtle, #f1f5f9);
+        border-radius: var(--scion-radius, 0.5rem);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
 
-    .empty-state {
-      text-align: center;
-      padding: 4rem 2rem;
-      background: var(--scion-surface, #ffffff);
-      border: 1px dashed var(--scion-border, #e2e8f0);
-      border-radius: var(--scion-radius-lg, 0.75rem);
-    }
+      .empty-state {
+        text-align: center;
+        padding: 4rem 2rem;
+        background: var(--scion-surface, #ffffff);
+        border: 1px dashed var(--scion-border, #e2e8f0);
+        border-radius: var(--scion-radius-lg, 0.75rem);
+      }
 
-    .empty-state > sl-icon {
-      font-size: 4rem;
-      color: var(--scion-text-muted, #64748b);
-      opacity: 0.5;
-      margin-bottom: 1rem;
-    }
+      .empty-state > sl-icon {
+        font-size: 4rem;
+        color: var(--scion-text-muted, #64748b);
+        opacity: 0.5;
+        margin-bottom: 1rem;
+      }
 
-    .empty-state h2 {
-      font-size: 1.25rem;
-      font-weight: 600;
-      color: var(--scion-text, #1e293b);
-      margin: 0 0 0.5rem 0;
-    }
+      .empty-state h2 {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--scion-text, #1e293b);
+        margin: 0 0 0.5rem 0;
+      }
 
-    .empty-state p {
-      color: var(--scion-text-muted, #64748b);
-      margin: 0;
-    }
+      .empty-state p {
+        color: var(--scion-text-muted, #64748b);
+        margin: 0;
+      }
 
-    .loading-state {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      padding: 4rem 2rem;
-      color: var(--scion-text-muted, #64748b);
-    }
+      .loading-state {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 4rem 2rem;
+        color: var(--scion-text-muted, #64748b);
+      }
 
-    .loading-state sl-spinner {
-      font-size: 2rem;
-      margin-bottom: 1rem;
-    }
+      .loading-state sl-spinner {
+        font-size: 2rem;
+        margin-bottom: 1rem;
+      }
 
-    .error-state {
-      text-align: center;
-      padding: 3rem 2rem;
-      background: var(--scion-surface, #ffffff);
-      border: 1px solid var(--sl-color-danger-200, #fecaca);
-      border-radius: var(--scion-radius-lg, 0.75rem);
-    }
+      .error-state {
+        text-align: center;
+        padding: 3rem 2rem;
+        background: var(--scion-surface, #ffffff);
+        border: 1px solid var(--sl-color-danger-200, #fecaca);
+        border-radius: var(--scion-radius-lg, 0.75rem);
+      }
 
-    .error-state sl-icon {
-      font-size: 3rem;
-      color: var(--sl-color-danger-500, #ef4444);
-      margin-bottom: 1rem;
-    }
+      .error-state sl-icon {
+        font-size: 3rem;
+        color: var(--sl-color-danger-500, #ef4444);
+        margin-bottom: 1rem;
+      }
 
-    .error-state h2 {
-      font-size: 1.25rem;
-      font-weight: 600;
-      color: var(--scion-text, #1e293b);
-      margin: 0 0 0.5rem 0;
-    }
+      .error-state h2 {
+        font-size: 1.25rem;
+        font-weight: 600;
+        color: var(--scion-text, #1e293b);
+        margin: 0 0 0.5rem 0;
+      }
 
-    .error-state p {
-      color: var(--scion-text-muted, #64748b);
-      margin: 0 0 1rem 0;
-    }
+      .error-state p {
+        color: var(--scion-text-muted, #64748b);
+        margin: 0 0 1rem 0;
+      }
 
-    .error-details {
-      font-family: var(--scion-font-mono, monospace);
-      font-size: 0.875rem;
-      background: var(--scion-bg-subtle, #f1f5f9);
-      padding: 0.75rem 1rem;
-      border-radius: var(--scion-radius, 0.5rem);
-      color: var(--sl-color-danger-700, #b91c1c);
-      margin-bottom: 1rem;
-    }
-  `,
+      .error-details {
+        font-family: var(--scion-font-mono, monospace);
+        font-size: 0.875rem;
+        background: var(--scion-bg-subtle, #f1f5f9);
+        padding: 0.75rem 1rem;
+        border-radius: var(--scion-radius, 0.5rem);
+        color: var(--sl-color-danger-700, #b91c1c);
+        margin-bottom: 1rem;
+      }
+    `,
   ];
 
   override connectedCallback(): void {
@@ -476,7 +476,12 @@ export class ScionPageBrokerDetail extends LitElement {
       ]);
 
       if (!brokerResponse.ok) {
-        throw new Error(await extractApiError(brokerResponse, `HTTP ${brokerResponse.status}: ${brokerResponse.statusText}`));
+        throw new Error(
+          await extractApiError(
+            brokerResponse,
+            `HTTP ${brokerResponse.status}: ${brokerResponse.statusText}`
+          )
+        );
       }
 
       this.broker = (await brokerResponse.json()) as RuntimeBroker;
@@ -638,7 +643,9 @@ export class ScionPageBrokerDetail extends LitElement {
           ? html`
               <div class="stat">
                 <span class="stat-label">Created By</span>
-                <span class="stat-value-sm">${this.broker.createdByName || this.broker.createdBy}</span>
+                <span class="stat-value-sm"
+                  >${this.broker.createdByName || this.broker.createdBy}</span
+                >
               </div>
             `
           : ''}
@@ -747,9 +754,7 @@ export class ScionPageBrokerDetail extends LitElement {
               <sl-icon name="cpu"></sl-icon>
               ${agent.name}
             </h3>
-            <div class="agent-meta">
-              <sl-icon name="code-square"></sl-icon> ${agent.template}
-            </div>
+            <div class="agent-meta"><sl-icon name="code-square"></sl-icon> ${agent.template}</div>
           </div>
           <scion-status-badge
             status=${getAgentDisplayStatus(agent) as StatusType}

--- a/web/src/components/pages/brokers.ts
+++ b/web/src/components/pages/brokers.ts
@@ -179,7 +179,9 @@ export class ScionPageBrokers extends LitElement {
       });
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       const data = (await response.json()) as { brokers?: RuntimeBroker[] } | RuntimeBroker[];
@@ -305,7 +307,9 @@ export class ScionPageBrokers extends LitElement {
 
   private renderGrid() {
     return html`
-      <div class="resource-grid">${this.brokers.map((broker) => this.renderBrokerCard(broker))}</div>
+      <div class="resource-grid">
+        ${this.brokers.map((broker) => this.renderBrokerCard(broker))}
+      </div>
     `;
   }
 
@@ -324,8 +328,7 @@ export class ScionPageBrokers extends LitElement {
           <div>
             <h3 class="resource-name">
               <sl-icon name="hdd-rack"></sl-icon>
-              ${broker.name}
-              ${this.renderBrokerTypeBadge(broker)}
+              ${broker.name} ${this.renderBrokerTypeBadge(broker)}
             </h3>
             ${broker.version ? html`<div class="broker-version">v${broker.version}</div>` : ''}
           </div>
@@ -397,15 +400,17 @@ export class ScionPageBrokers extends LitElement {
 
   private renderBrokerRow(broker: RuntimeBroker) {
     return html`
-      <tr class="clickable" @click=${() => {
-        window.history.pushState({}, '', `/brokers/${broker.id}`);
-        window.dispatchEvent(new PopStateEvent('popstate'));
-      }}>
+      <tr
+        class="clickable"
+        @click=${() => {
+          window.history.pushState({}, '', `/brokers/${broker.id}`);
+          window.dispatchEvent(new PopStateEvent('popstate'));
+        }}
+      >
         <td>
           <span class="name-cell">
             <sl-icon name="hdd-rack"></sl-icon>
-            ${broker.name}
-            ${this.renderBrokerTypeBadge(broker)}
+            ${broker.name} ${this.renderBrokerTypeBadge(broker)}
           </span>
         </td>
         <td class="hide-mobile">
@@ -422,9 +427,15 @@ export class ScionPageBrokers extends LitElement {
           ${broker.capabilities
             ? html`
                 <span class="capability-tags-inline">
-                  <span class="capability-tag ${broker.capabilities.webPTY ? 'enabled' : ''}">WebPTY</span>
-                  <span class="capability-tag ${broker.capabilities.sync ? 'enabled' : ''}">Sync</span>
-                  <span class="capability-tag ${broker.capabilities.attach ? 'enabled' : ''}">Attach</span>
+                  <span class="capability-tag ${broker.capabilities.webPTY ? 'enabled' : ''}"
+                    >WebPTY</span
+                  >
+                  <span class="capability-tag ${broker.capabilities.sync ? 'enabled' : ''}"
+                    >Sync</span
+                  >
+                  <span class="capability-tag ${broker.capabilities.attach ? 'enabled' : ''}"
+                    >Attach</span
+                  >
                 </span>
               `
             : '\u2014'}
@@ -432,9 +443,7 @@ export class ScionPageBrokers extends LitElement {
         <td>
           <span class="meta-text">${this.formatRelativeTime(broker.lastHeartbeat)}</span>
         </td>
-        <td class="hide-mobile">
-          ${broker.profiles ? broker.profiles.length : '\u2014'}
-        </td>
+        <td class="hide-mobile">${broker.profiles ? broker.profiles.length : '\u2014'}</td>
       </tr>
     `;
   }

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -625,12 +625,14 @@ export class ScionPageChat extends LitElement {
         threadName: '',
         defaultAgent: '',
         isDM: true,
-        peerName: '', // Will be resolved from DM data
+        peerName: '',
         peerId: '',
         peerKind: 'user',
       };
       this.classList.add('thread-open');
       dispatchPageTitle(this, 'DM', 'Chat');
+      // Resolve peer metadata from the DM list (handles page refresh).
+      void this.resolveDMPeerInfo(key);
       return;
     }
 
@@ -708,6 +710,41 @@ export class ScionPageChat extends LitElement {
 
   private handleNavigateApp(): void {
     navigateTo('/');
+  }
+
+  /**
+   * Resolve DM peer info from the DM list endpoint. This handles the case
+   * where the user navigates directly to /chat/dm/{key} (e.g., page refresh)
+   * and the peer metadata is not populated from the rail click event.
+   */
+  private async resolveDMPeerInfo(key: string): Promise<void> {
+    try {
+      const res = await apiFetch('/api/v1/chat/dms');
+      if (!res.ok) return;
+      const data = (await res.json()) as {
+        dms?: Array<{
+          conversationKey: string;
+          peerName?: string;
+          peerEmail?: string;
+          peerId: string;
+          peerKind: 'user' | 'agent';
+          peerSlug?: string;
+        }>;
+      };
+      const dm = data.dms?.find((d) => d.conversationKey === key);
+      if (dm && this.v2Conversation?.conversationKey === key) {
+        const peerName = dm.peerName || dm.peerSlug || dm.peerEmail || dm.peerId;
+        this.v2Conversation = {
+          ...this.v2Conversation,
+          peerName,
+          peerId: dm.peerId,
+          peerKind: dm.peerKind,
+        };
+        dispatchPageTitle(this, peerName, 'Chat');
+      }
+    } catch {
+      // Non-critical — the DM will still work, just without a resolved peer name.
+    }
   }
 
   private async loadV2Members(projectId: string): Promise<void> {
@@ -867,32 +904,42 @@ export class ScionPageChat extends LitElement {
     const conv = this.v2Conversation;
 
     return html`
-      ${conv.threadName
+      ${conv.isDM && conv.peerName
         ? html`
             <div class="v2-thread-header">
-              <span class="hash">#</span>
-              <span>${conv.threadName}</span>
-              ${conv.defaultAgent
-                ? html`
-                    <sl-tooltip content="Default agent: ${conv.defaultAgent}">
-                      <sl-icon
-                        name="cpu"
-                        style="font-size: 0.75rem; color: var(--scion-text-muted)"
-                      ></sl-icon>
-                    </sl-tooltip>
-                  `
-                : nothing}
-              <sl-icon-button
-                class="members-btn"
-                name="people"
-                label="Toggle members"
-                @click=${() => {
-                  this.v2MembersExpanded = !this.v2MembersExpanded;
-                }}
-              ></sl-icon-button>
+              <sl-icon
+                name=${conv.peerKind === 'agent' ? 'cpu' : 'person'}
+                style="font-size: 0.875rem; color: var(--scion-text-muted)"
+              ></sl-icon>
+              <span>${conv.peerName}</span>
             </div>
           `
-        : nothing}
+        : conv.threadName
+          ? html`
+              <div class="v2-thread-header">
+                <span class="hash">#</span>
+                <span>${conv.threadName}</span>
+                ${conv.defaultAgent
+                  ? html`
+                      <sl-tooltip content="Default agent: ${conv.defaultAgent}">
+                        <sl-icon
+                          name="cpu"
+                          style="font-size: 0.75rem; color: var(--scion-text-muted)"
+                        ></sl-icon>
+                      </sl-tooltip>
+                    `
+                  : nothing}
+                <sl-icon-button
+                  class="members-btn"
+                  name="people"
+                  label="Toggle members"
+                  @click=${() => {
+                    this.v2MembersExpanded = !this.v2MembersExpanded;
+                  }}
+                ></sl-icon-button>
+              </div>
+            `
+          : nothing}
       <scion-chat-thread
         conversationKey=${conv.conversationKey}
         projectId=${conv.projectId}

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -110,6 +110,7 @@ export class ScionPageChat extends LitElement {
   @state() private v2SpaceRailLoaded = false;
   private _onChatMessage = this.handleChatMessage.bind(this);
   private _onChatTopic = this.handleChatTopic.bind(this);
+  private _onRailLoaded = this.handleRailLoaded.bind(this);
 
   static override styles = css`
     :host {
@@ -369,6 +370,12 @@ export class ScionPageChat extends LitElement {
     if (this.isV2) {
       void this.initV2();
     } else {
+      // Guard: redirect v2 routes to /chat when v2 flag is OFF (O3)
+      const path = window.location.pathname;
+      if (path.startsWith('/chat/space/') || path.startsWith('/chat/dm/')) {
+        navigateTo('/chat');
+        return;
+      }
       this.parseRoute();
       void this.loadThreads();
       stateManager.addEventListener('user-message-created', this._onUserMessage);
@@ -380,6 +387,7 @@ export class ScionPageChat extends LitElement {
     if (this.isV2) {
       stateManager.removeEventListener('chat-message-received', this._onChatMessage);
       stateManager.removeEventListener('chat-topic-updated', this._onChatTopic);
+      this.removeEventListener('rail-loaded', this._onRailLoaded);
     } else {
       stateManager.removeEventListener('user-message-created', this._onUserMessage);
     }
@@ -557,6 +565,22 @@ export class ScionPageChat extends LitElement {
     // Subscribe to SSE events
     stateManager.addEventListener('chat-message-received', this._onChatMessage);
     stateManager.addEventListener('chat-topic-updated', this._onChatTopic);
+
+    // Listen for rail-loaded to set up the SSE scope with space IDs
+    this.addEventListener('rail-loaded', this._onRailLoaded);
+  }
+
+  /** Called when the space rail finishes loading its data. Sets up the SSE scope. */
+  private handleRailLoaded(e: Event): void {
+    const detail = (e as CustomEvent).detail as { spaceIds: string[] };
+    const userId = this.pageData?.user?.id || '';
+    if (detail.spaceIds.length > 0 && userId) {
+      stateManager.setScope({
+        type: 'chat',
+        spaceIds: detail.spaceIds,
+        userId,
+      });
+    }
   }
 
   private parseV2Route(): void {

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -40,10 +40,13 @@ import { apiFetch } from '../../client/api.js';
 import { navigateTo, stateManager } from '../../client/main.js';
 import { dispatchPageTitle } from '../../client/page-title.js';
 import { isFeatureEnabled, NATIVE_CHAT_V2_FLAG } from '../../utils/feature-flags.js';
+import { hashColor, getInitials } from '../shared/chat/chat-avatar.js';
 import '../shared/chat/chat-thread.js';
 
 // Lazy-load the space rail only when v2 is active
 const loadSpaceRail = () => import('../shared/chat/chat-space-rail.js');
+// Lazy-load the members sidebar only when v2 is active
+const loadChatMembers = () => import('../shared/chat/chat-members.js');
 
 // ---- V1 types ----
 
@@ -108,9 +111,18 @@ export class ScionPageChat extends LitElement {
   @state() private v2Members: SpaceMember[] = [];
   @state() private v2MembersExpanded = false;
   @state() private v2SpaceRailLoaded = false;
+  /** Human members for the members sidebar (from the members endpoint). */
+  @state() private v2HumanMembers: import('../shared/chat/chat-members.js').ChatHumanMember[] = [];
+  /** Agent members for the members sidebar. */
+  @state() private v2AgentMembers: import('../shared/chat/chat-members.js').ChatAgentMember[] = [];
   private _onChatMessage = this.handleChatMessage.bind(this);
   private _onChatTopic = this.handleChatTopic.bind(this);
+  private _onPresenceUpdated = this.handlePresenceUpdated.bind(this);
   private _onRailLoaded = this.handleRailLoaded.bind(this);
+  /** Presence heartbeat interval timer. */
+  private _presenceInterval: ReturnType<typeof setInterval> | null = null;
+  /** Tracked project IDs for presence heartbeat. */
+  private _presenceProjectIds: string[] = [];
 
   static override styles = css`
     :host {
@@ -387,7 +399,9 @@ export class ScionPageChat extends LitElement {
     if (this.isV2) {
       stateManager.removeEventListener('chat-message-received', this._onChatMessage);
       stateManager.removeEventListener('chat-topic-updated', this._onChatTopic);
+      stateManager.removeEventListener('chat-presence-updated', this._onPresenceUpdated);
       this.removeEventListener('rail-loaded', this._onRailLoaded);
+      this.stopPresenceHeartbeat();
     } else {
       stateManager.removeEventListener('user-message-created', this._onUserMessage);
     }
@@ -555,8 +569,8 @@ export class ScionPageChat extends LitElement {
   // =========================================================================
 
   private async initV2(): Promise<void> {
-    // Lazy-load the space rail component
-    await loadSpaceRail();
+    // Lazy-load the space rail and members components
+    await Promise.all([loadSpaceRail(), loadChatMembers()]);
     this.v2SpaceRailLoaded = true;
 
     // Parse initial route
@@ -565,6 +579,7 @@ export class ScionPageChat extends LitElement {
     // Subscribe to SSE events
     stateManager.addEventListener('chat-message-received', this._onChatMessage);
     stateManager.addEventListener('chat-topic-updated', this._onChatTopic);
+    stateManager.addEventListener('chat-presence-updated', this._onPresenceUpdated);
 
     // Listen for rail-loaded to set up the SSE scope with space IDs
     this.addEventListener('rail-loaded', this._onRailLoaded);
@@ -580,6 +595,9 @@ export class ScionPageChat extends LitElement {
         spaceIds: detail.spaceIds,
         userId,
       });
+      // Start presence heartbeat
+      this._presenceProjectIds = detail.spaceIds;
+      this.startPresenceHeartbeat();
     }
   }
 
@@ -752,12 +770,162 @@ export class ScionPageChat extends LitElement {
     try {
       const res = await apiFetch(`/api/v1/chat/spaces/${encodeURIComponent(projectId)}/members`);
       if (res.ok) {
-        const data = (await res.json()) as { members?: SpaceMember[] };
-        this.v2Members = data.members || [];
+        const data = (await res.json()) as {
+          humans?: Array<{
+            id: string;
+            kind: 'user';
+            displayName: string;
+            email?: string;
+            avatarUrl?: string;
+            role?: string;
+            presenceState?: 'active' | 'idle' | '';
+          }>;
+          agents?: Array<{
+            id: string;
+            kind: 'agent';
+            displayName: string;
+            slug?: string;
+            phase?: string;
+            activity?: string;
+          }>;
+          members?: SpaceMember[];
+        };
+        // Populate the sidebar member arrays
+        this.v2HumanMembers = (data.humans || []).map((h) => ({
+          id: h.id,
+          kind: 'user' as const,
+          displayName: h.displayName,
+          email: h.email || '',
+          avatarUrl: h.avatarUrl || '',
+          role: h.role || '',
+          presenceState: h.presenceState || '',
+        }));
+        this.v2AgentMembers = (data.agents || []).map((a) => ({
+          id: a.id,
+          kind: 'agent' as const,
+          displayName: a.displayName,
+          slug: a.slug || '',
+          phase: a.phase || '',
+          activity: a.activity || '',
+        }));
+        // Also populate the legacy v2Members for the thread component
+        this.v2Members = [
+          ...(data.humans || []).map((h) => ({
+            id: h.id,
+            name: h.displayName,
+            email: h.email || '',
+            avatarUrl: h.avatarUrl || '',
+            kind: 'user' as const,
+          })),
+          ...(data.agents || []).map((a) => ({
+            id: a.id,
+            name: a.displayName,
+            email: '',
+            slug: a.slug || '',
+            kind: 'agent' as const,
+          })),
+          ...(data.members || []),
+        ];
       }
     } catch {
       // Non-critical
     }
+  }
+
+  /** Handle presence SSE events to update member presence in real-time. */
+  private handlePresenceUpdated(e: Event): void {
+    const detail = (e as CustomEvent).detail as {
+      data?: { userId?: string; state?: string; displayName?: string };
+      userId?: string;
+      state?: string;
+    };
+    const eventData = detail?.data || detail;
+    const userId = (eventData as Record<string, unknown>).userId as string | undefined;
+    const state = (eventData as Record<string, unknown>).state as string | undefined;
+
+    if (!userId || !state) return;
+
+    // Update the human member's presence state
+    const updatedHumans = this.v2HumanMembers.map((h) => {
+      if (h.id === userId) {
+        return { ...h, presenceState: state as 'active' | 'idle' };
+      }
+      return h;
+    });
+
+    // Only trigger re-render if something actually changed
+    const changed = updatedHumans.some(
+      (h, i) => h.presenceState !== this.v2HumanMembers[i].presenceState
+    );
+    if (changed) {
+      this.v2HumanMembers = updatedHumans;
+    }
+  }
+
+  /** Start sending presence heartbeats every 60s while the tab is focused. */
+  private startPresenceHeartbeat(): void {
+    // Stop any existing heartbeat
+    this.stopPresenceHeartbeat();
+
+    // Send initial heartbeat
+    this.sendPresenceHeartbeat();
+
+    // Send heartbeat every 60 seconds
+    this._presenceInterval = setInterval(() => {
+      if (document.hasFocus()) {
+        this.sendPresenceHeartbeat();
+      }
+    }, 60000);
+
+    // Send heartbeat on focus regain
+    window.addEventListener('focus', this._onFocusPresence);
+  }
+
+  /** Stop the presence heartbeat interval. */
+  private stopPresenceHeartbeat(): void {
+    if (this._presenceInterval) {
+      clearInterval(this._presenceInterval);
+      this._presenceInterval = null;
+    }
+    window.removeEventListener('focus', this._onFocusPresence);
+  }
+
+  /** Focus handler for presence heartbeat. */
+  private _onFocusPresence = (): void => {
+    this.sendPresenceHeartbeat();
+  };
+
+  /** Send a presence heartbeat to the server. */
+  private sendPresenceHeartbeat(): void {
+    void apiFetch('/api/v1/chat/presence', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectIds: this._presenceProjectIds }),
+    });
+  }
+
+  /** Handle member click from the members sidebar to open a DM. */
+  private handleMemberClick(e: CustomEvent): void {
+    const detail = e.detail as {
+      memberId: string;
+      memberKind: 'user' | 'agent';
+      displayName: string;
+    };
+    if (!detail) return;
+
+    const userId = this.pageData?.user?.id || '';
+    let dmKey: string;
+
+    if (detail.memberKind === 'agent') {
+      dmKey = `dm:agent:${detail.memberId}:user:${userId}`;
+    } else {
+      // Sort UUIDs lexically for consistent DM keys
+      const ids = [detail.memberId, userId].sort();
+      dmKey = `dm:user:${ids[0]}:user:${ids[1]}`;
+    }
+
+    // Navigate to the DM
+    navigateTo(`/chat/dm/${encodeURIComponent(dmKey)}`);
   }
 
   // =========================================================================
@@ -818,8 +986,8 @@ export class ScionPageChat extends LitElement {
     const isSelected =
       thread.agentId === this.selectedAgentId || thread.agentSlug === this.selectedAgentId;
     const displayName = thread.agentName || thread.agentSlug || thread.agentId;
-    const avatarColor = this.hashColor(thread.agentSlug || thread.agentId);
-    const initials = this.getInitials(displayName);
+    const avatarColor = hashColor(thread.agentSlug || thread.agentId);
+    const initials = getInitials(displayName);
     const timeStr = thread.lastMessage?.createdAt
       ? this.formatRelativeTime(thread.lastMessage.createdAt)
       : '';
@@ -894,7 +1062,12 @@ export class ScionPageChat extends LitElement {
             }}
           ></sl-icon-button>
         </div>
-        <div class="v2-members-body">Members sidebar (W5)</div>
+        <scion-chat-members
+          .humans=${this.v2HumanMembers}
+          .agents=${this.v2AgentMembers}
+          current-user-id="${this.pageData?.user?.id || ''}"
+          @member-click=${this.handleMemberClick}
+        ></scion-chat-members>
       </div>
     `;
   }
@@ -970,23 +1143,6 @@ export class ScionPageChat extends LitElement {
   }
 
   // ---- Shared utilities ----
-
-  private hashColor(str: string): string {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-      hash = str.charCodeAt(i) + ((hash << 5) - hash);
-    }
-    const hue = ((hash % 360) + 360) % 360;
-    return `hsl(${hue}, 55%, 48%)`;
-  }
-
-  private getInitials(name: string): string {
-    const parts = name.split(/[-_\s]+/).filter(Boolean);
-    if (parts.length >= 2) {
-      return (parts[0][0] + parts[1][0]).toUpperCase();
-    }
-    return (name.slice(0, 2) || '?').toUpperCase();
-  }
 
   private formatRelativeTime(iso: string): string {
     const d = new Date(iso);

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -17,6 +17,24 @@
 /**
  * Chat page component — top-level chat mode.
  *
+ * Wave-2 Architecture (default, web.native_chat_v2 ON):
+ *
+ * This is the primary entry point for Native Chat. Wave-2 adds shared spaces
+ * (one per project), multi-participant threads, DMs (agent and human),
+ * a members sidebar with presence indicators, typing indicators,
+ * notifications, file attachments, and message search.
+ *
+ * Key design decisions:
+ * - **Dual-dialect store**: webchat_topic, webchat_read_state, webchat_dm,
+ *   webchat_user_prefs tables (SQLite + Postgres) for chat-specific state.
+ *   Messages live in the existing messages table with ThreadID as the routing key.
+ * - **One persistence path**: messages are persisted once via the hub's
+ *   inprocess spoke; the web channel bus only updates watermarks.
+ * - **SSE via stateManager**: a single multiplexed SSE connection per client
+ *   replaces per-thread EventSource streams. Events are project-scoped.
+ * - **Feature flag**: `web.native_chat_v2` (default ON as of W9). Setting
+ *   it OFF reverts to the wave-1 agent-per-thread UI for rollback safety.
+ *
  * Renders inside `<scion-chat-shell>` and supports two modes:
  *
  * **V1 (web.native_chat_v2 OFF):**
@@ -25,10 +43,10 @@
  * - `/chat/:agentId` opens the thread for that agent
  *
  * **V2 (web.native_chat_v2 ON):**
- * - Space rail (chat-space-rail) replacing agent-based thread rail
- * - Conversation view refactored to key-based
+ * - Space rail (chat-space-rail) with project grouping, threads, DMs
+ * - Conversation view keyed by conversationKey (topic UUID or DM key)
  * - Routes: `/chat`, `/chat/space/{projectId}`, `/chat/space/{projectId}/thread/{topicId}`, `/chat/dm/{key}`
- * - Members sidebar toggle (placeholder for W5)
+ * - Members sidebar with presence, typing indicators, search panel
  */
 
 import { LitElement, html, css, nothing } from 'lit';
@@ -51,6 +69,7 @@ const loadChatMembers = () => import('../shared/chat/chat-members.js');
 const loadChatSearch = () => import('../shared/chat/chat-search.js');
 
 // ---- V1 types ----
+// DEPRECATED(wave-1): Remove after v2 is stable and flag is permanently ON.
 
 /** Shape of a thread entry from GET /api/v1/chat/threads */
 interface ChatThread {
@@ -428,7 +447,8 @@ export class ScionPageChat extends LitElement {
   }
 
   // =========================================================================
-  // V1 Methods (preserved for flag-off compat)
+  // DEPRECATED(wave-1): Remove after v2 is stable and flag is permanently ON.
+  // V1 Methods — preserved for rollback when web.native_chat_v2 is OFF.
   // =========================================================================
 
   private handleUserMessage(): void {
@@ -945,7 +965,7 @@ export class ScionPageChat extends LitElement {
     return this.renderV1();
   }
 
-  // ---- V1 Render ----
+  // ---- DEPRECATED(wave-1): Remove after v2 is stable and flag is permanently ON. ----
 
   private renderV1() {
     return html`

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -47,6 +47,8 @@ import '../shared/chat/chat-thread.js';
 const loadSpaceRail = () => import('../shared/chat/chat-space-rail.js');
 // Lazy-load the members sidebar only when v2 is active
 const loadChatMembers = () => import('../shared/chat/chat-members.js');
+// Lazy-load the search component only when v2 is active
+const loadChatSearch = () => import('../shared/chat/chat-search.js');
 
 // ---- V1 types ----
 
@@ -119,6 +121,10 @@ export class ScionPageChat extends LitElement {
   private _onChatTopic = this.handleChatTopic.bind(this);
   private _onPresenceUpdated = this.handlePresenceUpdated.bind(this);
   private _onRailLoaded = this.handleRailLoaded.bind(this);
+  /** Whether the search panel is visible. */
+  @state() private v2SearchActive = false;
+  /** Whether the search component has been lazy-loaded. */
+  @state() private v2SearchLoaded = false;
   /** Presence heartbeat interval timer. */
   private _presenceInterval: ReturnType<typeof setInterval> | null = null;
   /** Tracked project IDs for presence heartbeat. */
@@ -1085,6 +1091,12 @@ export class ScionPageChat extends LitElement {
                 style="font-size: 0.875rem; color: var(--scion-text-muted)"
               ></sl-icon>
               <span>${conv.peerName}</span>
+              <sl-icon-button
+                class="members-btn"
+                name="search"
+                label="Search messages"
+                @click=${() => void this.openSearch()}
+              ></sl-icon-button>
             </div>
           `
         : conv.threadName
@@ -1104,6 +1116,12 @@ export class ScionPageChat extends LitElement {
                   : nothing}
                 <sl-icon-button
                   class="members-btn"
+                  name="search"
+                  label="Search messages"
+                  @click=${() => void this.openSearch()}
+                ></sl-icon-button>
+                <sl-icon-button
+                  class="members-btn"
                   name="people"
                   label="Toggle members"
                   @click=${() => {
@@ -1113,18 +1131,76 @@ export class ScionPageChat extends LitElement {
               </div>
             `
           : nothing}
-      <scion-chat-thread
-        conversationKey=${conv.conversationKey}
-        projectId=${conv.projectId}
-        threadName=${conv.threadName}
-        defaultAgent=${conv.defaultAgent}
-        ?isDM=${conv.isDM}
-        peerName=${conv.peerName}
-        ?canSend=${true}
-        .members=${this.v2Members}
-        .agents=${this.getAgentsFromMembers()}
-      ></scion-chat-thread>
+      ${this.v2SearchActive && this.v2SearchLoaded
+        ? html`
+            <scion-chat-search
+              projectId=${conv.projectId}
+              conversationKey=${conv.conversationKey}
+              conversationName=${conv.isDM ? conv.peerName : conv.threadName ? '#' + conv.threadName : ''}
+              @search-close=${this.handleSearchClose}
+              @search-navigate=${this.handleSearchNavigate}
+            ></scion-chat-search>
+          `
+        : html`
+            <scion-chat-thread
+              conversationKey=${conv.conversationKey}
+              projectId=${conv.projectId}
+              threadName=${conv.threadName}
+              defaultAgent=${conv.defaultAgent}
+              ?isDM=${conv.isDM}
+              peerName=${conv.peerName}
+              ?canSend=${true}
+              .members=${this.v2Members}
+              .agents=${this.getAgentsFromMembers()}
+            ></scion-chat-thread>
+          `}
     `;
+  }
+
+  /** Open the search panel, lazy-loading the component if needed. */
+  private async openSearch(): Promise<void> {
+    if (!this.v2SearchLoaded) {
+      await loadChatSearch();
+      this.v2SearchLoaded = true;
+    }
+    this.v2SearchActive = true;
+    // Focus the search input after render.
+    requestAnimationFrame(() => {
+      const search = this.shadowRoot?.querySelector('scion-chat-search') as
+        | import('../shared/chat/chat-search.js').ScionChatSearch
+        | null;
+      search?.open();
+    });
+  }
+
+  /** Handle search panel close. */
+  private handleSearchClose(): void {
+    this.v2SearchActive = false;
+  }
+
+  /** Handle navigation from a search result click. */
+  private handleSearchNavigate(e: CustomEvent): void {
+    const detail = e.detail as {
+      conversationKey: string;
+      messageId: string;
+      projectId: string;
+    };
+    if (!detail) return;
+
+    this.v2SearchActive = false;
+
+    // If the result is in a different conversation, navigate to it.
+    if (detail.conversationKey !== this.v2Conversation?.conversationKey) {
+      const isDM = detail.conversationKey.startsWith('dm:');
+      if (isDM) {
+        navigateTo(`/chat/dm/${encodeURIComponent(detail.conversationKey)}`);
+      } else if (detail.projectId) {
+        navigateTo(
+          `/chat/space/${encodeURIComponent(detail.projectId)}/thread/${encodeURIComponent(detail.conversationKey)}`
+        );
+      }
+    }
+    // TODO: scroll to the specific messageId within the conversation
   }
 
   /** Extract agent members as Agent-like objects for the mention autocomplete. */

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -15,17 +15,20 @@
  */
 
 /**
- * Chat page component for the top-level chat mode (Phase 5).
+ * Chat page component — top-level chat mode.
  *
- * Renders inside `<scion-chat-shell>` and provides:
+ * Renders inside `<scion-chat-shell>` and supports two modes:
+ *
+ * **V1 (web.native_chat_v2 OFF):**
  * - Thread rail listing agents with last-message preview and unread dot
- * - Selecting a thread opens the existing `<scion-chat-thread>` component
  * - `/chat` shows the rail with no thread selected
  * - `/chat/:agentId` opens the thread for that agent
  *
- * The thread rail reads from `GET /api/v1/chat/threads` which queries
- * the `webchat_thread` table — no aggregate query (AC19a).
- * Unread is a boolean (hasUnread), not a count — a dot is what the rail renders.
+ * **V2 (web.native_chat_v2 ON):**
+ * - Space rail (chat-space-rail) replacing agent-based thread rail
+ * - Conversation view refactored to key-based
+ * - Routes: `/chat`, `/chat/space/{projectId}`, `/chat/space/{projectId}/thread/{topicId}`, `/chat/dm/{key}`
+ * - Members sidebar toggle (placeholder for W5)
  */
 
 import { LitElement, html, css, nothing } from 'lit';
@@ -36,7 +39,13 @@ import { can } from '../../shared/types.js';
 import { apiFetch } from '../../client/api.js';
 import { navigateTo, stateManager } from '../../client/main.js';
 import { dispatchPageTitle } from '../../client/page-title.js';
+import { isFeatureEnabled, NATIVE_CHAT_V2_FLAG } from '../../utils/feature-flags.js';
 import '../shared/chat/chat-thread.js';
+
+// Lazy-load the space rail only when v2 is active
+const loadSpaceRail = () => import('../shared/chat/chat-space-rail.js');
+
+// ---- V1 types ----
 
 /** Shape of a thread entry from GET /api/v1/chat/threads */
 interface ChatThread {
@@ -54,28 +63,53 @@ interface ChatThread {
   hasUnread: boolean;
 }
 
+// ---- V2 types ----
+
+interface V2ConversationState {
+  conversationKey: string;
+  projectId: string;
+  threadName: string;
+  defaultAgent: string;
+  isDM: boolean;
+  peerName: string;
+  peerId: string;
+  peerKind: 'user' | 'agent';
+}
+
+interface SpaceMember {
+  id: string;
+  name: string;
+  email: string;
+  avatarUrl?: string;
+  kind: 'user' | 'agent';
+}
+
 @customElement('scion-page-chat')
 export class ScionPageChat extends LitElement {
   @property({ type: Object })
   pageData: PageData | null = null;
 
+  // ---- Shared state ----
+  private isV2 = isFeatureEnabled(NATIVE_CHAT_V2_FLAG);
+
+  // ---- V1 state ----
   @state() private threads: ChatThread[] = [];
   @state() private loadingThreads = false;
   @state() private selectedAgentId = '';
   @state() private selectedAgentName = '';
   @state() private selectedAgentCanSend = false;
-
-  /** Cached agent capabilities keyed by agentId, fetched when a thread is selected. */
   private agentCapabilities = new Map<string, Capabilities | undefined>();
-
-  /** Bound listener for SSE message events — used to refresh the thread rail. */
   private _onUserMessage = this.handleUserMessage.bind(this);
-
-  /** Debounce timer for rail refresh to avoid rapid-fire reloads. */
   private _refreshTimer: ReturnType<typeof setTimeout> | null = null;
-
-  /** Cached project ID to avoid redundant /api/v1/projects?limit=1 fetches. */
   private _cachedProjectId = '';
+
+  // ---- V2 state ----
+  @state() private v2Conversation: V2ConversationState | null = null;
+  @state() private v2Members: SpaceMember[] = [];
+  @state() private v2MembersExpanded = false;
+  @state() private v2SpaceRailLoaded = false;
+  private _onChatMessage = this.handleChatMessage.bind(this);
+  private _onChatTopic = this.handleChatTopic.bind(this);
 
   static override styles = css`
     :host {
@@ -84,7 +118,8 @@ export class ScionPageChat extends LitElement {
       overflow: hidden;
     }
 
-    /* Thread rail (left sidebar) */
+    /* ---- V1 Layout ---- */
+
     .thread-rail {
       width: 300px;
       min-width: 240px;
@@ -128,7 +163,6 @@ export class ScionPageChat extends LitElement {
       padding: 0.25rem 0;
     }
 
-    /* Individual thread item */
     .thread-item {
       display: flex;
       align-items: flex-start;
@@ -149,7 +183,6 @@ export class ScionPageChat extends LitElement {
       border-left-color: var(--scion-primary, #3b82f6);
     }
 
-    /* Agent avatar (color + initials) */
     .agent-avatar {
       width: 36px;
       height: 36px;
@@ -202,7 +235,8 @@ export class ScionPageChat extends LitElement {
       flex-shrink: 0;
     }
 
-    /* Main content area (thread view or empty state) */
+    /* ---- Shared layout ---- */
+
     .thread-content {
       flex: 1;
       display: flex;
@@ -236,7 +270,6 @@ export class ScionPageChat extends LitElement {
       font-size: 0.875rem;
     }
 
-    /* Loading state */
     .loading-rail {
       display: flex;
       align-items: center;
@@ -245,18 +278,86 @@ export class ScionPageChat extends LitElement {
       color: var(--scion-text-muted, #64748b);
     }
 
-    /* Responsive: on mobile, hide the rail when a thread is selected */
+    /* ---- V2 Layout ---- */
+
+    .v2-rail {
+      width: 260px;
+      min-width: 200px;
+      max-width: 320px;
+      border-right: 1px solid var(--scion-border, #e2e8f0);
+      overflow: hidden;
+    }
+
+    .v2-members {
+      width: 240px;
+      border-left: 1px solid var(--scion-border, #e2e8f0);
+      background: var(--scion-surface, #ffffff);
+      display: flex;
+      flex-direction: column;
+    }
+
+    .v2-members.collapsed {
+      display: none;
+    }
+
+    .v2-members-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.75rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      font-size: 0.8125rem;
+      font-weight: 600;
+    }
+
+    .v2-members-body {
+      flex: 1;
+      overflow-y: auto;
+      padding: 0.5rem;
+      font-size: 0.8125rem;
+      color: var(--scion-text-muted, #64748b);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .v2-thread-header {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+      background: var(--scion-surface, #ffffff);
+    }
+
+    .v2-thread-header .hash {
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .v2-thread-header .members-btn {
+      margin-left: auto;
+    }
+
     @media (max-width: 768px) {
-      .thread-rail {
+      .thread-rail,
+      .v2-rail {
         width: 100%;
         max-width: none;
       }
 
-      :host(.thread-open) .thread-rail {
+      :host(.thread-open) .thread-rail,
+      :host(.thread-open) .v2-rail {
         display: none;
       }
 
       :host(:not(.thread-open)) .thread-content {
+        display: none;
+      }
+
+      .v2-members {
         display: none;
       }
     }
@@ -264,16 +365,24 @@ export class ScionPageChat extends LitElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this.parseRoute();
-    void this.loadThreads();
 
-    // Subscribe to SSE message events to refresh the thread rail (O5).
-    stateManager.addEventListener('user-message-created', this._onUserMessage);
+    if (this.isV2) {
+      void this.initV2();
+    } else {
+      this.parseRoute();
+      void this.loadThreads();
+      stateManager.addEventListener('user-message-created', this._onUserMessage);
+    }
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    stateManager.removeEventListener('user-message-created', this._onUserMessage);
+    if (this.isV2) {
+      stateManager.removeEventListener('chat-message-received', this._onChatMessage);
+      stateManager.removeEventListener('chat-topic-updated', this._onChatTopic);
+    } else {
+      stateManager.removeEventListener('user-message-created', this._onUserMessage);
+    }
     if (this._refreshTimer) {
       clearTimeout(this._refreshTimer);
       this._refreshTimer = null;
@@ -282,14 +391,18 @@ export class ScionPageChat extends LitElement {
 
   override updated(changedProperties: Map<string, unknown>): void {
     if (changedProperties.has('pageData') && this.pageData) {
-      this.parseRoute();
+      if (this.isV2) {
+        this.parseV2Route();
+      } else {
+        this.parseRoute();
+      }
     }
   }
 
-  /**
-   * Handle SSE user-message events — debounce and reload the thread rail.
-   * Uses a 2-second debounce to avoid rapid-fire reloads during bursts.
-   */
+  // =========================================================================
+  // V1 Methods (preserved for flag-off compat)
+  // =========================================================================
+
   private handleUserMessage(): void {
     if (this._refreshTimer) {
       clearTimeout(this._refreshTimer);
@@ -300,7 +413,6 @@ export class ScionPageChat extends LitElement {
     }, 2000);
   }
 
-  /** Parse the current path to determine selected agent. */
   private parseRoute(): void {
     const path = this.pageData?.path || window.location.pathname;
     const match = path.match(/\/chat\/([^/]+)/);
@@ -308,10 +420,8 @@ export class ScionPageChat extends LitElement {
 
     if (newAgentId !== this.selectedAgentId) {
       this.selectedAgentId = newAgentId;
-      // Update class for responsive layout
       if (newAgentId) {
         this.classList.add('thread-open');
-        // Fetch capabilities to gate the compose box (O3).
         void this.fetchAgentCapabilities(newAgentId);
       } else {
         this.classList.remove('thread-open');
@@ -320,14 +430,10 @@ export class ScionPageChat extends LitElement {
     }
   }
 
-  /** Load thread list from the API. */
   private async loadThreads(): Promise<void> {
     this.loadingThreads = true;
 
     try {
-      // Use the first project the user has access to.
-      // The projectId must be determined from context. For now,
-      // look at the SSR page data or fetch the projects list.
       const projectId = await this.resolveProjectId();
       if (!projectId) {
         this.loadingThreads = false;
@@ -342,23 +448,20 @@ export class ScionPageChat extends LitElement {
         const data = (await res.json()) as { threads: ChatThread[] };
         this.threads = data.threads || [];
 
-        // If a thread is selected, try to find its name
         if (this.selectedAgentId) {
           this.resolveSelectedAgentName();
         }
       }
     } catch {
-      // Silently fail — rail will show empty
+      // Silently fail
     } finally {
       this.loadingThreads = false;
     }
   }
 
-  /** Resolve the project ID from page context. */
   private async resolveProjectId(): Promise<string> {
     if (this._cachedProjectId) return this._cachedProjectId;
 
-    // Try to get from URL query param
     const url = new URL(window.location.href);
     const qProject = url.searchParams.get('projectId');
     if (qProject) {
@@ -366,7 +469,6 @@ export class ScionPageChat extends LitElement {
       return qProject;
     }
 
-    // Fall back to fetching the user's projects and using the first one
     try {
       const res = await apiFetch('/api/v1/projects?limit=1');
       if (res.ok) {
@@ -383,7 +485,6 @@ export class ScionPageChat extends LitElement {
     return '';
   }
 
-  /** Update selectedAgentName from the thread list or API. */
   private resolveSelectedAgentName(): void {
     const thread = this.threads.find(
       (t) => t.agentId === this.selectedAgentId || t.agentSlug === this.selectedAgentId
@@ -394,9 +495,7 @@ export class ScionPageChat extends LitElement {
     }
   }
 
-  /** Fetch and cache agent capabilities to determine canSend. */
   private async fetchAgentCapabilities(agentId: string): Promise<void> {
-    // Return cached value if available.
     if (this.agentCapabilities.has(agentId)) {
       this.selectedAgentCanSend = can(this.agentCapabilities.get(agentId), 'message');
       return;
@@ -410,12 +509,10 @@ export class ScionPageChat extends LitElement {
         this.selectedAgentCanSend = can(agent._capabilities, 'message');
       }
     } catch {
-      // On failure, fail-closed: disable send.
       this.selectedAgentCanSend = false;
     }
   }
 
-  /** Mark a thread as read when opened. */
   private async markThreadRead(agentId: string): Promise<void> {
     const projectId = await this.resolveProjectId();
     if (!projectId) return;
@@ -425,17 +522,14 @@ export class ScionPageChat extends LitElement {
         `/api/v1/chat/threads/${encodeURIComponent(agentId)}/read?projectId=${encodeURIComponent(projectId)}`,
         { method: 'POST' }
       );
-
-      // Clear the unread indicator locally
       this.threads = this.threads.map((t) =>
         t.agentId === agentId ? { ...t, hasUnread: false } : t
       );
     } catch {
-      // Non-critical — unread dot will persist until next load
+      // Non-critical
     }
   }
 
-  /** Handle thread selection from the rail. */
   private selectThread(thread: ChatThread): void {
     const agentRef = thread.agentSlug || thread.agentId;
     navigateTo(`/chat/${encodeURIComponent(agentRef)}`);
@@ -444,19 +538,192 @@ export class ScionPageChat extends LitElement {
     this.classList.add('thread-open');
     dispatchPageTitle(this, this.selectedAgentName, 'Chat');
 
-    // Fetch capabilities to gate the compose box (O3).
     void this.fetchAgentCapabilities(thread.agentId);
-
-    // Mark as read (AC19b — server-side watermark)
     void this.markThreadRead(thread.agentId);
   }
 
+  // =========================================================================
+  // V2 Methods
+  // =========================================================================
+
+  private async initV2(): Promise<void> {
+    // Lazy-load the space rail component
+    await loadSpaceRail();
+    this.v2SpaceRailLoaded = true;
+
+    // Parse initial route
+    this.parseV2Route();
+
+    // Subscribe to SSE events
+    stateManager.addEventListener('chat-message-received', this._onChatMessage);
+    stateManager.addEventListener('chat-topic-updated', this._onChatTopic);
+  }
+
+  private parseV2Route(): void {
+    const path = this.pageData?.path || window.location.pathname;
+
+    // Match /chat/space/{projectId}/thread/{topicId}
+    const threadMatch = path.match(/\/chat\/space\/([^/]+)\/thread\/([^/]+)/);
+    if (threadMatch) {
+      const projectId = decodeURIComponent(threadMatch[1]);
+      const topicId = decodeURIComponent(threadMatch[2]);
+      this.v2Conversation = {
+        conversationKey: topicId,
+        projectId,
+        threadName: '', // Will be resolved from rail data
+        defaultAgent: '',
+        isDM: false,
+        peerName: '',
+        peerId: '',
+        peerKind: 'user',
+      };
+      this.classList.add('thread-open');
+      void this.loadV2Members(projectId);
+      dispatchPageTitle(this, 'Thread', 'Chat');
+      return;
+    }
+
+    // Match /chat/space/{projectId} — open #general
+    const spaceMatch = path.match(/\/chat\/space\/([^/]+)$/);
+    if (spaceMatch) {
+      // Space selected but no specific thread — will be resolved when rail loads
+      this.classList.add('thread-open');
+      return;
+    }
+
+    // Match /chat/dm/{key}
+    const dmMatch = path.match(/\/chat\/dm\/(.+)$/);
+    if (dmMatch) {
+      const key = decodeURIComponent(dmMatch[1]);
+      this.v2Conversation = {
+        conversationKey: key,
+        projectId: '',
+        threadName: '',
+        defaultAgent: '',
+        isDM: true,
+        peerName: '', // Will be resolved from DM data
+        peerId: '',
+        peerKind: 'user',
+      };
+      this.classList.add('thread-open');
+      dispatchPageTitle(this, 'DM', 'Chat');
+      return;
+    }
+
+    // /chat — no conversation selected
+    this.v2Conversation = null;
+    this.classList.remove('thread-open');
+  }
+
+  private handleChatMessage(): void {
+    // Debounce: reload the rail + backfill conversation
+    if (this._refreshTimer) clearTimeout(this._refreshTimer);
+    this._refreshTimer = setTimeout(() => {
+      this._refreshTimer = null;
+      const rail = this.shadowRoot?.querySelector('scion-chat-space-rail') as
+        | import('../shared/chat/chat-space-rail.js').ScionChatSpaceRail
+        | null;
+      if (rail) void rail.reload();
+    }, 2000);
+  }
+
+  private handleChatTopic(): void {
+    // Reload the rail when topics change
+    const rail = this.shadowRoot?.querySelector('scion-chat-space-rail') as
+      | import('../shared/chat/chat-space-rail.js').ScionChatSpaceRail
+      | null;
+    if (rail) void rail.reload();
+  }
+
+  private handleThreadSelect(e: CustomEvent): void {
+    const detail = e.detail as {
+      conversationKey: string;
+      projectId: string;
+      threadName: string;
+      defaultAgent?: string;
+    };
+    navigateTo(
+      `/chat/space/${encodeURIComponent(detail.projectId)}/thread/${encodeURIComponent(detail.conversationKey)}`
+    );
+    this.v2Conversation = {
+      conversationKey: detail.conversationKey,
+      projectId: detail.projectId,
+      threadName: detail.threadName,
+      defaultAgent: detail.defaultAgent || '',
+      isDM: false,
+      peerName: '',
+      peerId: '',
+      peerKind: 'user',
+    };
+    this.classList.add('thread-open');
+    dispatchPageTitle(this, `#${detail.threadName}`, 'Chat');
+    void this.loadV2Members(detail.projectId);
+  }
+
+  private handleDMSelect(e: CustomEvent): void {
+    const detail = e.detail as {
+      conversationKey: string;
+      peerName: string;
+      peerId: string;
+      peerKind: 'user' | 'agent';
+    };
+    navigateTo(`/chat/dm/${encodeURIComponent(detail.conversationKey)}`);
+    this.v2Conversation = {
+      conversationKey: detail.conversationKey,
+      projectId: '',
+      threadName: '',
+      defaultAgent: '',
+      isDM: true,
+      peerName: detail.peerName,
+      peerId: detail.peerId,
+      peerKind: detail.peerKind,
+    };
+    this.classList.add('thread-open');
+    dispatchPageTitle(this, detail.peerName, 'Chat');
+  }
+
+  private handleNavigateApp(): void {
+    navigateTo('/');
+  }
+
+  private async loadV2Members(projectId: string): Promise<void> {
+    if (!projectId) return;
+    try {
+      const res = await apiFetch(`/api/v1/chat/spaces/${encodeURIComponent(projectId)}/members`);
+      if (res.ok) {
+        const data = (await res.json()) as { members?: SpaceMember[] };
+        this.v2Members = data.members || [];
+      }
+    } catch {
+      // Non-critical
+    }
+  }
+
+  // =========================================================================
+  // Render
+  // =========================================================================
+
   override render() {
+    if (this.isV2) {
+      return this.renderV2();
+    }
+    return this.renderV1();
+  }
+
+  // ---- V1 Render ----
+
+  private renderV1() {
     return html`
       <div class="thread-rail">
         <div class="rail-header">
           <span>Conversations</span>
-          <a href="/" @click=${(e: Event) => { e.preventDefault(); navigateTo('/'); }}>
+          <a
+            href="/"
+            @click=${(e: Event) => {
+              e.preventDefault();
+              navigateTo('/');
+            }}
+          >
             <sl-icon name="arrow-left"></sl-icon>
             App
           </a>
@@ -465,7 +732,9 @@ export class ScionPageChat extends LitElement {
           ${this.loadingThreads
             ? html`<div class="loading-rail"><sl-spinner></sl-spinner></div>`
             : this.threads.length === 0
-              ? html`<div class="loading-rail" style="font-size: 0.8125rem">No conversations yet</div>`
+              ? html`<div class="loading-rail" style="font-size: 0.8125rem">
+                  No conversations yet
+                </div>`
               : this.threads.map((t) => this.renderThreadItem(t))}
         </div>
       </div>
@@ -486,8 +755,7 @@ export class ScionPageChat extends LitElement {
 
   private renderThreadItem(thread: ChatThread) {
     const isSelected =
-      thread.agentId === this.selectedAgentId ||
-      thread.agentSlug === this.selectedAgentId;
+      thread.agentId === this.selectedAgentId || thread.agentSlug === this.selectedAgentId;
     const displayName = thread.agentName || thread.agentSlug || thread.agentId;
     const avatarColor = this.hashColor(thread.agentSlug || thread.agentId);
     const initials = this.getInitials(displayName);
@@ -500,9 +768,7 @@ export class ScionPageChat extends LitElement {
         class="thread-item ${isSelected ? 'selected' : ''}"
         @click=${() => this.selectThread(thread)}
       >
-        <div class="agent-avatar" style="background: ${avatarColor}">
-          ${initials}
-        </div>
+        <div class="agent-avatar" style="background: ${avatarColor}">${initials}</div>
         <div class="thread-info">
           <div class="thread-name">
             <span>${displayName}</span>
@@ -527,7 +793,113 @@ export class ScionPageChat extends LitElement {
     `;
   }
 
-  /** Generate a deterministic color from a string (agent slug). */
+  // ---- V2 Render ----
+
+  private renderV2() {
+    return html`
+      <div class="v2-rail">
+        ${this.v2SpaceRailLoaded
+          ? html`
+              <scion-chat-space-rail
+                selectedKey=${this.v2Conversation?.conversationKey || ''}
+                @thread-select=${this.handleThreadSelect}
+                @dm-select=${this.handleDMSelect}
+                @navigate-app=${this.handleNavigateApp}
+              ></scion-chat-space-rail>
+            `
+          : html`<div class="loading-rail"><sl-spinner></sl-spinner></div>`}
+      </div>
+
+      <div class="thread-content">
+        ${this.v2Conversation
+          ? this.renderV2Conversation()
+          : html`
+              <div class="empty-state">
+                <sl-icon name="chat-dots"></sl-icon>
+                <span class="title">Select a conversation</span>
+                <span class="subtitle">Choose a thread or DM from the left to start chatting</span>
+              </div>
+            `}
+      </div>
+
+      <div class="v2-members ${this.v2MembersExpanded ? '' : 'collapsed'}">
+        <div class="v2-members-header">
+          <span>Members</span>
+          <sl-icon-button
+            name="x-lg"
+            label="Close"
+            @click=${() => {
+              this.v2MembersExpanded = false;
+            }}
+          ></sl-icon-button>
+        </div>
+        <div class="v2-members-body">Members sidebar (W5)</div>
+      </div>
+    `;
+  }
+
+  private renderV2Conversation() {
+    if (!this.v2Conversation) return nothing;
+    const conv = this.v2Conversation;
+
+    return html`
+      ${conv.threadName
+        ? html`
+            <div class="v2-thread-header">
+              <span class="hash">#</span>
+              <span>${conv.threadName}</span>
+              ${conv.defaultAgent
+                ? html`
+                    <sl-tooltip content="Default agent: ${conv.defaultAgent}">
+                      <sl-icon
+                        name="cpu"
+                        style="font-size: 0.75rem; color: var(--scion-text-muted)"
+                      ></sl-icon>
+                    </sl-tooltip>
+                  `
+                : nothing}
+              <sl-icon-button
+                class="members-btn"
+                name="people"
+                label="Toggle members"
+                @click=${() => {
+                  this.v2MembersExpanded = !this.v2MembersExpanded;
+                }}
+              ></sl-icon-button>
+            </div>
+          `
+        : nothing}
+      <scion-chat-thread
+        conversationKey=${conv.conversationKey}
+        projectId=${conv.projectId}
+        threadName=${conv.threadName}
+        defaultAgent=${conv.defaultAgent}
+        ?isDM=${conv.isDM}
+        peerName=${conv.peerName}
+        ?canSend=${true}
+        .members=${this.v2Members}
+        .agents=${this.getAgentsFromMembers()}
+      ></scion-chat-thread>
+    `;
+  }
+
+  /** Extract agent members as Agent-like objects for the mention autocomplete. */
+  private getAgentsFromMembers(): import('../../shared/types.js').Agent[] {
+    return this.v2Members
+      .filter((m) => m.kind === 'agent')
+      .map((m) => ({
+        id: m.id,
+        name: m.name,
+        slug: m.name,
+        projectId: this.v2Conversation?.projectId || '',
+        template: '',
+        phase: 'running' as const,
+        status: 'active' as const,
+      }));
+  }
+
+  // ---- Shared utilities ----
+
   private hashColor(str: string): string {
     let hash = 0;
     for (let i = 0; i < str.length; i++) {
@@ -537,7 +909,6 @@ export class ScionPageChat extends LitElement {
     return `hsl(${hue}, 55%, 48%)`;
   }
 
-  /** Get 1-2 character initials from a name. */
   private getInitials(name: string): string {
     const parts = name.split(/[-_\s]+/).filter(Boolean);
     if (parts.length >= 2) {
@@ -546,7 +917,6 @@ export class ScionPageChat extends LitElement {
     return (name.slice(0, 2) || '?').toUpperCase();
   }
 
-  /** Format a timestamp as a relative time string. */
   private formatRelativeTime(iso: string): string {
     const d = new Date(iso);
     if (isNaN(d.getTime())) return '';

--- a/web/src/components/pages/diagnostics.ts
+++ b/web/src/components/pages/diagnostics.ts
@@ -236,9 +236,7 @@ export class ScionPageDiagnostics extends LitElement {
 
   private buildCloudLoggingUrl(severity: string): string {
     if (!this.gcpProjectId) return '';
-    const filterParts = [
-      `logName != "projects/${this.gcpProjectId}/logs/scion_request_log"`,
-    ];
+    const filterParts = [`logName != "projects/${this.gcpProjectId}/logs/scion_request_log"`];
     if (severity && severity !== 'DEFAULT') {
       filterParts.push(`severity >= ${severity}`);
     }
@@ -292,8 +290,18 @@ export class ScionPageDiagnostics extends LitElement {
   private renderStatusBanner() {
     const health = this.hubHealth;
     const status = health?.status || 'unknown';
-    const statusClass = status === 'ok' || status === 'healthy' ? 'healthy' : status === 'unknown' ? 'unknown' : 'unhealthy';
-    const statusLabel = status === 'ok' || status === 'healthy' ? 'Healthy' : status === 'unknown' ? 'Unknown' : status;
+    const statusClass =
+      status === 'ok' || status === 'healthy'
+        ? 'healthy'
+        : status === 'unknown'
+          ? 'unknown'
+          : 'unhealthy';
+    const statusLabel =
+      status === 'ok' || status === 'healthy'
+        ? 'Healthy'
+        : status === 'unknown'
+          ? 'Unknown'
+          : status;
 
     const cloudStatus = this.cloudLoggingChecked
       ? this.cloudLoggingAvailable
@@ -331,9 +339,7 @@ export class ScionPageDiagnostics extends LitElement {
             : nothing}
         </div>
         <div class="status-right">
-          <a class="health-link" @click=${() => this.handleNavClick('/health')}>
-            View Health →
-          </a>
+          <a class="health-link" @click=${() => this.handleNavClick('/health')}> View Health → </a>
         </div>
       </div>
     `;
@@ -362,8 +368,8 @@ export class ScionPageDiagnostics extends LitElement {
           Cloud Logging is not configured
         </h3>
         <p>
-          The diagnostics log viewer requires Google Cloud Logging to
-          aggregate logs from hub, broker, and agent components.
+          The diagnostics log viewer requires Google Cloud Logging to aggregate logs from hub,
+          broker, and agent components.
         </p>
         <p>To enable:</p>
         <ol>
@@ -372,8 +378,8 @@ export class ScionPageDiagnostics extends LitElement {
           <li>Ensure the service account has <code>roles/logging.viewer</code></li>
         </ol>
         <p class="degradation-note">
-          Individual agent logs are still available on each agent's
-          detail page via the broker log relay.
+          Individual agent logs are still available on each agent's detail page via the broker log
+          relay.
         </p>
       </div>
     `;

--- a/web/src/components/pages/github-app-setup.ts
+++ b/web/src/components/pages/github-app-setup.ts
@@ -132,9 +132,7 @@ export class ScionPageGitHubAppSetup extends LitElement {
         };
         // Update the project in our list
         this.projects = this.projects.map((p) =>
-          p.id === project.id
-            ? { ...p, githubAppStatus: data.status || p.githubAppStatus }
-            : p
+          p.id === project.id ? { ...p, githubAppStatus: data.status || p.githubAppStatus } : p
         );
       }
     } catch (err) {
@@ -147,12 +145,8 @@ export class ScionPageGitHubAppSetup extends LitElement {
   }
 
   private async checkAllProjects(): Promise<void> {
-    const projectsWithInstallation = this.projects.filter(
-      (p) => p.githubInstallationId
-    );
-    await Promise.allSettled(
-      projectsWithInstallation.map((p) => this.checkProjectStatus(p))
-    );
+    const projectsWithInstallation = this.projects.filter((p) => p.githubInstallationId);
+    await Promise.allSettled(projectsWithInstallation.map((p) => this.checkProjectStatus(p)));
   }
 
   private navigateTo(path: string): void {
@@ -408,7 +402,10 @@ export class ScionPageGitHubAppSetup extends LitElement {
           <sl-icon name="github"></sl-icon>
           GitHub App Setup
         </h1>
-        <p>Your GitHub App installation has been recorded. Set up projects for your repositories below.</p>
+        <p>
+          Your GitHub App installation has been recorded. Set up projects for your repositories
+          below.
+        </p>
       </div>
 
       ${this.error
@@ -419,7 +416,6 @@ export class ScionPageGitHubAppSetup extends LitElement {
             </div>
           `
         : nothing}
-
       ${this.discoveryResult && this.discoveryResult.matched > 0
         ? html`
             <div class="success-banner">
@@ -436,10 +432,7 @@ export class ScionPageGitHubAppSetup extends LitElement {
       <div class="actions-card">
         <h2>Get Started</h2>
         <p>Create a new project linked to a GitHub repository to start running agents.</p>
-        <sl-button
-          variant="primary"
-          @click=${() => this.navigateTo('/projects/new')}
-        >
+        <sl-button variant="primary" @click=${() => this.navigateTo('/projects/new')}>
           <sl-icon slot="prefix" name="folder-plus"></sl-icon>
           Create New Project
         </sl-button>

--- a/web/src/components/pages/harness-config-detail.ts
+++ b/web/src/components/pages/harness-config-detail.ts
@@ -275,9 +275,15 @@ export class ScionPageHarnessConfigDetail extends LitElement {
       font-size: 0.75rem;
       font-weight: 500;
     }
-    .build-status-badge.running { color: var(--sl-color-primary-600); }
-    .build-status-badge.completed { color: var(--sl-color-success-600); }
-    .build-status-badge.failed { color: var(--sl-color-danger-600); }
+    .build-status-badge.running {
+      color: var(--sl-color-primary-600);
+    }
+    .build-status-badge.completed {
+      color: var(--sl-color-success-600);
+    }
+    .build-status-badge.failed {
+      color: var(--sl-color-danger-600);
+    }
 
     .source-url {
       display: inline-flex;
@@ -295,8 +301,12 @@ export class ScionPageHarnessConfigDetail extends LitElement {
       font-size: 0.85rem;
       margin-top: 0.5rem;
     }
-    .reimport-status.success { color: var(--sl-color-success-600); }
-    .reimport-status.error { color: var(--sl-color-danger-600); }
+    .reimport-status.success {
+      color: var(--sl-color-success-600);
+    }
+    .reimport-status.error {
+      color: var(--sl-color-danger-600);
+    }
 
     .build-error {
       color: var(--sl-color-danger-600);
@@ -452,8 +462,12 @@ export class ScionPageHarnessConfigDetail extends LitElement {
       border-radius: 50%;
       margin-right: 0.25rem;
     }
-    .reachable-dot.online { background: var(--sl-color-success-500); }
-    .reachable-dot.offline { background: var(--sl-color-neutral-400); }
+    .reachable-dot.online {
+      background: var(--sl-color-success-500);
+    }
+    .reachable-dot.offline {
+      background: var(--sl-color-neutral-400);
+    }
     .proxy-info-note {
       font-size: 0.8125rem;
       color: var(--sl-color-neutral-500);
@@ -543,7 +557,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
         throw new Error(await extractApiError(response, `HTTP ${response.status}`));
       }
       this.harnessConfig = (await response.json()) as HarnessConfig;
-      this.hasDockerfile = this.harnessConfig.files?.some(f => f.path === 'Dockerfile') ?? false;
+      this.hasDockerfile = this.harnessConfig.files?.some((f) => f.path === 'Dockerfile') ?? false;
       dispatchPageTitle(
         this,
         this.harnessConfig.displayName || this.harnessConfig.name || this.harnessConfigId,
@@ -627,7 +641,8 @@ export class ScionPageHarnessConfigDetail extends LitElement {
         )}
       </div>
 
-      ${this.renderHeader()} ${this.renderFilesSection()} ${this.renderImageSection()} ${this.renderBuildDialog()} ${this.renderBuildLog()} ${this.renderDeleteDialog()}
+      ${this.renderHeader()} ${this.renderFilesSection()} ${this.renderImageSection()}
+      ${this.renderBuildDialog()} ${this.renderBuildLog()} ${this.renderDeleteDialog()}
     `;
   }
 
@@ -643,29 +658,36 @@ export class ScionPageHarnessConfigDetail extends LitElement {
           <h1>${hc.displayName || hc.name}</h1>
           ${hc.harness ? html`<span class="harness-badge">${hc.harness}</span>` : ''}
           <div class="header-actions">
-            ${hc.sourceUrl ? html`
-              <sl-button
-                size="small"
-                variant="default"
-                @click=${this.startReimport}
-                ?disabled=${this.reimportRunning}
-                ?loading=${this.reimportRunning}
-              >
-                <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
-                Refresh from Source
-              </sl-button>
-            ` : nothing}
-            ${can(hc._capabilities, 'delete') || can(hc._capabilities, 'manage') ? html`
-              <sl-button
-                size="small"
-                variant="danger"
-                outline
-                @click=${() => { this.deleteDialogOpen = true; this.deleteError = ''; }}
-              >
-                <sl-icon slot="prefix" name="trash"></sl-icon>
-                Delete
-              </sl-button>
-            ` : nothing}
+            ${hc.sourceUrl
+              ? html`
+                  <sl-button
+                    size="small"
+                    variant="default"
+                    @click=${this.startReimport}
+                    ?disabled=${this.reimportRunning}
+                    ?loading=${this.reimportRunning}
+                  >
+                    <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
+                    Refresh from Source
+                  </sl-button>
+                `
+              : nothing}
+            ${can(hc._capabilities, 'delete') || can(hc._capabilities, 'manage')
+              ? html`
+                  <sl-button
+                    size="small"
+                    variant="danger"
+                    outline
+                    @click=${() => {
+                      this.deleteDialogOpen = true;
+                      this.deleteError = '';
+                    }}
+                  >
+                    <sl-icon slot="prefix" name="trash"></sl-icon>
+                    Delete
+                  </sl-button>
+                `
+              : nothing}
           </div>
         </div>
         ${hc.description ? html`<p class="resource-description">${hc.description}</p>` : ''}
@@ -679,13 +701,20 @@ export class ScionPageHarnessConfigDetail extends LitElement {
               ></span>`
             : ''}
           ${hc.sourceUrl
-            ? html`<span class="source-url">Source:
-                <a href=${hc.sourceUrl.replace(/^git\+/, '')} target="_blank" rel="noopener">${hc.sourceUrl}</a>
+            ? html`<span class="source-url"
+                >Source:
+                <a href=${hc.sourceUrl.replace(/^git\+/, '')} target="_blank" rel="noopener"
+                  >${hc.sourceUrl}</a
+                >
               </span>`
             : ''}
         </div>
-        ${this.reimportStatus ? html`<p class="reimport-status success">${this.reimportStatus}</p>` : ''}
-        ${this.reimportError ? html`<p class="reimport-status error">${this.reimportError}</p>` : ''}
+        ${this.reimportStatus
+          ? html`<p class="reimport-status success">${this.reimportStatus}</p>`
+          : ''}
+        ${this.reimportError
+          ? html`<p class="reimport-status error">${this.reimportError}</p>`
+          : ''}
       </div>
     `;
   }
@@ -756,12 +785,18 @@ export class ScionPageHarnessConfigDetail extends LitElement {
     }
   }
 
-  private brokerRollup(broker: NonNullable<NonNullable<typeof this.imageStatus>['brokers']>[0]): { label: string; cssClass: string } {
+  private brokerRollup(broker: NonNullable<NonNullable<typeof this.imageStatus>['brokers']>[0]): {
+    label: string;
+    cssClass: string;
+  } {
     if (!broker.reachable) return { label: 'unreachable', cssClass: 'rollup-badge-unreachable' };
     if (broker.unsupported) return { label: 'needs upgrade', cssClass: 'rollup-badge-stale' };
-    if (broker.local_short?.exists && !broker.local_long?.exists) return { label: 'local build only', cssClass: 'rollup-badge-local-only' };
-    if (broker.local_long?.exists && broker.newer_in_registry) return { label: 'stale pull', cssClass: 'rollup-badge-stale' };
-    if ((broker.local_long?.exists && !broker.newer_in_registry) || broker.local_short?.exists) return { label: 'up-to-date', cssClass: 'rollup-badge-up-to-date' };
+    if (broker.local_short?.exists && !broker.local_long?.exists)
+      return { label: 'local build only', cssClass: 'rollup-badge-local-only' };
+    if (broker.local_long?.exists && broker.newer_in_registry)
+      return { label: 'stale pull', cssClass: 'rollup-badge-stale' };
+    if ((broker.local_long?.exists && !broker.newer_in_registry) || broker.local_short?.exists)
+      return { label: 'up-to-date', cssClass: 'rollup-badge-up-to-date' };
     return { label: 'missing', cssClass: 'rollup-badge-missing' };
   }
 
@@ -770,12 +805,12 @@ export class ScionPageHarnessConfigDetail extends LitElement {
       <tr>
         <td class="image-entity-name">Registry</td>
         <td class="image-ref">${st?.registry?.image || '—'}</td>
-        <td class="image-hash">${st?.registry?.exists ? (st.registry.hash || '—') : ''}</td>
+        <td class="image-hash">${st?.registry?.exists ? st.registry.hash || '—' : ''}</td>
         <td>
           ${st
-            ? (st.registry?.exists
+            ? st.registry?.exists
               ? html`Available`
-              : html`<span class="not-found">Not found</span>`)
+              : html`<span class="not-found">Not found</span>`
             : html`<sl-spinner style="font-size: 0.75rem;"></sl-spinner> Checking...`}
         </td>
       </tr>
@@ -795,18 +830,28 @@ export class ScionPageHarnessConfigDetail extends LitElement {
           <h2>Images <span class="image-section-subtitle">Runtime: ${broker.broker_name}</span></h2>
           <table class="image-table">
             <thead>
-              <tr><th>Entity</th><th>Image</th><th>Hash</th><th>Status</th></tr>
+              <tr>
+                <th>Entity</th>
+                <th>Image</th>
+                <th>Hash</th>
+                <th>Status</th>
+              </tr>
             </thead>
             <tbody>
               ${this.renderRegistryRow(st)}
             </tbody>
           </table>
           <div class="proxy-info-note">
-            Runtime broker "${broker.broker_name}" is currently unreachable.
-            Local image state cannot be determined.
+            Runtime broker "${broker.broker_name}" is currently unreachable. Local image state
+            cannot be determined.
           </div>
           <div class="image-actions">
-            <sl-button size="small" variant="text" @click=${this.recheckImage} ?disabled=${this.imageActionRunning}>
+            <sl-button
+              size="small"
+              variant="text"
+              @click=${this.recheckImage}
+              ?disabled=${this.imageActionRunning}
+            >
               <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
               Re-check
             </sl-button>
@@ -821,51 +866,91 @@ export class ScionPageHarnessConfigDetail extends LitElement {
         <h2>Images <span class="image-section-subtitle">Runtime: ${broker.broker_name}</span></h2>
         <table class="image-table">
           <thead>
-            <tr><th>Entity</th><th>Image</th><th>Hash</th><th>Status</th></tr>
+            <tr>
+              <th>Entity</th>
+              <th>Image</th>
+              <th>Hash</th>
+              <th>Status</th>
+            </tr>
           </thead>
           <tbody>
             ${this.renderRegistryRow(st)}
             <tr class=${src === 'local_short' ? 'active-row' : ''}>
               <td class="image-entity-name">Local Build</td>
               <td class="image-ref">${st?.image || image || '—'}</td>
-              <td class="image-hash">${broker.local_short?.exists ? (broker.local_short.hash || '—') : ''}</td>
+              <td class="image-hash">
+                ${broker.local_short?.exists ? broker.local_short.hash || '—' : ''}
+              </td>
               <td>
                 ${broker.local_short?.exists
-                  ? html`Available${src === 'local_short' ? html`<span class="active-badge">Active</span>` : nothing}`
+                  ? html`Available${src === 'local_short'
+                      ? html`<span class="active-badge">Active</span>`
+                      : nothing}`
                   : html`<span class="not-found">Not found</span>`}
               </td>
             </tr>
             <tr class=${src === 'local_long' ? 'active-row' : ''}>
               <td class="image-entity-name">Pulled</td>
               <td class="image-ref">${st?.registry?.image || '—'}</td>
-              <td class="image-hash">${broker.local_long?.exists ? (broker.local_long.hash || '—') : ''}</td>
+              <td class="image-hash">
+                ${broker.local_long?.exists ? broker.local_long.hash || '—' : ''}
+              </td>
               <td>
                 ${broker.local_long?.exists
-                  ? html`Available${src === 'local_long' ? html`<span class="active-badge">Active</span>` : nothing}
-                    ${broker.newer_in_registry ? html`<span class="newer-badge">Newer in registry</span>` : nothing}`
+                  ? html`Available${src === 'local_long'
+                      ? html`<span class="active-badge">Active</span>`
+                      : nothing}
+                    ${broker.newer_in_registry
+                      ? html`<span class="newer-badge">Newer in registry</span>`
+                      : nothing}`
                   : html`<span class="not-found">Not found</span>`}
               </td>
             </tr>
           </tbody>
         </table>
         <div class="image-actions">
-          ${this.hasDockerfile ? html`
-            <sl-button size="small" variant="primary" @click=${this.openBuildDialog} ?disabled=${this.buildRunning}>
-              <sl-icon slot="prefix" name="hammer"></sl-icon>
-              ${this.buildRunning ? 'Building...' : 'Build Image'}
-            </sl-button>
-          ` : nothing}
-          <sl-button size="small" variant="default" @click=${() => this.pullLatestImage(broker.broker_id)} ?disabled=${this.imageActionRunning}>
+          ${this.hasDockerfile
+            ? html`
+                <sl-button
+                  size="small"
+                  variant="primary"
+                  @click=${this.openBuildDialog}
+                  ?disabled=${this.buildRunning}
+                >
+                  <sl-icon slot="prefix" name="hammer"></sl-icon>
+                  ${this.buildRunning ? 'Building...' : 'Build Image'}
+                </sl-button>
+              `
+            : nothing}
+          <sl-button
+            size="small"
+            variant="default"
+            @click=${() => this.pullLatestImage(broker.broker_id)}
+            ?disabled=${this.imageActionRunning}
+          >
             <sl-icon slot="prefix" name="cloud-download"></sl-icon>
             Pull Latest
           </sl-button>
-          ${broker.local_short?.exists ? html`
-            <sl-button size="small" variant="warning" outline @click=${() => this.deleteLocalImage(broker.broker_id)} ?disabled=${this.imageActionRunning}>
-              <sl-icon slot="prefix" name="trash"></sl-icon>
-              Delete Local
-            </sl-button>
-          ` : nothing}
-          <sl-button size="small" variant="text" @click=${this.recheckImage} ?disabled=${this.imageActionRunning}>
+          ${broker.local_short?.exists
+            ? html`
+                <sl-button
+                  size="small"
+                  variant="warning"
+                  outline
+                  @click=${() => this.deleteLocalImage(broker.broker_id)}
+                  ?disabled=${this.imageActionRunning}
+                >
+                  <sl-icon slot="prefix" name="trash"></sl-icon>
+                  Delete Local
+                </sl-button>
+              `
+            : nothing}
+          <sl-button
+            size="small"
+            variant="text"
+            @click=${this.recheckImage}
+            ?disabled=${this.imageActionRunning}
+          >
             <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
             Re-check
           </sl-button>
@@ -894,32 +979,50 @@ export class ScionPageHarnessConfigDetail extends LitElement {
         <h2>Images</h2>
         <table class="image-table">
           <thead>
-            <tr><th>Entity</th><th>Image</th><th>Hash</th><th>Status</th></tr>
+            <tr>
+              <th>Entity</th>
+              <th>Image</th>
+              <th>Hash</th>
+              <th>Status</th>
+            </tr>
           </thead>
           <tbody>
-            ${this.renderRegistryRow(st)}
-            ${brokers.map(b => this.renderBrokerRow(b, st))}
+            ${this.renderRegistryRow(st)} ${brokers.map((b) => this.renderBrokerRow(b, st))}
           </tbody>
         </table>
         <div class="image-actions">
-          ${this.hasDockerfile ? html`
-            <sl-button size="small" variant="primary" @click=${this.openBuildDialog} ?disabled=${this.buildRunning}>
-              <sl-icon slot="prefix" name="hammer"></sl-icon>
-              ${this.buildRunning ? 'Building...' : 'Build Image'}
-            </sl-button>
-          ` : nothing}
-          <sl-button size="small" variant="text" @click=${this.recheckImage} ?disabled=${this.imageActionRunning}>
+          ${this.hasDockerfile
+            ? html`
+                <sl-button
+                  size="small"
+                  variant="primary"
+                  @click=${this.openBuildDialog}
+                  ?disabled=${this.buildRunning}
+                >
+                  <sl-icon slot="prefix" name="hammer"></sl-icon>
+                  ${this.buildRunning ? 'Building...' : 'Build Image'}
+                </sl-button>
+              `
+            : nothing}
+          <sl-button
+            size="small"
+            variant="text"
+            @click=${this.recheckImage}
+            ?disabled=${this.imageActionRunning}
+          >
             <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
             Re-check
           </sl-button>
         </div>
-        ${proxyBrokers.length > 0 ? html`
-          <div class="proxy-info-note">
-            ${proxyBrokers.length} proxy broker${proxyBrokers.length > 1 ? 's' : ''}
-            (${proxyBrokers.map(p => p.broker_name).join(', ')}) —
-            images pulled by substrate at provision time.
-          </div>
-        ` : nothing}
+        ${proxyBrokers.length > 0
+          ? html`
+              <div class="proxy-info-note">
+                ${proxyBrokers.length} proxy broker${proxyBrokers.length > 1 ? 's' : ''}
+                (${proxyBrokers.map((p) => p.broker_name).join(', ')}) — images pulled by substrate
+                at provision time.
+              </div>
+            `
+          : nothing}
       </div>
     `;
   }
@@ -933,7 +1036,10 @@ export class ScionPageHarnessConfigDetail extends LitElement {
     const src = broker.resolution_source || '';
 
     return html`
-      <tr class="broker-row ${expanded ? 'broker-row-expanded' : ''}" @click=${() => this.toggleBroker(broker.broker_id)}>
+      <tr
+        class="broker-row ${expanded ? 'broker-row-expanded' : ''}"
+        @click=${() => this.toggleBroker(broker.broker_id)}
+      >
         <td class="image-entity-name">
           <span class="broker-toggle">${expanded ? '▾' : '▸'}</span>
           <span class="reachable-dot ${broker.reachable ? 'online' : 'offline'}"></span>
@@ -941,47 +1047,95 @@ export class ScionPageHarnessConfigDetail extends LitElement {
         </td>
         <td><span class="rollup-badge ${rollup.cssClass}">${rollup.label}</span></td>
         <td></td>
-        <td>${broker.resolved_image ? html`resolves: ${src === 'local_short' ? 'local build' : src === 'local_long' ? 'pulled' : src}` : ''}</td>
+        <td>
+          ${broker.resolved_image
+            ? html`resolves:
+              ${src === 'local_short' ? 'local build' : src === 'local_long' ? 'pulled' : src}`
+            : ''}
+        </td>
       </tr>
-      ${expanded && broker.reachable ? html`
-        <tr class="broker-detail-row">
-          <td class="image-entity-name">Local Build</td>
-          <td class="image-ref">${st?.image || '—'}</td>
-          <td class="image-hash">${broker.local_short?.exists ? (broker.local_short.hash || '—') : ''}</td>
-          <td>${broker.local_short?.exists
-            ? html`Available${src === 'local_short' ? html`<span class="active-badge">Active</span>` : nothing}`
-            : html`<span class="not-found">—</span>`}</td>
-        </tr>
-        <tr class="broker-detail-row">
-          <td class="image-entity-name">Pulled</td>
-          <td class="image-ref">${st?.registry?.image || '—'}</td>
-          <td class="image-hash">${broker.local_long?.exists ? (broker.local_long.hash || '—') : ''}</td>
-          <td>${broker.local_long?.exists
-            ? html`Available${src === 'local_long' ? html`<span class="active-badge">Active</span>` : nothing}
-              ${broker.newer_in_registry ? html`<span class="newer-badge">Newer in registry</span>` : nothing}`
-            : html`<span class="not-found">—</span>`}</td>
-        </tr>
-        <tr class="broker-detail-row">
-          <td colspan="4">
-            <div class="broker-actions">
-              <sl-button size="small" variant="default" @click=${(e: Event) => { e.stopPropagation(); void this.pullLatestImage(broker.broker_id); }} ?disabled=${this.imageActionRunning}>
-                <sl-icon slot="prefix" name="cloud-download"></sl-icon>
-                Pull Latest
-              </sl-button>
-              ${broker.local_short?.exists ? html`
-                <sl-button size="small" variant="warning" outline @click=${(e: Event) => { e.stopPropagation(); void this.deleteLocalImage(broker.broker_id); }} ?disabled=${this.imageActionRunning}>
-                  <sl-icon slot="prefix" name="trash"></sl-icon>
-                  Delete Local
-                </sl-button>
-              ` : nothing}
-              <sl-button size="small" variant="text" @click=${(e: Event) => { e.stopPropagation(); void this.recheckImage(); }} ?disabled=${this.imageActionRunning}>
-                <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
-                Re-check
-              </sl-button>
-            </div>
-          </td>
-        </tr>
-      ` : nothing}
+      ${expanded && broker.reachable
+        ? html`
+            <tr class="broker-detail-row">
+              <td class="image-entity-name">Local Build</td>
+              <td class="image-ref">${st?.image || '—'}</td>
+              <td class="image-hash">
+                ${broker.local_short?.exists ? broker.local_short.hash || '—' : ''}
+              </td>
+              <td>
+                ${broker.local_short?.exists
+                  ? html`Available${src === 'local_short'
+                      ? html`<span class="active-badge">Active</span>`
+                      : nothing}`
+                  : html`<span class="not-found">—</span>`}
+              </td>
+            </tr>
+            <tr class="broker-detail-row">
+              <td class="image-entity-name">Pulled</td>
+              <td class="image-ref">${st?.registry?.image || '—'}</td>
+              <td class="image-hash">
+                ${broker.local_long?.exists ? broker.local_long.hash || '—' : ''}
+              </td>
+              <td>
+                ${broker.local_long?.exists
+                  ? html`Available${src === 'local_long'
+                      ? html`<span class="active-badge">Active</span>`
+                      : nothing}
+                    ${broker.newer_in_registry
+                      ? html`<span class="newer-badge">Newer in registry</span>`
+                      : nothing}`
+                  : html`<span class="not-found">—</span>`}
+              </td>
+            </tr>
+            <tr class="broker-detail-row">
+              <td colspan="4">
+                <div class="broker-actions">
+                  <sl-button
+                    size="small"
+                    variant="default"
+                    @click=${(e: Event) => {
+                      e.stopPropagation();
+                      void this.pullLatestImage(broker.broker_id);
+                    }}
+                    ?disabled=${this.imageActionRunning}
+                  >
+                    <sl-icon slot="prefix" name="cloud-download"></sl-icon>
+                    Pull Latest
+                  </sl-button>
+                  ${broker.local_short?.exists
+                    ? html`
+                        <sl-button
+                          size="small"
+                          variant="warning"
+                          outline
+                          @click=${(e: Event) => {
+                            e.stopPropagation();
+                            void this.deleteLocalImage(broker.broker_id);
+                          }}
+                          ?disabled=${this.imageActionRunning}
+                        >
+                          <sl-icon slot="prefix" name="trash"></sl-icon>
+                          Delete Local
+                        </sl-button>
+                      `
+                    : nothing}
+                  <sl-button
+                    size="small"
+                    variant="text"
+                    @click=${(e: Event) => {
+                      e.stopPropagation();
+                      void this.recheckImage();
+                    }}
+                    ?disabled=${this.imageActionRunning}
+                  >
+                    <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
+                    Re-check
+                  </sl-button>
+                </div>
+              </td>
+            </tr>
+          `
+        : nothing}
     `;
   }
 
@@ -994,22 +1148,31 @@ export class ScionPageHarnessConfigDetail extends LitElement {
         <h2>Images</h2>
         <table class="image-table">
           <thead>
-            <tr><th>Entity</th><th>Image</th><th>Hash</th><th>Status</th></tr>
+            <tr>
+              <th>Entity</th>
+              <th>Image</th>
+              <th>Hash</th>
+              <th>Status</th>
+            </tr>
           </thead>
           <tbody>
             ${this.renderRegistryRow(st)}
           </tbody>
         </table>
         <div class="image-actions">
-          <sl-button size="small" variant="text" @click=${this.recheckImage} ?disabled=${this.imageActionRunning}>
+          <sl-button
+            size="small"
+            variant="text"
+            @click=${this.recheckImage}
+            ?disabled=${this.imageActionRunning}
+          >
             <sl-icon slot="prefix" name="arrow-repeat"></sl-icon>
             Re-check
           </sl-button>
         </div>
         <div class="proxy-info-note">
-          Agents on this hub run on proxy brokers.
-          Images are pulled by the substrate at provision time;
-          there is no node-local image state to inspect.
+          Agents on this hub run on proxy brokers. Images are pulled by the substrate at provision
+          time; there is no node-local image state to inspect.
         </div>
       </div>
     `;
@@ -1018,9 +1181,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
   private async recheckImage(): Promise<void> {
     this.imageActionRunning = true;
     try {
-      const resp = await apiFetch(
-        `/api/v1/harness-configs/${this.harnessConfigId}/image-status`
-      );
+      const resp = await apiFetch(`/api/v1/harness-configs/${this.harnessConfigId}/image-status`);
       if (resp.ok) {
         this.imageStatus = await resp.json();
       } else {
@@ -1077,14 +1238,11 @@ export class ScionPageHarnessConfigDetail extends LitElement {
     this.reimportError = '';
 
     try {
-      const response = await apiFetch(
-        `/api/v1/harness-configs/${this.harnessConfig.id}/reimport`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({}),
-        },
-      );
+      const response = await apiFetch(`/api/v1/harness-configs/${this.harnessConfig.id}/reimport`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
 
       if (!response.ok) {
         const errMsg = await extractApiError(response, `HTTP ${response.status}`);
@@ -1094,10 +1252,12 @@ export class ScionPageHarnessConfigDetail extends LitElement {
 
       const result = await response.json();
       const count = result?.count ?? result?.harnessConfigs?.length ?? 0;
-      const failed: Array<{name: string; reason: string}> = result?.failed ?? [];
+      const failed: Array<{ name: string; reason: string }> = result?.failed ?? [];
 
       if (failed.length > 0) {
-        const reasons = failed.map((f: {name: string; reason: string}) => `${f.name}: ${f.reason}`).join('\n');
+        const reasons = failed
+          .map((f: { name: string; reason: string }) => `${f.name}: ${f.reason}`)
+          .join('\n');
         this.reimportError = `${failed.length} config(s) failed validation:\n${reasons}`;
         if (count > 0) {
           this.reimportStatus = `${count} config(s) updated, but some failed.`;
@@ -1135,11 +1295,19 @@ export class ScionPageHarnessConfigDetail extends LitElement {
           @sl-input=${(e: Event) => (this.buildTag = (e.target as HTMLInputElement).value)}
         ></sl-input>
         <br />
-        <sl-checkbox ?checked=${this.buildPush} @sl-change=${(e: Event) => (this.buildPush = (e.target as HTMLInputElement).checked)}>
+        <sl-checkbox
+          ?checked=${this.buildPush}
+          @sl-change=${(e: Event) => (this.buildPush = (e.target as HTMLInputElement).checked)}
+        >
           Push to registry after building
         </sl-checkbox>
         ${this.buildError ? html`<p class="build-error">${this.buildError}</p>` : nothing}
-        <sl-button slot="footer" variant="primary" @click=${this.startBuild} ?loading=${this.buildRunning}>
+        <sl-button
+          slot="footer"
+          variant="primary"
+          @click=${this.startBuild}
+          ?loading=${this.buildRunning}
+        >
           Build
         </sl-button>
         <sl-button slot="footer" variant="default" @click=${() => (this.buildDialogOpen = false)}>
@@ -1170,7 +1338,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
               push: this.buildPush ? 'true' : 'false',
             },
           }),
-        },
+        }
       );
 
       if (!response.ok) {
@@ -1215,7 +1383,7 @@ export class ScionPageHarnessConfigDetail extends LitElement {
 
     try {
       const resp = await apiFetch(
-        `/api/v1/admin/maintenance/operations/build-harness-config-image/runs/${this.buildRunId}`,
+        `/api/v1/admin/maintenance/operations/build-harness-config-image/runs/${this.buildRunId}`
       );
       if (!resp.ok) {
         this.buildPollErrors++;
@@ -1268,7 +1436,12 @@ export class ScionPageHarnessConfigDetail extends LitElement {
   private renderBuildLog() {
     if (!this.buildLog && !this.buildRunning) return nothing;
 
-    const statusClass = this.buildStatus === 'completed' ? 'completed' : this.buildStatus === 'running' ? 'running' : 'failed';
+    const statusClass =
+      this.buildStatus === 'completed'
+        ? 'completed'
+        : this.buildStatus === 'running'
+          ? 'running'
+          : 'failed';
 
     return html`
       <div class="build-log-section">
@@ -1321,7 +1494,9 @@ export class ScionPageHarnessConfigDetail extends LitElement {
             variant="default"
             size="small"
             ?disabled=${this.deleteInProgress}
-            @click=${() => { this.deleteDialogOpen = false; }}
+            @click=${() => {
+              this.deleteDialogOpen = false;
+            }}
           >
             Cancel
           </sl-button>

--- a/web/src/components/pages/health-dashboard.ts
+++ b/web/src/components/pages/health-dashboard.ts
@@ -416,7 +416,7 @@ export class ScionPageHealthDashboard extends LitElement {
       color: var(--scion-text, #1e293b);
     }
 
-    .stall-edit-form input[type="number"] {
+    .stall-edit-form input[type='number'] {
       width: 60px;
       padding: 0.25rem 0.5rem;
       border: 1px solid var(--scion-border, #e2e8f0);
@@ -453,7 +453,8 @@ export class ScionPageHealthDashboard extends LitElement {
       color: var(--scion-text-muted, #64748b);
     }
 
-    .loading, .error-msg {
+    .loading,
+    .error-msg {
       text-align: center;
       padding: 3rem 1rem;
       color: var(--scion-text-muted, #64748b);
@@ -531,21 +532,28 @@ export class ScionPageHealthDashboard extends LitElement {
         </div>
         <div class="header-right">
           <label class="toggle-label">
-            <input type="checkbox" .checked=${this.autoRefresh}
-              @change=${() => this.toggleAutoRefresh()} />
+            <input
+              type="checkbox"
+              .checked=${this.autoRefresh}
+              @change=${() => this.toggleAutoRefresh()}
+            />
             Auto-refresh
           </label>
           <button class="refresh-btn" @click=${() => void this.fetchData()}>Refresh</button>
         </div>
       </div>
 
-      ${this.error ? html`<div class="error-msg" style="margin-bottom:1rem;text-align:left;padding:0.75rem;background:#fef2f2;border-radius:0.375rem;font-size:0.875rem">${this.error}</div>` : nothing}
+      ${this.error
+        ? html`<div
+            class="error-msg"
+            style="margin-bottom:1rem;text-align:left;padding:0.75rem;background:#fef2f2;border-radius:0.375rem;font-size:0.875rem"
+          >
+            ${this.error}
+          </div>`
+        : nothing}
 
       <!-- Hub & Database -->
-      <div class="grid-2">
-        ${this.renderHubCard(d)}
-        ${this.renderDatabaseCard(d)}
-      </div>
+      <div class="grid-2">${this.renderHubCard(d)} ${this.renderDatabaseCard(d)}</div>
 
       <!-- Brokers -->
       ${this.renderBrokersCard(d)}
@@ -554,10 +562,7 @@ export class ScionPageHealthDashboard extends LitElement {
       ${this.renderAgentsCard(d)}
 
       <!-- Dispatch & Stall Config -->
-      <div class="grid-2">
-        ${this.renderDispatchCard(d)}
-        ${this.renderStallCard(d)}
-      </div>
+      <div class="grid-2">${this.renderDispatchCard(d)} ${this.renderStallCard(d)}</div>
 
       <!-- Recent Alerts placeholder -->
       <div class="grid-full">
@@ -565,7 +570,12 @@ export class ScionPageHealthDashboard extends LitElement {
           <div class="card-title">Recent Alerts</div>
           <div style="font-size:0.875rem;color:var(--scion-text-muted,#64748b)">
             View recent alerts in the
-            <a class="alerts-link" href="https://console.cloud.google.com/monitoring/alerting" target="_blank" rel="noopener">
+            <a
+              class="alerts-link"
+              href="https://console.cloud.google.com/monitoring/alerting"
+              target="_blank"
+              rel="noopener"
+            >
               GCP Cloud Monitoring Console
             </a>
           </div>
@@ -579,32 +589,51 @@ export class ScionPageHealthDashboard extends LitElement {
       <div class="card">
         <div class="card-title">Hub Status</div>
         <div class="status-line">
-          <span style="color: ${this.statusColor(d.hub.status)}">${this.statusIcon(d.hub.status)}</span>
+          <span style="color: ${this.statusColor(d.hub.status)}"
+            >${this.statusIcon(d.hub.status)}</span
+          >
           ${d.hub.status}
         </div>
         <div class="stat-row"><span class="label">Uptime</span><span>${d.hub.uptime}</span></div>
         <div class="stat-row"><span class="label">Version</span><span>${d.hub.version}</span></div>
-        <div class="stat-row"><span class="label">Connected Brokers</span><span>${d.hub.connected_brokers}</span></div>
-        <div class="stat-row"><span class="label">Active Agents</span><span>${d.hub.active_agents}</span></div>
-        <div class="stat-row"><span class="label">Projects</span><span>${d.hub.projects}</span></div>
+        <div class="stat-row">
+          <span class="label">Connected Brokers</span><span>${d.hub.connected_brokers}</span>
+        </div>
+        <div class="stat-row">
+          <span class="label">Active Agents</span><span>${d.hub.active_agents}</span>
+        </div>
+        <div class="stat-row">
+          <span class="label">Projects</span><span>${d.hub.projects}</span>
+        </div>
       </div>
     `;
   }
 
   private renderDatabaseCard(d: HealthSummary) {
-    const poolUtil = d.database.pool_max > 0
-      ? Math.round((d.database.pool_active / d.database.pool_max) * 100)
-      : 0;
+    const poolUtil =
+      d.database.pool_max > 0
+        ? Math.round((d.database.pool_active / d.database.pool_max) * 100)
+        : 0;
     return html`
       <div class="card">
         <div class="card-title">Database</div>
         <div class="status-line">
-          <span style="color: ${this.statusColor(d.database.status)}">${this.statusIcon(d.database.status)}</span>
+          <span style="color: ${this.statusColor(d.database.status)}"
+            >${this.statusIcon(d.database.status)}</span
+          >
           ${d.database.status}
         </div>
-        <div class="stat-row"><span class="label">Pool</span><span>${d.database.pool_active}/${d.database.pool_max} active (${poolUtil}%)</span></div>
-        <div class="stat-row"><span class="label">Idle</span><span>${d.database.pool_idle}</span></div>
-        <div class="stat-row"><span class="label">Wait Count (Total)</span><span>${d.database.pool_wait_count_total}</span></div>
+        <div class="stat-row">
+          <span class="label">Pool</span
+          ><span>${d.database.pool_active}/${d.database.pool_max} active (${poolUtil}%)</span>
+        </div>
+        <div class="stat-row">
+          <span class="label">Idle</span><span>${d.database.pool_idle}</span>
+        </div>
+        <div class="stat-row">
+          <span class="label">Wait Count (Total)</span
+          ><span>${d.database.pool_wait_count_total}</span>
+        </div>
       </div>
     `;
   }
@@ -615,7 +644,9 @@ export class ScionPageHealthDashboard extends LitElement {
         <div class="grid-full">
           <div class="card">
             <div class="card-title">Brokers</div>
-            <div style="font-size:0.875rem;color:var(--scion-text-muted,#64748b)">No brokers registered</div>
+            <div style="font-size:0.875rem;color:var(--scion-text-muted,#64748b)">
+              No brokers registered
+            </div>
           </div>
         </div>
       `;
@@ -626,19 +657,31 @@ export class ScionPageHealthDashboard extends LitElement {
         <div class="card">
           <div class="card-title">Brokers</div>
           <div class="broker-grid">
-            ${d.brokers.map(b => html`
-              <div class="broker-card">
-                <div class="broker-name">${b.name || b.id}</div>
-                <div class="status-line" style="font-size:0.875rem">
-                  <span style="color: ${this.statusColor(b.status)}">${this.statusIcon(b.status)}</span>
-                  ${b.status}
+            ${d.brokers.map(
+              (b) => html`
+                <div class="broker-card">
+                  <div class="broker-name">${b.name || b.id}</div>
+                  <div class="status-line" style="font-size:0.875rem">
+                    <span style="color: ${this.statusColor(b.status)}"
+                      >${this.statusIcon(b.status)}</span
+                    >
+                    ${b.status}
+                  </div>
+                  <div class="broker-stat">Agents: ${b.agent_healthy}/${b.agent_count} healthy</div>
+                  <div class="broker-stat">
+                    Runtime: ${b.runtime} ${b.runtime_available ? '✓' : '✗'}
+                  </div>
+                  <div class="broker-stat" style="color:var(--scion-text-muted,#64748b)">
+                    NFS: not reported
+                  </div>
+                  ${b.last_heartbeat
+                    ? html`<div class="broker-stat">
+                        Heartbeat: ${this.timeAgo(b.last_heartbeat)}
+                      </div>`
+                    : nothing}
                 </div>
-                <div class="broker-stat">Agents: ${b.agent_healthy}/${b.agent_count} healthy</div>
-                <div class="broker-stat">Runtime: ${b.runtime} ${b.runtime_available ? '✓' : '✗'}</div>
-                <div class="broker-stat" style="color:var(--scion-text-muted,#64748b)">NFS: not reported</div>
-                ${b.last_heartbeat ? html`<div class="broker-stat">Heartbeat: ${this.timeAgo(b.last_heartbeat)}</div>` : nothing}
-              </div>
-            `)}
+              `
+            )}
           </div>
         </div>
       </div>
@@ -652,27 +695,37 @@ export class ScionPageHealthDashboard extends LitElement {
           <div class="card-title">Agents</div>
           <div class="agent-summary">
             <div><span class="stat">${d.agents.total}</span> Total</div>
-            ${Object.entries(d.agents.by_phase).map(([phase, count]) =>
-              html`<div><span class="stat">${count}</span> ${phase}</div>`
+            ${Object.entries(d.agents.by_phase).map(
+              ([phase, count]) => html`<div><span class="stat">${count}</span> ${phase}</div>`
             )}
           </div>
-          ${d.agents.stalled.length > 0 ? html`
-            <div class="agent-alert alert-warn">
-              ⚠ ${d.agents.stalled.length} stalled: ${d.agents.stalled.join(', ')}
-            </div>
-          ` : nothing}
-          ${d.agents.crashed.length > 0 ? html`
-            <div class="agent-alert alert-error">
-              ✗ ${d.agents.crashed.length} crashed: ${d.agents.crashed.join(', ')}
-            </div>
-          ` : nothing}
-          ${d.agents.errored.length > 0 ? html`
-            <div class="agent-alert alert-error">
-              ✗ ${d.agents.errored.length} errored: ${d.agents.errored.join(', ')}
-            </div>
-          ` : nothing}
-          ${d.agents.stalled.length === 0 && d.agents.crashed.length === 0 && d.agents.errored.length === 0
-            ? html`<div style="font-size:0.875rem;color:var(--scion-success,#22c55e)">All agents healthy</div>`
+          ${d.agents.stalled.length > 0
+            ? html`
+                <div class="agent-alert alert-warn">
+                  ⚠ ${d.agents.stalled.length} stalled: ${d.agents.stalled.join(', ')}
+                </div>
+              `
+            : nothing}
+          ${d.agents.crashed.length > 0
+            ? html`
+                <div class="agent-alert alert-error">
+                  ✗ ${d.agents.crashed.length} crashed: ${d.agents.crashed.join(', ')}
+                </div>
+              `
+            : nothing}
+          ${d.agents.errored.length > 0
+            ? html`
+                <div class="agent-alert alert-error">
+                  ✗ ${d.agents.errored.length} errored: ${d.agents.errored.join(', ')}
+                </div>
+              `
+            : nothing}
+          ${d.agents.stalled.length === 0 &&
+          d.agents.crashed.length === 0 &&
+          d.agents.errored.length === 0
+            ? html`<div style="font-size:0.875rem;color:var(--scion-success,#22c55e)">
+                All agents healthy
+              </div>`
             : nothing}
         </div>
       </div>
@@ -685,8 +738,8 @@ export class ScionPageHealthDashboard extends LitElement {
         <div class="card">
           <div class="card-title">Dispatch Pipeline</div>
           <div style="font-size:0.875rem;color:var(--scion-text-muted,#64748b)">
-            Dispatch metrics not yet available. A future update will expose dispatch
-            pipeline stats via the health summary API.
+            Dispatch metrics not yet available. A future update will expose dispatch pipeline stats
+            via the health summary API.
           </div>
         </div>
       `;
@@ -696,11 +749,17 @@ export class ScionPageHealthDashboard extends LitElement {
         <div class="card-title">Dispatch Pipeline</div>
         <div class="stat-row">
           <span class="label">Stuck Messages</span>
-          <span style="color: ${d.dispatch.stuck_messages > 0 ? 'var(--scion-error,#ef4444)' : 'inherit'}; font-weight: ${d.dispatch.stuck_messages > 0 ? '600' : 'normal'}">
+          <span
+            style="color: ${d.dispatch.stuck_messages > 0
+              ? 'var(--scion-error,#ef4444)'
+              : 'inherit'}; font-weight: ${d.dispatch.stuck_messages > 0 ? '600' : 'normal'}"
+          >
             ${d.dispatch.stuck_messages}
           </span>
         </div>
-        <div class="stat-row"><span class="label">Failed (1h)</span><span>${d.dispatch.failed_1h}</span></div>
+        <div class="stat-row">
+          <span class="label">Failed (1h)</span><span>${d.dispatch.failed_1h}</span>
+        </div>
       </div>
     `;
   }
@@ -715,18 +774,39 @@ export class ScionPageHealthDashboard extends LitElement {
                as read-only. Only auto_suspend_stalled is a runtime setting. -->
           <div class="stat-row" style="margin-bottom:0.75rem">
             <span class="label">Stalled Threshold</span>
-            <span>${Math.round(d.stall_config.threshold_seconds / 60)} min <span style="font-size:0.75rem;color:var(--scion-text-muted,#94a3b8)">(set at startup)</span></span>
+            <span
+              >${Math.round(d.stall_config.threshold_seconds / 60)} min
+              <span style="font-size:0.75rem;color:var(--scion-text-muted,#94a3b8)"
+                >(set at startup)</span
+              ></span
+            >
           </div>
           <div class="stall-edit-form">
             <label style="display:flex;align-items:center;gap:0.375rem">
-              <input type="checkbox" .checked=${this.stallAutoSuspend}
-                @change=${() => { this.stallAutoSuspend = !this.stallAutoSuspend; }} />
+              <input
+                type="checkbox"
+                .checked=${this.stallAutoSuspend}
+                @change=${() => {
+                  this.stallAutoSuspend = !this.stallAutoSuspend;
+                }}
+              />
               Auto-suspend stalled agents
             </label>
-            <button class="save-btn" ?disabled=${this.savingStall} @click=${() => void this.saveStallConfig()}>
+            <button
+              class="save-btn"
+              ?disabled=${this.savingStall}
+              @click=${() => void this.saveStallConfig()}
+            >
               ${this.savingStall ? 'Saving...' : 'Save'}
             </button>
-            <button class="cancel-btn" @click=${() => { this.editingStall = false; }}>Cancel</button>
+            <button
+              class="cancel-btn"
+              @click=${() => {
+                this.editingStall = false;
+              }}
+            >
+              Cancel
+            </button>
           </div>
         </div>
       `;
@@ -734,12 +814,28 @@ export class ScionPageHealthDashboard extends LitElement {
 
     return html`
       <div class="card">
-        <div class="card-title" style="display:flex;justify-content:space-between;align-items:center">
+        <div
+          class="card-title"
+          style="display:flex;justify-content:space-between;align-items:center"
+        >
           Stall Detection Settings
-          <button class="edit-btn" @click=${() => { this.editingStall = true; }}>Edit</button>
+          <button
+            class="edit-btn"
+            @click=${() => {
+              this.editingStall = true;
+            }}
+          >
+            Edit
+          </button>
         </div>
-        <div class="stat-row"><span class="label">Stalled Threshold</span><span>${Math.round(d.stall_config.threshold_seconds / 60)} min</span></div>
-        <div class="stat-row"><span class="label">Auto-Suspend Stalled</span><span>${d.stall_config.auto_suspend ? 'enabled' : 'disabled'}</span></div>
+        <div class="stat-row">
+          <span class="label">Stalled Threshold</span
+          ><span>${Math.round(d.stall_config.threshold_seconds / 60)} min</span>
+        </div>
+        <div class="stat-row">
+          <span class="label">Auto-Suspend Stalled</span
+          ><span>${d.stall_config.auto_suspend ? 'enabled' : 'disabled'}</span>
+        </div>
       </div>
     `;
   }

--- a/web/src/components/pages/home.ts
+++ b/web/src/components/pages/home.ts
@@ -85,7 +85,10 @@ export class ScionPageHome extends LitElement {
   override disconnectedCallback(): void {
     super.disconnectedCallback();
     stateManager.removeEventListener('agents-updated', this.boundOnAgentsUpdated as EventListener);
-    stateManager.removeEventListener('projects-updated', this.boundOnProjectsUpdated as EventListener);
+    stateManager.removeEventListener(
+      'projects-updated',
+      this.boundOnProjectsUpdated as EventListener
+    );
   }
 
   private onAgentsUpdated(): void {
@@ -97,7 +100,7 @@ export class ScionPageHome extends LitElement {
   }
 
   private get activeAgentCount(): number {
-    return this.agents.filter(a => isAgentRunning(a)).length;
+    return this.agents.filter((a) => isAgentRunning(a)).length;
   }
 
   private async loadData(): Promise<void> {
@@ -112,7 +115,9 @@ export class ScionPageHome extends LitElement {
       if (!this.isConnected || stateManager.currentScope?.type !== 'dashboard') return;
 
       if (agentsResp.ok) {
-        const data = (await agentsResp.json()) as { agents?: Agent[]; _capabilities?: Capabilities } | Agent[];
+        const data = (await agentsResp.json()) as
+          | { agents?: Agent[]; _capabilities?: Capabilities }
+          | Agent[];
         if (!this.isConnected || stateManager.currentScope?.type !== 'dashboard') return;
         const agents = Array.isArray(data) ? data : data.agents || [];
         this.agents = agents;
@@ -120,7 +125,9 @@ export class ScionPageHome extends LitElement {
       }
 
       if (projectsResp.ok) {
-        const data = (await projectsResp.json()) as { projects?: Project[]; _capabilities?: Capabilities } | Project[];
+        const data = (await projectsResp.json()) as
+          | { projects?: Project[]; _capabilities?: Capabilities }
+          | Project[];
         if (!this.isConnected || stateManager.currentScope?.type !== 'dashboard') return;
         const projects = Array.isArray(data) ? data : data.projects || [];
         this.projects = projects;
@@ -359,7 +366,9 @@ export class ScionPageHome extends LitElement {
         <div class="stat-card">
           <h3>Pending Invites</h3>
           <div class="stat-value">${this.inviteStats?.pendingInvites ?? '--'}</div>
-          <div class="stat-change">${this.inviteStats ? `${this.inviteStats.totalRedemptions} total redemptions` : ''}</div>
+          <div class="stat-change">
+            ${this.inviteStats ? `${this.inviteStats.totalRedemptions} total redemptions` : ''}
+          </div>
         </div>
         <div class="stat-card">
           <h3>Allow List</h3>
@@ -412,22 +421,32 @@ export class ScionPageHome extends LitElement {
         <h2 class="section-title">Recent Activity</h2>
         <div class="activity-list">
           ${this.inviteStats && this.inviteStats.recentRedemptions.length > 0
-            ? this.inviteStats.recentRedemptions.map(r => html`
-                <div class="activity-item">
-                  <div class="activity-icon">
-                    <sl-icon name="person-plus"></sl-icon>
+            ? this.inviteStats.recentRedemptions.map(
+                (r) => html`
+                  <div class="activity-item">
+                    <div class="activity-icon">
+                      <sl-icon name="person-plus"></sl-icon>
+                    </div>
+                    <div class="activity-content">
+                      <p class="activity-title">
+                        Invite <code>${r.codePrefix}...</code> redeemed
+                        (${r.useCount}/${r.maxUses > 0 ? r.maxUses : '∞'} uses)
+                      </p>
+                      <p class="activity-time">
+                        ${r.note ? r.note + ' • ' : ''}${this.formatRelativeTime(r.created)}
+                      </p>
+                    </div>
                   </div>
-                  <div class="activity-content">
-                    <p class="activity-title">Invite <code>${r.codePrefix}...</code> redeemed (${r.useCount}/${r.maxUses > 0 ? r.maxUses : '∞'} uses)</p>
-                    <p class="activity-time">${r.note ? r.note + ' • ' : ''}${this.formatRelativeTime(r.created)}</p>
-                  </div>
-                </div>
-              `)
+                `
+              )
             : html`
                 <div class="empty-state">
                   <sl-icon name="clock-history"></sl-icon>
                   <p>No recent activity to display.<br />Start by creating your first agent.</p>
-                  <a href="/agents/new" style="text-decoration: none; margin-top: 1rem; display: inline-block;">
+                  <a
+                    href="/agents/new"
+                    style="text-decoration: none; margin-top: 1rem; display: inline-block;"
+                  >
                     <sl-button variant="primary">
                       <sl-icon slot="prefix" name="plus-lg"></sl-icon>
                       Create Agent

--- a/web/src/components/pages/invite.ts
+++ b/web/src/components/pages/invite.ts
@@ -199,7 +199,8 @@ export class ScionPageInvite extends LitElement {
         this.pageState = 'unauthenticated';
         return;
       } else {
-        this.errorMessage = 'Something went wrong. Please try again or contact your hub administrator.';
+        this.errorMessage =
+          'Something went wrong. Please try again or contact your hub administrator.';
       }
       this.pageState = 'error';
     } catch {
@@ -246,13 +247,21 @@ export class ScionPageInvite extends LitElement {
       <p>Sign in to accept your invitation and join the hub.</p>
       <div class="providers">
         ${this.googleEnabled
-          ? html`<sl-button variant="default" size="large" @click=${() => this.handleLogin('google')}>
+          ? html`<sl-button
+              variant="default"
+              size="large"
+              @click=${() => this.handleLogin('google')}
+            >
               <sl-icon slot="prefix" name="google"></sl-icon>
               Sign in with Google
             </sl-button>`
           : nothing}
         ${this.githubEnabled
-          ? html`<sl-button variant="default" size="large" @click=${() => this.handleLogin('github')}>
+          ? html`<sl-button
+              variant="default"
+              size="large"
+              @click=${() => this.handleLogin('github')}
+            >
               <sl-icon slot="prefix" name="github"></sl-icon>
               Sign in with GitHub
             </sl-button>`
@@ -266,7 +275,13 @@ export class ScionPageInvite extends LitElement {
       <sl-icon class="icon success" name="check-circle"></sl-icon>
       <h1>Welcome!</h1>
       <p>You now have access to this hub.</p>
-      <sl-button variant="primary" size="large" @click=${() => { window.location.href = '/'; }}>
+      <sl-button
+        variant="primary"
+        size="large"
+        @click=${() => {
+          window.location.href = '/';
+        }}
+      >
         Go to Dashboard
       </sl-button>
     `;
@@ -277,7 +292,12 @@ export class ScionPageInvite extends LitElement {
       <sl-icon class="icon error" name="exclamation-triangle"></sl-icon>
       <h1>Invite Not Valid</h1>
       <p>${this.errorMessage}</p>
-      <sl-button variant="default" @click=${() => { window.location.href = '/'; }}>
+      <sl-button
+        variant="default"
+        @click=${() => {
+          window.location.href = '/';
+        }}
+      >
         Go to Home
       </sl-button>
     `;
@@ -287,8 +307,15 @@ export class ScionPageInvite extends LitElement {
     return html`
       <sl-icon class="icon error" name="exclamation-triangle"></sl-icon>
       <h1>No Invite Code</h1>
-      <p>This page requires a valid invite link. Please ask your hub administrator for an invite.</p>
-      <sl-button variant="default" @click=${() => { window.location.href = '/'; }}>
+      <p>
+        This page requires a valid invite link. Please ask your hub administrator for an invite.
+      </p>
+      <sl-button
+        variant="default"
+        @click=${() => {
+          window.location.href = '/';
+        }}
+      >
         Go to Home
       </sl-button>
     `;

--- a/web/src/components/pages/login.ts
+++ b/web/src/components/pages/login.ts
@@ -336,11 +336,11 @@ export class ScionLoginPage extends LitElement {
         if (data.providers) {
           // New-style response with provider list
           this._providers = data.providers.map((p) => ({
-              id: p.id,
-              name: p.name,
-              icon: p.id,
-              available: p.enabled,
-            }));
+            id: p.id,
+            name: p.name,
+            icon: p.id,
+            available: p.enabled,
+          }));
         } else {
           // Legacy fallback (defensive — should not occur after deploy)
           this._providers = [];
@@ -404,7 +404,10 @@ export class ScionLoginPage extends LitElement {
             ? html`
                 <div class="no-providers">
                   <p>Authentication is handled by your organization's identity provider.</p>
-                  <p>If you continue to see this page, the authenticating proxy may not be configured correctly.</p>
+                  <p>
+                    If you continue to see this page, the authenticating proxy may not be configured
+                    correctly.
+                  </p>
                 </div>
               `
             : hasProviders
@@ -433,14 +436,10 @@ export class ScionLoginPage extends LitElement {
         'You have been signed out because the server security credentials were updated. Please sign in again.',
       session_error:
         'Your session could not be saved. Please contact an administrator if this persists.',
-      state_mismatch:
-        'Login verification failed. Please try signing in again.',
-      exchange_failed:
-        'Could not complete sign-in with the provider. Please try again.',
-      unauthorized_domain:
-        'Your email domain is not authorized to access this application.',
-      user_create_failed:
-        'Could not create your account. Please contact an administrator.',
+      state_mismatch: 'Login verification failed. Please try signing in again.',
+      exchange_failed: 'Could not complete sign-in with the provider. Please try again.',
+      unauthorized_domain: 'Your email domain is not authorized to access this application.',
+      user_create_failed: 'Could not create your account. Please contact an administrator.',
     };
     return messages[this.error] ?? this.error;
   }

--- a/web/src/components/pages/metrics-dashboard.ts
+++ b/web/src/components/pages/metrics-dashboard.ts
@@ -59,8 +59,16 @@ interface TokensData {
 }
 
 const CHART_COLORS = [
-  '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6',
-  '#ec4899', '#06b6d4', '#84cc16', '#f97316', '#6366f1',
+  '#3b82f6',
+  '#10b981',
+  '#f59e0b',
+  '#ef4444',
+  '#8b5cf6',
+  '#ec4899',
+  '#06b6d4',
+  '#84cc16',
+  '#f97316',
+  '#6366f1',
 ];
 
 @customElement('scion-page-metrics')
@@ -257,9 +265,7 @@ export class ScionPageMetrics extends LitElement {
       const basePath = this.projectId
         ? `/api/v1/projects/${this.projectId}/metrics`
         : `/api/v1/metrics/`;
-      const response = await apiFetch(
-        `${basePath}?view=${view}&period=${this.periodDays}`
-      );
+      const response = await apiFetch(`${basePath}?view=${view}&period=${this.periodDays}`);
 
       if (!response.ok) {
         throw new Error(await extractApiError(response, `HTTP ${response.status}`));
@@ -316,7 +322,11 @@ export class ScionPageMetrics extends LitElement {
   }
 
   private static readonly CHART_PROPERTIES = new Set([
-    'sessions', 'modelCalls', 'tokens', 'activeTab', 'loading',
+    'sessions',
+    'modelCalls',
+    'tokens',
+    'activeTab',
+    'loading',
   ]);
 
   override updated(changedProperties: Map<string, unknown>): void {
@@ -335,24 +345,34 @@ export class ScionPageMetrics extends LitElement {
         if (this.sessions) {
           if (this.sessions.dailyCounts?.length) {
             const sorted = this.sortPointsByDate(this.sessions.dailyCounts);
-            this.renderChart('chart-sessions', 'bar', sorted.map(p => p.timestamp), [
-              {
-                label: 'Sessions',
-                data: sorted.map(p => p.value),
-                backgroundColor: CHART_COLORS[0],
-              },
-            ]);
+            this.renderChart(
+              'chart-sessions',
+              'bar',
+              sorted.map((p) => p.timestamp),
+              [
+                {
+                  label: 'Sessions',
+                  data: sorted.map((p) => p.value),
+                  backgroundColor: CHART_COLORS[0],
+                },
+              ]
+            );
           }
           if (this.sessions.activeAgents?.length) {
             const sorted = this.sortPointsByDate(this.sessions.activeAgents);
-            this.renderChart('chart-agents', 'line', sorted.map(p => p.timestamp), [
-              {
-                label: 'Active Agents',
-                data: sorted.map(p => p.value),
-                borderColor: CHART_COLORS[1],
-                backgroundColor: CHART_COLORS[1] + '33',
-              },
-            ]);
+            this.renderChart(
+              'chart-agents',
+              'line',
+              sorted.map((p) => p.timestamp),
+              [
+                {
+                  label: 'Active Agents',
+                  data: sorted.map((p) => p.value),
+                  borderColor: CHART_COLORS[1],
+                  backgroundColor: CHART_COLORS[1] + '33',
+                },
+              ]
+            );
           }
         }
         break;
@@ -482,7 +502,7 @@ export class ScionPageMetrics extends LitElement {
         </div>
         <div class="period-selector">
           ${[7, 14, 30].map(
-            d => html`
+            (d) => html`
               <button
                 class="period-btn ${this.periodDays === d ? 'active' : ''}"
                 @click=${() => this.handlePeriodChange(d)}
@@ -505,9 +525,15 @@ export class ScionPageMetrics extends LitElement {
 
       <sl-tab-group @sl-tab-show=${this.handleTabChange}>
         <sl-tab slot="nav" panel="summary" ?active=${this.activeTab === 'summary'}>Summary</sl-tab>
-        <sl-tab slot="nav" panel="sessions" ?active=${this.activeTab === 'sessions'}>Sessions & Users</sl-tab>
-        <sl-tab slot="nav" panel="model-calls" ?active=${this.activeTab === 'model-calls'}>Model Calls</sl-tab>
-        <sl-tab slot="nav" panel="tokens" ?active=${this.activeTab === 'tokens'}>Token Usage</sl-tab>
+        <sl-tab slot="nav" panel="sessions" ?active=${this.activeTab === 'sessions'}
+          >Sessions & Users</sl-tab
+        >
+        <sl-tab slot="nav" panel="model-calls" ?active=${this.activeTab === 'model-calls'}
+          >Model Calls</sl-tab
+        >
+        <sl-tab slot="nav" panel="tokens" ?active=${this.activeTab === 'tokens'}
+          >Token Usage</sl-tab
+        >
 
         <sl-tab-panel name="summary">${this.renderSummaryTab()}</sl-tab-panel>
         <sl-tab-panel name="sessions">${this.renderSessionsTab()}</sl-tab-panel>
@@ -635,6 +661,6 @@ export class ScionPageMetrics extends LitElement {
     for (const p of points) {
       map.set(p.timestamp, p.value);
     }
-    return dates.map(d => map.get(d) ?? 0);
+    return dates.map((d) => map.get(d) ?? 0);
   }
 }

--- a/web/src/components/pages/onboarding.ts
+++ b/web/src/components/pages/onboarding.ts
@@ -21,7 +21,6 @@ import { apiFetch, extractApiError } from '../../client/api.js';
 import type { HarnessConfig } from '../../shared/types.js';
 import '../shared/dir-browser.js';
 
-
 const ONBOARDING_STATUS_KEY = 'onboardingStatus';
 const TOTAL_STEPS = 6;
 
@@ -90,7 +89,10 @@ export class ScionPageOnboarding extends LitElement {
   // Step 4: Harnesses + Images (merged)
   @state() private harnessConfigs: HarnessConfig[] = [];
   @state() private selectedHarnesses = new Set<string>();
-  @state() private imageCheckStatuses = new Map<string, { imageStatus: string; source?: string | undefined; checking?: boolean | undefined }>();
+  @state() private imageCheckStatuses = new Map<
+    string,
+    { imageStatus: string; source?: string | undefined; checking?: boolean | undefined }
+  >();
   @state() private imagePulling = false;
   @state() private imageRechecking = false;
   @state() private pullIndex = 0;
@@ -106,7 +108,15 @@ export class ScionPageOnboarding extends LitElement {
   @state() private workspaceMode: 'choose' | 'hub' | 'linked' = 'choose';
   @state() private wsProjectName = '';
   @state() private wsLocalPath = '';
-  @state() private wsPathValidation: { resolved: string; exists: boolean; isDir: boolean; isGit: boolean; isManaged: boolean; alreadyLinked: boolean; error?: string } | null = null;
+  @state() private wsPathValidation: {
+    resolved: string;
+    exists: boolean;
+    isDir: boolean;
+    isGit: boolean;
+    isManaged: boolean;
+    alreadyLinked: boolean;
+    error?: string;
+  } | null = null;
   @state() private wsValidatingPath = false;
   @state() private wsCreating = false;
   @state() private wsEmbeddedBrokerID = '';
@@ -499,7 +509,9 @@ export class ScionPageOnboarding extends LitElement {
       if (stored) {
         try {
           status = JSON.parse(stored) as OnboardingStatus;
-        } catch { /* ignore parse errors */ }
+        } catch {
+          /* ignore parse errors */
+        }
       }
 
       if (!status) {
@@ -525,8 +537,10 @@ export class ScionPageOnboarding extends LitElement {
       const previouslyStarted = sessionStorage.getItem('onboardingStarted') === 'true';
       if (status && previouslyStarted) {
         if (status.identitySet && this.currentStep === 0) this.currentStep = 1;
-        if (status.runtimeOK && this.currentStep <= 2) this.currentStep = Math.max(this.currentStep, 3);
-        if (status.harnessesSeeded && this.currentStep <= 3) this.currentStep = Math.max(this.currentStep, 4);
+        if (status.runtimeOK && this.currentStep <= 2)
+          this.currentStep = Math.max(this.currentStep, 3);
+        if (status.harnessesSeeded && this.currentStep <= 3)
+          this.currentStep = Math.max(this.currentStep, 4);
       }
 
       // Prefill identity from current user
@@ -537,7 +551,9 @@ export class ScionPageOnboarding extends LitElement {
           if (me.displayName) this.displayName = me.displayName;
           if (me.email) this.email = me.email;
         }
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
     } finally {
       this.loading = false;
     }
@@ -557,16 +573,18 @@ export class ScionPageOnboarding extends LitElement {
 
     return html`
       <div class="wizard">
-        ${this.currentStep < TOTAL_STEPS ? html`
-          <div class="progress">
-            <div class="step-label">Step ${this.currentStep + 1} of ${TOTAL_STEPS}</div>
-            <sl-progress-bar value=${Math.round((this.currentStep / TOTAL_STEPS) * 100)}></sl-progress-bar>
-          </div>
-        ` : nothing}
-
+        ${this.currentStep < TOTAL_STEPS
+          ? html`
+              <div class="progress">
+                <div class="step-label">Step ${this.currentStep + 1} of ${TOTAL_STEPS}</div>
+                <sl-progress-bar
+                  value=${Math.round((this.currentStep / TOTAL_STEPS) * 100)}
+                ></sl-progress-bar>
+              </div>
+            `
+          : nothing}
         ${this.error ? html`<div class="error-banner">${this.error}</div>` : nothing}
         ${this.dnsWarning ? html`<div class="warning-banner">${this.dnsWarning}</div>` : nothing}
-
         ${this.renderStep()}
       </div>
     `;
@@ -574,14 +592,22 @@ export class ScionPageOnboarding extends LitElement {
 
   private renderStep() {
     switch (this.currentStep) {
-      case 0: return this.renderIdentity();
-      case 1: return this.renderSystemCheck();
-      case 2: return this.renderRuntime();
-      case 3: return this.renderRegistry();
-      case 4: return this.renderHarnessesAndImages();
-      case 5: return this.renderWorkspacePlaceholder();
-      case 6: return this.renderDone();
-      default: return nothing;
+      case 0:
+        return this.renderIdentity();
+      case 1:
+        return this.renderSystemCheck();
+      case 2:
+        return this.renderRuntime();
+      case 3:
+        return this.renderRegistry();
+      case 4:
+        return this.renderHarnessesAndImages();
+      case 5:
+        return this.renderWorkspacePlaceholder();
+      case 6:
+        return this.renderDone();
+      default:
+        return nothing;
     }
   }
 
@@ -597,7 +623,9 @@ export class ScionPageOnboarding extends LitElement {
         <sl-input
           placeholder="Your name"
           value=${this.displayName}
-          @sl-input=${(e: Event) => { this.displayName = (e.target as HTMLInputElement).value; }}
+          @sl-input=${(e: Event) => {
+            this.displayName = (e.target as HTMLInputElement).value;
+          }}
         ></sl-input>
       </div>
 
@@ -607,7 +635,9 @@ export class ScionPageOnboarding extends LitElement {
           type="email"
           placeholder="you@example.com"
           value=${this.email}
-          @sl-input=${(e: Event) => { this.email = (e.target as HTMLInputElement).value; }}
+          @sl-input=${(e: Event) => {
+            this.email = (e.target as HTMLInputElement).value;
+          }}
         ></sl-input>
       </div>
 
@@ -618,7 +648,8 @@ export class ScionPageOnboarding extends LitElement {
             variant="primary"
             ?loading=${this.stepLoading}
             @click=${this.handleIdentityNext}
-          >Next</sl-button>
+            >Next</sl-button
+          >
         </div>
       </div>
     `;
@@ -657,44 +688,66 @@ export class ScionPageOnboarding extends LitElement {
       <h2>System Check</h2>
       <p>Verifying your environment is ready.</p>
 
-      ${this.stepLoading ? html`
-        <div class="loading-state">
-          <sl-spinner></sl-spinner>
-          <p>Running checks...</p>
-        </div>
-      ` : html`
-        <div class="check-results">
-          ${this.checkResults.map(r => html`
-            <div class="check-item">
-              <span class="pill ${r.status}">${r.status}</span>
-              <span class="name">${r.name}</span>
-              <span class="message">${r.message}</span>
+      ${this.stepLoading
+        ? html`
+            <div class="loading-state">
+              <sl-spinner></sl-spinner>
+              <p>Running checks...</p>
             </div>
-          `)}
-          ${!this.gitVersionOK && this.gitVersion ? html`
-            <div class="check-item">
-              <span class="pill warn">warn</span>
-              <span class="name">Git version</span>
-              <span class="message">
-                Git 2.47+ is required for agent worktrees. Detected: ${this.gitVersion}.
-                Run <code>brew install git</code> to upgrade.
-              </span>
+          `
+        : html`
+            <div class="check-results">
+              ${this.checkResults.map(
+                (r) => html`
+                  <div class="check-item">
+                    <span class="pill ${r.status}">${r.status}</span>
+                    <span class="name">${r.name}</span>
+                    <span class="message">${r.message}</span>
+                  </div>
+                `
+              )}
+              ${!this.gitVersionOK && this.gitVersion
+                ? html`
+                    <div class="check-item">
+                      <span class="pill warn">warn</span>
+                      <span class="name">Git version</span>
+                      <span class="message">
+                        Git 2.47+ is required for agent worktrees. Detected: ${this.gitVersion}. Run
+                        <code>brew install git</code> to upgrade.
+                      </span>
+                    </div>
+                  `
+                : nothing}
             </div>
-          ` : nothing}
-        </div>
-      `}
+          `}
 
       <div class="footer">
-        <sl-button variant="text" @click=${() => { this.currentStep = 0; }}>Back</sl-button>
+        <sl-button
+          variant="text"
+          @click=${() => {
+            this.currentStep = 0;
+          }}
+          >Back</sl-button
+        >
         <div class="footer-right">
-          <sl-button variant="default" ?loading=${this.stepLoading} @click=${() => { void this.loadSystemCheck(); }}>
+          <sl-button
+            variant="default"
+            ?loading=${this.stepLoading}
+            @click=${() => {
+              void this.loadSystemCheck();
+            }}
+          >
             Re-check
           </sl-button>
           <sl-button
             variant="primary"
             ?disabled=${!this.checkReady || this.stepLoading}
-            @click=${() => { this.currentStep = 2; void this.loadRuntime(); }}
-          >Next</sl-button>
+            @click=${() => {
+              this.currentStep = 2;
+              void this.loadRuntime();
+            }}
+            >Next</sl-button
+          >
         </div>
       </div>
     `;
@@ -726,45 +779,58 @@ export class ScionPageOnboarding extends LitElement {
       <h2>Container Runtime</h2>
       <p>Select the container runtime for your workstation.</p>
 
-      ${this.stepLoading ? html`
-        <div class="loading-state">
-          <sl-spinner></sl-spinner>
-          <p>Detecting runtime...</p>
-        </div>
-      ` : html`
-        <div class="runtime-info">
-          <div class="runtime-detected">
-            Detected: <strong>${this.detectedRuntime || 'none'}</strong>
-          </div>
-          ${this.configuredRuntime ? html`
-            <div class="runtime-detected">
-              Currently configured: <strong>${this.configuredRuntime}</strong>
+      ${this.stepLoading
+        ? html`
+            <div class="loading-state">
+              <sl-spinner></sl-spinner>
+              <p>Detecting runtime...</p>
             </div>
-          ` : nothing}
-        </div>
+          `
+        : html`
+            <div class="runtime-info">
+              <div class="runtime-detected">
+                Detected: <strong>${this.detectedRuntime || 'none'}</strong>
+              </div>
+              ${this.configuredRuntime
+                ? html`
+                    <div class="runtime-detected">
+                      Currently configured: <strong>${this.configuredRuntime}</strong>
+                    </div>
+                  `
+                : nothing}
+            </div>
 
-        <div class="form-group">
-          <label>Runtime</label>
-          <sl-select
-            value=${this.selectedRuntime}
-            @sl-change=${(e: Event) => { this.selectedRuntime = (e.target as HTMLSelectElement).value; }}
-          >
-            ${this.renderRuntimeOption('docker', 'Docker')}
-            ${this.renderRuntimeOption('podman', 'Podman')}
-            ${this.renderRuntimeOption('container', 'Container (Apple Virtualization)')}
-          </sl-select>
-        </div>
-      `}
+            <div class="form-group">
+              <label>Runtime</label>
+              <sl-select
+                value=${this.selectedRuntime}
+                @sl-change=${(e: Event) => {
+                  this.selectedRuntime = (e.target as HTMLSelectElement).value;
+                }}
+              >
+                ${this.renderRuntimeOption('docker', 'Docker')}
+                ${this.renderRuntimeOption('podman', 'Podman')}
+                ${this.renderRuntimeOption('container', 'Container (Apple Virtualization)')}
+              </sl-select>
+            </div>
+          `}
 
       <div class="footer">
-        <sl-button variant="text" @click=${() => { this.currentStep = 1; }}>Back</sl-button>
+        <sl-button
+          variant="text"
+          @click=${() => {
+            this.currentStep = 1;
+          }}
+          >Back</sl-button
+        >
         <div class="footer-right">
           <sl-button
             variant="primary"
             ?loading=${this.stepLoading}
             ?disabled=${!this.selectedRuntime}
             @click=${this.handleRuntimeNext}
-          >Next</sl-button>
+            >Next</sl-button
+          >
         </div>
       </div>
     `;
@@ -836,28 +902,48 @@ export class ScionPageOnboarding extends LitElement {
   private renderRegistry() {
     return html`
       <h2>Image Registry</h2>
-      <p>Enter the container image registry where Scion images are hosted. This is required to pull harness images.</p>
+      <p>
+        Enter the container image registry where Scion images are hosted. This is required to pull
+        harness images.
+      </p>
       <div class="form-group">
         <label>Registry URL</label>
         <sl-input
           placeholder="e.g. us-central1-docker.pkg.dev/my-project/scion"
           value=${this.registryInput}
-          @sl-input=${(e: Event) => { this.registryInput = (e.target as HTMLInputElement).value; }}
+          @sl-input=${(e: Event) => {
+            this.registryInput = (e.target as HTMLInputElement).value;
+          }}
         ></sl-input>
       </div>
       <p style="font-size:0.8125rem;color:var(--scion-text-muted,#64748b);">
-        Images like <code>${this.registryInput || 'your-registry'}/scion-claude:latest</code> will be pulled during setup.
+        Images like <code>${this.registryInput || 'your-registry'}/scion-claude:latest</code> will
+        be pulled during setup.
       </p>
       <div class="footer">
-        <sl-button variant="text" @click=${() => { this.currentStep = 2; }}>Back</sl-button>
+        <sl-button
+          variant="text"
+          @click=${() => {
+            this.currentStep = 2;
+          }}
+          >Back</sl-button
+        >
         <div class="footer-right">
-          <sl-button variant="default" @click=${() => { this.currentStep = 4; void this.loadHarnessConfigs(); }}>Skip for now</sl-button>
+          <sl-button
+            variant="default"
+            @click=${() => {
+              this.currentStep = 4;
+              void this.loadHarnessConfigs();
+            }}
+            >Skip for now</sl-button
+          >
           <sl-button
             variant="primary"
             ?loading=${this.registrySaving}
             ?disabled=${!this.registryInput.trim()}
             @click=${this.handleSaveRegistryAndNext}
-          >Next</sl-button>
+            >Next</sl-button
+          >
         </div>
       </div>
     `;
@@ -875,8 +961,8 @@ export class ScionPageOnboarding extends LitElement {
 
   private renderHarnessesAndImages() {
     const registry = this.imageRegistry || this.registryInput;
-    const selectedList = this.harnessConfigs.filter(hc => this.selectedHarnesses.has(hc.slug));
-    const needsPull = selectedList.filter(hc => {
+    const selectedList = this.harnessConfigs.filter((hc) => this.selectedHarnesses.has(hc.slug));
+    const needsPull = selectedList.filter((hc) => {
       const cs = this.imageCheckStatuses.get(hc.id);
       const status = cs?.imageStatus ?? hc.imageStatus ?? 'unknown';
       const source = cs?.source;
@@ -886,111 +972,146 @@ export class ScionPageOnboarding extends LitElement {
       <h2>AI Harnesses</h2>
       <p>Select harnesses and ensure container images are ready.</p>
 
-      ${this.stepLoading ? html`
-        <div class="loading-state">
-          <sl-spinner></sl-spinner>
-          <p>Loading harness configurations...</p>
-        </div>
-      ` : html`
-        ${this.imagePulling && this.pullTotal > 0 ? html`
-          <div class="pull-summary">
-            <div class="pull-summary-text">
-              Pulling image ${this.pullIndex} of ${this.pullTotal}...
+      ${this.stepLoading
+        ? html`
+            <div class="loading-state">
+              <sl-spinner></sl-spinner>
+              <p>Loading harness configurations...</p>
             </div>
-            <sl-progress-bar
-              value=${Math.round((this.pullIndex / this.pullTotal) * 100)}
-            ></sl-progress-bar>
-          </div>
-        ` : nothing}
+          `
+        : html`
+            ${this.imagePulling && this.pullTotal > 0
+              ? html`
+                  <div class="pull-summary">
+                    <div class="pull-summary-text">
+                      Pulling image ${this.pullIndex} of ${this.pullTotal}...
+                    </div>
+                    <sl-progress-bar
+                      value=${Math.round((this.pullIndex / this.pullTotal) * 100)}
+                    ></sl-progress-bar>
+                  </div>
+                `
+              : nothing}
 
-        <div class="harness-list">
-          ${this.harnessConfigs.map(hc => {
-            const cs = this.imageCheckStatuses.get(hc.id);
-            const imageStatus = cs?.imageStatus ?? hc.imageStatus ?? 'unknown';
-            const source = cs?.source;
-            const checking = cs?.checking ?? false;
-            const imageName = hc.config?.image ?? '';
-            const displayName = hc.displayName || hc.name;
+            <div class="harness-list">
+              ${this.harnessConfigs.map((hc) => {
+                const cs = this.imageCheckStatuses.get(hc.id);
+                const imageStatus = cs?.imageStatus ?? hc.imageStatus ?? 'unknown';
+                const source = cs?.source;
+                const checking = cs?.checking ?? false;
+                const imageName = hc.config?.image ?? '';
+                const displayName = hc.displayName || hc.name;
 
-            return html`
-              <div class="harness-item" style="flex-wrap:wrap;">
-                <sl-checkbox
-                  ?checked=${this.selectedHarnesses.has(hc.slug)}
-                  @sl-change=${(e: Event) => {
-                    const checked = (e.target as HTMLInputElement).checked;
-                    const next = new Set(this.selectedHarnesses);
-                    if (checked) { next.add(hc.slug); } else { next.delete(hc.slug); }
-                    this.selectedHarnesses = next;
-                  }}
-                >
-                  <span class="harness-name">${displayName}</span>
-                </sl-checkbox>
-                <span style="flex:1;font-family:monospace;font-size:0.8125rem;color:var(--scion-text-muted,#64748b);text-align:right;">
-                  ${imageName}
-                </span>
-                ${checking
-                  ? html`<span class="image-status pulling"><sl-spinner></sl-spinner> checking</span>`
-                  : imageStatus === 'valid' && source === 'local'
-                    ? html`<span class="image-status done">✓ ready</span>`
-                    : imageStatus === 'valid' && source === 'registry'
-                      ? html`<span class="image-status pulling">↓ available</span>`
-                      : imageStatus === 'invalid'
-                        ? html`<span class="image-status error">✗ not found</span>`
-                        : imageStatus === 'error'
-                          ? html`<span class="image-status error">⚠ error</span>`
-                          : html`<span class="image-status queued">? unknown</span>`
-                }
-              </div>
-            `;
-          })}
-        </div>
+                return html`
+                  <div class="harness-item" style="flex-wrap:wrap;">
+                    <sl-checkbox
+                      ?checked=${this.selectedHarnesses.has(hc.slug)}
+                      @sl-change=${(e: Event) => {
+                        const checked = (e.target as HTMLInputElement).checked;
+                        const next = new Set(this.selectedHarnesses);
+                        if (checked) {
+                          next.add(hc.slug);
+                        } else {
+                          next.delete(hc.slug);
+                        }
+                        this.selectedHarnesses = next;
+                      }}
+                    >
+                      <span class="harness-name">${displayName}</span>
+                    </sl-checkbox>
+                    <span
+                      style="flex:1;font-family:monospace;font-size:0.8125rem;color:var(--scion-text-muted,#64748b);text-align:right;"
+                    >
+                      ${imageName}
+                    </span>
+                    ${checking
+                      ? html`<span class="image-status pulling"
+                          ><sl-spinner></sl-spinner> checking</span
+                        >`
+                      : imageStatus === 'valid' && source === 'local'
+                        ? html`<span class="image-status done">✓ ready</span>`
+                        : imageStatus === 'valid' && source === 'registry'
+                          ? html`<span class="image-status pulling">↓ available</span>`
+                          : imageStatus === 'invalid'
+                            ? html`<span class="image-status error">✗ not found</span>`
+                            : imageStatus === 'error'
+                              ? html`<span class="image-status error">⚠ error</span>`
+                              : html`<span class="image-status queued">? unknown</span>`}
+                  </div>
+                `;
+              })}
+            </div>
 
-        ${this.selectedHarnesses.size > 0 ? html`
-          <div class="image-actions" style="margin-top:1rem;display:flex;gap:0.5rem;">
-            ${needsPull.length > 0 ? html`
-              <sl-button
-                variant="primary"
-                size="small"
-                ?loading=${this.imagePulling}
-                ?disabled=${this.imagePulling || !registry}
-                @click=${this.handlePullSelected}
-              >Pull selected</sl-button>
-            ` : nothing}
-            <sl-button
-              variant="default"
-              size="small"
-              ?loading=${this.imageRechecking}
-              ?disabled=${this.imagePulling || this.imageRechecking}
-              @click=${this.handleRecheckImages}
-            >Re-check</sl-button>
-          </div>
-        ` : nothing}
+            ${this.selectedHarnesses.size > 0
+              ? html`
+                  <div class="image-actions" style="margin-top:1rem;display:flex;gap:0.5rem;">
+                    ${needsPull.length > 0
+                      ? html`
+                          <sl-button
+                            variant="primary"
+                            size="small"
+                            ?loading=${this.imagePulling}
+                            ?disabled=${this.imagePulling || !registry}
+                            @click=${this.handlePullSelected}
+                            >Pull selected</sl-button
+                          >
+                        `
+                      : nothing}
+                    <sl-button
+                      variant="default"
+                      size="small"
+                      ?loading=${this.imageRechecking}
+                      ?disabled=${this.imagePulling || this.imageRechecking}
+                      @click=${this.handleRecheckImages}
+                      >Re-check</sl-button
+                    >
+                  </div>
+                `
+              : nothing}
 
-        <p style="font-size:0.8125rem;color:var(--scion-text-muted,#64748b);margin-top:1rem;">
-          Additional harnesses can be imported and configured from Hub settings after onboarding.
-        </p>
-      `}
-
-      ${this.gcloudADCAvailable ? html`
-        <div style="margin-top:1rem;padding:0.75rem 1rem;border:1px solid var(--sl-color-neutral-200);border-radius:var(--sl-border-radius-medium);background:var(--sl-color-neutral-50);">
-          <sl-checkbox
-            ?checked=${this.autoInjectGcloudADC}
-            @sl-change=${(e: Event) => {
-              this.autoInjectGcloudADC = (e.target as HTMLInputElement).checked;
-            }}
-          >
-            Automatically inject gcloud credentials into agent containers
-          </sl-checkbox>
-          <p style="font-size:0.75rem;color:var(--scion-text-muted,#64748b);margin:0.25rem 0 0 1.75rem;">
-            Detected: ~/.config/gcloud/application_default_credentials.json
-          </p>
-        </div>
-      ` : nothing}
+            <p style="font-size:0.8125rem;color:var(--scion-text-muted,#64748b);margin-top:1rem;">
+              Additional harnesses can be imported and configured from Hub settings after
+              onboarding.
+            </p>
+          `}
+      ${this.gcloudADCAvailable
+        ? html`
+            <div
+              style="margin-top:1rem;padding:0.75rem 1rem;border:1px solid var(--sl-color-neutral-200);border-radius:var(--sl-border-radius-medium);background:var(--sl-color-neutral-50);"
+            >
+              <sl-checkbox
+                ?checked=${this.autoInjectGcloudADC}
+                @sl-change=${(e: Event) => {
+                  this.autoInjectGcloudADC = (e.target as HTMLInputElement).checked;
+                }}
+              >
+                Automatically inject gcloud credentials into agent containers
+              </sl-checkbox>
+              <p
+                style="font-size:0.75rem;color:var(--scion-text-muted,#64748b);margin:0.25rem 0 0 1.75rem;"
+              >
+                Detected: ~/.config/gcloud/application_default_credentials.json
+              </p>
+            </div>
+          `
+        : nothing}
 
       <div class="footer">
-        <sl-button variant="text" @click=${() => { this.currentStep = 3; }}>Back</sl-button>
+        <sl-button
+          variant="text"
+          @click=${() => {
+            this.currentStep = 3;
+          }}
+          >Back</sl-button
+        >
         <div class="footer-right">
-          <sl-button variant="default" @click=${() => { this.cleanupImageEvents(); this.currentStep = 5; }}>
+          <sl-button
+            variant="default"
+            @click=${() => {
+              this.cleanupImageEvents();
+              this.currentStep = 5;
+            }}
+          >
             Skip for now
           </sl-button>
           <sl-button
@@ -998,7 +1119,8 @@ export class ScionPageOnboarding extends LitElement {
             ?loading=${this.stepLoading}
             ?disabled=${this.selectedHarnesses.size === 0}
             @click=${this.handleHarnessesNext}
-          >Next</sl-button>
+            >Next</sl-button
+          >
         </div>
       </div>
     `;
@@ -1031,7 +1153,7 @@ export class ScionPageOnboarding extends LitElement {
   }
 
   private async checkStaleImageStatuses(): Promise<void> {
-    const staleConfigs = this.harnessConfigs.filter(hc => {
+    const staleConfigs = this.harnessConfigs.filter((hc) => {
       if (!hc.config?.image) return false;
       if (hc.imageStatus === 'unknown' || !hc.imageStatus) return true;
       if (hc.imageStatusCheckedAt) {
@@ -1044,7 +1166,7 @@ export class ScionPageOnboarding extends LitElement {
     const batchSize = 4;
     for (let i = 0; i < staleConfigs.length; i += batchSize) {
       const batch = staleConfigs.slice(i, i + batchSize);
-      await Promise.all(batch.map(hc => this.checkImageStatus(hc)));
+      await Promise.all(batch.map((hc) => this.checkImageStatus(hc)));
     }
   }
 
@@ -1054,11 +1176,17 @@ export class ScionPageOnboarding extends LitElement {
     this.imageCheckStatuses = next;
 
     try {
-      const res = await apiFetch(`/api/v1/harness-configs/${hc.id}/check-image`, { method: 'POST' });
+      const res = await apiFetch(`/api/v1/harness-configs/${hc.id}/check-image`, {
+        method: 'POST',
+      });
       if (res.ok) {
         const data = (await res.json()) as { image_status: string; source?: string };
         const updated = new Map(this.imageCheckStatuses);
-        updated.set(hc.id, { imageStatus: data.image_status, source: data.source, checking: false });
+        updated.set(hc.id, {
+          imageStatus: data.image_status,
+          source: data.source,
+          checking: false,
+        });
         this.imageCheckStatuses = updated;
       } else {
         const updated = new Map(this.imageCheckStatuses);
@@ -1105,15 +1233,15 @@ export class ScionPageOnboarding extends LitElement {
   private async handlePullSelected(): Promise<void> {
     this.error = null;
     this.imagePulling = true;
-    const selectedList = this.harnessConfigs.filter(hc => this.selectedHarnesses.has(hc.slug));
+    const selectedList = this.harnessConfigs.filter((hc) => this.selectedHarnesses.has(hc.slug));
     const harnesses = selectedList
-      .filter(hc => {
+      .filter((hc) => {
         const cs = this.imageCheckStatuses.get(hc.id);
         const status = cs?.imageStatus ?? hc.imageStatus ?? 'unknown';
         const source = cs?.source;
         return !(status === 'valid' && source === 'local');
       })
-      .map(hc => hc.slug);
+      .map((hc) => hc.slug);
 
     if (harnesses.length === 0) {
       this.imagePulling = false;
@@ -1167,7 +1295,10 @@ export class ScionPageOnboarding extends LitElement {
     es.addEventListener('update', (event: Event) => {
       lastEventTime = Date.now();
       try {
-        const wrapper = JSON.parse((event as MessageEvent).data) as { subject: string; data?: Record<string, unknown> };
+        const wrapper = JSON.parse((event as MessageEvent).data) as {
+          subject: string;
+          data?: Record<string, unknown>;
+        };
         const d = wrapper.data;
         if (!d) return;
 
@@ -1175,7 +1306,11 @@ export class ScionPageOnboarding extends LitElement {
           const fullImageName = d['image'] as string;
           const status = d['status'] as string;
 
-          if (status !== 'queued' && typeof d['index'] === 'number' && typeof d['total'] === 'number') {
+          if (
+            status !== 'queued' &&
+            typeof d['index'] === 'number' &&
+            typeof d['total'] === 'number'
+          ) {
             this.pullIndex = d['index'] as number;
             this.pullTotal = d['total'] as number;
           }
@@ -1215,7 +1350,7 @@ export class ScionPageOnboarding extends LitElement {
     const batchSize = 4;
     for (let i = 0; i < this.harnessConfigs.length; i += batchSize) {
       const batch = this.harnessConfigs.slice(i, i + batchSize);
-      await Promise.all(batch.map(hc => this.checkImageStatus(hc)));
+      await Promise.all(batch.map((hc) => this.checkImageStatus(hc)));
     }
   }
 
@@ -1265,33 +1400,67 @@ export class ScionPageOnboarding extends LitElement {
       <p>Create your first project to get started.</p>
 
       <div class="ws-cards">
-        <div class="ws-card" @click=${() => { this.workspaceMode = 'hub'; }}>
+        <div
+          class="ws-card"
+          @click=${() => {
+            this.workspaceMode = 'hub';
+          }}
+        >
           <sl-icon name="cloud"></sl-icon>
           <div class="ws-card-text">
             <div class="ws-card-title">Hub-managed project</div>
-            <div class="ws-card-desc">A workspace managed by the Hub. No git repository required.</div>
+            <div class="ws-card-desc">
+              A workspace managed by the Hub. No git repository required.
+            </div>
           </div>
         </div>
-        <div class="ws-card" @click=${() => { window.location.href = '/projects/new'; }}>
+        <div
+          class="ws-card"
+          @click=${() => {
+            window.location.href = '/projects/new';
+          }}
+        >
           <sl-icon name="git"></sl-icon>
           <div class="ws-card-text">
             <div class="ws-card-title">Link a git repo</div>
-            <div class="ws-card-desc">Connect to an existing git repository for source-controlled workspaces.</div>
+            <div class="ws-card-desc">
+              Connect to an existing git repository for source-controlled workspaces.
+            </div>
           </div>
         </div>
-        <div class="ws-card" @click=${() => { this.workspaceMode = 'linked'; void this.loadWsBrokerID(); }}>
+        <div
+          class="ws-card"
+          @click=${() => {
+            this.workspaceMode = 'linked';
+            void this.loadWsBrokerID();
+          }}
+        >
           <sl-icon name="folder-symlink"></sl-icon>
           <div class="ws-card-text">
             <div class="ws-card-title">Add local directory</div>
-            <div class="ws-card-desc">Link a local directory. It stays where it is and is operated on in place.</div>
+            <div class="ws-card-desc">
+              Link a local directory. It stays where it is and is operated on in place.
+            </div>
           </div>
         </div>
       </div>
 
       <div class="footer">
-        <sl-button variant="text" @click=${() => { this.currentStep = 4; }}>Back</sl-button>
+        <sl-button
+          variant="text"
+          @click=${() => {
+            this.currentStep = 4;
+          }}
+          >Back</sl-button
+        >
         <div class="footer-right">
-          <sl-button variant="default" @click=${() => { this.currentStep = 6; }}>Skip for now</sl-button>
+          <sl-button
+            variant="default"
+            @click=${() => {
+              this.currentStep = 6;
+            }}
+            >Skip for now</sl-button
+          >
         </div>
       </div>
     `;
@@ -1307,20 +1476,35 @@ export class ScionPageOnboarding extends LitElement {
         <sl-input
           placeholder="my-project"
           .value=${this.wsProjectName}
-          @sl-input=${(e: Event) => { this.wsProjectName = (e.target as HTMLInputElement).value; }}
+          @sl-input=${(e: Event) => {
+            this.wsProjectName = (e.target as HTMLInputElement).value;
+          }}
         ></sl-input>
       </div>
 
       <div class="footer">
-        <sl-button variant="text" @click=${() => { this.workspaceMode = 'choose'; }}>Back</sl-button>
+        <sl-button
+          variant="text"
+          @click=${() => {
+            this.workspaceMode = 'choose';
+          }}
+          >Back</sl-button
+        >
         <div class="footer-right">
-          <sl-button variant="default" @click=${() => { this.currentStep = 6; }}>Skip for now</sl-button>
+          <sl-button
+            variant="default"
+            @click=${() => {
+              this.currentStep = 6;
+            }}
+            >Skip for now</sl-button
+          >
           <sl-button
             variant="primary"
             ?loading=${this.wsCreating}
             ?disabled=${!this.wsProjectName.trim()}
             @click=${this.handleWsHubCreate}
-          >Create & Continue</sl-button>
+            >Create & Continue</sl-button
+          >
         </div>
       </div>
     `;
@@ -1348,7 +1532,11 @@ export class ScionPageOnboarding extends LitElement {
   }
 
   private renderWsLinked() {
-    const pathOk = this.wsPathValidation && !this.wsPathValidation.error && this.wsPathValidation.exists && this.wsPathValidation.isDir;
+    const pathOk =
+      this.wsPathValidation &&
+      !this.wsPathValidation.error &&
+      this.wsPathValidation.exists &&
+      this.wsPathValidation.isDir;
 
     return html`
       <h2>Add Local Directory</h2>
@@ -1359,7 +1547,9 @@ export class ScionPageOnboarding extends LitElement {
         <sl-input
           placeholder="my-project"
           .value=${this.wsProjectName}
-          @sl-input=${(e: Event) => { this.wsProjectName = (e.target as HTMLInputElement).value; }}
+          @sl-input=${(e: Event) => {
+            this.wsProjectName = (e.target as HTMLInputElement).value;
+          }}
         ></sl-input>
       </div>
 
@@ -1380,13 +1570,14 @@ export class ScionPageOnboarding extends LitElement {
         ></scion-dir-browser>
       </div>
 
-      ${this.wsLocalPath ? html`
-        <div class="form-group">
-          <label>Selected Path</label>
-          <sl-input readonly .value=${this.wsLocalPath}></sl-input>
-        </div>
-      ` : nothing}
-
+      ${this.wsLocalPath
+        ? html`
+            <div class="form-group">
+              <label>Selected Path</label>
+              <sl-input readonly .value=${this.wsLocalPath}></sl-input>
+            </div>
+          `
+        : nothing}
       ${this.wsValidatingPath
         ? html`<div class="ws-validation valid" style="display:flex;align-items:center;gap:0.5rem;">
             <sl-spinner style="font-size:0.875rem;"></sl-spinner> Validating…
@@ -1399,23 +1590,45 @@ export class ScionPageOnboarding extends LitElement {
                   ? html`<div class="ws-validation error">Path does not exist.</div>`
                   : !this.wsPathValidation.isDir
                     ? html`<div class="ws-validation error">Not a directory.</div>`
-                    : html`<div class="ws-validation valid">Path is valid: ${this.wsPathValidation.resolved}</div>
-                        ${this.wsPathValidation.isGit ? html`<div class="ws-validation warning" style="margin-top:0.25rem;">This is a git repository.</div>` : nothing}
-                        ${this.wsPathValidation.alreadyLinked ? html`<div class="ws-validation warning" style="margin-top:0.25rem;">Already linked to another project.</div>` : nothing}
-                      `}
+                    : html`<div class="ws-validation valid">
+                          Path is valid: ${this.wsPathValidation.resolved}
+                        </div>
+                        ${this.wsPathValidation.isGit
+                          ? html`<div class="ws-validation warning" style="margin-top:0.25rem;">
+                              This is a git repository.
+                            </div>`
+                          : nothing}
+                        ${this.wsPathValidation.alreadyLinked
+                          ? html`<div class="ws-validation warning" style="margin-top:0.25rem;">
+                              Already linked to another project.
+                            </div>`
+                          : nothing} `}
             `
           : nothing}
 
       <div class="footer">
-        <sl-button variant="text" @click=${() => { this.workspaceMode = 'choose'; }}>Back</sl-button>
+        <sl-button
+          variant="text"
+          @click=${() => {
+            this.workspaceMode = 'choose';
+          }}
+          >Back</sl-button
+        >
         <div class="footer-right">
-          <sl-button variant="default" @click=${() => { this.currentStep = 6; }}>Skip for now</sl-button>
+          <sl-button
+            variant="default"
+            @click=${() => {
+              this.currentStep = 6;
+            }}
+            >Skip for now</sl-button
+          >
           <sl-button
             variant="primary"
             ?loading=${this.wsCreating}
             ?disabled=${!pathOk || !this.wsProjectName.trim()}
             @click=${this.handleWsLinkedCreate}
-          >Create & Continue</sl-button>
+            >Create & Continue</sl-button
+          >
         </div>
       </div>
     `;
@@ -1428,7 +1641,9 @@ export class ScionPageOnboarding extends LitElement {
       if (!res.ok) return;
       const data = (await res.json()) as { embeddedBrokerID?: string };
       if (data.embeddedBrokerID) this.wsEmbeddedBrokerID = data.embeddedBrokerID;
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
   private async wsValidatePath(path: string): Promise<void> {
@@ -1442,8 +1657,11 @@ export class ScionPageOnboarding extends LitElement {
       });
       if (!res.ok) return;
       this.wsPathValidation = (await res.json()) as typeof this.wsPathValidation;
-    } catch { /* ignore */ }
-    finally { this.wsValidatingPath = false; }
+    } catch {
+      /* ignore */
+    } finally {
+      this.wsValidatingPath = false;
+    }
   }
 
   private async handleWsLinkedCreate(): Promise<void> {
@@ -1465,15 +1683,24 @@ export class ScionPageOnboarding extends LitElement {
       }
       const projData = (await projRes.json()) as { project?: { id: string }; id?: string };
       const projectId = projData.project?.id || projData.id;
-      if (!projectId) { this.error = 'No project ID in response'; return; }
+      if (!projectId) {
+        this.error = 'No project ID in response';
+        return;
+      }
 
       const provRes = await apiFetch(`/api/v1/projects/${projectId}/providers`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ brokerId: this.wsEmbeddedBrokerID, localPath: this.wsPathValidation!.resolved }),
+        body: JSON.stringify({
+          brokerId: this.wsEmbeddedBrokerID,
+          localPath: this.wsPathValidation!.resolved,
+        }),
       });
       if (!provRes.ok) {
-        this.error = await extractApiError(provRes, 'Project created but failed to link directory. You can retry.');
+        this.error = await extractApiError(
+          provRes,
+          'Project created but failed to link directory. You can retry.'
+        );
         return;
       }
       this.currentStep = 6;
@@ -1496,7 +1723,13 @@ export class ScionPageOnboarding extends LitElement {
         <sl-icon name="check-circle"></sl-icon>
         <h1>You're All Set</h1>
         <p>Your workstation is configured and ready to use.</p>
-        <sl-button variant="primary" size="large" @click=${() => { window.location.href = '/'; }}>
+        <sl-button
+          variant="primary"
+          size="large"
+          @click=${() => {
+            window.location.href = '/';
+          }}
+        >
           Go to Dashboard
         </sl-button>
       </div>

--- a/web/src/components/pages/profile-discord.ts
+++ b/web/src/components/pages/profile-discord.ts
@@ -52,7 +52,10 @@ export class ScionPageProfileDiscord extends LitElement {
       this._discordUsername = userName;
     }
     if (code) {
-      this._code = code.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 6);
+      this._code = code
+        .toUpperCase()
+        .replace(/[^A-Z0-9]/g, '')
+        .slice(0, 6);
       if (this._code.length === 6) {
         this._autoLinked = true;
         this._autoSubmit();
@@ -75,14 +78,17 @@ export class ScionPageProfileDiscord extends LitElement {
 
       if (resp.ok) {
         this._status = 'success';
-        this._message = 'Discord account linked successfully! You can close this page and return to Discord.';
+        this._message =
+          'Discord account linked successfully! You can close this page and return to Discord.';
         this._code = '';
       } else {
         const errData = (await resp.json().catch(() => null)) as {
           message?: string;
         } | null;
         this._status = 'error';
-        this._message = errData?.message || 'Code not found or expired. Please try again with a new code from the bot.';
+        this._message =
+          errData?.message ||
+          'Code not found or expired. Please try again with a new code from the bot.';
       }
     } catch {
       this._status = 'error';
@@ -222,7 +228,10 @@ export class ScionPageProfileDiscord extends LitElement {
 
   private _handleInput(e: Event): void {
     const input = e.target as HTMLInputElement & { value: string };
-    this._code = input.value.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 6);
+    this._code = input.value
+      .toUpperCase()
+      .replace(/[^A-Z0-9]/g, '')
+      .slice(0, 6);
     input.value = this._code;
   }
 
@@ -247,14 +256,17 @@ export class ScionPageProfileDiscord extends LitElement {
 
       if (resp.ok) {
         this._status = 'success';
-        this._message = 'Discord account linked successfully! You can close this page and return to Discord.';
+        this._message =
+          'Discord account linked successfully! You can close this page and return to Discord.';
         this._code = '';
       } else {
         const errData = (await resp.json().catch(() => null)) as {
           message?: string;
         } | null;
         this._status = 'error';
-        this._message = errData?.message || 'Code not found or expired. Please try again with a new code from the bot.';
+        this._message =
+          errData?.message ||
+          'Code not found or expired. Please try again with a new code from the bot.';
       }
     } catch {
       this._status = 'error';
@@ -315,7 +327,9 @@ export class ScionPageProfileDiscord extends LitElement {
         </div>
 
         ${this._discordUsername
-          ? html`<p class="discord-user">Linking as Discord user: <strong>${this._discordUsername}</strong></p>`
+          ? html`<p class="discord-user">
+              Linking as Discord user: <strong>${this._discordUsername}</strong>
+            </p>`
           : nothing}
 
         <form class="code-form" @submit=${this._handleSubmit}>

--- a/web/src/components/pages/profile-settings.ts
+++ b/web/src/components/pages/profile-settings.ts
@@ -285,7 +285,8 @@ export class ScionPageProfileSettings extends LitElement {
   }
 
   override render() {
-    const isDisabled = this._permissionState === 'unsupported' || this._permissionState === 'denied';
+    const isDisabled =
+      this._permissionState === 'unsupported' || this._permissionState === 'denied';
 
     return html`
       <div class="page-header">
@@ -305,8 +306,8 @@ export class ScionPageProfileSettings extends LitElement {
           <div class="setting-info">
             <p class="setting-label">Enable Push Notifications</p>
             <p class="setting-description">
-              Receive browser notifications when agents complete tasks, encounter errors,
-              or need your input.
+              Receive browser notifications when agents complete tasks, encounter errors, or need
+              your input.
             </p>
           </div>
           <div class="setting-control">
@@ -321,30 +322,34 @@ export class ScionPageProfileSettings extends LitElement {
         ${this._renderPermissionStatus()}
       </div>
 
-      ${this._gcloudADCAvailable && this._isWorkstation ? html`
-        <div class="settings-card">
-          <h2 class="section-title">
-            <sl-icon name="cloud"></sl-icon>
-            GCP Credentials
-          </h2>
+      ${this._gcloudADCAvailable && this._isWorkstation
+        ? html`
+            <div class="settings-card">
+              <h2 class="section-title">
+                <sl-icon name="cloud"></sl-icon>
+                GCP Credentials
+              </h2>
 
-          <div class="setting-row">
-            <div class="setting-info">
-              <p class="setting-label">Automatically inject gcloud credentials into agent containers</p>
-              <p class="setting-description">
-                When enabled, agents launched in workstation mode will have access to
-                your local gcloud Application Default Credentials.
-              </p>
+              <div class="setting-row">
+                <div class="setting-info">
+                  <p class="setting-label">
+                    Automatically inject gcloud credentials into agent containers
+                  </p>
+                  <p class="setting-description">
+                    When enabled, agents launched in workstation mode will have access to your local
+                    gcloud Application Default Credentials.
+                  </p>
+                </div>
+                <div class="setting-control">
+                  <sl-switch
+                    ?checked=${this._autoInjectGcloudADC}
+                    @sl-change=${this._handleADCToggle}
+                  ></sl-switch>
+                </div>
+              </div>
             </div>
-            <div class="setting-control">
-              <sl-switch
-                ?checked=${this._autoInjectGcloudADC}
-                @sl-change=${this._handleADCToggle}
-              ></sl-switch>
-            </div>
-          </div>
-        </div>
-      ` : nothing}
+          `
+        : nothing}
 
       <scion-subscription-manager compact></scion-subscription-manager>
     `;

--- a/web/src/components/pages/profile-teams.ts
+++ b/web/src/components/pages/profile-teams.ts
@@ -330,7 +330,9 @@ export class ScionPageProfileTeams extends LitElement {
       <div class="page-header">
         <div class="page-header-info">
           <h1>Microsoft Teams</h1>
-          <p>Link your Microsoft Teams account to receive notifications and interact with agents.</p>
+          <p>
+            Link your Microsoft Teams account to receive notifications and interact with agents.
+          </p>
         </div>
       </div>
 

--- a/web/src/components/pages/profile-tokens.ts
+++ b/web/src/components/pages/profile-tokens.ts
@@ -97,29 +97,27 @@ export class ScionPageProfileTokens extends LitElement {
     super.connectedCallback();
     this.checkGitHubApp();
   }
-private async checkGitHubApp(): Promise<void> {
-  try {
-    const [appRes, projectsRes] = await Promise.all([
-      apiFetch('/api/v1/github-app'),
-      apiFetch('/api/v1/projects?mine=true'),
-    ]);
+  private async checkGitHubApp(): Promise<void> {
+    try {
+      const [appRes, projectsRes] = await Promise.all([
+        apiFetch('/api/v1/github-app'),
+        apiFetch('/api/v1/projects?mine=true'),
+      ]);
 
-    if (!appRes.ok || !projectsRes.ok) return;
+      if (!appRes.ok || !projectsRes.ok) return;
 
-    const appData = (await appRes.json()) as GitHubAppInfo;
-    if (!appData.configured || !appData.installation_url) return;
+      const appData = (await appRes.json()) as GitHubAppInfo;
+      if (!appData.configured || !appData.installation_url) return;
 
-    const projectsData = (await projectsRes.json()) as { projects: Project[] };
-    const hasInstallation = (projectsData.projects || []).some(
-      (p) => p.githubInstallationId
-    );
-    if (hasInstallation) {
-      this.githubAppLink = appData.installation_url;
+      const projectsData = (await projectsRes.json()) as { projects: Project[] };
+      const hasInstallation = (projectsData.projects || []).some((p) => p.githubInstallationId);
+      if (hasInstallation) {
+        this.githubAppLink = appData.installation_url;
+      }
+    } catch {
+      // Non-fatal — the link is a convenience feature
     }
-  } catch {
-    // Non-fatal — the link is a convenience feature
   }
-}
 
   override render() {
     return html`
@@ -127,8 +125,8 @@ private async checkGitHubApp(): Promise<void> {
         <div class="page-header-info">
           <h1>Access Tokens</h1>
           <p>
-            Create and manage personal access tokens for CI/CD pipelines and automation.
-            Tokens are scoped to a specific project with limited permissions.
+            Create and manage personal access tokens for CI/CD pipelines and automation. Tokens are
+            scoped to a specific project with limited permissions.
           </p>
         </div>
       </div>
@@ -138,12 +136,7 @@ private async checkGitHubApp(): Promise<void> {
             <div class="github-app-card">
               <sl-icon name="github"></sl-icon>
               <span>Manage repository access and permissions for the GitHub App integration.</span>
-              <sl-button
-                size="small"
-                variant="default"
-                href=${this.githubAppLink}
-                target="_blank"
-              >
+              <sl-button size="small" variant="default" href=${this.githubAppLink} target="_blank">
                 <sl-icon slot="prefix" name="box-arrow-up-right"></sl-icon>
                 Configure GitHub App
               </sl-button>

--- a/web/src/components/pages/project-create.ts
+++ b/web/src/components/pages/project-create.ts
@@ -104,7 +104,7 @@ export class ScionPageProjectCreate extends LitElement {
 
   // Template mode state
   @state()
-  private templates: Array<{id: string; name: string; slug: string}> = [];
+  private templates: Array<{ id: string; name: string; slug: string }> = [];
 
   @state()
   private selectedTemplateId = '';
@@ -457,7 +457,9 @@ export class ScionPageProjectCreate extends LitElement {
     try {
       const res = await apiFetch('/api/v1/projects?isTemplate=true');
       if (res.ok) {
-        const data = (await res.json()) as { projects?: Array<{id: string; name: string; slug: string}> };
+        const data = (await res.json()) as {
+          projects?: Array<{ id: string; name: string; slug: string }>;
+        };
         this.templates = data.projects ?? [];
       } else {
         this.error = 'Failed to load templates. Please try again.';
@@ -499,9 +501,7 @@ export class ScionPageProjectCreate extends LitElement {
 
   private async checkExistingProjects(gitUrl: string): Promise<void> {
     try {
-      const response = await apiFetch(
-        `/api/v1/projects?gitRemote=${encodeURIComponent(gitUrl)}`,
-      );
+      const response = await apiFetch(`/api/v1/projects?gitRemote=${encodeURIComponent(gitUrl)}`);
       if (!response.ok) return;
       const data = (await response.json()) as {
         projects?: Array<{ id: string; name: string; slug: string }>;
@@ -533,12 +533,18 @@ export class ScionPageProjectCreate extends LitElement {
         this.error = 'Local directory path is required.';
         return;
       }
-      if (!this.pathValidation || this.pathValidation.error || !this.pathValidation.exists || !this.pathValidation.isDir) {
+      if (
+        !this.pathValidation ||
+        this.pathValidation.error ||
+        !this.pathValidation.exists ||
+        !this.pathValidation.isDir
+      ) {
         this.error = 'Please select a valid directory path.';
         return;
       }
       if (!this.embeddedBrokerID) {
-        this.error = 'No embedded broker available. Ensure the server is running in workstation mode.';
+        this.error =
+          'No embedded broker available. Ensure the server is running in workstation mode.';
         return;
       }
     }
@@ -563,7 +569,10 @@ export class ScionPageProjectCreate extends LitElement {
           }),
         });
         if (!response.ok) {
-          const errorText = await extractApiError(response, 'Failed to create project from template');
+          const errorText = await extractApiError(
+            response,
+            'Failed to create project from template'
+          );
           throw new Error(errorText);
         }
         const created = (await response.json()) as { id: string };
@@ -642,7 +651,10 @@ export class ScionPageProjectCreate extends LitElement {
           }),
         });
         if (!providerRes.ok) {
-          this.error = await extractApiError(providerRes, 'Project created but failed to link directory. You can retry.');
+          this.error = await extractApiError(
+            providerRes,
+            'Project created but failed to link directory. You can retry.'
+          );
           this.submitting = false;
           return;
         }
@@ -729,17 +741,22 @@ export class ScionPageProjectCreate extends LitElement {
                     @sl-input=${(e: Event) => this.onGitRemoteInput(e)}
                     required
                   ></sl-input>
-                  <div class="hint">
-                    HTTPS or SSH URL of the git repository.
-                  </div>
+                  <div class="hint">HTTPS or SSH URL of the git repository.</div>
                 </div>
 
                 ${this.githubAppUrl
                   ? html`
                       <div class="github-app-hint">
                         <sl-icon name="github"></sl-icon>
-                        <span>Ensure this repository is accessible via the
-                          <a href=${this.githubAppUrl} target="_blank" rel="noopener">GitHub App <sl-icon name="box-arrow-up-right" style="font-size: 0.7em; vertical-align: middle;"></sl-icon></a>
+                        <span
+                          >Ensure this repository is accessible via the
+                          <a href=${this.githubAppUrl} target="_blank" rel="noopener"
+                            >GitHub App
+                            <sl-icon
+                              name="box-arrow-up-right"
+                              style="font-size: 0.7em; vertical-align: middle;"
+                            ></sl-icon
+                          ></a>
                         </span>
                       </div>
                     `
@@ -758,21 +775,26 @@ export class ScionPageProjectCreate extends LitElement {
                     password-toggle
                   ></sl-input>
                   <div class="hint">
-                    Optional. A personal access token for cloning private repositories. Saved as a project secret.
+                    Optional. A personal access token for cloning private repositories. Saved as a
+                    project secret.
                   </div>
                 </div>
 
                 ${this.existingProjectsForRemote.length > 0
-
                   ? html`
                       <div class="info-banner">
                         <sl-icon name="info-circle"></sl-icon>
                         <div>
-                          <strong>${this.existingProjectsForRemote.length} existing project(s)</strong> share this git remote.
-                          A new project will be created with a unique slug.
+                          <strong
+                            >${this.existingProjectsForRemote.length} existing project(s)</strong
+                          >
+                          share this git remote. A new project will be created with a unique slug.
                           <ul style="margin: 0.25rem 0 0; padding-left: 1.25rem;">
                             ${this.existingProjectsForRemote.map(
-                              (p) => html`<li>${p.name} <span style="opacity: 0.7">(${p.slug})</span></li>`,
+                              (p) =>
+                                html`<li>
+                                  ${p.name} <span style="opacity: 0.7">(${p.slug})</span>
+                                </li>`
                             )}
                           </ul>
                         </div>
@@ -785,7 +807,8 @@ export class ScionPageProjectCreate extends LitElement {
                   <sl-radio-group
                     .value=${this.gitWorkspaceMode}
                     @sl-change=${(e: Event) => {
-                      this.gitWorkspaceMode = (e.target as HTMLElement & { value: string }).value as GitWorkspaceMode;
+                      this.gitWorkspaceMode = (e.target as HTMLElement & { value: string })
+                        .value as GitWorkspaceMode;
                     }}
                   >
                     <sl-radio-button value="per-agent">Clone per agent</sl-radio-button>
@@ -801,8 +824,9 @@ export class ScionPageProjectCreate extends LitElement {
                   </div>
                   ${this.gitWorkspaceMode === 'worktree-per-agent'
                     ? html`<div class="workspace-mode-note">
-                        A single base clone is created, and each agent gets a lightweight git worktree.
-                        Requires git ≥ 2.47 on the node. On Kubernetes, requires the NFS backend.
+                        A single base clone is created, and each agent gets a lightweight git
+                        worktree. Requires git ≥ 2.47 on the node. On Kubernetes, requires the NFS
+                        backend.
                       </div>`
                     : this.gitWorkspaceMode === 'shared'
                       ? html`<div class="workspace-mode-note">
@@ -813,37 +837,43 @@ export class ScionPageProjectCreate extends LitElement {
                 </div>
               `
             : nothing}
-
           ${this.mode === 'template'
             ? html`
                 <div class="form-field">
                   <label>Template</label>
-                  ${this.templatesLoading ? html`<sl-spinner></sl-spinner>` : html`
-                  <sl-select
-                    placeholder="Select a template..."
-                    .value=${this.selectedTemplateId}
-                    @sl-change=${(e: Event) => (this.selectedTemplateId = (e.target as HTMLSelectElement).value)}
-                  >
-                    ${this.templates.length === 0
-                      ? html`<sl-option disabled value="">No templates available</sl-option>`
-                      : this.templates.map(t => html`<sl-option value=${t.id}>${t.name}</sl-option>`)}
-                  </sl-select>
-                  `}
+                  ${this.templatesLoading
+                    ? html`<sl-spinner></sl-spinner>`
+                    : html`
+                        <sl-select
+                          placeholder="Select a template..."
+                          .value=${this.selectedTemplateId}
+                          @sl-change=${(e: Event) =>
+                            (this.selectedTemplateId = (e.target as HTMLSelectElement).value)}
+                        >
+                          ${this.templates.length === 0
+                            ? html`<sl-option disabled value="">No templates available</sl-option>`
+                            : this.templates.map(
+                                (t) => html`<sl-option value=${t.id}>${t.name}</sl-option>`
+                              )}
+                        </sl-select>
+                      `}
                 </div>
                 <div class="form-field">
                   <label>Git Remote URL (optional)</label>
                   <sl-input
                     placeholder="https://github.com/org/repo.git"
                     .value=${this.templateGitRemote}
-                    @sl-input=${(e: Event) => { this.templateGitRemote = (e.target as HTMLElement & {value: string}).value; }}
+                    @sl-input=${(e: Event) => {
+                      this.templateGitRemote = (e.target as HTMLElement & { value: string }).value;
+                    }}
                   ></sl-input>
                   <div class="hint">
-                    Override the git remote from the template. Leave blank to use the template's default.
+                    Override the git remote from the template. Leave blank to use the template's
+                    default.
                   </div>
                 </div>
               `
             : nothing}
-
           ${this.mode === 'linked'
             ? html`
                 <div class="form-field">
@@ -855,7 +885,12 @@ export class ScionPageProjectCreate extends LitElement {
                       .value=${this.localPath}
                       @sl-input=${(e: Event) => this.onLocalPathInput(e)}
                     ></sl-input>
-                    <sl-button variant="default" @click=${() => { this.browseDialogOpen = true; }}>
+                    <sl-button
+                      variant="default"
+                      @click=${() => {
+                        this.browseDialogOpen = true;
+                      }}
+                    >
                       Browse…
                     </sl-button>
                   </div>
@@ -865,7 +900,10 @@ export class ScionPageProjectCreate extends LitElement {
                 </div>
 
                 ${this.validatingPath
-                  ? html`<div class="validation-result valid" style="display: flex; align-items: center; gap: 0.5rem;">
+                  ? html`<div
+                      class="validation-result valid"
+                      style="display: flex; align-items: center; gap: 0.5rem;"
+                    >
                       <sl-spinner style="font-size: 0.875rem;"></sl-spinner> Validating path…
                     </div>`
                   : this.pathValidation
@@ -891,13 +929,20 @@ export class ScionPageProjectCreate extends LitElement {
                                     Path resolved to: ${this.pathValidation.resolved}
                                   </div>
                                   ${this.pathValidation.isGit
-                                    ? html`<div class="validation-result warning" style="margin-top: 0.25rem;">
+                                    ? html`<div
+                                        class="validation-result warning"
+                                        style="margin-top: 0.25rem;"
+                                      >
                                         <sl-icon name="info-circle"></sl-icon>
-                                        This is a git repository. Agents will operate on the working tree.
+                                        This is a git repository. Agents will operate on the working
+                                        tree.
                                       </div>`
                                     : nothing}
                                   ${this.pathValidation.alreadyLinked
-                                    ? html`<div class="validation-result warning" style="margin-top: 0.25rem;">
+                                    ? html`<div
+                                        class="validation-result warning"
+                                        style="margin-top: 0.25rem;"
+                                      >
                                         <sl-icon name="info-circle"></sl-icon>
                                         This directory is already linked to another project.
                                       </div>`
@@ -907,20 +952,22 @@ export class ScionPageProjectCreate extends LitElement {
                     : nothing}
               `
             : nothing}
-
-          ${this.mode !== 'template' ? html`
-          <div class="form-field">
-            <label for="slug">Slug</label>
-            <sl-input
-              id="slug"
-              placeholder="my-project"
-              .value=${this.slug}
-              @sl-input=${(e: Event) => this.onSlugInput(e)}
-            ></sl-input>
-            <div class="hint">URL-safe identifier. Auto-derived from name if left unchanged.</div>
-          </div>
-          ` : nothing}
-
+          ${this.mode !== 'template'
+            ? html`
+                <div class="form-field">
+                  <label for="slug">Slug</label>
+                  <sl-input
+                    id="slug"
+                    placeholder="my-project"
+                    .value=${this.slug}
+                    @sl-input=${(e: Event) => this.onSlugInput(e)}
+                  ></sl-input>
+                  <div class="hint">
+                    URL-safe identifier. Auto-derived from name if left unchanged.
+                  </div>
+                </div>
+              `
+            : nothing}
           ${this.mode === 'git'
             ? html`
                 <div class="form-field">
@@ -937,23 +984,24 @@ export class ScionPageProjectCreate extends LitElement {
                 </div>
               `
             : nothing}
-
-          ${this.mode !== 'template' ? html`
-          <div class="form-field">
-            <label for="visibility">Visibility</label>
-            <sl-select
-              id="visibility"
-              .value=${this.visibility}
-              @sl-change=${(e: Event) => {
-                this.visibility = (e.target as HTMLElement & { value: string }).value;
-              }}
-            >
-              <sl-option value="private">Private</sl-option>
-              <sl-option value="team">Team</sl-option>
-              <sl-option value="public">Public</sl-option>
-            </sl-select>
-          </div>
-          ` : nothing}
+          ${this.mode !== 'template'
+            ? html`
+                <div class="form-field">
+                  <label for="visibility">Visibility</label>
+                  <sl-select
+                    id="visibility"
+                    .value=${this.visibility}
+                    @sl-change=${(e: Event) => {
+                      this.visibility = (e.target as HTMLElement & { value: string }).value;
+                    }}
+                  >
+                    <sl-option value="private">Private</sl-option>
+                    <sl-option value="team">Team</sl-option>
+                    <sl-option value="public">Public</sl-option>
+                  </sl-select>
+                </div>
+              `
+            : nothing}
 
           <div class="form-actions">
             <sl-button
@@ -966,9 +1014,7 @@ export class ScionPageProjectCreate extends LitElement {
               Create Project
             </sl-button>
             <a href="/projects" style="text-decoration: none;">
-              <sl-button variant="default" ?disabled=${this.submitting}>
-                Cancel
-              </sl-button>
+              <sl-button variant="default" ?disabled=${this.submitting}> Cancel </sl-button>
             </a>
           </div>
         </div>
@@ -977,7 +1023,9 @@ export class ScionPageProjectCreate extends LitElement {
       <sl-dialog
         label="Browse Directory"
         ?open=${this.browseDialogOpen}
-        @sl-after-hide=${() => { this.browseDialogOpen = false; }}
+        @sl-after-hide=${() => {
+          this.browseDialogOpen = false;
+        }}
         style="--width: 36rem;"
       >
         <scion-dir-browser
@@ -988,11 +1036,11 @@ export class ScionPageProjectCreate extends LitElement {
       <sl-dialog
         label="Project Already Exists"
         ?open=${this.existingProjectId !== null}
-        @sl-after-hide=${() => { this.existingProjectId = null; }}
+        @sl-after-hide=${() => {
+          this.existingProjectId = null;
+        }}
       >
-        <div class="exists-dialog-body">
-          A project with this ID already exists.
-        </div>
+        <div class="exists-dialog-body">A project with this ID already exists.</div>
         <sl-button
           slot="footer"
           variant="primary"

--- a/web/src/components/pages/project-detail.ts
+++ b/web/src/components/pages/project-detail.ts
@@ -23,8 +23,22 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-import type { PageData, Project, Agent, AgentPhase, Capabilities, ProjectSessionMetricsSummary } from '../../shared/types.js';
-import { can, canAny, getAgentDisplayStatus, isAgentRunning, isTerminalAvailable, isSharedWorkspace } from '../../shared/types.js';
+import type {
+  PageData,
+  Project,
+  Agent,
+  AgentPhase,
+  Capabilities,
+  ProjectSessionMetricsSummary,
+} from '../../shared/types.js';
+import {
+  can,
+  canAny,
+  getAgentDisplayStatus,
+  isAgentRunning,
+  isTerminalAvailable,
+  isSharedWorkspace,
+} from '../../shared/types.js';
 import type { StatusType } from '../shared/status-badge.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { dispatchPageTitle } from '../../client/page-title.js';
@@ -37,9 +51,15 @@ import '../shared/agent-tree-view.js';
 import '../shared/agent-message-viewer.js';
 import '../shared/file-browser.js';
 import '../shared/file-editor.js';
-import { WorkspaceFileBrowserDataSource, SharedDirFileBrowserDataSource } from '../shared/file-browser.js';
+import {
+  WorkspaceFileBrowserDataSource,
+  SharedDirFileBrowserDataSource,
+} from '../shared/file-browser.js';
 import type { FileBrowserDataSource } from '../shared/file-browser.js';
-import { WorkspaceFileEditorDataSource, SharedDirFileEditorDataSource } from '../shared/file-editor.js';
+import {
+  WorkspaceFileEditorDataSource,
+  SharedDirFileEditorDataSource,
+} from '../shared/file-editor.js';
 import type { FileEditorDataSource } from '../shared/file-editor.js';
 import { showToast } from '../../utils/toast.js';
 import { showConfirm } from '../shared/confirm-dialog.js';
@@ -794,7 +814,12 @@ export class ScionPageProjectDetail extends LitElement {
 
     // Read persisted phase filter
     const storedPhase = localStorage.getItem(`scion-filter-project-agents-phase-${this.projectId}`);
-    if (storedPhase === 'running' || storedPhase === 'stopped' || storedPhase === 'suspended' || storedPhase === 'error') {
+    if (
+      storedPhase === 'running' ||
+      storedPhase === 'stopped' ||
+      storedPhase === 'suspended' ||
+      storedPhase === 'error'
+    ) {
       this.phaseFilter = storedPhase;
     }
 
@@ -805,13 +830,18 @@ export class ScionPageProjectDetail extends LitElement {
         const parsed = JSON.parse(storedSort);
         if (
           parsed &&
-          (parsed.field === 'name' || parsed.field === 'status' || parsed.field === 'created' || parsed.field === 'updated') &&
+          (parsed.field === 'name' ||
+            parsed.field === 'status' ||
+            parsed.field === 'created' ||
+            parsed.field === 'updated') &&
           (parsed.dir === 'asc' || parsed.dir === 'desc')
         ) {
           this.sortField = parsed.field;
           this.sortDir = parsed.dir;
         }
-      } catch { /* ignore invalid stored sort */ }
+      } catch {
+        /* ignore invalid stored sort */
+      }
     }
 
     void this.loadData();
@@ -829,7 +859,10 @@ export class ScionPageProjectDetail extends LitElement {
   override disconnectedCallback(): void {
     super.disconnectedCallback();
     stateManager.removeEventListener('agents-updated', this.boundOnAgentsUpdated as EventListener);
-    stateManager.removeEventListener('projects-updated', this.boundOnProjectsUpdated as EventListener);
+    stateManager.removeEventListener(
+      'projects-updated',
+      this.boundOnProjectsUpdated as EventListener
+    );
   }
 
   private onAgentsUpdated(): void {
@@ -888,7 +921,12 @@ export class ScionPageProjectDetail extends LitElement {
       ]);
 
       if (!projectResponse.ok) {
-        throw new Error(await extractApiError(projectResponse, `HTTP ${projectResponse.status}: ${projectResponse.statusText}`));
+        throw new Error(
+          await extractApiError(
+            projectResponse,
+            `HTTP ${projectResponse.status}: ${projectResponse.statusText}`
+          )
+        );
       }
 
       this.project = (await projectResponse.json()) as Project;
@@ -908,7 +946,7 @@ export class ScionPageProjectDetail extends LitElement {
         // Derive scope capabilities from per-agent capabilities when the
         // response doesn't include a top-level _capabilities field.
         if (!this.agentScopeCapabilities) {
-          this.agentScopeCapabilities = this.agents.find(a => a._capabilities)?._capabilities;
+          this.agentScopeCapabilities = this.agents.find((a) => a._capabilities)?._capabilities;
         }
       } else {
         // Fallback: if project-scoped agents endpoint fails, try filtering from all agents
@@ -927,7 +965,12 @@ export class ScionPageProjectDetail extends LitElement {
         this.getTabDataSource('workspace');
       }
       // For git-based projects (non-shared) with shared dirs, activate the first shared dir
-      if (this.project && this.project.gitRemote && !isSharedWorkspace(this.project) && this.project.sharedDirs?.length) {
+      if (
+        this.project &&
+        this.project.gitRemote &&
+        !isSharedWorkspace(this.project) &&
+        this.project.sharedDirs?.length
+      ) {
         this.activeFileTab = this.project.sharedDirs[0].name;
         this.getTabDataSource(this.project.sharedDirs[0].name);
       }
@@ -937,7 +980,12 @@ export class ScionPageProjectDetail extends LitElement {
       void this.loadSessionMetricsSummary();
 
       // Auto-discover GitHub App installation if project has a GitHub remote but no installation
-      if (this.project && this.project.gitRemote && /github\.com[/:]/.test(this.project.gitRemote) && this.project.githubInstallationId == null) {
+      if (
+        this.project &&
+        this.project.gitRemote &&
+        /github\.com[/:]/.test(this.project.gitRemote) &&
+        this.project.githubInstallationId == null
+      ) {
         void this.autoDiscoverGitHubApp();
       }
     } catch (err) {
@@ -988,7 +1036,7 @@ export class ScionPageProjectDetail extends LitElement {
   }
 
   private backgroundRefresh(): void {
-    this.fetchAndMergeAgents().catch(err => {
+    this.fetchAndMergeAgents().catch((err) => {
       console.warn('Background refresh failed:', err);
     });
   }
@@ -1016,7 +1064,7 @@ export class ScionPageProjectDetail extends LitElement {
       this.agentScopeCapabilities = data._capabilities;
     }
     if (!this.agentScopeCapabilities) {
-      this.agentScopeCapabilities = this.agents.find(a => a._capabilities)?._capabilities;
+      this.agentScopeCapabilities = this.agents.find((a) => a._capabilities)?._capabilities;
     }
     stateManager.seedAgents(this.agents);
   }
@@ -1030,7 +1078,9 @@ export class ScionPageProjectDetail extends LitElement {
       if (!configData.configured) return;
 
       // Trigger discovery — the hub will match installations to this project's git remote
-      const discoverRes = await apiFetch('/api/v1/github-app/installations/discover', { method: 'POST' });
+      const discoverRes = await apiFetch('/api/v1/github-app/installations/discover', {
+        method: 'POST',
+      });
       if (!discoverRes.ok) return;
 
       // Reload project data to pick up the newly associated installation
@@ -1050,7 +1100,12 @@ export class ScionPageProjectDetail extends LitElement {
 
   private renderLinkedBadge() {
     if (!this.project || this.project.projectType !== 'linked') return nothing;
-    return html` <sl-tooltip content="Linked project"><sl-icon name="link-45deg" style="font-size: 0.875rem; vertical-align: middle; opacity: 0.7;"></sl-icon></sl-tooltip>`;
+    return html` <sl-tooltip content="Linked project"
+      ><sl-icon
+        name="link-45deg"
+        style="font-size: 0.875rem; vertical-align: middle; opacity: 0.7;"
+      ></sl-icon
+    ></sl-tooltip>`;
   }
 
   private formatDate(dateString: string): string {
@@ -1073,7 +1128,10 @@ export class ScionPageProjectDetail extends LitElement {
       if (tabName === 'workspace') {
         this.fileBrowserDataSources[tabName] = new WorkspaceFileBrowserDataSource(this.projectId);
       } else {
-        this.fileBrowserDataSources[tabName] = new SharedDirFileBrowserDataSource(this.projectId, tabName);
+        this.fileBrowserDataSources[tabName] = new SharedDirFileBrowserDataSource(
+          this.projectId,
+          tabName
+        );
       }
     }
     return this.fileBrowserDataSources[tabName];
@@ -1084,7 +1142,10 @@ export class ScionPageProjectDetail extends LitElement {
       if (tabName === 'workspace') {
         this.editorDataSources[tabName] = new WorkspaceFileEditorDataSource(this.projectId);
       } else {
-        this.editorDataSources[tabName] = new SharedDirFileEditorDataSource(this.projectId, tabName);
+        this.editorDataSources[tabName] = new SharedDirFileEditorDataSource(
+          this.projectId,
+          tabName
+        );
       }
     }
     return this.editorDataSources[tabName];
@@ -1115,7 +1176,6 @@ export class ScionPageProjectDetail extends LitElement {
     this.refreshActiveFileBrowser();
   }
 
-
   private async handleAgentAction(
     agentId: string,
     action: 'start' | 'stop' | 'suspend' | 'resume' | 'delete',
@@ -1138,7 +1198,7 @@ export class ScionPageProjectDetail extends LitElement {
         }
 
         // Server confirmed — remove from local list
-        this.agents = this.agents.filter(a => a.id !== agentId);
+        this.agents = this.agents.filter((a) => a.id !== agentId);
         this.backgroundRefresh();
       } catch (err) {
         console.error('Failed to delete agent:', err);
@@ -1156,7 +1216,7 @@ export class ScionPageProjectDetail extends LitElement {
       suspend: 'stopping',
       resume: 'starting',
     };
-    const agentIndex = this.agents.findIndex(a => a.id === agentId);
+    const agentIndex = this.agents.findIndex((a) => a.id === agentId);
     if (agentIndex >= 0) {
       const updated = { ...this.agents[agentIndex] };
       updated.phase = optimisticPhase[action] as Agent['phase'];
@@ -1193,13 +1253,13 @@ export class ScionPageProjectDetail extends LitElement {
   private get displayAgents(): Agent[] {
     let list = this.agents;
     if (this.phaseFilter) {
-      list = list.filter(a => a.phase === this.phaseFilter);
+      list = list.filter((a) => a.phase === this.phaseFilter);
     }
     if (this.labelFilter.trim()) {
       const parts = this.labelFilter.trim().split('=');
       const filterKey = parts[0];
       const filterValue = parts.slice(1).join('=');
-      list = list.filter(a => {
+      list = list.filter((a) => {
         if (!a.labels) return false;
         if (filterValue) return a.labels[filterKey] === filterValue;
         return filterKey in a.labels;
@@ -1219,7 +1279,15 @@ export class ScionPageProjectDetail extends LitElement {
           cmp = (a.created || a.createdAt || '').localeCompare(b.created || b.createdAt || '');
           break;
         case 'updated':
-          cmp = ((a.lastActivityEvent && !a.lastActivityEvent.startsWith('0001')) ? a.lastActivityEvent : (a.updated || a.updatedAt || '')).localeCompare((b.lastActivityEvent && !b.lastActivityEvent.startsWith('0001')) ? b.lastActivityEvent : (b.updated || b.updatedAt || ''));
+          cmp = (
+            a.lastActivityEvent && !a.lastActivityEvent.startsWith('0001')
+              ? a.lastActivityEvent
+              : a.updated || a.updatedAt || ''
+          ).localeCompare(
+            b.lastActivityEvent && !b.lastActivityEvent.startsWith('0001')
+              ? b.lastActivityEvent
+              : b.updated || b.updatedAt || ''
+          );
           break;
       }
       return this.sortDir === 'asc' ? cmp : -cmp;
@@ -1244,7 +1312,10 @@ export class ScionPageProjectDetail extends LitElement {
       this.sortField = field;
       this.sortDir = field === 'name' ? 'asc' : 'desc';
     }
-    localStorage.setItem(`scion-sort-project-agents-${this.projectId}`, JSON.stringify({ field: this.sortField, dir: this.sortDir }));
+    localStorage.setItem(
+      `scion-sort-project-agents-${this.projectId}`,
+      JSON.stringify({ field: this.sortField, dir: this.sortDir })
+    );
   }
 
   private sortIndicator(field: AgentSortField): string {
@@ -1275,23 +1346,33 @@ export class ScionPageProjectDetail extends LitElement {
           <button
             class=${this.phaseFilter === '' ? 'active' : ''}
             @click=${() => this.setPhaseFilter('')}
-          >All</button>
+          >
+            All
+          </button>
           <button
             class=${this.phaseFilter === 'running' ? 'active' : ''}
             @click=${() => this.setPhaseFilter('running')}
-          >Running</button>
+          >
+            Running
+          </button>
           <button
             class=${this.phaseFilter === 'stopped' ? 'active' : ''}
             @click=${() => this.setPhaseFilter('stopped')}
-          >Stopped</button>
+          >
+            Stopped
+          </button>
           <button
             class=${this.phaseFilter === 'suspended' ? 'active' : ''}
             @click=${() => this.setPhaseFilter('suspended')}
-          >Suspended</button>
+          >
+            Suspended
+          </button>
           <button
             class=${this.phaseFilter === 'error' ? 'active' : ''}
             @click=${() => this.setPhaseFilter('error')}
-          >Error</button>
+          >
+            Error
+          </button>
         </div>
         <sl-input
           size="small"
@@ -1302,25 +1383,44 @@ export class ScionPageProjectDetail extends LitElement {
             this.labelFilter = (e.target as HTMLElement & { value: string }).value;
           }}
           @sl-change=${() => void this.backgroundRefresh()}
-          @sl-clear=${() => { this.labelFilter = ''; void this.backgroundRefresh(); }}
+          @sl-clear=${() => {
+            this.labelFilter = '';
+            void this.backgroundRefresh();
+          }}
           style="max-width: 220px;"
         >
           <sl-icon slot="prefix" name="tag"></sl-icon>
         </sl-input>
-        ${this.viewMode === 'grid' ? html`
-          <sl-dropdown>
-            <sl-button slot="trigger" size="small" outline>
-              <sl-icon slot="prefix" name=${this.sortDir === 'asc' ? 'sort-alpha-down' : 'sort-alpha-down-alt'}></sl-icon>
-              Sort: ${this.sortField}
-            </sl-button>
-            <sl-menu @sl-select=${(e: CustomEvent<{ item: { value: string } }>) => this.toggleSort(e.detail.item.value as AgentSortField)}>
-              <sl-menu-item value="name" ?checked=${this.sortField === 'name'}>Name</sl-menu-item>
-              <sl-menu-item value="status" ?checked=${this.sortField === 'status'}>Status</sl-menu-item>
-              <sl-menu-item value="created" ?checked=${this.sortField === 'created'}>Created</sl-menu-item>
-              <sl-menu-item value="updated" ?checked=${this.sortField === 'updated'}>Updated</sl-menu-item>
-            </sl-menu>
-          </sl-dropdown>
-        ` : nothing}
+        ${this.viewMode === 'grid'
+          ? html`
+              <sl-dropdown>
+                <sl-button slot="trigger" size="small" outline>
+                  <sl-icon
+                    slot="prefix"
+                    name=${this.sortDir === 'asc' ? 'sort-alpha-down' : 'sort-alpha-down-alt'}
+                  ></sl-icon>
+                  Sort: ${this.sortField}
+                </sl-button>
+                <sl-menu
+                  @sl-select=${(e: CustomEvent<{ item: { value: string } }>) =>
+                    this.toggleSort(e.detail.item.value as AgentSortField)}
+                >
+                  <sl-menu-item value="name" ?checked=${this.sortField === 'name'}
+                    >Name</sl-menu-item
+                  >
+                  <sl-menu-item value="status" ?checked=${this.sortField === 'status'}
+                    >Status</sl-menu-item
+                  >
+                  <sl-menu-item value="created" ?checked=${this.sortField === 'created'}
+                    >Created</sl-menu-item
+                  >
+                  <sl-menu-item value="updated" ?checked=${this.sortField === 'updated'}
+                    >Updated</sl-menu-item
+                  >
+                </sl-menu>
+              </sl-dropdown>
+            `
+          : nothing}
       </div>
     `;
   }
@@ -1339,7 +1439,7 @@ export class ScionPageProjectDetail extends LitElement {
     }
 
     // Optimistic: mark running agents as "stopping"
-    this.agents = this.agents.map(a =>
+    this.agents = this.agents.map((a) =>
       isAgentRunning(a) ? { ...a, phase: 'stopping' as const } : a
     );
     this.stopAllLoading = true;
@@ -1383,8 +1483,11 @@ export class ScionPageProjectDetail extends LitElement {
       if (!response.ok) {
         // Extract error message from structured APIError or legacy format
         const apiErr = result?.error;
-        let errorMsg = (typeof apiErr === 'object' ? apiErr?.message : null)
-          || result?.detail || result?.error || 'Pull failed';
+        let errorMsg =
+          (typeof apiErr === 'object' ? apiErr?.message : null) ||
+          result?.detail ||
+          result?.error ||
+          'Pull failed';
         // Append guidance hint if available
         const guidance = apiErr?.details?.guidance;
         if (guidance) {
@@ -1398,7 +1501,10 @@ export class ScionPageProjectDetail extends LitElement {
       // Refresh file list after pull
       this.refreshActiveFileBrowser();
     } catch (err) {
-      this.pullResult = { status: 'error', error: err instanceof Error ? err.message : 'Pull failed' };
+      this.pullResult = {
+        status: 'error',
+        error: err instanceof Error ? err.message : 'Pull failed',
+      };
     } finally {
       this.pullLoading = false;
     }
@@ -1511,9 +1617,7 @@ export class ScionPageProjectDetail extends LitElement {
           @sl-input=${(e: Event) => (this.templateName = (e.target as HTMLInputElement).value)}
           ?disabled=${this.templateLoading}
         ></sl-input>
-        ${this.templateError
-          ? html`<div class="clone-error">${this.templateError}</div>`
-          : nothing}
+        ${this.templateError ? html`<div class="clone-error">${this.templateError}</div>` : nothing}
         <sl-button
           slot="footer"
           variant="primary"
@@ -1554,17 +1658,13 @@ export class ScionPageProjectDetail extends LitElement {
           @sl-input=${(e: Event) => (this.cloneName = (e.target as HTMLInputElement).value)}
           ?disabled=${this.cloneLoading}
         ></sl-input>
-        <div class="clone-slug-preview">
-          Slug: ${this.slugify(this.cloneName) || '...'}
-        </div>
+        <div class="clone-slug-preview">Slug: ${this.slugify(this.cloneName) || '...'}</div>
         <div class="clone-summary">
           <strong>Copies:</strong> settings, labels, environment variables, injected skills,
           pre-start hook, project harness configs and templates.<br />
           <strong>Does not copy:</strong> secrets, agents, history, or chat integrations.
         </div>
-        ${this.cloneError
-          ? html`<div class="clone-error">${this.cloneError}</div>`
-          : nothing}
+        ${this.cloneError ? html`<div class="clone-error">${this.cloneError}</div>` : nothing}
         <sl-button
           slot="footer"
           variant="primary"
@@ -1611,7 +1711,9 @@ export class ScionPageProjectDetail extends LitElement {
             ${this.renderProjectIcon()}
             <h1>${this.project.name}${this.renderLinkedBadge()}</h1>
           </div>
-          <div class="header-path"><scion-git-remote-display .project=${this.project}></scion-git-remote-display></div>
+          <div class="header-path">
+            <scion-git-remote-display .project=${this.project}></scion-git-remote-display>
+          </div>
         </div>
         <div class="header-actions">
           ${can(this.agentScopeCapabilities, 'create')
@@ -1624,7 +1726,9 @@ export class ScionPageProjectDetail extends LitElement {
                 </a>
               `
             : nothing}
-          ${this.project && isSharedWorkspace(this.project) && can(this.project?._capabilities, 'update')
+          ${this.project &&
+          isSharedWorkspace(this.project) &&
+          can(this.project?._capabilities, 'update')
             ? html`
                 <sl-button
                   size="small"
@@ -1690,9 +1794,7 @@ export class ScionPageProjectDetail extends LitElement {
         </div>
         <div class="stat">
           <span class="stat-label">Running</span>
-          <span class="stat-value"
-            >${this.agents.filter((a) => isAgentRunning(a)).length}</span
-          >
+          <span class="stat-value">${this.agents.filter((a) => isAgentRunning(a)).length}</span>
         </div>
         <div class="stat">
           <span class="stat-label">Created</span>
@@ -1708,73 +1810,91 @@ export class ScionPageProjectDetail extends LitElement {
         </div>
       </div>
 
-      ${this.metricsSummary ? html`
-        <div class="stats-row" style="margin-top: 0.5rem;">
-          <div class="stat">
-            <span class="stat-label">Sessions (24h)</span>
-            <span class="stat-value">${this.metricsSummary.sessionsCount24h}</span>
-          </div>
-          <div class="stat">
-            <span class="stat-label">API Calls (24h)</span>
-            <span class="stat-value">${this.metricsSummary.apiCalls24h}</span>
-          </div>
-          <div class="stat">
-            <span class="stat-label">Tokens (24h)</span>
-            <span class="stat-value">${this.formatTokenCount(this.metricsSummary.tokenUsage24h)}</span>
-          </div>
-          <div class="stat">
-            <span class="stat-label">Active Agents (24h)</span>
-            <span class="stat-value">${this.metricsSummary.activeAgents24h}</span>
-          </div>
-          <div style="display: flex; align-items: center; margin-left: auto;">
-            <a href="/projects/${this.projectId}/metrics" style="text-decoration: none;">
-              <sl-button size="small" variant="text">
-                <sl-icon slot="prefix" name="graph-up"></sl-icon>
-                View Details
-              </sl-button>
-            </a>
-          </div>
-        </div>
-      ` : nothing}
-
-      ${this.sessionMetricsSummary ? html`
-        <div class="stats-row" style="margin-top: 0.5rem;">
-          <div class="stat">
-            <span class="stat-label">Total Sessions</span>
-            <span class="stat-value">${this.sessionMetricsSummary.totalSessions}</span>
-          </div>
-          <div class="stat">
-            <span class="stat-label">Total Tokens</span>
-            <span class="stat-value">${this.formatTokenCount(this.sessionMetricsSummary.totalTokensInput + this.sessionMetricsSummary.totalTokensOutput)}</span>
-          </div>
-          <div class="stat">
-            <span class="stat-label">Active Agents</span>
-            <span class="stat-value">${this.sessionMetricsSummary.activeAgents}</span>
-          </div>
-        </div>
-      ` : nothing}
-
+      ${this.metricsSummary
+        ? html`
+            <div class="stats-row" style="margin-top: 0.5rem;">
+              <div class="stat">
+                <span class="stat-label">Sessions (24h)</span>
+                <span class="stat-value">${this.metricsSummary.sessionsCount24h}</span>
+              </div>
+              <div class="stat">
+                <span class="stat-label">API Calls (24h)</span>
+                <span class="stat-value">${this.metricsSummary.apiCalls24h}</span>
+              </div>
+              <div class="stat">
+                <span class="stat-label">Tokens (24h)</span>
+                <span class="stat-value"
+                  >${this.formatTokenCount(this.metricsSummary.tokenUsage24h)}</span
+                >
+              </div>
+              <div class="stat">
+                <span class="stat-label">Active Agents (24h)</span>
+                <span class="stat-value">${this.metricsSummary.activeAgents24h}</span>
+              </div>
+              <div style="display: flex; align-items: center; margin-left: auto;">
+                <a href="/projects/${this.projectId}/metrics" style="text-decoration: none;">
+                  <sl-button size="small" variant="text">
+                    <sl-icon slot="prefix" name="graph-up"></sl-icon>
+                    View Details
+                  </sl-button>
+                </a>
+              </div>
+            </div>
+          `
+        : nothing}
+      ${this.sessionMetricsSummary
+        ? html`
+            <div class="stats-row" style="margin-top: 0.5rem;">
+              <div class="stat">
+                <span class="stat-label">Total Sessions</span>
+                <span class="stat-value">${this.sessionMetricsSummary.totalSessions}</span>
+              </div>
+              <div class="stat">
+                <span class="stat-label">Total Tokens</span>
+                <span class="stat-value"
+                  >${this.formatTokenCount(
+                    this.sessionMetricsSummary.totalTokensInput +
+                      this.sessionMetricsSummary.totalTokensOutput
+                  )}</span
+                >
+              </div>
+              <div class="stat">
+                <span class="stat-label">Active Agents</span>
+                <span class="stat-value">${this.sessionMetricsSummary.activeAgents}</span>
+              </div>
+            </div>
+          `
+        : nothing}
       ${this.pullResult
         ? html`
             <sl-alert
               variant=${this.pullResult.status === 'ok' ? 'success' : 'danger'}
               open
               closable
-              @sl-after-hide=${() => { this.pullResult = null; }}
+              @sl-after-hide=${() => {
+                this.pullResult = null;
+              }}
             >
-              <sl-icon slot="icon" name=${this.pullResult.status === 'ok' ? 'check-circle' : 'exclamation-triangle'}></sl-icon>
+              <sl-icon
+                slot="icon"
+                name=${this.pullResult.status === 'ok' ? 'check-circle' : 'exclamation-triangle'}
+              ></sl-icon>
               ${this.pullResult.status === 'ok'
-                ? this.pullResult.updated && this.pullResult.commits && this.pullResult.commits.length > 0
+                ? this.pullResult.updated &&
+                  this.pullResult.commits &&
+                  this.pullResult.commits.length > 0
                   ? html`
-                      Pulled ${this.pullResult.commits.length} commit${this.pullResult.commits.length === 1 ? '' : 's'}
+                      Pulled ${this.pullResult.commits.length}
+                      commit${this.pullResult.commits.length === 1 ? '' : 's'}
                       <div class="pull-commits">
                         ${this.pullResult.commits.map(
-                          (c) => html`<div><span class="commit-hash">${c.hash}</span>${c.subject}</div>`,
+                          (c) =>
+                            html`<div><span class="commit-hash">${c.hash}</span>${c.subject}</div>`
                         )}
                       </div>
                     `
                   : 'Already up to date.'
-                : (this.pullResult.error || 'Pull failed.')}
+                : this.pullResult.error || 'Pull failed.'}
             </sl-alert>
           `
         : nothing}
@@ -1787,38 +1907,40 @@ export class ScionPageProjectDetail extends LitElement {
             storageKey="scion-view-project-agents"
             @view-change=${this.onViewChange}
           ></scion-view-toggle>
-          ${can(this.agentScopeCapabilities, 'stop_all') && this.hasRunningAgents() ? html`
-            <sl-button
-              variant="danger"
-              size="small"
-              outline
-              ?loading=${this.stopAllLoading}
-              ?disabled=${this.stopAllLoading}
-              @click=${() => this.handleStopAll()}
-            >
-              <sl-icon slot="prefix" name="stop-circle"></sl-icon>
-              Stop All
-            </sl-button>
-          ` : nothing}
+          ${can(this.agentScopeCapabilities, 'stop_all') && this.hasRunningAgents()
+            ? html`
+                <sl-button
+                  variant="danger"
+                  size="small"
+                  outline
+                  ?loading=${this.stopAllLoading}
+                  ?disabled=${this.stopAllLoading}
+                  @click=${() => this.handleStopAll()}
+                >
+                  <sl-icon slot="prefix" name="stop-circle"></sl-icon>
+                  Stop All
+                </sl-button>
+              `
+            : nothing}
         </div>
       </div>
 
       ${this.agents.length === 0
         ? this.renderEmptyAgents()
         : html`
-          ${this.renderFilterBar()}
-          ${this.displayAgents.length === 0
-            ? html`<div class="empty-filter-state">No agents match the current filter.</div>`
-            : this.viewMode === 'graph'
-              ? html`<scion-agent-tree-view .agents=${this.displayAgents}></scion-agent-tree-view>`
-              : this.viewMode === 'grid' ? this.renderAgentGrid() : this.renderAgentTable()}
-        `}
-
+            ${this.renderFilterBar()}
+            ${this.displayAgents.length === 0
+              ? html`<div class="empty-filter-state">No agents match the current filter.</div>`
+              : this.viewMode === 'graph'
+                ? html`<scion-agent-tree-view
+                    .agents=${this.displayAgents}
+                  ></scion-agent-tree-view>`
+                : this.viewMode === 'grid'
+                  ? this.renderAgentGrid()
+                  : this.renderAgentTable()}
+          `}
       ${this.project?.cloudLogging ? this.renderMessagesSection() : nothing}
-
-      ${this.shouldShowFilesSection() ? this.renderFilesSection() : ''}
-
-      ${this.renderCloneDialog()}
+      ${this.shouldShowFilesSection() ? this.renderFilesSection() : ''} ${this.renderCloneDialog()}
       ${this.renderTemplateDialog()}
     `;
   }
@@ -1826,18 +1948,18 @@ export class ScionPageProjectDetail extends LitElement {
   private handleMessagesToggle(): void {
     if (this.messagesExpanded) {
       // Collapse: stop streaming and reset loaded state so next expand reloads
-      const viewer = this.shadowRoot?.querySelector(
-        'scion-agent-message-viewer'
-      ) as import('../shared/agent-message-viewer.js').ScionAgentMessageViewer | null;
+      const viewer = this.shadowRoot?.querySelector('scion-agent-message-viewer') as
+        | import('../shared/agent-message-viewer.js').ScionAgentMessageViewer
+        | null;
       viewer?.stopStream();
       viewer?.resetLoaded();
       this.messagesExpanded = false;
     } else {
       this.messagesExpanded = true;
       this.updateComplete.then(() => {
-        const viewer = this.shadowRoot?.querySelector(
-          'scion-agent-message-viewer'
-        ) as import('../shared/agent-message-viewer.js').ScionAgentMessageViewer | null;
+        const viewer = this.shadowRoot?.querySelector('scion-agent-message-viewer') as
+          | import('../shared/agent-message-viewer.js').ScionAgentMessageViewer
+          | null;
         viewer?.loadMessages();
       });
     }
@@ -1848,19 +1970,23 @@ export class ScionPageProjectDetail extends LitElement {
       <div class="workspace-section">
         <div class="section-header" style="cursor: pointer;" @click=${this.handleMessagesToggle}>
           <h2>
-            <sl-icon name=${this.messagesExpanded ? 'chevron-down' : 'chevron-right'}
-              style="font-size: 0.875rem; vertical-align: middle; margin-right: 0.25rem;"></sl-icon>
+            <sl-icon
+              name=${this.messagesExpanded ? 'chevron-down' : 'chevron-right'}
+              style="font-size: 0.875rem; vertical-align: middle; margin-right: 0.25rem;"
+            ></sl-icon>
             Messages
           </h2>
         </div>
-        ${this.messagesExpanded ? html`
-          <scion-agent-message-viewer
-            logsUrl=${`/api/v1/projects/${this.projectId}/message-logs`}
-            streamUrl=${`/api/v1/projects/${this.projectId}/message-logs/stream`}
-            broadcastUrl=${`/api/v1/projects/${this.projectId}/broadcast`}
-            ?canSend=${true}
-          ></scion-agent-message-viewer>
-        ` : nothing}
+        ${this.messagesExpanded
+          ? html`
+              <scion-agent-message-viewer
+                logsUrl=${`/api/v1/projects/${this.projectId}/message-logs`}
+                streamUrl=${`/api/v1/projects/${this.projectId}/message-logs/stream`}
+                broadcastUrl=${`/api/v1/projects/${this.projectId}/broadcast`}
+                ?canSend=${true}
+              ></scion-agent-message-viewer>
+            `
+          : nothing}
       </div>
     `;
   }
@@ -1940,7 +2066,9 @@ export class ScionPageProjectDetail extends LitElement {
                   ${tabs.map(
                     (tab) => html`
                       <sl-tab slot="nav" panel=${tab.key} ?active=${tab.key === this.activeFileTab}>
-                        <span class="tab-label-truncated" title=${tab.label}>${this.truncateTabLabel(tab.label)}</span>
+                        <span class="tab-label-truncated" title=${tab.label}
+                          >${this.truncateTabLabel(tab.label)}</span
+                        >
                       </sl-tab>
                     `
                   )}
@@ -2022,7 +2150,9 @@ export class ScionPageProjectDetail extends LitElement {
 
   private renderAgentGrid() {
     return html`
-      <div class="agent-grid">${this.displayAgents.map((agent) => this.renderAgentCard(agent))}</div>
+      <div class="agent-grid">
+        ${this.displayAgents.map((agent) => this.renderAgentCard(agent))}
+      </div>
     `;
   }
 
@@ -2035,17 +2165,23 @@ export class ScionPageProjectDetail extends LitElement {
               <th
                 class="sortable ${this.sortField === 'name' ? 'sorted' : ''}"
                 @click=${() => this.toggleSort('name')}
-              >Name <span class="sort-indicator">${this.sortIndicator('name')}</span></th>
+              >
+                Name <span class="sort-indicator">${this.sortIndicator('name')}</span>
+              </th>
               <th class="hide-mobile">Template</th>
               <th class="hide-mobile">Broker</th>
               <th
                 class="status-col sortable ${this.sortField === 'status' ? 'sorted' : ''}"
                 @click=${() => this.toggleSort('status')}
-              >Status <span class="sort-indicator">${this.sortIndicator('status')}</span></th>
+              >
+                Status <span class="sort-indicator">${this.sortIndicator('status')}</span>
+              </th>
               <th
                 class="hide-mobile sortable ${this.sortField === 'updated' ? 'sorted' : ''}"
                 @click=${() => this.toggleSort('updated')}
-              >Updated <span class="sort-indicator">${this.sortIndicator('updated')}</span></th>
+              >
+                Updated <span class="sort-indicator">${this.sortIndicator('updated')}</span>
+              </th>
               <th class="hide-mobile">Task</th>
               <th style="text-align: right">Actions</th>
             </tr>
@@ -2085,104 +2221,126 @@ export class ScionPageProjectDetail extends LitElement {
             size="small"
           ></scion-status-badge>
         </td>
-        <td class="hide-mobile">${((agent.lastActivityEvent && !agent.lastActivityEvent.startsWith('0001')) || agent.updated || agent.updatedAt) ? this.formatRelativeTime(((agent.lastActivityEvent && !agent.lastActivityEvent.startsWith('0001')) ? agent.lastActivityEvent : (agent.updated || agent.updatedAt))!) : '\u2014'}</td>
+        <td class="hide-mobile">
+          ${(agent.lastActivityEvent && !agent.lastActivityEvent.startsWith('0001')) ||
+          agent.updated ||
+          agent.updatedAt
+            ? this.formatRelativeTime(
+                (agent.lastActivityEvent && !agent.lastActivityEvent.startsWith('0001')
+                  ? agent.lastActivityEvent
+                  : agent.updated || agent.updatedAt)!
+              )
+            : '\u2014'}
+        </td>
         <td class="hide-mobile">
           <span class="task-cell">${agent.taskSummary || '\u2014'}</span>
         </td>
         <td class="actions-cell">
           <span class="table-actions">
-            ${can(agent._capabilities, 'attach') ? html`
-              <sl-tooltip content="Terminal">
-                <span style="display: inline-flex">
-                  <sl-button
-                    variant="primary"
-                    size="small"
-                    href="/agents/${agent.id}/terminal"
-                    ?disabled=${!isTerminalAvailable(agent)}
-                    aria-label="Terminal"
-                  >
-                    <sl-icon slot="prefix" name="terminal"></sl-icon>
-                  </sl-button>
-                </span>
-              </sl-tooltip>
-            ` : nothing}
-            ${isAgentRunning(agent)
-              ? can(agent._capabilities, 'stop') ? html`
-                  ${agent.harnessCapabilities?.resume?.support !== 'no' ? html`
-                    <sl-tooltip content="Suspend">
+            ${can(agent._capabilities, 'attach')
+              ? html`
+                  <sl-tooltip content="Terminal">
+                    <span style="display: inline-flex">
                       <sl-button
-                        variant="warning"
+                        variant="primary"
+                        size="small"
+                        href="/agents/${agent.id}/terminal"
+                        ?disabled=${!isTerminalAvailable(agent)}
+                        aria-label="Terminal"
+                      >
+                        <sl-icon slot="prefix" name="terminal"></sl-icon>
+                      </sl-button>
+                    </span>
+                  </sl-tooltip>
+                `
+              : nothing}
+            ${isAgentRunning(agent)
+              ? can(agent._capabilities, 'stop')
+                ? html`
+                    ${agent.harnessCapabilities?.resume?.support !== 'no'
+                      ? html`
+                          <sl-tooltip content="Suspend">
+                            <sl-button
+                              variant="warning"
+                              size="small"
+                              outline
+                              ?loading=${isLoading}
+                              ?disabled=${isLoading}
+                              @click=${() => this.handleAgentAction(agent.id, 'suspend')}
+                              aria-label="Suspend"
+                            >
+                              <sl-icon slot="prefix" name="pause-circle"></sl-icon>
+                            </sl-button>
+                          </sl-tooltip>
+                        `
+                      : nothing}
+                    <sl-tooltip content="Stop">
+                      <sl-button
+                        variant="danger"
                         size="small"
                         outline
                         ?loading=${isLoading}
                         ?disabled=${isLoading}
-                        @click=${() => this.handleAgentAction(agent.id, 'suspend')}
-                        aria-label="Suspend"
+                        @click=${() => this.handleAgentAction(agent.id, 'stop')}
+                        aria-label="Stop"
                       >
-                        <sl-icon slot="prefix" name="pause-circle"></sl-icon>
+                        <sl-icon slot="prefix" name="stop-circle"></sl-icon>
                       </sl-button>
                     </sl-tooltip>
-                  ` : nothing}
-                  <sl-tooltip content="Stop">
+                  `
+                : nothing
+              : agent.phase === 'suspended'
+                ? can(agent._capabilities, 'start')
+                  ? html`
+                      <sl-tooltip content="Resume">
+                        <sl-button
+                          variant="success"
+                          size="small"
+                          outline
+                          ?loading=${isLoading}
+                          ?disabled=${isLoading}
+                          @click=${() => this.handleAgentAction(agent.id, 'resume')}
+                          aria-label="Resume"
+                        >
+                          <sl-icon slot="prefix" name="play-circle"></sl-icon>
+                        </sl-button>
+                      </sl-tooltip>
+                    `
+                  : nothing
+                : can(agent._capabilities, 'start')
+                  ? html`
+                      <sl-tooltip content="Start">
+                        <sl-button
+                          variant="success"
+                          size="small"
+                          outline
+                          ?loading=${isLoading}
+                          ?disabled=${isLoading}
+                          @click=${() => this.handleAgentAction(agent.id, 'start')}
+                          aria-label="Start"
+                        >
+                          <sl-icon slot="prefix" name="play-circle"></sl-icon>
+                        </sl-button>
+                      </sl-tooltip>
+                    `
+                  : nothing}
+            ${can(agent._capabilities, 'delete')
+              ? html`
+                  <sl-tooltip content="Delete">
                     <sl-button
-                      variant="danger"
+                      variant="default"
                       size="small"
                       outline
                       ?loading=${isLoading}
                       ?disabled=${isLoading}
-                      @click=${() => this.handleAgentAction(agent.id, 'stop')}
-                      aria-label="Stop"
+                      @click=${(e: MouseEvent) => this.handleAgentAction(agent.id, 'delete', e)}
+                      aria-label="Delete"
                     >
-                      <sl-icon slot="prefix" name="stop-circle"></sl-icon>
+                      <sl-icon slot="prefix" name="trash"></sl-icon>
                     </sl-button>
                   </sl-tooltip>
-                ` : nothing
-              : agent.phase === 'suspended'
-                ? can(agent._capabilities, 'start') ? html`
-                    <sl-tooltip content="Resume">
-                      <sl-button
-                        variant="success"
-                        size="small"
-                        outline
-                        ?loading=${isLoading}
-                        ?disabled=${isLoading}
-                        @click=${() => this.handleAgentAction(agent.id, 'resume')}
-                        aria-label="Resume"
-                      >
-                        <sl-icon slot="prefix" name="play-circle"></sl-icon>
-                      </sl-button>
-                    </sl-tooltip>
-                  ` : nothing
-                : can(agent._capabilities, 'start') ? html`
-                    <sl-tooltip content="Start">
-                      <sl-button
-                        variant="success"
-                        size="small"
-                        outline
-                        ?loading=${isLoading}
-                        ?disabled=${isLoading}
-                        @click=${() => this.handleAgentAction(agent.id, 'start')}
-                        aria-label="Start"
-                      >
-                        <sl-icon slot="prefix" name="play-circle"></sl-icon>
-                      </sl-button>
-                    </sl-tooltip>
-                  ` : nothing}
-            ${can(agent._capabilities, 'delete') ? html`
-              <sl-tooltip content="Delete">
-                <sl-button
-                  variant="default"
-                  size="small"
-                  outline
-                  ?loading=${isLoading}
-                  ?disabled=${isLoading}
-                  @click=${(e: MouseEvent) => this.handleAgentAction(agent.id, 'delete', e)}
-                  aria-label="Delete"
-                >
-                  <sl-icon slot="prefix" name="trash"></sl-icon>
-                </sl-button>
-              </sl-tooltip>
-            ` : nothing}
+                `
+              : nothing}
           </span>
         </td>
       </tr>

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -23,7 +23,19 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-import type { PageData, Project, Template, AdminGroup, GitHubAppProjectStatus, GitHubTokenPermissions, RuntimeBroker, BrokerProfile, GCPServiceAccount, PreStartHook, PreStartHookSummary } from '../../shared/types.js';
+import type {
+  PageData,
+  Project,
+  Template,
+  AdminGroup,
+  GitHubAppProjectStatus,
+  GitHubTokenPermissions,
+  RuntimeBroker,
+  BrokerProfile,
+  GCPServiceAccount,
+  PreStartHook,
+  PreStartHookSummary,
+} from '../../shared/types.js';
 import { can, canAny } from '../../shared/types.js';
 import { normalizeModelAlias } from '../../shared/model-utils.js';
 import { KNOWN_HARNESS_NAMES, harnessDisplayName } from '../../shared/harness-utils.js';
@@ -43,7 +55,6 @@ import '../shared/injected-skills-panel.js';
 import '../shared/pre-start-hook-list.js';
 import { showToast } from '../../utils/toast.js';
 import { showConfirm } from '../shared/confirm-dialog.js';
-
 
 interface ProjectResourceSpec {
   requests?: { cpu?: string | undefined; memory?: string | undefined };
@@ -261,7 +272,6 @@ export class ScionPageProjectSettings extends LitElement {
   private brokersError: string | null = null;
 
   private brokerRelativeTimeInterval: ReturnType<typeof setInterval> | null = null;
-
 
   static override styles = css`
     :host {
@@ -630,10 +640,18 @@ export class ScionPageProjectSettings extends LitElement {
       border-radius: 50%;
     }
 
-    .github-status-dot.ok { background: #16a34a; }
-    .github-status-dot.degraded { background: #eab308; }
-    .github-status-dot.error { background: #dc2626; }
-    .github-status-dot.unchecked { background: #94a3b8; }
+    .github-status-dot.ok {
+      background: #16a34a;
+    }
+    .github-status-dot.degraded {
+      background: #eab308;
+    }
+    .github-status-dot.error {
+      background: #dc2626;
+    }
+    .github-status-dot.unchecked {
+      background: #94a3b8;
+    }
 
     .github-permissions {
       margin-top: 1rem;
@@ -697,9 +715,15 @@ export class ScionPageProjectSettings extends LitElement {
       flex-shrink: 0;
     }
 
-    .broker-status-dot.online { background: #16a34a; }
-    .broker-status-dot.offline { background: #94a3b8; }
-    .broker-status-dot.degraded { background: #eab308; }
+    .broker-status-dot.online {
+      background: #16a34a;
+    }
+    .broker-status-dot.offline {
+      background: #94a3b8;
+    }
+    .broker-status-dot.degraded {
+      background: #eab308;
+    }
 
     .broker-info {
       flex: 1;
@@ -822,7 +846,9 @@ export class ScionPageProjectSettings extends LitElement {
       const response = await apiFetch(`/api/v1/projects/${this.projectId}`);
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       this.project = (await response.json()) as Project;
@@ -991,9 +1017,7 @@ export class ScionPageProjectSettings extends LitElement {
         console.warn(
           '[project-settings] /settings/resolved returned 404, falling back to /settings'
         );
-        const fallbackResponse = await apiFetch(
-          `/api/v1/projects/${this.projectId}/settings`
-        );
+        const fallbackResponse = await apiFetch(`/api/v1/projects/${this.projectId}/settings`);
         if (fallbackResponse.ok) {
           this.settings = (await fallbackResponse.json()) as ProjectSettings;
         }
@@ -1002,9 +1026,7 @@ export class ScionPageProjectSettings extends LitElement {
         void this.loadHubTelemetryDefaultFallback();
       } else {
         // Other error — try the plain endpoint as fallback
-        const fallbackResponse = await apiFetch(
-          `/api/v1/projects/${this.projectId}/settings`
-        );
+        const fallbackResponse = await apiFetch(`/api/v1/projects/${this.projectId}/settings`);
         if (fallbackResponse.ok) {
           this.settings = (await fallbackResponse.json()) as ProjectSettings;
         }
@@ -1138,9 +1160,7 @@ export class ScionPageProjectSettings extends LitElement {
 
   private async loadGCPServiceAccounts(): Promise<void> {
     try {
-      const response = await apiFetch(
-        `/api/v1/projects/${this.projectId}/gcp-service-accounts`
-      );
+      const response = await apiFetch(`/api/v1/projects/${this.projectId}/gcp-service-accounts`);
       if (response.ok) {
         const data = (await response.json()) as { items?: GCPServiceAccount[] };
         this.gcpServiceAccounts = (data.items || []).filter((sa) => sa.verified);
@@ -1183,9 +1203,10 @@ export class ScionPageProjectSettings extends LitElement {
         }
       }
 
-      const defaultModel = this.defaultModelSelection === 'other'
-        ? this.defaultCustomModelId
-        : this.defaultModelSelection;
+      const defaultModel =
+        this.defaultModelSelection === 'other'
+          ? this.defaultCustomModelId
+          : this.defaultModelSelection;
 
       const body: ProjectSettings = {
         defaultTemplate: this.configDefaultTemplate || undefined,
@@ -1247,7 +1268,9 @@ export class ScionPageProjectSettings extends LitElement {
       });
 
       if (!response.ok && response.status !== 204) {
-        throw new Error(await extractApiError(response, `Failed to delete project: HTTP ${response.status}`));
+        throw new Error(
+          await extractApiError(response, `Failed to delete project: HTTP ${response.status}`)
+        );
       }
 
       // Navigate back to projects list
@@ -1281,10 +1304,7 @@ export class ScionPageProjectSettings extends LitElement {
         <h1>${this.project.name} Settings</h1>
       </div>
 
-      ${this.renderConfigSection()}
-
-      ${this.renderGitHubAppSection()}
-
+      ${this.renderConfigSection()} ${this.renderGitHubAppSection()}
       ${this.membersGroup
         ? html`
             <scion-group-member-editor
@@ -1296,9 +1316,7 @@ export class ScionPageProjectSettings extends LitElement {
             ></scion-group-member-editor>
           `
         : ''}
-
       ${this.renderResourcesSection()}
-
       ${this.pageData?.user
         ? html`
             <scion-subscription-manager
@@ -1307,9 +1325,7 @@ export class ScionPageProjectSettings extends LitElement {
             ></scion-subscription-manager>
           `
         : ''}
-
       ${this.renderSchedulesSection()}
-
       ${can(this.project._capabilities, 'delete')
         ? html`
             <div class="section danger-section">
@@ -1370,21 +1386,31 @@ export class ScionPageProjectSettings extends LitElement {
 
     const stateIcon = (s: string | undefined) => {
       switch (s) {
-        case 'ok': return html`<span class="github-status-dot ok"></span>`;
-        case 'degraded': return html`<span class="github-status-dot degraded"></span>`;
-        case 'error': return html`<span class="github-status-dot error"></span>`;
-        case 'unchecked': return html`<span class="github-status-dot unchecked"></span>`;
-        default: return '';
+        case 'ok':
+          return html`<span class="github-status-dot ok"></span>`;
+        case 'degraded':
+          return html`<span class="github-status-dot degraded"></span>`;
+        case 'error':
+          return html`<span class="github-status-dot error"></span>`;
+        case 'unchecked':
+          return html`<span class="github-status-dot unchecked"></span>`;
+        default:
+          return '';
       }
     };
 
     const stateLabel = (s: string | undefined) => {
       switch (s) {
-        case 'ok': return 'Active';
-        case 'degraded': return 'Degraded';
-        case 'error': return 'Error';
-        case 'unchecked': return 'Unchecked';
-        default: return 'Not configured';
+        case 'ok':
+          return 'Active';
+        case 'degraded':
+          return 'Degraded';
+        case 'error':
+          return 'Error';
+        case 'unchecked':
+          return 'Unchecked';
+        default:
+          return 'Not configured';
       }
     };
 
@@ -1393,119 +1419,165 @@ export class ScionPageProjectSettings extends LitElement {
         <h2>GitHub App Integration</h2>
         <p>Automatic token management for GitHub operations via GitHub App installation tokens.</p>
 
-        ${this.githubAppError ? html`
-          <div class="status-message error">${this.githubAppError}</div>
-        ` : ''}
+        ${this.githubAppError
+          ? html` <div class="status-message error">${this.githubAppError}</div> `
+          : ''}
+        ${!hasInstallation
+          ? html`
+              <div class="github-no-install">
+                <sl-icon
+                  name="github"
+                  style="font-size: 2rem; color: var(--scion-text-muted, #64748b);"
+                ></sl-icon>
+                ${this.githubAppLoading
+                  ? html` <p>Checking for GitHub App installation…</p> `
+                  : !this.githubAppConfigured
+                    ? html`
+                        <p>No GitHub App has been configured on this Hub.</p>
+                        <p class="field-help">
+                          Ask your Hub admin to configure the GitHub App integration, then install
+                          it on your organization or account.
+                        </p>
+                      `
+                    : html`
+                        <p>No GitHub App installation found for this project's repository.</p>
 
-        ${!hasInstallation ? html`
-          <div class="github-no-install">
-            <sl-icon name="github" style="font-size: 2rem; color: var(--scion-text-muted, #64748b);"></sl-icon>
-            ${this.githubAppLoading ? html`
-              <p>Checking for GitHub App installation…</p>
-            ` : !this.githubAppConfigured ? html`
-              <p>No GitHub App has been configured on this Hub.</p>
-              <p class="field-help">Ask your Hub admin to configure the GitHub App integration, then install it on your organization or account.</p>
-            ` : html`
-              <p>No GitHub App installation found for this project's repository.</p>
+                        ${this.githubAppInstallationUrl
+                          ? html`
+                              <p class="field-help">
+                                <a
+                                  href=${this.githubAppInstallationUrl}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                >
+                                  Install the GitHub App
+                                </a>
+                                on your organization or account, then click Discover.
+                              </p>
+                            `
+                          : html`
+                              <p class="field-help">
+                                Install the GitHub App on your organization or account, then click
+                                Discover.
+                              </p>
+                            `}
+                        <sl-button
+                          variant="default"
+                          size="small"
+                          @click=${() => this.discoverGitHubInstallation()}
+                        >
+                          <sl-icon slot="prefix" name="search"></sl-icon>
+                          Discover Installation
+                        </sl-button>
+                      `}
+              </div>
+            `
+          : html`
+              <div class="github-status-row">
+                <div class="github-status-item">
+                  <span class="field-help">Status</span>
+                  <div class="github-status-value">
+                    ${stateIcon(status?.state)}
+                    <strong>${stateLabel(status?.state)}</strong>
+                  </div>
+                </div>
+                <div class="github-status-item">
+                  <span class="field-help">Installation ID</span>
+                  <code>${this.githubAppInstallationId}</code>
+                </div>
+                ${status?.last_token_mint
+                  ? html`
+                      <div class="github-status-item">
+                        <span class="field-help">Last Token Mint</span>
+                        <span>${new Date(status.last_token_mint).toLocaleString()}</span>
+                      </div>
+                    `
+                  : ''}
+              </div>
 
-              ${this.githubAppInstallationUrl ? html`
-                <p class="field-help">
-                  <a href=${this.githubAppInstallationUrl} target="_blank" rel="noopener noreferrer">
-                    Install the GitHub App
-                  </a> on your organization or account, then click Discover.
-                </p>
-              ` : html`
-                <p class="field-help">Install the GitHub App on your organization or account, then click Discover.</p>
-              `}
-              <sl-button variant="default" size="small" @click=${() => this.discoverGitHubInstallation()}>
-                <sl-icon slot="prefix" name="search"></sl-icon>
-                Discover Installation
-              </sl-button>
+              ${status?.state === 'error' || status?.state === 'degraded'
+                ? html`
+                    <div class="status-message ${status.state === 'error' ? 'error' : 'warning'}">
+                      <strong>${this.formatGitHubErrorCode(status.error_code)}:</strong>
+                      ${status.error_message}
+                      ${status.state === 'error' && this.project?.gitRemote
+                        ? html` <br /><small>Agents will use PAT fallback if available.</small> `
+                        : ''}
+                    </div>
+                  `
+                : ''}
+
+              <div class="github-permissions">
+                <span class="field-help">Token Permissions</span>
+                <div class="github-perm-grid">
+                  ${this.renderPermBadge('Contents', this.githubAppPermissions?.contents)}
+                  ${this.renderPermBadge('Pull Requests', this.githubAppPermissions?.pull_requests)}
+                  ${this.renderPermBadge('Issues', this.githubAppPermissions?.issues)}
+                  ${this.renderPermBadge('Metadata', this.githubAppPermissions?.metadata)}
+                  ${this.renderPermBadge('Checks', this.githubAppPermissions?.checks)}
+                  ${this.renderPermBadge('Actions', this.githubAppPermissions?.actions)}
+                </div>
+              </div>
+
+              <div style="margin-top: 1rem; display: flex; align-items: center; gap: 0.5rem;">
+                <sl-button
+                  variant="default"
+                  size="small"
+                  ?loading=${this.githubAppLoading}
+                  ?disabled=${this.githubAppLoading}
+                  @click=${() => this.checkGitHubStatus()}
+                >
+                  <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+                  ${status?.state === 'unchecked' ? 'Check Status' : 'Recheck Status'}
+                </sl-button>
+                <a
+                  href=${`https://github.com/settings/installations/${this.githubAppInstallationId}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style="text-decoration: none;"
+                >
+                  <sl-button variant="text" size="small">
+                    <sl-icon slot="prefix" name="gear"></sl-icon>
+                    Configure Installation
+                  </sl-button>
+                </a>
+                <sl-button
+                  variant="text"
+                  size="small"
+                  @click=${() => this.removeGitHubInstallation()}
+                >
+                  <sl-icon slot="prefix" name="x-circle"></sl-icon>
+                  Remove
+                </sl-button>
+              </div>
             `}
-          </div>
-        ` : html`
-          <div class="github-status-row">
-            <div class="github-status-item">
-              <span class="field-help">Status</span>
-              <div class="github-status-value">
-                ${stateIcon(status?.state)}
-                <strong>${stateLabel(status?.state)}</strong>
-              </div>
-            </div>
-            <div class="github-status-item">
-              <span class="field-help">Installation ID</span>
-              <code>${this.githubAppInstallationId}</code>
-            </div>
-            ${status?.last_token_mint ? html`
-              <div class="github-status-item">
-                <span class="field-help">Last Token Mint</span>
-                <span>${new Date(status.last_token_mint).toLocaleString()}</span>
-              </div>
-            ` : ''}
-          </div>
-
-          ${status?.state === 'error' || status?.state === 'degraded' ? html`
-            <div class="status-message ${status.state === 'error' ? 'error' : 'warning'}">
-              <strong>${this.formatGitHubErrorCode(status.error_code)}:</strong> ${status.error_message}
-              ${status.state === 'error' && this.project?.gitRemote ? html`
-                <br><small>Agents will use PAT fallback if available.</small>
-              ` : ''}
-            </div>
-          ` : ''}
-
-          <div class="github-permissions">
-            <span class="field-help">Token Permissions</span>
-            <div class="github-perm-grid">
-              ${this.renderPermBadge('Contents', this.githubAppPermissions?.contents)}
-              ${this.renderPermBadge('Pull Requests', this.githubAppPermissions?.pull_requests)}
-              ${this.renderPermBadge('Issues', this.githubAppPermissions?.issues)}
-              ${this.renderPermBadge('Metadata', this.githubAppPermissions?.metadata)}
-              ${this.renderPermBadge('Checks', this.githubAppPermissions?.checks)}
-              ${this.renderPermBadge('Actions', this.githubAppPermissions?.actions)}
-            </div>
-          </div>
-
-          <div style="margin-top: 1rem; display: flex; align-items: center; gap: 0.5rem;">
-            <sl-button variant="default" size="small" ?loading=${this.githubAppLoading} ?disabled=${this.githubAppLoading} @click=${() => this.checkGitHubStatus()}>
-              <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
-              ${status?.state === 'unchecked' ? 'Check Status' : 'Recheck Status'}
-            </sl-button>
-            <a href=${`https://github.com/settings/installations/${this.githubAppInstallationId}`}
-               target="_blank" rel="noopener noreferrer" style="text-decoration: none;">
-              <sl-button variant="text" size="small">
-                <sl-icon slot="prefix" name="gear"></sl-icon>
-                Configure Installation
-              </sl-button>
-            </a>
-            <sl-button variant="text" size="small" @click=${() => this.removeGitHubInstallation()}>
-              <sl-icon slot="prefix" name="x-circle"></sl-icon>
-              Remove
-            </sl-button>
-          </div>
-        `}
       </div>
     `;
   }
 
   private renderPermBadge(label: string, value: string | undefined) {
     if (!value) return '';
-    return html`
-      <span class="github-perm-badge ${value}">
-        ${label}: ${value}
-      </span>
-    `;
+    return html` <span class="github-perm-badge ${value}"> ${label}: ${value} </span> `;
   }
 
   private formatGitHubErrorCode(code?: string): string {
     switch (code) {
-      case 'private_key_invalid': return 'Private Key Invalid';
-      case 'app_not_found': return 'App Not Found';
-      case 'installation_revoked': return 'Installation Revoked';
-      case 'installation_suspended': return 'Installation Suspended';
-      case 'repo_not_accessible': return 'Repository Not Accessible';
-      case 'permission_denied': return 'Permission Denied';
-      case 'token_mint_failed': return 'Token Mint Failed';
-      default: return code ?? 'Error';
+      case 'private_key_invalid':
+        return 'Private Key Invalid';
+      case 'app_not_found':
+        return 'App Not Found';
+      case 'installation_revoked':
+        return 'Installation Revoked';
+      case 'installation_suspended':
+        return 'Installation Suspended';
+      case 'repo_not_accessible':
+        return 'Repository Not Accessible';
+      case 'permission_denied':
+        return 'Permission Denied';
+      case 'token_mint_failed':
+        return 'Token Mint Failed';
+      default:
+        return code ?? 'Error';
     }
   }
 
@@ -1514,7 +1586,9 @@ export class ScionPageProjectSettings extends LitElement {
     this.githubAppLoading = true;
     try {
       // Actively verify the installation by minting a test token
-      const res = await apiFetch(`/api/v1/projects/${this.projectId}/github-status`, { method: 'POST' });
+      const res = await apiFetch(`/api/v1/projects/${this.projectId}/github-status`, {
+        method: 'POST',
+      });
       if (!res.ok) {
         const data = (await res.json().catch(() => ({}))) as { message?: string };
         throw new Error(data.message || `Check failed (${res.status})`);
@@ -1569,17 +1643,29 @@ export class ScionPageProjectSettings extends LitElement {
       this.githubAppPermissions = project.githubPermissions ?? null;
       // Update the project object in place so renderProjectIcon and other parts reflect the change
       if (this.project) {
-        this.project = { ...this.project, githubInstallationId: project.githubInstallationId, githubAppStatus: project.githubAppStatus, githubPermissions: project.githubPermissions };
+        this.project = {
+          ...this.project,
+          githubInstallationId: project.githubInstallationId,
+          githubAppStatus: project.githubAppStatus,
+          githubPermissions: project.githubPermissions,
+        };
       }
     }
   }
 
   private async removeGitHubInstallation(): Promise<void> {
-    if (!(await showConfirm('Remove GitHub App installation from this project? Agents will fall back to PAT authentication.'))) return;
+    if (
+      !(await showConfirm(
+        'Remove GitHub App installation from this project? Agents will fall back to PAT authentication.'
+      ))
+    )
+      return;
     this.githubAppLoading = true;
     this.githubAppError = null;
     try {
-      const res = await apiFetch(`/api/v1/projects/${this.projectId}/github-installation`, { method: 'DELETE' });
+      const res = await apiFetch(`/api/v1/projects/${this.projectId}/github-installation`, {
+        method: 'DELETE',
+      });
       if (!res.ok) {
         const data = (await res.json().catch(() => ({}))) as { message?: string };
         throw new Error(data.message || `Failed to remove installation (${res.status})`);
@@ -1588,7 +1674,12 @@ export class ScionPageProjectSettings extends LitElement {
       this.githubAppStatus = null;
       this.githubAppPermissions = null;
       if (this.project) {
-        this.project = { ...this.project, githubInstallationId: undefined, githubAppStatus: undefined, githubPermissions: undefined };
+        this.project = {
+          ...this.project,
+          githubInstallationId: undefined,
+          githubAppStatus: undefined,
+          githubPermissions: undefined,
+        };
       }
     } catch (err) {
       this.githubAppError = err instanceof Error ? err.message : 'Remove failed';
@@ -1635,10 +1726,19 @@ export class ScionPageProjectSettings extends LitElement {
 
           <sl-tab-panel name="general">
             <div class="config-form">
-              <div class="config-field ${this.isHubDefault('scion.io/default-template') ? 'hub-inherited' : ''}">
-                <label>Default Template ${this.renderHubIndicator('scion.io/default-template')}</label>
+              <div
+                class="config-field ${this.isHubDefault('scion.io/default-template')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
+                <label
+                  >Default Template ${this.renderHubIndicator('scion.io/default-template')}</label
+                >
                 <sl-select
-                  placeholder=${this.hubSelectLabel('scion.io/default-template', 'None (use server default)')}
+                  placeholder=${this.hubSelectLabel(
+                    'scion.io/default-template',
+                    'None (use server default)'
+                  )}
                   clearable
                   value=${this.configDefaultTemplate}
                   ?disabled=${!canEdit}
@@ -1655,10 +1755,20 @@ export class ScionPageProjectSettings extends LitElement {
                 >
               </div>
 
-              <div class="config-field ${this.isHubDefault('scion.io/default-harness-config') ? 'hub-inherited' : ''}">
-                <label>Default Harness Config ${this.renderHubIndicator('scion.io/default-harness-config')}</label>
+              <div
+                class="config-field ${this.isHubDefault('scion.io/default-harness-config')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
+                <label
+                  >Default Harness Config
+                  ${this.renderHubIndicator('scion.io/default-harness-config')}</label
+                >
                 <sl-select
-                  placeholder=${this.hubSelectLabel('scion.io/default-harness-config', 'None (use server default)')}
+                  placeholder=${this.hubSelectLabel(
+                    'scion.io/default-harness-config',
+                    'None (use server default)'
+                  )}
                   clearable
                   value=${this.configDefaultHarnessConfig}
                   ?disabled=${!canEdit}
@@ -1687,7 +1797,11 @@ export class ScionPageProjectSettings extends LitElement {
                 >
               </div>
 
-              <div class="config-field ${this.isHubDefault('scion.io/default-model') ? 'hub-inherited' : ''}">
+              <div
+                class="config-field ${this.isHubDefault('scion.io/default-model')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
                 <label>Default Model ${this.renderHubIndicator('scion.io/default-model')}</label>
                 <sl-select
                   placeholder="use harness default"
@@ -1695,7 +1809,13 @@ export class ScionPageProjectSettings extends LitElement {
                   value=${this.defaultModelSelection}
                   ?disabled=${!canEdit}
                   @sl-change=${(e: Event) => {
-                    const val = (e.target as HTMLSelectElement).value as '' | 'small' | 'medium' | 'large' | 'extra-large' | 'other';
+                    const val = (e.target as HTMLSelectElement).value as
+                      | ''
+                      | 'small'
+                      | 'medium'
+                      | 'large'
+                      | 'extra-large'
+                      | 'other';
                     this.defaultModelSelection = val;
                     if (val !== 'other') this.defaultCustomModelId = '';
                   }}
@@ -1706,9 +1826,7 @@ export class ScionPageProjectSettings extends LitElement {
                   <sl-option value="extra-large">Extra Large</sl-option>
                   <sl-option value="other">Other (specify)</sl-option>
                 </sl-select>
-                <span class="field-help"
-                  >Default model alias or ID used for new agents.</span
-                >
+                <span class="field-help">Default model alias or ID used for new agents.</span>
               </div>
 
               ${this.defaultModelSelection === 'other'
@@ -1727,30 +1845,62 @@ export class ScionPageProjectSettings extends LitElement {
                   `
                 : ''}
 
-              <div class="config-field ${this.isHubDefault('scion.io/default-thinking-level') ? 'hub-inherited' : ''}">
-                <label>Default Thinking Level ${this.renderHubIndicator('scion.io/default-thinking-level')}${this.defaultThinkingLevel !== null ? html` <span style="font-weight:normal;color:var(--sl-color-neutral-500)">(${this.defaultThinkingLevel})</span>` : ''}</label>
+              <div
+                class="config-field ${this.isHubDefault('scion.io/default-thinking-level')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
+                <label
+                  >Default Thinking Level
+                  ${this.renderHubIndicator('scion.io/default-thinking-level')}${this
+                    .defaultThinkingLevel !== null
+                    ? html` <span style="font-weight:normal;color:var(--sl-color-neutral-500)"
+                        >(${this.defaultThinkingLevel})</span
+                      >`
+                    : ''}</label
+                >
                 <div style="display:flex;align-items:center;gap:0.75rem">
                   <sl-range
-                    min="0" max="100" step="1"
+                    min="0"
+                    max="100"
+                    step="1"
                     .value=${this.defaultThinkingLevel ?? 50}
                     ?disabled=${this.defaultThinkingLevel === null || !canEdit}
                     style="flex:1"
-                    @sl-input=${(e: Event) => { this.defaultThinkingLevel = (e.target as HTMLInputElement & { value: number }).value; }}
+                    @sl-input=${(e: Event) => {
+                      this.defaultThinkingLevel = (
+                        e.target as HTMLInputElement & { value: number }
+                      ).value;
+                    }}
                   ></sl-range>
                   <sl-checkbox
                     ?checked=${this.defaultThinkingLevel !== null}
                     ?disabled=${!canEdit}
-                    @sl-change=${(e: Event) => { this.defaultThinkingLevel = (e.target as HTMLInputElement & { checked: boolean }).checked ? 50 : null; }}
-                  >Set</sl-checkbox>
+                    @sl-change=${(e: Event) => {
+                      this.defaultThinkingLevel = (
+                        e.target as HTMLInputElement & { checked: boolean }
+                      ).checked
+                        ? 50
+                        : null;
+                    }}
+                    >Set</sl-checkbox
+                  >
                 </div>
-                <span class="field-help" style="display:flex;justify-content:space-between;margin-top:0.25rem">
+                <span
+                  class="field-help"
+                  style="display:flex;justify-content:space-between;margin-top:0.25rem"
+                >
                   <span>0 = minimal reasoning</span>
                   <span>${this.defaultThinkingLevel === null ? 'Using harness default' : ''}</span>
                   <span>100 = maximum reasoning</span>
                 </span>
               </div>
 
-              <div class="config-field ${this.isHubDefault('scion.io/telemetry-enabled') ? 'hub-inherited' : ''}">
+              <div
+                class="config-field ${this.isHubDefault('scion.io/telemetry-enabled')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
                 <label>Telemetry ${this.renderHubIndicator('scion.io/telemetry-enabled')}</label>
                 <sl-select
                   value=${this.configTelemetryEnabled === true
@@ -1766,18 +1916,31 @@ export class ScionPageProjectSettings extends LitElement {
                   }}
                 >
                   <sl-option value="inherit"
-                    >Use hub default (${this.hubTelemetryDefault === null ? '…' : this.hubTelemetryDefault ? 'enabled' : 'disabled'})</sl-option
+                    >Use hub default
+                    (${this.hubTelemetryDefault === null
+                      ? '…'
+                      : this.hubTelemetryDefault
+                        ? 'enabled'
+                        : 'disabled'})</sl-option
                   >
                   <sl-option value="enabled">Enabled</sl-option>
                   <sl-option value="disabled">Disabled</sl-option>
                 </sl-select>
                 <span class="field-help"
-                  >Controls telemetry for agents in this project. "Use hub default" inherits the server-level setting.</span
+                  >Controls telemetry for agents in this project. "Use hub default" inherits the
+                  server-level setting.</span
                 >
               </div>
 
-              <div class="config-field ${this.isHubDefault('scion.io/auto-expose-ports-enabled') ? 'hub-inherited' : ''}">
-                <label>Auto-Expose Ports ${this.renderHubIndicator('scion.io/auto-expose-ports-enabled')}</label>
+              <div
+                class="config-field ${this.isHubDefault('scion.io/auto-expose-ports-enabled')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
+                <label
+                  >Auto-Expose Ports
+                  ${this.renderHubIndicator('scion.io/auto-expose-ports-enabled')}</label
+                >
                 <sl-select
                   value=${this.configAutoExposePortsEnabled === true
                     ? 'enabled'
@@ -1792,20 +1955,36 @@ export class ScionPageProjectSettings extends LitElement {
                   }}
                 >
                   <sl-option value="inherit"
-                    >Use hub default (${this.hubAutoExposePortsDefault === null ? '…' : this.hubAutoExposePortsDefault ? 'enabled' : 'disabled'})</sl-option
+                    >Use hub default
+                    (${this.hubAutoExposePortsDefault === null
+                      ? '…'
+                      : this.hubAutoExposePortsDefault
+                        ? 'enabled'
+                        : 'disabled'})</sl-option
                   >
                   <sl-option value="enabled">Enabled</sl-option>
                   <sl-option value="disabled">Disabled</sl-option>
                 </sl-select>
                 <span class="field-help"
-                  >Automatically detect and expose listening TCP ports in agent containers. "Use hub default" inherits the server-level setting.</span
+                  >Automatically detect and expose listening TCP ports in agent containers. "Use hub
+                  default" inherits the server-level setting.</span
                 >
               </div>
 
-              <div class="config-field ${this.isHubDefault('scion.io/default-agent-role') ? 'hub-inherited' : ''}">
-                <label>Default Agent Role ${this.renderHubIndicator('scion.io/default-agent-role')}</label>
+              <div
+                class="config-field ${this.isHubDefault('scion.io/default-agent-role')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
+                <label
+                  >Default Agent Role
+                  ${this.renderHubIndicator('scion.io/default-agent-role')}</label
+                >
                 <sl-select
-                  placeholder=${this.hubSelectLabel('scion.io/default-agent-role', 'Full (default)')}
+                  placeholder=${this.hubSelectLabel(
+                    'scion.io/default-agent-role',
+                    'Full (default)'
+                  )}
                   clearable
                   value=${this.configDefaultAgentRole}
                   ?disabled=${!canEdit}
@@ -1823,8 +2002,14 @@ export class ScionPageProjectSettings extends LitElement {
                 >
               </div>
 
-              <div class="config-field ${this.isHubDefault('scion.io/max-agent-role') ? 'hub-inherited' : ''}">
-                <label>Maximum Agent Role ${this.renderHubIndicator('scion.io/max-agent-role')}</label>
+              <div
+                class="config-field ${this.isHubDefault('scion.io/max-agent-role')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
+                <label
+                  >Maximum Agent Role ${this.renderHubIndicator('scion.io/max-agent-role')}</label
+                >
                 <sl-select
                   placeholder=${this.hubSelectLabel('scion.io/max-agent-role', 'Full (default)')}
                   clearable
@@ -1863,7 +2048,9 @@ export class ScionPageProjectSettings extends LitElement {
                   <sl-option value="assign">Assign Service Account</sl-option>
                 </sl-select>
                 <span class="field-help"
-                  >Controls GCP metadata server access for new agents. "Block" prevents access, "Passthrough" allows host identity, "Assign" binds a specific service account.</span
+                  >Controls GCP metadata server access for new agents. "Block" prevents access,
+                  "Passthrough" allows host identity, "Assign" binds a specific service
+                  account.</span
                 >
               </div>
 
@@ -1874,9 +2061,13 @@ export class ScionPageProjectSettings extends LitElement {
                       <div style="display: flex; align-items: center; gap: 0.25rem;">
                         ${this.configDefaultGCPIdentitySAID
                           ? html`
-                              <sl-tooltip content=${this.copiedDefaultSAEmail ? 'Copied!' : 'Copy email'}>
+                              <sl-tooltip
+                                content=${this.copiedDefaultSAEmail ? 'Copied!' : 'Copy email'}
+                              >
                                 <sl-icon-button
-                                  name=${this.copiedDefaultSAEmail ? 'clipboard-check' : 'clipboard'}
+                                  name=${this.copiedDefaultSAEmail
+                                    ? 'clipboard-check'
+                                    : 'clipboard'}
                                   label="Copy service account email"
                                   style="font-size: 1rem;"
                                   @click=${() => {
@@ -1884,12 +2075,15 @@ export class ScionPageProjectSettings extends LitElement {
                                       (s) => s.id === this.configDefaultGCPIdentitySAID
                                     );
                                     if (sa && navigator.clipboard) {
-                                      void navigator.clipboard.writeText(sa.email).then(() => {
-                                        this.copiedDefaultSAEmail = true;
-                                        setTimeout(() => {
-                                          this.copiedDefaultSAEmail = false;
-                                        }, 1500);
-                                      }).catch(() => {});
+                                      void navigator.clipboard
+                                        .writeText(sa.email)
+                                        .then(() => {
+                                          this.copiedDefaultSAEmail = true;
+                                          setTimeout(() => {
+                                            this.copiedDefaultSAEmail = false;
+                                          }, 1500);
+                                        })
+                                        .catch(() => {});
                                     }
                                   }}
                                 ></sl-icon-button>
@@ -1903,7 +2097,9 @@ export class ScionPageProjectSettings extends LitElement {
                           value=${this.configDefaultGCPIdentitySAID}
                           ?disabled=${!canEdit}
                           @sl-change=${(e: Event) => {
-                            this.configDefaultGCPIdentitySAID = (e.target as HTMLSelectElement).value;
+                            this.configDefaultGCPIdentitySAID = (
+                              e.target as HTMLSelectElement
+                            ).value;
                             this.copiedDefaultSAEmail = false;
                           }}
                         >
@@ -1922,7 +2118,8 @@ export class ScionPageProjectSettings extends LitElement {
                         </sl-select>
                       </div>
                       <span class="field-help"
-                        >The GCP service account to assign to new agents by default. Only verified accounts are shown.</span
+                        >The GCP service account to assign to new agents by default. Only verified
+                        accounts are shown.</span
                       >
                     </div>
                   `
@@ -1936,8 +2133,14 @@ export class ScionPageProjectSettings extends LitElement {
                 >Applied to new agents unless overridden by template or agent config.</span
               >
 
-              <div class="config-field ${this.isHubDefault('scion.io/default-max-turns') ? 'hub-inherited' : ''}">
-                <label>Default Max Turns ${this.renderHubIndicator('scion.io/default-max-turns')}</label>
+              <div
+                class="config-field ${this.isHubDefault('scion.io/default-max-turns')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
+                <label
+                  >Default Max Turns ${this.renderHubIndicator('scion.io/default-max-turns')}</label
+                >
                 <sl-input
                   type="number"
                   placeholder=${this.hubHint('scion.io/default-max-turns') || 'No limit'}
@@ -1951,8 +2154,15 @@ export class ScionPageProjectSettings extends LitElement {
                 <span class="field-help">Maximum conversation turns per agent.</span>
               </div>
 
-              <div class="config-field ${this.isHubDefault('scion.io/default-max-model-calls') ? 'hub-inherited' : ''}">
-                <label>Default Max Model Calls ${this.renderHubIndicator('scion.io/default-max-model-calls')}</label>
+              <div
+                class="config-field ${this.isHubDefault('scion.io/default-max-model-calls')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
+                <label
+                  >Default Max Model Calls
+                  ${this.renderHubIndicator('scion.io/default-max-model-calls')}</label
+                >
                 <sl-input
                   type="number"
                   placeholder=${this.hubHint('scion.io/default-max-model-calls') || 'No limit'}
@@ -1968,8 +2178,15 @@ export class ScionPageProjectSettings extends LitElement {
                 <span class="field-help">Maximum LLM API calls per agent.</span>
               </div>
 
-              <div class="config-field ${this.isHubDefault('scion.io/default-max-duration') ? 'hub-inherited' : ''}">
-                <label>Default Max Duration ${this.renderHubIndicator('scion.io/default-max-duration')}</label>
+              <div
+                class="config-field ${this.isHubDefault('scion.io/default-max-duration')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
+                <label
+                  >Default Max Duration
+                  ${this.renderHubIndicator('scion.io/default-max-duration')}</label
+                >
                 <sl-input
                   type="text"
                   placeholder=${this.hubHint('scion.io/default-max-duration') || 'e.g. 2h, 30m'}
@@ -1990,11 +2207,19 @@ export class ScionPageProjectSettings extends LitElement {
                 >Default resource requests and limits for new agents.</span
               >
 
-              <div class="config-field ${this.isHubDefault('scion.io/default-resources-cpu-request') ? 'hub-inherited' : ''}">
-                <label>CPU Request ${this.renderHubIndicator('scion.io/default-resources-cpu-request')}</label>
+              <div
+                class="config-field ${this.isHubDefault('scion.io/default-resources-cpu-request')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
+                <label
+                  >CPU Request
+                  ${this.renderHubIndicator('scion.io/default-resources-cpu-request')}</label
+                >
                 <sl-input
                   type="text"
-                  placeholder=${this.hubHint('scion.io/default-resources-cpu-request') || 'e.g. 500m, 1'}
+                  placeholder=${this.hubHint('scion.io/default-resources-cpu-request') ||
+                  'e.g. 500m, 1'}
                   .value=${this.configDefaultResCpuReq}
                   ?disabled=${!canEdit}
                   @sl-input=${(e: Event) => {
@@ -2003,11 +2228,19 @@ export class ScionPageProjectSettings extends LitElement {
                 ></sl-input>
               </div>
 
-              <div class="config-field ${this.isHubDefault('scion.io/default-resources-memory-request') ? 'hub-inherited' : ''}">
-                <label>Memory Request ${this.renderHubIndicator('scion.io/default-resources-memory-request')}</label>
+              <div
+                class="config-field ${this.isHubDefault('scion.io/default-resources-memory-request')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
+                <label
+                  >Memory Request
+                  ${this.renderHubIndicator('scion.io/default-resources-memory-request')}</label
+                >
                 <sl-input
                   type="text"
-                  placeholder=${this.hubHint('scion.io/default-resources-memory-request') || 'e.g. 512Mi, 1Gi'}
+                  placeholder=${this.hubHint('scion.io/default-resources-memory-request') ||
+                  'e.g. 512Mi, 1Gi'}
                   .value=${this.configDefaultResMemReq}
                   ?disabled=${!canEdit}
                   @sl-input=${(e: Event) => {
@@ -2016,8 +2249,15 @@ export class ScionPageProjectSettings extends LitElement {
                 ></sl-input>
               </div>
 
-              <div class="config-field ${this.isHubDefault('scion.io/default-resources-cpu-limit') ? 'hub-inherited' : ''}">
-                <label>CPU Limit ${this.renderHubIndicator('scion.io/default-resources-cpu-limit')}</label>
+              <div
+                class="config-field ${this.isHubDefault('scion.io/default-resources-cpu-limit')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
+                <label
+                  >CPU Limit
+                  ${this.renderHubIndicator('scion.io/default-resources-cpu-limit')}</label
+                >
                 <sl-input
                   type="text"
                   placeholder=${this.hubHint('scion.io/default-resources-cpu-limit') || 'e.g. 1, 2'}
@@ -2029,11 +2269,19 @@ export class ScionPageProjectSettings extends LitElement {
                 ></sl-input>
               </div>
 
-              <div class="config-field ${this.isHubDefault('scion.io/default-resources-memory-limit') ? 'hub-inherited' : ''}">
-                <label>Memory Limit ${this.renderHubIndicator('scion.io/default-resources-memory-limit')}</label>
+              <div
+                class="config-field ${this.isHubDefault('scion.io/default-resources-memory-limit')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
+                <label
+                  >Memory Limit
+                  ${this.renderHubIndicator('scion.io/default-resources-memory-limit')}</label
+                >
                 <sl-input
                   type="text"
-                  placeholder=${this.hubHint('scion.io/default-resources-memory-limit') || 'e.g. 1Gi, 2Gi'}
+                  placeholder=${this.hubHint('scion.io/default-resources-memory-limit') ||
+                  'e.g. 1Gi, 2Gi'}
                   .value=${this.configDefaultResMemLim}
                   ?disabled=${!canEdit}
                   @sl-input=${(e: Event) => {
@@ -2042,7 +2290,11 @@ export class ScionPageProjectSettings extends LitElement {
                 ></sl-input>
               </div>
 
-              <div class="config-field ${this.isHubDefault('scion.io/default-resources-disk') ? 'hub-inherited' : ''}">
+              <div
+                class="config-field ${this.isHubDefault('scion.io/default-resources-disk')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
                 <label>Disk ${this.renderHubIndicator('scion.io/default-resources-disk')}</label>
                 <sl-input
                   type="text"
@@ -2057,9 +2309,7 @@ export class ScionPageProjectSettings extends LitElement {
             </div>
           </sl-tab-panel>
 
-          <sl-tab-panel name="brokers">
-            ${this.renderBrokersContent()}
-          </sl-tab-panel>
+          <sl-tab-panel name="brokers"> ${this.renderBrokersContent()} </sl-tab-panel>
         </sl-tab-group>
 
         ${canEdit && this.activeConfigTab !== 'brokers'
@@ -2101,14 +2351,39 @@ export class ScionPageProjectSettings extends LitElement {
             this.activeResourcesTab = (e.detail as { name: string }).name;
           }}
         >
-          <sl-tab slot="nav" panel="env-vars" ?active=${this.activeResourcesTab === 'env-vars'}>Environment Variables</sl-tab>
-          <sl-tab slot="nav" panel="secrets" ?active=${this.activeResourcesTab === 'secrets'}>Secrets</sl-tab>
-          <sl-tab slot="nav" panel="shared-dirs" ?active=${this.activeResourcesTab === 'shared-dirs'}>Shared Directories</sl-tab>
-          <sl-tab slot="nav" panel="templates" ?active=${this.activeResourcesTab === 'templates'}>Templates</sl-tab>
-          <sl-tab slot="nav" panel="harness-configs" ?active=${this.activeResourcesTab === 'harness-configs'}>Harness Configs</sl-tab>
-          <sl-tab slot="nav" panel="pre-start-hooks" ?active=${this.activeResourcesTab === 'pre-start-hooks'}>Pre-Start Hooks</sl-tab>
-          <sl-tab slot="nav" panel="gcp-sa" ?active=${this.activeResourcesTab === 'gcp-sa'}>GCP Service Accounts</sl-tab>
-          <sl-tab slot="nav" panel="skills" ?active=${this.activeResourcesTab === 'skills'}>Skills</sl-tab>
+          <sl-tab slot="nav" panel="env-vars" ?active=${this.activeResourcesTab === 'env-vars'}
+            >Environment Variables</sl-tab
+          >
+          <sl-tab slot="nav" panel="secrets" ?active=${this.activeResourcesTab === 'secrets'}
+            >Secrets</sl-tab
+          >
+          <sl-tab
+            slot="nav"
+            panel="shared-dirs"
+            ?active=${this.activeResourcesTab === 'shared-dirs'}
+            >Shared Directories</sl-tab
+          >
+          <sl-tab slot="nav" panel="templates" ?active=${this.activeResourcesTab === 'templates'}
+            >Templates</sl-tab
+          >
+          <sl-tab
+            slot="nav"
+            panel="harness-configs"
+            ?active=${this.activeResourcesTab === 'harness-configs'}
+            >Harness Configs</sl-tab
+          >
+          <sl-tab
+            slot="nav"
+            panel="pre-start-hooks"
+            ?active=${this.activeResourcesTab === 'pre-start-hooks'}
+            >Pre-Start Hooks</sl-tab
+          >
+          <sl-tab slot="nav" panel="gcp-sa" ?active=${this.activeResourcesTab === 'gcp-sa'}
+            >GCP Service Accounts</sl-tab
+          >
+          <sl-tab slot="nav" panel="skills" ?active=${this.activeResourcesTab === 'skills'}
+            >Skills</sl-tab
+          >
 
           <sl-tab-panel name="env-vars">
             <scion-env-var-list
@@ -2133,17 +2408,13 @@ export class ScionPageProjectSettings extends LitElement {
             ></scion-shared-dir-list>
           </sl-tab-panel>
 
-          <sl-tab-panel name="templates">
-            ${this.renderTemplatesContent()}
-          </sl-tab-panel>
+          <sl-tab-panel name="templates"> ${this.renderTemplatesContent()} </sl-tab-panel>
 
           <sl-tab-panel name="harness-configs">
             ${this.renderHarnessConfigsContent()}
           </sl-tab-panel>
 
-          <sl-tab-panel name="pre-start-hooks">
-            ${this.renderPreStartHooksContent()}
-          </sl-tab-panel>
+          <sl-tab-panel name="pre-start-hooks"> ${this.renderPreStartHooksContent()} </sl-tab-panel>
 
           <sl-tab-panel name="gcp-sa">
             <scion-gcp-service-account-list
@@ -2190,7 +2461,8 @@ export class ScionPageProjectSettings extends LitElement {
         .scopeId=${this.projectId}
         detailBasePath="/projects/${this.projectId}"
         ?canClone=${canSync}
-        ?canDelete=${can(this.project!._capabilities, 'delete') || can(this.project!._capabilities, 'manage')}
+        ?canDelete=${can(this.project!._capabilities, 'delete') ||
+        can(this.project!._capabilities, 'manage')}
         ?cloneFromGlobal=${canSync}
         @resource-changed=${() => {
           this.refreshTemplatesList();
@@ -2206,8 +2478,8 @@ export class ScionPageProjectSettings extends LitElement {
       <div class="section-header" style="margin-bottom: 1rem;">
         <div class="section-header-text">
           <p style="margin: 0;">
-            Project-scoped harness configurations imported into the Hub. Open one to browse
-            and edit its files.
+            Project-scoped harness configurations imported into the Hub. Open one to browse and edit
+            its files.
           </p>
         </div>
       </div>
@@ -2227,7 +2499,8 @@ export class ScionPageProjectSettings extends LitElement {
         .scopeId=${this.projectId}
         detailBasePath="/projects/${this.projectId}"
         ?canClone=${canSync}
-        ?canDelete=${can(this.project!._capabilities, 'delete') || can(this.project!._capabilities, 'manage')}
+        ?canDelete=${can(this.project!._capabilities, 'delete') ||
+        can(this.project!._capabilities, 'manage')}
         ?cloneFromGlobal=${canSync}
         @resource-changed=${() => this.refreshHarnessConfigsList()}
       ></scion-resource-list>
@@ -2240,8 +2513,8 @@ export class ScionPageProjectSettings extends LitElement {
       <div class="section-header" style="margin-bottom: 1rem;">
         <div class="section-header-text">
           <p style="margin: 0;">
-            Project-scoped pre-start scripts staged before each agent container starts.
-            A project hook overrides the hub-wide default.
+            Project-scoped pre-start scripts staged before each agent container starts. A project
+            hook overrides the hub-wide default.
           </p>
         </div>
       </div>
@@ -2264,19 +2537,19 @@ export class ScionPageProjectSettings extends LitElement {
             this.activeSchedulesTab = (e.detail as { name: string }).name;
           }}
         >
-          <sl-tab slot="nav" panel="events" ?active=${this.activeSchedulesTab === 'events'}>Events</sl-tab>
-          <sl-tab slot="nav" panel="recurring" ?active=${this.activeSchedulesTab === 'recurring'}>Recurring</sl-tab>
+          <sl-tab slot="nav" panel="events" ?active=${this.activeSchedulesTab === 'events'}
+            >Events</sl-tab
+          >
+          <sl-tab slot="nav" panel="recurring" ?active=${this.activeSchedulesTab === 'recurring'}
+            >Recurring</sl-tab
+          >
 
           <sl-tab-panel name="events">
-            <scion-scheduled-event-list
-              .projectId=${this.project!.id}
-            ></scion-scheduled-event-list>
+            <scion-scheduled-event-list .projectId=${this.project!.id}></scion-scheduled-event-list>
           </sl-tab-panel>
 
           <sl-tab-panel name="recurring">
-            <scion-schedule-list
-              .projectId=${this.project!.id}
-            ></scion-schedule-list>
+            <scion-schedule-list .projectId=${this.project!.id}></scion-schedule-list>
           </sl-tab-panel>
         </sl-tab-group>
       </div>
@@ -2291,7 +2564,7 @@ export class ScionPageProjectSettings extends LitElement {
       if (!response.ok) {
         throw new Error(await extractApiError(response, 'Failed to load brokers'));
       }
-      const data = await response.json() as { brokers: RuntimeBrokerWithProvider[] };
+      const data = (await response.json()) as { brokers: RuntimeBrokerWithProvider[] };
       this.brokers = data.brokers || [];
 
       // Start relative time refresh if we have brokers
@@ -2427,7 +2700,9 @@ export class ScionPageProjectSettings extends LitElement {
                 <div class="broker-profiles">
                   ${broker.profiles.map(
                     (p: BrokerProfile) => html`
-                      <span class="broker-profile-badge ${p.available ? 'available' : ''}">${p.name} (${p.type})</span>
+                      <span class="broker-profile-badge ${p.available ? 'available' : ''}"
+                        >${p.name} (${p.type})</span
+                      >
                     `
                   )}
                 </div>

--- a/web/src/components/pages/projects.ts
+++ b/web/src/components/pages/projects.ts
@@ -146,7 +146,6 @@ export class ScionPageProjects extends LitElement {
       .scope-toggle button sl-icon {
         font-size: 0.875rem;
       }
-
     `,
   ];
 
@@ -197,7 +196,10 @@ export class ScionPageProjects extends LitElement {
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    stateManager.removeEventListener('projects-updated', this.boundOnProjectsUpdated as EventListener);
+    stateManager.removeEventListener(
+      'projects-updated',
+      this.boundOnProjectsUpdated as EventListener
+    );
   }
 
   private onProjectsUpdated(): void {
@@ -236,16 +238,21 @@ export class ScionPageProjects extends LitElement {
     this.error = null;
 
     try {
-      const url = this.projectScope !== 'all'
-        ? `/api/v1/projects?scope=${this.projectScope}`
-        : '/api/v1/projects';
+      const url =
+        this.projectScope !== 'all'
+          ? `/api/v1/projects?scope=${this.projectScope}`
+          : '/api/v1/projects';
       const response = await apiFetch(url);
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
-      const data = (await response.json()) as { projects?: Project[]; _capabilities?: Capabilities } | Project[];
+      const data = (await response.json()) as
+        | { projects?: Project[]; _capabilities?: Capabilities }
+        | Project[];
       if (Array.isArray(data)) {
         this.projects = data;
         this.scopeCapabilities = undefined;
@@ -288,49 +295,59 @@ export class ScionPageProjects extends LitElement {
       <div class="header">
         <h1>Projects</h1>
         <div class="header-actions">
-          ${this.pageData?.user ? html`
-            <div class="scope-toggle">
-              <button
-                class=${this.projectScope === 'all' ? 'active' : ''}
-                title="All projects"
-                @click=${() => this.setScope('all')}
-              >All</button>
-              <button
-                class=${this.projectScope === 'mine' ? 'active' : ''}
-                title="Projects I own"
-                @click=${() => this.setScope('mine')}
-              >
-                <sl-icon name="person"></sl-icon>
-                Mine
-              </button>
-              <button
-                class=${this.projectScope === 'shared' ? 'active' : ''}
-                title="Projects shared with me"
-                @click=${() => this.setScope('shared')}
-              >
-                <sl-icon name="people"></sl-icon>
-                Shared
-              </button>
-            </div>
-          ` : nothing}
+          ${this.pageData?.user
+            ? html`
+                <div class="scope-toggle">
+                  <button
+                    class=${this.projectScope === 'all' ? 'active' : ''}
+                    title="All projects"
+                    @click=${() => this.setScope('all')}
+                  >
+                    All
+                  </button>
+                  <button
+                    class=${this.projectScope === 'mine' ? 'active' : ''}
+                    title="Projects I own"
+                    @click=${() => this.setScope('mine')}
+                  >
+                    <sl-icon name="person"></sl-icon>
+                    Mine
+                  </button>
+                  <button
+                    class=${this.projectScope === 'shared' ? 'active' : ''}
+                    title="Projects shared with me"
+                    @click=${() => this.setScope('shared')}
+                  >
+                    <sl-icon name="people"></sl-icon>
+                    Shared
+                  </button>
+                </div>
+              `
+            : nothing}
           <scion-view-toggle
             .view=${this.viewMode}
             .showGraph=${false}
             storageKey="scion-view-projects"
             @view-change=${this.onViewChange}
           ></scion-view-toggle>
-          ${can(this.scopeCapabilities, 'create') ? html`
-            <a href="/projects/new" style="text-decoration: none;">
-              <sl-button variant="primary" size="small">
-                <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                New Project
-              </sl-button>
-            </a>
-          ` : nothing}
+          ${can(this.scopeCapabilities, 'create')
+            ? html`
+                <a href="/projects/new" style="text-decoration: none;">
+                  <sl-button variant="primary" size="small">
+                    <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+                    New Project
+                  </sl-button>
+                </a>
+              `
+            : nothing}
         </div>
       </div>
 
-      ${this.loading ? this.renderLoading() : this.error ? this.renderError() : this.renderProjects()}
+      ${this.loading
+        ? this.renderLoading()
+        : this.error
+          ? this.renderError()
+          : this.renderProjects()}
     `;
   }
 
@@ -381,7 +398,9 @@ export class ScionPageProjects extends LitElement {
       return this.renderEmptyState();
     }
 
-    return this.viewMode === 'grid' ? this.renderGrid(this.projects) : this.renderTable(this.projects);
+    return this.viewMode === 'grid'
+      ? this.renderGrid(this.projects)
+      : this.renderTable(this.projects);
   }
 
   private renderEmptyState() {
@@ -390,17 +409,22 @@ export class ScionPageProjects extends LitElement {
         <sl-icon name="folder2-open"></sl-icon>
         <h2>No Projects Found</h2>
         <p>
-          Projects are project workspaces that contain your agents.${can(this.scopeCapabilities, 'create') ? ' Create your first project to get started, or run' : ' Run'}
+          Projects are project workspaces that contain your
+          agents.${can(this.scopeCapabilities, 'create')
+            ? ' Create your first project to get started, or run'
+            : ' Run'}
           <code>scion init</code> in a project directory.
         </p>
-        ${can(this.scopeCapabilities, 'create') ? html`
-          <a href="/projects/new" style="text-decoration: none;">
-            <sl-button variant="primary">
-              <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-              Create Project
-            </sl-button>
-          </a>
-        ` : nothing}
+        ${can(this.scopeCapabilities, 'create')
+          ? html`
+              <a href="/projects/new" style="text-decoration: none;">
+                <sl-button variant="primary">
+                  <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+                  Create Project
+                </sl-button>
+              </a>
+            `
+          : nothing}
       </div>
     `;
   }
@@ -417,7 +441,12 @@ export class ScionPageProjects extends LitElement {
 
   private renderLinkedBadge(project: Project) {
     if (project.projectType !== 'linked') return nothing;
-    return html` <sl-tooltip content="Linked project"><sl-icon name="link-45deg" style="font-size: 0.875rem; vertical-align: middle; opacity: 0.7;"></sl-icon></sl-tooltip>`;
+    return html` <sl-tooltip content="Linked project"
+      ><sl-icon
+        name="link-45deg"
+        style="font-size: 0.875rem; vertical-align: middle; opacity: 0.7;"
+      ></sl-icon
+    ></sl-tooltip>`;
   }
 
   private renderProjectCard(project: Project) {
@@ -426,10 +455,14 @@ export class ScionPageProjects extends LitElement {
         <div class="project-header">
           <div>
             <h3 class="resource-name">
-              ${this.renderProjectIcon()}
-              ${project.name}${this.renderLinkedBadge(project)}
+              ${this.renderProjectIcon()} ${project.name}${this.renderLinkedBadge(project)}
             </h3>
-            <div class="project-path"><scion-git-remote-display .project=${project} stop-propagation></scion-git-remote-display></div>
+            <div class="project-path">
+              <scion-git-remote-display
+                .project=${project}
+                stop-propagation
+              ></scion-git-remote-display>
+            </div>
           </div>
         </div>
         <div class="project-stats">
@@ -470,17 +503,21 @@ export class ScionPageProjects extends LitElement {
 
   private renderProjectRow(project: Project) {
     return html`
-      <tr class="clickable" @click=${() => {
-        window.history.pushState({}, '', `/projects/${project.id}`);
-        window.dispatchEvent(new PopStateEvent('popstate'));
-      }}>
+      <tr
+        class="clickable"
+        @click=${() => {
+          window.history.pushState({}, '', `/projects/${project.id}`);
+          window.dispatchEvent(new PopStateEvent('popstate'));
+        }}
+      >
         <td>
           <span class="name-cell">
-            ${this.renderProjectIcon()}
-            ${project.name}${this.renderLinkedBadge(project)}
+            ${this.renderProjectIcon()} ${project.name}${this.renderLinkedBadge(project)}
           </span>
         </td>
-        <td class="mono-cell"><scion-git-remote-display .project=${project} stop-propagation></scion-git-remote-display></td>
+        <td class="mono-cell">
+          <scion-git-remote-display .project=${project} stop-propagation></scion-git-remote-display>
+        </td>
         <td>${project.agentCount}</td>
         <td class="hide-mobile">
           <span class="meta-text">${project.ownerName || '—'}</span>

--- a/web/src/components/pages/settings.ts
+++ b/web/src/components/pages/settings.ts
@@ -152,17 +152,16 @@ export class ScionPageSettings extends LitElement {
           <sl-tab slot="nav" panel="env-vars" ?active=${this.activeTab === 'env-vars'}
             >Environment Variables</sl-tab
           >
-          <sl-tab slot="nav" panel="secrets" ?active=${this.activeTab === 'secrets'}>Secrets</sl-tab>
+          <sl-tab slot="nav" panel="secrets" ?active=${this.activeTab === 'secrets'}
+            >Secrets</sl-tab
+          >
           <sl-tab slot="nav" panel="templates" ?active=${this.activeTab === 'templates'}
             >Templates</sl-tab
           >
           <sl-tab slot="nav" panel="harness-configs" ?active=${this.activeTab === 'harness-configs'}
             >Harness Configs</sl-tab
           >
-          <sl-tab
-            slot="nav"
-            panel="pre-start-hooks"
-            ?active=${this.activeTab === 'pre-start-hooks'}
+          <sl-tab slot="nav" panel="pre-start-hooks" ?active=${this.activeTab === 'pre-start-hooks'}
             >Pre-Start Hooks</sl-tab
           >
           <sl-tab
@@ -171,10 +170,11 @@ export class ScionPageSettings extends LitElement {
             ?active=${this.activeTab === 'service-accounts'}
             >Service Accounts</sl-tab
           >
-          <sl-tab slot="nav" panel="skills" ?active=${this.activeTab === 'skills'}
-            >Skills</sl-tab
-          >
-          <sl-tab slot="nav" panel="project-templates" ?active=${this.activeTab === 'project-templates'}
+          <sl-tab slot="nav" panel="skills" ?active=${this.activeTab === 'skills'}>Skills</sl-tab>
+          <sl-tab
+            slot="nav"
+            panel="project-templates"
+            ?active=${this.activeTab === 'project-templates'}
             >Project Templates</sl-tab
           >
 
@@ -248,32 +248,31 @@ export class ScionPageSettings extends LitElement {
           -->
           <sl-tab-panel name="service-accounts">
             <p class="tab-intro">
-              GCP service accounts registered at hub scope. They belong to the hub rather
-              than to any one project, which is why they are managed here.
+              GCP service accounts registered at hub scope. They belong to the hub rather than to
+              any one project, which is why they are managed here.
             </p>
             <p class="tab-intro">
-              Two things are not available yet. Registering a hub-scoped account — use a
-              project's settings to register an account for that project. And selecting a
-              hub-scoped account when creating an agent, so an account listed here is not
-              yet offered on any project's agent form.
+              Two things are not available yet. Registering a hub-scoped account — use a project's
+              settings to register an account for that project. And selecting a hub-scoped account
+              when creating an agent, so an account listed here is not yet offered on any project's
+              agent form.
             </p>
             <scion-gcp-service-account-list scope="hub"></scion-gcp-service-account-list>
           </sl-tab-panel>
 
           <sl-tab-panel name="skills">
             <p class="tab-intro">
-              Skills automatically injected into all agents on this hub. System entries are
-              seeded from built-in platform skills and are read-only. User-defined entries
-              can be added and removed by hub admins.
+              Skills automatically injected into all agents on this hub. System entries are seeded
+              from built-in platform skills and are read-only. User-defined entries can be added and
+              removed by hub admins.
             </p>
             <scion-injected-skills-panel scope="hub"></scion-injected-skills-panel>
           </sl-tab-panel>
 
           <sl-tab-panel name="project-templates">
             <p class="tab-intro">
-              Project templates for quick project setup. Create a template from any
-              existing project, then use it to create new projects with pre-configured
-              settings.
+              Project templates for quick project setup. Create a template from any existing
+              project, then use it to create new projects with pre-configured settings.
             </p>
             <scion-project-template-list></scion-project-template-list>
           </sl-tab-panel>

--- a/web/src/components/pages/skill-create.ts
+++ b/web/src/components/pages/skill-create.ts
@@ -1165,7 +1165,9 @@ export class ScionPageSkillCreate extends LitElement {
                         <span class="file-name">${sf.path}</span>
                         <span class="file-meta">
                           ${this.formatFileSize(sf.file.size)}
-                          ${sf.path === 'SKILL.md' && this.hasSkillMd ? '-- from content above' : ''}
+                          ${sf.path === 'SKILL.md' && this.hasSkillMd
+                            ? '-- from content above'
+                            : ''}
                         </span>
                       </div>
                       ${sf.path === 'SKILL.md' && this.hasSkillMd
@@ -1259,8 +1261,7 @@ export class ScionPageSkillCreate extends LitElement {
     };
 
     const stepActive = (s: FlowState) => this.flowState === s;
-    const stepError = (s: FlowState) =>
-      this.flowState === 'error' && s === 'publishing';
+    const stepError = (s: FlowState) => this.flowState === 'error' && s === 'publishing';
 
     const stepClass = (s: FlowState) => {
       if (stepDone(s)) return 'progress-step done';
@@ -1304,16 +1305,12 @@ export class ScionPageSkillCreate extends LitElement {
                 <div class=${stepClass('creating')}>
                   ${stepIcon('creating')}
                   <span class="step-label">Creating skill...</span>
-                  <span class="step-status"
-                    >${stepDone('creating') ? 'done' : ''}</span
-                  >
+                  <span class="step-status">${stepDone('creating') ? 'done' : ''}</span>
                 </div>
                 <div class=${stepClass('publishing')}>
                   ${stepIcon('publishing')}
                   <span class="step-label">Uploading & publishing...</span>
-                  <span class="step-status"
-                    >${stepDone('publishing') ? 'done' : ''}</span
-                  >
+                  <span class="step-status">${stepDone('publishing') ? 'done' : ''}</span>
                 </div>
               </div>
 

--- a/web/src/components/pages/skill-detail.ts
+++ b/web/src/components/pages/skill-detail.ts
@@ -43,7 +43,12 @@ export class ScionPageSkillDetail extends LitElement {
   @state() private versions: SkillVersion[] = [];
   @state() private error: string | null = null;
   @state() private editing = false;
-  @state() private editForm: Partial<{ name: string; description: string; visibility: string; tags: string }> = {};
+  @state() private editForm: Partial<{
+    name: string;
+    description: string;
+    visibility: string;
+    tags: string;
+  }> = {};
   @state() private saving = false;
   @state() private actionLoading: Record<string, boolean> = {};
 
@@ -62,7 +67,9 @@ export class ScionPageSkillDetail extends LitElement {
   @state() private filesLoading = false;
 
   static override styles = css`
-    :host { display: block; }
+    :host {
+      display: block;
+    }
 
     .back-link {
       display: inline-flex;
@@ -73,7 +80,9 @@ export class ScionPageSkillDetail extends LitElement {
       font-size: 0.875rem;
       margin-bottom: 1rem;
     }
-    .back-link:hover { color: var(--scion-primary, #3b82f6); }
+    .back-link:hover {
+      color: var(--scion-primary, #3b82f6);
+    }
 
     .header {
       display: flex;
@@ -82,7 +91,9 @@ export class ScionPageSkillDetail extends LitElement {
       margin-bottom: 1.5rem;
       gap: 1rem;
     }
-    .header-info { flex: 1; }
+    .header-info {
+      flex: 1;
+    }
     .header-title {
       display: flex;
       align-items: center;
@@ -111,8 +122,12 @@ export class ScionPageSkillDetail extends LitElement {
       flex-shrink: 0;
     }
 
-    sl-tab-group { --track-color: var(--scion-border, #e2e8f0); }
-    sl-tab-group::part(body) { padding-top: 1.5rem; }
+    sl-tab-group {
+      --track-color: var(--scion-border, #e2e8f0);
+    }
+    sl-tab-group::part(body) {
+      padding-top: 1.5rem;
+    }
 
     .card {
       background: var(--scion-surface, #ffffff);
@@ -141,7 +156,10 @@ export class ScionPageSkillDetail extends LitElement {
       grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
       gap: 1.5rem;
     }
-    .info-item { display: flex; flex-direction: column; }
+    .info-item {
+      display: flex;
+      flex-direction: column;
+    }
     .info-label {
       font-size: 0.75rem;
       color: var(--scion-text-muted, #64748b);
@@ -173,7 +191,8 @@ export class ScionPageSkillDetail extends LitElement {
       color: var(--scion-text, #1e293b);
     }
 
-    .scope-badge, .visibility-badge {
+    .scope-badge,
+    .visibility-badge {
       display: inline-flex;
       align-items: center;
       padding: 0.125rem 0.5rem;
@@ -213,7 +232,9 @@ export class ScionPageSkillDetail extends LitElement {
       color: var(--scion-text-muted, #64748b);
     }
 
-    .edit-field { margin-bottom: 1rem; }
+    .edit-field {
+      margin-bottom: 1rem;
+    }
     .edit-field label {
       display: block;
       font-size: 0.75rem;
@@ -235,7 +256,10 @@ export class ScionPageSkillDetail extends LitElement {
       border-radius: var(--scion-radius-lg, 0.75rem);
       overflow: hidden;
     }
-    .version-table table { width: 100%; border-collapse: collapse; }
+    .version-table table {
+      width: 100%;
+      border-collapse: collapse;
+    }
     .version-table th {
       text-align: left;
       padding: 0.75rem 1rem;
@@ -254,8 +278,13 @@ export class ScionPageSkillDetail extends LitElement {
       border-bottom: 1px solid var(--scion-border, #e2e8f0);
       vertical-align: middle;
     }
-    .version-table tr:last-child td { border-bottom: none; }
-    .version-table .actions-cell { text-align: right; white-space: nowrap; }
+    .version-table tr:last-child td {
+      border-bottom: none;
+    }
+    .version-table .actions-cell {
+      text-align: right;
+      white-space: nowrap;
+    }
 
     .file-table {
       background: var(--scion-surface, #ffffff);
@@ -263,7 +292,10 @@ export class ScionPageSkillDetail extends LitElement {
       border-radius: var(--scion-radius-lg, 0.75rem);
       overflow: hidden;
     }
-    .file-table table { width: 100%; border-collapse: collapse; }
+    .file-table table {
+      width: 100%;
+      border-collapse: collapse;
+    }
     .file-table th {
       text-align: left;
       padding: 0.75rem 1rem;
@@ -282,7 +314,9 @@ export class ScionPageSkillDetail extends LitElement {
       border-bottom: 1px solid var(--scion-border, #e2e8f0);
       vertical-align: middle;
     }
-    .file-table tr:last-child td { border-bottom: none; }
+    .file-table tr:last-child td {
+      border-bottom: none;
+    }
 
     .version-selector {
       margin-bottom: 1rem;
@@ -296,7 +330,10 @@ export class ScionPageSkillDetail extends LitElement {
       padding: 4rem 2rem;
       color: var(--scion-text-muted, #64748b);
     }
-    .loading-state sl-spinner { font-size: 2rem; margin-bottom: 1rem; }
+    .loading-state sl-spinner {
+      font-size: 2rem;
+      margin-bottom: 1rem;
+    }
 
     .error-state {
       text-align: center;
@@ -311,10 +348,15 @@ export class ScionPageSkillDetail extends LitElement {
       margin-bottom: 1rem;
     }
     .error-state h2 {
-      font-size: 1.25rem; font-weight: 600;
-      color: var(--scion-text, #1e293b); margin: 0 0 0.5rem 0;
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+      margin: 0 0 0.5rem 0;
     }
-    .error-state p { color: var(--scion-text-muted, #64748b); margin: 0 0 1rem 0; }
+    .error-state p {
+      color: var(--scion-text-muted, #64748b);
+      margin: 0 0 1rem 0;
+    }
     .error-details {
       font-family: var(--scion-font-mono, monospace);
       font-size: 0.875rem;
@@ -371,7 +413,9 @@ export class ScionPageSkillDetail extends LitElement {
 
       const versionsRes = await apiFetch(`/api/v1/skills/${this.skillId}/versions`);
       if (versionsRes.ok) {
-        const data = (await versionsRes.json()) as { items?: SkillVersion[]; versions?: SkillVersion[] } | SkillVersion[];
+        const data = (await versionsRes.json()) as
+          | { items?: SkillVersion[]; versions?: SkillVersion[] }
+          | SkillVersion[];
         if (Array.isArray(data)) {
           this.versions = data;
         } else {
@@ -400,7 +444,9 @@ export class ScionPageSkillDetail extends LitElement {
       if (hours < 24) return `${hours}h ago`;
       const days = Math.floor(hours / 24);
       return `${days}d ago`;
-    } catch { return dateString; }
+    } catch {
+      return dateString;
+    }
   }
 
   private formatFileSize(bytes: number): string {
@@ -411,10 +457,14 @@ export class ScionPageSkillDetail extends LitElement {
 
   private versionStatusType(status: string): StatusType {
     switch (status) {
-      case 'published': return 'success' as StatusType;
-      case 'deprecated': return 'warning' as StatusType;
-      case 'archived': return 'danger' as StatusType;
-      default: return 'default' as StatusType;
+      case 'published':
+        return 'success' as StatusType;
+      case 'deprecated':
+        return 'warning' as StatusType;
+      case 'archived':
+        return 'danger' as StatusType;
+      default:
+        return 'default' as StatusType;
     }
   }
 
@@ -429,7 +479,9 @@ export class ScionPageSkillDetail extends LitElement {
   private async copyUri(): Promise<void> {
     try {
       await navigator.clipboard.writeText(this.getSkillUri());
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
   }
 
   // -- Edit mode --
@@ -462,11 +514,17 @@ export class ScionPageSkillDetail extends LitElement {
       if (this.editForm.description !== undefined) {
         body.description = this.editForm.description;
       }
-      if (this.editForm.visibility !== undefined && this.editForm.visibility !== this.skill.visibility) {
+      if (
+        this.editForm.visibility !== undefined &&
+        this.editForm.visibility !== this.skill.visibility
+      ) {
         body.visibility = this.editForm.visibility;
       }
       if (this.editForm.tags !== undefined) {
-        body.tags = this.editForm.tags.split(',').map((t) => t.trim()).filter((t) => t);
+        body.tags = this.editForm.tags
+          .split(',')
+          .map((t) => t.trim())
+          .filter((t) => t);
       }
 
       const res = await apiFetch(`/api/v1/skills/${this.skillId}`, {
@@ -558,9 +616,13 @@ export class ScionPageSkillDetail extends LitElement {
   private async loadFiles(version: string): Promise<void> {
     this.filesLoading = true;
     try {
-      const res = await apiFetch(`/api/v1/skills/${this.skillId}/download?version=${encodeURIComponent(version)}`);
+      const res = await apiFetch(
+        `/api/v1/skills/${this.skillId}/download?version=${encodeURIComponent(version)}`
+      );
       if (res.ok) {
-        const data = (await res.json()) as { files?: SkillDownloadUrl[]; urls?: SkillDownloadUrl[] } | SkillDownloadUrl[];
+        const data = (await res.json()) as
+          | { files?: SkillDownloadUrl[]; urls?: SkillDownloadUrl[] }
+          | SkillDownloadUrl[];
         if (Array.isArray(data)) {
           this.fileUrls = data;
         } else {
@@ -616,8 +678,7 @@ export class ScionPageSkillDetail extends LitElement {
         <sl-tab-panel name="files">${this.renderFilesTab()}</sl-tab-panel>
       </sl-tab-group>
 
-      ${this.renderDeprecateDialog()}
-      ${this.renderPublishDialog()}
+      ${this.renderDeprecateDialog()} ${this.renderPublishDialog()}
     `;
   }
 
@@ -640,35 +701,48 @@ export class ScionPageSkillDetail extends LitElement {
           </div>
         </div>
         <div class="header-actions">
-          ${can(skill._capabilities, 'update') ? html`
-            <sl-button variant="default" size="small" outline @click=${() => this.startEditing()}>
-              <sl-icon slot="prefix" name="pencil"></sl-icon>
-              Edit
-            </sl-button>
-          ` : nothing}
-          ${can(skill._capabilities, 'update') ? html`
-            <sl-button
-              variant="primary"
-              size="small"
-              @click=${() => { this.publishDialogOpen = true; }}
-            >
-              <sl-icon slot="prefix" name="upload"></sl-icon>
-              Publish Version
-            </sl-button>
-          ` : nothing}
-          ${can(skill._capabilities, 'delete') ? html`
-            <sl-button
-              variant="danger"
-              size="small"
-              outline
-              ?loading=${this.actionLoading['archive']}
-              ?disabled=${this.actionLoading['archive']}
-              @click=${() => this.handleArchive()}
-            >
-              <sl-icon slot="prefix" name="trash"></sl-icon>
-              Archive
-            </sl-button>
-          ` : nothing}
+          ${can(skill._capabilities, 'update')
+            ? html`
+                <sl-button
+                  variant="default"
+                  size="small"
+                  outline
+                  @click=${() => this.startEditing()}
+                >
+                  <sl-icon slot="prefix" name="pencil"></sl-icon>
+                  Edit
+                </sl-button>
+              `
+            : nothing}
+          ${can(skill._capabilities, 'update')
+            ? html`
+                <sl-button
+                  variant="primary"
+                  size="small"
+                  @click=${() => {
+                    this.publishDialogOpen = true;
+                  }}
+                >
+                  <sl-icon slot="prefix" name="upload"></sl-icon>
+                  Publish Version
+                </sl-button>
+              `
+            : nothing}
+          ${can(skill._capabilities, 'delete')
+            ? html`
+                <sl-button
+                  variant="danger"
+                  size="small"
+                  outline
+                  ?loading=${this.actionLoading['archive']}
+                  ?disabled=${this.actionLoading['archive']}
+                  @click=${() => this.handleArchive()}
+                >
+                  <sl-icon slot="prefix" name="trash"></sl-icon>
+                  Archive
+                </sl-button>
+              `
+            : nothing}
         </div>
       </div>
     `;
@@ -704,40 +778,55 @@ export class ScionPageSkillDetail extends LitElement {
           </div>
           <div class="info-item">
             <span class="info-label">Description</span>
-            <span class="info-value">${skill.description || html`<span style="color: var(--scion-text-muted);">No description</span>`}</span>
+            <span class="info-value"
+              >${skill.description ||
+              html`<span style="color: var(--scion-text-muted);">No description</span>`}</span
+            >
           </div>
           <div class="info-item">
             <span class="info-label">Scope</span>
             <span class="info-value"><span class="scope-badge">${skill.scope}</span></span>
           </div>
-          ${skill.scopeId ? html`
-            <div class="info-item">
-              <span class="info-label">Scope ID</span>
-              <span class="info-value mono">${skill.scopeId}</span>
-            </div>
-          ` : nothing}
+          ${skill.scopeId
+            ? html`
+                <div class="info-item">
+                  <span class="info-label">Scope ID</span>
+                  <span class="info-value mono">${skill.scopeId}</span>
+                </div>
+              `
+            : nothing}
           <div class="info-item">
             <span class="info-label">Visibility</span>
-            <span class="info-value"><span class="visibility-badge ${skill.visibility}">${skill.visibility}</span></span>
+            <span class="info-value"
+              ><span class="visibility-badge ${skill.visibility}">${skill.visibility}</span></span
+            >
           </div>
-          ${skill.ownerId ? html`
-            <div class="info-item">
-              <span class="info-label">Owner</span>
-              <span class="info-value">${skill.ownerId}</span>
-            </div>
-          ` : nothing}
+          ${skill.ownerId
+            ? html`
+                <div class="info-item">
+                  <span class="info-label">Owner</span>
+                  <span class="info-value">${skill.ownerId}</span>
+                </div>
+              `
+            : nothing}
           <div class="info-item">
             <span class="info-label">Tags</span>
             <span class="info-value">
               ${skill.tags?.length
-                ? html`<div class="tag-list">${skill.tags.map((t) => html`<span class="tag-item">${t}</span>`)}</div>`
+                ? html`<div class="tag-list">
+                    ${skill.tags.map((t) => html`<span class="tag-item">${t}</span>`)}
+                  </div>`
                 : html`<span style="color: var(--scion-text-muted);">No tags</span>`}
             </span>
           </div>
           <div class="info-item">
             <span class="info-label">Status</span>
             <span class="info-value">
-              <scion-status-badge status=${skill.status as StatusType} label=${skill.status} size="small"></scion-status-badge>
+              <scion-status-badge
+                status=${skill.status as StatusType}
+                label=${skill.status}
+                size="small"
+              ></scion-status-badge>
             </span>
           </div>
           <div class="info-item">
@@ -761,14 +850,24 @@ export class ScionPageSkillDetail extends LitElement {
           <label>Name</label>
           <sl-input
             .value=${this.editForm.name || ''}
-            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, name: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-input=${(e: Event) => {
+              this.editForm = {
+                ...this.editForm,
+                name: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
           ></sl-input>
         </div>
         <div class="edit-field">
           <label>Description</label>
           <sl-textarea
             .value=${this.editForm.description || ''}
-            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, description: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-input=${(e: Event) => {
+              this.editForm = {
+                ...this.editForm,
+                description: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
             rows="3"
             help-text="Once set, this field cannot be cleared."
           ></sl-textarea>
@@ -777,7 +876,12 @@ export class ScionPageSkillDetail extends LitElement {
           <label>Visibility</label>
           <sl-radio-group
             .value=${this.editForm.visibility || 'private'}
-            @sl-change=${(e: Event) => { this.editForm = { ...this.editForm, visibility: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-change=${(e: Event) => {
+              this.editForm = {
+                ...this.editForm,
+                visibility: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
           >
             <sl-radio-button value="private">Private</sl-radio-button>
             <sl-radio-button value="public">Public</sl-radio-button>
@@ -787,15 +891,30 @@ export class ScionPageSkillDetail extends LitElement {
           <label>Tags</label>
           <sl-input
             .value=${this.editForm.tags || ''}
-            @sl-input=${(e: Event) => { this.editForm = { ...this.editForm, tags: (e.target as HTMLElement & { value: string }).value }; }}
+            @sl-input=${(e: Event) => {
+              this.editForm = {
+                ...this.editForm,
+                tags: (e.target as HTMLElement & { value: string }).value,
+              };
+            }}
             placeholder="comma-separated tags"
           ></sl-input>
         </div>
         <div class="edit-actions">
-          <sl-button variant="primary" size="small" ?loading=${this.saving} @click=${() => this.saveEdit()}>
+          <sl-button
+            variant="primary"
+            size="small"
+            ?loading=${this.saving}
+            @click=${() => this.saveEdit()}
+          >
             Save
           </sl-button>
-          <sl-button variant="default" size="small" ?disabled=${this.saving} @click=${() => this.cancelEditing()}>
+          <sl-button
+            variant="default"
+            size="small"
+            ?disabled=${this.saving}
+            @click=${() => this.cancelEditing()}
+          >
             Cancel
           </sl-button>
         </div>
@@ -808,9 +927,9 @@ export class ScionPageSkillDetail extends LitElement {
       return html`
         <div class="empty-versions">
           <p>No versions published yet.</p>
-          ${can(this.skill?._capabilities, 'update') ? html`
-            <p>Use the "Publish Version" button to upload the first version.</p>
-          ` : nothing}
+          ${can(this.skill?._capabilities, 'update')
+            ? html` <p>Use the "Publish Version" button to upload the first version.</p> `
+            : nothing}
         </div>
       `;
     }
@@ -850,18 +969,30 @@ export class ScionPageSkillDetail extends LitElement {
         </td>
         <td class="hide-mobile">
           ${v.contentHash
-            ? html`<scion-hash-display .hash=${v.contentHash} max-width="14ch"></scion-hash-display>`
+            ? html`<scion-hash-display
+                .hash=${v.contentHash}
+                max-width="14ch"
+              ></scion-hash-display>`
             : '—'}
         </td>
         <td class="hide-mobile">${v.files?.length ?? 0} files</td>
         <td class="hide-mobile">${v.downloadCount}</td>
         <td class="hide-mobile">${this.formatRelativeTime(v.created)}</td>
         <td class="actions-cell">
-          ${v.status === 'published' && can(this.skill?._capabilities, 'update') ? html`
-            <sl-button size="small" variant="warning" outline @click=${() => { this.deprecateVersionId = v.id; }}>
-              Deprecate
-            </sl-button>
-          ` : nothing}
+          ${v.status === 'published' && can(this.skill?._capabilities, 'update')
+            ? html`
+                <sl-button
+                  size="small"
+                  variant="warning"
+                  outline
+                  @click=${() => {
+                    this.deprecateVersionId = v.id;
+                  }}
+                >
+                  Deprecate
+                </sl-button>
+              `
+            : nothing}
         </td>
       </tr>
     `;
@@ -889,64 +1020,82 @@ export class ScionPageSkillDetail extends LitElement {
         >
           ${published.map((v) => html`<sl-option value=${v.version}>v${v.version}</sl-option>`)}
         </sl-select>
-        ${!this.filesLoading && this.fileUrls.length > 0 ? html`
-          <span style="font-size: 0.875rem; color: var(--scion-text-muted, #64748b);">${this.fileUrls.length} file${this.fileUrls.length !== 1 ? 's' : ''}</span>
-        ` : nothing}
+        ${!this.filesLoading && this.fileUrls.length > 0
+          ? html`
+              <span style="font-size: 0.875rem; color: var(--scion-text-muted, #64748b);"
+                >${this.fileUrls.length} file${this.fileUrls.length !== 1 ? 's' : ''}</span
+              >
+            `
+          : nothing}
       </div>
 
-      ${this.filesLoading ? html`
-        <div class="loading-state" style="padding: 2rem;">
-          <sl-spinner></sl-spinner>
-          <p>Loading files...</p>
-        </div>
-      ` : this.fileUrls.length === 0 ? html`
-        <div class="empty-versions">
-          <p>No files found for this version.</p>
-        </div>
-      ` : html`
-        <div class="file-table">
-          <table>
-            <thead>
-              <tr>
-                <th>Path</th>
-                <th>Size</th>
-                <th class="hide-mobile">Hash</th>
-                <th style="text-align: right">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              ${this.fileUrls.map((f) => html`
-                <tr>
-                  <td>
-                    <span style="display: flex; align-items: center; gap: 0.5rem;">
-                      <sl-icon name="file-earmark"></sl-icon>
-                      ${f.path}
-                    </span>
-                  </td>
-                  <td>${this.formatFileSize(f.size)}</td>
-                  <td class="hide-mobile">
-                    ${f.hash
-                      ? html`<scion-hash-display .hash=${f.hash} max-width="14ch"></scion-hash-display>`
-                      : '—'}
-                  </td>
-                  <td style="text-align: right">
-                    <sl-button size="small" variant="default" outline @click=${() => {
-                      const a = document.createElement('a');
-                      a.href = f.url;
-                      a.target = '_blank';
-                      a.rel = 'noopener noreferrer';
-                      a.click();
-                    }}>
-                      <sl-icon slot="prefix" name="download"></sl-icon>
-                      Download
-                    </sl-button>
-                  </td>
-                </tr>
-              `)}
-            </tbody>
-          </table>
-        </div>
-      `}
+      ${this.filesLoading
+        ? html`
+            <div class="loading-state" style="padding: 2rem;">
+              <sl-spinner></sl-spinner>
+              <p>Loading files...</p>
+            </div>
+          `
+        : this.fileUrls.length === 0
+          ? html`
+              <div class="empty-versions">
+                <p>No files found for this version.</p>
+              </div>
+            `
+          : html`
+              <div class="file-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Path</th>
+                      <th>Size</th>
+                      <th class="hide-mobile">Hash</th>
+                      <th style="text-align: right">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    ${this.fileUrls.map(
+                      (f) => html`
+                        <tr>
+                          <td>
+                            <span style="display: flex; align-items: center; gap: 0.5rem;">
+                              <sl-icon name="file-earmark"></sl-icon>
+                              ${f.path}
+                            </span>
+                          </td>
+                          <td>${this.formatFileSize(f.size)}</td>
+                          <td class="hide-mobile">
+                            ${f.hash
+                              ? html`<scion-hash-display
+                                  .hash=${f.hash}
+                                  max-width="14ch"
+                                ></scion-hash-display>`
+                              : '—'}
+                          </td>
+                          <td style="text-align: right">
+                            <sl-button
+                              size="small"
+                              variant="default"
+                              outline
+                              @click=${() => {
+                                const a = document.createElement('a');
+                                a.href = f.url;
+                                a.target = '_blank';
+                                a.rel = 'noopener noreferrer';
+                                a.click();
+                              }}
+                            >
+                              <sl-icon slot="prefix" name="download"></sl-icon>
+                              Download
+                            </sl-button>
+                          </td>
+                        </tr>
+                      `
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            `}
     `;
   }
 
@@ -955,21 +1104,27 @@ export class ScionPageSkillDetail extends LitElement {
       <sl-dialog
         label="Deprecate Version"
         ?open=${this.deprecateVersionId !== null}
-        @sl-after-hide=${() => { this.deprecateVersionId = null; }}
+        @sl-after-hide=${() => {
+          this.deprecateVersionId = null;
+        }}
       >
         <div style="display: flex; flex-direction: column; gap: 1rem;">
           <sl-textarea
             label="Deprecation Message"
             placeholder="Reason for deprecation..."
             .value=${this.deprecateMessage}
-            @sl-input=${(e: Event) => { this.deprecateMessage = (e.target as HTMLElement & { value: string }).value; }}
+            @sl-input=${(e: Event) => {
+              this.deprecateMessage = (e.target as HTMLElement & { value: string }).value;
+            }}
             required
           ></sl-textarea>
           <sl-input
             label="Replacement URI (optional)"
             placeholder="global:replacement-skill@1.0.0"
             .value=${this.deprecateReplacement}
-            @sl-input=${(e: Event) => { this.deprecateReplacement = (e.target as HTMLElement & { value: string }).value; }}
+            @sl-input=${(e: Event) => {
+              this.deprecateReplacement = (e.target as HTMLElement & { value: string }).value;
+            }}
           ></sl-input>
         </div>
         <sl-button
@@ -998,8 +1153,13 @@ export class ScionPageSkillDetail extends LitElement {
         .skillId=${this.skillId}
         ?open=${this.publishDialogOpen}
         .latestVersion=${this.latestPublishedVersion}
-        @sl-after-hide=${() => { this.publishDialogOpen = false; }}
-        @skill-version-published=${() => { this.publishDialogOpen = false; void this.loadData(); }}
+        @sl-after-hide=${() => {
+          this.publishDialogOpen = false;
+        }}
+        @skill-version-published=${() => {
+          this.publishDialogOpen = false;
+          void this.loadData();
+        }}
       ></scion-skill-publish-dialog>
     `;
   }

--- a/web/src/components/pages/skills.ts
+++ b/web/src/components/pages/skills.ts
@@ -219,10 +219,14 @@ export class ScionPageSkills extends LitElement {
           this.sortField = parsed.field;
           this.sortDir = parsed.dir;
         }
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
     }
 
-    const ssrData = this.pageData?.data as { skills?: Skill[]; _capabilities?: Capabilities } | undefined;
+    const ssrData = this.pageData?.data as
+      | { skills?: Skill[]; _capabilities?: Capabilities }
+      | undefined;
     if (ssrData?.skills && this.scopeFilter === '' && !this.searchQuery) {
       this.skills = ssrData.skills;
       this.scopeCapabilities = ssrData._capabilities;
@@ -244,10 +248,14 @@ export class ScionPageSkills extends LitElement {
 
       const response = await apiFetch(`/api/v1/skills?${params.toString()}`);
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
-      const data = (await response.json()) as { skills?: Skill[]; items?: Skill[]; _capabilities?: Capabilities } | Skill[];
+      const data = (await response.json()) as
+        | { skills?: Skill[]; items?: Skill[]; _capabilities?: Capabilities }
+        | Skill[];
       if (Array.isArray(data)) {
         this.skills = data;
         this.scopeCapabilities = undefined;
@@ -324,7 +332,10 @@ export class ScionPageSkills extends LitElement {
       this.sortField = field;
       this.sortDir = field === 'name' ? 'asc' : 'desc';
     }
-    localStorage.setItem('scion-sort-skills', JSON.stringify({ field: this.sortField, dir: this.sortDir }));
+    localStorage.setItem(
+      'scion-sort-skills',
+      JSON.stringify({ field: this.sortField, dir: this.sortDir })
+    );
   }
 
   private sortIndicator(field: SkillSortField): string {
@@ -342,21 +353,24 @@ export class ScionPageSkills extends LitElement {
             storageKey="scion-view-skills"
             @view-change=${this.onViewChange}
           ></scion-view-toggle>
-          ${can(this.scopeCapabilities, 'create') ? html`
-            <a href="/skills/new" style="text-decoration: none;">
-              <sl-button variant="primary" size="small">
-                <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-                Create Skill
-              </sl-button>
-            </a>
-          ` : nothing}
+          ${can(this.scopeCapabilities, 'create')
+            ? html`
+                <a href="/skills/new" style="text-decoration: none;">
+                  <sl-button variant="primary" size="small">
+                    <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+                    Create Skill
+                  </sl-button>
+                </a>
+              `
+            : nothing}
         </div>
       </div>
 
-      ${this.loading ? this.renderLoading() : this.error ? this.renderError() : html`
-        ${this.renderFilterBar()}
-        ${this.renderSkills()}
-      `}
+      ${this.loading
+        ? this.renderLoading()
+        : this.error
+          ? this.renderError()
+          : html` ${this.renderFilterBar()} ${this.renderSkills()} `}
     `;
   }
 
@@ -386,19 +400,33 @@ export class ScionPageSkills extends LitElement {
           <sl-option value="project">Project</sl-option>
           <sl-option value="user">User</sl-option>
         </sl-select>
-        ${this.viewMode === 'grid' ? html`
-          <sl-dropdown>
-            <sl-button slot="trigger" size="small" outline>
-              <sl-icon slot="prefix" name=${this.sortDir === 'asc' ? 'sort-alpha-down' : 'sort-alpha-down-alt'}></sl-icon>
-              Sort: ${this.sortField}
-            </sl-button>
-            <sl-menu @sl-select=${(e: CustomEvent<{ item: { value: string } }>) => this.toggleSort(e.detail.item.value as SkillSortField)}>
-              <sl-menu-item value="name" ?checked=${this.sortField === 'name'}>Name</sl-menu-item>
-              <sl-menu-item value="created" ?checked=${this.sortField === 'created'}>Created</sl-menu-item>
-              <sl-menu-item value="updated" ?checked=${this.sortField === 'updated'}>Updated</sl-menu-item>
-            </sl-menu>
-          </sl-dropdown>
-        ` : nothing}
+        ${this.viewMode === 'grid'
+          ? html`
+              <sl-dropdown>
+                <sl-button slot="trigger" size="small" outline>
+                  <sl-icon
+                    slot="prefix"
+                    name=${this.sortDir === 'asc' ? 'sort-alpha-down' : 'sort-alpha-down-alt'}
+                  ></sl-icon>
+                  Sort: ${this.sortField}
+                </sl-button>
+                <sl-menu
+                  @sl-select=${(e: CustomEvent<{ item: { value: string } }>) =>
+                    this.toggleSort(e.detail.item.value as SkillSortField)}
+                >
+                  <sl-menu-item value="name" ?checked=${this.sortField === 'name'}
+                    >Name</sl-menu-item
+                  >
+                  <sl-menu-item value="created" ?checked=${this.sortField === 'created'}
+                    >Created</sl-menu-item
+                  >
+                  <sl-menu-item value="updated" ?checked=${this.sortField === 'updated'}
+                    >Updated</sl-menu-item
+                  >
+                </sl-menu>
+              </sl-dropdown>
+            `
+          : nothing}
       </div>
     `;
   }
@@ -452,23 +480,30 @@ export class ScionPageSkills extends LitElement {
         <sl-icon name="lightning-charge"></sl-icon>
         <h2>No Skills Found</h2>
         <p>
-          Skills are reusable capabilities for agents.${can(this.scopeCapabilities, 'create') ? ' Create your first skill to get started.' : ''}
+          Skills are reusable capabilities for
+          agents.${can(this.scopeCapabilities, 'create')
+            ? ' Create your first skill to get started.'
+            : ''}
         </p>
-        ${can(this.scopeCapabilities, 'create') ? html`
-          <a href="/skills/new" style="text-decoration: none;">
-            <sl-button variant="primary">
-              <sl-icon slot="prefix" name="plus-lg"></sl-icon>
-              Create Skill
-            </sl-button>
-          </a>
-        ` : nothing}
+        ${can(this.scopeCapabilities, 'create')
+          ? html`
+              <a href="/skills/new" style="text-decoration: none;">
+                <sl-button variant="primary">
+                  <sl-icon slot="prefix" name="plus-lg"></sl-icon>
+                  Create Skill
+                </sl-button>
+              </a>
+            `
+          : nothing}
       </div>
     `;
   }
 
   private renderGrid() {
     return html`
-      <div class="resource-grid">${this.displaySkills.map((skill) => this.renderSkillCard(skill))}</div>
+      <div class="resource-grid">
+        ${this.displaySkills.map((skill) => this.renderSkillCard(skill))}
+      </div>
     `;
   }
 
@@ -488,17 +523,18 @@ export class ScionPageSkills extends LitElement {
           </div>
         </div>
 
-        ${skill.description ? html`<div class="skill-description">${skill.description}</div>` : nothing}
+        ${skill.description
+          ? html`<div class="skill-description">${skill.description}</div>`
+          : nothing}
+        ${skill.tags?.length
+          ? html`
+              <div class="skill-tags">
+                ${skill.tags.map((tag) => html`<span class="skill-tag">${tag}</span>`)}
+              </div>
+            `
+          : nothing}
 
-        ${skill.tags?.length ? html`
-          <div class="skill-tags">
-            ${skill.tags.map((tag) => html`<span class="skill-tag">${tag}</span>`)}
-          </div>
-        ` : nothing}
-
-        <div class="skill-footer">
-          Updated ${this.formatRelativeTime(skill.updated)}
-        </div>
+        <div class="skill-footer">Updated ${this.formatRelativeTime(skill.updated)}</div>
       </a>
     `;
   }
@@ -512,14 +548,18 @@ export class ScionPageSkills extends LitElement {
               <th
                 class="sortable ${this.sortField === 'name' ? 'sorted' : ''}"
                 @click=${() => this.toggleSort('name')}
-              >Name <span class="sort-indicator">${this.sortIndicator('name')}</span></th>
+              >
+                Name <span class="sort-indicator">${this.sortIndicator('name')}</span>
+              </th>
               <th>Scope</th>
               <th class="hide-mobile">Visibility</th>
               <th class="hide-mobile">Tags</th>
               <th
                 class="sortable ${this.sortField === 'updated' ? 'sorted' : ''}"
                 @click=${() => this.toggleSort('updated')}
-              >Updated <span class="sort-indicator">${this.sortIndicator('updated')}</span></th>
+              >
+                Updated <span class="sort-indicator">${this.sortIndicator('updated')}</span>
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -532,7 +572,13 @@ export class ScionPageSkills extends LitElement {
 
   private renderSkillRow(skill: Skill) {
     return html`
-      <tr class="clickable" @click=${() => { window.history.pushState({}, '', `/skills/${skill.id}`); window.dispatchEvent(new PopStateEvent('popstate')); }}>
+      <tr
+        class="clickable"
+        @click=${() => {
+          window.history.pushState({}, '', `/skills/${skill.id}`);
+          window.dispatchEvent(new PopStateEvent('popstate'));
+        }}
+      >
         <td>
           <span class="name-cell">
             <sl-icon name="lightning-charge"></sl-icon>
@@ -540,7 +586,9 @@ export class ScionPageSkills extends LitElement {
           </span>
         </td>
         <td><span class="scope-badge">${skill.scope}</span></td>
-        <td class="hide-mobile"><span class="visibility-badge ${skill.visibility}">${skill.visibility}</span></td>
+        <td class="hide-mobile">
+          <span class="visibility-badge ${skill.visibility}">${skill.visibility}</span>
+        </td>
         <td class="hide-mobile">
           ${skill.tags?.length
             ? skill.tags.map((tag) => html`<span class="skill-tag">${tag}</span> `)

--- a/web/src/components/pages/template-detail.ts
+++ b/web/src/components/pages/template-detail.ts
@@ -169,7 +169,9 @@ export class ScionPageTemplateDetail extends LitElement {
   override connectedCallback(): void {
     super.connectedCallback();
     if (typeof window !== 'undefined') {
-      const projectMatch = window.location.pathname.match(/\/projects\/([^/]+)\/templates\/([^/]+)/);
+      const projectMatch = window.location.pathname.match(
+        /\/projects\/([^/]+)\/templates\/([^/]+)/
+      );
       if (projectMatch) {
         this.projectId = projectMatch[1];
         this.templateId = projectMatch[2];
@@ -207,7 +209,11 @@ export class ScionPageTemplateDetail extends LitElement {
         throw new Error(await extractApiError(response, `HTTP ${response.status}`));
       }
       this.template = (await response.json()) as Template;
-      dispatchPageTitle(this, this.template.displayName || this.template.name || this.templateId, 'Templates');
+      dispatchPageTitle(
+        this,
+        this.template.displayName || this.template.name || this.templateId,
+        'Templates'
+      );
 
       // Create data sources
       this.fileBrowserDataSource = new TemplateFileBrowserDataSource(this.templateId);
@@ -247,9 +253,9 @@ export class ScionPageTemplateDetail extends LitElement {
   }
 
   private refreshFileBrowser(): void {
-    const browser = this.shadowRoot?.querySelector(
-      'scion-file-browser'
-    ) as import('../shared/file-browser.js').ScionFileBrowser | null;
+    const browser = this.shadowRoot?.querySelector('scion-file-browser') as
+      | import('../shared/file-browser.js').ScionFileBrowser
+      | null;
     browser?.loadFiles();
   }
 
@@ -282,8 +288,7 @@ export class ScionPageTemplateDetail extends LitElement {
         )}
       </div>
 
-      ${this.renderHeader()}
-      ${this.renderFilesSection()}
+      ${this.renderHeader()} ${this.renderFilesSection()}
     `;
   }
 
@@ -292,7 +297,10 @@ export class ScionPageTemplateDetail extends LitElement {
     return html`
       <div class="template-header">
         <div class="template-title">
-          <sl-icon name="file-earmark-code" style="font-size: 1.25rem; color: var(--sl-color-neutral-500);"></sl-icon>
+          <sl-icon
+            name="file-earmark-code"
+            style="font-size: 1.25rem; color: var(--sl-color-neutral-500);"
+          ></sl-icon>
           <h1>${t.displayName || t.name}</h1>
           ${t.harness ? html`<span class="harness-badge">${t.harness}</span>` : ''}
         </div>
@@ -301,7 +309,10 @@ export class ScionPageTemplateDetail extends LitElement {
           <span>Scope: ${t.scope}</span>
           <span>Status: ${t.status}</span>
           ${t.contentHash
-            ? html`<span class="hash-meta">Hash: <scion-hash-display .hash=${t.contentHash} max-width="14ch"></scion-hash-display></span>`
+            ? html`<span class="hash-meta"
+                >Hash:
+                <scion-hash-display .hash=${t.contentHash} max-width="14ch"></scion-hash-display
+              ></span>`
             : ''}
         </div>
       </div>

--- a/web/src/components/pages/terminal.test.ts
+++ b/web/src/components/pages/terminal.test.ts
@@ -98,14 +98,17 @@ function makeFetchMock(calls: Call[], opts: MockOptions = {}) {
 
     // Agent info (returns a minimal agent object)
     if (href.includes('/api/v1/agents/')) {
-      return jsonResponse({
-        id: 'test-agent',
-        name: 'test-agent',
-        phase: 'running',
-        projectId: 'proj-1',
-        activity: '',
-        exposedPorts: [],
-      }, 200);
+      return jsonResponse(
+        {
+          id: 'test-agent',
+          name: 'test-agent',
+          phase: 'running',
+          projectId: 'proj-1',
+          activity: '',
+          exposedPorts: [],
+        },
+        200
+      );
     }
 
     return jsonResponse({}, 200);
@@ -200,7 +203,13 @@ describe('terminal — _handleFileDrop size validation', () => {
 
     const bigFile = new File(['x'], 'big.bin');
     Object.defineProperty(bigFile, 'size', { value: 51 * 1024 * 1024 });
-    const fileList = { length: 1, 0: bigFile, [Symbol.iterator]: function* () { yield bigFile; } } as unknown as FileList;
+    const fileList = {
+      length: 1,
+      0: bigFile,
+      [Symbol.iterator]: function* () {
+        yield bigFile;
+      },
+    } as unknown as FileList;
 
     await (el as any)._handleFileDrop(fileList);
 
@@ -227,7 +236,9 @@ describe('terminal — _handleFileDrop size validation', () => {
       0: file1,
       1: file2,
       2: file3,
-      [Symbol.iterator]: function* () { for (const f of files) yield f; },
+      [Symbol.iterator]: function* () {
+        for (const f of files) yield f;
+      },
     } as unknown as FileList;
 
     await (el as any)._handleFileDrop(fileList);
@@ -249,11 +260,7 @@ describe('terminal — resolveUploadTarget', () => {
   it('prefers scratchpad when available', async () => {
     const calls: Call[] = [];
     const el = await createForUploadTest(calls, {
-      sharedDirs: [
-        { name: 'data' },
-        { name: 'scratchpad' },
-        { name: 'other' },
-      ],
+      sharedDirs: [{ name: 'data' }, { name: 'scratchpad' }, { name: 'other' }],
     });
 
     await (el as any).resolveUploadTarget();
@@ -332,9 +339,13 @@ describe('terminal — _handleFileDrop upload paths', () => {
   function makeFileList(...files: File[]): FileList {
     const fl: any = {
       length: files.length,
-      [Symbol.iterator]: function* () { for (const f of files) yield f; },
+      [Symbol.iterator]: function* () {
+        for (const f of files) yield f;
+      },
     };
-    files.forEach((f, i) => { fl[i] = f; });
+    files.forEach((f, i) => {
+      fl[i] = f;
+    });
     return fl as FileList;
   }
 
@@ -350,9 +361,9 @@ describe('terminal — _handleFileDrop upload paths', () => {
   }
 
   it('shows error and disables upload on 409 response', async () => {
-    const el = setupElement(vi.fn(async () =>
-      jsonResponse({ error: { message: 'upload failed' } }, 409)
-    ));
+    const el = setupElement(
+      vi.fn(async () => jsonResponse({ error: { message: 'upload failed' } }, 409))
+    );
 
     const file = new File(['hello'], 'test.txt');
     await (el as any)._handleFileDrop(makeFileList(file));
@@ -366,9 +377,9 @@ describe('terminal — _handleFileDrop upload paths', () => {
   });
 
   it('shows error on non-ok HTTP response', async () => {
-    const el = setupElement(vi.fn(async () =>
-      jsonResponse({ error: { message: 'server error details' } }, 500)
-    ));
+    const el = setupElement(
+      vi.fn(async () => jsonResponse({ error: { message: 'server error details' } }, 500))
+    );
 
     const file = new File(['hello'], 'test.txt');
     await (el as any)._handleFileDrop(makeFileList(file));
@@ -380,9 +391,11 @@ describe('terminal — _handleFileDrop upload paths', () => {
   });
 
   it('shows error on network failure', async () => {
-    const el = setupElement(vi.fn(async () => {
-      throw new Error('Network failure');
-    }));
+    const el = setupElement(
+      vi.fn(async () => {
+        throw new Error('Network failure');
+      })
+    );
 
     const file = new File(['hello'], 'test.txt');
     await (el as any)._handleFileDrop(makeFileList(file));
@@ -393,12 +406,12 @@ describe('terminal — _handleFileDrop upload paths', () => {
   });
 
   it('calls sendData with shell-quoted paths on success', async () => {
-    const el = setupElement(vi.fn(async () =>
-      jsonResponse({ ok: true }, 200)
-    ));
+    const el = setupElement(vi.fn(async () => jsonResponse({ ok: true }, 200)));
     // Mock sendData to capture what gets sent to the terminal
     const sendDataCalls: string[] = [];
-    el.sendData = (data: string) => { sendDataCalls.push(data); };
+    el.sendData = (data: string) => {
+      sendDataCalls.push(data);
+    };
 
     const file = new File(['hello'], 'test.txt');
     await (el as any)._handleFileDrop(makeFileList(file));
@@ -413,11 +426,11 @@ describe('terminal — _handleFileDrop upload paths', () => {
   });
 
   it('sends multiple shell-quoted paths on multi-file success', async () => {
-    const el = setupElement(vi.fn(async () =>
-      jsonResponse({ ok: true }, 200)
-    ));
+    const el = setupElement(vi.fn(async () => jsonResponse({ ok: true }, 200)));
     const sendDataCalls: string[] = [];
-    el.sendData = (data: string) => { sendDataCalls.push(data); };
+    el.sendData = (data: string) => {
+      sendDataCalls.push(data);
+    };
 
     const file1 = new File(['a'], 'doc.pdf');
     const file2 = new File(['b'], 'has spaces.txt');

--- a/web/src/components/pages/terminal.ts
+++ b/web/src/components/pages/terminal.ts
@@ -24,7 +24,13 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-import type { PageData, Agent, AgentPhase, AgentActivity, ExposedPort } from '../../shared/types.js';
+import type {
+  PageData,
+  Agent,
+  AgentPhase,
+  AgentActivity,
+  ExposedPort,
+} from '../../shared/types.js';
 import { isTerminalAvailable } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { dispatchPageTitle } from '../../client/page-title.js';
@@ -107,11 +113,11 @@ export class ScionPageTerminal extends LitElement {
   // --- Drag-and-drop file upload state ---
   @state() private uploadEnabled = false;
   @state() private uploadDisabledReason = '';
-  @state() private uploadTargetDir = '';     // shared dir name (e.g. "scratchpad")
-  @state() private uploadBasePath = '';      // container path (e.g. "/scion-volumes/scratchpad")
+  @state() private uploadTargetDir = ''; // shared dir name (e.g. "scratchpad")
+  @state() private uploadBasePath = ''; // container path (e.g. "/scion-volumes/scratchpad")
   @state() private isDragOver = false;
   @state() private isUploading = false;
-  @state() private uploadStatus = '';        // progress/error message in overlay
+  @state() private uploadStatus = ''; // progress/error message in overlay
 
   private terminal: Terminal | null = null;
   private fitAddon: FitAddon | null = null;
@@ -258,7 +264,9 @@ export class ScionPageTerminal extends LitElement {
       cursor: pointer;
       line-height: 1;
       padding: 0;
-      transition: color 0.15s, background 0.15s;
+      transition:
+        color 0.15s,
+        background 0.15s;
     }
 
     .toggle-group button:first-child {
@@ -427,7 +435,9 @@ export class ScionPageTerminal extends LitElement {
       font-size: 0.75rem;
       text-decoration: none;
       white-space: nowrap;
-      transition: border-color 0.15s, background 0.15s;
+      transition:
+        border-color 0.15s,
+        background 0.15s;
       animation: port-appear 0.3s ease-out;
       cursor: pointer;
     }
@@ -439,8 +449,14 @@ export class ScionPageTerminal extends LitElement {
     }
 
     @keyframes port-appear {
-      from { opacity: 0; transform: scale(0.9); }
-      to   { opacity: 1; transform: scale(1); }
+      from {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+      to {
+        opacity: 1;
+        transform: scale(1);
+      }
     }
 
     /* Port dropdown for 4+ ports */
@@ -516,8 +532,12 @@ export class ScionPageTerminal extends LitElement {
     // Prevent the browser from navigating to a dropped file (which would
     // destroy the terminal session). Must be on window, not the drop target,
     // to catch near-miss drops outside the wrapper.
-    this._windowDragOver = (e: DragEvent) => { e.preventDefault(); };
-    this._windowDrop = (e: DragEvent) => { e.preventDefault(); };
+    this._windowDragOver = (e: DragEvent) => {
+      e.preventDefault();
+    };
+    this._windowDrop = (e: DragEvent) => {
+      e.preventDefault();
+    };
     window.addEventListener('dragover', this._windowDragOver);
     window.addEventListener('drop', this._windowDrop);
 
@@ -539,7 +559,9 @@ export class ScionPageTerminal extends LitElement {
       });
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       const agent = (await response.json()) as Agent;
@@ -558,9 +580,10 @@ export class ScionPageTerminal extends LitElement {
       }
 
       if (!isTerminalAvailable(agent)) {
-        this.error = agent.activity === 'offline'
-          ? 'Agent is offline. Terminal is not available while the agent is unreachable.'
-          : `Agent phase is ${agent.phase}. Terminal is not available until the agent has started.`;
+        this.error =
+          agent.activity === 'offline'
+            ? 'Agent is offline. Terminal is not available while the agent is unreachable.'
+            : `Agent phase is ${agent.phase}. Terminal is not available until the agent has started.`;
         this.loading = false;
         return;
       }
@@ -714,7 +737,13 @@ export class ScionPageTerminal extends LitElement {
       // Shift+Enter: send ESC CR (\x1b\r) so that inner applications
       // (e.g. claude-code) can distinguish it from plain Enter.
       // This matches what native terminals send for Alt+Enter / Alt+Shift+Enter.
-      if (event.key === 'Enter' && event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey) {
+      if (
+        event.key === 'Enter' &&
+        event.shiftKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.metaKey
+      ) {
         if (event.type === 'keydown') {
           console.debug('[Terminal] Shift+Enter detected, sending ESC CR');
           this.sendData('\x1b\r');
@@ -797,12 +826,15 @@ export class ScionPageTerminal extends LitElement {
     const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
     if (!isMac || !this.terminal) return;
 
-    const selectionService = (this.terminal as Terminal & {
-      _core?: { _selectionService?: { shouldForceSelection?: (event: MouseEvent) => boolean } };
-    })._core?._selectionService;
+    const selectionService = (
+      this.terminal as Terminal & {
+        _core?: { _selectionService?: { shouldForceSelection?: (event: MouseEvent) => boolean } };
+      }
+    )._core?._selectionService;
     if (!selectionService?.shouldForceSelection) return;
 
-    const originalShouldForceSelection = selectionService.shouldForceSelection.bind(selectionService);
+    const originalShouldForceSelection =
+      selectionService.shouldForceSelection.bind(selectionService);
     selectionService.shouldForceSelection = (event: MouseEvent): boolean => {
       return event.shiftKey || originalShouldForceSelection(event);
     };
@@ -834,7 +866,11 @@ export class ScionPageTerminal extends LitElement {
       try {
         const raw = event.data;
         if (typeof raw !== 'string') {
-          console.warn('[Terminal] Received non-string message frame (binary/Blob), type:', typeof raw, raw);
+          console.warn(
+            '[Terminal] Received non-string message frame (binary/Blob), type:',
+            typeof raw,
+            raw
+          );
           return;
         }
         const msg = JSON.parse(raw) as PTYMessage;
@@ -906,7 +942,11 @@ export class ScionPageTerminal extends LitElement {
         return;
       }
       const data = await resp.json();
-      const dirs = (data.sharedDirs ?? []) as Array<{ name: string; read_only?: boolean; in_workspace?: boolean }>;
+      const dirs = (data.sharedDirs ?? []) as Array<{
+        name: string;
+        read_only?: boolean;
+        in_workspace?: boolean;
+      }>;
       // Filter: writable, non-in_workspace
       const candidates = dirs.filter((d) => !d.read_only && !d.in_workspace);
       const target = candidates.find((d) => d.name === 'scratchpad') || candidates[0];
@@ -957,7 +997,7 @@ export class ScionPageTerminal extends LitElement {
 
   private async _handleFileDrop(files: FileList): Promise<void> {
     // Client-side size validation
-    const MAX_FILE = 50 * 1024 * 1024;  // 50MB
+    const MAX_FILE = 50 * 1024 * 1024; // 50MB
     const MAX_TOTAL = 100 * 1024 * 1024; // 100MB
     let total = 0;
     for (const f of files) {
@@ -973,9 +1013,10 @@ export class ScionPageTerminal extends LitElement {
     }
 
     this.isUploading = true;
-    const batchId = (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function')
-      ? crypto.randomUUID()
-      : Math.random().toString(36).substring(2, 15) + Date.now().toString(36);
+    const batchId =
+      typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : Math.random().toString(36).substring(2, 15) + Date.now().toString(36);
     const formData = new FormData();
     const paths: string[] = [];
 
@@ -1180,7 +1221,7 @@ export class ScionPageTerminal extends LitElement {
         return;
       }
 
-      const result = await response.json() as { output: string; exitCode: number };
+      const result = (await response.json()) as { output: string; exitCode: number };
 
       if (result.exitCode === 0) {
         showToast('Credentials captured successfully.', 'success');
@@ -1212,30 +1253,42 @@ export class ScionPageTerminal extends LitElement {
   private renderCaptureAuthConflictDialog() {
     if (!this.captureAuthConflicts) return nothing;
     const secrets = this.captureAuthConflicts;
-    const label = secrets.length === 1
-      ? `Secret "${secrets[0]}" already exists`
-      : `${secrets.length} secrets already exist`;
+    const label =
+      secrets.length === 1
+        ? `Secret "${secrets[0]}" already exists`
+        : `${secrets.length} secrets already exist`;
     return html`
       <sl-dialog
         label=${label}
         open
-        @sl-request-close=${() => { if (!this.captureAuthLoading) this.captureAuthConflicts = null; }}
+        @sl-request-close=${() => {
+          if (!this.captureAuthLoading) this.captureAuthConflicts = null;
+        }}
       >
-        <p>The following secret${secrets.length > 1 ? 's' : ''} already exist${secrets.length === 1 ? 's' : ''}:</p>
-        <ul>${secrets.map(s => html`<li><code>${s}</code></li>`)}</ul>
+        <p>
+          The following secret${secrets.length > 1 ? 's' : ''} already
+          exist${secrets.length === 1 ? 's' : ''}:
+        </p>
+        <ul>
+          ${secrets.map((s) => html`<li><code>${s}</code></li>`)}
+        </ul>
         <p>Do you want to force-update ${secrets.length > 1 ? 'them' : 'it'}?</p>
         <sl-button
           slot="footer"
           variant="default"
           ?disabled=${this.captureAuthLoading}
-          @click=${() => { this.captureAuthConflicts = null; }}
-        >Cancel</sl-button>
+          @click=${() => {
+            this.captureAuthConflicts = null;
+          }}
+          >Cancel</sl-button
+        >
         <sl-button
           slot="footer"
           variant="warning"
           ?loading=${this.captureAuthLoading}
           @click=${() => void this.handleCaptureAuth(true)}
-        >Force Update</sl-button>
+          >Force Update</sl-button
+        >
       </sl-dialog>
     `;
   }
@@ -1263,22 +1316,51 @@ export class ScionPageTerminal extends LitElement {
 
   /** Robot icon (agent) */
   private renderRobotIcon() {
-    return html`<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><line x1="12" y1="7" x2="12" y2="11"/><line x1="8" y1="16" x2="8" y2="16" stroke-width="3" stroke-linecap="round"/><line x1="16" y1="16" x2="16" y2="16" stroke-width="3" stroke-linecap="round"/></svg>`;
+    return html`<svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <rect x="3" y="11" width="18" height="10" rx="2" />
+      <circle cx="12" cy="5" r="2" />
+      <line x1="12" y1="7" x2="12" y2="11" />
+      <line x1="8" y1="16" x2="8" y2="16" stroke-width="3" stroke-linecap="round" />
+      <line x1="16" y1="16" x2="16" y2="16" stroke-width="3" stroke-linecap="round" />
+    </svg>`;
   }
 
   /** Terminal/shell icon */
   private renderTerminalIcon() {
-    return html`<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>`;
+    return html`<svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <polyline points="4 17 10 11 4 5" />
+      <line x1="12" y1="19" x2="20" y2="19" />
+    </svg>`;
   }
 
   override render() {
     if (this.loading) {
       return html`
         <div class="toolbar">
-          ${this.projectId ? html`<a href="/projects/${this.projectId}" class="back-link">&larr; Back to Project</a>` : ''}
-          <a href="/agents/${this.agentId}" class="back-link">
-            &larr; Back to Agent
-          </a>
+          ${this.projectId
+            ? html`<a href="/projects/${this.projectId}" class="back-link"
+                >&larr; Back to Project</a
+              >`
+            : ''}
+          <a href="/agents/${this.agentId}" class="back-link"> &larr; Back to Agent </a>
         </div>
         <div class="loading-state">
           <div class="spinner"></div>
@@ -1290,10 +1372,12 @@ export class ScionPageTerminal extends LitElement {
     if (this.error && !this.terminal) {
       return html`
         <div class="toolbar">
-          ${this.projectId ? html`<a href="/projects/${this.projectId}" class="back-link">&larr; Back to Project</a>` : ''}
-          <a href="/agents/${this.agentId}" class="back-link">
-            &larr; Back to Agent
-          </a>
+          ${this.projectId
+            ? html`<a href="/projects/${this.projectId}" class="back-link"
+                >&larr; Back to Project</a
+              >`
+            : ''}
+          <a href="/agents/${this.agentId}" class="back-link"> &larr; Back to Agent </a>
           ${this.agentName
             ? html`
                 <div class="separator"></div>
@@ -1311,10 +1395,10 @@ export class ScionPageTerminal extends LitElement {
 
     return html`
       <div class="toolbar">
-        ${this.projectId ? html`<a href="/projects/${this.projectId}" class="back-link">&larr; Back to Project</a>` : ''}
-        <a href="/agents/${this.agentId}" class="back-link">
-          &larr; Back to Agent
-        </a>
+        ${this.projectId
+          ? html`<a href="/projects/${this.projectId}" class="back-link">&larr; Back to Project</a>`
+          : ''}
+        <a href="/agents/${this.agentId}" class="back-link"> &larr; Back to Agent </a>
         <div class="separator"></div>
         <span class="agent-name">${this.agentName || this.agentId}</span>
         <div class="toggle-group" title="Switch between agent and shell tmux windows">
@@ -1323,13 +1407,17 @@ export class ScionPageTerminal extends LitElement {
             title="Agent window"
             @click=${() => this.switchToAgent()}
             ?disabled=${!this.connected}
-          >${this.renderRobotIcon()}</button>
+          >
+            ${this.renderRobotIcon()}
+          </button>
           <button
             class=${this.activeWindow === 'shell' ? 'active' : ''}
             title="Shell window"
             @click=${() => this.switchToShell()}
             ?disabled=${!this.connected}
-          >${this.renderTerminalIcon()}</button>
+          >
+            ${this.renderTerminalIcon()}
+          </button>
         </div>
         <div class="spacer"></div>
         ${this.renderPortButtons()}
@@ -1383,15 +1471,20 @@ export class ScionPageTerminal extends LitElement {
               <span class="overlay-text">DISCONNECTED</span>
             </div>`
           : ''}
-        <div class="drop-overlay ${this.isDragOver || this.uploadStatus ? 'visible' : ''} ${!this.uploadEnabled ? 'disabled' : ''}">
+        <div
+          class="drop-overlay ${this.isDragOver || this.uploadStatus ? 'visible' : ''} ${!this
+            .uploadEnabled
+            ? 'disabled'
+            : ''}"
+        >
           ${this.isUploading
             ? html`<sl-spinner></sl-spinner><span>${this.uploadStatus}</span>`
             : this.uploadStatus
               ? html`<sl-icon name="x-circle"></sl-icon><span>${this.uploadStatus}</span>`
               : this.uploadEnabled
                 ? html`<sl-icon name="cloud-upload"></sl-icon><span>Drop files to upload</span>`
-                : html`<sl-icon name="x-circle"></sl-icon><span>${this.uploadDisabledReason}</span>`
-          }
+                : html`<sl-icon name="x-circle"></sl-icon
+                    ><span>${this.uploadDisabledReason}</span>`}
         </div>
       </div>
       ${this.renderCaptureAuthConflictDialog()}

--- a/web/src/components/profile/profile-shell.ts
+++ b/web/src/components/profile/profile-shell.ts
@@ -167,7 +167,11 @@ export class ScionProfileShell extends LitElement {
         placement="start"
         @sl-hide=${(): void => this.handleDrawerClose()}
       >
-        <scion-profile-nav .user=${this.user} .currentPath=${this.currentPath} .hideCollapse=${true}></scion-profile-nav>
+        <scion-profile-nav
+          .user=${this.user}
+          .currentPath=${this.currentPath}
+          .hideCollapse=${true}
+        ></scion-profile-nav>
       </sl-drawer>
 
       <main class="main">

--- a/web/src/components/shared/agent-log-viewer.ts
+++ b/web/src/components/shared/agent-log-viewer.ts
@@ -143,11 +143,27 @@ export class ScionAgentLogViewer extends LitElement {
       letter-spacing: 0.03em;
       line-height: 1.4;
     }
-    .sev-DEBUG { background: var(--scion-neutral-100, #f1f5f9); color: var(--scion-neutral-500, #64748b); }
-    .sev-INFO { background: var(--scion-primary-50, #eff6ff); color: var(--scion-primary-700, #1d4ed8); }
-    .sev-WARNING { background: var(--scion-warning-50, #fffbeb); color: var(--scion-warning-700, #b45309); }
-    .sev-ERROR { background: var(--scion-danger-50, #fef2f2); color: var(--scion-danger-700, #b91c1c); }
-    .sev-CRITICAL { background: var(--scion-danger-100, #fee2e2); color: var(--scion-danger-800, #991b1b); font-weight: 700; }
+    .sev-DEBUG {
+      background: var(--scion-neutral-100, #f1f5f9);
+      color: var(--scion-neutral-500, #64748b);
+    }
+    .sev-INFO {
+      background: var(--scion-primary-50, #eff6ff);
+      color: var(--scion-primary-700, #1d4ed8);
+    }
+    .sev-WARNING {
+      background: var(--scion-warning-50, #fffbeb);
+      color: var(--scion-warning-700, #b45309);
+    }
+    .sev-ERROR {
+      background: var(--scion-danger-50, #fef2f2);
+      color: var(--scion-danger-700, #b91c1c);
+    }
+    .sev-CRITICAL {
+      background: var(--scion-danger-100, #fee2e2);
+      color: var(--scion-danger-800, #991b1b);
+      font-weight: 700;
+    }
 
     /* Timestamp */
     .ts {
@@ -220,8 +236,13 @@ export class ScionAgentLogViewer extends LitElement {
       animation: pulse 1.5s ease-in-out infinite;
     }
     @keyframes pulse {
-      0%, 100% { opacity: 1; }
-      50% { opacity: 0.3; }
+      0%,
+      100% {
+        opacity: 1;
+      }
+      50% {
+        opacity: 0.3;
+      }
     }
   `;
 
@@ -266,9 +287,14 @@ export class ScionAgentLogViewer extends LitElement {
 
       const res = await apiFetch(url);
       if (!res.ok) {
-        const errData = await res.json().catch(() => ({})) as { error?: { message?: string }; message?: string };
+        const errData = (await res.json().catch(() => ({}))) as {
+          error?: { message?: string };
+          message?: string;
+        };
         throw new Error(
-          (errData.error as { message?: string })?.message || errData.message || `HTTP ${res.status}`
+          (errData.error as { message?: string })?.message ||
+            errData.message ||
+            `HTTP ${res.status}`
         );
       }
 
@@ -289,15 +315,20 @@ export class ScionAgentLogViewer extends LitElement {
     try {
       const res = await apiFetch(`/api/v1/agents/${this.agentId}/logs?tail=500`);
       if (!res.ok) {
-        const errData = await res.json().catch(() => ({})) as { error?: { message?: string }; message?: string };
+        const errData = (await res.json().catch(() => ({}))) as {
+          error?: { message?: string };
+          message?: string;
+        };
         throw new Error(
-          (errData.error as { message?: string })?.message || errData.message || `HTTP ${res.status}`
+          (errData.error as { message?: string })?.message ||
+            errData.message ||
+            `HTTP ${res.status}`
         );
       }
 
       const contentType = res.headers.get('Content-Type') || '';
       if (contentType.includes('application/json')) {
-        const data = await res.json() as { logs?: string };
+        const data = (await res.json()) as { logs?: string };
         this.brokerLogs = data.logs || '';
       } else {
         this.brokerLogs = await res.text();
@@ -437,15 +468,9 @@ export class ScionAgentLogViewer extends LitElement {
 
   override render() {
     if (!this.cloudLogging) {
-      return html`
-        ${this.renderBrokerToolbar()}
-        ${this.renderBrokerContent()}
-      `;
+      return html` ${this.renderBrokerToolbar()} ${this.renderBrokerContent()} `;
     }
-    return html`
-      ${this.renderToolbar()}
-      ${this.renderContent()}
-    `;
+    return html` ${this.renderToolbar()} ${this.renderContent()} `;
   }
 
   private renderBrokerToolbar() {
@@ -512,8 +537,7 @@ export class ScionAgentLogViewer extends LitElement {
                 style="min-width: 10rem"
               >
                 ${brokerEntries.map(
-                  ([id, name]) =>
-                    html`<sl-option value=${id}>${name || id}</sl-option>`
+                  ([id, name]) => html`<sl-option value=${id}>${name || id}</sl-option>`
                 )}
               </sl-select>
             `
@@ -526,10 +550,7 @@ export class ScionAgentLogViewer extends LitElement {
           @sl-change=${this.handleSeverityFilter}
           style="min-width: 9rem"
         >
-          ${SEVERITY_LEVELS.map(
-            (level) =>
-              html`<sl-option value=${level}>${level} +</sl-option>`
-          )}
+          ${SEVERITY_LEVELS.map((level) => html`<sl-option value=${level}>${level} +</sl-option>`)}
         </sl-select>
         ${this.streaming
           ? html`<span class="stream-indicator"><span class="stream-dot"></span>Streaming</span>`
@@ -583,7 +604,11 @@ export class ScionAgentLogViewer extends LitElement {
       `;
     }
 
-    return html`<table class="log-table"><tbody>${this.renderEntries()}</tbody></table>`;
+    return html`<table class="log-table">
+      <tbody>
+        ${this.renderEntries()}
+      </tbody>
+    </table>`;
   }
 
   private renderEntries() {
@@ -592,20 +617,31 @@ export class ScionAgentLogViewer extends LitElement {
 
     for (const entry of this.entries) {
       const d = new Date(entry.timestamp);
-      const dateStr = d.toLocaleDateString('en', { year: 'numeric', month: 'short', day: 'numeric' });
+      const dateStr = d.toLocaleDateString('en', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
 
       if (dateStr !== lastDate) {
         lastDate = dateStr;
         rows.push(html`
-          <tr><td colspan="4" class="date-divider">${dateStr}</td></tr>
+          <tr>
+            <td colspan="4" class="date-divider">${dateStr}</td>
+          </tr>
         `);
       }
 
       const isExpanded = this.expandedIds.has(entry.insertId);
-      const timeStr = d.toLocaleTimeString('en', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit', fractionalSecondDigits: 3 } as Intl.DateTimeFormatOptions);
-      const subsystem = entry.jsonPayload?.['subsystem'] as string
-        || entry.labels?.['component']
-        || '';
+      const timeStr = d.toLocaleTimeString('en', {
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        fractionalSecondDigits: 3,
+      } as Intl.DateTimeFormatOptions);
+      const subsystem =
+        (entry.jsonPayload?.['subsystem'] as string) || entry.labels?.['component'] || '';
 
       rows.push(html`
         <tr class="log-row" @click=${() => this.toggleExpand(entry.insertId)}>
@@ -620,7 +656,10 @@ export class ScionAgentLogViewer extends LitElement {
         rows.push(html`
           <tr class="detail-row">
             <td colspan="4">
-              <scion-json-browser .data=${this.buildDetailObject(entry)} expand-first></scion-json-browser>
+              <scion-json-browser
+                .data=${this.buildDetailObject(entry)}
+                expand-first
+              ></scion-json-browser>
             </td>
           </tr>
         `);

--- a/web/src/components/shared/agent-message-viewer.ts
+++ b/web/src/components/shared/agent-message-viewer.ts
@@ -215,8 +215,13 @@ export class ScionAgentMessageViewer extends LitElement {
       animation: pulse 1.5s ease-in-out infinite;
     }
     @keyframes pulse {
-      0%, 100% { opacity: 1; }
-      50% { opacity: 0.3; }
+      0%,
+      100% {
+        opacity: 1;
+      }
+      50% {
+        opacity: 0.3;
+      }
     }
 
     /* Message list */
@@ -433,9 +438,14 @@ export class ScionAgentMessageViewer extends LitElement {
       }
       const res = await apiFetch(`${baseUrl}?${params.toString()}`);
       if (!res.ok) {
-        const errData = await res.json().catch(() => ({})) as { error?: { message?: string }; message?: string };
+        const errData = (await res.json().catch(() => ({}))) as {
+          error?: { message?: string };
+          message?: string;
+        };
         throw new Error(
-          (errData.error as { message?: string })?.message || errData.message || `HTTP ${res.status}`
+          (errData.error as { message?: string })?.message ||
+            errData.message ||
+            `HTTP ${res.status}`
         );
       }
       const logData = (await res.json()) as MessageLogsResponse;
@@ -451,9 +461,8 @@ export class ScionAgentMessageViewer extends LitElement {
   private parseHubMessage(msg: Message): ParsedMessage {
     // Hub store: senderId === agentId means the agent sent the message (outbound).
     // Otherwise the agent is the recipient (inbound from human).
-    const direction: 'sent' | 'received' = !this.agentId || msg.senderId === this.agentId
-      ? 'sent'
-      : 'received';
+    const direction: 'sent' | 'received' =
+      !this.agentId || msg.senderId === this.agentId ? 'sent' : 'received';
 
     return {
       sender: msg.sender,
@@ -497,8 +506,8 @@ export class ScionAgentMessageViewer extends LitElement {
     const sender = labels['sender'] || (payload['sender'] as string) || '';
     const recipient = labels['recipient'] || (payload['recipient'] as string) || '';
     const msgType = labels['msg_type'] || (payload['msg_type'] as string) || '';
-    const urgent = (payload['urgent'] === true) || (labels['urgent'] === 'true');
-    const broadcasted = (payload['broadcasted'] === true) || (labels['broadcasted'] === 'true');
+    const urgent = payload['urgent'] === true || labels['urgent'] === 'true';
+    const broadcasted = payload['broadcasted'] === true || labels['broadcasted'] === 'true';
 
     // Determine direction relative to this agent using unique IDs.
     // Check sender_id and recipient_id labels first (UUID-based, unambiguous).
@@ -526,8 +535,7 @@ export class ScionAgentMessageViewer extends LitElement {
     // payload['message'] and entry.message are the Cloud Logging message
     // (e.g. "message dispatched"), NOT the scion message content.
     // The actual message body is in payload['message_content'].
-    const body = (payload['message_content'] as string)
-      || '';
+    const body = (payload['message_content'] as string) || '';
 
     return {
       sender,
@@ -712,8 +720,7 @@ export class ScionAgentMessageViewer extends LitElement {
 
   override render() {
     return html`
-      ${this.canSend ? this.renderCompose() : nothing}
-      ${this.renderToolbar()}
+      ${this.canSend ? this.renderCompose() : nothing} ${this.renderToolbar()}
       ${this.renderContent()}
     `;
   }
@@ -727,19 +734,23 @@ export class ScionAgentMessageViewer extends LitElement {
 
     return html`
       <div class="compose-box">
-        ${isBroadcast ? html`
-          <div class="compose-label">
-            <sl-icon name="broadcast-pin" style="font-size: 0.875rem;"></sl-icon>
-            Broadcast to all running agents in this project
-          </div>
-        ` : nothing}
+        ${isBroadcast
+          ? html`
+              <div class="compose-label">
+                <sl-icon name="broadcast-pin" style="font-size: 0.875rem;"></sl-icon>
+                Broadcast to all running agents in this project
+              </div>
+            `
+          : nothing}
         <div class="compose-row">
           <div class="compose-input">
             <sl-input
               placeholder=${placeholder}
               size="small"
               .value=${this.composeText}
-              @sl-input=${(e: Event) => { this.composeText = (e.target as HTMLInputElement).value; }}
+              @sl-input=${(e: Event) => {
+                this.composeText = (e.target as HTMLInputElement).value;
+              }}
               @keydown=${this.handleComposeKeydown}
               ?disabled=${this.sending}
             ></sl-input>
@@ -750,7 +761,9 @@ export class ScionAgentMessageViewer extends LitElement {
               <sl-checkbox
                 size="small"
                 ?checked=${this.composePlain}
-                @sl-change=${(e: Event) => { this.composePlain = (e.target as HTMLInputElement).checked; }}
+                @sl-change=${(e: Event) => {
+                  this.composePlain = (e.target as HTMLInputElement).checked;
+                }}
               ></sl-checkbox>
               Plain
             </label>
@@ -758,7 +771,9 @@ export class ScionAgentMessageViewer extends LitElement {
               <sl-checkbox
                 size="small"
                 ?checked=${this.composeInterrupt}
-                @sl-change=${(e: Event) => { this.composeInterrupt = (e.target as HTMLInputElement).checked; }}
+                @sl-change=${(e: Event) => {
+                  this.composeInterrupt = (e.target as HTMLInputElement).checked;
+                }}
               ></sl-checkbox>
               Interrupt
             </label>
@@ -846,7 +861,11 @@ export class ScionAgentMessageViewer extends LitElement {
 
     for (const msg of this.messages) {
       const d = new Date(msg.timestamp);
-      const dateStr = d.toLocaleDateString('en', { year: 'numeric', month: 'short', day: 'numeric' });
+      const dateStr = d.toLocaleDateString('en', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
 
       if (dateStr !== lastDate) {
         lastDate = dateStr;
@@ -854,7 +873,10 @@ export class ScionAgentMessageViewer extends LitElement {
       }
 
       const timeStr = d.toLocaleTimeString('en', {
-        hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit',
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
       });
       const isExpanded = this.expandedIds.has(msg.insertId);
 
@@ -875,9 +897,13 @@ export class ScionAgentMessageViewer extends LitElement {
               <sl-icon name="arrow-right" class="msg-arrow" style="font-size:0.6875rem"></sl-icon>
               <span class="msg-target">${toLabel}</span>
               <div class="msg-badges">
-                ${msg.msgType ? html`<span class="msg-badge badge-type">${msg.msgType}</span>` : nothing}
+                ${msg.msgType
+                  ? html`<span class="msg-badge badge-type">${msg.msgType}</span>`
+                  : nothing}
                 ${msg.urgent ? html`<span class="msg-badge badge-urgent">urgent</span>` : nothing}
-                ${msg.broadcasted ? html`<span class="msg-badge badge-broadcast">broadcast</span>` : nothing}
+                ${msg.broadcasted
+                  ? html`<span class="msg-badge badge-broadcast">broadcast</span>`
+                  : nothing}
               </div>
               <span class="msg-time">${timeStr}</span>
             </div>

--- a/web/src/components/shared/agent-tree-view.test.ts
+++ b/web/src/components/shared/agent-tree-view.test.ts
@@ -48,7 +48,9 @@ function agent(id: string, name: string, ancestry?: string[]): Agent {
 }
 
 function pressKey(key: string, init: KeyboardEventInit = {}, target: EventTarget = window): void {
-  target.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, composed: true, ...init }));
+  target.dispatchEvent(
+    new KeyboardEvent('keydown', { key, bubbles: true, composed: true, ...init })
+  );
 }
 
 describe('scion-agent-tree-view keyboard shortcuts', () => {
@@ -68,7 +70,7 @@ describe('scion-agent-tree-view keyboard shortcuts', () => {
 
   it('toggles orientation on "t" and dispatches orientation-change', () => {
     let eventOrientation: string | null = null;
-    el.addEventListener('orientation-change', e => {
+    el.addEventListener('orientation-change', (e) => {
       eventOrientation = (e as CustomEvent<{ orientation: string }>).detail.orientation;
     });
 

--- a/web/src/components/shared/agent-tree-view.ts
+++ b/web/src/components/shared/agent-tree-view.ts
@@ -223,7 +223,9 @@ export class ScionAgentTreeView extends LitElement {
       stroke: var(--sl-color-neutral-400);
       stroke-width: 1.6;
       fill: none;
-      transition: opacity 0.2s ease, stroke 0.2s ease;
+      transition:
+        opacity 0.2s ease,
+        stroke 0.2s ease;
       marker-end: url(#arrow-neutral);
     }
 
@@ -490,7 +492,10 @@ export class ScionAgentTreeView extends LitElement {
     super.willUpdate(changedProperties);
     // Flipping the flow direction swaps the canvas aspect ratio; re-fit so
     // the whole forest stays visible.
-    if (changedProperties.has('orientation') && changedProperties.get('orientation') !== undefined) {
+    if (
+      changedProperties.has('orientation') &&
+      changedProperties.get('orientation') !== undefined
+    ) {
       this.didAutoFit = false;
     }
     if (changedProperties.has('agents')) {
@@ -569,7 +574,8 @@ export class ScionAgentTreeView extends LitElement {
     for (const el of e.composedPath()) {
       if (el === this.canvasEl) break;
       const tag = (el as HTMLElement).tagName;
-      if (tag === 'A' || tag === 'BUTTON' || tag === 'SL-BUTTON' || tag === 'SL-ICON-BUTTON') return;
+      if (tag === 'A' || tag === 'BUTTON' || tag === 'SL-BUTTON' || tag === 'SL-ICON-BUTTON')
+        return;
     }
     e.preventDefault();
     this.dragging = true;
@@ -689,7 +695,7 @@ export class ScionAgentTreeView extends LitElement {
       return related;
     }
 
-    const byId = new Map(agents.map(a => [a.id, a]));
+    const byId = new Map(agents.map((a) => [a.id, a]));
     const hovered = byId.get(this.hoverId);
     if (!hovered) return null;
 
@@ -734,11 +740,9 @@ export class ScionAgentTreeView extends LitElement {
   private renderToolbar() {
     return html`
       <div class="toolbar">
-        <sl-switch
-          size="small"
-          ?checked=${this.showUsers}
-          @sl-change=${this.onShowUsersChange}
-        >Show users</sl-switch>
+        <sl-switch size="small" ?checked=${this.showUsers} @sl-change=${this.onShowUsersChange}
+          >Show users</sl-switch
+        >
         <div class="orientation-toggle" role="group" aria-label="Graph orientation">
           <button
             class=${this.orientation === 'vertical' ? 'active' : ''}
@@ -790,7 +794,7 @@ export class ScionAgentTreeView extends LitElement {
     // the fit retries on the next render rather than getting permanently
     // skipped.
     if (!this.didAutoFit) {
-      const focus = this.focusId ? nodes.find(n => n.agent.id === this.focusId) : undefined;
+      const focus = this.focusId ? nodes.find((n) => n.agent.id === this.focusId) : undefined;
       const capturedW = width;
       const capturedH = height;
       requestAnimationFrame(() => {
@@ -822,18 +826,29 @@ export class ScionAgentTreeView extends LitElement {
         @pointercancel=${this.onPointerUp}
         @pointerleave=${() => (this.hoverId = null)}
       >
-        <div class="stage" style="transform: translate(${this.panX}px, ${this.panY}px) scale(${this.scale})">
+        <div
+          class="stage"
+          style="transform: translate(${this.panX}px, ${this.panY}px) scale(${this.scale})"
+        >
           <svg width=${width} height=${height} aria-hidden="true">
-            ${this.renderEdgeMarkers()}
-            ${edges.map(e => this.renderEdge(e, related))}
+            ${this.renderEdgeMarkers()} ${edges.map((e) => this.renderEdge(e, related))}
           </svg>
-          ${users.map(u => this.renderUserNode(u, agents, edges, related))}
-          ${nodes.map(n => this.renderNode(n, related, hiddenCounts))}
+          ${users.map((u) => this.renderUserNode(u, agents, edges, related))}
+          ${nodes.map((n) => this.renderNode(n, related, hiddenCounts))}
         </div>
         <div class="zoom-controls">
-          <sl-button size="small" @click=${() => this.zoomButtons(1.25)} title="Zoom in (+)">+</sl-button>
-          <sl-button size="small" @click=${() => this.zoomButtons(1 / 1.25)} title="Zoom out (−)">−</sl-button>
-          <sl-button size="small" @click=${() => this.fitToView(width, height)} title="Fit to view (F)">Fit</sl-button>
+          <sl-button size="small" @click=${() => this.zoomButtons(1.25)} title="Zoom in (+)"
+            >+</sl-button
+          >
+          <sl-button size="small" @click=${() => this.zoomButtons(1 / 1.25)} title="Zoom out (−)"
+            >−</sl-button
+          >
+          <sl-button
+            size="small"
+            @click=${() => this.fitToView(width, height)}
+            title="Fit to view (F)"
+            >Fit</sl-button
+          >
         </div>
       </div>
 
@@ -841,7 +856,9 @@ export class ScionAgentTreeView extends LitElement {
         agentId=${this.quickMessageAgentId}
         agentName=${this.quickMessageAgentName}
         ?open=${this.quickMessageOpen}
-        @sl-request-close=${() => { this.quickMessageOpen = false; }}
+        @sl-request-close=${() => {
+          this.quickMessageOpen = false;
+        }}
       ></scion-quick-message-dialog>
     `;
   }
@@ -909,13 +926,17 @@ export class ScionAgentTreeView extends LitElement {
     this.collapsedIds = next;
   }
 
-  private renderNode(n: PositionedNode, related: Set<string> | null, hiddenCounts: Map<string, number>) {
+  private renderNode(
+    n: PositionedNode,
+    related: Set<string> | null,
+    hiddenCounts: Map<string, number>
+  ) {
     const agent = n.agent;
     const status = getAgentDisplayStatus(agent);
     const color = VARIANT_COLOR[getStateDisplay(status).variant];
     const creator = agent.appliedConfig?.creatorName || agent.createdBy || '';
     const parentId = parentIdOf(agent);
-    const isRoot = !parentId || !this.agents.some(a => a.id === parentId);
+    const isRoot = !parentId || !this.agents.some((a) => a.id === parentId);
     const dim = related !== null && !related.has(agent.id);
     const descendants = hiddenCounts.get(agent.id) ?? 0;
     const collapsed = this.collapsedIds.has(agent.id);
@@ -945,36 +966,46 @@ export class ScionAgentTreeView extends LitElement {
           ></scion-status-badge>
           ${agent.template ? html`<span class="meta">${agent.template}</span>` : nothing}
         </a>
-        ${can(agent._capabilities, 'message') ? html`
-          <sl-icon-button
-            class="message-btn"
-            name="chat-dots"
-            label="Message"
-            @click=${(e: Event) => {
-              e.preventDefault();
-              e.stopPropagation();
-              this.quickMessageAgentId = agent.id;
-              this.quickMessageAgentName = agent.name;
-              this.quickMessageOpen = true;
-            }}
-          ></sl-icon-button>
-        ` : nothing}
-        ${can(agent._capabilities, 'attach') ? html`
-          <sl-icon-button
-            class="terminal-btn"
-            name="terminal"
-            label="Terminal"
-            href=${isTerminalAvailable(agent) ? `/agents/${agent.id}/terminal` : nothing}
-            ?disabled=${!isTerminalAvailable(agent)}
-          ></sl-icon-button>
-        ` : nothing}
-        ${descendants > 0 ? html`
-          <button
-            class="collapse-chip ${this.orientation === 'horizontal' ? 'horizontal' : ''}"
-            title=${collapsed ? `Expand ${descendants} hidden agent${descendants === 1 ? '' : 's'}` : 'Collapse subtree'}
-            @click=${(e: Event) => this.toggleCollapse(agent.id, e)}
-          >${collapsed ? `+${descendants}` : '−'}</button>
-        ` : nothing}
+        ${can(agent._capabilities, 'message')
+          ? html`
+              <sl-icon-button
+                class="message-btn"
+                name="chat-dots"
+                label="Message"
+                @click=${(e: Event) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  this.quickMessageAgentId = agent.id;
+                  this.quickMessageAgentName = agent.name;
+                  this.quickMessageOpen = true;
+                }}
+              ></sl-icon-button>
+            `
+          : nothing}
+        ${can(agent._capabilities, 'attach')
+          ? html`
+              <sl-icon-button
+                class="terminal-btn"
+                name="terminal"
+                label="Terminal"
+                href=${isTerminalAvailable(agent) ? `/agents/${agent.id}/terminal` : nothing}
+                ?disabled=${!isTerminalAvailable(agent)}
+              ></sl-icon-button>
+            `
+          : nothing}
+        ${descendants > 0
+          ? html`
+              <button
+                class="collapse-chip ${this.orientation === 'horizontal' ? 'horizontal' : ''}"
+                title=${collapsed
+                  ? `Expand ${descendants} hidden agent${descendants === 1 ? '' : 's'}`
+                  : 'Collapse subtree'}
+                @click=${(e: Event) => this.toggleCollapse(agent.id, e)}
+              >
+                ${collapsed ? `+${descendants}` : '−'}
+              </button>
+            `
+          : nothing}
       </div>
     `;
   }
@@ -993,7 +1024,7 @@ export class ScionAgentTreeView extends LitElement {
       if (label) break;
     }
     if (!label) label = u.id.slice(0, 8);
-    const started = edges.filter(e => e.parentId === key).length;
+    const started = edges.filter((e) => e.parentId === key).length;
     const dim = related !== null && !related.has(key);
     return html`
       <div

--- a/web/src/components/shared/chat/chat-avatar.ts
+++ b/web/src/components/shared/chat/chat-avatar.ts
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared avatar component for chat: renders initials with a hash-seeded
+ * colour, optional image URL, and optional presence indicator.
+ *
+ * Replaces the duplicated hashColor / getInitials helpers in
+ * chat-message.ts, chat-space-rail.ts, and chat.ts.
+ *
+ * Usage:
+ *   <scion-chat-avatar
+ *     name="Scout"
+ *     size="32"
+ *     presenceState="active">
+ *   </scion-chat-avatar>
+ *
+ *   <scion-chat-avatar
+ *     name="Alice"
+ *     avatarUrl="https://..."
+ *     size="36"
+ *     presenceState="idle">
+ *   </scion-chat-avatar>
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+/** Hash a string to a consistent HSL colour. */
+export function hashColor(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const hue = ((hash % 360) + 360) % 360;
+  return `hsl(${hue}, 55%, 48%)`;
+}
+
+/** Extract initials from a display name. */
+export function getInitials(name: string): string {
+  const parts = name.split(/[-_\s]+/).filter(Boolean);
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[1][0]).toUpperCase();
+  }
+  return (name.slice(0, 2) || '?').toUpperCase();
+}
+
+@customElement('scion-chat-avatar')
+export class ScionChatAvatar extends LitElement {
+  /** Display name used for initials and colour hashing. */
+  @property()
+  name = '';
+
+  /** Optional image URL; when set, renders an <img> instead of initials. */
+  @property({ attribute: 'avatar-url' })
+  avatarUrl = '';
+
+  /** Size in pixels (width and height). Default 32. */
+  @property({ type: Number })
+  size = 32;
+
+  /** Optional presence state: "active" shows a green dot, "idle" shows
+   *  a moon/sleep overlay. Omit for no indicator. */
+  @property({ attribute: 'presence-state' })
+  presenceState: 'active' | 'idle' | '' = '';
+
+  static override styles = css`
+    :host {
+      display: inline-block;
+      position: relative;
+      flex-shrink: 0;
+    }
+
+    .avatar {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50%;
+      color: #fff;
+      font-weight: 600;
+      user-select: none;
+      overflow: hidden;
+    }
+
+    .avatar img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      border-radius: 50%;
+    }
+
+    /* Presence indicator dot */
+    .presence-dot {
+      position: absolute;
+      bottom: 0;
+      right: 0;
+      border-radius: 50%;
+      border: 2px solid var(--scion-surface, #fff);
+      box-sizing: border-box;
+    }
+
+    .presence-dot.active {
+      background: #22c55e;
+    }
+
+    .presence-dot.idle {
+      background: #f59e0b;
+    }
+  `;
+
+  override render() {
+    const s = this.size;
+    const fontSize = Math.max(10, Math.round(s * 0.4));
+    const dotSize = Math.max(8, Math.round(s * 0.3));
+
+    const hasImage = this.avatarUrl && this.avatarUrl.length > 0;
+    const bg = hasImage ? 'transparent' : hashColor(this.name);
+    const initials = getInitials(this.name);
+
+    return html`
+      <div
+        class="avatar"
+        style="width:${s}px;height:${s}px;font-size:${fontSize}px;background:${bg}"
+      >
+        ${hasImage ? html`<img src="${this.avatarUrl}" alt="${this.name}" />` : initials}
+      </div>
+      ${this.presenceState
+        ? html`<span
+            class="presence-dot ${this.presenceState}"
+            style="width:${dotSize}px;height:${dotSize}px"
+          ></span>`
+        : nothing}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-chat-avatar': ScionChatAvatar;
+  }
+}

--- a/web/src/components/shared/chat/chat-composer.ts
+++ b/web/src/components/shared/chat/chat-composer.ts
@@ -347,6 +347,11 @@ export class ScionChatComposer extends LitElement {
     this.text = target.value;
     this.runeCount = countRunes(this.text);
 
+    // Dispatch typing event so the parent can send a typing indicator
+    if (this.text.length > 0) {
+      this.dispatchEvent(new CustomEvent('chat-typing', { bubbles: true, composed: true }));
+    }
+
     // Update live mention override for destination chip
     this.updateLiveMentionOverride();
 

--- a/web/src/components/shared/chat/chat-composer.ts
+++ b/web/src/components/shared/chat/chat-composer.ts
@@ -37,6 +37,15 @@ import './mention-autocomplete.js';
 /** Maximum message length in rune count. */
 const MAX_MESSAGE_LENGTH = 2000;
 
+/** Uploaded attachment info returned from the server. */
+export interface UploadedAttachment {
+  id: string;
+  name: string;
+  mime: string;
+  size: number;
+  url: string;
+}
+
 /** Event detail for the chat-send custom event. */
 export interface ChatSendDetail {
   text: string;
@@ -44,6 +53,8 @@ export interface ChatSendDetail {
   interrupt: boolean;
   onSuccess: () => void;
   mentions: string[];
+  /** W7: Attachment IDs to include with the message. */
+  attachmentIds: string[];
 }
 
 /** Member info for human mention in v2 mode. */
@@ -99,6 +110,10 @@ export class ScionChatComposer extends LitElement {
   @property()
   peerName = '';
 
+  /** Project ID for upload authz scope (v2 mode). */
+  @property()
+  projectId = '';
+
   @state() private text = '';
   @state() private plain = false;
   @state() private interrupt = false;
@@ -106,6 +121,12 @@ export class ScionChatComposer extends LitElement {
 
   /** Live mention override for the destination chip. */
   @state() private liveMentionOverride = '';
+
+  /** W7: Pending file uploads before send. */
+  @state() private pendingFiles: UploadedAttachment[] = [];
+
+  /** W7: Upload in progress. */
+  @state() private uploading = false;
 
   /** Set of accepted mention slugs. Filtered to those still present on send. */
   private acceptedMentions = new Set<string>();
@@ -227,19 +248,103 @@ export class ScionChatComposer extends LitElement {
     .destination-chip.dm {
       background: var(--scion-primary-50, #eff6ff);
     }
+
+    /* W7: File upload styles */
+    .attach-btn {
+      flex-shrink: 0;
+    }
+
+    .attach-btn::part(base) {
+      font-size: 1rem;
+    }
+
+    .pending-files {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.375rem;
+      padding: 0 0.25rem;
+    }
+
+    .pending-file {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.25rem 0.5rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.375rem;
+      font-size: 0.6875rem;
+      color: var(--scion-text, #1e293b);
+      max-width: 200px;
+    }
+
+    .pending-file img {
+      width: 24px;
+      height: 24px;
+      object-fit: cover;
+      border-radius: 0.25rem;
+    }
+
+    .pending-file .file-name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      flex: 1;
+    }
+
+    .pending-file .remove-btn {
+      cursor: pointer;
+      color: var(--scion-text-muted, #94a3b8);
+      padding: 0;
+      line-height: 1;
+      background: none;
+      border: none;
+      font-size: 0.875rem;
+    }
+
+    .pending-file .remove-btn:hover {
+      color: var(--scion-danger-600, #dc2626);
+    }
+
+    .upload-progress {
+      font-size: 0.6875rem;
+      color: var(--scion-text-muted, #64748b);
+      padding: 0 0.25rem;
+    }
   `;
 
   override render() {
     const isOverLimit = this.runeCount > MAX_MESSAGE_LENGTH;
     const isNearLimit = this.runeCount > MAX_MESSAGE_LENGTH * 0.9;
-    const canSend = this.text.trim().length > 0 && !isOverLimit && !this.disabled;
+    const hasContent = this.text.trim().length > 0 || this.pendingFiles.length > 0;
+    const canSend = hasContent && !isOverLimit && !this.disabled && !this.uploading;
 
     const counterClass = isOverLimit ? 'over' : isNearLimit ? 'warn' : '';
 
     return html`
       ${this.conversationMode ? this.renderDestinationChip() : nothing}
       <div class="composer">
+        ${this.pendingFiles.length > 0 ? this.renderPendingFiles() : nothing}
+        ${this.uploading ? html`<div class="upload-progress">Uploading...</div>` : nothing}
         <div class="input-row">
+          ${this.conversationMode
+            ? html`
+                <sl-icon-button
+                  class="attach-btn"
+                  name="paperclip"
+                  label="Attach file"
+                  @click=${this.handleAttachClick}
+                  ?disabled=${this.disabled || this.uploading}
+                ></sl-icon-button>
+                <input
+                  type="file"
+                  multiple
+                  accept="image/jpeg,image/png,image/gif,image/webp,application/pdf,text/plain,text/markdown,application/zip"
+                  style="display:none"
+                  @change=${this.handleFileSelected}
+                />
+              `
+            : nothing}
           <div class="textarea-wrapper">
             <sl-textarea
               placeholder="Send a message..."
@@ -433,6 +538,100 @@ export class ScionChatComposer extends LitElement {
     });
   }
 
+  /** Render the pending uploaded files as previews/chips. */
+  private renderPendingFiles() {
+    return html`
+      <div class="pending-files">
+        ${this.pendingFiles.map(
+          (file, idx) => html`
+            <div class="pending-file">
+              ${file.mime.startsWith('image/')
+                ? html`<img src=${file.url} alt=${file.name} />`
+                : html`<sl-icon name="file-earmark" style="font-size:0.875rem"></sl-icon>`}
+              <span class="file-name" title=${file.name}>${file.name}</span>
+              <button class="remove-btn" @click=${() => this.removePendingFile(idx)}>&times;</button>
+            </div>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  /** Open the hidden file input. */
+  private handleAttachClick(): void {
+    const input = this.shadowRoot?.querySelector('input[type="file"]') as HTMLInputElement | null;
+    if (input) {
+      input.value = '';
+      input.click();
+    }
+  }
+
+  /** Handle file selection from the file picker. */
+  private async handleFileSelected(e: Event): Promise<void> {
+    const input = e.target as HTMLInputElement;
+    const files = input.files;
+    if (!files || files.length === 0) return;
+
+    // Enforce max attachments.
+    if (this.pendingFiles.length + files.length > 10) {
+      this.dispatchEvent(
+        new CustomEvent('composer-error', {
+          detail: { message: 'Maximum 10 attachments per message' },
+          bubbles: true,
+          composed: true,
+        })
+      );
+      return;
+    }
+
+    this.uploading = true;
+    try {
+      const formData = new FormData();
+      formData.append('project_id', this.projectId);
+      for (const file of Array.from(files)) {
+        formData.append('files', file);
+      }
+
+      const { apiFetch } = await import('../../../shared/api.js');
+      const res = await apiFetch('/api/v1/chat/attachments', {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({ message: 'Upload failed' }));
+        this.dispatchEvent(
+          new CustomEvent('composer-error', {
+            detail: { message: (errData as Record<string, string>).message || 'Upload failed' },
+            bubbles: true,
+            composed: true,
+          })
+        );
+        return;
+      }
+
+      const data = (await res.json()) as {
+        attachments: UploadedAttachment[];
+      };
+      this.pendingFiles = [...this.pendingFiles, ...data.attachments];
+    } catch (err) {
+      this.dispatchEvent(
+        new CustomEvent('composer-error', {
+          detail: { message: err instanceof Error ? err.message : 'Upload failed' },
+          bubbles: true,
+          composed: true,
+        })
+      );
+    } finally {
+      this.uploading = false;
+    }
+  }
+
+  /** Remove a pending file from the list. */
+  private removePendingFile(index: number): void {
+    this.pendingFiles = this.pendingFiles.filter((_, i) => i !== index);
+  }
+
   private handlePlainToggle(e: Event): void {
     this.plain = (e.target as HTMLInputElement).checked;
   }
@@ -443,10 +642,14 @@ export class ScionChatComposer extends LitElement {
 
   private handleSend(): void {
     const trimmed = this.text.trim();
-    if (!trimmed || this.runeCount > MAX_MESSAGE_LENGTH || this.disabled) return;
+    const hasAttachments = this.pendingFiles.length > 0;
+    if ((!trimmed && !hasAttachments) || this.runeCount > MAX_MESSAGE_LENGTH || this.disabled) return;
 
     // Filter accepted mentions to those still literally present in the text.
     const mentions = [...this.acceptedMentions].filter((slug) => trimmed.includes(`@${slug}`));
+
+    // W7: Collect attachment IDs from pending uploads.
+    const attachmentIds = this.pendingFiles.map((f) => f.id);
 
     this.dispatchEvent(
       new CustomEvent<ChatSendDetail>('chat-send', {
@@ -455,10 +658,12 @@ export class ScionChatComposer extends LitElement {
           plain: this.plain,
           interrupt: this.interrupt,
           mentions,
+          attachmentIds,
           onSuccess: () => {
             this.text = '';
             this.runeCount = 0;
             this.acceptedMentions.clear();
+            this.pendingFiles = [];
           },
         },
         bubbles: true,

--- a/web/src/components/shared/chat/chat-composer.ts
+++ b/web/src/components/shared/chat/chat-composer.ts
@@ -592,7 +592,7 @@ export class ScionChatComposer extends LitElement {
         formData.append('files', file);
       }
 
-      const { apiFetch } = await import('../../../shared/api.js');
+      const { apiFetch } = await import('../../../client/api.js');
       const res = await apiFetch('/api/v1/chat/attachments', {
         method: 'POST',
         body: formData,

--- a/web/src/components/shared/chat/chat-composer.ts
+++ b/web/src/components/shared/chat/chat-composer.ts
@@ -46,6 +46,15 @@ export interface ChatSendDetail {
   mentions: string[];
 }
 
+/** Member info for human mention in v2 mode. */
+export interface MemberInfo {
+  id: string;
+  name: string;
+  email: string;
+  avatarUrl?: string;
+  kind: 'user' | 'agent';
+}
+
 /**
  * Count "runes" (user-perceived characters) in a string.
  * Uses Intl.Segmenter where available, falls back to spread length.
@@ -72,10 +81,31 @@ export class ScionChatComposer extends LitElement {
   @property({ type: Array })
   agents: Agent[] = [];
 
+  // ---- Wave-2 v2 properties ----
+
+  /** Members available for @-mention in v2 mode. */
+  @property({ type: Array })
+  members: MemberInfo[] = [];
+
+  /** Default agent slug for this thread (v2 mode). */
+  @property()
+  defaultAgent = '';
+
+  /** Conversation mode: 'thread' or 'dm' (v2 mode). */
+  @property()
+  conversationMode: 'thread' | 'dm' | '' = '';
+
+  /** DM peer name (v2 DM mode). */
+  @property()
+  peerName = '';
+
   @state() private text = '';
   @state() private plain = false;
   @state() private interrupt = false;
   @state() private runeCount = 0;
+
+  /** Live mention override for the destination chip. */
+  @state() private liveMentionOverride = '';
 
   /** Set of accepted mention slugs. Filtered to those still present on send. */
   private acceptedMentions = new Set<string>();
@@ -155,6 +185,48 @@ export class ScionChatComposer extends LitElement {
       color: var(--scion-danger-600, #dc2626);
       font-weight: 600;
     }
+
+    /* Destination chip (v2) */
+    .destination-chip {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0.25rem 0.75rem;
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border-radius: 0.5rem 0.5rem 0 0;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-bottom: none;
+      margin: 0 1rem;
+      margin-bottom: -1px;
+      position: relative;
+      z-index: 1;
+    }
+
+    .destination-chip .arrow {
+      font-weight: 700;
+      color: var(--scion-primary, #3b82f6);
+    }
+
+    .destination-chip .agent-name {
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .destination-chip .hint {
+      font-style: italic;
+      opacity: 0.8;
+    }
+
+    .destination-chip .mention-override {
+      font-weight: 600;
+      color: var(--scion-warning-600, #d97706);
+    }
+
+    .destination-chip.dm {
+      background: var(--scion-primary-50, #eff6ff);
+    }
   `;
 
   override render() {
@@ -165,6 +237,7 @@ export class ScionChatComposer extends LitElement {
     const counterClass = isOverLimit ? 'over' : isNearLimit ? 'warn' : '';
 
     return html`
+      ${this.conversationMode ? this.renderDestinationChip() : nothing}
       <div class="composer">
         <div class="input-row">
           <div class="textarea-wrapper">
@@ -180,6 +253,7 @@ export class ScionChatComposer extends LitElement {
             ></sl-textarea>
             <scion-mention-autocomplete
               .agents=${this.agents}
+              .members=${this.members}
               @mention-accept=${this.handleMentionAccept}
             ></scion-mention-autocomplete>
           </div>
@@ -225,15 +299,61 @@ export class ScionChatComposer extends LitElement {
     `;
   }
 
+  /** Render the destination chip showing where the message will go. */
+  private renderDestinationChip() {
+    if (this.conversationMode === 'dm') {
+      return html`
+        <div class="destination-chip dm">
+          <span class="arrow">&rarr;</span>
+          <span class="agent-name">@${this.peerName}</span>
+        </div>
+      `;
+    }
+
+    // Thread mode with live mention override
+    if (this.liveMentionOverride) {
+      return html`
+        <div class="destination-chip">
+          <span class="arrow">&rarr;</span>
+          <span class="mention-override">@${this.liveMentionOverride}</span>
+          <span class="hint">(mention)</span>
+        </div>
+      `;
+    }
+
+    // Thread mode with default agent
+    if (this.defaultAgent) {
+      return html`
+        <div class="destination-chip">
+          <span class="arrow">&rarr;</span>
+          <sl-icon name="cpu" style="font-size: 0.75rem"></sl-icon>
+          <span class="agent-name">${this.defaultAgent}</span>
+          <span class="hint">(thread default)</span>
+        </div>
+      `;
+    }
+
+    // Thread mode with no default
+    return html`
+      <div class="destination-chip">
+        <span class="arrow">&rarr;</span>
+        <span class="hint">no agent &mdash; visible to space members</span>
+      </div>
+    `;
+  }
+
   private handleInput(e: Event): void {
     const target = e.target as HTMLInputElement;
     this.text = target.value;
     this.runeCount = countRunes(this.text);
 
+    // Update live mention override for destination chip
+    this.updateLiveMentionOverride();
+
     // Feed the autocomplete component.
-    const autocomplete = this.shadowRoot?.querySelector(
-      'scion-mention-autocomplete'
-    ) as import('./mention-autocomplete.js').ScionMentionAutocomplete | null;
+    const autocomplete = this.shadowRoot?.querySelector('scion-mention-autocomplete') as
+      | import('./mention-autocomplete.js').ScionMentionAutocomplete
+      | null;
     if (autocomplete) {
       const textarea = this.getTextareaElement();
       if (textarea) {
@@ -242,11 +362,33 @@ export class ScionChatComposer extends LitElement {
     }
   }
 
+  /** Update live mention override based on @mentions in the text. */
+  private updateLiveMentionOverride(): void {
+    if (!this.conversationMode || this.conversationMode === 'dm') {
+      this.liveMentionOverride = '';
+      return;
+    }
+    // Find the first @mention in the text
+    const mentionMatch = this.text.match(/@(\S+)/);
+    if (mentionMatch) {
+      const slug = mentionMatch[1];
+      // Check if this matches a known agent
+      const matchedAgent = this.agents.find(
+        (a) => (a.slug || a.name || '').toLowerCase() === slug.toLowerCase()
+      );
+      if (matchedAgent) {
+        this.liveMentionOverride = matchedAgent.slug || matchedAgent.name || slug;
+        return;
+      }
+    }
+    this.liveMentionOverride = '';
+  }
+
   private handleKeydown(e: KeyboardEvent): void {
     // Let the autocomplete handle keys first.
-    const autocomplete = this.shadowRoot?.querySelector(
-      'scion-mention-autocomplete'
-    ) as import('./mention-autocomplete.js').ScionMentionAutocomplete | null;
+    const autocomplete = this.shadowRoot?.querySelector('scion-mention-autocomplete') as
+      | import('./mention-autocomplete.js').ScionMentionAutocomplete
+      | null;
     if (autocomplete?.handleKeydown(e)) {
       return; // consumed by autocomplete
     }
@@ -276,7 +418,7 @@ export class ScionChatComposer extends LitElement {
 
     // Restore cursor position after the inserted text.
     const newCursorPos = triggerStart + insertion.length;
-    this.updateComplete.then(() => {
+    void this.updateComplete.then(() => {
       const ta = this.getTextareaElement();
       if (ta) {
         ta.value = this.text;
@@ -299,9 +441,7 @@ export class ScionChatComposer extends LitElement {
     if (!trimmed || this.runeCount > MAX_MESSAGE_LENGTH || this.disabled) return;
 
     // Filter accepted mentions to those still literally present in the text.
-    const mentions = [...this.acceptedMentions].filter((slug) =>
-      trimmed.includes(`@${slug}`)
-    );
+    const mentions = [...this.acceptedMentions].filter((slug) => trimmed.includes(`@${slug}`));
 
     this.dispatchEvent(
       new CustomEvent<ChatSendDetail>('chat-send', {
@@ -329,10 +469,7 @@ export class ScionChatComposer extends LitElement {
     const slTextarea = this.shadowRoot?.querySelector('sl-textarea');
     if (!slTextarea) return null;
     // Shoelace sl-textarea wraps a native <textarea> inside its shadow root.
-    return (
-      (slTextarea.shadowRoot?.querySelector('textarea') as HTMLTextAreaElement) ??
-      null
-    );
+    return (slTextarea.shadowRoot?.querySelector('textarea') as HTMLTextAreaElement) ?? null;
   }
 }
 

--- a/web/src/components/shared/chat/chat-members.ts
+++ b/web/src/components/shared/chat/chat-members.ts
@@ -1,0 +1,283 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Members sidebar component for the chat view.
+ *
+ * Renders two sections:
+ * - **Humans** — project members with presence indicators
+ *   (green dot = active, moon = idle)
+ * - **Agents** — project agents with status badges
+ *
+ * Listens to `chat.presence` SSE events (via the parent passing updated
+ * presence state) to update presence indicators in real time.
+ *
+ * Clicking a member opens a DM in the centre panel.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import './chat-avatar.js';
+
+/** A human member from the GET /chat/spaces/{id}/members endpoint. */
+export interface ChatHumanMember {
+  id: string;
+  kind: 'user';
+  displayName: string;
+  email?: string;
+  avatarUrl?: string;
+  role?: string;
+  presenceState?: 'active' | 'idle' | '';
+}
+
+/** An agent member from the GET /chat/spaces/{id}/members endpoint. */
+export interface ChatAgentMember {
+  id: string;
+  kind: 'agent';
+  displayName: string;
+  slug?: string;
+  phase?: string;
+  activity?: string;
+}
+
+export type ChatMember = ChatHumanMember | ChatAgentMember;
+
+/** Detail emitted when a member is clicked (to open a DM). */
+export interface MemberClickDetail {
+  memberId: string;
+  memberKind: 'user' | 'agent';
+  displayName: string;
+}
+
+@customElement('scion-chat-members')
+export class ScionChatMembers extends LitElement {
+  /** Human members of the space. */
+  @property({ type: Array })
+  humans: ChatHumanMember[] = [];
+
+  /** Agent members of the space. */
+  @property({ type: Array })
+  agents: ChatAgentMember[] = [];
+
+  /** Current user ID — used to skip "DM yourself" on click. */
+  @property({ attribute: 'current-user-id' })
+  currentUserId = '';
+
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      overflow-y: auto;
+      font-family: var(--sl-font-sans);
+    }
+
+    .section-label {
+      padding: 12px 16px 4px;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--scion-text-muted, #94a3b8);
+    }
+
+    .member-item {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 6px 16px;
+      cursor: pointer;
+      border-radius: 4px;
+      margin: 0 8px;
+      transition: background 0.15s;
+    }
+
+    .member-item:hover {
+      background: var(--scion-surface-hover, rgba(0, 0, 0, 0.05));
+    }
+
+    .member-info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .member-name {
+      font-size: 0.8125rem;
+      font-weight: 500;
+      color: var(--scion-text, #1e293b);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .member-role {
+      font-size: 0.6875rem;
+      color: var(--scion-text-muted, #94a3b8);
+    }
+
+    .agent-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 0.6875rem;
+      color: var(--scion-text-muted, #94a3b8);
+    }
+
+    .agent-status .dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+
+    .dot.running {
+      background: #22c55e;
+    }
+
+    .dot.idle {
+      background: #f59e0b;
+    }
+
+    .dot.stopped {
+      background: #94a3b8;
+    }
+
+    .dot.error {
+      background: #ef4444;
+    }
+
+    .empty-note {
+      padding: 12px 16px;
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #94a3b8);
+      font-style: italic;
+    }
+  `;
+
+  override render() {
+    return html` ${this.renderHumans()} ${this.renderAgents()} `;
+  }
+
+  private renderHumans() {
+    const sorted = [...this.humans].sort((a, b) => {
+      // Active users first, then alphabetical
+      const aActive = a.presenceState === 'active' ? 0 : 1;
+      const bActive = b.presenceState === 'active' ? 0 : 1;
+      if (aActive !== bActive) return aActive - bActive;
+      return a.displayName.localeCompare(b.displayName);
+    });
+
+    return html`
+      <div class="section-label">People — ${sorted.length}</div>
+      ${sorted.length === 0
+        ? html`<div class="empty-note">No members</div>`
+        : sorted.map((m) => this.renderHuman(m))}
+    `;
+  }
+
+  private renderHuman(m: ChatHumanMember) {
+    return html`
+      <div
+        class="member-item"
+        @click=${() => this.handleMemberClick(m.id, 'user', m.displayName)}
+        title="${m.email || m.displayName}"
+      >
+        <scion-chat-avatar
+          name="${m.displayName}"
+          avatar-url="${m.avatarUrl || ''}"
+          size="28"
+          presence-state="${m.presenceState || ''}"
+        ></scion-chat-avatar>
+        <div class="member-info">
+          <div class="member-name">${m.displayName}</div>
+          ${m.role ? html`<div class="member-role">${m.role}</div>` : nothing}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderAgents() {
+    const sorted = [...this.agents].sort((a, b) => {
+      // Running agents first, then alphabetical
+      const aRunning = a.phase === 'running' ? 0 : 1;
+      const bRunning = b.phase === 'running' ? 0 : 1;
+      if (aRunning !== bRunning) return aRunning - bRunning;
+      return a.displayName.localeCompare(b.displayName);
+    });
+
+    return html`
+      <div class="section-label">Agents — ${sorted.length}</div>
+      ${sorted.length === 0
+        ? html`<div class="empty-note">No agents</div>`
+        : sorted.map((a) => this.renderAgent(a))}
+    `;
+  }
+
+  private renderAgent(a: ChatAgentMember) {
+    const dotClass = this.agentDotClass(a.phase || '');
+    const statusLabel = a.activity || a.phase || 'unknown';
+
+    return html`
+      <div
+        class="member-item"
+        @click=${() => this.handleMemberClick(a.id, 'agent', a.displayName)}
+        title="${a.slug || a.displayName}"
+      >
+        <scion-chat-avatar name="${a.slug || a.displayName}" size="28"></scion-chat-avatar>
+        <div class="member-info">
+          <div class="member-name">${a.displayName}</div>
+          <div class="agent-status">
+            <span class="dot ${dotClass}"></span>
+            ${statusLabel}
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private agentDotClass(phase: string): string {
+    switch (phase) {
+      case 'running':
+        return 'running';
+      case 'idle':
+      case 'waiting':
+        return 'idle';
+      case 'error':
+      case 'failed':
+        return 'error';
+      default:
+        return 'stopped';
+    }
+  }
+
+  private handleMemberClick(id: string, kind: 'user' | 'agent', displayName: string) {
+    if (kind === 'user' && id === this.currentUserId) return;
+
+    this.dispatchEvent(
+      new CustomEvent<MemberClickDetail>('member-click', {
+        detail: { memberId: id, memberKind: kind, displayName },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-chat-members': ScionChatMembers;
+  }
+}

--- a/web/src/components/shared/chat/chat-message.ts
+++ b/web/src/components/shared/chat/chat-message.ts
@@ -31,6 +31,24 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { getMarkdownRenderer } from '../../../utils/markdown.js';
 import { hashColor, getInitials } from './chat-avatar.js';
 
+/** Structured attachment reference from the W7 API. */
+export interface AttachmentRefInfo {
+  id: string;
+  name: string;
+  mime: string;
+  size: number;
+}
+
+/** Image MIME types rendered inline. */
+const IMAGE_MIMES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+
+/** Format file size for display. */
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 @customElement('scion-chat-message')
 export class ScionChatMessage extends LitElement {
   /** The message body text. */
@@ -93,9 +111,16 @@ export class ScionChatMessage extends LitElement {
   @property()
   dispatchFailureReason = '';
 
-  /** File attachment paths. */
+  /** File attachment paths (wave-1 agent-style). */
   @property({ type: Array })
   attachments: string[] = [];
+
+  /**
+   * Structured attachment refs (wave-2 W7).
+   * Each entry has {id, name, mime, size}.
+   */
+  @property({ type: Array })
+  attachmentRefs: AttachmentRefInfo[] = [];
 
   @state()
   private renderedHtml = '';
@@ -385,6 +410,67 @@ export class ScionChatMessage extends LitElement {
       font-size: 0.75rem;
     }
 
+    /* W7: Inline image attachments */
+    .attachment-images {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-top: 0.375rem;
+    }
+
+    .attachment-image {
+      max-width: 320px;
+      max-height: 240px;
+      border-radius: 0.5rem;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      cursor: pointer;
+      object-fit: contain;
+      background: var(--scion-bg-subtle, #f8fafc);
+      transition: opacity 0.2s ease;
+    }
+
+    .attachment-image:hover {
+      opacity: 0.85;
+    }
+
+    /* W7: Download chips for non-image files */
+    .download-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0.375rem 0.625rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.5rem;
+      font-size: 0.75rem;
+      color: var(--scion-text, #1e293b);
+      cursor: pointer;
+      text-decoration: none;
+      transition: background 0.15s ease;
+    }
+
+    .download-chip:hover {
+      background: var(--scion-border, #e2e8f0);
+    }
+
+    .download-chip sl-icon {
+      font-size: 0.875rem;
+      color: var(--scion-primary, #3b82f6);
+    }
+
+    .download-chip .file-name {
+      font-weight: 500;
+      max-width: 200px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .download-chip .file-size {
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.6875rem;
+    }
+
     /* Verbose (recessed) rendering — no bubble, muted text, small label */
     .message-wrapper.verbose .bubble-content {
       background: none;
@@ -644,6 +730,12 @@ export class ScionChatMessage extends LitElement {
   }
 
   private renderAttachments() {
+    // W7: Render structured attachment refs (v2 mode).
+    if (this.attachmentRefs && this.attachmentRefs.length > 0) {
+      return this.renderV2Attachments();
+    }
+
+    // Wave-1: Render file path chips.
     if (!this.attachments || this.attachments.length === 0) return nothing;
 
     return html`
@@ -659,6 +751,54 @@ export class ScionChatMessage extends LitElement {
           `
         )}
       </div>
+    `;
+  }
+
+  /** Render W7 structured attachments: inline images + download chips. */
+  private renderV2Attachments() {
+    const images = this.attachmentRefs.filter((a) => IMAGE_MIMES.has(a.mime));
+    const files = this.attachmentRefs.filter((a) => !IMAGE_MIMES.has(a.mime));
+
+    return html`
+      ${images.length > 0
+        ? html`
+            <div class="attachment-images">
+              ${images.map(
+                (img) => html`
+                  <a href="/api/v1/chat/attachments/${img.id}" target="_blank" rel="noopener">
+                    <img
+                      class="attachment-image"
+                      src="/api/v1/chat/attachments/${img.id}"
+                      alt=${img.name}
+                      title=${img.name}
+                      loading="lazy"
+                    />
+                  </a>
+                `
+              )}
+            </div>
+          `
+        : nothing}
+      ${files.length > 0
+        ? html`
+            <div class="attachments">
+              ${files.map(
+                (file) => html`
+                  <a
+                    class="download-chip"
+                    href="/api/v1/chat/attachments/${file.id}"
+                    download=${file.name}
+                    title="Download ${file.name}"
+                  >
+                    <sl-icon name="file-earmark-arrow-down"></sl-icon>
+                    <span class="file-name">${file.name}</span>
+                    <span class="file-size">${formatFileSize(file.size)}</span>
+                  </a>
+                `
+              )}
+            </div>
+          `
+        : nothing}
     `;
   }
 

--- a/web/src/components/shared/chat/chat-message.ts
+++ b/web/src/components/shared/chat/chat-message.ts
@@ -29,6 +29,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { getMarkdownRenderer } from '../../../utils/markdown.js';
+import { hashColor, getInitials } from './chat-avatar.js';
 
 @customElement('scion-chat-message')
 export class ScionChatMessage extends LitElement {
@@ -675,30 +676,14 @@ export class ScionChatMessage extends LitElement {
     }
   }
 
-  /** Simple deterministic colour from the agent slug. */
+  /** Deterministic colour from the agent slug or sender name. */
   private getAvatarColor(): string {
-    const colors = [
-      '#3b82f6',
-      '#8b5cf6',
-      '#06b6d4',
-      '#10b981',
-      '#f59e0b',
-      '#ef4444',
-      '#ec4899',
-      '#6366f1',
-    ];
-    let hash = 0;
-    const s = this.agentSlug || this.sender || '';
-    for (let i = 0; i < s.length; i++) {
-      hash = s.charCodeAt(i) + ((hash << 5) - hash);
-    }
-    return colors[Math.abs(hash) % colors.length];
+    return hashColor(this.agentSlug || this.sender || '');
   }
 
-  /** First two characters of the agent slug or sender name. */
+  /** Initials derived from the agent slug or sender name. */
   private getInitials(): string {
-    const s = this.agentSlug || this.sender || '';
-    return s.substring(0, 2);
+    return getInitials(this.agentSlug || this.sender || '');
   }
 
   /** Extract the file basename from a path. */

--- a/web/src/components/shared/chat/chat-message.ts
+++ b/web/src/components/shared/chat/chat-message.ts
@@ -52,6 +52,10 @@ export class ScionChatMessage extends LitElement {
   @property()
   agentSlug = '';
 
+  /** Sender display name for v2 multi-sender rendering. */
+  @property()
+  senderName = '';
+
   /** Timestamp string. */
   @property()
   timestamp = '';
@@ -216,9 +220,15 @@ export class ScionChatMessage extends LitElement {
       margin-top: 0;
     }
 
-    .md-content h1 { font-size: 1.25rem; }
-    .md-content h2 { font-size: 1.125rem; }
-    .md-content h3 { font-size: 1rem; }
+    .md-content h1 {
+      font-size: 1.25rem;
+    }
+    .md-content h2 {
+      font-size: 1.125rem;
+    }
+    .md-content h3 {
+      font-size: 1rem;
+    }
 
     .md-content a {
       color: var(--sl-color-primary-600, #2563eb);
@@ -492,9 +502,8 @@ export class ScionChatMessage extends LitElement {
       btn.className = 'copy-btn';
       btn.textContent = 'Copy';
       btn.addEventListener('click', () => {
-        const code =
-          pre.querySelector('code')?.textContent ?? pre.textContent ?? '';
-        navigator.clipboard.writeText(code);
+        const code = pre.querySelector('code')?.textContent ?? pre.textContent ?? '';
+        void navigator.clipboard.writeText(code);
         btn.textContent = 'Copied!';
         setTimeout(() => {
           btn.textContent = 'Copy';
@@ -532,7 +541,9 @@ export class ScionChatMessage extends LitElement {
     return html`
       <div class="message-wrapper ${dirClass}${visClass}">
         ${this.showHeader && this.fromAgent
-          ? html`<div class="avatar" style="background: ${this.getAvatarColor()}">${this.getInitials()}</div>`
+          ? html`<div class="avatar" style="background: ${this.getAvatarColor()}">
+              ${this.getInitials()}
+            </div>`
           : this.fromAgent
             ? html`<div class="avatar-spacer"></div>`
             : nothing}
@@ -553,12 +564,8 @@ export class ScionChatMessage extends LitElement {
                 </div>
               `
             : nothing}
-          <div class="bubble-content">
-            ${this.renderBody()}
-          </div>
-          ${this.renderDeliveryState()}
-          ${this.renderBadges()}
-          ${this.renderAttachments()}
+          <div class="bubble-content">${this.renderBody()}</div>
+          ${this.renderDeliveryState()} ${this.renderBadges()} ${this.renderAttachments()}
         </div>
       </div>
     `;
@@ -671,8 +678,14 @@ export class ScionChatMessage extends LitElement {
   /** Simple deterministic colour from the agent slug. */
   private getAvatarColor(): string {
     const colors = [
-      '#3b82f6', '#8b5cf6', '#06b6d4', '#10b981',
-      '#f59e0b', '#ef4444', '#ec4899', '#6366f1',
+      '#3b82f6',
+      '#8b5cf6',
+      '#06b6d4',
+      '#10b981',
+      '#f59e0b',
+      '#ef4444',
+      '#ec4899',
+      '#6366f1',
     ];
     let hash = 0;
     const s = this.agentSlug || this.sender || '';

--- a/web/src/components/shared/chat/chat-search.ts
+++ b/web/src/components/shared/chat/chat-search.ts
@@ -1,0 +1,499 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Chat Search Component (W8)
+ *
+ * Provides a search bar and results panel for searching chat messages.
+ * Features:
+ * - Debounced search input (300ms)
+ * - Minimum 2 character query
+ * - Results show conversation name, sender, highlighted snippet, timestamp
+ * - Click result navigates to conversation
+ * - Toggle between "current conversation" and "all" search scope
+ * - Keyset pagination via cursor
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { apiFetch } from '../../../client/api.js';
+
+/** Shape of a search result from GET /api/v1/chat/search */
+interface SearchResult {
+  messageId: string;
+  conversationKey: string;
+  threadName: string;
+  senderName: string;
+  content: string;
+  snippet: string;
+  timestamp: string;
+  projectId: string;
+}
+
+interface SearchResponse {
+  results: SearchResult[];
+  nextCursor?: string;
+}
+
+@customElement('scion-chat-search')
+export class ScionChatSearch extends LitElement {
+  /** Current project ID for scoped search. */
+  @property()
+  projectId = '';
+
+  /** Current conversation key for scoped search. */
+  @property()
+  conversationKey = '';
+
+  /** Current conversation name for display. */
+  @property()
+  conversationName = '';
+
+  @state() private query = '';
+  @state() private results: SearchResult[] = [];
+  @state() private loading = false;
+  @state() private searchActive = false;
+  @state() private scopeAll = false;
+  @state() private nextCursor = '';
+  @state() private loadingMore = false;
+  @state() private noResults = false;
+
+  private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      background: var(--scion-bg, #f8fafc);
+    }
+
+    .search-header {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      background: var(--scion-surface, #ffffff);
+    }
+
+    .search-input-wrap {
+      flex: 1;
+      position: relative;
+      display: flex;
+      align-items: center;
+    }
+
+    .search-input-wrap sl-icon {
+      position: absolute;
+      left: 0.5rem;
+      font-size: 0.875rem;
+      color: var(--scion-text-muted, #64748b);
+      pointer-events: none;
+    }
+
+    .search-input {
+      width: 100%;
+      padding: 0.375rem 0.5rem 0.375rem 1.75rem;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 6px;
+      font-size: 0.8125rem;
+      outline: none;
+      background: var(--scion-bg, #f8fafc);
+      color: var(--scion-text, #1e293b);
+    }
+
+    .search-input:focus {
+      border-color: var(--scion-primary, #3b82f6);
+      box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+    }
+
+    .search-input::placeholder {
+      color: var(--scion-text-muted, #94a3b8);
+    }
+
+    .close-btn {
+      flex-shrink: 0;
+    }
+
+    .scope-toggle {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.375rem 0.75rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      background: var(--scion-surface, #ffffff);
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .scope-btn {
+      padding: 0.25rem 0.5rem;
+      border-radius: 4px;
+      cursor: pointer;
+      border: 1px solid transparent;
+      background: none;
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .scope-btn:hover {
+      background: var(--scion-bg-subtle, #f1f5f9);
+    }
+
+    .scope-btn.active {
+      background: var(--scion-primary-50, #eff6ff);
+      color: var(--scion-primary, #3b82f6);
+      border-color: var(--scion-primary, #3b82f6);
+    }
+
+    .results-list {
+      flex: 1;
+      overflow-y: auto;
+      padding: 0.25rem 0;
+    }
+
+    .result-item {
+      display: flex;
+      flex-direction: column;
+      gap: 0.125rem;
+      padding: 0.625rem 0.75rem;
+      cursor: pointer;
+      border-bottom: 1px solid var(--scion-border-subtle, #f1f5f9);
+      transition: background 0.1s;
+    }
+
+    .result-item:hover {
+      background: var(--scion-bg-subtle, #f1f5f9);
+    }
+
+    .result-top {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5rem;
+    }
+
+    .result-thread {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      color: var(--scion-text-muted, #64748b);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .result-time {
+      font-size: 0.625rem;
+      color: var(--scion-text-muted, #94a3b8);
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    .result-sender {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .result-snippet {
+      font-size: 0.75rem;
+      color: var(--scion-text, #334155);
+      line-height: 1.4;
+      word-break: break-word;
+    }
+
+    .result-snippet mark {
+      background: #fef08a;
+      color: inherit;
+      border-radius: 2px;
+      padding: 0 1px;
+    }
+
+    .status-msg {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.8125rem;
+      text-align: center;
+    }
+
+    .load-more {
+      display: flex;
+      justify-content: center;
+      padding: 0.75rem;
+    }
+
+    .load-more button {
+      padding: 0.375rem 1rem;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 6px;
+      background: var(--scion-surface, #ffffff);
+      color: var(--scion-text, #1e293b);
+      font-size: 0.75rem;
+      cursor: pointer;
+    }
+
+    .load-more button:hover {
+      background: var(--scion-bg-subtle, #f1f5f9);
+    }
+  `;
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this._debounceTimer) {
+      clearTimeout(this._debounceTimer);
+      this._debounceTimer = null;
+    }
+  }
+
+  /** Close the search panel and reset state. */
+  close(): void {
+    this.searchActive = false;
+    this.query = '';
+    this.results = [];
+    this.nextCursor = '';
+    this.noResults = false;
+    this.dispatchEvent(new CustomEvent('search-close', { bubbles: true, composed: true }));
+  }
+
+  /** Open the search panel and focus the input. */
+  open(): void {
+    this.searchActive = true;
+    this.requestUpdate();
+    // Focus the input after render.
+    requestAnimationFrame(() => {
+      const input = this.shadowRoot?.querySelector('.search-input') as HTMLInputElement;
+      input?.focus();
+    });
+  }
+
+  private handleInput(e: Event): void {
+    const input = e.target as HTMLInputElement;
+    this.query = input.value;
+
+    if (this._debounceTimer) {
+      clearTimeout(this._debounceTimer);
+    }
+
+    if (this.query.trim().length < 2) {
+      this.results = [];
+      this.nextCursor = '';
+      this.noResults = false;
+      return;
+    }
+
+    this._debounceTimer = setTimeout(() => {
+      void this.performSearch();
+    }, 300);
+  }
+
+  private handleKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') {
+      this.close();
+    }
+  }
+
+  private async performSearch(append = false): Promise<void> {
+    const q = this.query.trim();
+    if (q.length < 2) return;
+
+    if (append) {
+      this.loadingMore = true;
+    } else {
+      this.loading = true;
+      this.results = [];
+      this.nextCursor = '';
+    }
+
+    try {
+      const params = new URLSearchParams({ q });
+
+      if (!this.scopeAll && this.conversationKey) {
+        params.set('key', this.conversationKey);
+      } else if (!this.scopeAll && this.projectId) {
+        params.set('projectId', this.projectId);
+      }
+
+      if (append && this.nextCursor) {
+        params.set('cursor', this.nextCursor);
+      }
+
+      params.set('limit', '20');
+
+      const res = await apiFetch(`/api/v1/chat/search?${params.toString()}`);
+      if (!res.ok) return;
+
+      const data = (await res.json()) as SearchResponse;
+
+      if (append) {
+        this.results = [...this.results, ...data.results];
+      } else {
+        this.results = data.results || [];
+      }
+
+      this.nextCursor = data.nextCursor || '';
+      this.noResults = this.results.length === 0 && !append;
+    } catch {
+      // Silently fail
+    } finally {
+      this.loading = false;
+      this.loadingMore = false;
+    }
+  }
+
+  private toggleScope(all: boolean): void {
+    if (this.scopeAll === all) return;
+    this.scopeAll = all;
+    if (this.query.trim().length >= 2) {
+      void this.performSearch();
+    }
+  }
+
+  private handleResultClick(result: SearchResult): void {
+    this.dispatchEvent(
+      new CustomEvent('search-navigate', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          conversationKey: result.conversationKey,
+          messageId: result.messageId,
+          projectId: result.projectId,
+        },
+      })
+    );
+  }
+
+  private formatTime(iso: string): string {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return '';
+    const now = Date.now();
+    const diffMs = now - d.getTime();
+    const diffMin = Math.floor(diffMs / 60000);
+
+    if (diffMin < 1) return 'now';
+    if (diffMin < 60) return `${diffMin}m ago`;
+    const diffHrs = Math.floor(diffMin / 60);
+    if (diffHrs < 24) return `${diffHrs}h ago`;
+    const diffDays = Math.floor(diffHrs / 24);
+    if (diffDays < 7) return `${diffDays}d ago`;
+
+    return d.toLocaleDateString('en', { month: 'short', day: 'numeric' });
+  }
+
+  /** Sanitize snippet HTML to only allow <mark> tags. */
+  private sanitizeSnippet(snippet: string): string {
+    // Replace <mark> and </mark> with placeholders, escape everything else,
+    // then restore the placeholders.
+    return snippet
+      .replace(/<mark>/g, '\x01MARK_OPEN\x01')
+      .replace(/<\/mark>/g, '\x01MARK_CLOSE\x01')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\x01MARK_OPEN\x01/g, '<mark>')
+      .replace(/\x01MARK_CLOSE\x01/g, '</mark>');
+  }
+
+  override render() {
+    if (!this.searchActive) return nothing;
+
+    const hasConversation = !!this.conversationKey;
+
+    return html`
+      <div class="search-header">
+        <div class="search-input-wrap">
+          <sl-icon name="search"></sl-icon>
+          <input
+            class="search-input"
+            type="text"
+            placeholder="Search messages..."
+            .value=${this.query}
+            @input=${this.handleInput}
+            @keydown=${this.handleKeydown}
+          />
+        </div>
+        <sl-icon-button
+          class="close-btn"
+          name="x-lg"
+          label="Close search"
+          @click=${() => this.close()}
+        ></sl-icon-button>
+      </div>
+
+      ${hasConversation
+        ? html`
+            <div class="scope-toggle">
+              <button
+                class="scope-btn ${!this.scopeAll ? 'active' : ''}"
+                @click=${() => this.toggleScope(false)}
+              >
+                In ${this.conversationName || 'this conversation'}
+              </button>
+              <button
+                class="scope-btn ${this.scopeAll ? 'active' : ''}"
+                @click=${() => this.toggleScope(true)}
+              >
+                All conversations
+              </button>
+            </div>
+          `
+        : nothing}
+
+      <div class="results-list">
+        ${this.loading
+          ? html`<div class="status-msg"><sl-spinner></sl-spinner></div>`
+          : this.noResults
+            ? html`<div class="status-msg">No messages found</div>`
+            : this.results.length === 0 && this.query.trim().length < 2
+              ? html`<div class="status-msg">Type at least 2 characters to search</div>`
+              : this.results.map((r) => this.renderResult(r))}
+        ${this.nextCursor && !this.loading
+          ? html`
+              <div class="load-more">
+                ${this.loadingMore
+                  ? html`<sl-spinner></sl-spinner>`
+                  : html`<button @click=${() => void this.performSearch(true)}>
+                      Load more
+                    </button>`}
+              </div>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderResult(result: SearchResult) {
+    return html`
+      <div class="result-item" @click=${() => this.handleResultClick(result)}>
+        <div class="result-top">
+          <span class="result-thread">${result.threadName || result.conversationKey}</span>
+          <span class="result-time">${this.formatTime(result.timestamp)}</span>
+        </div>
+        <span class="result-sender">${result.senderName}</span>
+        <span class="result-snippet">${unsafeHTML(this.sanitizeSnippet(result.snippet))}</span>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-chat-search': ScionChatSearch;
+  }
+}

--- a/web/src/components/shared/chat/chat-space-rail.ts
+++ b/web/src/components/shared/chat/chat-space-rail.ts
@@ -35,6 +35,8 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { apiFetch } from '../../../client/api.js';
+import { hashColor, getInitials } from './chat-avatar.js';
+import './chat-avatar.js';
 
 /** A space (project) in the rail. */
 export interface ChatSpace {
@@ -819,23 +821,6 @@ export class ScionChatSpaceRail extends LitElement {
   // Utility
   // ---------------------------------------------------------------------------
 
-  private hashColor(str: string): string {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-      hash = str.charCodeAt(i) + ((hash << 5) - hash);
-    }
-    const hue = ((hash % 360) + 360) % 360;
-    return `hsl(${hue}, 55%, 48%)`;
-  }
-
-  private getInitials(name: string): string {
-    const parts = name.split(/[-_\s]+/).filter(Boolean);
-    if (parts.length >= 2) {
-      return (parts[0][0] + parts[1][0]).toUpperCase();
-    }
-    return (name.slice(0, 2) || '?').toUpperCase();
-  }
-
   // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
@@ -1018,8 +1003,8 @@ export class ScionChatSpaceRail extends LitElement {
 
   private renderDM(dm: ChatDM) {
     const isSelected = dm.conversationKey === this.selectedKey;
-    const avatarColor = this.hashColor(dm.peerId);
-    const initials = this.getInitials(dm.peerName);
+    const avatarColor = hashColor(dm.peerId);
+    const initials = getInitials(dm.peerName);
     const icon = dm.peerKind === 'agent' ? 'cpu' : 'person';
 
     return html`

--- a/web/src/components/shared/chat/chat-space-rail.ts
+++ b/web/src/components/shared/chat/chat-space-rail.ts
@@ -465,6 +465,14 @@ export class ScionChatSpaceRail extends LitElement {
       await Promise.all([this.loadSpaces(), this.loadDMs(), this.loadPrefs()]);
     } finally {
       this.loading = false;
+      // Notify parent that rail data is ready (for SSE scope setup)
+      this.dispatchEvent(
+        new CustomEvent('rail-loaded', {
+          detail: { spaceIds: this.getSpaceIds() },
+          bubbles: true,
+          composed: true,
+        })
+      );
     }
   }
 

--- a/web/src/components/shared/chat/chat-space-rail.ts
+++ b/web/src/components/shared/chat/chat-space-rail.ts
@@ -1,0 +1,1078 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Space rail component — the left sidebar in Wave 2 chat.
+ *
+ * Replaces the wave-1 agent-based thread rail with a space-oriented hierarchy:
+ *   - Spaces section: one per project the user can access
+ *   - Each space is collapsible (chevron toggle)
+ *   - Under each space: thread list (#general first, pinned, then sorted)
+ *   - DM section below spaces
+ *
+ * Data sources:
+ *   - GET /api/v1/chat/spaces — visible spaces with unread rollup
+ *   - GET /api/v1/chat/spaces/{projectId}/threads — threads per space
+ *   - GET /api/v1/chat/dms — DM conversations
+ *   - GET /api/v1/chat/prefs — user preferences (sort mode, custom order)
+ *
+ * Interactions: thread select, context menu, create thread, sorting, DnD.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { apiFetch } from '../../../client/api.js';
+
+/** A space (project) in the rail. */
+export interface ChatSpace {
+  projectId: string;
+  projectName: string;
+  unreadCount: number;
+  hasUnreadMention: boolean;
+}
+
+/** A thread within a space. */
+export interface ChatSpaceThread {
+  id: string;
+  name: string;
+  isGeneral: boolean;
+  pinned: boolean;
+  defaultAgent?: string;
+  lastActivityAt?: string;
+  lastMessagePreview?: string;
+  hasUnread: boolean;
+  hasUnreadMention: boolean;
+}
+
+/** A DM conversation. */
+export interface ChatDM {
+  conversationKey: string;
+  peerName: string;
+  peerId: string;
+  peerKind: 'user' | 'agent';
+  peerAvatarUrl?: string;
+  lastMessagePreview?: string;
+  lastActivityAt?: string;
+  hasUnread: boolean;
+}
+
+/** User preferences for rail display. */
+interface RailPrefs {
+  spaceSortMode: 'activity' | 'alpha' | 'custom';
+  threadSortMode: 'activity' | 'alpha';
+  spaceOrder: string[] | undefined;
+}
+
+/** Event detail for thread selection. */
+export interface ThreadSelectDetail {
+  conversationKey: string;
+  projectId: string;
+  threadName: string;
+  defaultAgent: string;
+}
+
+/** Event detail for DM selection. */
+export interface DMSelectDetail {
+  conversationKey: string;
+  peerName: string;
+  peerId: string;
+  peerKind: 'user' | 'agent';
+}
+
+@customElement('scion-chat-space-rail')
+export class ScionChatSpaceRail extends LitElement {
+  /** Currently selected conversation key. */
+  @property()
+  selectedKey = '';
+
+  @state() private spaces: ChatSpace[] = [];
+  @state() private threadsBySpace = new Map<string, ChatSpaceThread[]>();
+  @state() private dms: ChatDM[] = [];
+  @state() private collapsedSpaces = new Set<string>();
+  @state() private loading = true;
+  @state() private prefs: RailPrefs = {
+    spaceSortMode: 'activity',
+    threadSortMode: 'activity',
+    spaceOrder: undefined,
+  };
+  @state() private creatingThread = '';
+  @state() private newThreadName = '';
+  @state() private contextMenuTarget: {
+    type: 'thread';
+    thread: ChatSpaceThread;
+    projectId: string;
+  } | null = null;
+  @state() private contextMenuPos = { x: 0, y: 0 };
+  @state() private renamingThread: string | null = null;
+  @state() private renameValue = '';
+  @state() private dmSectionCollapsed = false;
+
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      overflow: hidden;
+      background: var(--scion-surface, #ffffff);
+    }
+
+    .rail-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      font-weight: 600;
+      font-size: 0.875rem;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .rail-header a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--scion-primary, #3b82f6);
+      text-decoration: none;
+      cursor: pointer;
+    }
+
+    .rail-header a:hover {
+      text-decoration: underline;
+    }
+
+    .rail-body {
+      flex: 1;
+      overflow-y: auto;
+      padding: 0.25rem 0;
+    }
+
+    /* Space section */
+    .space-section {
+      margin-bottom: 0.25rem;
+    }
+
+    .space-header {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0.375rem 0.75rem;
+      cursor: pointer;
+      font-size: 0.6875rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--scion-text-muted, #64748b);
+      user-select: none;
+    }
+
+    .space-header:hover {
+      color: var(--scion-text, #1e293b);
+    }
+
+    .space-header .chevron {
+      transition: transform 0.15s;
+      font-size: 0.75rem;
+    }
+
+    .space-header .chevron.collapsed {
+      transform: rotate(-90deg);
+    }
+
+    .space-header .space-name {
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .space-header .unread-badge {
+      background: var(--scion-primary, #3b82f6);
+      color: #fff;
+      font-size: 0.5625rem;
+      font-weight: 700;
+      padding: 0.0625rem 0.3125rem;
+      border-radius: 0.5rem;
+      min-width: 1rem;
+      text-align: center;
+    }
+
+    .space-header .mention-badge {
+      background: var(--scion-danger-500, #ef4444);
+      color: #fff;
+      font-size: 0.5625rem;
+      font-weight: 700;
+      padding: 0.0625rem 0.3125rem;
+      border-radius: 0.5rem;
+      min-width: 1rem;
+      text-align: center;
+    }
+
+    .space-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+
+    .space-actions sl-icon-button::part(base) {
+      font-size: 0.75rem;
+      padding: 0.125rem;
+    }
+
+    /* Thread items */
+    .thread-list {
+      padding-left: 0;
+    }
+
+    .thread-item {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0.3125rem 0.75rem 0.3125rem 1.75rem;
+      cursor: pointer;
+      font-size: 0.8125rem;
+      color: var(--scion-text, #1e293b);
+      transition: background 0.1s;
+      position: relative;
+    }
+
+    .thread-item:hover {
+      background: var(--scion-bg-subtle, #f1f5f9);
+    }
+
+    .thread-item.selected {
+      background: var(--scion-primary-50, #eff6ff);
+      font-weight: 600;
+    }
+
+    .thread-item .hash {
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.75rem;
+      flex-shrink: 0;
+    }
+
+    .thread-item .thread-name {
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .thread-item .thread-name.unread {
+      font-weight: 700;
+    }
+
+    .thread-item .unread-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--scion-primary, #3b82f6);
+      flex-shrink: 0;
+    }
+
+    .thread-item .mention-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--scion-danger-500, #ef4444);
+      flex-shrink: 0;
+    }
+
+    .thread-item .pin-icon {
+      font-size: 0.625rem;
+      color: var(--scion-text-muted, #64748b);
+      flex-shrink: 0;
+    }
+
+    /* Create thread inline input */
+    .create-thread {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0.25rem 0.75rem 0.25rem 1.75rem;
+    }
+
+    .create-thread sl-input::part(base) {
+      font-size: 0.8125rem;
+      min-height: 1.75rem;
+    }
+
+    /* DM section */
+    .dm-section {
+      border-top: 1px solid var(--scion-border, #e2e8f0);
+      margin-top: 0.25rem;
+      padding-top: 0.25rem;
+    }
+
+    .dm-item {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.375rem 0.75rem 0.375rem 1rem;
+      cursor: pointer;
+      font-size: 0.8125rem;
+      color: var(--scion-text, #1e293b);
+      transition: background 0.1s;
+    }
+
+    .dm-item:hover {
+      background: var(--scion-bg-subtle, #f1f5f9);
+    }
+
+    .dm-item.selected {
+      background: var(--scion-primary-50, #eff6ff);
+      font-weight: 600;
+    }
+
+    .dm-avatar {
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.625rem;
+      font-weight: 600;
+      color: #fff;
+      flex-shrink: 0;
+    }
+
+    .dm-info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .dm-name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .dm-name.unread {
+      font-weight: 700;
+    }
+
+    /* Context menu */
+    .context-menu {
+      position: fixed;
+      z-index: 1000;
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.5rem;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+      min-width: 160px;
+      padding: 0.25rem 0;
+    }
+
+    .context-menu-item {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.375rem 0.75rem;
+      font-size: 0.8125rem;
+      cursor: pointer;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .context-menu-item:hover {
+      background: var(--scion-bg-subtle, #f1f5f9);
+    }
+
+    .context-menu-item.danger {
+      color: var(--scion-danger-600, #dc2626);
+    }
+
+    .context-menu-item sl-icon {
+      font-size: 0.875rem;
+    }
+
+    /* Loading / empty */
+    .loading-state {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    /* Sort dropdown */
+    .sort-selector {
+      padding: 0.375rem 0.75rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+    }
+
+    /* Rename input */
+    .rename-input {
+      width: 100%;
+    }
+
+    .rename-input::part(base) {
+      font-size: 0.8125rem;
+      min-height: 1.5rem;
+    }
+  `;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    void this.loadData();
+    // Close context menu on outside click
+    this._outsideClickHandler = this.handleOutsideClick.bind(this);
+    document.addEventListener('click', this._outsideClickHandler);
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this._outsideClickHandler) {
+      document.removeEventListener('click', this._outsideClickHandler);
+    }
+  }
+
+  private _outsideClickHandler: ((e: Event) => void) | null = null;
+
+  private handleOutsideClick(): void {
+    if (this.contextMenuTarget) {
+      this.contextMenuTarget = null;
+    }
+  }
+
+  /** Reload all data (called externally when SSE events indicate changes). */
+  async reload(): Promise<void> {
+    await this.loadData();
+  }
+
+  /** Returns the list of space project IDs for SSE subscription. */
+  getSpaceIds(): string[] {
+    return this.spaces.map((s) => s.projectId);
+  }
+
+  private async loadData(): Promise<void> {
+    this.loading = true;
+    try {
+      await Promise.all([this.loadSpaces(), this.loadDMs(), this.loadPrefs()]);
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private async loadSpaces(): Promise<void> {
+    try {
+      const res = await apiFetch('/api/v1/chat/spaces');
+      if (res.ok) {
+        const data = (await res.json()) as { spaces?: ChatSpace[] };
+        this.spaces = data.spaces || [];
+        // Load threads for each space
+        await Promise.all(this.spaces.map((s) => this.loadThreads(s.projectId)));
+      }
+    } catch {
+      // Silently fail
+    }
+  }
+
+  private async loadThreads(projectId: string): Promise<void> {
+    try {
+      const res = await apiFetch(`/api/v1/chat/spaces/${encodeURIComponent(projectId)}/threads`);
+      if (res.ok) {
+        const data = (await res.json()) as { threads?: ChatSpaceThread[] };
+        const newMap = new Map(this.threadsBySpace);
+        newMap.set(projectId, data.threads || []);
+        this.threadsBySpace = newMap;
+      }
+    } catch {
+      // Silently fail
+    }
+  }
+
+  private async loadDMs(): Promise<void> {
+    try {
+      const res = await apiFetch('/api/v1/chat/dms');
+      if (res.ok) {
+        const data = (await res.json()) as { dms?: ChatDM[] };
+        this.dms = data.dms || [];
+      }
+    } catch {
+      // Silently fail
+    }
+  }
+
+  private async loadPrefs(): Promise<void> {
+    try {
+      const res = await apiFetch('/api/v1/chat/prefs');
+      if (res.ok) {
+        const data = (await res.json()) as {
+          space_sort_mode?: string;
+          thread_sort_mode?: string;
+          space_order?: string[];
+        };
+        this.prefs = {
+          spaceSortMode: (data.space_sort_mode as RailPrefs['spaceSortMode']) || 'activity',
+          threadSortMode: (data.thread_sort_mode as RailPrefs['threadSortMode']) || 'activity',
+          spaceOrder: data.space_order,
+        };
+      }
+    } catch {
+      // Use defaults
+    }
+  }
+
+  /** Save user preferences. Exposed for sort mode changes. */
+  async savePrefs(update: Partial<RailPrefs>): Promise<void> {
+    const newPrefs = { ...this.prefs, ...update };
+    this.prefs = newPrefs;
+    try {
+      await apiFetch('/api/v1/chat/prefs', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          space_sort_mode: newPrefs.spaceSortMode,
+          thread_sort_mode: newPrefs.threadSortMode,
+          space_order: newPrefs.spaceOrder,
+        }),
+      });
+    } catch {
+      // Non-critical
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sorting
+  // ---------------------------------------------------------------------------
+
+  private getSortedSpaces(): ChatSpace[] {
+    const spaces = [...this.spaces];
+    switch (this.prefs.spaceSortMode) {
+      case 'alpha':
+        spaces.sort((a, b) => a.projectName.localeCompare(b.projectName));
+        break;
+      case 'custom':
+        if (this.prefs.spaceOrder) {
+          const order = this.prefs.spaceOrder;
+          spaces.sort((a, b) => {
+            const ai = order.indexOf(a.projectId);
+            const bi = order.indexOf(b.projectId);
+            if (ai === -1 && bi === -1) return 0;
+            if (ai === -1) return 1;
+            if (bi === -1) return -1;
+            return ai - bi;
+          });
+        }
+        break;
+      case 'activity':
+      default:
+        // activity sort: spaces with more recent activity first
+        // We use the threads' lastActivityAt to derive this
+        spaces.sort((a, b) => {
+          const aTime = this.getSpaceLastActivity(a.projectId);
+          const bTime = this.getSpaceLastActivity(b.projectId);
+          return bTime - aTime;
+        });
+        break;
+    }
+    return spaces;
+  }
+
+  private getSpaceLastActivity(projectId: string): number {
+    const threads = this.threadsBySpace.get(projectId) || [];
+    let maxTime = 0;
+    for (const t of threads) {
+      if (t.lastActivityAt) {
+        const time = new Date(t.lastActivityAt).getTime();
+        if (time > maxTime) maxTime = time;
+      }
+    }
+    return maxTime;
+  }
+
+  private getSortedThreads(projectId: string): ChatSpaceThread[] {
+    const threads = [...(this.threadsBySpace.get(projectId) || [])];
+
+    // Separate #general, pinned, and regular
+    const general = threads.filter((t) => t.isGeneral);
+    const pinned = threads.filter((t) => !t.isGeneral && t.pinned);
+    const regular = threads.filter((t) => !t.isGeneral && !t.pinned);
+
+    // Sort pinned and regular
+    const sortFn =
+      this.prefs.threadSortMode === 'alpha'
+        ? (a: ChatSpaceThread, b: ChatSpaceThread) => a.name.localeCompare(b.name)
+        : (a: ChatSpaceThread, b: ChatSpaceThread) => {
+            const aTime = a.lastActivityAt ? new Date(a.lastActivityAt).getTime() : 0;
+            const bTime = b.lastActivityAt ? new Date(b.lastActivityAt).getTime() : 0;
+            return bTime - aTime;
+          };
+
+    pinned.sort(sortFn);
+    regular.sort(sortFn);
+
+    return [...general, ...pinned, ...regular];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Actions
+  // ---------------------------------------------------------------------------
+
+  private handleThreadClick(thread: ChatSpaceThread, projectId: string): void {
+    this.dispatchEvent(
+      new CustomEvent<ThreadSelectDetail>('thread-select', {
+        detail: {
+          conversationKey: thread.id,
+          projectId,
+          threadName: thread.name,
+          defaultAgent: thread.defaultAgent || '',
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private handleSpaceHeaderClick(space: ChatSpace): void {
+    if (this.collapsedSpaces.has(space.projectId)) {
+      // Expanding — do nothing special
+      const newSet = new Set(this.collapsedSpaces);
+      newSet.delete(space.projectId);
+      this.collapsedSpaces = newSet;
+    } else {
+      // Collapsing
+      const newSet = new Set(this.collapsedSpaces);
+      newSet.add(space.projectId);
+      this.collapsedSpaces = newSet;
+    }
+  }
+
+  private handleCollapsedSpaceClick(space: ChatSpace): void {
+    // If collapsed, clicking opens #general
+    const threads = this.threadsBySpace.get(space.projectId) || [];
+    const general = threads.find((t) => t.isGeneral);
+    if (general) {
+      // Expand and select #general
+      const newSet = new Set(this.collapsedSpaces);
+      newSet.delete(space.projectId);
+      this.collapsedSpaces = newSet;
+      this.handleThreadClick(general, space.projectId);
+    }
+  }
+
+  private handleDMClick(dm: ChatDM): void {
+    this.dispatchEvent(
+      new CustomEvent<DMSelectDetail>('dm-select', {
+        detail: {
+          conversationKey: dm.conversationKey,
+          peerName: dm.peerName,
+          peerId: dm.peerId,
+          peerKind: dm.peerKind,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private handleContextMenu(e: MouseEvent, thread: ChatSpaceThread, projectId: string): void {
+    e.preventDefault();
+    e.stopPropagation();
+    this.contextMenuTarget = { type: 'thread', thread, projectId };
+    this.contextMenuPos = { x: e.clientX, y: e.clientY };
+  }
+
+  private async handleMarkRead(thread: ChatSpaceThread, projectId: string): Promise<void> {
+    this.contextMenuTarget = null;
+    try {
+      await apiFetch(`/api/v1/chat/conversations/${encodeURIComponent(thread.id)}/read`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      // Update locally
+      this.updateThread(projectId, thread.id, { hasUnread: false, hasUnreadMention: false });
+    } catch {
+      // Non-critical
+    }
+  }
+
+  private async handleMarkSpaceRead(projectId: string): Promise<void> {
+    this.contextMenuTarget = null;
+    try {
+      await apiFetch(`/api/v1/chat/spaces/${encodeURIComponent(projectId)}/read`, {
+        method: 'POST',
+      });
+      // Update all threads in this space locally
+      const threads = this.threadsBySpace.get(projectId) || [];
+      const newMap = new Map(this.threadsBySpace);
+      newMap.set(
+        projectId,
+        threads.map((t) => ({ ...t, hasUnread: false, hasUnreadMention: false }))
+      );
+      this.threadsBySpace = newMap;
+    } catch {
+      // Non-critical
+    }
+  }
+
+  private startRename(thread: ChatSpaceThread): void {
+    this.contextMenuTarget = null;
+    if (thread.isGeneral) return;
+    this.renamingThread = thread.id;
+    this.renameValue = thread.name;
+  }
+
+  private async submitRename(projectId: string): Promise<void> {
+    if (!this.renamingThread || !this.renameValue.trim()) {
+      this.renamingThread = null;
+      return;
+    }
+    try {
+      await apiFetch(`/api/v1/chat/threads/${encodeURIComponent(this.renamingThread)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: this.renameValue.trim() }),
+      });
+      this.updateThread(projectId, this.renamingThread, { name: this.renameValue.trim() });
+    } catch {
+      // Non-critical
+    }
+    this.renamingThread = null;
+  }
+
+  private async handleDeleteThread(thread: ChatSpaceThread, projectId: string): Promise<void> {
+    this.contextMenuTarget = null;
+    if (thread.isGeneral) return;
+    if (!confirm(`Delete #${thread.name}? This cannot be undone.`)) return;
+    try {
+      await apiFetch(`/api/v1/chat/threads/${encodeURIComponent(thread.id)}`, {
+        method: 'DELETE',
+      });
+      // Remove locally
+      const threads = this.threadsBySpace.get(projectId) || [];
+      const newMap = new Map(this.threadsBySpace);
+      newMap.set(
+        projectId,
+        threads.filter((t) => t.id !== thread.id)
+      );
+      this.threadsBySpace = newMap;
+    } catch {
+      // Non-critical
+    }
+  }
+
+  private startCreateThread(projectId: string): void {
+    this.creatingThread = projectId;
+    this.newThreadName = '';
+  }
+
+  private async submitCreateThread(projectId: string): Promise<void> {
+    if (!this.newThreadName.trim()) {
+      this.creatingThread = '';
+      return;
+    }
+    try {
+      const res = await apiFetch(`/api/v1/chat/spaces/${encodeURIComponent(projectId)}/threads`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: this.newThreadName.trim() }),
+      });
+      if (res.ok) {
+        await this.loadThreads(projectId);
+      }
+    } catch {
+      // Non-critical
+    }
+    this.creatingThread = '';
+  }
+
+  private updateThread(
+    projectId: string,
+    threadId: string,
+    update: Partial<ChatSpaceThread>
+  ): void {
+    const threads = this.threadsBySpace.get(projectId) || [];
+    const newMap = new Map(this.threadsBySpace);
+    newMap.set(
+      projectId,
+      threads.map((t) => (t.id === threadId ? { ...t, ...update } : t))
+    );
+    this.threadsBySpace = newMap;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Utility
+  // ---------------------------------------------------------------------------
+
+  private hashColor(str: string): string {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      hash = str.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    const hue = ((hash % 360) + 360) % 360;
+    return `hsl(${hue}, 55%, 48%)`;
+  }
+
+  private getInitials(name: string): string {
+    const parts = name.split(/[-_\s]+/).filter(Boolean);
+    if (parts.length >= 2) {
+      return (parts[0][0] + parts[1][0]).toUpperCase();
+    }
+    return (name.slice(0, 2) || '?').toUpperCase();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  override render() {
+    return html`
+      <div class="rail-header">
+        <span>Chat</span>
+        <a
+          href="/"
+          @click=${(e: Event) => {
+            e.preventDefault();
+            this.dispatchEvent(new CustomEvent('navigate-app', { bubbles: true, composed: true }));
+          }}
+        >
+          <sl-icon name="arrow-left"></sl-icon>
+          App
+        </a>
+      </div>
+
+      ${this.loading
+        ? html`<div class="loading-state"><sl-spinner></sl-spinner></div>`
+        : html` <div class="rail-body">${this.renderSpaces()} ${this.renderDMs()}</div> `}
+      ${this.contextMenuTarget ? this.renderContextMenu() : nothing}
+    `;
+  }
+
+  private renderSpaces() {
+    const sorted = this.getSortedSpaces();
+    if (sorted.length === 0) {
+      return html`<div class="loading-state" style="font-size: 0.8125rem">
+        No spaces available
+      </div>`;
+    }
+    return sorted.map((space) => this.renderSpace(space));
+  }
+
+  private renderSpace(space: ChatSpace) {
+    const isCollapsed = this.collapsedSpaces.has(space.projectId);
+    const threads = this.getSortedThreads(space.projectId);
+
+    return html`
+      <div class="space-section">
+        <div
+          class="space-header"
+          @click=${() =>
+            isCollapsed
+              ? this.handleCollapsedSpaceClick(space)
+              : this.handleSpaceHeaderClick(space)}
+        >
+          <sl-icon name="chevron-down" class="chevron ${isCollapsed ? 'collapsed' : ''}"></sl-icon>
+          <span class="space-name">${space.projectName}</span>
+          <div class="space-actions">
+            ${space.hasUnreadMention
+              ? html`<span class="mention-badge">@</span>`
+              : space.unreadCount > 0
+                ? html`<span class="unread-badge">${space.unreadCount}</span>`
+                : nothing}
+            <sl-icon-button
+              name="plus-lg"
+              label="Create thread"
+              @click=${(e: Event) => {
+                e.stopPropagation();
+                this.startCreateThread(space.projectId);
+              }}
+            ></sl-icon-button>
+          </div>
+        </div>
+        ${!isCollapsed
+          ? html`
+              <div class="thread-list">
+                ${threads.map((t) => this.renderThread(t, space.projectId))}
+                ${this.creatingThread === space.projectId
+                  ? this.renderCreateThread(space.projectId)
+                  : nothing}
+              </div>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderThread(thread: ChatSpaceThread, projectId: string) {
+    const isSelected = thread.id === this.selectedKey;
+
+    if (this.renamingThread === thread.id) {
+      return html`
+        <div class="thread-item">
+          <span class="hash">#</span>
+          <sl-input
+            class="rename-input"
+            size="small"
+            .value=${this.renameValue}
+            @sl-input=${(e: Event) => {
+              this.renameValue = (e.target as HTMLInputElement).value;
+            }}
+            @keydown=${(e: KeyboardEvent) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                void this.submitRename(projectId);
+              }
+              if (e.key === 'Escape') {
+                this.renamingThread = null;
+              }
+            }}
+            @sl-blur=${() => void this.submitRename(projectId)}
+          ></sl-input>
+        </div>
+      `;
+    }
+
+    return html`
+      <div
+        class="thread-item ${isSelected ? 'selected' : ''}"
+        @click=${() => this.handleThreadClick(thread, projectId)}
+        @contextmenu=${(e: MouseEvent) => this.handleContextMenu(e, thread, projectId)}
+      >
+        <span class="hash">#</span>
+        <span class="thread-name ${thread.hasUnread ? 'unread' : ''}">${thread.name}</span>
+        ${thread.pinned ? html`<sl-icon name="star-fill" class="pin-icon"></sl-icon>` : nothing}
+        ${thread.hasUnreadMention
+          ? html`<span class="mention-dot"></span>`
+          : thread.hasUnread
+            ? html`<span class="unread-dot"></span>`
+            : nothing}
+      </div>
+    `;
+  }
+
+  private renderCreateThread(projectId: string) {
+    return html`
+      <div class="create-thread">
+        <span class="hash" style="color: var(--scion-text-muted)">#</span>
+        <sl-input
+          size="small"
+          placeholder="thread-name"
+          .value=${this.newThreadName}
+          @sl-input=${(e: Event) => {
+            this.newThreadName = (e.target as HTMLInputElement).value;
+          }}
+          @keydown=${(e: KeyboardEvent) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              void this.submitCreateThread(projectId);
+            }
+            if (e.key === 'Escape') {
+              this.creatingThread = '';
+            }
+          }}
+          @sl-blur=${() => {
+            if (!this.newThreadName.trim()) this.creatingThread = '';
+          }}
+          style="flex: 1"
+        ></sl-input>
+      </div>
+    `;
+  }
+
+  private renderDMs() {
+    if (this.dms.length === 0) return nothing;
+
+    return html`
+      <div class="dm-section">
+        <div
+          class="space-header"
+          @click=${() => {
+            this.dmSectionCollapsed = !this.dmSectionCollapsed;
+          }}
+        >
+          <sl-icon
+            name="chevron-down"
+            class="chevron ${this.dmSectionCollapsed ? 'collapsed' : ''}"
+          ></sl-icon>
+          <span class="space-name">Direct Messages</span>
+        </div>
+        ${!this.dmSectionCollapsed ? this.dms.map((dm) => this.renderDM(dm)) : nothing}
+      </div>
+    `;
+  }
+
+  private renderDM(dm: ChatDM) {
+    const isSelected = dm.conversationKey === this.selectedKey;
+    const avatarColor = this.hashColor(dm.peerId);
+    const initials = this.getInitials(dm.peerName);
+    const icon = dm.peerKind === 'agent' ? 'cpu' : 'person';
+
+    return html`
+      <div class="dm-item ${isSelected ? 'selected' : ''}" @click=${() => this.handleDMClick(dm)}>
+        <div class="dm-avatar" style="background: ${avatarColor}">${initials}</div>
+        <div class="dm-info">
+          <span class="dm-name ${dm.hasUnread ? 'unread' : ''}">
+            <sl-icon name="${icon}" style="font-size: 0.6875rem; vertical-align: -1px"></sl-icon>
+            ${dm.peerName}
+          </span>
+        </div>
+        ${dm.hasUnread
+          ? html`<span
+              class="unread-dot"
+              style="width: 6px; height: 6px; border-radius: 50%; background: var(--scion-primary, #3b82f6); flex-shrink: 0;"
+            ></span>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderContextMenu() {
+    if (!this.contextMenuTarget) return nothing;
+    const { thread, projectId } = this.contextMenuTarget;
+
+    return html`
+      <div
+        class="context-menu"
+        style="left: ${this.contextMenuPos.x}px; top: ${this.contextMenuPos.y}px"
+        @click=${(e: Event) => e.stopPropagation()}
+      >
+        <div class="context-menu-item" @click=${() => this.handleMarkRead(thread, projectId)}>
+          <sl-icon name="check-circle"></sl-icon>
+          Mark as read
+        </div>
+        <div class="context-menu-item" @click=${() => this.handleMarkSpaceRead(projectId)}>
+          <sl-icon name="check-lg"></sl-icon>
+          Mark space read
+        </div>
+        ${!thread.isGeneral
+          ? html`
+              <div class="context-menu-item" @click=${() => this.startRename(thread)}>
+                <sl-icon name="pencil"></sl-icon>
+                Rename
+              </div>
+              <div
+                class="context-menu-item danger"
+                @click=${() => this.handleDeleteThread(thread, projectId)}
+              >
+                <sl-icon name="trash"></sl-icon>
+                Delete
+              </div>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-chat-space-rail': ScionChatSpaceRail;
+  }
+}

--- a/web/src/components/shared/chat/chat-system-line.ts
+++ b/web/src/components/shared/chat/chat-system-line.ts
@@ -77,13 +77,9 @@ export class ScionChatSystemLine extends LitElement {
 
     return html`
       <div class="system-line">
-        ${iconName
-          ? html`<sl-icon name=${iconName}></sl-icon>`
-          : null}
+        ${iconName ? html`<sl-icon name=${iconName}></sl-icon>` : null}
         <span class="system-text">${this.message}</span>
-        ${timeStr
-          ? html`<span class="system-time">${timeStr}</span>`
-          : null}
+        ${timeStr ? html`<span class="system-time">${timeStr}</span>` : null}
       </div>
     `;
   }

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -353,6 +353,59 @@ export class ScionChatThread extends LitElement {
     }
   `;
 
+  /** Auto-trigger loadHistory when the component first renders in v2 mode. */
+  override firstUpdated(): void {
+    if (this.isV2) {
+      this.loadHistory();
+    }
+  }
+
+  /**
+   * Detect conversationKey changes for v2 mode.
+   * When the user switches threads/DMs, the same component instance gets a
+   * new conversationKey — we must tear down old state and reload.
+   */
+  override updated(changedProperties: Map<string, unknown>): void {
+    if (
+      changedProperties.has('conversationKey') &&
+      changedProperties.get('conversationKey') !== undefined
+    ) {
+      const oldKey = changedProperties.get('conversationKey') as string;
+      if (oldKey !== this.conversationKey && this.isV2) {
+        this.resetV2State();
+        this.loadHistory();
+      }
+    }
+  }
+
+  /** Tear down v2 state so a fresh load can happen. */
+  private resetV2State(): void {
+    // Stop any active SSE listener
+    stateManager.removeEventListener('chat-message-received', this._v2MessageHandler);
+    this.streaming = false;
+
+    // Clear message state
+    this.messageMap.clear();
+    this.messages = [];
+    this.nextCursor = null;
+    this.lastKnownTimestamp = null;
+    this.hasOlderMessages = true;
+    this.loaded = false;
+    this.error = null;
+    this.sendError = null;
+    this.pinnedToBottom = true;
+    this.loadingOlder = false;
+
+    // Clear read tracking timer
+    if (this._readDebounceTimer) {
+      clearTimeout(this._readDebounceTimer);
+      this._readDebounceTimer = null;
+    }
+
+    // Increment fetchId to invalidate any in-flight requests
+    this.fetchId++;
+  }
+
   override disconnectedCallback(): void {
     super.disconnectedCallback();
     this.stopStream();
@@ -739,10 +792,19 @@ export class ScionChatThread extends LitElement {
     this.streaming = true;
   }
 
-  /** Handle v2 SSE chat message events. Backfill from REST to get the actual message. */
-  private handleV2ChatMessage(): void {
-    // The stateManager event doesn't include the full message payload for a specific
-    // conversation, so we backfill from REST to pick up new messages.
+  /** Handle v2 SSE chat message events. Only backfill if the event is for this conversation. */
+  private handleV2ChatMessage(e: Event): void {
+    const detail = (e as CustomEvent).detail as {
+      data?: { threadId?: string; conversationKey?: string; topicId?: string };
+    };
+    const eventData = detail?.data;
+    if (eventData) {
+      // Filter: only process events for this conversation
+      const eventKey = eventData.threadId || eventData.conversationKey || eventData.topicId || '';
+      if (eventKey && eventKey !== this.conversationKey) {
+        return; // Not for this conversation
+      }
+    }
     void this.backfillV2();
   }
 

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -42,6 +42,7 @@ import { apiFetch, extractApiError } from '../../../client/api.js';
 import type { Agent, Message } from '../../../shared/types.js';
 import type { ChatSendDetail } from './chat-composer.js';
 import type { VisibilityMode, VisibilityChangeDetail } from './chat-visibility-toggle.js';
+import { stateManager } from '../../../client/main.js';
 import './chat-message.js';
 import './chat-system-line.js';
 import './chat-composer.js';
@@ -94,6 +95,50 @@ export class ScionChatThread extends LitElement {
   @property({ type: Array })
   agents: Agent[] = [];
 
+  // ---- Wave-2 v2 properties ----
+
+  /**
+   * Conversation key for v2 mode (topic UUID or DM key).
+   * When set, the component uses v2 conversation endpoints and SSE.
+   */
+  @property()
+  conversationKey = '';
+
+  /** The project ID this conversation belongs to (for v2 mode). */
+  @property()
+  projectId = '';
+
+  /** Thread name for display (v2 mode). */
+  @property()
+  threadName = '';
+
+  /** Default agent slug for this thread (v2 mode). */
+  @property()
+  defaultAgent = '';
+
+  /** Whether this is a DM conversation (v2 mode). */
+  @property({ type: Boolean })
+  isDM = false;
+
+  /** DM peer name (v2 mode). */
+  @property()
+  peerName = '';
+
+  /** Members available for @-mention in v2 mode. */
+  @property({ type: Array })
+  members: Array<{
+    id: string;
+    name: string;
+    email: string;
+    avatarUrl?: string;
+    kind: 'user' | 'agent';
+  }> = [];
+
+  /** Whether v2 mode is active. Derived from conversationKey presence. */
+  private get isV2(): boolean {
+    return this.conversationKey.length > 0;
+  }
+
   @state() private messages: Message[] = [];
   @state() private messageMap = new Map<string, Message>();
   @state() private loading = false;
@@ -113,6 +158,24 @@ export class ScionChatThread extends LitElement {
   private lastKnownTimestamp: string | null = null;
   private hadError = false;
   private fetchId = 0;
+
+  /** Bound listener for v2 SSE chat-message events via stateManager. */
+  private _v2MessageHandler = this.handleV2ChatMessage.bind(this);
+
+  /** Read tracking: debounce timer for advancing watermark. */
+  private _readDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Read tracking: whether the tab is focused. */
+  private _tabFocused = true;
+
+  /** Focus/blur handlers for read tracking. */
+  private _focusHandler = () => {
+    this._tabFocused = true;
+    this.maybeAdvanceReadWatermark();
+  };
+  private _blurHandler = () => {
+    this._tabFocused = false;
+  };
 
   static override styles = css`
     :host {
@@ -156,8 +219,13 @@ export class ScionChatThread extends LitElement {
     }
 
     @keyframes pulse {
-      0%, 100% { opacity: 1; }
-      50% { opacity: 0.3; }
+      0%,
+      100% {
+        opacity: 1;
+      }
+      50% {
+        opacity: 0.3;
+      }
     }
 
     /* Message scroll area */
@@ -288,13 +356,26 @@ export class ScionChatThread extends LitElement {
   override disconnectedCallback(): void {
     super.disconnectedCallback();
     this.stopStream();
+    // Clean up v2 SSE listener
+    stateManager.removeEventListener('chat-message-received', this._v2MessageHandler);
+    // Clean up read tracking
+    window.removeEventListener('focus', this._focusHandler);
+    window.removeEventListener('blur', this._blurHandler);
+    if (this._readDebounceTimer) {
+      clearTimeout(this._readDebounceTimer);
+      this._readDebounceTimer = null;
+    }
   }
 
   /** Called by the parent when the chat view is first shown. */
   loadHistory(): void {
     if (this.loaded) return;
     this.loaded = true;
-    void this.loadPrefsAndHistory();
+    if (this.isV2) {
+      void this.initialLoadV2();
+    } else {
+      void this.loadPrefsAndHistory();
+    }
   }
 
   /** Load saved preferences first, then fetch history. */
@@ -310,7 +391,10 @@ export class ScionChatThread extends LitElement {
       const res = await apiFetch(`/api/v1/chat/prefs?agentId=${encodeURIComponent(this.agentId)}`);
       if (res.ok) {
         const data = (await res.json()) as { visibility_mode?: string };
-        if (data.visibility_mode && ['conversation', 'verbose', 'full'].includes(data.visibility_mode)) {
+        if (
+          data.visibility_mode &&
+          ['conversation', 'verbose', 'full'].includes(data.visibility_mode)
+        ) {
           this.visibilityMode = data.visibility_mode as VisibilityMode;
         }
       }
@@ -374,11 +458,36 @@ export class ScionChatThread extends LitElement {
     }
   }
 
+  /** Check if a message sender is an agent (v2 multi-sender). */
+  private isSenderAgent(msg: Message): boolean {
+    // Agent messages have sender like "agent:slug" or recipient patterns
+    if (msg.sender.startsWith('agent:')) return true;
+    // Check against known members
+    const member = this.members.find((m) => m.id === msg.senderId || m.email === msg.sender);
+    if (member) return member.kind === 'agent';
+    // If sender is not in the current user's perspective, check the type
+    return msg.type === 'assistant-reply' || msg.type === 'mention-reply';
+  }
+
+  /** Get display name for a message sender (v2 multi-sender). */
+  private getSenderDisplayName(msg: Message): string {
+    const member = this.members.find((m) => m.id === msg.senderId || m.email === msg.sender);
+    if (member) return member.name;
+    // Fall back to parsing the sender string
+    if (msg.sender.startsWith('agent:')) return msg.sender.slice(6);
+    if (msg.sender.startsWith('user:')) return msg.sender.slice(5);
+    return msg.sender;
+  }
+
   /** Stop the SSE stream. Called on tab hide / disconnect. */
   stopStream(): void {
     if (this.eventSource) {
       this.eventSource.close();
       this.eventSource = null;
+    }
+    // Also clean up v2 SSE listener
+    if (this.isV2) {
+      stateManager.removeEventListener('chat-message-received', this._v2MessageHandler);
     }
     this.streaming = false;
   }
@@ -537,11 +646,11 @@ export class ScionChatThread extends LitElement {
 
     this.eventSource.addEventListener('message', (event: Event) => {
       try {
-        const msg = JSON.parse((event as MessageEvent).data) as Message;
+        const msg = JSON.parse((event as MessageEvent).data as string) as Message;
         const wasPinned = this.pinnedToBottom;
         this.mergeMessages([msg]);
         if (wasPinned) {
-          this.updateComplete.then(() => this.scrollToBottom());
+          void this.updateComplete.then(() => this.scrollToBottom());
         }
       } catch {
         // Skip unparseable entries
@@ -568,6 +677,212 @@ export class ScionChatThread extends LitElement {
   }
 
   // ---------------------------------------------------------------------------
+  // V2 mode: conversation-key-based loading + stateManager SSE
+  // ---------------------------------------------------------------------------
+
+  private async initialLoadV2(): Promise<void> {
+    this.loading = true;
+    this.error = null;
+
+    try {
+      await this.fetchHistoryV2();
+      this.startStreamV2();
+      // Set up read tracking
+      window.addEventListener('focus', this._focusHandler);
+      window.addEventListener('blur', this._blurHandler);
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to load messages';
+    } finally {
+      this.loading = false;
+      this.scrollToBottom();
+    }
+  }
+
+  private async fetchHistoryV2(cursor?: string): Promise<void> {
+    const currentId = this.fetchId;
+    const params = new URLSearchParams({ limit: String(HISTORY_PAGE_SIZE) });
+    if (cursor) {
+      params.set('cursor', cursor);
+    }
+
+    const res = await apiFetch(
+      `/api/v1/chat/conversations/${encodeURIComponent(this.conversationKey)}/messages?${params.toString()}`
+    );
+
+    if (currentId !== this.fetchId) return;
+
+    if (!res.ok) {
+      throw new Error(await extractApiError(res, 'Failed to fetch messages'));
+    }
+
+    const data = (await res.json()) as {
+      items?: Message[];
+      nextCursor?: string;
+    };
+
+    const items = data?.items ?? [];
+
+    if (items.length < HISTORY_PAGE_SIZE) {
+      this.hasOlderMessages = false;
+    }
+
+    if (data?.nextCursor) {
+      this.nextCursor = data.nextCursor;
+    }
+
+    this.mergeMessages(items);
+  }
+
+  /** Start listening for v2 messages via stateManager instead of per-thread EventSource. */
+  private startStreamV2(): void {
+    stateManager.addEventListener('chat-message-received', this._v2MessageHandler);
+    this.streaming = true;
+  }
+
+  /** Handle v2 SSE chat message events. Backfill from REST to get the actual message. */
+  private handleV2ChatMessage(): void {
+    // The stateManager event doesn't include the full message payload for a specific
+    // conversation, so we backfill from REST to pick up new messages.
+    void this.backfillV2();
+  }
+
+  private async backfillV2(): Promise<void> {
+    if (!this.conversationKey) return;
+    const currentId = this.fetchId;
+    const params = new URLSearchParams({
+      limit: String(HISTORY_PAGE_SIZE),
+    });
+
+    const res = await apiFetch(
+      `/api/v1/chat/conversations/${encodeURIComponent(this.conversationKey)}/messages?${params.toString()}`
+    );
+
+    if (currentId !== this.fetchId) return;
+    if (!res.ok) return;
+
+    const data = (await res.json()) as { items?: Message[] };
+    const items = data?.items ?? [];
+    const wasPinned = this.pinnedToBottom;
+    this.mergeMessages(items);
+    if (wasPinned) {
+      void this.updateComplete.then(() => this.scrollToBottom());
+    }
+    // Advance read watermark if applicable
+    this.maybeAdvanceReadWatermark();
+  }
+
+  /** Send a message in v2 mode. */
+  private async handleChatSendV2(e: CustomEvent<ChatSendDetail>): Promise<void> {
+    const { text, plain, mentions, onSuccess } = e.detail;
+    if (!text || this.sending) return;
+
+    // Check for /default slash command
+    if (text.startsWith('/default ')) {
+      await this.handleDefaultCommand(text);
+      onSuccess();
+      return;
+    }
+
+    this.sending = true;
+    this.sendError = null;
+
+    try {
+      const body: Record<string, unknown> = {
+        structured_message: { msg: text, plain },
+      };
+      if (mentions && mentions.length > 0) {
+        body.mentions = mentions;
+      }
+
+      const res = await apiFetch(
+        `/api/v1/chat/conversations/${encodeURIComponent(this.conversationKey)}/messages`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        }
+      );
+
+      if (!res.ok) {
+        this.sendError = await extractApiError(res, 'Failed to send message');
+      } else {
+        onSuccess();
+        // Backfill to pick up the message immediately
+        void this.backfillV2();
+      }
+    } catch (err) {
+      this.sendError = err instanceof Error ? err.message : 'Failed to send message';
+    } finally {
+      this.sending = false;
+    }
+  }
+
+  /** Handle /default slash command. */
+  private async handleDefaultCommand(text: string): Promise<void> {
+    const arg = text.slice('/default '.length).trim();
+    if (!this.conversationKey || this.isDM) return;
+
+    try {
+      const body: Record<string, unknown> = {};
+      if (arg === 'clear') {
+        body.default_agent = null;
+      } else {
+        body.default_agent = arg;
+      }
+      const res = await apiFetch(
+        `/api/v1/chat/threads/${encodeURIComponent(this.conversationKey)}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        }
+      );
+      if (res.ok) {
+        this.defaultAgent = arg === 'clear' ? '' : arg;
+        this.dispatchEvent(
+          new CustomEvent('default-agent-changed', {
+            detail: { defaultAgent: this.defaultAgent },
+            bubbles: true,
+            composed: true,
+          })
+        );
+      }
+    } catch {
+      // Non-critical
+    }
+  }
+
+  /** Advance the read watermark if conditions are met. */
+  private maybeAdvanceReadWatermark(): void {
+    if (!this.isV2 || !this._tabFocused || !this.pinnedToBottom) return;
+    if (this.messages.length === 0) return;
+
+    // Debounce
+    if (this._readDebounceTimer) clearTimeout(this._readDebounceTimer);
+    this._readDebounceTimer = setTimeout(() => {
+      const lastMsg = this.messages[this.messages.length - 1];
+      if (lastMsg) {
+        void this.advanceReadWatermark(lastMsg.id);
+      }
+    }, 1000);
+  }
+
+  private async advanceReadWatermark(messageId: string): Promise<void> {
+    try {
+      await apiFetch(
+        `/api/v1/chat/conversations/${encodeURIComponent(this.conversationKey)}/read`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ last_read_message_id: messageId }),
+        }
+      );
+    } catch {
+      // Non-critical
+    }
+  }
+
+  // ---------------------------------------------------------------------------
   // Scroll handling
   // ---------------------------------------------------------------------------
 
@@ -583,7 +898,16 @@ export class ScionChatThread extends LitElement {
       this.hasOlderMessages &&
       this.nextCursor
     ) {
-      void this.loadOlderMessages(el);
+      if (this.isV2) {
+        void this.loadOlderMessagesV2(el);
+      } else {
+        void this.loadOlderMessages(el);
+      }
+    }
+
+    // Advance read watermark in v2 mode
+    if (this.pinnedToBottom) {
+      this.maybeAdvanceReadWatermark();
     }
   }
 
@@ -598,6 +922,22 @@ export class ScionChatThread extends LitElement {
     } finally {
       this.loadingOlder = false;
       // Preserve scroll position after prepending
+      await this.updateComplete;
+      const newScrollHeight = scrollEl.scrollHeight;
+      scrollEl.scrollTop += newScrollHeight - prevScrollHeight;
+    }
+  }
+
+  private async loadOlderMessagesV2(scrollEl: HTMLElement): Promise<void> {
+    this.loadingOlder = true;
+    const prevScrollHeight = scrollEl.scrollHeight;
+
+    try {
+      await this.fetchHistoryV2(this.nextCursor || undefined);
+    } catch {
+      // Silently fail for older messages
+    } finally {
+      this.loadingOlder = false;
       await this.updateComplete;
       const newScrollHeight = scrollEl.scrollHeight;
       scrollEl.scrollTop += newScrollHeight - prevScrollHeight;
@@ -679,13 +1019,13 @@ export class ScionChatThread extends LitElement {
   // ---------------------------------------------------------------------------
 
   override render() {
+    if (this.isV2) {
+      return this.renderV2();
+    }
     return html`
       <div class="thread-container">
-        ${this.renderStreamBar()}
-        ${this.renderContent()}
-        ${this.sendError
-          ? html`<div class="send-error">${this.sendError}</div>`
-          : nothing}
+        ${this.renderStreamBar()} ${this.renderContent()}
+        ${this.sendError ? html`<div class="send-error">${this.sendError}</div>` : nothing}
         ${this.canSend
           ? html`
               <scion-chat-composer
@@ -699,15 +1039,31 @@ export class ScionChatThread extends LitElement {
     `;
   }
 
+  private renderV2() {
+    return html`
+      <div class="thread-container">
+        ${this.renderStreamBar()} ${this.renderContent()}
+        ${this.sendError ? html`<div class="send-error">${this.sendError}</div>` : nothing}
+        <scion-chat-composer
+          ?disabled=${this.sending}
+          .agents=${this.agents}
+          .members=${this.members}
+          .defaultAgent=${this.defaultAgent}
+          .conversationMode=${this.isDM ? 'dm' : 'thread'}
+          .peerName=${this.peerName}
+          @chat-send=${this.handleChatSendV2}
+        ></scion-chat-composer>
+      </div>
+    `;
+  }
+
   private renderStreamBar() {
     // Show the bar when streaming OR when the toggle is visible (they share the row).
     if (!this.streaming && !this.showVisibilityToggle) return nothing;
     return html`
       <div class="stream-bar">
         <span class="stream-indicator">
-          ${this.streaming
-            ? html`<span class="stream-dot"></span> Live`
-            : nothing}
+          ${this.streaming ? html`<span class="stream-dot"></span> Live` : nothing}
         </span>
         ${this.showVisibilityToggle
           ? html`
@@ -736,7 +1092,13 @@ export class ScionChatThread extends LitElement {
         <div class="state-msg">
           <sl-icon name="exclamation-triangle"></sl-icon>
           <span>${this.error}</span>
-          <sl-button size="small" @click=${() => { this.loaded = false; this.loadHistory(); }}>
+          <sl-button
+            size="small"
+            @click=${() => {
+              this.loaded = false;
+              this.loadHistory();
+            }}
+          >
             Retry
           </sl-button>
         </div>
@@ -824,15 +1186,22 @@ export class ScionChatThread extends LitElement {
       const withinWindow = msgTime - prevTimestamp < GROUP_WINDOW_MS;
       const showHeader = !sameSender || !withinWindow;
 
-      const isFromAgent = msg.senderId === this.agentId;
+      // In v2 mode, determine if from agent by checking sender against known members
+      const isFromAgent = this.isV2 ? this.isSenderAgent(msg) : msg.senderId === this.agentId;
+      const senderDisplayName = this.isV2
+        ? this.getSenderDisplayName(msg)
+        : isFromAgent
+          ? this.agentName || ''
+          : '';
 
       rows.push(html`
         <scion-chat-message
           body=${msg.msg}
           sender=${msg.sender}
+          senderName=${senderDisplayName}
           ?fromAgent=${isFromAgent}
           ?plain=${msg.plain ?? false}
-          agentSlug=${isFromAgent ? (this.agentName || '') : ''}
+          agentSlug=${isFromAgent ? senderDisplayName : ''}
           timestamp=${msg.createdAt}
           ?showHeader=${showHeader}
           ?urgent=${msg.urgent ?? false}
@@ -851,15 +1220,11 @@ export class ScionChatThread extends LitElement {
       if (msgMentionResults) {
         const delivered = msgMentionResults.filter((r) => r.status === 'delivered');
         if (delivered.length > 0) {
-          const slugs = delivered.map(
-            (r) => html`<span class="mention-slug">@${r.slug}</span>`
-          );
+          const slugs = delivered.map((r) => html`<span class="mention-slug">@${r.slug}</span>`);
           rows.push(html`
             <div class="mention-results">
-              Also notified: ${slugs.reduce(
-                (acc, s, i) => (i === 0 ? [s] : [...acc, ', ', s]),
-                [] as unknown[]
-              )}
+              Also notified:
+              ${slugs.reduce((acc, s, i) => (i === 0 ? [s] : [...acc, ', ', s]), [] as unknown[])}
             </div>
           `);
         }
@@ -871,7 +1236,6 @@ export class ScionChatThread extends LitElement {
 
     return rows;
   }
-
 }
 
 declare global {

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -73,6 +73,12 @@ const GROUP_WINDOW_MS = 5 * 60 * 1000;
 /** System/state-change message types. */
 const SYSTEM_MESSAGE_TYPES = new Set(['state-change', 'system']);
 
+/** Typing indicator expiry in ms. */
+const TYPING_EXPIRY_MS = 6000;
+
+/** Typing send throttle in ms. */
+const TYPING_SEND_THROTTLE_MS = 4000;
+
 @customElement('scion-chat-thread')
 export class ScionChatThread extends LitElement {
   @property()
@@ -161,6 +167,23 @@ export class ScionChatThread extends LitElement {
 
   /** Bound listener for v2 SSE chat-message events via stateManager. */
   private _v2MessageHandler = this.handleV2ChatMessage.bind(this);
+
+  /** Bound listener for v2 SSE typing events via stateManager. */
+  private _v2TypingHandler = this.handleV2TypingEvent.bind(this);
+
+  // ---- Typing indicator state ----
+
+  /** Map of userId -> { displayName, timer } for active typing indicators. */
+  @state() private typingUsers = new Map<
+    string,
+    { displayName: string; timer: ReturnType<typeof setTimeout> }
+  >();
+
+  /** Last time we sent a typing event (for client-side throttle). */
+  private _lastTypingSent = 0;
+
+  /** Current user ID (derived from stateManager scope). */
+  private _currentUserId = '';
 
   /** Read tracking: debounce timer for advancing watermark. */
   private _readDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -351,6 +374,52 @@ export class ScionChatThread extends LitElement {
     .mention-results .mention-slug {
       font-weight: 600;
     }
+
+    /* Typing indicator */
+    .typing-indicator {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 16px;
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+      min-height: 20px;
+    }
+
+    .typing-dots {
+      display: inline-flex;
+      gap: 2px;
+      align-items: center;
+    }
+
+    .typing-dots span {
+      width: 4px;
+      height: 4px;
+      border-radius: 50%;
+      background: var(--scion-text-muted, #64748b);
+      animation: typing-bounce 1.4s ease-in-out infinite;
+    }
+
+    .typing-dots span:nth-child(2) {
+      animation-delay: 0.2s;
+    }
+
+    .typing-dots span:nth-child(3) {
+      animation-delay: 0.4s;
+    }
+
+    @keyframes typing-bounce {
+      0%,
+      60%,
+      100% {
+        transform: translateY(0);
+        opacity: 0.4;
+      }
+      30% {
+        transform: translateY(-3px);
+        opacity: 1;
+      }
+    }
   `;
 
   /** Auto-trigger loadHistory when the component first renders in v2 mode. */
@@ -382,6 +451,7 @@ export class ScionChatThread extends LitElement {
   private resetV2State(): void {
     // Stop any active SSE listener
     stateManager.removeEventListener('chat-message-received', this._v2MessageHandler);
+    stateManager.removeEventListener('chat-typing-received', this._v2TypingHandler);
     this.streaming = false;
 
     // Clear message state
@@ -396,6 +466,12 @@ export class ScionChatThread extends LitElement {
     this.pinnedToBottom = true;
     this.loadingOlder = false;
 
+    // Clear typing state
+    for (const entry of this.typingUsers.values()) {
+      clearTimeout(entry.timer);
+    }
+    this.typingUsers = new Map();
+
     // Clear read tracking timer
     if (this._readDebounceTimer) {
       clearTimeout(this._readDebounceTimer);
@@ -409,8 +485,13 @@ export class ScionChatThread extends LitElement {
   override disconnectedCallback(): void {
     super.disconnectedCallback();
     this.stopStream();
-    // Clean up v2 SSE listener
+    // Clean up v2 SSE listeners
     stateManager.removeEventListener('chat-message-received', this._v2MessageHandler);
+    stateManager.removeEventListener('chat-typing-received', this._v2TypingHandler);
+    // Clean up typing timers
+    for (const entry of this.typingUsers.values()) {
+      clearTimeout(entry.timer);
+    }
     // Clean up read tracking
     window.removeEventListener('focus', this._focusHandler);
     window.removeEventListener('blur', this._blurHandler);
@@ -538,9 +619,10 @@ export class ScionChatThread extends LitElement {
       this.eventSource.close();
       this.eventSource = null;
     }
-    // Also clean up v2 SSE listener
+    // Also clean up v2 SSE listeners
     if (this.isV2) {
       stateManager.removeEventListener('chat-message-received', this._v2MessageHandler);
+      stateManager.removeEventListener('chat-typing-received', this._v2TypingHandler);
     }
     this.streaming = false;
   }
@@ -789,6 +871,12 @@ export class ScionChatThread extends LitElement {
   /** Start listening for v2 messages via stateManager instead of per-thread EventSource. */
   private startStreamV2(): void {
     stateManager.addEventListener('chat-message-received', this._v2MessageHandler);
+    stateManager.addEventListener('chat-typing-received', this._v2TypingHandler);
+    // Capture current user ID from the stateManager scope for typing self-filter.
+    const scope = stateManager.currentScope;
+    if (scope && scope.type === 'chat') {
+      this._currentUserId = scope.userId;
+    }
     this.streaming = true;
   }
 
@@ -806,6 +894,56 @@ export class ScionChatThread extends LitElement {
       }
     }
     void this.backfillV2();
+  }
+
+  /** Handle v2 SSE typing events. Only show for this conversation, and skip self. */
+  private handleV2TypingEvent(e: Event): void {
+    const detail = (e as CustomEvent).detail as {
+      data?: { threadId?: string; userId?: string; displayName?: string };
+    };
+    const eventData = detail?.data || (detail as Record<string, unknown>);
+    const threadId = (eventData as Record<string, unknown>).threadId as string | undefined;
+    const userId = (eventData as Record<string, unknown>).userId as string | undefined;
+    const displayName = (eventData as Record<string, unknown>).displayName as string | undefined;
+
+    if (!threadId || !userId || !displayName) return;
+
+    // Only show for this conversation
+    if (threadId !== this.conversationKey) return;
+
+    // Don't show own typing indicator
+    if (userId === this._currentUserId) return;
+
+    // Clear existing timer for this user if any
+    const existing = this.typingUsers.get(userId);
+    if (existing) {
+      clearTimeout(existing.timer);
+    }
+
+    // Set a new timer to expire the typing indicator
+    const timer = setTimeout(() => {
+      const updated = new Map(this.typingUsers);
+      updated.delete(userId);
+      this.typingUsers = updated;
+    }, TYPING_EXPIRY_MS);
+
+    const updated = new Map(this.typingUsers);
+    updated.set(userId, { displayName, timer });
+    this.typingUsers = updated;
+  }
+
+  /** Send a typing event to the server (client-throttled to once per 4s). */
+  private sendTypingEvent(): void {
+    if (!this.isV2 || !this.conversationKey) return;
+
+    const now = Date.now();
+    if (now - this._lastTypingSent < TYPING_SEND_THROTTLE_MS) return;
+    this._lastTypingSent = now;
+
+    // Fire and forget — typing is ephemeral, errors are acceptable
+    void apiFetch(`/api/v1/chat/conversations/${encodeURIComponent(this.conversationKey)}/typing`, {
+      method: 'POST',
+    });
   }
 
   private async backfillV2(): Promise<void> {
@@ -1104,7 +1242,7 @@ export class ScionChatThread extends LitElement {
   private renderV2() {
     return html`
       <div class="thread-container">
-        ${this.renderStreamBar()} ${this.renderContent()}
+        ${this.renderStreamBar()} ${this.renderContent()} ${this.renderTypingIndicator()}
         ${this.sendError ? html`<div class="send-error">${this.sendError}</div>` : nothing}
         <scion-chat-composer
           ?disabled=${this.sending}
@@ -1114,7 +1252,30 @@ export class ScionChatThread extends LitElement {
           .conversationMode=${this.isDM ? 'dm' : 'thread'}
           .peerName=${this.peerName}
           @chat-send=${this.handleChatSendV2}
+          @chat-typing=${() => this.sendTypingEvent()}
         ></scion-chat-composer>
+      </div>
+    `;
+  }
+
+  /** Render the typing indicator below messages, above the composer. */
+  private renderTypingIndicator() {
+    if (this.typingUsers.size === 0) return nothing;
+
+    const names = Array.from(this.typingUsers.values()).map((v) => v.displayName);
+    let text: string;
+    if (names.length === 1) {
+      text = `${names[0]} is typing...`;
+    } else if (names.length === 2) {
+      text = `${names[0]} and ${names[1]} are typing...`;
+    } else {
+      text = `${names[0]} and ${names.length - 1} others are typing...`;
+    }
+
+    return html`
+      <div class="typing-indicator">
+        <span class="typing-dots"> <span></span><span></span><span></span> </span>
+        <span class="typing-text">${text}</span>
       </div>
     `;
   }

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -159,6 +159,9 @@ export class ScionChatThread extends LitElement {
   /** Mention results keyed by message ID (for "also notified" footer per message). */
   @state() private mentionResultsByMessageId = new Map<string, MentionResult[]>();
 
+  /** W7: Attachment refs keyed by message ID (from history endpoint + send response). */
+  private v2AttachmentMap = new Map<string, import('./chat-message.js').AttachmentRefInfo[]>();
+
   private eventSource: EventSource | null = null;
   private nextCursor: string | null = null;
   private lastKnownTimestamp: string | null = null;
@@ -592,6 +595,13 @@ export class ScionChatThread extends LitElement {
     }
   }
 
+  /** W7: Get attachment refs for a message (from history or send response). */
+  private getMessageAttachmentRefs(
+    messageId: string
+  ): import('./chat-message.js').AttachmentRefInfo[] {
+    return this.v2AttachmentMap.get(messageId) ?? [];
+  }
+
   /** Check if a message sender is an agent (v2 multi-sender). */
   private isSenderAgent(msg: Message): boolean {
     // Agent messages have sender like "agent:slug" or recipient patterns
@@ -852,10 +862,22 @@ export class ScionChatThread extends LitElement {
 
     const data = (await res.json()) as {
       items?: Message[];
+      messages?: Message[];
       nextCursor?: string;
+      messageAttachments?: Record<
+        string,
+        import('./chat-message.js').AttachmentRefInfo[]
+      >;
     };
 
-    const items = data?.items ?? [];
+    const items = data?.items ?? data?.messages ?? [];
+
+    // W7: Merge attachment refs from history response.
+    if (data?.messageAttachments) {
+      for (const [msgId, refs] of Object.entries(data.messageAttachments)) {
+        this.v2AttachmentMap.set(msgId, refs);
+      }
+    }
 
     if (items.length < HISTORY_PAGE_SIZE) {
       this.hasOlderMessages = false;
@@ -960,8 +982,23 @@ export class ScionChatThread extends LitElement {
     if (currentId !== this.fetchId) return;
     if (!res.ok) return;
 
-    const data = (await res.json()) as { items?: Message[] };
-    const items = data?.items ?? [];
+    const data = (await res.json()) as {
+      items?: Message[];
+      messages?: Message[];
+      messageAttachments?: Record<
+        string,
+        import('./chat-message.js').AttachmentRefInfo[]
+      >;
+    };
+    const items = data?.items ?? data?.messages ?? [];
+
+    // W7: Merge attachment refs from history response.
+    if (data?.messageAttachments) {
+      for (const [msgId, refs] of Object.entries(data.messageAttachments)) {
+        this.v2AttachmentMap.set(msgId, refs);
+      }
+    }
+
     const wasPinned = this.pinnedToBottom;
     this.mergeMessages(items);
     if (wasPinned) {
@@ -973,8 +1010,9 @@ export class ScionChatThread extends LitElement {
 
   /** Send a message in v2 mode. */
   private async handleChatSendV2(e: CustomEvent<ChatSendDetail>): Promise<void> {
-    const { text, plain, mentions, onSuccess } = e.detail;
-    if (!text || this.sending) return;
+    const { text, mentions, attachmentIds, onSuccess } = e.detail;
+    const hasContent = text.length > 0 || (attachmentIds && attachmentIds.length > 0);
+    if (!hasContent || this.sending) return;
 
     // Check for /default slash command
     if (text.startsWith('/default ')) {
@@ -988,10 +1026,14 @@ export class ScionChatThread extends LitElement {
 
     try {
       const body: Record<string, unknown> = {
-        structured_message: { msg: text, plain },
+        content: text,
       };
       if (mentions && mentions.length > 0) {
         body.mentions = mentions;
+      }
+      // W7: Include attachment IDs.
+      if (attachmentIds && attachmentIds.length > 0) {
+        body.attachments = attachmentIds;
       }
 
       const res = await apiFetch(
@@ -1006,6 +1048,14 @@ export class ScionChatThread extends LitElement {
       if (!res.ok) {
         this.sendError = await extractApiError(res, 'Failed to send message');
       } else {
+        // W7: Parse attachment refs from the send response.
+        const resData = (await res.json().catch(() => null)) as {
+          id?: string;
+          attachments?: import('./chat-message.js').AttachmentRefInfo[];
+        } | null;
+        if (resData?.id && resData?.attachments && resData.attachments.length > 0) {
+          this.v2AttachmentMap.set(resData.id, resData.attachments);
+        }
         onSuccess();
         // Backfill to pick up the message immediately
         void this.backfillV2();
@@ -1251,6 +1301,7 @@ export class ScionChatThread extends LitElement {
           .defaultAgent=${this.defaultAgent}
           .conversationMode=${this.isDM ? 'dm' : 'thread'}
           .peerName=${this.peerName}
+          .projectId=${this.projectId}
           @chat-send=${this.handleChatSendV2}
           @chat-typing=${() => this.sendTypingEvent()}
         ></scion-chat-composer>
@@ -1435,6 +1486,7 @@ export class ScionChatThread extends LitElement {
           dispatchState=${msg.dispatchState || ''}
           dispatchFailureReason=${msg.dispatchFailureReason || ''}
           .attachments=${msg.attachments || []}
+          .attachmentRefs=${this.getMessageAttachmentRefs(msg.id)}
         ></scion-chat-message>
       `);
 

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -81,19 +81,23 @@ const TYPING_SEND_THROTTLE_MS = 4000;
 
 @customElement('scion-chat-thread')
 export class ScionChatThread extends LitElement {
+  // DEPRECATED(wave-1): agentId-based mode — remove after v2 is stable and flag is permanently ON.
   @property()
   agentId = '';
 
+  // DEPRECATED(wave-1): agentId-based mode — remove after v2 is stable and flag is permanently ON.
   @property()
   agentName = '';
 
   @property({ type: Boolean })
   canSend = false;
 
+  // DEPRECATED(wave-1): per-agent visibility mode — remove after v2 is stable and flag is permanently ON.
   @property()
   visibilityMode: VisibilityMode = 'conversation';
 
   /** Whether the visibility toggle is shown in the header. */
+  // DEPRECATED(wave-1): visibility toggle — remove after v2 is stable and flag is permanently ON.
   @property({ type: Boolean })
   showVisibilityToggle = false;
 
@@ -515,6 +519,7 @@ export class ScionChatThread extends LitElement {
     }
   }
 
+  // DEPRECATED(wave-1): agentId-based load path — remove after v2 is stable and flag is permanently ON.
   /** Load saved preferences first, then fetch history. */
   private async loadPrefsAndHistory(): Promise<void> {
     await this.loadPrefs();
@@ -641,6 +646,7 @@ export class ScionChatThread extends LitElement {
   // Data loading
   // ---------------------------------------------------------------------------
 
+  // DEPRECATED(wave-1): agentId-based load path — remove after v2 is stable and flag is permanently ON.
   private async initialLoad(): Promise<void> {
     this.loading = true;
     this.error = null;
@@ -685,6 +691,7 @@ export class ScionChatThread extends LitElement {
     }
   }
 
+  // DEPRECATED(wave-1): agentId-based history fetch — remove after v2 is stable and flag is permanently ON.
   private async fetchHistory(cursor?: string): Promise<void> {
     const currentId = this.fetchId;
     const params = new URLSearchParams({ limit: String(HISTORY_PAGE_SIZE) });
@@ -782,6 +789,7 @@ export class ScionChatThread extends LitElement {
   // SSE Streaming
   // ---------------------------------------------------------------------------
 
+  // DEPRECATED(wave-1): agentId-based SSE stream — remove after v2 is stable and flag is permanently ON.
   private startStream(): void {
     if (!this.isConnected || this.eventSource || !this.agentId) return;
 
@@ -1210,6 +1218,7 @@ export class ScionChatThread extends LitElement {
   // Send message
   // ---------------------------------------------------------------------------
 
+  // DEPRECATED(wave-1): agentId-based send — remove after v2 is stable and flag is permanently ON.
   private async handleChatSend(e: CustomEvent<ChatSendDetail>): Promise<void> {
     const { text, plain, interrupt, mentions, onSuccess } = e.detail;
     if (!text || this.sending) return;

--- a/web/src/components/shared/chat/chat-visibility-toggle.ts
+++ b/web/src/components/shared/chat/chat-visibility-toggle.ts
@@ -26,8 +26,8 @@
  * user changes the selection.
  */
 
-import {LitElement, html, css} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 
 export type VisibilityMode = 'conversation' | 'verbose' | 'full';
 
@@ -52,11 +52,7 @@ export class ScionChatVisibilityToggle extends LitElement {
 
   override render() {
     return html`
-      <sl-radio-group
-        value=${this.mode}
-        size="small"
-        @sl-change=${this.handleChange}
-      >
+      <sl-radio-group value=${this.mode} size="small" @sl-change=${this.handleChange}>
         <sl-radio-button value="conversation">
           <sl-icon slot="prefix" name="chat-dots" style="font-size: 0.75rem"></sl-icon>
           Conversation
@@ -79,7 +75,7 @@ export class ScionChatVisibilityToggle extends LitElement {
     this.mode = value;
     this.dispatchEvent(
       new CustomEvent<VisibilityChangeDetail>('visibility-change', {
-        detail: {mode: value},
+        detail: { mode: value },
         bubbles: true,
         composed: true,
       })

--- a/web/src/components/shared/chat/mention-autocomplete.ts
+++ b/web/src/components/shared/chat/mention-autocomplete.ts
@@ -47,17 +47,38 @@ export interface MentionAcceptDetail {
   triggerStart: number;
 }
 
+/** Human member for mention autocomplete (v2). */
+export interface MentionMember {
+  id: string;
+  name: string;
+  email: string;
+  avatarUrl?: string;
+  kind: 'user' | 'agent';
+}
+
+/** A unified candidate for the dropdown. */
+interface MentionCandidate {
+  slug: string;
+  name: string;
+  kind: 'agent' | 'user';
+  avatarUrl: string | undefined;
+}
+
 @customElement('scion-mention-autocomplete')
 export class ScionMentionAutocomplete extends LitElement {
   /** All agents available for mentioning. Set by the parent. */
   @property({ type: Array })
   agents: Agent[] = [];
 
+  /** Human members available for mentioning (v2). Set by the parent. */
+  @property({ type: Array })
+  members: MentionMember[] = [];
+
   /** Whether the autocomplete is currently active. */
   @state() active = false;
 
   /** Matched candidates (already filtered + ranked). */
-  @state() private candidates: Agent[] = [];
+  @state() private candidates: MentionCandidate[] = [];
 
   /** Index of the highlighted candidate. */
   @state() private highlightIndex = 0;
@@ -155,16 +176,24 @@ export class ScionMentionAutocomplete extends LitElement {
         @mousedown=${this.handleMouseDown}
       >
         ${this.candidates.map(
-          (agent, i) => html`
+          (candidate, i) => html`
             <div
               class="dropdown-item ${i === this.highlightIndex ? 'highlighted' : ''}"
               data-index=${i}
               @click=${() => this.acceptCandidate(i)}
-              @mouseenter=${() => { this.highlightIndex = i; }}
+              @mouseenter=${() => {
+                this.highlightIndex = i;
+              }}
             >
-              <span class="slug">@${agent.slug || agent.name}</span>
-              ${agent.slug && agent.name && agent.slug !== agent.name
-                ? html`<span class="name">${agent.name}</span>`
+              <span class="slug">
+                <sl-icon
+                  name="${candidate.kind === 'agent' ? 'cpu' : 'person'}"
+                  style="font-size: 0.6875rem; vertical-align: -1px; margin-right: 0.125rem;"
+                ></sl-icon>
+                @${candidate.slug}
+              </span>
+              ${candidate.slug !== candidate.name
+                ? html`<span class="name">${candidate.name}</span>`
                 : nothing}
             </div>
           `
@@ -193,8 +222,8 @@ export class ScionMentionAutocomplete extends LitElement {
     this.triggerStart = triggerInfo.start;
     const query = text.slice(triggerInfo.start + 1, cursorPos);
 
-    // Filter and rank agents.
-    const matched = this.matchAgents(query);
+    // Filter and rank agents + members.
+    const matched = this.matchCandidates(query);
 
     if (matched.length === 0) {
       this.dismiss();
@@ -263,10 +292,7 @@ export class ScionMentionAutocomplete extends LitElement {
    * - The `@` must be at position 0 or preceded by whitespace (word boundary).
    * - The `@` must NOT be inside a fenced code block (AC17).
    */
-  private findTrigger(
-    text: string,
-    cursorPos: number
-  ): { start: number } | null {
+  private findTrigger(text: string, cursorPos: number): { start: number } | null {
     // Walk backwards from cursor to find @.
     for (let i = cursorPos - 1; i >= 0; i--) {
       const ch = text[i];
@@ -306,37 +332,65 @@ export class ScionMentionAutocomplete extends LitElement {
   }
 
   /**
-   * Match agents against a query string using case-insensitive subsequence
-   * matching over slug and name. Exact-prefix matches ranked first.
+   * Match agents and human members against a query string using case-insensitive
+   * subsequence matching over slug and name. Exact-prefix matches ranked first.
+   * Agents appear first, then humans (distinct icon styling in the dropdown).
    */
-  private matchAgents(query: string): Agent[] {
-    const agents = this.agents || [];
-    if (query === '') {
-      // Show all agents when just @ is typed, capped at MAX_DROPDOWN_ITEMS.
-      return agents.slice(0, MAX_DROPDOWN_ITEMS);
+  private matchCandidates(query: string): MentionCandidate[] {
+    // Build a unified list of candidates from agents + members
+    const allCandidates: MentionCandidate[] = [];
+
+    for (const agent of this.agents || []) {
+      allCandidates.push({
+        slug: agent.slug || agent.name || '',
+        name: agent.name || '',
+        kind: 'agent',
+        avatarUrl: undefined,
+      });
     }
 
-    const lowerQuery = query.toLowerCase();
-
-    const prefixMatches: Agent[] = [];
-    const subsequenceMatches: Agent[] = [];
-
-    for (const agent of agents) {
-      const slug = (agent.slug || agent.name || '').toLowerCase();
-      const name = (agent.name || '').toLowerCase();
-
-      // Check exact prefix match on slug or name.
-      if (slug.startsWith(lowerQuery) || name.startsWith(lowerQuery)) {
-        prefixMatches.push(agent);
-      } else if (
-        this.isSubsequence(lowerQuery, slug) ||
-        this.isSubsequence(lowerQuery, name)
-      ) {
-        subsequenceMatches.push(agent);
+    for (const member of this.members || []) {
+      // Avoid duplicate entries if a member is also an agent
+      const slug = member.name.toLowerCase().replace(/\s+/g, '-');
+      if (!allCandidates.some((c) => c.slug === slug)) {
+        allCandidates.push({
+          slug,
+          name: member.name,
+          kind: member.kind === 'agent' ? 'agent' : 'user',
+          avatarUrl: member.avatarUrl,
+        });
       }
     }
 
-    // Prefix matches first, then subsequence matches.
+    if (query === '') {
+      return allCandidates.slice(0, MAX_DROPDOWN_ITEMS);
+    }
+
+    const lowerQuery = query.toLowerCase();
+    const prefixMatches: MentionCandidate[] = [];
+    const subsequenceMatches: MentionCandidate[] = [];
+
+    for (const candidate of allCandidates) {
+      const slug = candidate.slug.toLowerCase();
+      const name = candidate.name.toLowerCase();
+
+      if (slug.startsWith(lowerQuery) || name.startsWith(lowerQuery)) {
+        prefixMatches.push(candidate);
+      } else if (this.isSubsequence(lowerQuery, slug) || this.isSubsequence(lowerQuery, name)) {
+        subsequenceMatches.push(candidate);
+      }
+    }
+
+    // Agents first, then humans, within each tier
+    const sortByKind = (a: MentionCandidate, b: MentionCandidate) =>
+      a.kind === 'agent' && b.kind !== 'agent'
+        ? -1
+        : a.kind !== 'agent' && b.kind === 'agent'
+          ? 1
+          : 0;
+    prefixMatches.sort(sortByKind);
+    subsequenceMatches.sort(sortByKind);
+
     return [...prefixMatches, ...subsequenceMatches].slice(0, MAX_DROPDOWN_ITEMS);
   }
 
@@ -351,15 +405,13 @@ export class ScionMentionAutocomplete extends LitElement {
 
   /** Dispatch the accept event and close the dropdown. */
   private acceptCandidate(index: number): void {
-    const agent = this.candidates[index];
-    if (!agent) return;
-
-    const slug = agent.slug || agent.name;
+    const candidate = this.candidates[index];
+    if (!candidate) return;
 
     this.dispatchEvent(
       new CustomEvent<MentionAcceptDetail>('mention-accept', {
         detail: {
-          slug,
+          slug: candidate.slug,
           triggerStart: this.triggerStart,
         },
         bubbles: true,
@@ -372,10 +424,21 @@ export class ScionMentionAutocomplete extends LitElement {
 
   /** Styles copied from the textarea onto the mirror div. */
   private static readonly MIRROR_STYLES = [
-    'font-family', 'font-size', 'font-weight', 'line-height',
-    'letter-spacing', 'word-spacing', 'padding-top', 'padding-right',
-    'padding-bottom', 'padding-left', 'border-width', 'box-sizing',
-    'white-space', 'word-wrap', 'overflow-wrap',
+    'font-family',
+    'font-size',
+    'font-weight',
+    'line-height',
+    'letter-spacing',
+    'word-spacing',
+    'padding-top',
+    'padding-right',
+    'padding-bottom',
+    'padding-left',
+    'border-width',
+    'box-sizing',
+    'white-space',
+    'word-wrap',
+    'overflow-wrap',
   ] as const;
 
   /**
@@ -424,10 +487,7 @@ export class ScionMentionAutocomplete extends LitElement {
     const markerRect = this.mirrorMarker!.getBoundingClientRect();
     const hostRect = this.getBoundingClientRect();
 
-    this.dropdownLeft = Math.max(
-      0,
-      markerRect.left - hostRect.left
-    );
+    this.dropdownLeft = Math.max(0, markerRect.left - hostRect.left);
   }
 
   /**

--- a/web/src/components/shared/code-editor.ts
+++ b/web/src/components/shared/code-editor.ts
@@ -154,7 +154,15 @@ export class ScionCodeEditor extends LitElement {
       min-height: 200px;
       max-height: calc(100vh - 16rem);
       font-size: 0.875rem;
-      font-family: var(--scion-font-mono, 'SF Mono', 'Fira Code', 'Fira Mono', Menlo, Consolas, monospace);
+      font-family: var(
+        --scion-font-mono,
+        'SF Mono',
+        'Fira Code',
+        'Fira Mono',
+        Menlo,
+        Consolas,
+        monospace
+      );
     }
 
     .editor-container .cm-editor.cm-focused {
@@ -230,21 +238,38 @@ export class ScionCodeEditor extends LitElement {
 
     try {
       const cm = await loadCodeMirror();
-      const { EditorView, keymap, lineNumbers, highlightActiveLine, highlightActiveLineGutter,
-        drawSelection, rectangularSelection, highlightSpecialChars, dropCursor } = cm.view;
+      const {
+        EditorView,
+        keymap,
+        lineNumbers,
+        highlightActiveLine,
+        highlightActiveLineGutter,
+        drawSelection,
+        rectangularSelection,
+        highlightSpecialChars,
+        dropCursor,
+      } = cm.view;
       const { EditorState } = cm.state;
       const { defaultKeymap, history, historyKeymap, indentWithTab } = cm.commands;
-      const { syntaxHighlighting, defaultHighlightStyle, indentOnInput,
-        bracketMatching, foldGutter, foldKeymap } = cm.language;
+      const {
+        syntaxHighlighting,
+        defaultHighlightStyle,
+        indentOnInput,
+        bracketMatching,
+        foldGutter,
+        foldKeymap,
+      } = cm.language;
       const { searchKeymap, highlightSelectionMatches } = cm.search;
-      const { autocompletion, completionKeymap, closeBrackets, closeBracketsKeymap } = cm.autocomplete;
+      const { autocompletion, completionKeymap, closeBrackets, closeBracketsKeymap } =
+        cm.autocomplete;
 
       // Detect dark mode from document theme or system preference
-      const isDark = document.documentElement.getAttribute('data-theme') === 'dark'
-        || document.documentElement.classList.contains('sl-theme-dark')
-        || document.documentElement.classList.contains('dark')
-        || (!document.documentElement.getAttribute('data-theme')
-            && window.matchMedia('(prefers-color-scheme: dark)').matches);
+      const isDark =
+        document.documentElement.getAttribute('data-theme') === 'dark' ||
+        document.documentElement.classList.contains('sl-theme-dark') ||
+        document.documentElement.classList.contains('dark') ||
+        (!document.documentElement.getAttribute('data-theme') &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches);
 
       // Build a dark-mode-aware highlight style
       const { HighlightStyle } = cm.language;
@@ -257,10 +282,30 @@ export class ScionCodeEditor extends LitElement {
         { tag: [tags.function(tags.variableName), tags.labelName], color: '#61afef' },
         { tag: [tags.color, tags.constant(tags.name), tags.standard(tags.name)], color: '#d19a66' },
         { tag: [tags.definition(tags.name), tags.separator], color: '#abb2bf' },
-        { tag: [tags.typeName, tags.className, tags.number, tags.changed, tags.annotation,
-                tags.modifier, tags.self, tags.namespace], color: '#e5c07b' },
-        { tag: [tags.operator, tags.operatorKeyword, tags.url, tags.escape,
-                tags.regexp, tags.special(tags.string)], color: '#56b6c2' },
+        {
+          tag: [
+            tags.typeName,
+            tags.className,
+            tags.number,
+            tags.changed,
+            tags.annotation,
+            tags.modifier,
+            tags.self,
+            tags.namespace,
+          ],
+          color: '#e5c07b',
+        },
+        {
+          tag: [
+            tags.operator,
+            tags.operatorKeyword,
+            tags.url,
+            tags.escape,
+            tags.regexp,
+            tags.special(tags.string),
+          ],
+          color: '#56b6c2',
+        },
         { tag: [tags.meta, tags.comment], color: '#7f848e' },
         { tag: tags.strong, fontWeight: 'bold' },
         { tag: tags.emphasis, fontStyle: 'italic' },
@@ -366,17 +411,19 @@ export class ScionCodeEditor extends LitElement {
 
       // Change listener: dispatch content-changed event
       extensions.push(
-        EditorView.updateListener.of((update: { docChanged: boolean; state: { doc: { toString(): string } } }) => {
-          if (update.docChanged) {
-            this.dispatchEvent(
-              new CustomEvent('content-changed', {
-                detail: { content: update.state.doc.toString() },
-                bubbles: true,
-                composed: true,
-              })
-            );
+        EditorView.updateListener.of(
+          (update: { docChanged: boolean; state: { doc: { toString(): string } } }) => {
+            if (update.docChanged) {
+              this.dispatchEvent(
+                new CustomEvent('content-changed', {
+                  detail: { content: update.state.doc.toString() },
+                  bubbles: true,
+                  composed: true,
+                })
+              );
+            }
           }
-        })
+        )
       );
 
       // Destroy previous editor if exists

--- a/web/src/components/shared/confirm-dialog.ts
+++ b/web/src/components/shared/confirm-dialog.ts
@@ -46,10 +46,7 @@ export interface ConfirmOptions {
  * Show a confirmation dialog and return a promise that resolves to `true`
  * (confirmed) or `false` (cancelled / dismissed).
  */
-export function showConfirm(
-  message: string,
-  options?: ConfirmOptions,
-): Promise<boolean> {
+export function showConfirm(message: string, options?: ConfirmOptions): Promise<boolean> {
   const title = options?.title ?? 'Confirm';
   const confirmText = options?.confirmText ?? 'Confirm';
   const cancelText = options?.cancelText ?? 'Cancel';
@@ -99,7 +96,14 @@ export function showConfirm(
     dialog.addEventListener('keydown', (e: KeyboardEvent) => {
       if (e.key === 'Enter') {
         const tag = (e.target as HTMLElement)?.tagName?.toLowerCase();
-        if (tag === 'textarea' || tag === 'input' || tag === 'sl-textarea' || tag === 'sl-input' || tag === 'button' || tag === 'sl-button') {
+        if (
+          tag === 'textarea' ||
+          tag === 'input' ||
+          tag === 'sl-textarea' ||
+          tag === 'sl-input' ||
+          tag === 'button' ||
+          tag === 'sl-button'
+        ) {
           return;
         }
         e.preventDefault();
@@ -119,7 +123,7 @@ export function showConfirm(
           dialog.remove();
           resolve(result);
         },
-        { once: true },
+        { once: true }
       );
     }
 

--- a/web/src/components/shared/debug-panel.ts
+++ b/web/src/components/shared/debug-panel.ts
@@ -148,10 +148,18 @@ export class ScionDebugPanel extends LitElement {
       display: inline-block;
     }
 
-    .dot.green { background: #22c55e; }
-    .dot.yellow { background: #f59e0b; }
-    .dot.red { background: #ef4444; }
-    .dot.gray { background: #64748b; }
+    .dot.green {
+      background: #22c55e;
+    }
+    .dot.yellow {
+      background: #f59e0b;
+    }
+    .dot.red {
+      background: #ef4444;
+    }
+    .dot.gray {
+      background: #64748b;
+    }
 
     /* Panel - full height right side */
     .panel {
@@ -286,9 +294,15 @@ export class ScionDebugPanel extends LitElement {
       white-space: nowrap;
     }
 
-    .info-value.success { color: #22c55e; }
-    .info-value.warning { color: #f59e0b; }
-    .info-value.error { color: #ef4444; }
+    .info-value.success {
+      color: #22c55e;
+    }
+    .info-value.warning {
+      color: #f59e0b;
+    }
+    .info-value.error {
+      color: #ef4444;
+    }
 
     /* Status indicator */
     .status-row {
@@ -305,14 +319,28 @@ export class ScionDebugPanel extends LitElement {
       flex-shrink: 0;
     }
 
-    .status-dot.connected { background: #22c55e; }
-    .status-dot.reconnecting { background: #f59e0b; animation: pulse 1s infinite; }
-    .status-dot.disconnected { background: #ef4444; }
-    .status-dot.idle { background: #64748b; }
+    .status-dot.connected {
+      background: #22c55e;
+    }
+    .status-dot.reconnecting {
+      background: #f59e0b;
+      animation: pulse 1s infinite;
+    }
+    .status-dot.disconnected {
+      background: #ef4444;
+    }
+    .status-dot.idle {
+      background: #64748b;
+    }
 
     @keyframes pulse {
-      0%, 100% { opacity: 1; }
-      50% { opacity: 0.4; }
+      0%,
+      100% {
+        opacity: 1;
+      }
+      50% {
+        opacity: 0.4;
+      }
     }
 
     /* Subject list */
@@ -388,9 +416,18 @@ export class ScionDebugPanel extends LitElement {
       flex-shrink: 0;
     }
 
-    .log-badge.sse { background: #1e3a5f; color: #60a5fa; }
-    .log-badge.state { background: #14532d; color: #4ade80; }
-    .log-badge.connection { background: #422006; color: #fbbf24; }
+    .log-badge.sse {
+      background: #1e3a5f;
+      color: #60a5fa;
+    }
+    .log-badge.state {
+      background: #14532d;
+      color: #4ade80;
+    }
+    .log-badge.connection {
+      background: #422006;
+      color: #fbbf24;
+    }
 
     .log-label {
       color: #e2e8f0;
@@ -577,8 +614,16 @@ export class ScionDebugPanel extends LitElement {
 
   private formatTime(ts: number): string {
     const d = new Date(ts);
-    return d.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit' })
-      + '.' + String(d.getMilliseconds()).padStart(3, '0');
+    return (
+      d.toLocaleTimeString('en-US', {
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }) +
+      '.' +
+      String(d.getMilliseconds()).padStart(3, '0')
+    );
   }
 
   private formatJson(data: unknown): string {
@@ -599,7 +644,14 @@ export class ScionDebugPanel extends LitElement {
     }
 
     const connStatus = this.getConnectionStatus();
-    const dotClass = connStatus === 'connected' ? 'green' : connStatus === 'reconnecting' ? 'yellow' : connStatus === 'idle' ? 'gray' : 'red';
+    const dotClass =
+      connStatus === 'connected'
+        ? 'green'
+        : connStatus === 'reconnecting'
+          ? 'yellow'
+          : connStatus === 'idle'
+            ? 'gray'
+            : 'red';
 
     return html`
       <button class="toggle-button" @click=${() => this.togglePanel()}>
@@ -616,11 +668,8 @@ export class ScionDebugPanel extends LitElement {
           </div>
         </div>
         <div class="panel-content">
-          ${this.renderConnectionStatus()}
-          ${this.renderCurrentScope()}
-          ${this.renderActiveSubscriptions()}
-          ${this.renderStateSummary()}
-          ${this.renderEventLog()}
+          ${this.renderConnectionStatus()} ${this.renderCurrentScope()}
+          ${this.renderActiveSubscriptions()} ${this.renderStateSummary()} ${this.renderEventLog()}
           ${this.renderAuthDebug()}
         </div>
       </div>
@@ -643,24 +692,30 @@ export class ScionDebugPanel extends LitElement {
           <span class="info-label">Endpoint</span>
           <span class="info-value">/events</span>
         </div>
-        ${debugLog.connectionId ? html`
-          <div class="info-row">
-            <span class="info-label">Connection ID</span>
-            <span class="info-value">${debugLog.connectionId}</span>
-          </div>
-        ` : nothing}
-        ${status !== 'idle' ? html`
-          <div class="info-row">
-            <span class="info-label">Reconnect Attempts</span>
-            <span class="info-value">${sse.reconnectAttemptCount}</span>
-          </div>
-        ` : nothing}
-        ${subjects.length > 0 ? html`
-          <div class="info-row">
-            <span class="info-label">Subjects</span>
-            <span class="info-value">${subjects.length}</span>
-          </div>
-        ` : nothing}
+        ${debugLog.connectionId
+          ? html`
+              <div class="info-row">
+                <span class="info-label">Connection ID</span>
+                <span class="info-value">${debugLog.connectionId}</span>
+              </div>
+            `
+          : nothing}
+        ${status !== 'idle'
+          ? html`
+              <div class="info-row">
+                <span class="info-label">Reconnect Attempts</span>
+                <span class="info-value">${sse.reconnectAttemptCount}</span>
+              </div>
+            `
+          : nothing}
+        ${subjects.length > 0
+          ? html`
+              <div class="info-row">
+                <span class="info-label">Subjects</span>
+                <span class="info-value">${subjects.length}</span>
+              </div>
+            `
+          : nothing}
       </div>
     `;
   }
@@ -699,10 +754,10 @@ export class ScionDebugPanel extends LitElement {
         ${subjects.length === 0
           ? html`<div class="empty-state">No active subscriptions</div>`
           : html`
-            <ul class="subject-list">
-              ${subjects.map(s => html`<li class="subject-item">${s}</li>`)}
-            </ul>
-          `}
+              <ul class="subject-list">
+                ${subjects.map((s) => html`<li class="subject-item">${s}</li>`)}
+              </ul>
+            `}
       </div>
     `;
   }
@@ -713,7 +768,12 @@ export class ScionDebugPanel extends LitElement {
     return html`
       <div class="section">
         <div class="section-title">
-          <span class="collapsible-title" @click=${() => { this.stateIdsExpanded = !this.stateIdsExpanded; }}>
+          <span
+            class="collapsible-title"
+            @click=${() => {
+              this.stateIdsExpanded = !this.stateIdsExpanded;
+            }}
+          >
             State Summary ${this.stateIdsExpanded ? '[-]' : '[+]'}
           </span>
         </div>
@@ -729,30 +789,50 @@ export class ScionDebugPanel extends LitElement {
           <span class="info-label">Brokers</span>
           <span class="info-value">${snap.brokerCount}</span>
         </div>
-        ${snap.deletedProjectIds.length > 0 ? html`
-          <div class="info-row">
-            <span class="info-label">Deleted Projects</span>
-            <span class="info-value warning">${snap.deletedProjectIds.length}</span>
-          </div>
-        ` : nothing}
-        ${this.stateIdsExpanded ? html`
-          ${snap.agentIds.length > 0 ? html`
-            <div class="info-label" style="margin-top: 0.4rem;">Agent IDs:</div>
-            <ul class="id-list">${snap.agentIds.map(id => html`<li>${id}</li>`)}</ul>
-          ` : nothing}
-          ${snap.projectIds.length > 0 ? html`
-            <div class="info-label" style="margin-top: 0.4rem;">Project IDs:</div>
-            <ul class="id-list">${snap.projectIds.map(id => html`<li>${id}</li>`)}</ul>
-          ` : nothing}
-          ${snap.brokerIds.length > 0 ? html`
-            <div class="info-label" style="margin-top: 0.4rem;">Broker IDs:</div>
-            <ul class="id-list">${snap.brokerIds.map(id => html`<li>${id}</li>`)}</ul>
-          ` : nothing}
-          ${snap.deletedProjectIds.length > 0 ? html`
-            <div class="info-label" style="margin-top: 0.4rem;">Deleted Project IDs:</div>
-            <ul class="id-list">${snap.deletedProjectIds.map(id => html`<li>${id}</li>`)}</ul>
-          ` : nothing}
-        ` : nothing}
+        ${snap.deletedProjectIds.length > 0
+          ? html`
+              <div class="info-row">
+                <span class="info-label">Deleted Projects</span>
+                <span class="info-value warning">${snap.deletedProjectIds.length}</span>
+              </div>
+            `
+          : nothing}
+        ${this.stateIdsExpanded
+          ? html`
+              ${snap.agentIds.length > 0
+                ? html`
+                    <div class="info-label" style="margin-top: 0.4rem;">Agent IDs:</div>
+                    <ul class="id-list">
+                      ${snap.agentIds.map((id) => html`<li>${id}</li>`)}
+                    </ul>
+                  `
+                : nothing}
+              ${snap.projectIds.length > 0
+                ? html`
+                    <div class="info-label" style="margin-top: 0.4rem;">Project IDs:</div>
+                    <ul class="id-list">
+                      ${snap.projectIds.map((id) => html`<li>${id}</li>`)}
+                    </ul>
+                  `
+                : nothing}
+              ${snap.brokerIds.length > 0
+                ? html`
+                    <div class="info-label" style="margin-top: 0.4rem;">Broker IDs:</div>
+                    <ul class="id-list">
+                      ${snap.brokerIds.map((id) => html`<li>${id}</li>`)}
+                    </ul>
+                  `
+                : nothing}
+              ${snap.deletedProjectIds.length > 0
+                ? html`
+                    <div class="info-label" style="margin-top: 0.4rem;">Deleted Project IDs:</div>
+                    <ul class="id-list">
+                      ${snap.deletedProjectIds.map((id) => html`<li>${id}</li>`)}
+                    </ul>
+                  `
+                : nothing}
+            `
+          : nothing}
       </div>
     `;
   }
@@ -767,10 +847,10 @@ export class ScionDebugPanel extends LitElement {
         ${this.logEntries.length === 0
           ? html`<div class="empty-state">No events captured</div>`
           : html`
-            <ul class="event-log-list" @scroll=${() => this.handleLogScroll()}>
-              ${this.logEntries.map(entry => this.renderLogEntry(entry))}
-            </ul>
-          `}
+              <ul class="event-log-list" @scroll=${() => this.handleLogScroll()}>
+                ${this.logEntries.map((entry) => this.renderLogEntry(entry))}
+              </ul>
+            `}
       </div>
     `;
   }
@@ -786,9 +866,9 @@ export class ScionDebugPanel extends LitElement {
           <span class="log-label">${entry.label}</span>
           ${entry.subject ? html`<span class="log-subject">${entry.subject}</span>` : nothing}
         </div>
-        ${isExpanded && entry.data != null ? html`
-          <div class="log-detail">${this.formatJson(entry.data)}</div>
-        ` : nothing}
+        ${isExpanded && entry.data != null
+          ? html` <div class="log-detail">${this.formatJson(entry.data)}</div> `
+          : nothing}
       </li>
     `;
   }
@@ -797,19 +877,34 @@ export class ScionDebugPanel extends LitElement {
     return html`
       <div class="section">
         <div class="section-title">
-          <span class="collapsible-title" @click=${() => { this.authExpanded = !this.authExpanded; }}>
+          <span
+            class="collapsible-title"
+            @click=${() => {
+              this.authExpanded = !this.authExpanded;
+            }}
+          >
             Auth Debug ${this.authExpanded ? '[-]' : '[+]'}
           </span>
-          ${this.authExpanded ? html`
-            <button class="action-button" ?disabled=${this.loading} @click=${() => this.loadDebugData()}>
-              ${this.loading ? 'Loading...' : 'Refresh'}
-            </button>
-          ` : nothing}
+          ${this.authExpanded
+            ? html`
+                <button
+                  class="action-button"
+                  ?disabled=${this.loading}
+                  @click=${() => this.loadDebugData()}
+                >
+                  ${this.loading ? 'Loading...' : 'Refresh'}
+                </button>
+              `
+            : nothing}
         </div>
-        ${this.authExpanded ? html`
-          ${this.error ? html`<div class="error-message">${this.error}</div>` : nothing}
-          ${this.loading ? html`<div class="empty-state">Loading...</div>` : this.renderAuthData()}
-        ` : nothing}
+        ${this.authExpanded
+          ? html`
+              ${this.error ? html`<div class="error-message">${this.error}</div>` : nothing}
+              ${this.loading
+                ? html`<div class="empty-state">Loading...</div>`
+                : this.renderAuthData()}
+            `
+          : nothing}
       </div>
     `;
   }

--- a/web/src/components/shared/dir-browser.ts
+++ b/web/src/components/shared/dir-browser.ts
@@ -247,11 +247,13 @@ export class ScionDirBrowser extends LitElement {
 
   private selectCurrentPath(): void {
     this.selectedPath = this.currentPath;
-    this.dispatchEvent(new CustomEvent('path-selected', {
-      detail: { path: this.currentPath },
-      bubbles: true,
-      composed: true,
-    }));
+    this.dispatchEvent(
+      new CustomEvent('path-selected', {
+        detail: { path: this.currentPath },
+        bubbles: true,
+        composed: true,
+      })
+    );
   }
 
   private async handleNewFolder(): Promise<void> {
@@ -287,7 +289,7 @@ export class ScionDirBrowser extends LitElement {
   private get filteredEntries(): DirEntry[] {
     if (!this.filterText) return this.entries;
     const lower = this.filterText.toLowerCase();
-    return this.entries.filter(e => e.name.toLowerCase().includes(lower));
+    return this.entries.filter((e) => e.name.toLowerCase().includes(lower));
   }
 
   private onFilterInput(e: Event): void {
@@ -301,12 +303,12 @@ export class ScionDirBrowser extends LitElement {
     }
     if (e.key === 'Tab') {
       e.preventDefault();
-      const dirMatches = this.filteredEntries.filter(entry => entry.isDir);
+      const dirMatches = this.filteredEntries.filter((entry) => entry.isDir);
       if (dirMatches.length === 1) {
         this.filterText = '';
         void this.navigate(this.joinPath(this.currentPath, dirMatches[0].name));
       } else if (dirMatches.length > 1) {
-        const prefix = this.commonPrefix(dirMatches.map(d => d.name));
+        const prefix = this.commonPrefix(dirMatches.map((d) => d.name));
         if (prefix.length > this.filterText.length) {
           this.filterText = prefix;
         }
@@ -314,7 +316,7 @@ export class ScionDirBrowser extends LitElement {
       return;
     }
     if (e.key === 'Enter') {
-      const matches = this.filteredEntries.filter(entry => entry.isDir);
+      const matches = this.filteredEntries.filter((entry) => entry.isDir);
       if (matches.length === 1) {
         this.filterText = '';
         void this.navigate(this.joinPath(this.currentPath, matches[0].name));
@@ -347,10 +349,14 @@ export class ScionDirBrowser extends LitElement {
           <button class="breadcrumb-segment" @click=${() => void this.navigate('/')}>
             <sl-icon name="house"></sl-icon>
           </button>
-          ${segments.map((seg, i) => html`
-            <span class="breadcrumb-sep">/</span>
-            <button class="breadcrumb-segment" @click=${() => this.navigateToBreadcrumb(i)}>${seg}</button>
-          `)}
+          ${segments.map(
+            (seg, i) => html`
+              <span class="breadcrumb-sep">/</span>
+              <button class="breadcrumb-segment" @click=${() => this.navigateToBreadcrumb(i)}>
+                ${seg}
+              </button>
+            `
+          )}
           <sl-input
             class="filter-input"
             size="small"
@@ -361,68 +367,110 @@ export class ScionDirBrowser extends LitElement {
           ></sl-input>
         </div>
 
-        ${this.loading ? html`
-          <div class="loading-state"><sl-spinner></sl-spinner></div>
-        ` : this.error ? html`
-          <div class="empty-state">${this.error}</div>
-        ` : this.entries.length === 0 ? html`
-          <div class="empty-state">Empty directory</div>
-        ` : html`
-          ${this.entries.length > 5 ? html`
-            <div style="padding: 0.375rem 0.75rem; border-bottom: 1px solid var(--scion-border, #e2e8f0);">
-              <sl-input
-                size="small"
-                placeholder="Filter…"
-                clearable
-                .value=${this.filterText}
-                @sl-input=${this.onFilterInput}
-                @keydown=${this.onFilterKeydown}
-              >
-                <sl-icon slot="prefix" name="funnel"></sl-icon>
-              </sl-input>
-            </div>
-          ` : nothing}
-          <div class="entry-list">
-            ${!(segments.length === 0 || (segments.length === 1 && /^[a-zA-Z]:$/.test(segments[0]))) ? html`
-              <div class="entry" @click=${() => this.navigateUp()}>
-                <sl-icon name="arrow-up"></sl-icon>
-                <span class="name">..</span>
+        ${this.loading
+          ? html` <div class="loading-state"><sl-spinner></sl-spinner></div> `
+          : this.error
+            ? html` <div class="empty-state">${this.error}</div> `
+            : this.entries.length === 0
+              ? html` <div class="empty-state">Empty directory</div> `
+              : html`
+                  ${this.entries.length > 5
+                    ? html`
+                        <div
+                          style="padding: 0.375rem 0.75rem; border-bottom: 1px solid var(--scion-border, #e2e8f0);"
+                        >
+                          <sl-input
+                            size="small"
+                            placeholder="Filter…"
+                            clearable
+                            .value=${this.filterText}
+                            @sl-input=${this.onFilterInput}
+                            @keydown=${this.onFilterKeydown}
+                          >
+                            <sl-icon slot="prefix" name="funnel"></sl-icon>
+                          </sl-input>
+                        </div>
+                      `
+                    : nothing}
+                  <div class="entry-list">
+                    ${!(
+                      segments.length === 0 ||
+                      (segments.length === 1 && /^[a-zA-Z]:$/.test(segments[0]))
+                    )
+                      ? html`
+                          <div class="entry" @click=${() => this.navigateUp()}>
+                            <sl-icon name="arrow-up"></sl-icon>
+                            <span class="name">..</span>
+                          </div>
+                        `
+                      : nothing}
+                    ${this.filteredEntries.length === 0 && this.filterText
+                      ? html` <div class="empty-state">No matches for "${this.filterText}"</div> `
+                      : nothing}
+                    ${this.filteredEntries.map(
+                      (e) => html`
+                        <div
+                          class="entry ${e.isDir ? '' : 'is-file'}"
+                          @click=${() => this.onEntryClick(e)}
+                        >
+                          <sl-icon
+                            name=${e.isDir ? (e.isGit ? 'git' : 'folder') : 'file-earmark'}
+                          ></sl-icon>
+                          <span class="name">${e.name}</span>
+                          ${e.isGit ? html`<span class="badge">git</span>` : nothing}
+                        </div>
+                      `
+                    )}
+                  </div>
+                `}
+        ${this.newFolderMode
+          ? html`
+              <div class="new-folder-row">
+                <sl-input
+                  size="small"
+                  placeholder="New folder name"
+                  .value=${this.newFolderName}
+                  @sl-input=${(e: Event) => {
+                    this.newFolderName = (e.target as HTMLInputElement).value;
+                  }}
+                  @keydown=${(e: KeyboardEvent) => {
+                    if (e.key === 'Enter') void this.handleNewFolder();
+                  }}
+                ></sl-input>
+                <sl-button
+                  size="small"
+                  variant="primary"
+                  ?loading=${this.creatingFolder}
+                  @click=${() => void this.handleNewFolder()}
+                >
+                  Create
+                </sl-button>
+                <sl-button
+                  size="small"
+                  variant="default"
+                  @click=${() => {
+                    this.newFolderMode = false;
+                  }}
+                >
+                  Cancel
+                </sl-button>
               </div>
-            ` : nothing}
-            ${this.filteredEntries.length === 0 && this.filterText ? html`
-              <div class="empty-state">No matches for "${this.filterText}"</div>
-            ` : nothing}
-            ${this.filteredEntries.map(e => html`
-              <div class="entry ${e.isDir ? '' : 'is-file'}" @click=${() => this.onEntryClick(e)}>
-                <sl-icon name=${e.isDir ? (e.isGit ? 'git' : 'folder') : 'file-earmark'}></sl-icon>
-                <span class="name">${e.name}</span>
-                ${e.isGit ? html`<span class="badge">git</span>` : nothing}
-              </div>
-            `)}
-          </div>
-        `}
-
-        ${this.newFolderMode ? html`
-          <div class="new-folder-row">
-            <sl-input
-              size="small"
-              placeholder="New folder name"
-              .value=${this.newFolderName}
-              @sl-input=${(e: Event) => { this.newFolderName = (e.target as HTMLInputElement).value; }}
-              @keydown=${(e: KeyboardEvent) => { if (e.key === 'Enter') void this.handleNewFolder(); }}
-            ></sl-input>
-            <sl-button size="small" variant="primary" ?loading=${this.creatingFolder} @click=${() => void this.handleNewFolder()}>
-              Create
-            </sl-button>
-            <sl-button size="small" variant="default" @click=${() => { this.newFolderMode = false; }}>
-              Cancel
-            </sl-button>
-          </div>
-          ${this.newFolderError ? html`<div class="error-msg">${this.newFolderError}</div>` : nothing}
-        ` : nothing}
+              ${this.newFolderError
+                ? html`<div class="error-msg">${this.newFolderError}</div>`
+                : nothing}
+            `
+          : nothing}
 
         <div class="toolbar">
-          <sl-button size="small" variant="default" @click=${() => { this.newFolderMode = true; this.newFolderName = ''; this.newFolderError = null; }}>
+          <sl-button
+            size="small"
+            variant="default"
+            @click=${() => {
+              this.newFolderMode = true;
+              this.newFolderName = '';
+              this.newFolderError = null;
+            }}
+          >
             <sl-icon slot="prefix" name="folder-plus"></sl-icon>
             New folder
           </sl-button>

--- a/web/src/components/shared/env-editor.ts
+++ b/web/src/components/shared/env-editor.ts
@@ -66,11 +66,11 @@ export class ScionEnvEditor extends LitElement {
       width: 100%;
     }
 
-    .env-row.required sl-input[data-field="key"]::part(base) {
+    .env-row.required sl-input[data-field='key']::part(base) {
       border-left: 3px solid var(--sl-color-warning-500, #f59e0b);
     }
 
-    .env-row.missing sl-input[data-field="value"]::part(base) {
+    .env-row.missing sl-input[data-field='value']::part(base) {
       border-color: var(--sl-color-danger-500, #ef4444);
     }
 

--- a/web/src/components/shared/env-var-list.ts
+++ b/web/src/components/shared/env-var-list.ts
@@ -72,11 +72,15 @@ export class ScionEnvVarList extends LitElement {
 
     try {
       const url =
-        this.scope !== 'project' ? `${this.apiBasePath}/env?scope=${this.scope}` : `${this.apiBasePath}/env`;
+        this.scope !== 'project'
+          ? `${this.apiBasePath}/env?scope=${this.scope}`
+          : `${this.apiBasePath}/env`;
       const response = await apiFetch(url);
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       const data = (await response.json()) as { envVars?: EnvVar[] } | EnvVar[];
@@ -155,7 +159,9 @@ export class ScionEnvVarList extends LitElement {
       });
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       this.closeDialog();
@@ -169,7 +175,10 @@ export class ScionEnvVarList extends LitElement {
   }
 
   private async handleDelete(envVar: EnvVar, event?: MouseEvent): Promise<void> {
-    if (!event?.altKey && !(await showConfirm(`Delete environment variable "${envVar.key}"? This cannot be undone.`))) {
+    if (
+      !event?.altKey &&
+      !(await showConfirm(`Delete environment variable "${envVar.key}"? This cannot be undone.`))
+    ) {
       return;
     }
 
@@ -183,7 +192,9 @@ export class ScionEnvVarList extends LitElement {
       const response = await apiFetch(deleteUrl, { method: 'DELETE' });
 
       if (!response.ok && response.status !== 204) {
-        throw new Error(await extractApiError(response, `Failed to delete (HTTP ${response.status})`));
+        throw new Error(
+          await extractApiError(response, `Failed to delete (HTTP ${response.status})`)
+        );
       }
 
       await this.loadEnvVars();
@@ -272,7 +283,11 @@ export class ScionEnvVarList extends LitElement {
         <div class="section-header">
           <div class="section-header-info">
             <h2>Environment Variables</h2>
-            <p>Manage environment variables injected into ${this.scope === 'hub' ? 'all agents on this hub' : 'agents in this project'} at runtime.</p>
+            <p>
+              Manage environment variables injected into
+              ${this.scope === 'hub' ? 'all agents on this hub' : 'agents in this project'} at
+              runtime.
+            </p>
           </div>
           <sl-button variant="primary" size="small" @click=${this.openCreateDialog}>
             <sl-icon slot="prefix" name="plus-lg"></sl-icon>
@@ -384,7 +399,11 @@ export class ScionEnvVarList extends LitElement {
         <h3>No Environment Variables</h3>
         <p>
           Add environment variables that will be injected into
-          ${this.compact ? (this.scope === 'hub' ? 'all agents on this hub' : 'agents in this project') : 'your agents'}.
+          ${this.compact
+            ? this.scope === 'hub'
+              ? 'all agents on this hub'
+              : 'agents in this project'
+            : 'your agents'}.
         </p>
         <sl-button variant="primary" size="small" @click=${this.openCreateDialog}>
           <sl-icon slot="prefix" name="plus-lg"></sl-icon>

--- a/web/src/components/shared/file-browser.ts
+++ b/web/src/components/shared/file-browser.ts
@@ -362,20 +362,75 @@ export class HarnessConfigFileBrowserDataSource implements FileBrowserDataSource
 
 const PREVIEWABLE_EXTENSIONS = new Set([
   // Images
-  '.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.bmp', '.ico',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.svg',
+  '.webp',
+  '.bmp',
+  '.ico',
   // Text
-  '.txt', '.log', '.csv', '.tsv',
+  '.txt',
+  '.log',
+  '.csv',
+  '.tsv',
   // Markdown
   '.md',
   // Code
-  '.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs',
-  '.py', '.go', '.rs', '.java', '.c', '.cpp', '.h', '.hpp', '.cs',
-  '.css', '.scss', '.less', '.html', '.htm', '.xml', '.xsl',
-  '.json', '.yaml', '.yml', '.toml', '.ini', '.cfg', '.conf',
-  '.sh', '.bash', '.zsh', '.fish',
-  '.sql', '.rb', '.php', '.swift', '.kt', '.scala', '.r', '.lua',
-  '.pl', '.ex', '.exs', '.elm', '.hs', '.clj', '.vim',
-  '.dockerfile', '.makefile', '.env', '.gitignore', '.editorconfig',
+  '.js',
+  '.ts',
+  '.jsx',
+  '.tsx',
+  '.mjs',
+  '.cjs',
+  '.py',
+  '.go',
+  '.rs',
+  '.java',
+  '.c',
+  '.cpp',
+  '.h',
+  '.hpp',
+  '.cs',
+  '.css',
+  '.scss',
+  '.less',
+  '.html',
+  '.htm',
+  '.xml',
+  '.xsl',
+  '.json',
+  '.yaml',
+  '.yml',
+  '.toml',
+  '.ini',
+  '.cfg',
+  '.conf',
+  '.sh',
+  '.bash',
+  '.zsh',
+  '.fish',
+  '.sql',
+  '.rb',
+  '.php',
+  '.swift',
+  '.kt',
+  '.scala',
+  '.r',
+  '.lua',
+  '.pl',
+  '.ex',
+  '.exs',
+  '.elm',
+  '.hs',
+  '.clj',
+  '.vim',
+  '.dockerfile',
+  '.makefile',
+  '.env',
+  '.gitignore',
+  '.editorconfig',
   // PDF
   '.pdf',
 ]);
@@ -385,20 +440,64 @@ const EDITABLE_EXTENSIONS = new Set([
   // Markdown
   '.md',
   // Data formats
-  '.json', '.yaml', '.yml', '.toml',
+  '.json',
+  '.yaml',
+  '.yml',
+  '.toml',
   // Shell
-  '.sh', '.bash', '.zsh',
+  '.sh',
+  '.bash',
+  '.zsh',
   // Programming languages
-  '.go', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
-  '.py', '.rs', '.java', '.c', '.cpp', '.h', '.hpp', '.cs',
-  '.rb', '.php', '.swift', '.kt', '.scala', '.r', '.lua',
-  '.pl', '.ex', '.exs', '.elm', '.hs', '.clj',
+  '.go',
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.py',
+  '.rs',
+  '.java',
+  '.c',
+  '.cpp',
+  '.h',
+  '.hpp',
+  '.cs',
+  '.rb',
+  '.php',
+  '.swift',
+  '.kt',
+  '.scala',
+  '.r',
+  '.lua',
+  '.pl',
+  '.ex',
+  '.exs',
+  '.elm',
+  '.hs',
+  '.clj',
   // Web
-  '.css', '.scss', '.less', '.html', '.htm', '.xml', '.xsl',
+  '.css',
+  '.scss',
+  '.less',
+  '.html',
+  '.htm',
+  '.xml',
+  '.xsl',
   // Config & text
-  '.txt', '.log', '.csv', '.tsv', '.ini', '.cfg', '.conf',
-  '.env', '.gitignore', '.editorconfig',
-  '.dockerfile', '.makefile',
+  '.txt',
+  '.log',
+  '.csv',
+  '.tsv',
+  '.ini',
+  '.cfg',
+  '.conf',
+  '.env',
+  '.gitignore',
+  '.editorconfig',
+  '.dockerfile',
+  '.makefile',
   // SQL
   '.sql',
 ]);
@@ -926,7 +1025,7 @@ export class ScionFileBrowser extends LitElement {
 
     try {
       await this.dataSource.deleteFile(filePath);
-      this.files = this.files.filter(f => f.path !== filePath);
+      this.files = this.files.filter((f) => f.path !== filePath);
       void this.loadFiles();
     } catch (err) {
       console.error('Failed to delete file:', err);
@@ -992,10 +1091,7 @@ export class ScionFileBrowser extends LitElement {
   // ── Render ──
 
   override render() {
-    return html`
-      ${this.renderToolbar()}
-      ${this.renderContent()}
-    `;
+    return html` ${this.renderToolbar()} ${this.renderContent()} `;
   }
 
   private renderToolbar() {
@@ -1007,7 +1103,8 @@ export class ScionFileBrowser extends LitElement {
       const localMatches = this.applyFilter(base);
       const localCount = localMatches.length;
       if (this.backendSearching) {
-        countLabel = html`${localCount} local match${localCount !== 1 ? 'es' : ''} · <sl-spinner class="search-spinner"></sl-spinner> searching workspace…`;
+        countLabel = html`${localCount} local match${localCount !== 1 ? 'es' : ''} ·
+          <sl-spinner class="search-spinner"></sl-spinner> searching workspace…`;
       } else if (this.backendError) {
         countLabel = html`${localCount} local match${localCount !== 1 ? 'es' : ''}
           <sl-tooltip content="Workspace search unavailable — showing local results only">
@@ -1061,7 +1158,8 @@ export class ScionFileBrowser extends LitElement {
                   @sl-change=${(e: Event) => {
                     this.showDotFiles = (e.target as HTMLInputElement).checked;
                   }}
-                >show .dot files</sl-checkbox>
+                  >show .dot files</sl-checkbox
+                >
               `
             : nothing}
         </div>
@@ -1070,7 +1168,8 @@ export class ScionFileBrowser extends LitElement {
             ? html`
                 <div class="provider-warning">
                   <sl-icon name="exclamation-triangle"></sl-icon>
-                  Showing files from this server only — ${this.providerCount} brokers serve this project
+                  Showing files from this server only — ${this.providerCount} brokers serve this
+                  project
                 </div>
               `
             : nothing}
@@ -1082,7 +1181,11 @@ export class ScionFileBrowser extends LitElement {
           ></sl-icon-button>
           ${this.showArchive && this.dataSource?.getArchiveUrl?.() && this.files.length > 0
             ? html`
-                <sl-button size="small" variant="default" @click=${() => this.handleArchiveDownload()}>
+                <sl-button
+                  size="small"
+                  variant="default"
+                  @click=${() => this.handleArchiveDownload()}
+                >
                   <sl-icon slot="prefix" name="file-earmark-zip"></sl-icon>
                   Download Zip
                 </sl-button>
@@ -1090,11 +1193,7 @@ export class ScionFileBrowser extends LitElement {
             : nothing}
           ${this.editable
             ? html`
-                <sl-button
-                  size="small"
-                  variant="default"
-                  @click=${() => this.handleNewFile()}
-                >
+                <sl-button size="small" variant="default" @click=${() => this.handleNewFile()}>
                   <sl-icon slot="prefix" name="plus-lg"></sl-icon>
                   New File
                 </sl-button>
@@ -1138,9 +1237,7 @@ export class ScionFileBrowser extends LitElement {
       return html`
         <div class="empty-state">
           <sl-icon name="file-earmark"></sl-icon>
-          <p>
-            No files in this directory.${this.editable ? ' Upload files to get started.' : ''}
-          </p>
+          <p>No files in this directory.${this.editable ? ' Upload files to get started.' : ''}</p>
           ${this.editable
             ? html`
                 <sl-button
@@ -1168,99 +1265,100 @@ export class ScionFileBrowser extends LitElement {
         ${this.filterText && displayFiles.length === 0 && !this.backendSearching
           ? html`<div class="empty-filter">No files match the current filter.</div>`
           : html`
-        <table class="file-table">
-          <thead>
-            <tr>
-              <th
-                class="sortable ${this.sortField === 'name' ? 'sorted' : ''}"
-                @click=${() => this.toggleSort('name')}
-              >
-                <span class="sort-indicator">${this.sortIndicator('name')}</span>
-                Name
-              </th>
-              <th
-                class="sortable ${this.sortField === 'size' ? 'sorted' : ''}"
-                @click=${() => this.toggleSort('size')}
-              >
-                <span class="sort-indicator">${this.sortIndicator('size')}</span>
-                Size
-              </th>
-              <th
-                class="sortable hide-mobile ${this.sortField === 'modified' ? 'sorted' : ''}"
-                @click=${() => this.toggleSort('modified')}
-              >
-                <span class="sort-indicator">${this.sortIndicator('modified')}</span>
-                Modified
-              </th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            ${displayFiles.slice(0, 1000).map(
-              (file) => html`
-                <tr>
-                  <td>
-                    <span class="file-name">
-                      <sl-icon name="file-earmark"></sl-icon>
-                      ${file.path}
-                    </span>
-                  </td>
-                  <td><span class="file-size">${formatFileSize(file.size)}</span></td>
-                  <td class="hide-mobile">
-                    <span class="file-date">${this.formatDate(file.modTime)}</span>
-                  </td>
-                  <td class="file-actions">
-                    ${isPreviewable(file.path)
-                      ? html`
+              <table class="file-table">
+                <thead>
+                  <tr>
+                    <th
+                      class="sortable ${this.sortField === 'name' ? 'sorted' : ''}"
+                      @click=${() => this.toggleSort('name')}
+                    >
+                      <span class="sort-indicator">${this.sortIndicator('name')}</span>
+                      Name
+                    </th>
+                    <th
+                      class="sortable ${this.sortField === 'size' ? 'sorted' : ''}"
+                      @click=${() => this.toggleSort('size')}
+                    >
+                      <span class="sort-indicator">${this.sortIndicator('size')}</span>
+                      Size
+                    </th>
+                    <th
+                      class="sortable hide-mobile ${this.sortField === 'modified' ? 'sorted' : ''}"
+                      @click=${() => this.toggleSort('modified')}
+                    >
+                      <span class="sort-indicator">${this.sortIndicator('modified')}</span>
+                      Modified
+                    </th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  ${displayFiles.slice(0, 1000).map(
+                    (file) => html`
+                      <tr>
+                        <td>
+                          <span class="file-name">
+                            <sl-icon name="file-earmark"></sl-icon>
+                            ${file.path}
+                          </span>
+                        </td>
+                        <td><span class="file-size">${formatFileSize(file.size)}</span></td>
+                        <td class="hide-mobile">
+                          <span class="file-date">${this.formatDate(file.modTime)}</span>
+                        </td>
+                        <td class="file-actions">
+                          ${isPreviewable(file.path)
+                            ? html`
+                                <sl-icon-button
+                                  name="eye"
+                                  label="Preview ${file.path}"
+                                  @click=${() => this.handlePreview(file.path)}
+                                ></sl-icon-button>
+                              `
+                            : html`
+                                <sl-icon-button
+                                  name="eye"
+                                  label="Preview not available for this format"
+                                  class="preview-disabled"
+                                  disabled
+                                ></sl-icon-button>
+                              `}
+                          ${this.editable && isEditable(file.path, file.size)
+                            ? html`
+                                <sl-icon-button
+                                  name="pencil"
+                                  label="Edit ${file.path}"
+                                  @click=${() => this.handleEdit(file.path)}
+                                ></sl-icon-button>
+                              `
+                            : nothing}
                           <sl-icon-button
-                            name="eye"
-                            label="Preview ${file.path}"
-                            @click=${() => this.handlePreview(file.path)}
+                            name="download"
+                            label="Download ${file.path}"
+                            @click=${() => this.handleDownload(file.path)}
                           ></sl-icon-button>
-                        `
-                      : html`
-                          <sl-icon-button
-                            name="eye"
-                            label="Preview not available for this format"
-                            class="preview-disabled"
-                            disabled
-                          ></sl-icon-button>
-                        `}
-                    ${this.editable && isEditable(file.path, file.size)
-                      ? html`
-                          <sl-icon-button
-                            name="pencil"
-                            label="Edit ${file.path}"
-                            @click=${() => this.handleEdit(file.path)}
-                          ></sl-icon-button>
-                        `
-                      : nothing}
-                    <sl-icon-button
-                      name="download"
-                      label="Download ${file.path}"
-                      @click=${() => this.handleDownload(file.path)}
-                    ></sl-icon-button>
-                    ${this.editable
-                      ? html`
-                          <sl-icon-button
-                            name="trash"
-                            label="Delete ${file.path}"
-                            @click=${(e: MouseEvent) => this.handleDelete(file.path, e)}
-                          ></sl-icon-button>
-                        `
-                      : nothing}
-                  </td>
-                </tr>
-              `
-            )}
-          </tbody>
-        </table>
-        ${displayFiles.length > 1000
-          ? html`<div class="file-list-truncated">
-              File list truncated — showing 1,000 of ${displayFiles.length.toLocaleString()} files
-            </div>`
-          : nothing}
-        `}
+                          ${this.editable
+                            ? html`
+                                <sl-icon-button
+                                  name="trash"
+                                  label="Delete ${file.path}"
+                                  @click=${(e: MouseEvent) => this.handleDelete(file.path, e)}
+                                ></sl-icon-button>
+                              `
+                            : nothing}
+                        </td>
+                      </tr>
+                    `
+                  )}
+                </tbody>
+              </table>
+              ${displayFiles.length > 1000
+                ? html`<div class="file-list-truncated">
+                    File list truncated — showing 1,000 of ${displayFiles.length.toLocaleString()}
+                    files
+                  </div>`
+                : nothing}
+            `}
       </div>
     `;
   }

--- a/web/src/components/shared/file-editor.ts
+++ b/web/src/components/shared/file-editor.ts
@@ -52,7 +52,11 @@ export interface FileEditorDataSource {
   /** Fetch file content as JSON (for editing). */
   getFileContent(path: string): Promise<FileContentResponse>;
   /** Save file content. Returns updated metadata. */
-  saveFileContent(path: string, content: string, expectedModTime?: string): Promise<{ modTime: string }>;
+  saveFileContent(
+    path: string,
+    content: string,
+    expectedModTime?: string
+  ): Promise<{ modTime: string }>;
 }
 
 // ────────────────────────────────────────────────────────────
@@ -79,7 +83,11 @@ export class WorkspaceFileEditorDataSource implements FileEditorDataSource {
     return (await res.json()) as FileContentResponse;
   }
 
-  async saveFileContent(path: string, content: string, expectedModTime?: string): Promise<{ modTime: string }> {
+  async saveFileContent(
+    path: string,
+    content: string,
+    expectedModTime?: string
+  ): Promise<{ modTime: string }> {
     const body: Record<string, string> = { content };
     if (expectedModTime) body.expectedModTime = expectedModTime;
 
@@ -107,7 +115,11 @@ export class SharedDirFileEditorDataSource implements FileEditorDataSource {
     return (await res.json()) as FileContentResponse;
   }
 
-  async saveFileContent(path: string, content: string, expectedModTime?: string): Promise<{ modTime: string }> {
+  async saveFileContent(
+    path: string,
+    content: string,
+    expectedModTime?: string
+  ): Promise<{ modTime: string }> {
     const body: Record<string, string> = { content };
     if (expectedModTime) body.expectedModTime = expectedModTime;
 
@@ -135,7 +147,11 @@ export class TemplateFileEditorDataSource implements FileEditorDataSource {
     return (await res.json()) as FileContentResponse;
   }
 
-  async saveFileContent(path: string, content: string, _expectedModTime?: string): Promise<{ modTime: string }> {
+  async saveFileContent(
+    path: string,
+    content: string,
+    _expectedModTime?: string
+  ): Promise<{ modTime: string }> {
     const body: Record<string, string> = { content };
 
     const res = await apiFetch(`${this.basePath}/${encodeFilePath(path)}`, {
@@ -168,7 +184,11 @@ export class HarnessConfigFileEditorDataSource implements FileEditorDataSource {
     return (await res.json()) as FileContentResponse;
   }
 
-  async saveFileContent(path: string, content: string, _expectedModTime?: string): Promise<{ modTime: string }> {
+  async saveFileContent(
+    path: string,
+    content: string,
+    _expectedModTime?: string
+  ): Promise<{ modTime: string }> {
     const body: Record<string, string> = { content };
 
     const res = await apiFetch(`${this.basePath}/${encodeFilePath(path)}`, {
@@ -295,9 +315,15 @@ export class ScionFileEditor extends LitElement {
     }
 
     @keyframes fade-out {
-      0% { opacity: 1; }
-      70% { opacity: 1; }
-      100% { opacity: 0; }
+      0% {
+        opacity: 1;
+      }
+      70% {
+        opacity: 1;
+      }
+      100% {
+        opacity: 0;
+      }
     }
 
     .new-file-input {
@@ -355,7 +381,11 @@ export class ScionFileEditor extends LitElement {
   }
 
   override updated(changed: Map<string, unknown>): void {
-    if ((changed.has('filePath') || changed.has('dataSource')) && this.filePath && this.dataSource) {
+    if (
+      (changed.has('filePath') || changed.has('dataSource')) &&
+      this.filePath &&
+      this.dataSource
+    ) {
       void this.loadFile();
     }
   }
@@ -418,7 +448,9 @@ export class ScionFileEditor extends LitElement {
       }
 
       this.saveSuccess = true;
-      setTimeout(() => { this.saveSuccess = false; }, 2000);
+      setTimeout(() => {
+        this.saveSuccess = false;
+      }, 2000);
 
       this.dispatchEvent(
         new CustomEvent('file-saved', {
@@ -487,9 +519,7 @@ export class ScionFileEditor extends LitElement {
           `
         : this.showPreview && this.isMarkdown
           ? html`
-              <scion-markdown-preview
-                .content=${this.currentContent}
-              ></scion-markdown-preview>
+              <scion-markdown-preview .content=${this.currentContent}></scion-markdown-preview>
             `
           : html`
               <scion-code-editor
@@ -523,7 +553,9 @@ export class ScionFileEditor extends LitElement {
               `
             : html`
                 <span class="file-name">${this.filePath}</span>
-                ${this.dirty ? html`<span class="dirty-indicator" title="Unsaved changes"></span>` : nothing}
+                ${this.dirty
+                  ? html`<span class="dirty-indicator" title="Unsaved changes"></span>`
+                  : nothing}
               `}
           ${this.saveSuccess ? html`<span class="save-flash">Saved</span>` : nothing}
         </div>
@@ -563,9 +595,7 @@ export class ScionFileEditor extends LitElement {
                 </sl-button>
               `
             : nothing}
-          <sl-button size="small" variant="default" @click=${this.handleClose}>
-            Close
-          </sl-button>
+          <sl-button size="small" variant="default" @click=${this.handleClose}> Close </sl-button>
         </div>
       </div>
     `;

--- a/web/src/components/shared/gcp-service-account-list.ts
+++ b/web/src/components/shared/gcp-service-account-list.ts
@@ -40,7 +40,12 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-import type { GCPServiceAccount, GCPVerificationStatus, Capabilities, GCPMintQuotaInfo } from '../../shared/types.js';
+import type {
+  GCPServiceAccount,
+  GCPVerificationStatus,
+  Capabilities,
+  GCPMintQuotaInfo,
+} from '../../shared/types.js';
 import { can } from '../../shared/types.js';
 import type { GCPSAListScope } from '../../shared/gcp-service-account-urls.js';
 import {
@@ -257,7 +262,9 @@ export class ScionGCPServiceAccountList extends LitElement {
       const response = await apiFetch(saListUrl(this.scope, this.scopeId));
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       const data = (await response.json()) as
@@ -317,14 +324,11 @@ export class ScionGCPServiceAccountList extends LitElement {
         throw new Error('Minting is only available for a project');
       }
 
-      const response = await apiFetch(
-        url,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body),
-        }
-      );
+      const response = await apiFetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
 
       if (!response.ok) {
         throw new Error(
@@ -396,7 +400,9 @@ export class ScionGCPServiceAccountList extends LitElement {
       });
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       // Check if auto-verification failed after registration
@@ -479,7 +485,9 @@ export class ScionGCPServiceAccountList extends LitElement {
       const response = await apiFetch(saRef(account), { method: 'DELETE' });
 
       if (!response.ok && response.status !== 204) {
-        throw new Error(await extractApiError(response, `Failed to delete (HTTP ${response.status})`));
+        throw new Error(
+          await extractApiError(response, `Failed to delete (HTTP ${response.status})`)
+        );
       }
 
       await this.loadAccounts();
@@ -620,7 +628,6 @@ export class ScionGCPServiceAccountList extends LitElement {
             : ''}
         </div>
         ${this.renderQuotaInfo()}
-
         ${this.loading
           ? html`<div class="section-loading">
               <sl-spinner></sl-spinner> Loading service accounts...
@@ -835,7 +842,9 @@ export class ScionGCPServiceAccountList extends LitElement {
             label="GCP Project ID"
             placeholder="e.g. my-project-123"
             value=${this.dialogProjectId}
-            help-text=${this.extractProjectFromEmail(this.dialogEmail) ? 'Auto-detected from service account email' : ''}
+            help-text=${this.extractProjectFromEmail(this.dialogEmail)
+              ? 'Auto-detected from service account email'
+              : ''}
             @sl-input=${(e: Event) => {
               this.dialogProjectId = (e.target as HTMLInputElement).value;
             }}
@@ -944,8 +953,8 @@ export class ScionGCPServiceAccountList extends LitElement {
           >
             Allow this service account to act as itself
             <div slot="help-text">
-              Enables using this SA as a project default, allowing agents to create
-              sub-agents that run as this same identity. Recommended for most use cases.
+              Enables using this SA as a project default, allowing agents to create sub-agents that
+              run as this same identity. Recommended for most use cases.
             </div>
           </sl-checkbox>
 
@@ -955,7 +964,9 @@ export class ScionGCPServiceAccountList extends LitElement {
             automatically verified for impersonation by the Hub.
           </div>
 
-          ${this.mintDialogError ? html`<div class="dialog-error">${this.mintDialogError}</div>` : nothing}
+          ${this.mintDialogError
+            ? html`<div class="dialog-error">${this.mintDialogError}</div>`
+            : nothing}
         </form>
 
         <sl-button
@@ -1030,7 +1041,9 @@ export class ScionGCPServiceAccountList extends LitElement {
             assignment until verification succeeds.
           </p>
           <p>After granting the role, click the refresh icon to re-check verification.</p>
-          <p><strong>Note:</strong> GCP IAM permission changes may take several minutes to propagate.</p>
+          <p>
+            <strong>Note:</strong> GCP IAM permission changes may take several minutes to propagate.
+          </p>
         </div>
 
         <sl-button slot="footer" variant="primary" @click=${this.closeVerifyFailedDialog}>

--- a/web/src/components/shared/git-remote-display.ts
+++ b/web/src/components/shared/git-remote-display.ts
@@ -72,7 +72,8 @@ export class ScionGitRemoteDisplay extends LitElement {
 
   static gitHubLink(remote: string): { url: string; display: string } | null {
     const sshMatch = remote.match(/^git@github\.com:(.+?)(?:\.git)?$/);
-    if (sshMatch) return { url: `https://github.com/${sshMatch[1]}`, display: `github.com/${sshMatch[1]}` };
+    if (sshMatch)
+      return { url: `https://github.com/${sshMatch[1]}`, display: `github.com/${sshMatch[1]}` };
     const httpsMatch = remote.match(/^https?:\/\/(github\.com\/.+?)(?:\.git)?$/);
     if (httpsMatch) return { url: `https://${httpsMatch[1]}`, display: httpsMatch[1] };
     const bareMatch = remote.match(/^(github\.com\/.+?)(?:\.git)?$/);
@@ -95,22 +96,39 @@ export class ScionGitRemoteDisplay extends LitElement {
 
     const ghLink = ScionGitRemoteDisplay.gitHubLink(project.gitRemote);
     const urlContent = ghLink
-      ? html`<a href="${ghLink.url}" target="_blank" rel="noopener noreferrer" @click=${this.handleLinkClick}>${ghLink.display}</a>`
+      ? html`<a
+          href="${ghLink.url}"
+          target="_blank"
+          rel="noopener noreferrer"
+          @click=${this.handleLinkClick}
+          >${ghLink.display}</a
+        >`
       : project.gitRemote;
 
     const worktree = isWorktreeWorkspace(project);
     const shared = isSharedWorkspace(project);
     const workspaceModeIcon = shared
-      ? html`<sl-tooltip content="Shared workspace"><sl-icon name="folder-fill" class="decorator-icon"></sl-icon></sl-tooltip>`
+      ? html`<sl-tooltip content="Shared workspace"
+          ><sl-icon name="folder-fill" class="decorator-icon"></sl-icon
+        ></sl-tooltip>`
       : worktree
-        ? html`<sl-tooltip content="Worktree per agent"><sl-icon name="diagram-3-fill" class="decorator-icon"></sl-icon></sl-tooltip>`
-        : html`<sl-tooltip content="Clone per agent"><sl-icon name="robot" class="decorator-icon"></sl-icon></sl-tooltip>`;
+        ? html`<sl-tooltip content="Worktree per agent"
+            ><sl-icon name="diagram-3-fill" class="decorator-icon"></sl-icon
+          ></sl-tooltip>`
+        : html`<sl-tooltip content="Clone per agent"
+            ><sl-icon name="robot" class="decorator-icon"></sl-icon
+          ></sl-tooltip>`;
 
-    const githubIcon = project.githubInstallationId != null
-      ? html`<sl-tooltip content="GitHub App installed"><sl-icon name="github" class="decorator-icon"></sl-icon></sl-tooltip>`
-      : nothing;
+    const githubIcon =
+      project.githubInstallationId != null
+        ? html`<sl-tooltip content="GitHub App installed"
+            ><sl-icon name="github" class="decorator-icon"></sl-icon
+          ></sl-tooltip>`
+        : nothing;
 
-    return html`<span class="git-remote-display">${urlContent}${workspaceModeIcon}${githubIcon}</span>`;
+    return html`<span class="git-remote-display"
+      >${urlContent}${workspaceModeIcon}${githubIcon}</span
+    >`;
   }
 }
 

--- a/web/src/components/shared/group-member-editor.ts
+++ b/web/src/components/shared/group-member-editor.ts
@@ -67,7 +67,8 @@ export class ScionGroupMemberEditor extends LitElement {
 
   // User search autocomplete state
   @state() private userSearchQuery = '';
-  @state() private userSearchResults: Array<{ id: string; email: string; displayName: string }> = [];
+  @state() private userSearchResults: Array<{ id: string; email: string; displayName: string }> =
+    [];
   @state() private userSearchLoading = false;
   @state() private userSearchOpen = false;
   private userSearchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -435,9 +436,7 @@ export class ScionGroupMemberEditor extends LitElement {
     this.error = null;
 
     try {
-      const response = await apiFetch(
-        `/api/v1/groups/${encodeURIComponent(this.groupId)}/members`
-      );
+      const response = await apiFetch(`/api/v1/groups/${encodeURIComponent(this.groupId)}/members`);
 
       if (!response.ok) {
         throw new Error(await extractApiError(response, `HTTP ${response.status}`));
@@ -494,11 +493,11 @@ export class ScionGroupMemberEditor extends LitElement {
     this.userSearchLoading = true;
     this.userSearchOpen = true;
     try {
-      const response = await apiFetch(
-        `/api/v1/users?search=${encodeURIComponent(query)}&limit=10`
-      );
+      const response = await apiFetch(`/api/v1/users?search=${encodeURIComponent(query)}&limit=10`);
       if (response.ok) {
-        const data = (await response.json()) as { users?: Array<{ id: string; email: string; displayName: string }> };
+        const data = (await response.json()) as {
+          users?: Array<{ id: string; email: string; displayName: string }>;
+        };
         this.userSearchResults = data.users || [];
       }
     } catch (err) {
@@ -536,11 +535,12 @@ export class ScionGroupMemberEditor extends LitElement {
     e.preventDefault();
 
     if (!this.addMemberInput.trim()) {
-      this.addMemberError = this.addMemberType === 'user'
-        ? 'Please search for and select a user'
-        : this.addMemberType === 'group'
-          ? 'Please select a group'
-          : 'Member ID is required';
+      this.addMemberError =
+        this.addMemberType === 'user'
+          ? 'Please search for and select a user'
+          : this.addMemberType === 'group'
+            ? 'Please select a group'
+            : 'Member ID is required';
       return;
     }
 
@@ -562,7 +562,9 @@ export class ScionGroupMemberEditor extends LitElement {
       );
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       this.closeAddDialog();
@@ -591,7 +593,9 @@ export class ScionGroupMemberEditor extends LitElement {
       );
 
       if (!response.ok && response.status !== 204) {
-        throw new Error(await extractApiError(response, `Failed to remove member (HTTP ${response.status})`));
+        throw new Error(
+          await extractApiError(response, `Failed to remove member (HTTP ${response.status})`)
+        );
       }
 
       await this.loadMembers();
@@ -666,10 +670,7 @@ export class ScionGroupMemberEditor extends LitElement {
           : nothing}
       </div>
 
-      ${this.error
-        ? html`<div class="error-state">${this.error}</div>`
-        : nothing}
-
+      ${this.error ? html`<div class="error-state">${this.error}</div>` : nothing}
       ${this.loading
         ? html`<div class="loading-state"><sl-spinner></sl-spinner> Loading members...</div>`
         : this.members.length === 0
@@ -685,9 +686,7 @@ export class ScionGroupMemberEditor extends LitElement {
         <div class="section-header">
           <div class="section-header-info">
             <h2>${this.sectionTitle} <span class="member-count">(${this.members.length})</span></h2>
-            ${this.sectionDescription
-              ? html`<p>${this.sectionDescription}</p>`
-              : nothing}
+            ${this.sectionDescription ? html`<p>${this.sectionDescription}</p>` : nothing}
           </div>
           ${!this.readOnly
             ? html`
@@ -699,10 +698,7 @@ export class ScionGroupMemberEditor extends LitElement {
             : nothing}
         </div>
 
-        ${this.error
-          ? html`<div class="error-state">${this.error}</div>`
-          : nothing}
-
+        ${this.error ? html`<div class="error-state">${this.error}</div>` : nothing}
         ${this.loading
           ? html`<div class="loading-state"><sl-spinner></sl-spinner> Loading members...</div>`
           : this.members.length === 0
@@ -749,7 +745,9 @@ export class ScionGroupMemberEditor extends LitElement {
             <div class="member-info">
               <span class="member-name">${displayName}</span>
               <span class="member-detail">
-                ${member.memberType}${showId ? html` &middot; <span class="member-id">${member.memberId}</span>` : nothing}
+                ${member.memberType}${showId
+                  ? html` &middot; <span class="member-id">${member.memberId}</span>`
+                  : nothing}
               </span>
             </div>
           </div>
@@ -797,17 +795,19 @@ export class ScionGroupMemberEditor extends LitElement {
   private renderAddDialog() {
     if (this.readOnly) return nothing;
 
-    const inputLabel = this.addMemberType === 'user'
-      ? 'User'
-      : this.addMemberType === 'group'
-        ? 'Group'
-        : 'Agent ID';
+    const inputLabel =
+      this.addMemberType === 'user'
+        ? 'User'
+        : this.addMemberType === 'group'
+          ? 'Group'
+          : 'Agent ID';
 
-    const inputHint = this.addMemberType === 'user'
-      ? 'Enter the user\'s email address'
-      : this.addMemberType === 'group'
-        ? 'Select a group to add as a member'
-        : 'Enter the agent ID';
+    const inputHint =
+      this.addMemberType === 'user'
+        ? "Enter the user's email address"
+        : this.addMemberType === 'group'
+          ? 'Select a group to add as a member'
+          : 'Enter the agent ID';
 
     return html`
       <sl-dialog
@@ -858,7 +858,10 @@ export class ScionGroupMemberEditor extends LitElement {
                     : this.availableGroups.length === 0
                       ? html`<sl-option value="" disabled>No groups available</sl-option>`
                       : this.availableGroups.map(
-                          (g) => html`<sl-option value=${g.id}>${g.name} <small>(${g.slug})</small></sl-option>`
+                          (g) =>
+                            html`<sl-option value=${g.id}
+                              >${g.name} <small>(${g.slug})</small></sl-option
+                            >`
                         )}
                 </sl-select>
               `
@@ -877,7 +880,9 @@ export class ScionGroupMemberEditor extends LitElement {
                       }}
                       @sl-blur=${() => {
                         // Delay to allow click on dropdown
-                        setTimeout(() => { this.userSearchOpen = false; }, 200);
+                        setTimeout(() => {
+                          this.userSearchOpen = false;
+                        }, 200);
                       }}
                       required
                     ></sl-input>
@@ -885,7 +890,9 @@ export class ScionGroupMemberEditor extends LitElement {
                       ? html`
                           <div class="user-search-dropdown">
                             ${this.userSearchLoading
-                              ? html`<div class="user-search-loading"><sl-spinner></sl-spinner> Searching...</div>`
+                              ? html`<div class="user-search-loading">
+                                  <sl-spinner></sl-spinner> Searching...
+                                </div>`
                               : this.userSearchResults.length === 0
                                 ? html`<div class="user-search-empty">No users found</div>`
                                 : this.userSearchResults.map(
@@ -897,7 +904,9 @@ export class ScionGroupMemberEditor extends LitElement {
                                           this.selectUser(user);
                                         }}
                                       >
-                                        <span class="user-name">${user.displayName || user.email}</span>
+                                        <span class="user-name"
+                                          >${user.displayName || user.email}</span
+                                        >
                                         ${user.displayName
                                           ? html`<span class="user-email">${user.email}</span>`
                                           : nothing}

--- a/web/src/components/shared/header.ts
+++ b/web/src/components/shared/header.ts
@@ -310,7 +310,11 @@ export class ScionHeader extends LitElement {
 
     return html`
       <div class="user-buttons">
-        <a href="/profile" class="profile-link" @click=${(e: Event): void => this.handleProfileClick(e)}>
+        <a
+          href="/profile"
+          class="profile-link"
+          @click=${(e: Event): void => this.handleProfileClick(e)}
+        >
           <sl-icon name="person"></sl-icon>
           Profile
         </a>

--- a/web/src/components/shared/inbox-tray.ts
+++ b/web/src/components/shared/inbox-tray.ts
@@ -509,9 +509,7 @@ export class ScionInboxTray extends LitElement {
             : nothing}
         </div>
         <div class="panel-list">
-          ${count > 0
-            ? this.messages.map((m) => this.renderItem(m))
-            : this.renderEmpty()}
+          ${count > 0 ? this.messages.map((m) => this.renderItem(m)) : this.renderEmpty()}
         </div>
       </div>
     `;
@@ -529,10 +527,7 @@ export class ScionInboxTray extends LitElement {
           <div class="msg-meta">
             <span>${this.relativeTime(msg.createdAt)}</span>
             ${msg.type ? html`<span class="msg-type-badge">${msg.type}</span>` : nothing}
-            <button
-              class="mark-read-link"
-              @click=${(): void => void this.markOne(msg.id)}
-            >
+            <button class="mark-read-link" @click=${(): void => void this.markOne(msg.id)}>
               Mark read
             </button>
           </div>

--- a/web/src/components/shared/index.ts
+++ b/web/src/components/shared/index.ts
@@ -38,9 +38,18 @@ export { ScionAgentLogViewer } from './agent-log-viewer.js';
 export { ScionSharedDirList } from './shared-dir-list.js';
 export { ScionFileBrowser } from './file-browser.js';
 export type { FileEntry, FileListResult, FileBrowserDataSource } from './file-browser.js';
-export { WorkspaceFileBrowserDataSource, SharedDirFileBrowserDataSource, TemplateFileBrowserDataSource } from './file-browser.js';
+export {
+  WorkspaceFileBrowserDataSource,
+  SharedDirFileBrowserDataSource,
+  TemplateFileBrowserDataSource,
+} from './file-browser.js';
 export { ScionCodeEditor, getLanguageFromPath } from './code-editor.js';
-export { ScionFileEditor, WorkspaceFileEditorDataSource, SharedDirFileEditorDataSource, TemplateFileEditorDataSource } from './file-editor.js';
+export {
+  ScionFileEditor,
+  WorkspaceFileEditorDataSource,
+  SharedDirFileEditorDataSource,
+  TemplateFileEditorDataSource,
+} from './file-editor.js';
 export type { FileEditorDataSource, FileContentResponse } from './file-editor.js';
 export { ScionGCPServiceAccountList } from './gcp-service-account-list.js';
 export { ScionSubscriptionManager } from './subscription-manager.js';

--- a/web/src/components/shared/injected-skills-panel.test.ts
+++ b/web/src/components/shared/injected-skills-panel.test.ts
@@ -115,10 +115,7 @@ function makeFetchMock(calls: Call[], opts: MockOptions = {}) {
 
     // Hub list GET and project/user list GET have different shapes; return both
     // keys so either read path finds the configured list.
-    return jsonResponse(
-      { entries: opts.entries ?? [], system: [], user_defined: [] },
-      200
-    );
+    return jsonResponse({ entries: opts.entries ?? [], system: [], user_defined: [] }, 200);
   };
 }
 
@@ -337,7 +334,10 @@ describe('injected-skills-panel — handleDiscoverDirectory', () => {
   it('sends projectId for project scope', async () => {
     const calls: Call[] = [];
     const el = await createPanel('project', calls, {
-      discover: { status: 200, body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 } },
+      discover: {
+        status: 200,
+        body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 },
+      },
     });
     el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
     await el.handleDiscoverDirectory();
@@ -349,7 +349,10 @@ describe('injected-skills-panel — handleDiscoverDirectory', () => {
   it('sends no projectId for hub scope', async () => {
     const calls: Call[] = [];
     const el = await createPanel('hub', calls, {
-      discover: { status: 200, body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 } },
+      discover: {
+        status: 200,
+        body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 },
+      },
     });
     el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
     await el.handleDiscoverDirectory();
@@ -364,7 +367,10 @@ describe('injected-skills-panel — handleDiscoverDirectory', () => {
     // unauthenticated fetch of a public repo.
     const calls: Call[] = [];
     const el = await createPanel('user', calls, {
-      discover: { status: 200, body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 } },
+      discover: {
+        status: 200,
+        body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 },
+      },
     });
     el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
     await el.handleDiscoverDirectory();
@@ -376,7 +382,10 @@ describe('injected-skills-panel — handleDiscoverDirectory', () => {
   it('posts the raw directory URL, not the normalized form', async () => {
     const calls: Call[] = [];
     const el = await createPanel('project', calls, {
-      discover: { status: 200, body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 } },
+      discover: {
+        status: 200,
+        body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 },
+      },
     });
     el.dialogUri = 'https://github.com/org/repo/tree/main/custom/dir';
     el.dialogTransformed = 'https://github.com/org/repo/tree/main/custom/dir';
@@ -493,7 +502,10 @@ describe('injected-skills-panel — handleDiscoverDirectory', () => {
 
     const el = await createPanel('project', [], {
       discoverGate: gate,
-      discover: { status: 200, body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 } },
+      discover: {
+        status: 200,
+        body: { skills: [{ uri: 'gh://org/repo/a@main', name: 'a' }], count: 1 },
+      },
     });
     el.dialogUri = 'https://github.com/org/repo/tree/main/skills';
 

--- a/web/src/components/shared/injected-skills-panel.ts
+++ b/web/src/components/shared/injected-skills-panel.ts
@@ -80,10 +80,13 @@ function validateGHShorthand(uri: string): string {
   if (qIdx >= 0) {
     const query = main.slice(qIdx + 1);
     main = main.slice(0, qIdx);
-    if (!query.startsWith('token=')) throw new Error('Invalid gh:// URI: only ?token=SECRET_NAME is supported');
+    if (!query.startsWith('token='))
+      throw new Error('Invalid gh:// URI: only ?token=SECRET_NAME is supported');
     const tokenName = query.slice('token='.length);
     if (!tokenName || !/^[A-Z][A-Z0-9_]*$/.test(tokenName)) {
-      throw new Error('Invalid gh:// URI: ?token= value must be an uppercase env-var name (e.g. SKILLS_TOKEN)');
+      throw new Error(
+        'Invalid gh:// URI: ?token= value must be an uppercase env-var name (e.g. SKILLS_TOKEN)'
+      );
     }
     tokenSuffix = '?' + query;
   }
@@ -91,13 +94,16 @@ function validateGHShorthand(uri: string): string {
   const atIdx = main.lastIndexOf('@');
   if (atIdx >= 0) {
     const ref = main.slice(atIdx + 1);
-    if (!ref || ref === '.' || ref === '..') throw new Error('Invalid gh:// URI: invalid ref (must not be empty, ".", or "..")');
+    if (!ref || ref === '.' || ref === '..')
+      throw new Error('Invalid gh:// URI: invalid ref (must not be empty, ".", or "..")');
     main = main.slice(0, atIdx);
     refSuffix = '@' + ref;
   }
   const parts = main.split('/');
   if (parts.length !== 3 || parts.some((p) => !p || p === '.' || p === '..')) {
-    throw new Error('Invalid gh:// URI: expected gh://owner/repo/skill-name[@ref][?token=SECRET_NAME]');
+    throw new Error(
+      'Invalid gh:// URI: expected gh://owner/repo/skill-name[@ref][?token=SECRET_NAME]'
+    );
   }
   return 'gh://' + main + refSuffix + tokenSuffix;
 }
@@ -115,32 +121,57 @@ function normalizeGitHubURL(uri: string): string {
   if (qIdx >= 0) {
     const query = rest.slice(qIdx + 1);
     rest = rest.slice(0, qIdx);
-    if (!query.startsWith('token=')) throw new Error('Invalid GitHub URL: only ?token=SECRET_NAME is supported');
+    if (!query.startsWith('token='))
+      throw new Error('Invalid GitHub URL: only ?token=SECRET_NAME is supported');
     const tokenName = query.slice('token='.length);
     if (!tokenName || !/^[A-Z][A-Z0-9_]*$/.test(tokenName)) {
-      throw new Error('Invalid GitHub URL: ?token= value must be an uppercase env-var name (e.g. SKILLS_TOKEN)');
+      throw new Error(
+        'Invalid GitHub URL: ?token= value must be an uppercase env-var name (e.g. SKILLS_TOKEN)'
+      );
     }
     tokenSuffix = '?' + query;
   }
   const segments = rest.split('/');
   const [owner, repo, keyword, ref, ...pathParts] = segments;
-  if (!owner || !repo || !keyword || !ref || owner === '.' || owner === '..' || repo === '.' || repo === '..' || ref === '.' || ref === '..') {
-    throw new Error('Invalid GitHub URL: expected https://github.com/owner/repo/tree/ref/path/to/skill');
+  if (
+    !owner ||
+    !repo ||
+    !keyword ||
+    !ref ||
+    owner === '.' ||
+    owner === '..' ||
+    repo === '.' ||
+    repo === '..' ||
+    ref === '.' ||
+    ref === '..'
+  ) {
+    throw new Error(
+      'Invalid GitHub URL: expected https://github.com/owner/repo/tree/ref/path/to/skill'
+    );
   }
   const kw = keyword.toLowerCase();
   let fullPath: string;
   if (kw === 'tree') {
     fullPath = pathParts.join('/');
-    if (!fullPath) throw new Error('Invalid GitHub URL: missing skill path after ref; example: .../tree/main/skills/my-skill');
+    if (!fullPath)
+      throw new Error(
+        'Invalid GitHub URL: missing skill path after ref; example: .../tree/main/skills/my-skill'
+      );
   } else if (kw === 'blob') {
     const filePath = pathParts.join('/');
     if (!filePath) throw new Error('Invalid GitHub URL: missing file path after ref');
     const lastSlash = filePath.lastIndexOf('/');
-    if (lastSlash < 0) throw new Error('Invalid GitHub URL: cannot determine skill directory from blob URL (no parent directory)');
+    if (lastSlash < 0)
+      throw new Error(
+        'Invalid GitHub URL: cannot determine skill directory from blob URL (no parent directory)'
+      );
     fullPath = filePath.slice(0, lastSlash);
-    if (!fullPath) throw new Error('Invalid GitHub URL: cannot determine skill directory from blob URL');
+    if (!fullPath)
+      throw new Error('Invalid GitHub URL: cannot determine skill directory from blob URL');
   } else {
-    throw new Error(`Invalid GitHub URL: expected /tree/ or /blob/ after owner/repo, got /${keyword}/`);
+    throw new Error(
+      `Invalid GitHub URL: expected /tree/ or /blob/ after owner/repo, got /${keyword}/`
+    );
   }
   // Use gh:// shorthand for skills/skill-name paths (standard layout).
   const pathSegs = fullPath.split('/');
@@ -545,9 +576,7 @@ export class ScionInjectedSkillsPanel extends LitElement {
   private async addEntry(uri: string, skillAs: string, optional: boolean): Promise<void> {
     if (this.scope === 'hub') {
       // For hub: append to user_defined and PUT the full user_defined list
-      const userDefined = this.rows
-        .filter((r) => !r.readonly)
-        .map((r) => this.rowToSkillRef(r));
+      const userDefined = this.rows.filter((r) => !r.readonly).map((r) => this.rowToSkillRef(r));
       userDefined.push(this.buildSkillRef(uri, skillAs, optional));
       await this.putHubUserDefined(userDefined);
     } else {
@@ -636,9 +665,7 @@ export class ScionInjectedSkillsPanel extends LitElement {
 
   private async reorder(newOrder: SkillRow[]): Promise<void> {
     if (this.scope === 'hub') {
-      const userDefined = newOrder
-        .filter((r) => !r.readonly)
-        .map((r) => this.rowToSkillRef(r));
+      const userDefined = newOrder.filter((r) => !r.readonly).map((r) => this.rowToSkillRef(r));
       await this.putHubUserDefined(userDefined);
     } else {
       const entries = newOrder.map((r, i) => ({
@@ -654,7 +681,9 @@ export class ScionInjectedSkillsPanel extends LitElement {
         body: JSON.stringify({ entries }),
       });
       if (!res.ok) {
-        throw new Error(await extractApiError(res, `Failed to reorder skills (HTTP ${res.status})`));
+        throw new Error(
+          await extractApiError(res, `Failed to reorder skills (HTTP ${res.status})`)
+        );
       }
     }
     await this.load();
@@ -690,7 +719,9 @@ export class ScionInjectedSkillsPanel extends LitElement {
       body: JSON.stringify({ user_defined: userDefined }),
     });
     if (!res.ok) {
-      throw new Error(await extractApiError(res, `Failed to update hub skills (HTTP ${res.status})`));
+      throw new Error(
+        await extractApiError(res, `Failed to update hub skills (HTTP ${res.status})`)
+      );
     }
   }
 
@@ -762,7 +793,9 @@ export class ScionInjectedSkillsPanel extends LitElement {
       );
       if (res.ok) {
         const data = (await res.json()) as { skills?: Skill[] } | Skill[];
-        this.dialogSkillResults = Array.isArray(data) ? data : (data as { skills?: Skill[] }).skills || [];
+        this.dialogSkillResults = Array.isArray(data)
+          ? data
+          : (data as { skills?: Skill[] }).skills || [];
       }
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') return; // Stale request — discard
@@ -1088,7 +1121,6 @@ export class ScionInjectedSkillsPanel extends LitElement {
           : this.rows.length === 0
             ? this.renderEmpty()
             : this.renderTable()}
-
       ${this.renderDialog()} ${this.renderDiscoveryDialog()}
     `;
   }
@@ -1200,13 +1232,9 @@ export class ScionInjectedSkillsPanel extends LitElement {
           : nothing}
         <td>
           <div class="skill-info">
-            ${row.skillName
-              ? html`<span class="skill-name">${row.skillName}</span>`
-              : nothing}
+            ${row.skillName ? html`<span class="skill-name">${row.skillName}</span>` : nothing}
             ${this.renderMiddleTruncatedUri(row.uri)}
-            ${row.skillSlug
-              ? html`<span class="skill-uri">/${row.skillSlug}</span>`
-              : nothing}
+            ${row.skillSlug ? html`<span class="skill-uri">/${row.skillSlug}</span>` : nothing}
           </div>
           ${rowReadonly
             ? html`
@@ -1220,12 +1248,20 @@ export class ScionInjectedSkillsPanel extends LitElement {
         <td>
           ${row.as
             ? html`<span class="key-cell">${row.as}</span>`
-            : html`<span style="color: var(--scion-text-muted, #64748b); font-size: 0.8125rem;">—</span>`}
+            : html`<span style="color: var(--scion-text-muted, #64748b); font-size: 0.8125rem;"
+                >—</span
+              >`}
         </td>
         <td>
           ${row.optional
-            ? html`<sl-icon name="check-circle" style="color: var(--sl-color-success-600, #16a34a);"></sl-icon>`
-            : html`<sl-icon name="x-circle" style="color: var(--scion-text-muted, #64748b);"></sl-icon>`}
+            ? html`<sl-icon
+                name="check-circle"
+                style="color: var(--sl-color-success-600, #16a34a);"
+              ></sl-icon>`
+            : html`<sl-icon
+                name="x-circle"
+                style="color: var(--scion-text-muted, #64748b);"
+              ></sl-icon>`}
         </td>
         ${canEdit
           ? html`
@@ -1250,7 +1286,11 @@ export class ScionInjectedSkillsPanel extends LitElement {
 
   private async handleDeleteRow(row: SkillRow, rowIndex: number): Promise<void> {
     const label = row.skillName || row.uri;
-    if (!(await showConfirm(`Remove skill "${label}" from this ${this.scope === 'hub' ? 'hub' : this.scope === 'project' ? 'project' : 'profile'}?`))) {
+    if (
+      !(await showConfirm(
+        `Remove skill "${label}" from this ${this.scope === 'hub' ? 'hub' : this.scope === 'project' ? 'project' : 'profile'}?`
+      ))
+    ) {
       return;
     }
     // Guard against stale rowIndex: a concurrent drag-reorder between the click
@@ -1331,18 +1371,26 @@ export class ScionInjectedSkillsPanel extends LitElement {
                         ${this.dialogSkillResults.map(
                           (skill) => html`
                             <div
-                              class="search-result-item ${this.dialogSelectedSkill?.id === skill.id ? 'selected' : ''}"
+                              class="search-result-item ${this.dialogSelectedSkill?.id === skill.id
+                                ? 'selected'
+                                : ''}"
                               @click=${() => {
                                 this.dialogSelectedSkill = skill;
                               }}
                             >
-                              <sl-icon name="puzzle" style="color: var(--scion-primary, #3b82f6);"></sl-icon>
+                              <sl-icon
+                                name="puzzle"
+                                style="color: var(--scion-primary, #3b82f6);"
+                              ></sl-icon>
                               <div>
                                 <div>${skill.name}</div>
                                 <div class="skill-slug">${skill.slug}</div>
                               </div>
                               ${this.dialogSelectedSkill?.id === skill.id
-                                ? html`<sl-icon name="check-circle-fill" style="margin-left: auto; color: var(--scion-primary, #3b82f6);"></sl-icon>`
+                                ? html`<sl-icon
+                                    name="check-circle-fill"
+                                    style="margin-left: auto; color: var(--scion-primary, #3b82f6);"
+                                  ></sl-icon>`
                                 : nothing}
                             </div>
                           `
@@ -1350,9 +1398,10 @@ export class ScionInjectedSkillsPanel extends LitElement {
                       </div>
                     `
                   : this.dialogSkillQuery && !this.dialogSkillSearching
-                    ? html`<div class="no-results">No skills found matching "${this.dialogSkillQuery}"</div>`
+                    ? html`<div class="no-results">
+                        No skills found matching "${this.dialogSkillQuery}"
+                      </div>`
                     : nothing}
-
                 ${this.dialogSelectedSkill
                   ? html`
                       <div class="dialog-hint">
@@ -1426,9 +1475,7 @@ export class ScionInjectedSkillsPanel extends LitElement {
             </span>
           </label>
 
-          ${this.dialogError
-            ? html`<div class="dialog-error">${this.dialogError}</div>`
-            : nothing}
+          ${this.dialogError ? html`<div class="dialog-error">${this.dialogError}</div>` : nothing}
         </div>
 
         <sl-button

--- a/web/src/components/shared/json-browser.ts
+++ b/web/src/components/shared/json-browser.ts
@@ -122,7 +122,11 @@ export class ScionJsonBrowser extends LitElement {
     return this.renderValue(this.data, '', true);
   }
 
-  private renderValue(value: unknown, path: string, isRoot: boolean): TemplateResult | typeof nothing {
+  private renderValue(
+    value: unknown,
+    path: string,
+    isRoot: boolean
+  ): TemplateResult | typeof nothing {
     if (value === null || value === undefined) {
       return html`<span class="val-null">null</span>`;
     }
@@ -218,11 +222,7 @@ export class ScionJsonBrowser extends LitElement {
     `;
   }
 
-  private renderCompositeEntry(
-    key: string,
-    val: unknown,
-    path: string
-  ): TemplateResult {
+  private renderCompositeEntry(key: string, val: unknown, path: string): TemplateResult {
     const isOpen = this.expanded.has(path);
     const isArr = Array.isArray(val);
     const count = isArr ? (val as unknown[]).length : Object.keys(val as object).length;

--- a/web/src/components/shared/markdown-preview.ts
+++ b/web/src/components/shared/markdown-preview.ts
@@ -68,10 +68,22 @@ export class ScionMarkdownPreview extends LitElement {
       color: var(--scion-text, #1e293b);
     }
 
-    .preview-container h1 { font-size: 1.75rem; border-bottom: 1px solid var(--scion-border, #e2e8f0); padding-bottom: 0.3em; }
-    .preview-container h2 { font-size: 1.375rem; border-bottom: 1px solid var(--scion-border, #e2e8f0); padding-bottom: 0.3em; }
-    .preview-container h3 { font-size: 1.125rem; }
-    .preview-container h4 { font-size: 1rem; }
+    .preview-container h1 {
+      font-size: 1.75rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      padding-bottom: 0.3em;
+    }
+    .preview-container h2 {
+      font-size: 1.375rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      padding-bottom: 0.3em;
+    }
+    .preview-container h3 {
+      font-size: 1.125rem;
+    }
+    .preview-container h4 {
+      font-size: 1rem;
+    }
 
     .preview-container p {
       margin: 0 0 1em;

--- a/web/src/components/shared/notification-tray.ts
+++ b/web/src/components/shared/notification-tray.ts
@@ -633,9 +633,7 @@ export class ScionNotificationTray extends LitElement {
             : nothing}
         </div>
         <div class="panel-list">
-          ${count > 0
-            ? this.notifications.map((n) => this.renderItem(n))
-            : this.renderEmpty()}
+          ${count > 0 ? this.notifications.map((n) => this.renderItem(n)) : this.renderEmpty()}
         </div>
         <div class="panel-footer">
           <a
@@ -648,7 +646,8 @@ export class ScionNotificationTray extends LitElement {
               window.history.pushState({}, '', '/projects');
               window.dispatchEvent(new PopStateEvent('popstate'));
             }}
-          >Manage subscriptions</a>
+            >Manage subscriptions</a
+          >
         </div>
       </div>
     `;
@@ -667,13 +666,13 @@ export class ScionNotificationTray extends LitElement {
           </sl-tooltip>
           <div class="notif-meta">
             <span>${this.relativeTime(n.createdAt)}</span>
-            <a href="/agents/${n.agentId}" @click=${(e: Event): void => this.navigateToAgent(e, n.agentId)}>
+            <a
+              href="/agents/${n.agentId}"
+              @click=${(e: Event): void => this.navigateToAgent(e, n.agentId)}
+            >
               View agent
             </a>
-            <button
-              class="mark-read-link"
-              @click=${(): void => void this.ackOne(n.id)}
-            >
+            <button class="mark-read-link" @click=${(): void => void this.ackOne(n.id)}>
               Mark read
             </button>
           </div>

--- a/web/src/components/shared/project-template-list.ts
+++ b/web/src/components/shared/project-template-list.ts
@@ -207,7 +207,9 @@ export class ScionProjectTemplateList extends LitElement {
       const response = await apiFetch('/api/v1/projects?limit=100');
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const data = (await response.json()) as { projects?: ProjectItem[] };
-      this.sourceProjects = (data.projects ?? []).slice().sort((a, b) => a.name.localeCompare(b.name));
+      this.sourceProjects = (data.projects ?? [])
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name));
     } catch (err) {
       this.createError = err instanceof Error ? err.message : 'Failed to load projects';
     } finally {
@@ -223,8 +225,8 @@ export class ScionProjectTemplateList extends LitElement {
   private onSourceProjectChange(e: Event): void {
     const oldSourceId = this.selectedSourceId;
     this.selectedSourceId = (e.target as HTMLSelectElement).value;
-    const oldProject = this.sourceProjects.find(p => p.id === oldSourceId);
-    const project = this.sourceProjects.find(p => p.id === this.selectedSourceId);
+    const oldProject = this.sourceProjects.find((p) => p.id === oldSourceId);
+    const project = this.sourceProjects.find((p) => p.id === this.selectedSourceId);
     if (project) {
       const oldDefaultName = oldProject ? `${oldProject.name} Template` : '';
       if (!this.newTemplateName || this.newTemplateName === oldDefaultName) {
@@ -408,22 +410,15 @@ export class ScionProjectTemplateList extends LitElement {
             </div>
           `
         : html`
-            <div class="template-list">
-              ${this.templates.map(t => this.renderTemplate(t))}
-            </div>
+            <div class="template-list">${this.templates.map((t) => this.renderTemplate(t))}</div>
           `}
-
-      ${this.renderCreateDialog()}
-      ${this.renderCreateFromDialog()}
-      ${this.renderRenameDialog()}
+      ${this.renderCreateDialog()} ${this.renderCreateFromDialog()} ${this.renderRenameDialog()}
       ${this.renderDeleteDialog()}
     `;
   }
 
   private renderTemplate(template: ProjectTemplate) {
-    const created = template.created
-      ? new Date(template.created).toLocaleDateString()
-      : '';
+    const created = template.created ? new Date(template.created).toLocaleDateString() : '';
     return html`
       <div class="template-row">
         <sl-icon class="template-icon" name="file-earmark-code"></sl-icon>
@@ -446,7 +441,10 @@ export class ScionProjectTemplateList extends LitElement {
                 Rename
               </sl-menu-item>
               <sl-divider></sl-divider>
-              <sl-menu-item class="menu-item-danger" @click=${() => this.openDeleteDialog(template)}>
+              <sl-menu-item
+                class="menu-item-danger"
+                @click=${() => this.openDeleteDialog(template)}
+              >
                 <sl-icon slot="prefix" name="trash"></sl-icon>
                 Delete
               </sl-menu-item>
@@ -482,7 +480,9 @@ export class ScionProjectTemplateList extends LitElement {
               >
                 ${this.sourceProjects.length === 0
                   ? html`<sl-option disabled value="">No projects available</sl-option>`
-                  : this.sourceProjects.map(p => html`<sl-option value=${p.id}>${p.name}</sl-option>`)}
+                  : this.sourceProjects.map(
+                      (p) => html`<sl-option value=${p.id}>${p.name}</sl-option>`
+                    )}
               </sl-select>
             `}
         <sl-input
@@ -507,7 +507,9 @@ export class ScionProjectTemplateList extends LitElement {
             variant="primary"
             size="small"
             ?loading=${this.createLoading}
-            ?disabled=${this.createLoading || !this.selectedSourceId || !this.newTemplateName.trim()}
+            ?disabled=${this.createLoading ||
+            !this.selectedSourceId ||
+            !this.newTemplateName.trim()}
             @click=${() => this.confirmCreateTemplate()}
           >
             Create Template
@@ -539,7 +541,9 @@ export class ScionProjectTemplateList extends LitElement {
           @sl-input=${(e: Event) => (this.createFromName = (e.target as HTMLInputElement).value)}
           ?disabled=${this.createFromLoading}
         ></sl-input>
-        ${this.createFromError ? html`<div class="dialog-error">${this.createFromError}</div>` : nothing}
+        ${this.createFromError
+          ? html`<div class="dialog-error">${this.createFromError}</div>`
+          : nothing}
         <div slot="footer">
           <sl-button
             variant="default"

--- a/web/src/components/shared/quick-message-dialog.ts
+++ b/web/src/components/shared/quick-message-dialog.ts
@@ -108,8 +108,7 @@ export class ScionQuickMessageDialog extends LitElement {
       // Success — close dialog
       this.close();
     } catch (err) {
-      this.sendError =
-        err instanceof Error ? err.message : 'Failed to send message';
+      this.sendError = err instanceof Error ? err.message : 'Failed to send message';
     } finally {
       this.sending = false;
     }
@@ -123,16 +122,10 @@ export class ScionQuickMessageDialog extends LitElement {
   }
 
   render() {
-    const label = this.agentName
-      ? `Message ${this.agentName}`
-      : 'Send Message';
+    const label = this.agentName ? `Message ${this.agentName}` : 'Send Message';
 
     return html`
-      <sl-dialog
-        label=${label}
-        ?open=${this.open}
-        @sl-request-close=${this.close}
-      >
+      <sl-dialog label=${label} ?open=${this.open} @sl-request-close=${this.close}>
         <div class="dialog-body">
           <sl-textarea
             placeholder="Type your message…"
@@ -144,17 +137,10 @@ export class ScionQuickMessageDialog extends LitElement {
             @keydown=${this.handleKeydown}
             ?disabled=${this.sending}
           ></sl-textarea>
-          ${this.sendError
-            ? html`<div class="dialog-error">${this.sendError}</div>`
-            : nothing}
+          ${this.sendError ? html`<div class="dialog-error">${this.sendError}</div>` : nothing}
         </div>
 
-        <sl-button
-          slot="footer"
-          variant="default"
-          @click=${this.close}
-          ?disabled=${this.sending}
-        >
+        <sl-button slot="footer" variant="default" @click=${this.close} ?disabled=${this.sending}>
           Cancel
         </sl-button>
         <sl-button

--- a/web/src/components/shared/resource-import.ts
+++ b/web/src/components/shared/resource-import.ts
@@ -245,8 +245,7 @@ export class ScionResourceImport extends LitElement {
         discoverEndpoint = '/api/v1/resources/discover';
         discoverBody = { kind: this.kind, scope: 'global', sourceUrl: this.source };
       } else {
-        const path =
-          this.kind === 'template' ? 'discover-templates' : 'discover-harness-configs';
+        const path = this.kind === 'template' ? 'discover-templates' : 'discover-harness-configs';
         discoverEndpoint = `/api/v1/projects/${this.scopeId}/${path}`;
         discoverBody =
           this.mode === 'workspace'
@@ -261,9 +260,7 @@ export class ScionResourceImport extends LitElement {
       });
 
       if (!discoverResponse.ok) {
-        throw new Error(
-          await extractApiError(discoverResponse, `Failed to discover ${this.noun}`)
-        );
+        throw new Error(await extractApiError(discoverResponse, `Failed to discover ${this.noun}`));
       }
 
       const discovered = (await discoverResponse.json()) as {
@@ -525,9 +522,7 @@ export class ScionResourceImport extends LitElement {
             ?indeterminate=${!allSelected && !noneSelected}
             @sl-change=${(e: Event) => {
               const checked = (e.target as HTMLInputElement).checked;
-              this.selectedNames = checked
-                ? new Set(this.discoveredNames)
-                : new Set();
+              this.selectedNames = checked ? new Set(this.discoveredNames) : new Set();
               this.requestUpdate();
             }}
           >

--- a/web/src/components/shared/resource-list.ts
+++ b/web/src/components/shared/resource-list.ts
@@ -709,11 +709,7 @@ export class ScionResourceList extends LitElement {
         ></span>`;
       case 'error':
         return html`<span class="refresh-status"
-          ><sl-icon
-            class="refresh-error"
-            name="x-circle"
-            aria-label="Refresh failed"
-          ></sl-icon
+          ><sl-icon class="refresh-error" name="x-circle" aria-label="Refresh failed"></sl-icon
         ></span>`;
     }
   }

--- a/web/src/components/shared/schedule-list.ts
+++ b/web/src/components/shared/schedule-list.ts
@@ -81,21 +81,24 @@ export class ScionScheduleList extends LitElement {
   @state() private detailSchedule: Schedule | null = null;
   @state() private detailOpen = false;
 
-  static override styles = [resourceStyles, css`
-    .detail-row {
-      padding: 0.375rem 0;
-      font-size: 0.875rem;
-      color: var(--scion-text, #1e293b);
-      line-height: 1.5;
-    }
-    .detail-row strong {
-      display: inline-block;
-      min-width: 100px;
-      color: var(--scion-text-muted, #64748b);
-      font-weight: 600;
-      font-size: 0.8125rem;
-    }
-  `];
+  static override styles = [
+    resourceStyles,
+    css`
+      .detail-row {
+        padding: 0.375rem 0;
+        font-size: 0.875rem;
+        color: var(--scion-text, #1e293b);
+        line-height: 1.5;
+      }
+      .detail-row strong {
+        display: inline-block;
+        min-width: 100px;
+        color: var(--scion-text-muted, #64748b);
+        font-weight: 600;
+        font-size: 0.8125rem;
+      }
+    `,
+  ];
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -113,7 +116,9 @@ export class ScionScheduleList extends LitElement {
       );
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       const data = (await response.json()) as ListResponse;
@@ -371,9 +376,7 @@ export class ScionScheduleList extends LitElement {
                   </div>
                 `
               : this.renderTable()}
-
-        ${this.renderCreateDialog()}
-        ${this.renderDetailDialog()}
+        ${this.renderCreateDialog()} ${this.renderDetailDialog()}
       </div>
     `;
   }
@@ -419,9 +422,7 @@ export class ScionScheduleList extends LitElement {
             </div>
           `
         : this.renderTable()}
-
-      ${this.renderCreateDialog()}
-      ${this.renderDetailDialog()}
+      ${this.renderCreateDialog()} ${this.renderDetailDialog()}
     `;
   }
 
@@ -458,10 +459,20 @@ export class ScionScheduleList extends LitElement {
       <tr @click=${() => this.showDetail(sched)} style="cursor: pointer;">
         <td><strong>${sched.name}</strong></td>
         <td><span class="type-badge environment">${sched.eventType}</span></td>
-        <td><span class="meta-text" style="font-family: var(--scion-font-mono, monospace); font-size: 0.8125rem;">${sched.cronExpr}</span></td>
+        <td>
+          <span
+            class="meta-text"
+            style="font-family: var(--scion-font-mono, monospace); font-size: 0.8125rem;"
+            >${sched.cronExpr}</span
+          >
+        </td>
         <td><span class="meta-text">${nextRun}</span></td>
         <td><span class="badge ${this.statusBadgeClass(sched.status)}">${sched.status}</span></td>
-        <td class="hide-mobile"><span class="meta-text">${sched.runCount}${sched.errorCount > 0 ? ` (${sched.errorCount} err)` : ''}</span></td>
+        <td class="hide-mobile">
+          <span class="meta-text"
+            >${sched.runCount}${sched.errorCount > 0 ? ` (${sched.errorCount} err)` : ''}</span
+          >
+        </td>
         <td class="actions-cell" @click=${(e: Event) => e.stopPropagation()}>
           ${isActive
             ? html`
@@ -502,9 +513,7 @@ export class ScionScheduleList extends LitElement {
         @sl-request-close=${this.closeDialog}
       >
         <form class="dialog-form" @submit=${this.handleCreate}>
-          ${this.dialogError
-            ? html`<div class="dialog-error">${this.dialogError}</div>`
-            : nothing}
+          ${this.dialogError ? html`<div class="dialog-error">${this.dialogError}</div>` : nothing}
 
           <sl-input
             label="Name"
@@ -526,15 +535,20 @@ export class ScionScheduleList extends LitElement {
           <sl-select
             label="Event Type"
             .value=${this.dialogEventType}
-            @sl-change=${(e: Event) => (this.dialogEventType = (e.target as HTMLSelectElement).value)}
+            @sl-change=${(e: Event) =>
+              (this.dialogEventType = (e.target as HTMLSelectElement).value)}
           >
             <sl-option value="message">Message</sl-option>
             <sl-option value="dispatch_agent">Dispatch Agent</sl-option>
           </sl-select>
 
           <sl-input
-            label=${this.dialogEventType === 'dispatch_agent' ? 'Agent Name (to create)' : 'Target Agent'}
-            placeholder=${this.dialogEventType === 'dispatch_agent' ? 'worker-1' : 'agent-name or all'}
+            label=${this.dialogEventType === 'dispatch_agent'
+              ? 'Agent Name (to create)'
+              : 'Target Agent'}
+            placeholder=${this.dialogEventType === 'dispatch_agent'
+              ? 'worker-1'
+              : 'agent-name or all'}
             .value=${this.dialogAgent}
             @sl-input=${(e: Event) => (this.dialogAgent = (e.target as HTMLInputElement).value)}
             required
@@ -546,7 +560,8 @@ export class ScionScheduleList extends LitElement {
                   label="Message"
                   placeholder="Message to send"
                   .value=${this.dialogMessage}
-                  @sl-input=${(e: Event) => (this.dialogMessage = (e.target as HTMLTextAreaElement).value)}
+                  @sl-input=${(e: Event) =>
+                    (this.dialogMessage = (e.target as HTMLTextAreaElement).value)}
                   required
                 ></sl-textarea>
 
@@ -559,7 +574,9 @@ export class ScionScheduleList extends LitElement {
                   />
                   <span class="checkbox-text">
                     <span>Interrupt agent</span>
-                    <span class="checkbox-description">Interrupt the agent's current task before delivering the message.</span>
+                    <span class="checkbox-description"
+                      >Interrupt the agent's current task before delivering the message.</span
+                    >
                   </span>
                 </label>
               `
@@ -568,21 +585,24 @@ export class ScionScheduleList extends LitElement {
                   label="Template"
                   placeholder="template-name (optional)"
                   .value=${this.dialogTemplate}
-                  @sl-input=${(e: Event) => (this.dialogTemplate = (e.target as HTMLInputElement).value)}
+                  @sl-input=${(e: Event) =>
+                    (this.dialogTemplate = (e.target as HTMLInputElement).value)}
                 ></sl-input>
 
                 <sl-textarea
                   label="Task / Prompt"
                   placeholder="Task for the agent (optional)"
                   .value=${this.dialogTask}
-                  @sl-input=${(e: Event) => (this.dialogTask = (e.target as HTMLTextAreaElement).value)}
+                  @sl-input=${(e: Event) =>
+                    (this.dialogTask = (e.target as HTMLTextAreaElement).value)}
                 ></sl-textarea>
 
                 <sl-input
                   label="Branch"
                   placeholder="feature-branch (optional)"
                   .value=${this.dialogBranch}
-                  @sl-input=${(e: Event) => (this.dialogBranch = (e.target as HTMLInputElement).value)}
+                  @sl-input=${(e: Event) =>
+                    (this.dialogBranch = (e.target as HTMLInputElement).value)}
                 ></sl-input>
               `}
         </form>
@@ -618,31 +638,61 @@ export class ScionScheduleList extends LitElement {
         @sl-request-close=${this.closeDetail}
       >
         <div class="dialog-form">
-          <div class="detail-row"><strong>ID:</strong> <span style="font-family: var(--scion-font-mono, monospace); font-size: 0.8125rem;">${sched.id}</span></div>
-          <div class="detail-row"><strong>Status:</strong> <span class="badge ${this.statusBadgeClass(sched.status)}">${sched.status}</span></div>
+          <div class="detail-row">
+            <strong>ID:</strong>
+            <span style="font-family: var(--scion-font-mono, monospace); font-size: 0.8125rem;"
+              >${sched.id}</span
+            >
+          </div>
+          <div class="detail-row">
+            <strong>Status:</strong>
+            <span class="badge ${this.statusBadgeClass(sched.status)}">${sched.status}</span>
+          </div>
           <div class="detail-row"><strong>Cron:</strong> ${sched.cronExpr}</div>
           <div class="detail-row"><strong>Event Type:</strong> ${sched.eventType}</div>
           <div class="detail-row"><strong>Target Agent:</strong> ${agent}</div>
           ${sched.eventType === 'message' && payloadDetails.message
-            ? html`<div class="detail-row"><strong>Message:</strong> ${payloadDetails.message}</div>`
+            ? html`<div class="detail-row">
+                <strong>Message:</strong> ${payloadDetails.message}
+              </div>`
             : nothing}
           ${sched.eventType === 'dispatch_agent' && payloadDetails.template
-            ? html`<div class="detail-row"><strong>Template:</strong> ${payloadDetails.template}</div>`
+            ? html`<div class="detail-row">
+                <strong>Template:</strong> ${payloadDetails.template}
+              </div>`
             : nothing}
           ${sched.eventType === 'dispatch_agent' && payloadDetails.task
             ? html`<div class="detail-row"><strong>Task:</strong> ${payloadDetails.task}</div>`
             : nothing}
           ${sched.nextRunAt
-            ? html`<div class="detail-row"><strong>Next Run:</strong> ${this.formatFutureTime(sched.nextRunAt)} (${new Date(sched.nextRunAt).toLocaleString()})</div>`
+            ? html`<div class="detail-row">
+                <strong>Next Run:</strong> ${this.formatFutureTime(sched.nextRunAt)}
+                (${new Date(sched.nextRunAt).toLocaleString()})
+              </div>`
             : nothing}
           ${sched.lastRunAt
-            ? html`<div class="detail-row"><strong>Last Run:</strong> ${this.formatRelativeTime(sched.lastRunAt)} (${sched.lastRunStatus || 'unknown'})</div>`
+            ? html`<div class="detail-row">
+                <strong>Last Run:</strong> ${this.formatRelativeTime(sched.lastRunAt)}
+                (${sched.lastRunStatus || 'unknown'})
+              </div>`
             : nothing}
-          <div class="detail-row"><strong>Run Count:</strong> ${sched.runCount} total${sched.errorCount > 0 ? `, ${sched.errorCount} errors` : ''}</div>
+          <div class="detail-row">
+            <strong>Run Count:</strong> ${sched.runCount}
+            total${sched.errorCount > 0 ? `, ${sched.errorCount} errors` : ''}
+          </div>
           ${sched.lastRunError
-            ? html`<div class="detail-row"><strong>Last Error:</strong> <span style="color: var(--sl-color-danger-600, #dc2626);">${sched.lastRunError}</span></div>`
+            ? html`<div class="detail-row">
+                <strong>Last Error:</strong>
+                <span style="color: var(--sl-color-danger-600, #dc2626);"
+                  >${sched.lastRunError}</span
+                >
+              </div>`
             : nothing}
-          <div class="detail-row"><strong>Created:</strong> ${this.formatRelativeTime(sched.createdAt)}${sched.createdBy ? ` by ${sched.createdBy}` : ''}</div>
+          <div class="detail-row">
+            <strong>Created:</strong> ${this.formatRelativeTime(sched.createdAt)}${sched.createdBy
+              ? ` by ${sched.createdBy}`
+              : ''}
+          </div>
         </div>
 
         <sl-button slot="footer" variant="default" @click=${this.closeDetail}>Close</sl-button>

--- a/web/src/components/shared/scheduled-event-list.ts
+++ b/web/src/components/shared/scheduled-event-list.ts
@@ -87,7 +87,9 @@ export class ScionScheduledEventList extends LitElement {
       );
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       const data = (await response.json()) as ListResponse;
@@ -283,7 +285,6 @@ export class ScionScheduledEventList extends LitElement {
                   </div>
                 `
               : this.renderTable()}
-
         ${this.renderDialog()}
       </div>
     `;
@@ -330,7 +331,6 @@ export class ScionScheduledEventList extends LitElement {
             </div>
           `
         : this.renderTable()}
-
       ${this.renderDialog()}
     `;
   }
@@ -413,9 +413,7 @@ export class ScionScheduledEventList extends LitElement {
         @sl-request-close=${this.closeDialog}
       >
         <form class="dialog-form" @submit=${this.handleCreate}>
-          ${this.dialogError
-            ? html`<div class="dialog-error">${this.dialogError}</div>`
-            : nothing}
+          ${this.dialogError ? html`<div class="dialog-error">${this.dialogError}</div>` : nothing}
 
           <sl-input
             label="Target Agent"
@@ -429,7 +427,8 @@ export class ScionScheduledEventList extends LitElement {
             label="Message"
             placeholder="Message to send"
             .value=${this.dialogMessage}
-            @sl-input=${(e: Event) => (this.dialogMessage = (e.target as HTMLTextAreaElement).value)}
+            @sl-input=${(e: Event) =>
+              (this.dialogMessage = (e.target as HTMLTextAreaElement).value)}
             required
           ></sl-textarea>
 

--- a/web/src/components/shared/secret-list.test.ts
+++ b/web/src/components/shared/secret-list.test.ts
@@ -41,7 +41,9 @@ function encodeValue(raw: string): string {
 }
 
 /** Create the component, append to DOM, and wait for render. */
-async function createComponent(fetchMock: (url: string | URL | Request, init?: RequestInit) => Promise<Response>) {
+async function createComponent(
+  fetchMock: (url: string | URL | Request, init?: RequestInit) => Promise<Response>
+) {
   vi.stubGlobal('fetch', vi.fn(fetchMock));
   const el = document.createElement('scion-secret-list') as InstanceType<typeof ScionSecretList>;
   el.setAttribute('scope', 'user');
@@ -68,10 +70,10 @@ function makeBasicFetch(putSpy?: (body: Record<string, unknown>) => void) {
         }
       }
       return Promise.resolve(
-        new Response(
-          JSON.stringify({ secret: { key: 'TEST', version: 1 }, created: true }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        ),
+        new Response(JSON.stringify({ secret: { key: 'TEST', version: 1 }, created: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
       );
     }
     // GET /api/v1/secrets — return empty list.
@@ -79,7 +81,7 @@ function makeBasicFetch(putSpy?: (body: Record<string, unknown>) => void) {
       new Response(JSON.stringify({ secrets: [] }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
-      }),
+      })
     );
   };
 }
@@ -99,7 +101,11 @@ describe('scion-secret-list — base64 encoding before send (issue #251)', () =>
     const rawValue = 'my-plain-secret';
     let capturedBody: Record<string, unknown> = {};
 
-    const el = await createComponent(makeBasicFetch((body) => { capturedBody = body; }));
+    const el = await createComponent(
+      makeBasicFetch((body) => {
+        capturedBody = body;
+      })
+    );
 
     // Simulate the user opening the dialog and typing a value.
     (el as any).dialogKey = 'MY_SECRET';
@@ -121,7 +127,11 @@ describe('scion-secret-list — base64 encoding before send (issue #251)', () =>
     const unicodeValue = 'こんにちは🔑secret';
     let capturedBody: Record<string, unknown> = {};
 
-    const el = await createComponent(makeBasicFetch((body) => { capturedBody = body; }));
+    const el = await createComponent(
+      makeBasicFetch((body) => {
+        capturedBody = body;
+      })
+    );
 
     (el as any).dialogKey = 'UNICODE_KEY';
     (el as any).dialogValue = unicodeValue;
@@ -155,7 +165,11 @@ describe('scion-secret-list — base64 encoding before send (issue #251)', () =>
     const rawValue = 'api-key-value';
     let capturedBody: Record<string, unknown> = {};
 
-    const el = await createComponent(makeBasicFetch((body) => { capturedBody = body; }));
+    const el = await createComponent(
+      makeBasicFetch((body) => {
+        capturedBody = body;
+      })
+    );
 
     (el as any).dialogKey = 'API_KEY';
     (el as any).dialogValue = rawValue;

--- a/web/src/components/shared/secret-list.ts
+++ b/web/src/components/shared/secret-list.ts
@@ -89,7 +89,9 @@ export class ScionSecretList extends LitElement {
       const response = await apiFetch(url);
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       const data = (await response.json()) as { secrets?: Secret[] } | Secret[];
@@ -151,7 +153,11 @@ export class ScionSecretList extends LitElement {
 
     try {
       const body: Record<string, unknown> = {
-        value: btoa(Array.from(new TextEncoder().encode(this.dialogValue), b => String.fromCharCode(b)).join('')),
+        value: btoa(
+          Array.from(new TextEncoder().encode(this.dialogValue), (b) =>
+            String.fromCharCode(b)
+          ).join('')
+        ),
         scope: this.scope,
         description: this.dialogDescription || undefined,
         type: this.dialogType,
@@ -171,7 +177,9 @@ export class ScionSecretList extends LitElement {
       });
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       this.closeDialog();
@@ -185,7 +193,10 @@ export class ScionSecretList extends LitElement {
   }
 
   private async handleDelete(secret: Secret, event?: MouseEvent): Promise<void> {
-    if (!event?.altKey && !(await showConfirm(`Delete secret "${secret.key}"? This cannot be undone.`))) {
+    if (
+      !event?.altKey &&
+      !(await showConfirm(`Delete secret "${secret.key}"? This cannot be undone.`))
+    ) {
       return;
     }
 
@@ -199,7 +210,9 @@ export class ScionSecretList extends LitElement {
       const response = await apiFetch(deleteUrl, { method: 'DELETE' });
 
       if (!response.ok && response.status !== 204) {
-        throw new Error(await extractApiError(response, `Failed to delete (HTTP ${response.status})`));
+        throw new Error(
+          await extractApiError(response, `Failed to delete (HTTP ${response.status})`)
+        );
       }
 
       await this.loadSecrets();
@@ -302,8 +315,9 @@ export class ScionSecretList extends LitElement {
           <div class="section-header-info">
             <h2>Secrets</h2>
             <p>
-              Manage encrypted secrets for ${this.scope === 'hub' ? 'all agents on this hub' : 'agents in this project'}. Values are write-only and cannot be
-              retrieved after saving.
+              Manage encrypted secrets for
+              ${this.scope === 'hub' ? 'all agents on this hub' : 'agents in this project'}. Values
+              are write-only and cannot be retrieved after saving.
             </p>
           </div>
           <sl-button variant="primary" size="small" @click=${this.openCreateDialog}>
@@ -376,17 +390,25 @@ export class ScionSecretList extends LitElement {
             : html`<span class="badge inject-always">always</span>`}
         </td>
         ${this.scope === 'user'
-          ? html`<td>${secret.allowProgeny ? html`<sl-icon name="check-lg" title="Progeny can access"></sl-icon>` : '\u2014'}</td>`
+          ? html`<td>
+              ${secret.allowProgeny
+                ? html`<sl-icon name="check-lg" title="Progeny can access"></sl-icon>`
+                : '\u2014'}
+            </td>`
           : nothing}
         <td class="description-cell hide-mobile">${secret.description || '\u2014'}</td>
         <td>
           ${secret.secretRef
-            ? html`<sl-tooltip content=${this.copiedSecretKey === secret.key ? 'Copied!' : secret.secretRef} hoist>
+            ? html`<sl-tooltip
+                content=${this.copiedSecretKey === secret.key ? 'Copied!' : secret.secretRef}
+                hoist
+              >
                 <span
                   class="version-badge version-badge-copyable"
                   @click=${() => this.copySecretRef(secret)}
                   title=""
-                >v${secret.version}</span>
+                  >v${secret.version}</span
+                >
               </sl-tooltip>`
             : html`<span class="version-badge">v${secret.version}</span>`}
         </td>
@@ -418,7 +440,11 @@ export class ScionSecretList extends LitElement {
         <h3>No Secrets</h3>
         <p>
           Add encrypted secrets that will be securely injected into
-          ${this.compact ? (this.scope === 'hub' ? 'all agents on this hub' : 'agents in this project') : 'your agents'}.
+          ${this.compact
+            ? this.scope === 'hub'
+              ? 'all agents on this hub'
+              : 'agents in this project'
+            : 'your agents'}.
         </p>
         <sl-button variant="primary" size="small" @click=${this.openCreateDialog}>
           <sl-icon slot="prefix" name="plus-lg"></sl-icon>
@@ -542,11 +568,11 @@ export class ScionSecretList extends LitElement {
                   Allow agent progeny to access
                 </sl-switch>
                 <span class="radio-field-help">
-                  When enabled, agents spawned by your agents (and their descendants) will also receive this secret.
+                  When enabled, agents spawned by your agents (and their descendants) will also
+                  receive this secret.
                 </span>
               `
             : nothing}
-
           ${this.dialogError ? html`<div class="dialog-error">${this.dialogError}</div>` : nothing}
         </form>
 

--- a/web/src/components/shared/shared-dir-list.ts
+++ b/web/src/components/shared/shared-dir-list.ts
@@ -73,7 +73,9 @@ export class ScionSharedDirList extends LitElement {
       const response = await apiFetch(`${this.basePath}/shared-dirs`);
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       const data = (await response.json()) as { sharedDirs?: SharedDir[] } | SharedDir[];
@@ -113,8 +115,7 @@ export class ScionSharedDirList extends LitElement {
     }
 
     if (!SLUG_PATTERN.test(name)) {
-      this.dialogError =
-        'Name must be lowercase alphanumeric with hyphens (e.g. "build-cache")';
+      this.dialogError = 'Name must be lowercase alphanumeric with hyphens (e.g. "build-cache")';
       return;
     }
 
@@ -140,7 +141,9 @@ export class ScionSharedDirList extends LitElement {
       });
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
       this.closeDialog();
@@ -172,7 +175,9 @@ export class ScionSharedDirList extends LitElement {
       );
 
       if (!response.ok && response.status !== 204) {
-        throw new Error(await extractApiError(response, `Failed to delete (HTTP ${response.status})`));
+        throw new Error(
+          await extractApiError(response, `Failed to delete (HTTP ${response.status})`)
+        );
       }
 
       await this.loadSharedDirs();
@@ -193,7 +198,8 @@ export class ScionSharedDirList extends LitElement {
           <div class="section-header-info">
             <h2>Shared Directories</h2>
             <p>
-              Shared directories provide filesystem-level state sharing between agents in this project.
+              Shared directories provide filesystem-level state sharing between agents in this
+              project.
             </p>
           </div>
           <sl-button variant="primary" size="small" @click=${this.openCreateDialog}>
@@ -283,8 +289,8 @@ export class ScionSharedDirList extends LitElement {
         <sl-icon name="folder"></sl-icon>
         <h3>No Shared Directories</h3>
         <p>
-          Add shared directories to enable filesystem-level state sharing between agents
-          (e.g. build caches, artifacts, coordination files).
+          Add shared directories to enable filesystem-level state sharing between agents (e.g. build
+          caches, artifacts, coordination files).
         </p>
         <sl-button variant="primary" size="small" @click=${this.openCreateDialog}>
           <sl-icon slot="prefix" name="plus-lg"></sl-icon>
@@ -341,16 +347,14 @@ export class ScionSharedDirList extends LitElement {
               <span class="checkbox-text">
                 <span>Mount in workspace</span>
                 <span class="checkbox-description">
-                  Mount at /workspace/.scion-volumes/ instead of /scion-volumes/.
-                  Useful for caches that tools expect relative to the project root.
+                  Mount at /workspace/.scion-volumes/ instead of /scion-volumes/. Useful for caches
+                  that tools expect relative to the project root.
                 </span>
               </span>
             </label>
           </div>
 
-          ${this.dialogError
-            ? html`<div class="dialog-error">${this.dialogError}</div>`
-            : nothing}
+          ${this.dialogError ? html`<div class="dialog-error">${this.dialogError}</div>` : nothing}
         </form>
 
         <sl-button

--- a/web/src/components/shared/skill-publish-dialog.ts
+++ b/web/src/components/shared/skill-publish-dialog.ts
@@ -50,7 +50,9 @@ export class ScionSkillPublishDialog extends LitElement {
   private fileInputRef: HTMLInputElement | null = null;
 
   static override styles = css`
-    :host { display: contents; }
+    :host {
+      display: contents;
+    }
 
     .step-content {
       display: flex;
@@ -76,7 +78,8 @@ export class ScionSkillPublishDialog extends LitElement {
       color: var(--scion-text-muted, #64748b);
       font-size: 0.875rem;
     }
-    .drop-zone:hover, .drop-zone.dragover {
+    .drop-zone:hover,
+    .drop-zone.dragover {
       border-color: var(--scion-primary, #3b82f6);
       background: var(--sl-color-primary-50, #eff6ff);
       color: var(--scion-primary, #3b82f6);
@@ -129,9 +132,12 @@ export class ScionSkillPublishDialog extends LitElement {
       color: var(--scion-text-muted, #64748b);
       line-height: 1;
     }
-    .remove-btn:hover { color: var(--sl-color-danger-600, #dc2626); }
+    .remove-btn:hover {
+      color: var(--sl-color-danger-600, #dc2626);
+    }
 
-    .validation-error, .error-banner {
+    .validation-error,
+    .error-banner {
       background: var(--sl-color-danger-50, #fef2f2);
       border: 1px solid var(--sl-color-danger-200, #fecaca);
       border-radius: var(--scion-radius, 0.5rem);
@@ -142,7 +148,8 @@ export class ScionSkillPublishDialog extends LitElement {
       color: var(--sl-color-danger-700, #b91c1c);
       font-size: 0.875rem;
     }
-    .validation-error sl-icon, .error-banner sl-icon {
+    .validation-error sl-icon,
+    .error-banner sl-icon {
       flex-shrink: 0;
       margin-top: 0.125rem;
     }
@@ -173,7 +180,9 @@ export class ScionSkillPublishDialog extends LitElement {
       margin: 0 auto 0.5rem;
     }
 
-    input[type="file"] { display: none; }
+    input[type='file'] {
+      display: none;
+    }
   `;
 
   override updated(changed: Map<PropertyKey, unknown>): void {
@@ -274,7 +283,8 @@ export class ScionSkillPublishDialog extends LitElement {
 
   private validate(): string | null {
     if (!this.version.trim()) return 'Version is required.';
-    if (!this.validateSemver(this.version.trim())) return 'Version must be valid semver (e.g. 1.0.0).';
+    if (!this.validateSemver(this.version.trim()))
+      return 'Version must be valid semver (e.g. 1.0.0).';
     if (this.selectedFiles.length === 0) return 'At least one file is required.';
     if (!this.selectedFiles.some((f) => f.file.name === 'SKILL.md' || f.path === 'SKILL.md'))
       return 'A file named exactly SKILL.md is required.';
@@ -320,11 +330,13 @@ export class ScionSkillPublishDialog extends LitElement {
       this.createdVersion = data.version ?? null;
       this.step = 'done';
 
-      this.dispatchEvent(new CustomEvent('skill-version-published', {
-        detail: { version: this.createdVersion },
-        bubbles: true,
-        composed: true,
-      }));
+      this.dispatchEvent(
+        new CustomEvent('skill-version-published', {
+          detail: { version: this.createdVersion },
+          bubbles: true,
+          composed: true,
+        })
+      );
     } catch (err) {
       console.error('Publish failed:', err);
       this.step = 'error';
@@ -360,19 +372,23 @@ export class ScionSkillPublishDialog extends LitElement {
   private renderInput() {
     return html`
       <div class="step-content">
-        ${this.validationError ? html`
-          <div class="validation-error">
-            <sl-icon name="exclamation-triangle"></sl-icon>
-            <span>${this.validationError}</span>
-          </div>
-        ` : nothing}
+        ${this.validationError
+          ? html`
+              <div class="validation-error">
+                <sl-icon name="exclamation-triangle"></sl-icon>
+                <span>${this.validationError}</span>
+              </div>
+            `
+          : nothing}
 
         <div class="form-field">
           <label>Version</label>
           <sl-input
             placeholder="1.0.0"
             .value=${this.version}
-            @sl-input=${(e: Event) => { this.version = (e.target as HTMLElement & { value: string }).value; }}
+            @sl-input=${(e: Event) => {
+              this.version = (e.target as HTMLElement & { value: string }).value;
+            }}
           ></sl-input>
         </div>
 
@@ -390,25 +406,35 @@ export class ScionSkillPublishDialog extends LitElement {
           </div>
         </div>
 
-        ${this.selectedFiles.length > 0 ? html`
-          <ul class="file-list">
-            ${this.selectedFiles.map((sf, i) => html`
-              <li class="file-item">
-                <div class="file-info">
-                  <sl-icon name="file-earmark"></sl-icon>
-                  <span class="file-name">${sf.path}</span>
-                  <span class="file-size">${this.formatFileSize(sf.file.size)}</span>
-                </div>
-                <button class="remove-btn" @click=${() => this.removeFile(i)} title="Remove">
-                  <sl-icon name="x-lg"></sl-icon>
-                </button>
-              </li>
-            `)}
-          </ul>
-        ` : nothing}
+        ${this.selectedFiles.length > 0
+          ? html`
+              <ul class="file-list">
+                ${this.selectedFiles.map(
+                  (sf, i) => html`
+                    <li class="file-item">
+                      <div class="file-info">
+                        <sl-icon name="file-earmark"></sl-icon>
+                        <span class="file-name">${sf.path}</span>
+                        <span class="file-size">${this.formatFileSize(sf.file.size)}</span>
+                      </div>
+                      <button class="remove-btn" @click=${() => this.removeFile(i)} title="Remove">
+                        <sl-icon name="x-lg"></sl-icon>
+                      </button>
+                    </li>
+                  `
+                )}
+              </ul>
+            `
+          : nothing}
       </div>
 
-      <sl-button slot="footer" variant="default" @click=${() => { this.open = false; }}>
+      <sl-button
+        slot="footer"
+        variant="default"
+        @click=${() => {
+          this.open = false;
+        }}
+      >
         Cancel
       </sl-button>
       <sl-button
@@ -444,7 +470,13 @@ export class ScionSkillPublishDialog extends LitElement {
           <p><strong>Version ${this.version} published successfully!</strong></p>
         </div>
       </div>
-      <sl-button slot="footer" variant="primary" @click=${() => { this.open = false; }}>
+      <sl-button
+        slot="footer"
+        variant="primary"
+        @click=${() => {
+          this.open = false;
+        }}
+      >
         Close
       </sl-button>
     `;
@@ -458,7 +490,13 @@ export class ScionSkillPublishDialog extends LitElement {
           <span>${this.error}</span>
         </div>
       </div>
-      <sl-button slot="footer" variant="default" @click=${() => { this.open = false; }}>
+      <sl-button
+        slot="footer"
+        variant="default"
+        @click=${() => {
+          this.open = false;
+        }}
+      >
         Cancel
       </sl-button>
       <sl-button slot="footer" variant="primary" @click=${() => this.startPublish()}>

--- a/web/src/components/shared/subscription-manager.ts
+++ b/web/src/components/shared/subscription-manager.ts
@@ -38,7 +38,14 @@ interface SubscriptionTemplate {
 }
 
 const DEFAULT_TRIGGERS = ['COMPLETED', 'WAITING_FOR_INPUT', 'LIMITS_EXCEEDED'];
-const ALL_TRIGGERS = ['COMPLETED', 'WAITING_FOR_INPUT', 'LIMITS_EXCEEDED', 'STALLED', 'ERROR', 'DELETED'];
+const ALL_TRIGGERS = [
+  'COMPLETED',
+  'WAITING_FOR_INPUT',
+  'LIMITS_EXCEEDED',
+  'STALLED',
+  'ERROR',
+  'DELETED',
+];
 
 @customElement('scion-subscription-manager')
 export class ScionSubscriptionManager extends LitElement {
@@ -96,10 +103,15 @@ export class ScionSubscriptionManager extends LitElement {
       const response = await apiFetch(url);
 
       if (!response.ok) {
-        throw new Error(await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`));
+        throw new Error(
+          await extractApiError(response, `HTTP ${response.status}: ${response.statusText}`)
+        );
       }
 
-      const data = (await response.json()) as Subscription[] | { subscriptions?: Subscription[] } | null;
+      const data = (await response.json()) as
+        | Subscription[]
+        | { subscriptions?: Subscription[] }
+        | null;
       if (data == null) {
         this.subscriptions = [];
       } else if (Array.isArray(data)) {
@@ -296,7 +308,9 @@ export class ScionSubscriptionManager extends LitElement {
         </div>
 
         ${this.loading
-          ? html`<div class="section-loading"><sl-spinner></sl-spinner> Loading subscriptions...</div>`
+          ? html`<div class="section-loading">
+              <sl-spinner></sl-spinner> Loading subscriptions...
+            </div>`
           : this.error
             ? html`
                 <div class="section-error">
@@ -309,11 +323,17 @@ export class ScionSubscriptionManager extends LitElement {
                   <div class="empty-state">
                     <sl-icon name="bell-slash"></sl-icon>
                     <h3>No Subscriptions</h3>
-                    <p>${this.projectId
-                      ? 'Subscribe to get notified about agent activity in this project.'
-                      : 'You have no notification subscriptions. Subscribe from a project or agent page.'}</p>
+                    <p>
+                      ${this.projectId
+                        ? 'Subscribe to get notified about agent activity in this project.'
+                        : 'You have no notification subscriptions. Subscribe from a project or agent page.'}
+                    </p>
                     ${this.projectId
-                      ? html`<sl-button variant="primary" size="small" @click=${this.openCreateDialog}>
+                      ? html`<sl-button
+                          variant="primary"
+                          size="small"
+                          @click=${this.openCreateDialog}
+                        >
                           <sl-icon slot="prefix" name="bell"></sl-icon>
                           Subscribe
                         </sl-button>`
@@ -321,7 +341,6 @@ export class ScionSubscriptionManager extends LitElement {
                   </div>
                 `
               : this.renderTable()}
-
         ${this.renderDialog()}
       </div>
     `;
@@ -368,7 +387,6 @@ export class ScionSubscriptionManager extends LitElement {
             </div>
           `
         : this.renderTable()}
-
       ${this.renderDialog()}
     `;
   }
@@ -406,7 +424,10 @@ export class ScionSubscriptionManager extends LitElement {
       <tr>
         <td>
           <span class="key-info">
-            <sl-icon name=${scopeIcon} style="color: var(--scion-primary, #3b82f6); flex-shrink: 0;"></sl-icon>
+            <sl-icon
+              name=${scopeIcon}
+              style="color: var(--scion-primary, #3b82f6); flex-shrink: 0;"
+            ></sl-icon>
             <span>${sub.scope}</span>
           </span>
         </td>
@@ -486,10 +507,7 @@ export class ScionSubscriptionManager extends LitElement {
         @sl-request-close=${this.closeDialog}
       >
         <form class="dialog-form" @submit=${this.handleCreate}>
-          ${this.dialogError
-            ? html`<div class="dialog-error">${this.dialogError}</div>`
-            : nothing}
-
+          ${this.dialogError ? html`<div class="dialog-error">${this.dialogError}</div>` : nothing}
           ${!this.agentId
             ? html`
                 <div class="radio-field">
@@ -497,7 +515,8 @@ export class ScionSubscriptionManager extends LitElement {
                   <sl-radio-group
                     .value=${this.dialogScope}
                     @sl-change=${(e: Event) =>
-                      (this.dialogScope = (e.target as HTMLInputElement).value as SubscriptionScope)}
+                      (this.dialogScope = (e.target as HTMLInputElement)
+                        .value as SubscriptionScope)}
                   >
                     <sl-radio-button value="project">Entire Project</sl-radio-button>
                     <sl-radio-button value="agent">Specific Agent</sl-radio-button>
@@ -510,7 +529,6 @@ export class ScionSubscriptionManager extends LitElement {
                 </div>
               `
             : nothing}
-
           ${this.dialogScope === 'agent' && !this.agentId
             ? html`
                 <sl-input
@@ -523,7 +541,6 @@ export class ScionSubscriptionManager extends LitElement {
                 ></sl-input>
               `
             : nothing}
-
           ${this.templates.length > 0
             ? html`
                 <div class="radio-field">
@@ -539,9 +556,7 @@ export class ScionSubscriptionManager extends LitElement {
                     }}
                   >
                     ${this.templates.map(
-                      (tmpl) => html`
-                        <sl-option value=${tmpl.id}>${tmpl.name}</sl-option>
-                      `
+                      (tmpl) => html` <sl-option value=${tmpl.id}>${tmpl.name}</sl-option> `
                     )}
                   </sl-select>
                 </div>
@@ -586,7 +601,8 @@ export class ScionSubscriptionManager extends LitElement {
           ?loading=${this.dialogLoading}
           ?disabled=${this.dialogTriggers.size === 0}
           @click=${this.handleCreate}
-        >Subscribe</sl-button>
+          >Subscribe</sl-button
+        >
       </sl-dialog>
     `;
   }

--- a/web/src/components/shared/token-list.ts
+++ b/web/src/components/shared/token-list.ts
@@ -45,7 +45,11 @@ interface AccessToken {
 
 const AVAILABLE_SCOPES = [
   { value: 'project:read', label: 'project:read', description: 'Read project metadata' },
-  { value: 'agent:dispatch', label: 'agent:dispatch', description: 'Dispatch agents (create + start)' },
+  {
+    value: 'agent:dispatch',
+    label: 'agent:dispatch',
+    description: 'Dispatch agents (create + start)',
+  },
   { value: 'agent:read', label: 'agent:read', description: 'Read agent status/metadata' },
   { value: 'agent:list', label: 'agent:list', description: 'List agents in the project' },
   { value: 'agent:create', label: 'agent:create', description: 'Create agents' },
@@ -54,7 +58,11 @@ const AVAILABLE_SCOPES = [
   { value: 'agent:delete', label: 'agent:delete', description: 'Delete agents' },
   { value: 'agent:message', label: 'agent:message', description: 'Send messages to agents' },
   { value: 'agent:attach', label: 'agent:attach', description: 'Attach to agent sessions' },
-  { value: 'agent:manage', label: 'agent:manage', description: 'All agent actions (convenience alias)' },
+  {
+    value: 'agent:manage',
+    label: 'agent:manage',
+    description: 'All agent actions (convenience alias)',
+  },
 ] as const;
 
 @customElement('scion-token-list')
@@ -345,7 +353,11 @@ export class ScionTokenList extends LitElement {
   // ── Revoke / Delete ────────────────────────────────────────────────
 
   private async handleRevoke(token: AccessToken): Promise<void> {
-    if (!(await showConfirm(`Revoke token "${token.name}"? It will no longer be usable for authentication.`))) {
+    if (
+      !(await showConfirm(
+        `Revoke token "${token.name}"? It will no longer be usable for authentication.`
+      ))
+    ) {
       return;
     }
 
@@ -489,8 +501,7 @@ export class ScionTokenList extends LitElement {
         </sl-button>
       </div>
       ${this.tokens.length === 0 ? this.renderEmpty() : this.renderTable()}
-      ${this.renderCreateDialog()}
-      ${this.renderRevealDialog()}
+      ${this.renderCreateDialog()} ${this.renderRevealDialog()}
     `;
   }
 
@@ -500,8 +511,8 @@ export class ScionTokenList extends LitElement {
         <sl-icon name="key"></sl-icon>
         <h3>No Access Tokens</h3>
         <p>
-          Create personal access tokens to authenticate CI/CD pipelines
-          and automation tools with your projects.
+          Create personal access tokens to authenticate CI/CD pipelines and automation tools with
+          your projects.
         </p>
         <sl-button variant="primary" size="small" @click=${this.openCreateDialog}>
           <sl-icon slot="prefix" name="plus-lg"></sl-icon>
@@ -543,7 +554,10 @@ export class ScionTokenList extends LitElement {
       <tr class=${status === 'revoked' ? 'revoked' : ''}>
         <td class="key-cell">
           <div class="key-info">
-            <div class="key-icon" style="background: var(--sl-color-primary-100, #dbeafe); color: var(--sl-color-primary-600, #2563eb);">
+            <div
+              class="key-icon"
+              style="background: var(--sl-color-primary-100, #dbeafe); color: var(--sl-color-primary-600, #2563eb);"
+            >
               <sl-icon name="key"></sl-icon>
             </div>
             <div>
@@ -564,9 +578,7 @@ export class ScionTokenList extends LitElement {
         </td>
         <td class="hide-mobile">
           <div class="scopes-cell">
-            ${token.scopes.map(
-              (scope) => html`<span class="scope-badge">${scope}</span>`
-            )}
+            ${token.scopes.map((scope) => html`<span class="scope-badge">${scope}</span>`)}
           </div>
         </td>
         <td class="hide-mobile">
@@ -631,10 +643,11 @@ export class ScionTokenList extends LitElement {
             }}
             required
           >
-
             ${this.projects.map(
               (project) =>
-                html`<sl-option value=${project.id}>${project.name || project.slug || project.id}</sl-option>`
+                html`<sl-option value=${project.id}
+                  >${project.name || project.slug || project.id}</sl-option
+                >`
             )}
           </sl-select>
 
@@ -672,9 +685,7 @@ export class ScionTokenList extends LitElement {
             <sl-option value="365">365 days (maximum)</sl-option>
           </sl-select>
 
-          ${this.createError
-            ? html`<div class="dialog-error">${this.createError}</div>`
-            : nothing}
+          ${this.createError ? html`<div class="dialog-error">${this.createError}</div>` : nothing}
         </form>
 
         <sl-button

--- a/web/src/components/shared/unified-log-viewer.ts
+++ b/web/src/components/shared/unified-log-viewer.ts
@@ -136,7 +136,9 @@ export class ScionUnifiedLogViewer extends LitElement {
       font-family: var(--scion-font-mono, monospace);
       cursor: pointer;
       border: 1px solid transparent;
-      transition: opacity 0.15s, border-color 0.15s;
+      transition:
+        opacity 0.15s,
+        border-color 0.15s;
       user-select: none;
     }
 
@@ -162,8 +164,13 @@ export class ScionUnifiedLogViewer extends LitElement {
     }
 
     @keyframes pulse {
-      0%, 100% { opacity: 1; }
-      50% { opacity: 0.3; }
+      0%,
+      100% {
+        opacity: 1;
+      }
+      50% {
+        opacity: 0.3;
+      }
     }
 
     .reconnect-indicator {
@@ -241,12 +248,32 @@ export class ScionUnifiedLogViewer extends LitElement {
       line-height: 1.4;
     }
 
-    .sev-DEFAULT { background: var(--scion-neutral-100, #f1f5f9); color: var(--scion-neutral-500, #64748b); }
-    .sev-DEBUG { background: var(--scion-neutral-100, #f1f5f9); color: var(--scion-neutral-500, #64748b); opacity: 0.7; }
-    .sev-INFO { background: var(--scion-primary-50, #eff6ff); color: var(--scion-primary-700, #1d4ed8); }
-    .sev-WARNING { background: var(--scion-warning-50, #fffbeb); color: var(--scion-warning-700, #b45309); }
-    .sev-ERROR { background: var(--scion-danger-50, #fef2f2); color: var(--scion-danger-700, #b91c1c); }
-    .sev-CRITICAL { background: var(--scion-danger-100, #fee2e2); color: var(--scion-danger-800, #991b1b); font-weight: 700; }
+    .sev-DEFAULT {
+      background: var(--scion-neutral-100, #f1f5f9);
+      color: var(--scion-neutral-500, #64748b);
+    }
+    .sev-DEBUG {
+      background: var(--scion-neutral-100, #f1f5f9);
+      color: var(--scion-neutral-500, #64748b);
+      opacity: 0.7;
+    }
+    .sev-INFO {
+      background: var(--scion-primary-50, #eff6ff);
+      color: var(--scion-primary-700, #1d4ed8);
+    }
+    .sev-WARNING {
+      background: var(--scion-warning-50, #fffbeb);
+      color: var(--scion-warning-700, #b45309);
+    }
+    .sev-ERROR {
+      background: var(--scion-danger-50, #fef2f2);
+      color: var(--scion-danger-700, #b91c1c);
+    }
+    .sev-CRITICAL {
+      background: var(--scion-danger-100, #fee2e2);
+      color: var(--scion-danger-800, #991b1b);
+      font-weight: 700;
+    }
 
     .sub {
       color: var(--scion-text-secondary, #475569);
@@ -325,7 +352,8 @@ export class ScionUnifiedLogViewer extends LitElement {
       background: var(--scion-bg-subtle, #f1f5f9);
       border: 1px solid var(--scion-border, #e2e8f0);
       border-top: 0;
-      border-radius: 0 0 var(--sl-border-radius-medium, 0.5rem) var(--sl-border-radius-medium, 0.5rem);
+      border-radius: 0 0 var(--sl-border-radius-medium, 0.5rem)
+        var(--sl-border-radius-medium, 0.5rem);
       font-size: 0.75rem;
       color: var(--scion-text-muted, #64748b);
     }
@@ -416,9 +444,7 @@ export class ScionUnifiedLogViewer extends LitElement {
 
     this.eventSource.addEventListener('log', (event: Event) => {
       try {
-        const entry = JSON.parse(
-          (event as MessageEvent).data
-        ) as DiagnosticLogEntry;
+        const entry = JSON.parse((event as MessageEvent).data) as DiagnosticLogEntry;
         this.mergeEntries([entry]);
 
         // Only count entries that pass current filters for the "new entries" banner
@@ -478,9 +504,7 @@ export class ScionUnifiedLogViewer extends LitElement {
           if (this.severity) params.set('severity', this.severity);
           // Entries are sorted oldest-first (ascending), so last element is the latest
           params.set('since', this.entries[this.entries.length - 1].timestamp);
-          const res = await apiFetch(
-            `/api/v1/admin/diagnostics/logs?${params}`
-          );
+          const res = await apiFetch(`/api/v1/admin/diagnostics/logs?${params}`);
           if (res.ok) {
             const data = (await res.json()) as DiagnosticsLogResponse;
             this.mergeEntries(data.entries);
@@ -620,8 +644,7 @@ export class ScionUnifiedLogViewer extends LitElement {
 
   private handleScroll(e: Event): void {
     const el = e.target as HTMLElement;
-    const atBottom =
-      el.scrollHeight - el.scrollTop - el.clientHeight < AUTO_SCROLL_THRESHOLD;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < AUTO_SCROLL_THRESHOLD;
 
     if (atBottom && !this.autoScroll) {
       this.autoScroll = true;
@@ -666,8 +689,7 @@ export class ScionUnifiedLogViewer extends LitElement {
     // Compute filtered entries once and pass to both sub-renders to avoid double-filtering.
     const filteredEntries = this.getFilteredEntries();
     return html`
-      ${this.renderFilterBar()}
-      ${this.renderLogContainer(filteredEntries)}
+      ${this.renderFilterBar()} ${this.renderLogContainer(filteredEntries)}
       ${this.renderStatusBar(filteredEntries)}
     `;
   }
@@ -683,9 +705,14 @@ export class ScionUnifiedLogViewer extends LitElement {
             return html`
               <span
                 class="source-toggle ${enabled ? '' : 'disabled'}"
-                style="background: ${enabled ? config.bg : 'transparent'}; color: ${config.color}; border-color: ${enabled ? config.color + '40' : 'var(--scion-border, #e2e8f0)'};"
+                style="background: ${enabled
+                  ? config.bg
+                  : 'transparent'}; color: ${config.color}; border-color: ${enabled
+                  ? config.color + '40'
+                  : 'var(--scion-border, #e2e8f0)'};"
                 @click=${() => this.handleSourceToggle(src)}
-              >${config.badge}</span>
+                >${config.badge}</span
+              >
             `;
           })}
         </div>
@@ -718,7 +745,9 @@ export class ScionUnifiedLogViewer extends LitElement {
         ${this.streaming
           ? html`<span class="stream-indicator"><span class="stream-dot"></span>Live</span>`
           : this.reconnecting
-            ? html`<span class="reconnect-indicator"><sl-spinner style="font-size: 0.75rem;"></sl-spinner> Reconnecting...</span>`
+            ? html`<span class="reconnect-indicator"
+                ><sl-spinner style="font-size: 0.75rem;"></sl-spinner> Reconnecting...</span
+              >`
             : nothing}
         <sl-button size="small" variant="text" @click=${this.handleClear}>
           <sl-icon slot="prefix" name="trash"></sl-icon>
@@ -788,9 +817,7 @@ export class ScionUnifiedLogViewer extends LitElement {
         fractionalSecondDigits: 3,
       } as Intl.DateTimeFormatOptions);
       const subsystem =
-        (entry.jsonPayload?.['subsystem'] as string) ||
-        entry.labels?.['component'] ||
-        '';
+        (entry.jsonPayload?.['subsystem'] as string) || entry.labels?.['component'] || '';
       const isExpanded = this.expandedIds.has(entry.insertId);
 
       rows.push(html`
@@ -800,10 +827,9 @@ export class ScionUnifiedLogViewer extends LitElement {
           @click=${() => this.toggleExpand(entry.insertId)}
         >
           <span class="ts">${timeStr}</span>
-          <span
-            class="source-badge"
-            style="background: ${config.bg}; color: ${config.color};"
-          >${config.badge}</span>
+          <span class="source-badge" style="background: ${config.bg}; color: ${config.color};"
+            >${config.badge}</span
+          >
           <span class="sev sev-${entry.severity}">${entry.severity}</span>
           <span class="sub" title=${subsystem}>${subsystem}</span>
           <span class="msg" title=${entry.message}>${entry.message}</span>
@@ -830,24 +856,35 @@ export class ScionUnifiedLogViewer extends LitElement {
             ${fullTimestamp}
           </span>
           ${entry.logName
-            ? html`<span class="detail-meta-item"><span class="detail-meta-label">Log:</span> ${entry.logName}</span>`
+            ? html`<span class="detail-meta-item"
+                ><span class="detail-meta-label">Log:</span> ${entry.logName}</span
+              >`
             : nothing}
           ${entry.labels?.['agent_id']
-            ? html`<span class="detail-meta-item"><span class="detail-meta-label">Agent:</span> ${entry.labels['agent_id']}</span>`
+            ? html`<span class="detail-meta-item"
+                ><span class="detail-meta-label">Agent:</span> ${entry.labels['agent_id']}</span
+              >`
             : nothing}
           ${entry.labels?.['project_id']
-            ? html`<span class="detail-meta-item"><span class="detail-meta-label">Project:</span> ${entry.labels['project_id']}</span>`
+            ? html`<span class="detail-meta-item"
+                ><span class="detail-meta-label">Project:</span> ${entry.labels['project_id']}</span
+              >`
             : nothing}
           ${entry.labels?.['broker_id']
-            ? html`<span class="detail-meta-item"><span class="detail-meta-label">Broker:</span> ${entry.labels['broker_id']}</span>`
+            ? html`<span class="detail-meta-item"
+                ><span class="detail-meta-label">Broker:</span> ${entry.labels['broker_id']}</span
+              >`
             : nothing}
           ${this.gcpProjectId && entry.insertId
             ? html`
                 <a
                   class="detail-cloud-link"
-                  href="https://console.cloud.google.com/logs/query;query=insertId%3D%22${encodeURIComponent(entry.insertId)}%22?project=${this.gcpProjectId}"
+                  href="https://console.cloud.google.com/logs/query;query=insertId%3D%22${encodeURIComponent(
+                    entry.insertId
+                  )}%22?project=${this.gcpProjectId}"
                   target="_blank"
-                >View in Cloud Logging →</a>
+                  >View in Cloud Logging →</a
+                >
               `
             : nothing}
         </div>
@@ -859,9 +896,7 @@ export class ScionUnifiedLogViewer extends LitElement {
     `;
   }
 
-  private buildDetailObject(
-    entry: DiagnosticLogEntry
-  ): Record<string, unknown> {
+  private buildDetailObject(entry: DiagnosticLogEntry): Record<string, unknown> {
     const obj: Record<string, unknown> = {
       timestamp: entry.timestamp,
       severity: entry.severity,
@@ -897,7 +932,10 @@ export class ScionUnifiedLogViewer extends LitElement {
 
     return html`
       <div class="status-bar">
-        <span>${streamState} · ${filtered.length} entries (${this.entries.length} total) · Buffer: ${this.entries.length}/${MAX_BUFFER}</span>
+        <span
+          >${streamState} · ${filtered.length} entries (${this.entries.length} total) · Buffer:
+          ${this.entries.length}/${MAX_BUFFER}</span
+        >
         <span>${scrollState}</span>
       </div>
     `;

--- a/web/src/shared/harness-utils.test.ts
+++ b/web/src/shared/harness-utils.test.ts
@@ -47,9 +47,7 @@ const IDENT = String.raw`'(?:${FORBIDDEN_IDENTS.join('|')})'`;
  * anywhere in the array -- so reordering the elements, or leading with a name
  * that is not a harness, does not defeat it.
  */
-const HARNESS_ARRAY_LITERAL = new RegExp(
-  String.raw`\[[^\]]*${IDENT}\s*,\s*${IDENT}`
-);
+const HARNESS_ARRAY_LITERAL = new RegExp(String.raw`\[[^\]]*${IDENT}\s*,\s*${IDENT}`);
 
 describe('KNOWN_HARNESS_NAMES', () => {
   it('matches the harnesses/ directory, which is the source of truth', () => {

--- a/web/src/shared/lineage.test.ts
+++ b/web/src/shared/lineage.test.ts
@@ -62,9 +62,9 @@ describe('buildLineageForest', () => {
 
     expect(roots).toHaveLength(1);
     expect(roots[0].agent.id).toBe('c1');
-    expect(roots[0].children.map(c => c.agent.id).sort()).toEqual(['e1', 't1']);
-    const tl = roots[0].children.find(c => c.agent.id === 't1')!;
-    expect(tl.children.map(c => c.agent.id)).toEqual(['h1']);
+    expect(roots[0].children.map((c) => c.agent.id).sort()).toEqual(['e1', 't1']);
+    const tl = roots[0].children.find((c) => c.agent.id === 't1')!;
+    expect(tl.children.map((c) => c.agent.id)).toEqual(['h1']);
     expect(tl.children[0].depth).toBe(2);
   });
 
@@ -72,8 +72,8 @@ describe('buildLineageForest', () => {
     const a = agent('a1', 'alpha', ['user-1']);
     const b = agent('b1', 'beta', ['user-2']);
     const roots = buildLineageForest([a, b]);
-    expect(roots.map(r => r.agent.id).sort()).toEqual(['a1', 'b1']);
-    expect(roots.every(r => r.depth === 0)).toBe(true);
+    expect(roots.map((r) => r.agent.id).sort()).toEqual(['a1', 'b1']);
+    expect(roots.every((r) => r.depth === 0)).toBe(true);
   });
 
   it('promotes agents whose parent is outside the set to roots', () => {
@@ -90,7 +90,7 @@ describe('buildLineageForest', () => {
     const roots = buildLineageForest([a, b]);
     const layout = layoutForest(roots);
     expect(layout.nodes).toHaveLength(2);
-    const ids = layout.nodes.map(n => n.agent.id).sort();
+    const ids = layout.nodes.map((n) => n.agent.id).sort();
     expect(ids).toEqual(['a1', 'b1']);
   });
 
@@ -110,7 +110,7 @@ describe('layoutForest', () => {
 
     const { nodes, edges } = layoutForest(buildLineageForest([parent, left, right]));
 
-    const byId = new Map(nodes.map(n => [n.agent.id, n]));
+    const byId = new Map(nodes.map((n) => [n.agent.id, n]));
     const leftX = byId.get('l1')!.px;
     const rightX = byId.get('r1')!.px;
     const parentX = byId.get('p1')!.px;
@@ -161,10 +161,10 @@ describe('pruneCollapsed', () => {
       new Set(['l1'])
     );
     const { nodes, edges } = layoutForest(forest);
-    const ids = nodes.map(n => n.agent.id).sort();
+    const ids = nodes.map((n) => n.agent.id).sort();
     expect(ids).toEqual(['l1', 'r1', 'r2']);
-    expect(edges.some(e => e.childId === 'lk')).toBe(false);
-    expect(edges.some(e => e.childId === 'r2')).toBe(true);
+    expect(edges.some((e) => e.childId === 'lk')).toBe(false);
+    expect(edges.some((e) => e.childId === 'r2')).toBe(true);
   });
 
   it('collapsing the root leaves only the root visible', () => {
@@ -172,7 +172,7 @@ describe('pruneCollapsed', () => {
     const kid = agent('k1', 'kid', ['user-1', 'r1']);
     const forest = pruneCollapsed(buildLineageForest([root, kid]), new Set(['r1']));
     const { nodes, edges } = layoutForest(forest);
-    expect(nodes.map(n => n.agent.id)).toEqual(['r1']);
+    expect(nodes.map((n) => n.agent.id)).toEqual(['r1']);
     expect(edges).toHaveLength(0);
   });
 });
@@ -194,7 +194,7 @@ describe('layoutForestWithUsers', () => {
     expect(users).toHaveLength(1);
     expect(users[0].id).toBe('user-1');
     expect(users[0].py).toBe(PAD);
-    const byId = new Map(nodes.map(n => [n.agent.id, n]));
+    const byId = new Map(nodes.map((n) => [n.agent.id, n]));
     expect(byId.get('a1')!.py).toBe(PAD + NODE_H + GAP_Y);
     expect(byId.get('c1')!.py).toBe(PAD + 2 * (NODE_H + GAP_Y));
   });
@@ -205,32 +205,32 @@ describe('layoutForestWithUsers', () => {
     const c = agent('c1', 'gamma', ['user-2']);
     const { nodes, users, edges } = layoutForestWithUsers(buildLineageForest([a, b, c]));
 
-    expect(users.map(u => u.id).sort()).toEqual(['user-1', 'user-2']);
-    const u1 = users.find(u => u.id === 'user-1')!;
-    const byId = new Map(nodes.map(n => [n.agent.id, n]));
+    expect(users.map((u) => u.id).sort()).toEqual(['user-1', 'user-2']);
+    const u1 = users.find((u) => u.id === 'user-1')!;
+    const byId = new Map(nodes.map((n) => [n.agent.id, n]));
     expect(u1.px).toBe((byId.get('a1')!.px + byId.get('b1')!.px) / 2);
 
-    const u1Edges = edges.filter(e => e.parentId === userKey('user-1'));
-    expect(u1Edges.map(e => e.childId).sort()).toEqual(['a1', 'b1']);
-    const u2Edges = edges.filter(e => e.parentId === userKey('user-2'));
-    expect(u2Edges.map(e => e.childId)).toEqual(['c1']);
+    const u1Edges = edges.filter((e) => e.parentId === userKey('user-1'));
+    expect(u1Edges.map((e) => e.childId).sort()).toEqual(['a1', 'b1']);
+    const u2Edges = edges.filter((e) => e.parentId === userKey('user-2'));
+    expect(u2Edges.map((e) => e.childId)).toEqual(['c1']);
   });
 
   it('keeps agent-to-agent edges alongside user edges', () => {
     const root = agent('r1', 'root', ['user-1']);
     const child = agent('k1', 'kid', ['user-1', 'r1']);
     const { edges } = layoutForestWithUsers(buildLineageForest([root, child]));
-    expect(edges.some(e => e.parentId === 'r1' && e.childId === 'k1')).toBe(true);
-    expect(edges.some(e => e.parentId === userKey('user-1') && e.childId === 'r1')).toBe(true);
+    expect(edges.some((e) => e.parentId === 'r1' && e.childId === 'k1')).toBe(true);
+    expect(edges.some((e) => e.parentId === userKey('user-1') && e.childId === 'r1')).toBe(true);
   });
 
   it('leaves roots without ancestry parentless but positioned', () => {
     const known = agent('a1', 'alpha', ['user-1']);
     const unknown = agent('u1', 'mystery');
     const { nodes, users, edges } = layoutForestWithUsers(buildLineageForest([known, unknown]));
-    expect(users.map(u => u.id)).toEqual(['user-1']);
-    expect(nodes.map(n => n.agent.id).sort()).toEqual(['a1', 'u1']);
-    expect(edges.filter(e => e.childId === 'u1')).toHaveLength(0);
+    expect(users.map((u) => u.id)).toEqual(['user-1']);
+    expect(nodes.map((n) => n.agent.id).sort()).toEqual(['a1', 'u1']);
+    expect(edges.filter((e) => e.childId === 'u1')).toHaveLength(0);
   });
 });
 
@@ -241,7 +241,7 @@ describe('transposeLayout', () => {
     const right = agent('r1', 'b-right', ['user-1', 'p1']);
 
     const layout = transposeLayout(layoutForest(buildLineageForest([parent, left, right])));
-    const byId = new Map(layout.nodes.map(n => [n.agent.id, n]));
+    const byId = new Map(layout.nodes.map((n) => [n.agent.id, n]));
 
     // Depth → x: root in the leftmost column, children one column right.
     expect(byId.get('p1')!.px).toBe(PAD);
@@ -260,10 +260,10 @@ describe('transposeLayout', () => {
     const right = agent('r1', 'b-right', ['user-1', 'p1']);
 
     const layout = transposeLayout(layoutForest(buildLineageForest([parent, left, right])));
-    const byId = new Map(layout.nodes.map(n => [n.agent.id, n]));
+    const byId = new Map(layout.nodes.map((n) => [n.agent.id, n]));
 
     expect(layout.edges).toHaveLength(2);
-    expect(layout.edges.map(e => `${e.parentId}->${e.childId}`).sort()).toEqual([
+    expect(layout.edges.map((e) => `${e.parentId}->${e.childId}`).sort()).toEqual([
       'p1->l1',
       'p1->r1',
     ]);
@@ -285,7 +285,9 @@ describe('transposeLayout', () => {
     const leafB = agent('lb', 'leaf-b', ['user-1', 'r1', 'm1']);
     const solo = agent('s1', 'solo', ['user-2']);
 
-    const layout = transposeLayout(layoutForest(buildLineageForest([root, mid, leafA, leafB, solo])));
+    const layout = transposeLayout(
+      layoutForest(buildLineageForest([root, mid, leafA, leafB, solo]))
+    );
     for (const n of layout.nodes) {
       expect(n.px).toBeGreaterThanOrEqual(PAD);
       expect(n.py).toBeGreaterThanOrEqual(PAD);
@@ -301,7 +303,7 @@ describe('transposeLayout', () => {
     const b = agent('b1', 'beta', ['user-1']);
 
     const layout = transposeLayout(layoutForestWithUsers(buildLineageForest([a, b])));
-    const byId = new Map(layout.nodes.map(n => [n.agent.id, n]));
+    const byId = new Map(layout.nodes.map((n) => [n.agent.id, n]));
 
     expect(layout.users).toHaveLength(1);
     const u = layout.users[0];
@@ -311,8 +313,8 @@ describe('transposeLayout', () => {
     expect(u.py).toBe((byId.get('a1')!.py + byId.get('b1')!.py) / 2);
 
     // User → root edges leave the user card's right edge.
-    const uEdges = layout.edges.filter(e => e.parentId === userKey('user-1'));
-    expect(uEdges.map(e => e.childId).sort()).toEqual(['a1', 'b1']);
+    const uEdges = layout.edges.filter((e) => e.parentId === userKey('user-1'));
+    expect(uEdges.map((e) => e.childId).sort()).toEqual(['a1', 'b1']);
     for (const e of uEdges) {
       expect(e.x1).toBe(u.px + NODE_W);
       expect(e.y1).toBe(u.py + NODE_H / 2);

--- a/web/src/shared/lineage.ts
+++ b/web/src/shared/lineage.ts
@@ -145,7 +145,7 @@ export function buildLineageForest(agents: Agent[]): LineageNode[] {
     if (visited.has(node.agent.id)) return;
     visited.add(node.agent.id);
     node.depth = depth;
-    node.children = node.children.filter(c => !visited.has(c.agent.id));
+    node.children = node.children.filter((c) => !visited.has(c.agent.id));
     for (const child of node.children) visit(child, depth + 1);
   };
   for (const root of roots) visit(root, 0);
@@ -183,7 +183,10 @@ export function descendantCounts(roots: LineageNode[]): Map<string, number> {
  * subtrees. Mutates the given forest (buildLineageForest returns a fresh
  * one per call) and returns it for chaining.
  */
-export function pruneCollapsed(roots: LineageNode[], collapsed: ReadonlySet<string>): LineageNode[] {
+export function pruneCollapsed(
+  roots: LineageNode[],
+  collapsed: ReadonlySet<string>
+): LineageNode[] {
   const walk = (node: LineageNode): void => {
     if (collapsed.has(node.agent.id)) {
       node.children = [];
@@ -282,12 +285,12 @@ export function layoutForestWithUsers(roots: LineageNode[]): ForestLayout {
   for (const root of ordered) bump(root, 1);
 
   const base = layoutForest(ordered);
-  const nodeById = new Map(base.nodes.map(n => [n.agent.id, n]));
+  const nodeById = new Map(base.nodes.map((n) => [n.agent.id, n]));
 
   const users: PositionedUser[] = [];
   const edges = [...base.edges];
   for (const [uid, groupRoots] of groups) {
-    const xs = groupRoots.map(r => nodeById.get(r.agent.id)!.px);
+    const xs = groupRoots.map((r) => nodeById.get(r.agent.id)!.px);
     const px = (Math.min(...xs) + Math.max(...xs)) / 2;
     const py = PAD;
     users.push({ id: uid, px, py });
@@ -327,12 +330,12 @@ export function transposeLayout(layout: ForestLayout): ForestLayout {
   const hx = (depth: number) => PAD + depth * (NODE_W + H_GAP_X);
   const hy = (slot: number) => PAD + slot * (NODE_H + H_GAP_Y);
 
-  const nodes: PositionedNode[] = layout.nodes.map(n => ({
+  const nodes: PositionedNode[] = layout.nodes.map((n) => ({
     agent: n.agent,
     px: hx(depthOf(n.py)),
     py: hy(slotOf(n.px)),
   }));
-  const users: PositionedUser[] = layout.users.map(u => ({
+  const users: PositionedUser[] = layout.users.map((u) => ({
     id: u.id,
     px: hx(depthOf(u.py)),
     py: hy(slotOf(u.px)),

--- a/web/src/utils/feature-flags.ts
+++ b/web/src/utils/feature-flags.ts
@@ -65,3 +65,10 @@ export function isFeatureEnabled(name: string): boolean {
   // Default: on for flags in DEFAULT_ON_FLAGS, off otherwise
   return DEFAULT_ON_FLAGS.has(name);
 }
+
+/**
+ * Wave-2 native chat feature flag.
+ * Default OFF — not in DEFAULT_ON_FLAGS.
+ * Enable via server injection or localStorage: scion:feature:web.native_chat_v2
+ */
+export const NATIVE_CHAT_V2_FLAG = 'web.native_chat_v2';

--- a/web/src/utils/feature-flags.ts
+++ b/web/src/utils/feature-flags.ts
@@ -34,7 +34,7 @@ declare global {
  * Feature flags that are ON by default (Phase 5+).
  * These can still be disabled via server injection or localStorage override.
  */
-const DEFAULT_ON_FLAGS = new Set(['web.native_chat']);
+const DEFAULT_ON_FLAGS = new Set(['web.native_chat', 'web.native_chat_v2']);
 
 /**
  * Check whether a feature flag is enabled.
@@ -66,7 +66,8 @@ export function isFeatureEnabled(name: string): boolean {
 
 /**
  * Wave-2 native chat feature flag.
- * Default OFF — not in DEFAULT_ON_FLAGS.
- * Enable via server injection or localStorage: scion:feature:web.native_chat_v2
+ * Default ON (W9) — added to DEFAULT_ON_FLAGS for general availability.
+ * Disable via server injection or localStorage: scion:feature:web.native_chat_v2=false
+ * to fall back to wave-1 UI for rollback.
  */
 export const NATIVE_CHAT_V2_FLAG = 'web.native_chat_v2';

--- a/web/src/utils/feature-flags.ts
+++ b/web/src/utils/feature-flags.ts
@@ -34,9 +34,7 @@ declare global {
  * Feature flags that are ON by default (Phase 5+).
  * These can still be disabled via server injection or localStorage override.
  */
-const DEFAULT_ON_FLAGS = new Set([
-  'web.native_chat',
-]);
+const DEFAULT_ON_FLAGS = new Set(['web.native_chat']);
 
 /**
  * Check whether a feature flag is enabled.

--- a/web/src/utils/markdown.ts
+++ b/web/src/utils/markdown.ts
@@ -40,10 +40,7 @@ let rendererPromise: Promise<MarkdownRenderer> | null = null;
 export async function getMarkdownRenderer(): Promise<MarkdownRenderer> {
   if (!rendererPromise) {
     rendererPromise = (async () => {
-      const [{ marked }, DOMPurify] = await Promise.all([
-        import('marked'),
-        import('dompurify'),
-      ]);
+      const [{ marked }, DOMPurify] = await Promise.all([import('marked'), import('dompurify')]);
 
       const purify = DOMPurify.default ?? DOMPurify;
 

--- a/web/src/utils/toast.ts
+++ b/web/src/utils/toast.ts
@@ -21,12 +21,7 @@
  * notification surface across the entire frontend. Replaces native `alert()`.
  */
 
-export type ToastVariant =
-  | 'primary'
-  | 'success'
-  | 'neutral'
-  | 'warning'
-  | 'danger';
+export type ToastVariant = 'primary' | 'success' | 'neutral' | 'warning' | 'danger';
 
 export interface ToastOptions {
   /** Shoelace icon name. Defaults to a variant-appropriate icon. */
@@ -65,7 +60,7 @@ const DEFAULT_DURATIONS: Record<ToastVariant, number> = {
 export function showToast(
   message: string,
   variant: ToastVariant = 'danger',
-  options?: ToastOptions,
+  options?: ToastOptions
 ): void {
   const icon = options?.icon ?? DEFAULT_ICONS[variant];
   const duration = options?.duration ?? DEFAULT_DURATIONS[variant];
@@ -90,9 +85,13 @@ export function showToast(
 
   // Remove the alert element from the DOM after it hides to prevent
   // accumulation — same pattern used in confirm-dialog.ts.
-  alert.addEventListener('sl-after-hide', () => {
-    alert.remove();
-  }, { once: true });
+  alert.addEventListener(
+    'sl-after-hide',
+    () => {
+      alert.remove();
+    },
+    { once: true }
+  );
 
   document.body.appendChild(alert);
   void (alert as HTMLElement & { toast(): Promise<void> }).toast();


### PR DESCRIPTION
Wave 2 of native web chat: project-scoped spaces with shared threads, human-to-human and human-to-agent DMs (global pair), members sidebar with presence and typing indicators, composer default-agent disambiguation, attachments, search, and notifications. 10 phases, all reviewed. Ref: ptone/scion#983