### PR TITLE
fix(lint): apply De Morgan's law to satisfy QF1001 in oauth.go

### DIFF
--- a/pkg/hub/oauth.go
+++ b/pkg/hub/oauth.go
@@ -1050,7 +1050,7 @@ func validateOIDCLoginConfig(cfg *config.OIDCLoginConfig) error {
 	}
 	// Require https, but allow http for localhost/127.0.0.1 (local dev).
 	host := parsed.Hostname()
-	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && (host == "localhost" || host == "127.0.0.1")) {
+	if parsed.Scheme != "https" && (parsed.Scheme != "http" || (host != "localhost" && host != "127.0.0.1")) {
 		return fmt.Errorf("issuerUrl must use https scheme (got %q)", parsed.Scheme)
 	}
 	if parsed.RawQuery != "" {


### PR DESCRIPTION
Simplifies a negated boolean expression in validateOIDCLoginConfig to satisfy golangci-lint staticcheck QF1001. Logically equivalent — no behavioral change.

This lint failure is currently on main and blocking golangci-lint CI for all fork PRs.

Fork PR: https://github.com/ptone/scion/pull/998