### PR TITLE
docs: nightly documentation update for Aug 12

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -241,6 +241,10 @@ _See also_: Hub
 
 ## Messaging
 
+**Native Web Chat**:
+The built-in interactive messaging interface in the Web Dashboard (enabled via the `web.native_chat` feature flag) that promotes chat to a top-level fourth ShellType (alongside standalone, profile, and app). It features a dedicated thread rail, unread indicators, three-state visibility filtering (Conversation/Verbose/Full), @-mention autocomplete, and cross-channel reply coherence.
+_Avoid_: chat plugin, external chat, messages tab (only for the old tab)
+
 **Message Group**:
 A set of recipients addressed by a single send, correlated by a shared `group_id`, as opposed to a direct message to one recipient or a broadcast to all agents in a project.
 _Avoid_: group, set, group chat, room, thread

--- a/docs-site/src/content/docs/glossary.md
+++ b/docs-site/src/content/docs/glossary.md
@@ -161,6 +161,9 @@ A scoped, revocable bearer token (prefixed with `scion_pat_`) linked to a user a
 
 ## Messaging
 
+### Native Web Chat
+The built-in interactive messaging interface in the Web Dashboard (enabled via the `web.native_chat` feature flag) that promotes chat to a top-level fourth ShellType (alongside standalone, profile, and app). It features a dedicated thread rail, unread indicators, three-state visibility filtering (Conversation/Verbose/Full), @-mention autocomplete, and cross-channel reply coherence.
+
 ### Message Group
 A set of recipients addressed by a single send, correlated by a shared `group_id`, as opposed to a direct message to one recipient or a broadcast to all agents in a project. Distinct from **Group** (Hub users).
 

--- a/docs-site/src/content/docs/hosted/user/a2a-bridge.md
+++ b/docs-site/src/content/docs/hosted/user/a2a-bridge.md
@@ -330,6 +330,11 @@ The A2A bridge supports three authentication schemes for granular access control
 * **How it works**: Callers present an OIDC ID token issued by a trusted federation provider.
 * **Token Verification & Bookkeeping**: The bridge decodes the OIDC token and performs local bookkeeping. It fully supports RFC 7519 `aud` (audience) claim validation, accepting the claim in either string or array-of-strings format.
 * **Transport Auth Wiring**: Integrated with Google Cloud Identity-Aware Proxy (IAP) transport auth wiring to automatically resolve and bypass platform-level guards when accessing protected backends.
+* **OIDC & JWKS Discovery Proxying**: Behind IAP, third-party federation callers cannot access the Scion Hub's OIDC discovery and JWKS public keys because they lack IAP credentials. The bridge resolves this by proxying `/.well-known/openid-configuration` and `/.well-known/jwks.json`:
+  - It uses its own internal **bridge transport auth** (IAP credentials) to fetch these documents from the Hub.
+  - It rewrites the returned `jwks_uri` inside the OIDC config to point back to the bridge's own `/.well-known/jwks.json` endpoint.
+  - It serves these endpoints publicly and caches them for **5 minutes** to ensure high performance and reduce Hub load.
+  - For air-gapped or manual distribution, administrators can also use the **Download JWKS** button on the federation admin page in the Web Dashboard to download public keys out-of-band.
 
 ### Per-User Isolation Benefits
 
@@ -351,6 +356,8 @@ The bridge exposes the following HTTP endpoints:
 | Endpoint | Method | Authentication | Description |
 | :--- | :--- | :--- | :--- |
 | `/.well-known/agent-card.json` | GET | None | Base bridge registry agent card. |
+| `/.well-known/openid-configuration` | GET | None | OIDC discovery proxy document for deployments behind IAP. Uses bridge transport auth to fetch from the Hub and rewrites the `jwks_uri` to point back to the bridge. Cached for 5 minutes. |
+| `/.well-known/jwks.json` | GET | None | JSON Web Key Set (JWKS) proxy endpoint. Serves Hub public keys with a 5-minute cache. |
 | `/projects/{projectSlug}/agents/{agentSlug}/.well-known/agent-card.json` | GET | Configured Scheme | Per-agent capabilities card. |
 | `/projects/{projectSlug}/agents/{agentSlug}/jsonrpc` | POST | Configured Scheme | Primary A2A JSON-RPC 2.0 communication endpoint. |
 | `/healthz` | GET | None | Liveness check (returns HTTP 200). |

--- a/docs-site/src/content/docs/hosted/user/external-channels.md
+++ b/docs-site/src/content/docs/hosted/user/external-channels.md
@@ -189,11 +189,13 @@ The Microsoft Teams integration (powered by the `scion-plugin-teams` plugin) bri
 
 ### Key Capabilities
 
-- **Bidirectional Messaging**: Users interact with agents in Channels or Group Chats, with inbound topics automatically routed using the canonical `scion.project` format.
+- **Bidirectional Messaging**: Users interact with agents in Channels or Group Chats. The inbound message path correctly maps inbound message Types (`"instruction"`), Channels (`"teams"`), ThreadIDs (fallback to normalized conversation IDs), and Recipient attributes (`agent:<slug>`).
+- **Interactive Setup Cards**: Confirm setups using modern adaptive cards switching from standard submit actions to Azure Bot Framework `Action.Execute` (invoke activities), with mutex-safe state management.
 - **Card-Level Agent Attribution**: While Teams utilizes a single bot identity (as defined in the downloadable App Manifest), outbound cards are styled as **Adaptive Cards** and explicitly display the sending agent's name (bolded, accent-colored) and project slug in the header for clear attribution.
+- **Resilient Suffix Normalization**: Automatically normalizes conversation IDs using `stripThreadSuffix()` across all channel links, ensuring setup confirmation persistence succeeds across Teams restarts and multi-instance deployments.
 - **Authentication**: Bidirectional communication is secured via Azure Active Directory (Azure AD) OAuth2 and JWT validation.
-- **Flexible Storage**: Supports both local SQLite and robust PostgreSQL backends.
-- **Sideloading and Deployment**: Admins configure the plugin via the Scion Admin UI, download the automatically compiled App Manifest package (`.zip`), and sideload or publish it to the Teams Admin Center.
+- **Flexible Storage**: Supports both local SQLite and robust PostgreSQL backends, migrating account link-codes from memory maps to DB for high-availability setups.
+- **Sideloading and Deployment**: Admins configure the plugin via the Scion Admin UI, download the automatically compiled App Manifest package (version `1.1.0` for smooth Admin Center updates, `.zip` format), and sideload or publish it to the Teams Admin Center.
 - **Channel Prefix Resiliency**: Handles the hidden `28:` bot prefix Teams adds to bot entity IDs in channel contexts, ensuring slash and bot commands work flawlessly in all group contexts.
 
 ### Bot Commands
@@ -204,6 +206,7 @@ Interact with the Teams bot using these `@-mention` commands:
 - **`@BotName register`**: Pairs your Teams account with your Scion Hub identity.
 - **`@BotName unregister`**: Unlinks your Teams account from the Hub.
 - **`@BotName agents`**: Lists all running agents within the bound project.
+- **`@BotName default [agent]`**: Sets or clears the channel-specific default routing agent, matching the Discord integration behavior and allowing untagged messages to route automatically.
 
 For step-by-step setup guides, App Manifest templates, and Azure AD registration details, see the [Microsoft Teams Plugin Guide](https://github.com/GoogleCloudPlatform/scion/tree/main/extras/scion-teams/README.md).
 

--- a/docs-site/src/content/docs/hosted/user/messaging.md
+++ b/docs-site/src/content/docs/hosted/user/messaging.md
@@ -12,6 +12,40 @@ In the Web Dashboard, the **Inbox Tray** provides a centralized view of all mess
 - **Mark as Read:** You can mark individual messages or all messages as read, helping you keep track of what needs your attention.
 - **Contextual Links:** Messages in the tray often link directly to the agent that sent them, allowing you to quickly jump in and provide the requested input or review the agent's work.
 
+## Native Web Chat
+
+Scion features an interactive, top-level **Native Web Chat** interface in the Web Dashboard (enabled via the `web.native_chat` feature flag). Rather than being isolated inside a single tab, chat is promoted to a top-level workspace view (a fourth `ShellType` in the SPA) that provides a cohesive environment for real-time collaboration with all agents in your project.
+
+### Core Layout & Navigation
+
+- **The Thread Rail**: A left-hand navigation sidebar that lists all active chat threads. Unread badges ("unread dots") update in real-time as messages arrive, instantly alerting you to agents requiring attention.
+- **Chat/Log Toggle**: Located on the main `scion-chat-thread` panel, this toggle lets you switch between a clean, dialogue-focused **Chat** view and a live **Execution Log** stream for that agent.
+- **Zero-Reload Navigation**: Move between threads, project views, and configuration pages instantly with deep-linking support and no full-page reloads, ensuring no interruption to your active chat context or log streams.
+
+### Three-State Visibility Filtering
+
+To prevent notification noise from overwhelming your conversation, the chat thread supports three distinct visibility filters:
+
+1. **Conversation**: The cleanest view. Displays only direct human instructions and agent replies.
+2. **Verbose**: Adds CCs, explicit `@-mentions`, and user-directed warnings.
+3. **Full**: Displays every message, including background agent-to-agent operations, state-change notifications, and system warnings.
+
+The visibility filter is processed **server-side** for efficiency, and your filter preferences are persisted **per-agent** so your preferred density level is remembered when you return to a thread. Dispatched messages feature real-time delivery state indicators, showing a success checkmark or a failure icon with a detailed tooltip (e.g. for delivery-failed notices).
+
+### Interactive @-Mentions & Autocomplete
+
+When writing instructions, you can easily pull other agents into the thread:
+- **Autocomplete Popup**: Typing `@` in the chat input opens a dropdown list of active agents in the project. The list supports fuzzy-matching as you type, and full keyboard navigation (arrow keys to select, `Enter` to insert).
+- **Code-Fence Guard**: The mention autocomplete is smart — it automatically disables itself when typing inside Markdown code fences (e.g., ` ``` ` blocks) so code snippets don't trigger unwanted dropdowns.
+- **Fan-Out Restrictions**: For platform stability, a single message is fanned out to a maximum of **10 recipients** per `@-mention` broadcast.
+
+### Cross-Channel Coherence
+
+If you use external messaging systems alongside the Web Dashboard, Scion ensures that conversations remain coherent across all channels:
+- **Broker Inbound Persistence**: Inbound messages received from external message brokers (such as Discord or Teams) are persisted in the Hub's main database, making them instantly visible in the Web Chat.
+- **Reply Affinity**: Scion tracks user, project, and agent reply affinity so that replies are routed back to the initiating channel.
+- **TouchThread & Broadcast Propagation**: Messages and read states propagate smoothly across surfaces via `TouchThread` and `Broadcasted` events, ensuring that reading or replying to a thread on Discord or Teams instantly syncs the unread badges in your Web Dashboard.
+
 ## CLI Message Management
 
 You can also interact with the messaging system directly from the CLI using the `scion messages` command (aliases: `msgs`, `inbox`).

--- a/docs-site/src/content/docs/reference/admin-settings.md
+++ b/docs-site/src/content/docs/reference/admin-settings.md
@@ -22,7 +22,7 @@ Settings are classified into two layers:
 | Layer | Examples | Behavior |
 |-------|----------|----------|
 | **Layer-0** (bootstrap) | `server.mode`, `server.database.*`, `server.storage.*`, `server.secrets.*`, `server.hub.port`, `server.auth.dev_mode` | Always resolved from bootstrap configuration. Cannot be changed via the admin UI in database mode. |
-| **Layer-1** (operational) | `server.hub.admin_emails`, `server.auth.user_access_mode`, `telemetry.*`, `agent_defaults.*`, `server.github_app.*`, `server.notification_channels`, `server.federation.*` | In database mode, stored in the database and editable via the admin UI. Bootstrap values serve as initial defaults. |
+| **Layer-1** (operational) | `server.hub.admin_emails`, `server.auth.user_access_mode`, `telemetry.*`, `agent_defaults.*`, `server.github_app.*`, `server.notification_channels`, `server.federation.*`, `runtimes`, `profiles`, `harness_configs` | In database mode, stored in the database and editable via the admin UI. Bootstrap values serve as initial defaults. |
 
 ### Database Mode
 
@@ -168,6 +168,19 @@ To streamline management of complex environments, the **General** settings tab i
    - Introduces **Default Model** (`default_model`), **Default Thinking Level** (`default_thinking_level`), and **Default Agent Role** (`default_agent_role`) fields directly into the agent default pipeline (with the default agent role updated from `baseline` to `full` for usability).
    - Houses the **Telemetry Toggle**, which has been moved to this card to keep telemetry configuration closely aligned with operational defaults.
 3. **Project Default Settings Card**: Configures platform-level default annotations and behaviors for newly created projects.
+
+### Runtimes & Profiles Tab
+
+To support complete infrastructure configuration directly from the Web Dashboard, the admin page features a dedicated **Runtimes & Profiles** tab. This tab provides full CRUD (Create, Read, Update, Delete) editors for core execution settings:
+
+- **Runtimes Editor**: Type-aware input fields tailored to specific runtime types:
+  - **Docker & Podman**: Fields for daemon sockets, host networks, and storage paths.
+  - **Kubernetes (GKE)**: Fields for cluster endpoints, namespace scoping, service account bindings, and PVC volumes.
+  - **Cloud Run**: Fields for service endpoints, memory limits, and CPU allocation.
+- **Profiles Editor**: Configures resource constraints (limits), target container image registries, and specific template overrides. Supports a native Runtime Profile Selector when launching or configuring agents.
+- **Harness Configs Editor**: Features a rich JSON textarea for writing and editing raw harness properties directly, making it easy to tune model parameters or customize env environments.
+
+In highly available (HA) Postgres deployments, all configurations edited through this tab are stored in the database's `hub_settings` table as whole-map JSONB documents. This ensures edits propagate immediately to all replicas, support optimistic locking (CAS), and are never silently dropped or ignored on server PUT actions.
 
 #### Navigation Updates
 

--- a/docs-site/src/content/docs/reference/server-config.md
+++ b/docs-site/src/content/docs/reference/server-config.md
@@ -197,6 +197,33 @@ Backend for managing encrypted secrets. The `local` backend is read-only and rej
 | `gcp_project_id` | string | | GCP Project ID for Secret Manager. Required when `backend` is `gcpsm`. |
 | `gcp_credentials` | string | | Path to GCP service account JSON or the JSON content itself. Optional if using Application Default Credentials. |
 
+### Workspace Storage (`server.workspace_storage`)
+
+Configures the backend and mount settings for storing and managing agent workspaces. This is a critical setting for high-availability deployments where multiple Hub and Broker replicas need shared, durable access to project workspaces.
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `backend` | string | `"local"` | Storage backend pivot: `"local"` (node-local directories), `"nfs"` (Network File System mounts), `"cloudrun-volume"` (Cloud Run platform-managed volume mounts), or `"gke-shared-volume"` (GKE shared CSI-backed PVC mounts). |
+| `nfs.mount_root` | string | | The host base directory under which NFS exports are mounted. |
+| `nfs.mount_options` | string | `"vers=3,hard,nconnect=4,_netdev"` | Standard mount options passed to the `mount.nfs` utility. |
+| `nfs.uid` | integer | `1000` | Node-independent owner UID for NFS-backed workspace trees to ensure consistent container write permissions. |
+| `nfs.gid` | integer | `1000` | Node-independent owner GID for NFS-backed workspace trees. |
+| `nfs.storage_class` | string | | The Kubernetes StorageClass name used to dynamically allocate volumes on GKE. |
+| `nfs.subpath_root` | string | `"projects"` | The default base folder name within the share for project workspaces. |
+| `nfs.shares` | list of objects | `[]` | List of NFS share objects. Each share requires: `id` (stable ID), `server` (IP address or hostname), `export` (exported path, e.g., `/scion-workspaces`), and optional `pv_name` (for GKE). |
+| `cloudrun_volume.volume_name` | string | | The name of the platform volume declared in the Cloud Run service specification. |
+| `cloudrun_volume.subpath_root` | string | `"projects"` | Sub-directory prefix within the Cloud Run volume. |
+| `gke_shared_volume.volume_name` | string | | The K8s volume name referencing the persistent volume claim (PVC). |
+| `gke_shared_volume.pv_claim_name` | string | | The name of the GKE-managed PVC bound to the shared storage backend (e.g. Filestore). |
+| `gke_shared_volume.subpath_root` | string | `"projects"` | Sub-directory prefix within the GKE volume. |
+
+#### Ephemeral Storage & 503 Safety Gate
+
+To protect deployments from silent data loss, the Hub implements a strict **503 Safety Gate**:
+* If the Hub is deployed on serverless environments like Google Cloud Run with the `local` backend selected, its local workspace paths map to ephemeral, non-durable container storage.
+* The Hub detects this non-durable state and automatically intercepts all file write and modification endpoints (including WebDAV, inline file editing, and git cloning).
+* Affected endpoints will return `503 Service Unavailable` with a descriptive message rather than allowing writes to persist ephemerally on the container's scratch space, enforcing the transition to a durable backend (`nfs`, `cloudrun-volume`, or `gke-shared-volume`) for production.
+
 ### Scheduler (`server.scheduler`)
 
 Controls the background task scheduler in the Hub. This regulates the tick interval and concurrency of recurring maintenance tasks (such as telemetry aggregation, session cleanups, and heartbeats) to match database capacity.
@@ -547,7 +574,7 @@ Because env overrides on Layer-1 keys reintroduce per-node drift, the system war
 
 ### Admin API Behavior Notes
 
-**PUT partitioning**: The request body is partitioned by the section registry. Layer-1 fields are written to DB sections. Layer-0 fields trigger a `422` rejection. Unclassified fields (e.g. `runtimes`, `profiles`) are ignored and reported in `ignored_keys`.
+**PUT partitioning**: The request body is partitioned by the section registry. Layer-1 fields (including `runtimes`, `profiles`, and `harness_configs`) are written to DB sections in the `hub_settings` table as whole-map JSONB documents. Layer-0 fields trigger a `422` rejection. Unclassified fields (non-registered settings) are ignored and reported in `ignored_keys`.
 
 **Revision CAS**: The request body may include `expected_revisions` — a map of section name to expected revision number. On mismatch, the response is `409 Conflict` with the conflicting sections and their current revisions. Omitted sections use last-writer-wins semantics. Sections are written in alphabetical order for deterministic partial-apply behavior.
 

--- a/docs-site/src/content/docs/supported-harnesses.md
+++ b/docs-site/src/content/docs/supported-harnesses.md
@@ -212,7 +212,7 @@ the Antigravity bundle's `capture_auth.py` (which can also extract the token fro
 - **MCP**: `~/.gemini/config/mcp_config.json`.
 - **Hooks**: Antigravity ships a hook dialect (`dialect.yaml`) mapping `agy` events to Scion lifecycle events. Hooks fire **project-locally** (wired via `/workspace/.agents/hooks.json`).
 - **Runtime**: requires gnome-keyring and D-Bus in the container (provided by the base image); a generated wrapper script bootstraps the keyring and injects the token before launching `agy`.
-- **Default model**: `Gemini 3.5 Flash` (override via `AGY_MODEL`).
+- **Default model**: `Gemini 3.6 Flash (Medium)` (override via `AGY_MODEL`).
 
 ### Known Limitations
 - **System Prompt**: approximated via `GEMINI.md` (no native override).

--- a/docs-site/src/content/docs/workstation/dashboard.md
+++ b/docs-site/src/content/docs/workstation/dashboard.md
@@ -18,6 +18,14 @@ The dashboard features an integrated notification framework with real-time SSE d
 - **Notification Tray**: Provides agent-scoped filtering for status events, accessible directly from the top navigation.
 - **Browser Push Notifications**: Opt-in native browser push notifications ensure you receive alerts even when the dashboard is in the background. Default triggers include `stalled` and `error` states, as well as requests for user input.
 
+### Native Web Chat
+When enabled via the `web.native_chat` feature flag, the dashboard includes a top-level **Native Web Chat** workspace (a fourth ShellType in the SPA). It offers a rich interface for direct communication and coordination with your running agents.
+- **Thread Rail & Unread dots**: Access all active agent conversations from a persistent left-hand sidebar, complete with unread dots indicating new activity.
+- **Chat/Log Switcher**: Instantly toggle between standard conversational chat with the agent and a real-time stream of the agent's raw execution logs inside the same view.
+- **@-Mentions & Autocomplete**: Call other agents into the thread by typing `@` to trigger a fuzzy-matching, keyboard-navigable agent dropdown. Protected by code-fence guards to prevent triggering inside Markdown code snippets.
+- **Visibility Density Filters**: Choose from three filter levels—**Conversation** (pure dialogue), **Verbose** (adds mentions/CCs), or **Full** (adds state updates and background processes)—with preferences saved individually per agent.
+- **Coherence Sync**: Real-time sync ensures actions taken on external channels (e.g. Discord or Teams) propagate instantly to the Web UI, with delivery state tooltips indicating whether messages succeeded.
+
 ### Projects
 View and manage your registered projects.
 - **Create/Register Project**: Create a Hub-Managed workspace directly on the Hub, or connect a new remote Git repository. Includes a confirmation dialog when creating a project for an existing git repository.


### PR DESCRIPTION
## Summary
Changelog-driven documentation updates for the 2026-08-12 release.

### Changes
- messaging.md: New native web chat section (Phases 2-6)
- external-channels.md: Teams default agent command, setup card fixes
- a2a-bridge.md: JWKS/OIDC discovery proxy for IAP deployments
- admin-settings.md: Runtimes and Profiles admin tab
- server-config.md: workspace_storage, native_chat, Layer-1 settings
- dashboard.md: Web dashboard chat mode
- supported-harnesses.md: Updated model strings
- glossary.md: New terms

9 files, 105 insertions, 6 deletions

Tracking: ptone/scion#999
