### PR TITLE
test: add guard test asserting AllHarnessNames matches disk

### DIFF
--- a/pkg/harness/harness_test.go
+++ b/pkg/harness/harness_test.go
@@ -15,6 +15,7 @@
 package harness
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -81,6 +82,8 @@ func TestAllHarnessNames_MatchesDisk(t *testing.T) {
 		configPath := filepath.Join(harnessesDir, e.Name(), "config.yaml")
 		if _, err := os.Stat(configPath); err == nil {
 			diskNames = append(diskNames, e.Name())
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("unexpected error checking %s: %v", configPath, err)
 		}
 	}
 	sort.Strings(diskNames)

--- a/pkg/harness/harness_test.go
+++ b/pkg/harness/harness_test.go
@@ -15,8 +15,12 @@
 package harness
 
 import (
+	"os"
+	"path/filepath"
+	"sort"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,4 +51,53 @@ func TestAllHarnessNames_IncludesAll(t *testing.T) {
 	assert.Contains(t, names, "antigravity")
 	assert.Contains(t, names, "copilot")
 	assert.Contains(t, names, "hermes")
+}
+
+// TestAllHarnessNames_MatchesDisk asserts that AllHarnessNames() (derived from
+// the hand-maintained //go:embed directive in harnesses/embed.go) matches the
+// real harnesses/ directory on disk. If a new harness directory is added under
+// harnesses/ but not listed in the embed directive, this test fails and names
+// the missing entry — making the embed line self-policing.
+func TestAllHarnessNames_MatchesDisk(t *testing.T) {
+	root, err := util.RepoRoot()
+	if err != nil {
+		t.Skipf("skipping: could not locate repo root: %v", err)
+	}
+
+	harnessesDir := filepath.Join(root, "harnesses")
+
+	entries, err := os.ReadDir(harnessesDir)
+	if err != nil {
+		t.Fatalf("failed to read harnesses/ directory: %v", err)
+	}
+
+	// Collect directories that contain a config.yaml — these are real harness
+	// bundles. Directories without config.yaml (e.g. gen/) are not harnesses.
+	var diskNames []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		configPath := filepath.Join(harnessesDir, e.Name(), "config.yaml")
+		if _, err := os.Stat(configPath); err == nil {
+			diskNames = append(diskNames, e.Name())
+		}
+	}
+	sort.Strings(diskNames)
+
+	embedNames := AllHarnessNames()
+
+	// Check for harnesses on disk but missing from the embed.
+	for _, name := range diskNames {
+		assert.Contains(t, embedNames, name,
+			"harness %q exists on disk (harnesses/%s/config.yaml) but is missing from "+
+				"AllHarnessNames(); add it to the //go:embed directive in harnesses/embed.go", name, name)
+	}
+
+	// Check for harnesses in the embed but missing from disk.
+	for _, name := range embedNames {
+		assert.Contains(t, diskNames, name,
+			"harness %q is in AllHarnessNames() (via embed) but has no directory with "+
+				"config.yaml under harnesses/", name)
+	}
 }


### PR DESCRIPTION
Add TestAllHarnessNames_MatchesDisk to pkg/harness/harness_test.go. The test reads the real harnesses/ directory, filters to directories containing config.yaml, and asserts the result matches AllHarnessNames() from the embedded FS.

This makes the hand-maintained //go:embed directive in harnesses/embed.go self-policing: if a new harness directory is added but not listed in the embed directive, the test fails and names the missing entry.

Ref: ptone/scion#593 (section 8)
