### PR TITLE
fix: map dialect name to harness ID at templateimport boundary

### DIFF
--- a/pkg/config/templateimport/templateimport_test.go
+++ b/pkg/config/templateimport/templateimport_test.go
@@ -474,7 +474,7 @@ func TestWriteTemplate_Gemini(t *testing.T) {
 	require.NoError(t, err)
 	var cfg api.ScionConfig
 	require.NoError(t, yaml.Unmarshal(data, &cfg))
-	assert.Equal(t, "gemini", cfg.DefaultHarnessConfig)
+	assert.Equal(t, "gemini-cli", cfg.DefaultHarnessConfig)
 	assert.Empty(t, cfg.Harness, "agnostic templates should not have harness field")
 	assert.Equal(t, "gemini-2.5-pro", cfg.Model)
 

--- a/pkg/config/templateimport/writer.go
+++ b/pkg/config/templateimport/writer.go
@@ -110,7 +110,17 @@ func updateScionAgentConfig(templateDir string, agent *ImportedAgent) error {
 		cfg.Model = agent.Model
 	}
 	if agent.Harness != "" {
-		cfg.DefaultHarnessConfig = agent.Harness
+		// Map config-file dialect names to harness identifiers. The dialect names
+		// ("claude", "gemini") are on-disk path conventions (.claude/, .gemini/) and
+		// must not be renamed. The harness identifiers are the runtime names under
+		// harnesses/ that DefaultHarnessConfig expects.
+		harnessID := agent.Harness
+		switch agent.Harness {
+		case "gemini":
+			harnessID = "gemini-cli"
+		// "claude" maps to "claude" — no translation needed.
+		}
+		cfg.DefaultHarnessConfig = harnessID
 	}
 
 	out, err := yaml.Marshal(&cfg)

--- a/pkg/config/templateimport/writer.go
+++ b/pkg/config/templateimport/writer.go
@@ -118,7 +118,7 @@ func updateScionAgentConfig(templateDir string, agent *ImportedAgent) error {
 		switch agent.Harness {
 		case "gemini":
 			harnessID = "gemini-cli"
-		// "claude" maps to "claude" — no translation needed.
+			// "claude" maps to "claude" — no translation needed.
 		}
 		cfg.DefaultHarnessConfig = harnessID
 	}


### PR DESCRIPTION
Fix the dialect/identifier boundary bug in templateimport (section 5 of ptone/scion#593).

writer.go:113 assigned the dialect name ("gemini") directly into DefaultHarnessConfig, which expects a harness ID ("gemini-cli"). This caused imported Gemini templates to produce scion-agent.yaml with default-harness-config: gemini — a slug that does not resolve.

Fix: add a mapping at the boundary (dialect "gemini" -> harness ID "gemini-cli") before the assignment. Dialect names and .gemini/ paths are untouched — this is a translation, not a rename.

Updated test pin in templateimport_test.go:477 to expect "gemini-cli".

Ref: ptone/scion#593
