### PR TITLE
fix(web): sync SA list changes to default SA dropdown without reload

### DIFF
--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -1170,6 +1170,36 @@ export class ScionPageProjectSettings extends LitElement {
     }
   }
 
+  /**
+   * Handles `sa-list-changed` events from `<scion-gcp-service-account-list>`.
+   * Updates the local `gcpServiceAccounts` state used by the "Default Service
+   * Account" dropdown so it reflects additions, verifications, and deletions
+   * without requiring a full page reload.
+   */
+  private handleSAListChanged(
+    e: CustomEvent<{ action: string; account: GCPServiceAccount }>
+  ): void {
+    const { action, account } = e.detail;
+
+    if (action === 'deleted') {
+      this.gcpServiceAccounts = this.gcpServiceAccounts.filter((sa) => sa.id !== account.id);
+      return;
+    }
+
+    // Only add verified accounts to the dropdown
+    if (!account.verified) return;
+
+    // Dedupe by id — replace if exists, append if new
+    const exists = this.gcpServiceAccounts.some((sa) => sa.id === account.id);
+    if (exists) {
+      this.gcpServiceAccounts = this.gcpServiceAccounts.map((sa) =>
+        sa.id === account.id ? account : sa
+      );
+    } else {
+      this.gcpServiceAccounts = [...this.gcpServiceAccounts, account];
+    }
+  }
+
   private async handleSaveConfig(): Promise<void> {
     this.settingsSaving = true;
     this.settingsError = null;
@@ -2420,6 +2450,7 @@ export class ScionPageProjectSettings extends LitElement {
             <scion-gcp-service-account-list
               scope="project"
               scopeId=${this.projectId}
+              @sa-list-changed=${this.handleSAListChanged}
             ></scion-gcp-service-account-list>
           </sl-tab-panel>
 

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -46,6 +46,7 @@ import '../shared/secret-list.js';
 import '../shared/shared-dir-list.js';
 import '../shared/group-member-editor.js';
 import '../shared/gcp-service-account-list.js';
+import type { SAListChangedDetail } from '../shared/gcp-service-account-list.js';
 import '../shared/scheduled-event-list.js';
 import '../shared/subscription-manager.js';
 import '../shared/schedule-list.js';
@@ -1176,13 +1177,15 @@ export class ScionPageProjectSettings extends LitElement {
    * Account" dropdown so it reflects additions, verifications, and deletions
    * without requiring a full page reload.
    */
-  private handleSAListChanged(
-    e: CustomEvent<{ action: string; account: GCPServiceAccount }>
-  ): void {
+  private handleSAListChanged(e: CustomEvent<SAListChangedDetail>): void {
     const { action, account } = e.detail;
 
     if (action === 'deleted') {
       this.gcpServiceAccounts = this.gcpServiceAccounts.filter((sa) => sa.id !== account.id);
+      // Clear the default SA selection if the deleted account was selected.
+      if (this.configDefaultGCPIdentitySAID === account.id) {
+        this.configDefaultGCPIdentitySAID = '';
+      }
       return;
     }
 

--- a/web/src/components/shared/gcp-service-account-list.ts
+++ b/web/src/components/shared/gcp-service-account-list.ts
@@ -61,6 +61,12 @@ import { resourceStyles } from './resource-styles.js';
 import { showToast } from '../../utils/toast.js';
 import { showConfirm } from './confirm-dialog.js';
 
+/** Detail payload for the `sa-list-changed` CustomEvent. */
+export interface SAListChangedDetail {
+  action: 'registered' | 'verified' | 'minted' | 'deleted';
+  account: GCPServiceAccount;
+}
+
 @customElement('scion-gcp-service-account-list')
 export class ScionGCPServiceAccountList extends LitElement {
   /** 'project' for a Scion project's own accounts, 'hub' for hub-scoped ones. */
@@ -254,6 +260,21 @@ export class ScionGCPServiceAccountList extends LitElement {
     return can(this.listCapabilities, 'mint');
   }
 
+  /**
+   * Dispatches a bubbling `sa-list-changed` event so parent components can
+   * react to registration, verification, minting, or deletion of a service
+   * account without a full page reload.
+   */
+  private dispatchSAChange(detail: SAListChangedDetail): void {
+    this.dispatchEvent(
+      new CustomEvent('sa-list-changed', {
+        bubbles: true,
+        composed: true,
+        detail,
+      })
+    );
+  }
+
   private async loadAccounts(): Promise<void> {
     this.loading = true;
     this.error = null;
@@ -336,8 +357,15 @@ export class ScionGCPServiceAccountList extends LitElement {
         );
       }
 
+      // Parse the minted SA from the response before any other consumption.
+      const mintedSA = (await response.json().catch(() => null)) as GCPServiceAccount | null;
+
       this.closeMintDialog();
       await this.loadAccounts();
+
+      if (mintedSA?.id) {
+        this.dispatchSAChange({ action: 'minted', account: mintedSA });
+      }
     } catch (err) {
       console.error('Failed to mint service account:', err);
       this.mintDialogError = err instanceof Error ? err.message : 'Failed to mint service account';
@@ -405,14 +433,19 @@ export class ScionGCPServiceAccountList extends LitElement {
         );
       }
 
-      // Check if auto-verification failed after registration
-      const data = (await response.json().catch(() => ({}))) as {
+      // Parse the created SA (and verification metadata) before any other
+      // consumption — response.json() can only be read once.
+      const data = (await response.json().catch(() => ({}))) as GCPServiceAccount & {
         verificationFailed?: boolean;
         verificationDetails?: { hubServiceAccountEmail?: string; targetEmail?: string };
       };
 
       this.closeDialog();
       await this.loadAccounts();
+
+      if (data.id) {
+        this.dispatchSAChange({ action: 'registered', account: data });
+      }
 
       if (data.verificationFailed) {
         this.verifyFailedHubEmail = data.verificationDetails?.hubServiceAccountEmail || '';
@@ -456,7 +489,14 @@ export class ScionGCPServiceAccountList extends LitElement {
         return;
       }
 
+      // Parse the updated SA from the verify response before reloading.
+      const updatedSA = (await response.json().catch(() => null)) as GCPServiceAccount | null;
+
       await this.loadAccounts();
+
+      if (updatedSA?.id) {
+        this.dispatchSAChange({ action: 'verified', account: updatedSA });
+      }
     } catch (err) {
       console.error('Failed to verify service account:', err);
       this.verifyFailedHubEmail = '';
@@ -491,6 +531,7 @@ export class ScionGCPServiceAccountList extends LitElement {
       }
 
       await this.loadAccounts();
+      this.dispatchSAChange({ action: 'deleted', account });
     } catch (err) {
       console.error('Failed to delete service account:', err);
       showToast(err instanceof Error ? err.message : 'Failed to delete');


### PR DESCRIPTION
## Summary
- SA list child component now dispatches sa-list-changed CustomEvents on register, verify, mint, and delete
- Project settings parent component listens and updates the Default SA dropdown immediately without page reload
- Properly typed with exported SAListChangedDetail interface
- Clears stale default SA selection when the selected SA is deleted

## Test plan
- [ ] Register a new SA — verify it appears in Default SA dropdown immediately
- [ ] Verify an unverified SA — verify it appears in dropdown after verification
- [ ] Mint a new SA — verify it appears in dropdown immediately
- [ ] Delete the currently-selected default SA — verify dropdown selection clears
- [ ] TypeScript compiles cleanly (npx tsc --noEmit)
