### PR TITLE
docs: nightly documentation update for Aug 13

### DIFF
--- a/docs-site/src/content/docs/hosted/user/messaging.md
+++ b/docs-site/src/content/docs/hosted/user/messaging.md
@@ -14,13 +14,20 @@ In the Web Dashboard, the **Inbox Tray** provides a centralized view of all mess
 
 ## Native Web Chat
 
-Scion features an interactive, top-level **Native Web Chat** interface in the Web Dashboard (enabled via the `web.native_chat` feature flag). Rather than being isolated inside a single tab, chat is promoted to a top-level workspace view (a fourth `ShellType` in the SPA) that provides a cohesive environment for real-time collaboration with all agents in your project.
+Scion features an interactive, top-level **Native Web Chat** interface in the Web Dashboard (enabled via the `web.native_chat` feature flag). Rather than being isolated inside a single tab, chat is promoted to a top-level workspace view (a fourth `ShellType` in the SPA) that provides a cohesive environment for real-time collaboration with all agents and team members.
 
 ### Core Layout & Navigation
 
-- **The Thread Rail**: A left-hand navigation sidebar that lists all active chat threads. Unread badges ("unread dots") update in real-time as messages arrive, instantly alerting you to agents requiring attention.
+- **Project-Scoped Spaces & Shared Threads**: Chat is organized into distinct spaces scoped to specific Projects. Within a project-scoped space, users and agents participate in shared discussion threads, creating focused hubs of collaboration.
+- **Direct Messaging (DMs)**: In addition to collaborative project spaces, the chat interface supports 1-on-1 Direct Messages. This includes both **human-to-human (H2H)** communication between team members and **human-to-agent (H2A)** chats. DMs are structured as a "global pair"—a single, unified consolidated thread per participant pair.
+- **Members Sidebar, Presence & Typing**: A right-hand members sidebar lists all participants in the active project space or DM. This includes real-time online **presence indicators** (active, away, offline) and live **typing indicators** to show when a team member or agent is actively composing a message.
+- **The Thread Rail**: A left-hand navigation sidebar lists all active chat spaces, threads, and DMs. Unread badges ("unread dots") update in real-time as messages arrive, instantly alerting you to new activity requiring attention.
 - **Chat/Log Toggle**: Located on the main `scion-chat-thread` panel, this toggle lets you switch between a clean, dialogue-focused **Chat** view and a live **Execution Log** stream for that agent.
-- **Zero-Reload Navigation**: Move between threads, project views, and configuration pages instantly with deep-linking support and no full-page reloads, ensuring no interruption to your active chat context or log streams.
+- **Zero-Reload Navigation**: Move between threads, project spaces, and configuration pages instantly with deep-linking support and no full-page reloads, ensuring no interruption to your active chat context or log streams.
+- **Attachments, Search & Notifications**:
+  - **Attachments**: The chat composer supports file and image uploads, allowing users to send documents or visual context directly to threads.
+  - **Search**: Built-in chat search lets you quickly query across historical messages and active threads to find crucial context.
+  - **Notifications**: Integrated chat-specific notifications, including native browser push notifications and persistent unread counts, ensure you stay informed of incoming messages.
 
 ### Three-State Visibility Filtering
 
@@ -38,6 +45,7 @@ When writing instructions, you can easily pull other agents into the thread:
 - **Autocomplete Popup**: Typing `@` in the chat input opens a dropdown list of active agents in the project. The list supports fuzzy-matching as you type, and full keyboard navigation (arrow keys to select, `Enter` to insert).
 - **Code-Fence Guard**: The mention autocomplete is smart — it automatically disables itself when typing inside Markdown code fences (e.g., ` ``` ` blocks) so code snippets don't trigger unwanted dropdowns.
 - **Fan-Out Restrictions**: For platform stability, a single message is fanned out to a maximum of **10 recipients** per `@-mention` broadcast.
+- **Composer Default-Agent Disambiguation**: When sending messages in collaborative project spaces with multiple active agents, typing a message without an explicit target or `@-mention` triggers a smart disambiguation interface. This guides the user to select which agent the message should target (or fall back to the project's configured default agent), keeping routing unambiguous and conversations clear.
 
 ### Cross-Channel Coherence
 

--- a/docs-site/src/content/docs/hosted/user/messaging.md
+++ b/docs-site/src/content/docs/hosted/user/messaging.md
@@ -19,7 +19,7 @@ Scion features an interactive, top-level **Native Web Chat** interface in the We
 ### Core Layout & Navigation
 
 - **Project-Scoped Spaces & Shared Threads**: Chat is organized into distinct spaces scoped to specific Projects. Within a project-scoped space, users and agents participate in shared discussion threads, creating focused hubs of collaboration.
-- **Direct Messaging (DMs)**: In addition to collaborative project spaces, the chat interface supports 1-on-1 Direct Messages. This includes both **human-to-human (H2H)** communication between team members and **human-to-agent (H2A)** chats. DMs are structured as a "global pair"—a single, unified consolidated thread per participant pair.
+- **Direct Messaging (DMs)**: In addition to collaborative project spaces, the chat interface supports 1-on-1 Direct Messages. This includes both **human-to-human (H2H)** communication between team members and **human-to-agent (H2A)** chats. DMs are structured as a "global pair"—a single, consolidated thread per participant pair.
 - **Members Sidebar, Presence & Typing**: A right-hand members sidebar lists all participants in the active project space or DM. This includes real-time online **presence indicators** (active, away, offline) and live **typing indicators** to show when a team member or agent is actively composing a message.
 - **The Thread Rail**: A left-hand navigation sidebar lists all active chat spaces, threads, and DMs. Unread badges ("unread dots") update in real-time as messages arrive, instantly alerting you to new activity requiring attention.
 - **Chat/Log Toggle**: Located on the main `scion-chat-thread` panel, this toggle lets you switch between a clean, dialogue-focused **Chat** view and a live **Execution Log** stream for that agent.

--- a/docs-site/src/content/docs/local/custom-images.md
+++ b/docs-site/src/content/docs/local/custom-images.md
@@ -19,7 +19,7 @@ Scion images are built in layers:
 core-base          System dependencies (Go, Node, Python, Git)
   └── scion-base   Scion CLI, sciontool binary, scion user, entrypoint
         ├── scion-claude     Claude Code harness
-        ├── scion-gemini     Gemini CLI harness
+        ├── scion-gemini-cli Gemini CLI harness
         ├── scion-opencode   OpenCode harness
         ├── scion-codex      Codex harness
         └── scion-hub        Scion hub server
@@ -132,7 +132,7 @@ When `image_registry` is set, Scion transforms the default image reference:
 | Default Image | `image_registry` | Resolved Image |
 | :--- | :--- | :--- |
 | `us-central1-docker.pkg.dev/.../scion-claude:latest` | `ghcr.io/myorg` | `ghcr.io/myorg/scion-claude:latest` |
-| `us-central1-docker.pkg.dev/.../scion-gemini:latest` | `ghcr.io/myorg` | `ghcr.io/myorg/scion-gemini:latest` |
+| `us-central1-docker.pkg.dev/.../scion-gemini-cli:latest` | `ghcr.io/myorg` | `ghcr.io/myorg/scion-gemini-cli:latest` |
 
 ### Setting It
 
@@ -204,7 +204,7 @@ Targets resolve to an ordered list of step IDs (one step per image):
 | :--- | :--- | :--- |
 | `core-base` | `core-base` | Foundation tools layer. |
 | `scion-base` | `scion-base` | Adds sciontool. Reuses existing `core-base:<tag>`. |
-| `harnesses` | `scion-claude`, `scion-gemini`, `scion-opencode`, `scion-codex` | Reuses existing `scion-base:<tag>`. |
+| `harnesses` | `scion-claude`, `scion-gemini-cli`, `scion-opencode`, `scion-codex` | Reuses existing `scion-base:<tag>`. |
 | `hub` | `scion-hub` | Hub server image. Reuses existing `scion-base:<tag>`. |
 | `common` (default) | `scion-base` + harnesses + hub | Skips `core-base`. Most common rebuild. |
 | `all` | Full DAG | Rebuilds everything from `core-base`. |

--- a/docs-site/src/content/docs/local/local-governance.md
+++ b/docs-site/src/content/docs/local/local-governance.md
@@ -56,13 +56,13 @@ Harness Configs define *what* agent harness runs, with what configurations. They
 ```yaml
 harness_configs:
   gemini:
-    harness: gemini
-    image: "us-central1-docker.pkg.dev/.../scion-gemini:latest"
+    harness: gemini-cli
+    image: "us-central1-docker.pkg.dev/.../scion-gemini-cli:latest"
     user: scion
     
   gemini-dev:
-    harness: gemini
-    image: "gemini:local-dev"
+    harness: gemini-cli
+    image: "gemini-cli:local-dev"
     env:
       DEBUG: "true"
 ```
@@ -87,7 +87,7 @@ For development, you might want to mount a local directory (like a shared librar
 ```yaml
 harness_configs:
   gemini-with-lib:
-    harness: gemini
+    harness: gemini-cli
     volumes:
       - source: "/Users/me/code/shared-lib"
         target: "/home/scion/shared-lib"

--- a/docs-site/src/content/docs/local/templates.md
+++ b/docs-site/src/content/docs/local/templates.md
@@ -323,9 +323,9 @@ model_aliases:
 ```
 
 ```yaml
-# ~/.scion/harness-configs/gemini/config.yaml
-harness: gemini
-image: scion-gemini:latest
+# ~/.scion/harness-configs/gemini-cli/config.yaml
+harness: gemini-cli
+image: scion-gemini-cli:latest
 model_aliases:
   small: gemini-flash-lite
   medium: gemini-flash

--- a/docs-site/src/content/docs/reference/admin-settings.md
+++ b/docs-site/src/content/docs/reference/admin-settings.md
@@ -182,6 +182,8 @@ To support complete infrastructure configuration directly from the Web Dashboard
 
 In highly available (HA) Postgres deployments, all configurations edited through this tab are stored in the database's `hub_settings` table as whole-map JSONB documents. This ensures edits propagate immediately to all replicas, support optimistic locking (CAS), and are never silently dropped or ignored on server PUT actions.
 
+Furthermore, these database-backed settings are wired directly into the runtime broker consumption path. During agent dispatch, both the Scion Hub and the Runtime Broker resolve runtime execution environments and resource profiles dynamically from these persisted database settings. This eliminates the need to distribute or maintain on-disk configuration files (such as local `settings.yaml` files) on individual broker nodes, ensuring a centralized, real-time control plane.
+
 #### Navigation Updates
 
 - **Message Broker Integration**: The Message Broker configuration has been consolidated and moved from the General tab to the **Hub Server** tab, grouping external integrations and network-bound transports in one logical place.

--- a/docs-site/src/content/docs/reference/orchestrator-settings.md
+++ b/docs-site/src/content/docs/reference/orchestrator-settings.md
@@ -121,8 +121,8 @@ Named configurations for agent harnesses. This replaces the legacy `harnesses` m
 ```yaml
 harness_configs:
   gemini:
-    harness: gemini
-    image: "us-central1-docker.pkg.dev/.../scion-gemini:latest"
+    harness: gemini-cli
+    image: "us-central1-docker.pkg.dev/.../scion-gemini-cli:latest"
     user: scion
     model: "gemini-1.5-pro"
   
@@ -135,7 +135,7 @@ harness_configs:
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `harness` | string | **Required**. The harness type (e.g., `gemini`, `claude`, `opencode`). |
+| `harness` | string | **Required**. The harness type (e.g., `gemini-cli`, `claude`, `opencode`). |
 | `image` | string | Container image to use. |
 | `user` | string | Unix username inside the container. |
 | `model` | string | Default model identifier. |

--- a/docs-site/src/content/docs/supported-harnesses.md
+++ b/docs-site/src/content/docs/supported-harnesses.md
@@ -14,11 +14,11 @@ projection, and MCP configuration across all bundles. See
 [Harness-Specific Settings](/scion/reference/harness-settings/) for how bundles are packaged and
 managed.
 
-`claude` and `gemini` are installed by default. `opencode`, `codex`, `copilot`, `hermes`, and
+`claude` and `gemini-cli` are installed by default. `opencode`, `codex`, `copilot`, `hermes`, and
 `antigravity` are opt-in bundles you add via a [harness-config](/scion/reference/harness-settings/#managing-harness-configs).
 :::
 
-## 1. Gemini CLI (`gemini`)
+## 1. Gemini CLI (`gemini-cli`)
 
 The default harness for interacting with Google's Gemini models via the `gemini` CLI tool.
 
@@ -248,7 +248,7 @@ The following table summarizes the capabilities supported by each agent harness 
 * **Enqueue**: Ability to send messages to the agent while it's running (supported via the built-in Tmux session).
 * **Hooks**: Support for lifecycle hooks (e.g., `SessionStart`, `AfterTool`).
 * **OpenTelemetry**: Specific events vary by harness and native emitter schema.
-* **System Prompt Override**: Support for providing a custom system prompt to the agent (e.g. via `system_prompt.md`). The `gemini` harness has full support via `~/.gemini/system_prompt.md`. ◐ = *partial* — the harness has no native system-prompt flag, so Scion prepends the system prompt to the harness's instructions file: `AGENTS.md` for Hermes, `GEMINI.md` for Antigravity, and `copilot-instructions.md` for Copilot.
+* **System Prompt Override**: Support for providing a custom system prompt to the agent (e.g. via `system_prompt.md`). The `gemini-cli` harness has full support via `~/.gemini/system_prompt.md`. ◐ = *partial* — the harness has no native system-prompt flag, so Scion prepends the system prompt to the harness's instructions file: `AGENTS.md` for Hermes, `GEMINI.md` for Antigravity, and `copilot-instructions.md` for Copilot.
 * **Auth types**: The universal auth types (`api-key`, `oauth-token`, `auth-file`, `vertex-ai`) each harness accepts. Set an explicit type with `--harness-auth` or `auth_selectedType`; otherwise Scion auto-detects. See [Harness Authentication](/scion/local/agent-credentials/).
     * ¹ **Copilot** authenticates with a **GitHub token** (`COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN`) under the `api-key` type, not an LLM-provider key.
     * ² **Antigravity**'s `oauth-token` default type is a **file-based** OAuth token (`AGY_TOKEN` at `~/.gemini/antigravity-cli/antigravity-oauth-token`), captured under the auth-file capability — it does not accept a raw injected OAuth token the way Claude does.

--- a/docs-site/src/content/docs/workstation/dashboard.md
+++ b/docs-site/src/content/docs/workstation/dashboard.md
@@ -19,8 +19,13 @@ The dashboard features an integrated notification framework with real-time SSE d
 - **Browser Push Notifications**: Opt-in native browser push notifications ensure you receive alerts even when the dashboard is in the background. Default triggers include `stalled` and `error` states, as well as requests for user input.
 
 ### Native Web Chat
-When enabled via the `web.native_chat` feature flag, the dashboard includes a top-level **Native Web Chat** workspace (a fourth ShellType in the SPA). It offers a rich interface for direct communication and coordination with your running agents.
-- **Thread Rail & Unread dots**: Access all active agent conversations from a persistent left-hand sidebar, complete with unread dots indicating new activity.
+When enabled via the `web.native_chat` feature flag, the dashboard includes a top-level **Native Web Chat** workspace (a fourth ShellType in the SPA). It offers a rich interface for direct communication and coordination with your running agents and team.
+- **Project-Scoped Spaces & Shared Threads**: Conversations are organized into distinct spaces scoped to specific Projects. Within these spaces, users and agents can collaborate on shared discussion threads.
+- **Direct Messages (DMs)**: Start 1-on-1 direct messages covering both human-to-human (H2H) and human-to-agent (H2A) communication, consolidated as a single "global pair" thread per pair.
+- **Members Sidebar, Presence & Typing**: A right-hand sidebar displays active project members, showcasing real-time online presence status and typing indicators.
+- **Composer Default-Agent Disambiguation**: When sending messages in spaces with multiple active agents, the composer helps resolve which agent is targeted if no explicit mention is used.
+- **Attachments**: Upload file or image attachments directly within the composer.
+- **Search**: Built-in chat search lets you query across historical messages and threads.
 - **Chat/Log Switcher**: Instantly toggle between standard conversational chat with the agent and a real-time stream of the agent's raw execution logs inside the same view.
 - **@-Mentions & Autocomplete**: Call other agents into the thread by typing `@` to trigger a fuzzy-matching, keyboard-navigable agent dropdown. Protected by code-fence guards to prevent triggering inside Markdown code snippets.
 - **Visibility Density Filters**: Choose from three filter levels—**Conversation** (pure dialogue), **Verbose** (adds mentions/CCs), or **Full** (adds state updates and background processes)—with preferences saved individually per agent.


### PR DESCRIPTION
## Summary
Changelog-driven documentation updates for the 2026-08-13 release.

### Changes
- messaging.md: Native web chat Wave 2 (spaces, threads, DMs, presence)
- dashboard.md: Chat Wave 2 dashboard integration
- admin-settings.md: DB-backed runtimes/profiles wired to broker dispatch
- supported-harnesses.md: Harness naming corrections
- custom-images.md, templates.md, local-governance.md, orchestrator-settings.md: Harness ID consistency

8 files, 37 insertions, 22 deletions

Tracking: ptone/scion#1011
