### PR TITLE
fix: migrate secrets from per-plugin config files, not just inline settings

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2570,8 +2570,8 @@ func initPluginManager(ctx context.Context, secretBackend secret.SecretBackend, 
 	if secretBackend != nil {
 		runWithAdvisoryLock(ctx, dataStore, store.LockInlineSecretsMigration, "inline secrets migration", func() {
 			for name, entry := range vs.Server.Plugins.Broker {
-				if entry.Config != nil {
-					migrateInlineSecrets(ctx, secretBackend, name, entry.Config)
+				if entry.Config != nil || entry.ConfigFile != "" {
+					migrateInlineSecrets(ctx, secretBackend, name, entry.Config, entry.ConfigFile)
 				}
 			}
 		})
@@ -2855,20 +2855,30 @@ func requireImageRegistryForBroker() error {
 }
 
 // migrateInlineSecrets performs a one-shot migration of secret config keys found
-// in the raw inline settings.yaml config into the secret backend. This prevents
-// existing users who followed the Telegram/Discord READMEs (which have
-// bot_token directly in settings.yaml) from losing their credentials when
-// ResolvePluginConfig strips inline secrets.
-func migrateInlineSecrets(ctx context.Context, sb secret.SecretBackend, pluginName string, inlineConfig map[string]string) {
+// in the raw plugin config into the secret backend. Both sources of raw config
+// are considered: the inline map in settings.yaml and the per-plugin YAML file
+// referenced by config_file. This prevents existing users who followed the
+// Telegram/Discord READMEs (which have bot_token directly in settings.yaml or in
+// the per-plugin config file) from losing their credentials when
+// ResolvePluginConfig strips secrets from both sources.
+//
+// When a secret key is present in both sources the inline value wins, matching
+// the merge precedence in config.LoadPluginConfigFile.
+func migrateInlineSecrets(ctx context.Context, sb secret.SecretBackend, pluginName string, inlineConfig map[string]string, configFile string) {
 	mappings, ok := config.PluginSecretKeyMap[pluginName]
 	if !ok {
 		return
 	}
 
+	fileConfig := loadPluginConfigFileForMigration(pluginName, configFile)
+
 	hubID := sb.HubID()
 	for _, m := range mappings {
-		val, has := inlineConfig[m.ConfigKey]
-		if !has || val == "" {
+		val, source := inlineConfig[m.ConfigKey], "settings.yaml"
+		if val == "" {
+			val, source = fileConfig[m.ConfigKey], configFile
+		}
+		if val == "" {
 			continue
 		}
 		existing, err := sb.Get(ctx, m.SecretKey, store.ScopeHub, hubID)
@@ -2886,14 +2896,30 @@ func migrateInlineSecrets(ctx context.Context, sb secret.SecretBackend, pluginNa
 			InjectionMode: "as_needed",
 			Scope:         store.ScopeHub,
 			ScopeID:       hubID,
-			Description:   fmt.Sprintf("Auto-migrated from inline config for plugin %s", pluginName),
+			Description:   fmt.Sprintf("Auto-migrated from %s for plugin %s", source, pluginName),
 		})
 		if err != nil {
-			log.Printf("Warning: failed to migrate inline secret %s for plugin %q: %v", m.ConfigKey, pluginName, err)
+			log.Printf("Warning: failed to migrate secret %s for plugin %q: %v", m.ConfigKey, pluginName, err)
 			continue
 		}
-		log.Printf("Migrated inline %s to secret backend for plugin %q — remove it from settings.yaml", m.ConfigKey, pluginName)
+		log.Printf("Migrated %s to secret backend for plugin %q — remove it from %s", m.ConfigKey, pluginName, source)
 	}
+}
+
+// loadPluginConfigFileForMigration reads the raw per-plugin YAML config file so
+// migrateInlineSecrets can see secrets that live only in that file. A missing
+// file yields an empty map; any load failure is logged and treated as empty so
+// migration still proceeds for inline config.
+func loadPluginConfigFileForMigration(pluginName, configFile string) map[string]string {
+	if configFile == "" {
+		return nil
+	}
+	fileConfig, err := config.LoadPluginConfigFile(configFile, nil)
+	if err != nil {
+		log.Printf("Warning: failed to read config file %q for plugin %q during secret migration: %v", configFile, pluginName, err)
+		return nil
+	}
+	return fileConfig
 }
 
 // stripSecretKeys returns a copy of the config map with all secret config keys removed.

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2869,8 +2869,8 @@ func requireImageRegistryForBroker() error {
 //     the secret backend's lifecycle — rotation, auditing, scoped access — instead
 //     of leaving copies scattered across plaintext YAML on disk.
 //
-// When a secret key is present in both sources the inline value wins, matching
-// the merge precedence in config.LoadPluginConfigFile.
+// When a secret key is present in both sources the config file value wins — see
+// pluginSecretMigrationSource.
 //
 // Known limitation (no code change here — this is the existing precedence):
 // migrating a key out of a config file does not deactivate the file copy. Because
@@ -2891,10 +2891,7 @@ func migrateInlineSecrets(ctx context.Context, sb secret.SecretBackend, pluginNa
 
 	hubID := sb.HubID()
 	for _, m := range mappings {
-		val, source := inlineConfig[m.ConfigKey], "settings.yaml"
-		if val == "" {
-			val, source = fileConfig[m.ConfigKey], configFile
-		}
+		val, source := pluginSecretMigrationSource(m.ConfigKey, inlineConfig, fileConfig, configFile)
 		if val == "" {
 			continue
 		}
@@ -2923,6 +2920,23 @@ func migrateInlineSecrets(ctx context.Context, sb secret.SecretBackend, pluginNa
 		}
 		log.Printf("Migrated %s to secret backend for plugin %q — remove it from %s", m.ConfigKey, pluginName, source)
 	}
+}
+
+// pluginSecretMigrationSource picks which raw value to migrate for one secret
+// config key, and returns a label naming where it came from for logging.
+//
+// The per-plugin config file wins over inline config. That is the opposite of
+// config.LoadPluginConfigFile's merge order, and deliberately so: when
+// config_file is set, ResolvePluginConfig drops every secret config key from
+// inline config and takes the file's value, so the file holds the credential the
+// plugin is actually running on. Migrating the inline value instead would put a
+// different — possibly stale — credential in the backend, and the plugin would
+// silently switch to it once the operator cleaned the key out of the file.
+func pluginSecretMigrationSource(configKey string, inlineConfig, fileConfig map[string]string, configFile string) (value, source string) {
+	if v := fileConfig[configKey]; v != "" {
+		return v, configFile
+	}
+	return inlineConfig[configKey], "settings.yaml"
 }
 
 // loadPluginConfigFileForMigration reads the raw per-plugin YAML config file so

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2857,13 +2857,30 @@ func requireImageRegistryForBroker() error {
 // migrateInlineSecrets performs a one-shot migration of secret config keys found
 // in the raw plugin config into the secret backend. Both sources of raw config
 // are considered: the inline map in settings.yaml and the per-plugin YAML file
-// referenced by config_file. This prevents existing users who followed the
-// Telegram/Discord READMEs (which have bot_token directly in settings.yaml or in
-// the per-plugin config file) from losing their credentials when
-// ResolvePluginConfig strips secrets from both sources.
+// referenced by config_file.
+//
+// The two sources need migrating for different reasons:
+//
+//   - Inline settings.yaml: ResolvePluginConfig strips secret config keys
+//     (bot_token, signing_key, ...) from inline config, so without migration the
+//     credential never reaches the plugin.
+//   - Per-plugin config file: these keys are NOT stripped and do reach the plugin,
+//     so nothing breaks today. Migrating them puts every plugin credential under
+//     the secret backend's lifecycle — rotation, auditing, scoped access — instead
+//     of leaving copies scattered across plaintext YAML on disk.
 //
 // When a secret key is present in both sources the inline value wins, matching
 // the merge precedence in config.LoadPluginConfigFile.
+//
+// Known limitation (no code change here — this is the existing precedence):
+// migrating a key out of a config file does not deactivate the file copy. Because
+// injectPluginSecretsIntoConfig only fills in keys the merged config leaves empty,
+// a value still present in the config file continues to win over the backend copy,
+// which stays inert until the operator removes the key from the file. An operator
+// who later rotates the secret in the backend will keep running on the stale file
+// value. The log line below tells them which file to clean up; note that it prints
+// configFile as written in settings.yaml, so a relative or "~/"-prefixed path is
+// shown unresolved.
 func migrateInlineSecrets(ctx context.Context, sb secret.SecretBackend, pluginName string, inlineConfig map[string]string, configFile string) {
 	mappings, ok := config.PluginSecretKeyMap[pluginName]
 	if !ok {
@@ -2896,7 +2913,9 @@ func migrateInlineSecrets(ctx context.Context, sb secret.SecretBackend, pluginNa
 			InjectionMode: "as_needed",
 			Scope:         store.ScopeHub,
 			ScopeID:       hubID,
-			Description:   fmt.Sprintf("Auto-migrated from %s for plugin %s", source, pluginName),
+			// Only the file name goes into backend metadata — a full host path
+			// would leak the operator's username and directory layout.
+			Description: fmt.Sprintf("Auto-migrated from %s for plugin %s", filepath.Base(source), pluginName),
 		})
 		if err != nil {
 			log.Printf("Warning: failed to migrate secret %s for plugin %q: %v", m.ConfigKey, pluginName, err)

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1212,7 +1212,7 @@ func migrateStore(ctx context.Context, cfg *config.GlobalConfig, s *entadapter.C
 // safe because all guarded boot migrations are idempotent: each one checks
 // whether its work has already been done (e.g. MigrateStorageOnFirstBoot
 // checks for existing namespaced objects, BootstrapBundledResources uses
-// SkipIfAnyExist, migrateInlineSecrets checks for existing secret values)
+// SkipIfAnyExist, migratePluginSecrets checks for existing secret values)
 // and no-ops if so. The winning replica does the work; the others skip it
 // here and will see the completed state on their next access.
 func runWithAdvisoryLock(ctx context.Context, s store.Store, key store.AdvisoryLockKey, label string, fn func()) {
@@ -2565,14 +2565,14 @@ func initPluginManager(ctx context.Context, secretBackend secret.SecretBackend, 
 	pluginsCfg := scionplugin.PluginsConfig{
 		Broker: make(map[string]scionplugin.PluginEntry),
 	}
-	// Migrate inline secrets under advisory lock to prevent concurrent replicas
-	// from racing the one-shot migration (audit finding C6).
+	// Migrate plugin secrets under advisory lock to prevent concurrent replicas
+	// from racing the one-shot migration (audit finding C6). The lock key stays
+	// LockInlineSecretsMigration: it is a persisted name, and renaming it would
+	// stop replicas on different versions from excluding each other.
 	if secretBackend != nil {
-		runWithAdvisoryLock(ctx, dataStore, store.LockInlineSecretsMigration, "inline secrets migration", func() {
+		runWithAdvisoryLock(ctx, dataStore, store.LockInlineSecretsMigration, "plugin secrets migration", func() {
 			for name, entry := range vs.Server.Plugins.Broker {
-				if entry.Config != nil || entry.ConfigFile != "" {
-					migrateInlineSecrets(ctx, secretBackend, name, entry.Config, entry.ConfigFile)
-				}
+				migratePluginSecrets(ctx, secretBackend, name, entry.Config, entry.ConfigFile)
 			}
 		})
 	}
@@ -2854,7 +2854,7 @@ func requireImageRegistryForBroker() error {
 		"See image-build/README.md for instructions on building and pushing images")
 }
 
-// migrateInlineSecrets performs a one-shot migration of secret config keys found
+// migratePluginSecrets performs a one-shot migration of secret config keys found
 // in the raw plugin config into the secret backend. Both sources of raw config
 // are considered: the inline map in settings.yaml and the per-plugin YAML file
 // referenced by config_file.
@@ -2881,7 +2881,13 @@ func requireImageRegistryForBroker() error {
 // value. The log line below tells them which file to clean up; note that it prints
 // configFile as written in settings.yaml, so a relative or "~/"-prefixed path is
 // shown unresolved.
-func migrateInlineSecrets(ctx context.Context, sb secret.SecretBackend, pluginName string, inlineConfig map[string]string, configFile string) {
+//
+// The same divergence bites in the other direction: the migration never refreshes
+// a secret that already exists in the backend, so an operator who rotates the
+// credential in the config file and later removes the key — as the log advises —
+// drops the plugin back onto the stale backend value. Whichever copy the operator
+// stops maintaining, the two must be reconciled by hand.
+func migratePluginSecrets(ctx context.Context, sb secret.SecretBackend, pluginName string, inlineConfig map[string]string, configFile string) {
 	mappings, ok := config.PluginSecretKeyMap[pluginName]
 	if !ok {
 		return
@@ -2940,7 +2946,7 @@ func pluginSecretMigrationSource(configKey string, inlineConfig, fileConfig map[
 }
 
 // loadPluginConfigFileForMigration reads the raw per-plugin YAML config file so
-// migrateInlineSecrets can see secrets that live only in that file. A missing
+// migratePluginSecrets can see secrets that live only in that file. A missing
 // file yields an empty map; any load failure is logged and treated as empty so
 // migration still proceeds for inline config.
 func loadPluginConfigFileForMigration(pluginName, configFile string) map[string]string {

--- a/cmd/server_foreground_migratesecrets_test.go
+++ b/cmd/server_foreground_migratesecrets_test.go
@@ -15,9 +15,12 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
@@ -28,23 +31,19 @@ import (
 // fakeSecretBackend is an in-memory secret.SecretBackend for migration tests.
 // Only Get, Set and HubID are exercised by migrateInlineSecrets.
 type fakeSecretBackend struct {
-	hubID   string
-	values  map[string]string
-	getErr  error
-	setErrs map[string]error
-	sets    int
+	hubID        string
+	values       map[string]string
+	descriptions map[string]string
+	sets         int
 }
 
 func newFakeSecretBackend() *fakeSecretBackend {
-	return &fakeSecretBackend{hubID: "hub-1", values: map[string]string{}, setErrs: map[string]error{}}
+	return &fakeSecretBackend{hubID: "hub-1", values: map[string]string{}, descriptions: map[string]string{}}
 }
 
 func (f *fakeSecretBackend) HubID() string { return f.hubID }
 
 func (f *fakeSecretBackend) Get(_ context.Context, name, _, _ string) (*secret.SecretWithValue, error) {
-	if f.getErr != nil {
-		return nil, f.getErr
-	}
 	v, ok := f.values[name]
 	if !ok {
 		return nil, store.ErrNotFound
@@ -53,10 +52,8 @@ func (f *fakeSecretBackend) Get(_ context.Context, name, _, _ string) (*secret.S
 }
 
 func (f *fakeSecretBackend) Set(_ context.Context, in *secret.SetSecretInput) (bool, *secret.SecretMeta, error) {
-	if err := f.setErrs[in.Name]; err != nil {
-		return false, nil, err
-	}
 	f.sets++
+	f.descriptions[in.Name] = in.Description
 	_, existed := f.values[in.Name]
 	f.values[in.Name] = in.Value
 	return !existed, &secret.SecretMeta{Name: in.Name}, nil
@@ -86,6 +83,17 @@ func writePluginConfigFile(t *testing.T, contents string) string {
 	return path
 }
 
+// captureLog collects everything written to the standard logger while fn runs.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(prev)
+	fn()
+	return buf.String()
+}
+
 func TestMigrateInlineSecrets_FromConfigFile(t *testing.T) {
 	sb := newFakeSecretBackend()
 	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\ninbound_mode: \"webhook\"\n")
@@ -94,6 +102,23 @@ func TestMigrateInlineSecrets_FromConfigFile(t *testing.T) {
 
 	if got := sb.values[config.SecretTelegramBotToken]; got != "file-token" {
 		t.Errorf("expected bot_token from config file to be migrated, got %q", got)
+	}
+}
+
+// The secret description must name the config file without exposing the host
+// path, which would leak the operator's username and directory layout.
+func TestMigrateInlineSecrets_DescriptionOmitsHostPath(t *testing.T) {
+	sb := newFakeSecretBackend()
+	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\n")
+
+	migrateInlineSecrets(context.Background(), sb, "telegram", nil, cfgFile)
+
+	desc := sb.descriptions[config.SecretTelegramBotToken]
+	if !strings.Contains(desc, "scion-telegram.yaml") {
+		t.Errorf("expected description to name the config file, got %q", desc)
+	}
+	if strings.Contains(desc, filepath.Dir(cfgFile)) {
+		t.Errorf("description must not contain the host path, got %q", desc)
 	}
 }
 
@@ -164,11 +189,22 @@ func TestMigrateInlineSecrets_UnknownPluginNoOp(t *testing.T) {
 
 func TestMigrateInlineSecrets_MalformedConfigFileFallsBackToInline(t *testing.T) {
 	sb := newFakeSecretBackend()
-	cfgFile := writePluginConfigFile(t, "bot_token: [unterminated\n")
+	// bot_token appears only in the file, webhook_secret only inline: if the file
+	// parsed, bot_token would migrate too.
+	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\nwebhook_secret: [unterminated\n")
+	inline := map[string]string{"webhook_secret": "inline-secret"}
 
-	migrateInlineSecrets(context.Background(), sb, "telegram", map[string]string{"bot_token": "inline-token"}, cfgFile)
+	out := captureLog(t, func() {
+		migrateInlineSecrets(context.Background(), sb, "telegram", inline, cfgFile)
+	})
 
-	if got := sb.values[config.SecretTelegramBotToken]; got != "inline-token" {
+	if got := sb.values[config.SecretTelegramWebhookKey]; got != "inline-secret" {
 		t.Errorf("malformed config file should not block inline migration, got %q", got)
+	}
+	if got, ok := sb.values[config.SecretTelegramBotToken]; ok {
+		t.Errorf("unparseable config file must yield no file values, got %q", got)
+	}
+	if !strings.Contains(out, "failed to read config file") {
+		t.Errorf("expected a warning about the unreadable config file, got log: %q", out)
 	}
 }

--- a/cmd/server_foreground_migratesecrets_test.go
+++ b/cmd/server_foreground_migratesecrets_test.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// fakeSecretBackend is an in-memory secret.SecretBackend for migration tests.
+// Only Get, Set and HubID are exercised by migrateInlineSecrets.
+type fakeSecretBackend struct {
+	hubID   string
+	values  map[string]string
+	getErr  error
+	setErrs map[string]error
+	sets    int
+}
+
+func newFakeSecretBackend() *fakeSecretBackend {
+	return &fakeSecretBackend{hubID: "hub-1", values: map[string]string{}, setErrs: map[string]error{}}
+}
+
+func (f *fakeSecretBackend) HubID() string { return f.hubID }
+
+func (f *fakeSecretBackend) Get(_ context.Context, name, _, _ string) (*secret.SecretWithValue, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	v, ok := f.values[name]
+	if !ok {
+		return nil, store.ErrNotFound
+	}
+	return &secret.SecretWithValue{SecretMeta: secret.SecretMeta{Name: name}, Value: v}, nil
+}
+
+func (f *fakeSecretBackend) Set(_ context.Context, in *secret.SetSecretInput) (bool, *secret.SecretMeta, error) {
+	if err := f.setErrs[in.Name]; err != nil {
+		return false, nil, err
+	}
+	f.sets++
+	_, existed := f.values[in.Name]
+	f.values[in.Name] = in.Value
+	return !existed, &secret.SecretMeta{Name: in.Name}, nil
+}
+
+func (f *fakeSecretBackend) Delete(context.Context, string, string, string) error { return nil }
+
+func (f *fakeSecretBackend) List(context.Context, secret.Filter) ([]secret.SecretMeta, error) {
+	return nil, nil
+}
+
+func (f *fakeSecretBackend) GetMeta(context.Context, string, string, string) (*secret.SecretMeta, error) {
+	return nil, store.ErrNotFound
+}
+
+func (f *fakeSecretBackend) Resolve(context.Context, string, string, string, *secret.ResolveOpts) ([]secret.SecretWithValue, error) {
+	return nil, nil
+}
+
+// writePluginConfigFile writes a per-plugin YAML config file and returns its path.
+func writePluginConfigFile(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "scion-telegram.yaml")
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+	return path
+}
+
+func TestMigrateInlineSecrets_FromConfigFile(t *testing.T) {
+	sb := newFakeSecretBackend()
+	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\ninbound_mode: \"webhook\"\n")
+
+	migrateInlineSecrets(context.Background(), sb, "telegram", nil, cfgFile)
+
+	if got := sb.values[config.SecretTelegramBotToken]; got != "file-token" {
+		t.Errorf("expected bot_token from config file to be migrated, got %q", got)
+	}
+}
+
+func TestMigrateInlineSecrets_FromInlineConfig(t *testing.T) {
+	sb := newFakeSecretBackend()
+	inline := map[string]string{"bot_token": "inline-token"}
+
+	migrateInlineSecrets(context.Background(), sb, "telegram", inline, "")
+
+	if got := sb.values[config.SecretTelegramBotToken]; got != "inline-token" {
+		t.Errorf("expected inline bot_token to be migrated, got %q", got)
+	}
+}
+
+func TestMigrateInlineSecrets_InlineWinsOverConfigFile(t *testing.T) {
+	sb := newFakeSecretBackend()
+	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\nwebhook_secret: \"file-secret\"\n")
+	inline := map[string]string{"bot_token": "inline-token"}
+
+	migrateInlineSecrets(context.Background(), sb, "telegram", inline, cfgFile)
+
+	if got := sb.values[config.SecretTelegramBotToken]; got != "inline-token" {
+		t.Errorf("expected inline value to win, got %q", got)
+	}
+	// Keys absent from inline config still migrate from the file.
+	if got := sb.values[config.SecretTelegramWebhookKey]; got != "file-secret" {
+		t.Errorf("expected webhook_secret from config file, got %q", got)
+	}
+}
+
+func TestMigrateInlineSecrets_MissingConfigFile(t *testing.T) {
+	sb := newFakeSecretBackend()
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	inline := map[string]string{"bot_token": "inline-token"}
+
+	migrateInlineSecrets(context.Background(), sb, "telegram", inline, missing)
+
+	if got := sb.values[config.SecretTelegramBotToken]; got != "inline-token" {
+		t.Errorf("missing config file should not block inline migration, got %q", got)
+	}
+}
+
+func TestMigrateInlineSecrets_DoesNotOverwriteExisting(t *testing.T) {
+	sb := newFakeSecretBackend()
+	sb.values[config.SecretTelegramBotToken] = "already-migrated"
+	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\n")
+
+	migrateInlineSecrets(context.Background(), sb, "telegram", map[string]string{"bot_token": "inline-token"}, cfgFile)
+
+	if got := sb.values[config.SecretTelegramBotToken]; got != "already-migrated" {
+		t.Errorf("existing secret must not be overwritten, got %q", got)
+	}
+	if sb.sets != 0 {
+		t.Errorf("expected no Set calls, got %d", sb.sets)
+	}
+}
+
+func TestMigrateInlineSecrets_UnknownPluginNoOp(t *testing.T) {
+	sb := newFakeSecretBackend()
+	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\n")
+
+	migrateInlineSecrets(context.Background(), sb, "not-a-known-plugin", map[string]string{"bot_token": "x"}, cfgFile)
+
+	if sb.sets != 0 {
+		t.Errorf("expected no migration for unknown plugin, got %d Set calls", sb.sets)
+	}
+}
+
+func TestMigrateInlineSecrets_MalformedConfigFileFallsBackToInline(t *testing.T) {
+	sb := newFakeSecretBackend()
+	cfgFile := writePluginConfigFile(t, "bot_token: [unterminated\n")
+
+	migrateInlineSecrets(context.Background(), sb, "telegram", map[string]string{"bot_token": "inline-token"}, cfgFile)
+
+	if got := sb.values[config.SecretTelegramBotToken]; got != "inline-token" {
+		t.Errorf("malformed config file should not block inline migration, got %q", got)
+	}
+}

--- a/cmd/server_foreground_migratesecrets_test.go
+++ b/cmd/server_foreground_migratesecrets_test.go
@@ -133,19 +133,21 @@ func TestMigrateInlineSecrets_FromInlineConfig(t *testing.T) {
 	}
 }
 
-func TestMigrateInlineSecrets_InlineWinsOverConfigFile(t *testing.T) {
+// When config_file is set, ResolvePluginConfig runs the plugin on the file's
+// value, so that is the credential the backend must receive.
+func TestMigrateInlineSecrets_ConfigFileWinsOverInline(t *testing.T) {
 	sb := newFakeSecretBackend()
-	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\nwebhook_secret: \"file-secret\"\n")
-	inline := map[string]string{"bot_token": "inline-token"}
+	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\n")
+	inline := map[string]string{"bot_token": "inline-token", "webhook_secret": "inline-secret"}
 
 	migrateInlineSecrets(context.Background(), sb, "telegram", inline, cfgFile)
 
-	if got := sb.values[config.SecretTelegramBotToken]; got != "inline-token" {
-		t.Errorf("expected inline value to win, got %q", got)
+	if got := sb.values[config.SecretTelegramBotToken]; got != "file-token" {
+		t.Errorf("expected config file value to win, got %q", got)
 	}
-	// Keys absent from inline config still migrate from the file.
-	if got := sb.values[config.SecretTelegramWebhookKey]; got != "file-secret" {
-		t.Errorf("expected webhook_secret from config file, got %q", got)
+	// Keys absent from the file still migrate from inline config.
+	if got := sb.values[config.SecretTelegramWebhookKey]; got != "inline-secret" {
+		t.Errorf("expected webhook_secret from inline config, got %q", got)
 	}
 }
 
@@ -206,5 +208,33 @@ func TestMigrateInlineSecrets_MalformedConfigFileFallsBackToInline(t *testing.T)
 	}
 	if !strings.Contains(out, "failed to read config file") {
 		t.Errorf("expected a warning about the unreadable config file, got log: %q", out)
+	}
+}
+
+// initPluginManager must run the migration for a plugin whose only raw config is
+// a config_file — the inline config map is nil in that case.
+func TestInitPluginManager_MigratesConfigFileOnlyPlugin(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	globalDir := filepath.Join(home, ".scion")
+	if err := os.MkdirAll(globalDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	cfgFile := filepath.Join(globalDir, "scion-telegram.yaml")
+	if err := os.WriteFile(cfgFile, []byte("bot_token: \"file-only-token\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	settings := "server:\n  plugins:\n    broker:\n      telegram:\n        config_file: " + cfgFile + "\n"
+	if err := os.WriteFile(filepath.Join(globalDir, "settings.yaml"), []byte(settings), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	sb := newFakeSecretBackend()
+	captureLog(t, func() {
+		initPluginManager(context.Background(), sb, nil)
+	})
+
+	if got := sb.values[config.SecretTelegramBotToken]; got != "file-only-token" {
+		t.Errorf("expected config-file-only secret to be migrated, got %q", got)
 	}
 }

--- a/cmd/server_foreground_pluginsecrets_test.go
+++ b/cmd/server_foreground_pluginsecrets_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 // fakeSecretBackend is an in-memory secret.SecretBackend for migration tests.
-// Only Get, Set and HubID are exercised by migrateInlineSecrets.
+// Only Get, Set and HubID are exercised by migratePluginSecrets.
 type fakeSecretBackend struct {
 	hubID        string
 	values       map[string]string
@@ -94,11 +94,11 @@ func captureLog(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
-func TestMigrateInlineSecrets_FromConfigFile(t *testing.T) {
+func TestMigratePluginSecrets_FromConfigFile(t *testing.T) {
 	sb := newFakeSecretBackend()
 	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\ninbound_mode: \"webhook\"\n")
 
-	migrateInlineSecrets(context.Background(), sb, "telegram", nil, cfgFile)
+	migratePluginSecrets(context.Background(), sb, "telegram", nil, cfgFile)
 
 	if got := sb.values[config.SecretTelegramBotToken]; got != "file-token" {
 		t.Errorf("expected bot_token from config file to be migrated, got %q", got)
@@ -107,11 +107,11 @@ func TestMigrateInlineSecrets_FromConfigFile(t *testing.T) {
 
 // The secret description must name the config file without exposing the host
 // path, which would leak the operator's username and directory layout.
-func TestMigrateInlineSecrets_DescriptionOmitsHostPath(t *testing.T) {
+func TestMigratePluginSecrets_DescriptionOmitsHostPath(t *testing.T) {
 	sb := newFakeSecretBackend()
 	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\n")
 
-	migrateInlineSecrets(context.Background(), sb, "telegram", nil, cfgFile)
+	migratePluginSecrets(context.Background(), sb, "telegram", nil, cfgFile)
 
 	desc := sb.descriptions[config.SecretTelegramBotToken]
 	if !strings.Contains(desc, "scion-telegram.yaml") {
@@ -122,11 +122,11 @@ func TestMigrateInlineSecrets_DescriptionOmitsHostPath(t *testing.T) {
 	}
 }
 
-func TestMigrateInlineSecrets_FromInlineConfig(t *testing.T) {
+func TestMigratePluginSecrets_FromInlineConfig(t *testing.T) {
 	sb := newFakeSecretBackend()
 	inline := map[string]string{"bot_token": "inline-token"}
 
-	migrateInlineSecrets(context.Background(), sb, "telegram", inline, "")
+	migratePluginSecrets(context.Background(), sb, "telegram", inline, "")
 
 	if got := sb.values[config.SecretTelegramBotToken]; got != "inline-token" {
 		t.Errorf("expected inline bot_token to be migrated, got %q", got)
@@ -135,12 +135,12 @@ func TestMigrateInlineSecrets_FromInlineConfig(t *testing.T) {
 
 // When config_file is set, ResolvePluginConfig runs the plugin on the file's
 // value, so that is the credential the backend must receive.
-func TestMigrateInlineSecrets_ConfigFileWinsOverInline(t *testing.T) {
+func TestMigratePluginSecrets_ConfigFileWinsOverInline(t *testing.T) {
 	sb := newFakeSecretBackend()
 	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\n")
 	inline := map[string]string{"bot_token": "inline-token", "webhook_secret": "inline-secret"}
 
-	migrateInlineSecrets(context.Background(), sb, "telegram", inline, cfgFile)
+	migratePluginSecrets(context.Background(), sb, "telegram", inline, cfgFile)
 
 	if got := sb.values[config.SecretTelegramBotToken]; got != "file-token" {
 		t.Errorf("expected config file value to win, got %q", got)
@@ -151,24 +151,51 @@ func TestMigrateInlineSecrets_ConfigFileWinsOverInline(t *testing.T) {
 	}
 }
 
-func TestMigrateInlineSecrets_MissingConfigFile(t *testing.T) {
+// An empty value in the config file is not a value — inline is used instead.
+func TestMigratePluginSecrets_EmptyConfigFileValueFallsBackToInline(t *testing.T) {
+	sb := newFakeSecretBackend()
+	cfgFile := writePluginConfigFile(t, "bot_token: \"\"\n")
+	inline := map[string]string{"bot_token": "inline-token"}
+
+	migratePluginSecrets(context.Background(), sb, "telegram", inline, cfgFile)
+
+	if got := sb.values[config.SecretTelegramBotToken]; got != "inline-token" {
+		t.Errorf("expected fallback to inline value, got %q", got)
+	}
+}
+
+// Backend-style key names (TELEGRAM_BOT_TOKEN) are stripped from file config by
+// LoadPluginConfigFile, so they are not a migration source — only the plugin
+// config key (bot_token) is.
+func TestMigratePluginSecrets_IgnoresBackendKeyNameInConfigFile(t *testing.T) {
+	sb := newFakeSecretBackend()
+	cfgFile := writePluginConfigFile(t, config.SecretTelegramBotToken+": \"backend-style-token\"\n")
+
+	migratePluginSecrets(context.Background(), sb, "telegram", nil, cfgFile)
+
+	if sb.sets != 0 {
+		t.Errorf("expected no migration from a backend-style key, got %d Set calls", sb.sets)
+	}
+}
+
+func TestMigratePluginSecrets_MissingConfigFile(t *testing.T) {
 	sb := newFakeSecretBackend()
 	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
 	inline := map[string]string{"bot_token": "inline-token"}
 
-	migrateInlineSecrets(context.Background(), sb, "telegram", inline, missing)
+	migratePluginSecrets(context.Background(), sb, "telegram", inline, missing)
 
 	if got := sb.values[config.SecretTelegramBotToken]; got != "inline-token" {
 		t.Errorf("missing config file should not block inline migration, got %q", got)
 	}
 }
 
-func TestMigrateInlineSecrets_DoesNotOverwriteExisting(t *testing.T) {
+func TestMigratePluginSecrets_DoesNotOverwriteExisting(t *testing.T) {
 	sb := newFakeSecretBackend()
 	sb.values[config.SecretTelegramBotToken] = "already-migrated"
 	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\n")
 
-	migrateInlineSecrets(context.Background(), sb, "telegram", map[string]string{"bot_token": "inline-token"}, cfgFile)
+	migratePluginSecrets(context.Background(), sb, "telegram", map[string]string{"bot_token": "inline-token"}, cfgFile)
 
 	if got := sb.values[config.SecretTelegramBotToken]; got != "already-migrated" {
 		t.Errorf("existing secret must not be overwritten, got %q", got)
@@ -178,18 +205,18 @@ func TestMigrateInlineSecrets_DoesNotOverwriteExisting(t *testing.T) {
 	}
 }
 
-func TestMigrateInlineSecrets_UnknownPluginNoOp(t *testing.T) {
+func TestMigratePluginSecrets_UnknownPluginNoOp(t *testing.T) {
 	sb := newFakeSecretBackend()
 	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\n")
 
-	migrateInlineSecrets(context.Background(), sb, "not-a-known-plugin", map[string]string{"bot_token": "x"}, cfgFile)
+	migratePluginSecrets(context.Background(), sb, "not-a-known-plugin", map[string]string{"bot_token": "x"}, cfgFile)
 
 	if sb.sets != 0 {
 		t.Errorf("expected no migration for unknown plugin, got %d Set calls", sb.sets)
 	}
 }
 
-func TestMigrateInlineSecrets_MalformedConfigFileFallsBackToInline(t *testing.T) {
+func TestMigratePluginSecrets_MalformedConfigFileFallsBackToInline(t *testing.T) {
 	sb := newFakeSecretBackend()
 	// bot_token appears only in the file, webhook_secret only inline: if the file
 	// parsed, bot_token would migrate too.
@@ -197,7 +224,7 @@ func TestMigrateInlineSecrets_MalformedConfigFileFallsBackToInline(t *testing.T)
 	inline := map[string]string{"webhook_secret": "inline-secret"}
 
 	out := captureLog(t, func() {
-		migrateInlineSecrets(context.Background(), sb, "telegram", inline, cfgFile)
+		migratePluginSecrets(context.Background(), sb, "telegram", inline, cfgFile)
 	})
 
 	if got := sb.values[config.SecretTelegramWebhookKey]; got != "inline-secret" {


### PR DESCRIPTION
## Summary

migrateInlineSecrets() (now migratePluginSecrets()) only read secrets from the inline config map in settings.yaml. Secrets stored in per-plugin YAML config files (e.g. ~/.scion/scion-telegram.yaml via entry.ConfigFile) were never migrated to the secret backend.

Ref: ptone/scion#409

## Key changes

- `cmd/server_foreground.go`: renamed `migrateInlineSecrets` to `migratePluginSecrets`, added `configFile` parameter, new helper `pluginSecretMigrationSource()`
- `cmd/server_foreground_pluginsecrets_test.go`: 11 new tests

## Test plan

- All 11 new tests pass
- go vet and golangci-lint clean
