### PR TITLE
fix(hub): allow agents to manage their own notification subscriptions

### DIFF
--- a/pkg/hub/handlers_notifications.go
+++ b/pkg/hub/handlers_notifications.go
@@ -160,11 +160,25 @@ func (s *Server) agentMaySubscribe(w http.ResponseWriter, r *http.Request, calle
 	if cleared[req.AgentID] {
 		return true
 	}
-	target, err := s.store.GetAgent(r.Context(), req.AgentID)
+	if !s.agentTargetInProject(w, r, caller, req.AgentID) {
+		return false
+	}
+	if cleared != nil {
+		cleared[req.AgentID] = true
+	}
+	return true
+}
+
+// agentTargetInProject reports whether agentID names an agent in the caller's
+// project. An agent that does not exist draws the same 403 as one in another
+// project, so the answer never confirms or denies the existence of an agent the
+// caller has no business naming.
+//
+// Returns false when a response has already been written.
+func (s *Server) agentTargetInProject(w http.ResponseWriter, r *http.Request, caller *notificationSubscriber, agentID string) bool {
+	target, err := s.store.GetAgent(r.Context(), agentID)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
-			// Don't confirm or deny the existence of an agent the caller has
-			// no business naming.
 			Forbidden(w)
 			return false
 		}
@@ -174,9 +188,6 @@ func (s *Server) agentMaySubscribe(w http.ResponseWriter, r *http.Request, calle
 	if target.ProjectID != caller.ProjectID {
 		Forbidden(w)
 		return false
-	}
-	if cleared != nil {
-		cleared[req.AgentID] = true
 	}
 	return true
 }
@@ -246,6 +257,12 @@ func (s *Server) handleNotifications(w http.ResponseWriter, r *http.Request) {
 		if agentID == "" {
 			notifs, err = s.store.GetNotifications(r.Context(), caller.Type, caller.ID, onlyUnacknowledged)
 		} else {
+			// An agent may only name an agent in its own project. The rows
+			// returned are scoped either way, but the query itself should not
+			// reach across the project boundary.
+			if caller.isAgent() && !s.agentTargetInProject(w, r, caller, agentID) {
+				return
+			}
 			notifs, err = s.store.GetNotificationsByAgent(r.Context(), agentID, caller.Type, caller.ID, onlyUnacknowledged)
 		}
 		if err != nil {

--- a/pkg/hub/handlers_notifications.go
+++ b/pkg/hub/handlers_notifications.go
@@ -112,6 +112,10 @@ func (s *Server) notificationCaller(ctx context.Context) (*notificationSubscribe
 	agent, err := s.store.GetAgent(ctx, agentIdent.ID())
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
+			// A valid token for a deleted agent, or one issued for a record
+			// that never existed. Worth a line: it should not happen.
+			slog.Warn("Notification caller token names an unknown agent",
+				"agentID", agentIdent.ID(), "projectID", agentIdent.ProjectID())
 			return nil, nil
 		}
 		return nil, err
@@ -119,6 +123,8 @@ func (s *Server) notificationCaller(ctx context.Context) (*notificationSubscribe
 	// The token's project is what authorization is granted against; a record
 	// that disagrees with it must not be usable.
 	if agent.ProjectID != agentIdent.ProjectID() {
+		slog.Warn("Notification caller token project disagrees with the agent record",
+			"agentID", agentIdent.ID(), "tokenProjectID", agentIdent.ProjectID(), "agentProjectID", agent.ProjectID)
 		return nil, nil
 	}
 
@@ -127,6 +133,42 @@ func (s *Server) notificationCaller(ctx context.Context) (*notificationSubscribe
 		ID:        agent.Slug,
 		ProjectID: agent.ProjectID,
 	}, nil
+}
+
+// agentMaySubscribe reports whether an agent caller is allowed to create the
+// requested subscription. Both the project the subscription is filed under and
+// the agent it watches must belong to the caller's project — otherwise an agent
+// could file a subscription in its own project that watches a foreign agent and
+// receive that agent's activity transitions. User callers are unrestricted.
+//
+// Returns false when a response has already been written.
+func (s *Server) agentMaySubscribe(w http.ResponseWriter, r *http.Request, caller *notificationSubscriber, req *createSubscriptionRequest) bool {
+	if !caller.isAgent() {
+		return true
+	}
+	if req.ProjectID != caller.ProjectID {
+		Forbidden(w)
+		return false
+	}
+	if req.Scope != store.SubscriptionScopeAgent || req.AgentID == "" {
+		return true
+	}
+	target, err := s.store.GetAgent(r.Context(), req.AgentID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			// Don't confirm or deny the existence of an agent the caller has
+			// no business naming.
+			Forbidden(w)
+			return false
+		}
+		writeErrorFromErr(w, err, "")
+		return false
+	}
+	if target.ProjectID != caller.ProjectID {
+		Forbidden(w)
+		return false
+	}
+	return true
 }
 
 // resolveNotificationCaller resolves the caller and writes the failure response
@@ -262,7 +304,7 @@ func (s *Server) handleNotificationRoutes(w http.ResponseWriter, r *http.Request
 		// for an agent would span every project that reuses its slug. There is
 		// no project-scoped variant, so agents ack individually instead.
 		if caller.isAgent() {
-			writeError(w, http.StatusBadRequest, "bad_request",
+			writeError(w, http.StatusNotImplemented, "not_implemented",
 				"agent tokens must acknowledge notifications individually", nil)
 			return
 		}
@@ -362,9 +404,9 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			writeError(w, http.StatusBadRequest, "bad_request", "triggerActivities must be non-empty", nil)
 			return
 		}
-		// Agent callers may only subscribe within their own project.
-		if caller.isAgent() && req.ProjectID != caller.ProjectID {
-			Forbidden(w)
+		// Agent callers may only subscribe within their own project, and may
+		// only watch agents in it.
+		if !s.agentMaySubscribe(w, r, caller, &req) {
 			return
 		}
 
@@ -526,15 +568,13 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			writeError(w, http.StatusBadRequest, "bad_request", "Empty request array", nil)
 			return
 		}
-		// Agent callers may only subscribe within their own project. An
-		// authorization denial fails the whole request rather than silently
-		// dropping entries the way malformed items are dropped below.
-		if caller.isAgent() {
-			for _, req := range reqs {
-				if req.ProjectID != caller.ProjectID {
-					Forbidden(w)
-					return
-				}
+		// Agent callers may only subscribe within their own project, and may
+		// only watch agents in it. An authorization denial fails the whole
+		// request rather than silently dropping entries the way malformed
+		// items are dropped below.
+		for i := range reqs {
+			if !s.agentMaySubscribe(w, r, caller, &reqs[i]) {
+				return
 			}
 		}
 

--- a/pkg/hub/handlers_notifications.go
+++ b/pkg/hub/handlers_notifications.go
@@ -15,6 +15,7 @@
 package hub
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -24,19 +25,59 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
+// notificationCaller resolves the notification subscriber identity of the
+// caller. Users subscribe under their user ID; agents subscribe under their
+// slug, matching the subscriber ID the dispatcher writes for agent
+// subscriptions (see notifications.go). Returns empty strings when the
+// request carries no identity, or when the calling agent has no agent record.
+func (s *Server) notificationCaller(ctx context.Context) (subscriberType, subscriberID string) {
+	if user := GetUserIdentityFromContext(ctx); user != nil {
+		return store.SubscriberTypeUser, user.ID()
+	}
+	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+		agent, err := s.store.GetAgent(ctx, agentIdent.ID())
+		if err != nil {
+			return "", ""
+		}
+		return store.SubscriberTypeAgent, agent.Slug
+	}
+	return "", ""
+}
+
+// isCallingAgent reports whether an agentId filter names the calling agent,
+// accepting either the agent's slug or its record ID.
+func (s *Server) isCallingAgent(ctx context.Context, agentID, callerSlug string) bool {
+	if agentID == callerSlug {
+		return true
+	}
+	agentIdent := GetAgentIdentityFromContext(ctx)
+	return agentIdent != nil && agentID == agentIdent.ID()
+}
+
+// agentProjectAllowed reports whether an agent caller may act on the given
+// project. Non-agent callers are unaffected.
+func agentProjectAllowed(ctx context.Context, projectID string) bool {
+	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+		return agentIdent.ProjectID() == projectID
+	}
+	return true
+}
+
 // handleNotifications handles GET /api/v1/notifications.
-// Lists notifications for the authenticated user.
+// Lists notifications for the authenticated caller (user or agent).
 //
 // Without agentId: returns flat []Notification array (existing tray behavior).
 // With ?agentId=X: returns { userNotifications: [...], agentNotifications: [...] }.
+// Agent callers may only read their own notifications, so agentId must be
+// empty or identify the calling agent.
 func (s *Server) handleNotifications(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		MethodNotAllowed(w)
 		return
 	}
 
-	user := GetUserIdentityFromContext(r.Context())
-	if user == nil {
+	subType, subID := s.notificationCaller(r.Context())
+	if subType == "" {
 		Forbidden(w)
 		return
 	}
@@ -46,9 +87,25 @@ func (s *Server) handleNotifications(w http.ResponseWriter, r *http.Request) {
 
 	agentID := r.URL.Query().Get("agentId")
 
+	if subType == store.SubscriberTypeAgent {
+		// Agents only ever see notifications addressed to themselves; the
+		// agentId filter may only name the caller.
+		if agentID != "" && !s.isCallingAgent(r.Context(), agentID, subID) {
+			Forbidden(w)
+			return
+		}
+		notifs, err := s.store.GetNotifications(r.Context(), subType, subID, onlyUnacknowledged)
+		if err != nil {
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		writeJSON(w, http.StatusOK, notifs)
+		return
+	}
+
 	if agentID == "" {
 		// Existing behaviour: flat array of user notifications
-		notifs, err := s.store.GetNotifications(r.Context(), "user", user.ID(), onlyUnacknowledged)
+		notifs, err := s.store.GetNotifications(r.Context(), subType, subID, onlyUnacknowledged)
 		if err != nil {
 			writeErrorFromErr(w, err, "")
 			return
@@ -58,7 +115,7 @@ func (s *Server) handleNotifications(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Agent-scoped: return combined response
-	userNotifs, err := s.store.GetNotificationsByAgent(r.Context(), agentID, "user", user.ID(), onlyUnacknowledged)
+	userNotifs, err := s.store.GetNotificationsByAgent(r.Context(), agentID, subType, subID, onlyUnacknowledged)
 	if err != nil {
 		writeErrorFromErr(w, err, "")
 		return
@@ -93,8 +150,8 @@ type agentNotificationsResponse struct {
 //   - POST /api/v1/notifications/subscriptions/bulk: Bulk create subscriptions
 //   - POST /api/v1/notifications/subscriptions/bulk-delete: Bulk delete subscriptions
 func (s *Server) handleNotificationRoutes(w http.ResponseWriter, r *http.Request) {
-	user := GetUserIdentityFromContext(r.Context())
-	if user == nil {
+	subType, subID := s.notificationCaller(r.Context())
+	if subType == "" {
 		Forbidden(w)
 		return
 	}
@@ -103,24 +160,24 @@ func (s *Server) handleNotificationRoutes(w http.ResponseWriter, r *http.Request
 
 	// POST /api/v1/notifications/ack-all
 	if id == "ack-all" && r.Method == http.MethodPost {
-		if err := s.store.AcknowledgeAllNotifications(r.Context(), "user", user.ID()); err != nil {
+		if err := s.store.AcknowledgeAllNotifications(r.Context(), subType, subID); err != nil {
 			writeErrorFromErr(w, err, "")
 			return
 		}
-		slog.Info("All notifications acknowledged", "userID", user.ID())
+		slog.Info("All notifications acknowledged", "subscriberType", subType, "subscriberID", subID)
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 		return
 	}
 
 	// Subscription routes: /api/v1/notifications/subscriptions[/...]
 	if id == "subscriptions" {
-		s.handleSubscriptionRoutes(w, r, user, action)
+		s.handleSubscriptionRoutes(w, r, subType, subID, action)
 		return
 	}
 
 	// Subscription template routes: /api/v1/notifications/templates[/...]
 	if id == "templates" {
-		s.handleSubscriptionTemplateRoutes(w, r, user, action)
+		s.handleSubscriptionTemplateRoutes(w, r, subID, action)
 		return
 	}
 
@@ -130,7 +187,7 @@ func (s *Server) handleNotificationRoutes(w http.ResponseWriter, r *http.Request
 			writeErrorFromErr(w, err, "")
 			return
 		}
-		slog.Info("Notification acknowledged", "notificationID", id, "userID", user.ID())
+		slog.Info("Notification acknowledged", "notificationID", id, "subscriberType", subType, "subscriberID", subID)
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 		return
 	}
@@ -157,7 +214,7 @@ type updateSubscriptionRequest struct {
 }
 
 // handleSubscriptionRoutes handles CRUD for notification subscriptions.
-func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request, user UserIdentity, subID string) {
+func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request, subscriberType, subscriberID, subID string) {
 	ctx := r.Context()
 
 	switch {
@@ -190,10 +247,15 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			writeError(w, http.StatusBadRequest, "bad_request", "triggerActivities must be non-empty", nil)
 			return
 		}
+		// Agent callers may only subscribe within their own project.
+		if !agentProjectAllowed(ctx, req.ProjectID) {
+			Forbidden(w)
+			return
+		}
 
 		// Enforce subscription limit if configured
 		if s.config.MaxSubscriptionsPerUser > 0 {
-			existing, err := s.store.GetSubscriptionsForSubscriber(ctx, store.SubscriberTypeUser, user.ID())
+			existing, err := s.store.GetSubscriptionsForSubscriber(ctx, subscriberType, subscriberID)
 			if err != nil {
 				writeErrorFromErr(w, err, "")
 				return
@@ -209,17 +271,17 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			ID:                api.NewUUID(),
 			Scope:             req.Scope,
 			AgentID:           req.AgentID,
-			SubscriberType:    store.SubscriberTypeUser,
-			SubscriberID:      user.ID(),
+			SubscriberType:    subscriberType,
+			SubscriberID:      subscriberID,
 			ProjectID:         req.ProjectID,
 			TriggerActivities: req.TriggerActivities,
-			CreatedBy:         user.ID(),
+			CreatedBy:         subscriberID,
 		}
 
 		if err := s.store.CreateNotificationSubscription(ctx, sub); err != nil {
 			if err == store.ErrAlreadyExists {
 				// Idempotent: return existing subscription
-				existing, listErr := s.store.GetSubscriptionsForSubscriber(ctx, store.SubscriberTypeUser, user.ID())
+				existing, listErr := s.store.GetSubscriptionsForSubscriber(ctx, subscriberType, subscriberID)
 				if listErr == nil {
 					for _, e := range existing {
 						if e.Scope == req.Scope && e.AgentID == req.AgentID && e.ProjectID == req.ProjectID {
@@ -236,12 +298,12 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 		}
 
 		slog.Info("Subscription created",
-			"subscriptionID", sub.ID, "scope", sub.Scope, "userID", user.ID())
+			"subscriptionID", sub.ID, "scope", sub.Scope, "subscriberType", subscriberType, "subscriberID", subscriberID)
 		writeJSON(w, http.StatusCreated, sub)
 
 	// GET /api/v1/notifications/subscriptions — List
 	case subID == "" && r.Method == http.MethodGet:
-		subs, err := s.store.GetSubscriptionsForSubscriber(ctx, store.SubscriberTypeUser, user.ID())
+		subs, err := s.store.GetSubscriptionsForSubscriber(ctx, subscriberType, subscriberID)
 		if err != nil {
 			writeErrorFromErr(w, err, "")
 			return
@@ -292,7 +354,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			writeErrorFromErr(w, err, "Subscription")
 			return
 		}
-		if sub.SubscriberType != store.SubscriberTypeUser || sub.SubscriberID != user.ID() {
+		if sub.SubscriberType != subscriberType || sub.SubscriberID != subscriberID {
 			Forbidden(w)
 			return
 		}
@@ -315,7 +377,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 		// Return the updated subscription
 		sub.TriggerActivities = req.TriggerActivities
 		slog.Info("Subscription updated",
-			"subscriptionID", subID, "userID", user.ID())
+			"subscriptionID", subID, "subscriberType", subscriberType, "subscriberID", subscriberID)
 		writeJSON(w, http.StatusOK, sub)
 
 	// DELETE /api/v1/notifications/subscriptions/{id} — Delete
@@ -326,7 +388,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			writeErrorFromErr(w, err, "Subscription")
 			return
 		}
-		if sub.SubscriberType != store.SubscriberTypeUser || sub.SubscriberID != user.ID() {
+		if sub.SubscriberType != subscriberType || sub.SubscriberID != subscriberID {
 			Forbidden(w)
 			return
 		}
@@ -337,7 +399,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 		}
 
 		slog.Info("Subscription deleted",
-			"subscriptionID", subID, "userID", user.ID())
+			"subscriptionID", subID, "subscriberType", subscriberType, "subscriberID", subscriberID)
 		w.WriteHeader(http.StatusNoContent)
 
 	// POST /api/v1/notifications/subscriptions/bulk — Bulk create
@@ -354,7 +416,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 
 		// Enforce subscription limit if configured
 		if s.config.MaxSubscriptionsPerUser > 0 {
-			existing, err := s.store.GetSubscriptionsForSubscriber(ctx, store.SubscriberTypeUser, user.ID())
+			existing, err := s.store.GetSubscriptionsForSubscriber(ctx, subscriberType, subscriberID)
 			if err != nil {
 				writeErrorFromErr(w, err, "")
 				return
@@ -377,22 +439,26 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			if req.Scope == store.SubscriptionScopeAgent && req.AgentID == "" {
 				continue
 			}
+			// Agent callers may only subscribe within their own project.
+			if !agentProjectAllowed(ctx, req.ProjectID) {
+				continue
+			}
 
 			sub := &store.NotificationSubscription{
 				ID:                api.NewUUID(),
 				Scope:             req.Scope,
 				AgentID:           req.AgentID,
-				SubscriberType:    store.SubscriberTypeUser,
-				SubscriberID:      user.ID(),
+				SubscriberType:    subscriberType,
+				SubscriberID:      subscriberID,
 				ProjectID:         req.ProjectID,
 				TriggerActivities: req.TriggerActivities,
-				CreatedBy:         user.ID(),
+				CreatedBy:         subscriberID,
 			}
 
 			if err := s.store.CreateNotificationSubscription(ctx, sub); err != nil {
 				if err == store.ErrAlreadyExists {
 					// Idempotent: find and return existing
-					existing, listErr := s.store.GetSubscriptionsForSubscriber(ctx, store.SubscriberTypeUser, user.ID())
+					existing, listErr := s.store.GetSubscriptionsForSubscriber(ctx, subscriberType, subscriberID)
 					if listErr == nil {
 						for _, e := range existing {
 							if e.Scope == req.Scope && e.AgentID == req.AgentID && e.ProjectID == req.ProjectID {
@@ -411,7 +477,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 		}
 
 		slog.Info("Bulk subscriptions created",
-			"count", len(results), "userID", user.ID())
+			"count", len(results), "subscriberType", subscriberType, "subscriberID", subscriberID)
 		writeJSON(w, http.StatusCreated, results)
 
 	// POST /api/v1/notifications/subscriptions/bulk-delete — Bulk delete
@@ -434,7 +500,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			if err != nil {
 				continue
 			}
-			if sub.SubscriberType != store.SubscriberTypeUser || sub.SubscriberID != user.ID() {
+			if sub.SubscriberType != subscriberType || sub.SubscriberID != subscriberID {
 				continue
 			}
 			if err := s.store.DeleteNotificationSubscription(ctx, id); err != nil {
@@ -444,7 +510,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 		}
 
 		slog.Info("Bulk subscriptions deleted",
-			"deleted", deleted, "requested", len(req.IDs), "userID", user.ID())
+			"deleted", deleted, "requested", len(req.IDs), "subscriberType", subscriberType, "subscriberID", subscriberID)
 		writeJSON(w, http.StatusOK, map[string]int{"deleted": deleted})
 
 	default:
@@ -477,7 +543,7 @@ func (r *createTemplateRequest) UnmarshalJSON(data []byte) error {
 }
 
 // handleSubscriptionTemplateRoutes handles CRUD for subscription templates.
-func (s *Server) handleSubscriptionTemplateRoutes(w http.ResponseWriter, r *http.Request, user UserIdentity, templateID string) {
+func (s *Server) handleSubscriptionTemplateRoutes(w http.ResponseWriter, r *http.Request, subscriberID, templateID string) {
 	ctx := r.Context()
 
 	switch {
@@ -506,7 +572,7 @@ func (s *Server) handleSubscriptionTemplateRoutes(w http.ResponseWriter, r *http
 			Scope:             req.Scope,
 			TriggerActivities: req.TriggerActivities,
 			ProjectID:         req.ProjectID,
-			CreatedBy:         user.ID(),
+			CreatedBy:         subscriberID,
 		}
 
 		if err := s.store.CreateSubscriptionTemplate(ctx, tmpl); err != nil {
@@ -519,7 +585,7 @@ func (s *Server) handleSubscriptionTemplateRoutes(w http.ResponseWriter, r *http
 		}
 
 		slog.Info("Subscription template created",
-			"templateID", tmpl.ID, "name", tmpl.Name, "userID", user.ID())
+			"templateID", tmpl.ID, "name", tmpl.Name, "createdBy", subscriberID)
 		writeJSON(w, http.StatusCreated, tmpl)
 
 	// GET /api/v1/notifications/templates — List
@@ -542,7 +608,7 @@ func (s *Server) handleSubscriptionTemplateRoutes(w http.ResponseWriter, r *http
 			writeErrorFromErr(w, err, "Template")
 			return
 		}
-		if tmpl.CreatedBy != user.ID() {
+		if tmpl.CreatedBy != subscriberID {
 			Forbidden(w)
 			return
 		}
@@ -551,7 +617,7 @@ func (s *Server) handleSubscriptionTemplateRoutes(w http.ResponseWriter, r *http
 			return
 		}
 		slog.Info("Subscription template deleted",
-			"templateID", templateID, "userID", user.ID())
+			"templateID", templateID, "createdBy", subscriberID)
 		w.WriteHeader(http.StatusNoContent)
 
 	default:

--- a/pkg/hub/handlers_notifications.go
+++ b/pkg/hub/handlers_notifications.go
@@ -17,6 +17,7 @@ package hub
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -25,40 +26,135 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
-// notificationCaller resolves the notification subscriber identity of the
-// caller. Users subscribe under their user ID; agents subscribe under their
-// slug, matching the subscriber ID the dispatcher writes for agent
-// subscriptions (see notifications.go). Returns empty strings when the
-// request carries no identity, or when the calling agent has no agent record.
-func (s *Server) notificationCaller(ctx context.Context) (subscriberType, subscriberID string) {
-	if user := GetUserIdentityFromContext(ctx); user != nil {
-		return store.SubscriberTypeUser, user.ID()
+// notificationSubscriber identifies the caller of the notification endpoints.
+//
+// Users are global: their user ID is unique hub-wide. Agents are not — an agent
+// subscribes under its slug (matching the subscriber ID the dispatcher writes
+// for agent subscriptions, see notifications.go), and slugs are unique only
+// within a project (pkg/ent/schema/agent.go). The subscriber identity of an
+// agent is therefore the pair (ProjectID, ID), and every read and ownership
+// check for an agent caller must qualify by project — the store keys
+// notifications and subscriptions on (subscriberType, subscriberID) alone.
+type notificationSubscriber struct {
+	Type      string // store.SubscriberTypeUser or store.SubscriberTypeAgent
+	ID        string // user ID, or agent slug
+	ProjectID string // agent callers only; empty for users
+}
+
+// isAgent reports whether the caller is an agent.
+func (n *notificationSubscriber) isAgent() bool {
+	return n.Type == store.SubscriberTypeAgent
+}
+
+// ownsSubscription reports whether sub belongs to this caller.
+func (n *notificationSubscriber) ownsSubscription(sub *store.NotificationSubscription) bool {
+	if sub.SubscriberType != n.Type || sub.SubscriberID != n.ID {
+		return false
 	}
-	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
-		agent, err := s.store.GetAgent(ctx, agentIdent.ID())
-		if err != nil {
-			return "", ""
+	return !n.isAgent() || sub.ProjectID == n.ProjectID
+}
+
+// ownsNotification reports whether notif was addressed to this caller.
+func (n *notificationSubscriber) ownsNotification(notif *store.Notification) bool {
+	if notif.SubscriberType != n.Type || notif.SubscriberID != n.ID {
+		return false
+	}
+	return !n.isAgent() || notif.ProjectID == n.ProjectID
+}
+
+// scopeNotifications drops rows outside the caller's project. Agent slugs are
+// reused across projects, so a store lookup by subscriber ID alone can return
+// another project's rows.
+func (n *notificationSubscriber) scopeNotifications(notifs []store.Notification) []store.Notification {
+	if !n.isAgent() {
+		return notifs
+	}
+	scoped := make([]store.Notification, 0, len(notifs))
+	for _, notif := range notifs {
+		if notif.ProjectID == n.ProjectID {
+			scoped = append(scoped, notif)
 		}
-		return store.SubscriberTypeAgent, agent.Slug
 	}
-	return "", ""
+	return scoped
 }
 
-// isCallingAgent reports whether an agentId filter names the calling agent,
-// accepting either the agent's slug or its record ID.
-func (s *Server) isCallingAgent(ctx context.Context, agentID, callerSlug string) bool {
-	if agentID == callerSlug {
-		return true
+// scopeSubscriptions drops rows outside the caller's project, for the same
+// reason as scopeNotifications.
+func (n *notificationSubscriber) scopeSubscriptions(subs []store.NotificationSubscription) []store.NotificationSubscription {
+	if !n.isAgent() {
+		return subs
 	}
+	scoped := make([]store.NotificationSubscription, 0, len(subs))
+	for _, sub := range subs {
+		if sub.ProjectID == n.ProjectID {
+			scoped = append(scoped, sub)
+		}
+	}
+	return scoped
+}
+
+// notificationCaller resolves the notification subscriber identity of the
+// caller. Returns nil when the request carries no usable identity; returns an
+// error only when the identity could not be resolved because of a store
+// failure.
+func (s *Server) notificationCaller(ctx context.Context) (*notificationSubscriber, error) {
+	if user := GetUserIdentityFromContext(ctx); user != nil {
+		return &notificationSubscriber{Type: store.SubscriberTypeUser, ID: user.ID()}, nil
+	}
+
 	agentIdent := GetAgentIdentityFromContext(ctx)
-	return agentIdent != nil && agentID == agentIdent.ID()
+	if agentIdent == nil {
+		return nil, nil
+	}
+
+	// The slug is not on the token, so the agent record is needed to build the
+	// subscriber identity.
+	agent, err := s.store.GetAgent(ctx, agentIdent.ID())
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	// The token's project is what authorization is granted against; a record
+	// that disagrees with it must not be usable.
+	if agent.ProjectID != agentIdent.ProjectID() {
+		return nil, nil
+	}
+
+	return &notificationSubscriber{
+		Type:      store.SubscriberTypeAgent,
+		ID:        agent.Slug,
+		ProjectID: agent.ProjectID,
+	}, nil
 }
 
-// agentProjectAllowed reports whether an agent caller may act on the given
-// project. Non-agent callers are unaffected.
-func agentProjectAllowed(ctx context.Context, projectID string) bool {
-	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
-		return agentIdent.ProjectID() == projectID
+// resolveNotificationCaller resolves the caller and writes the failure response
+// itself. Returns nil when the request should not proceed.
+func (s *Server) resolveNotificationCaller(w http.ResponseWriter, r *http.Request) *notificationSubscriber {
+	caller, err := s.notificationCaller(r.Context())
+	if err != nil {
+		slog.Error("Failed to resolve notification caller identity", "error", err)
+		writeErrorFromErr(w, err, "")
+		return nil
+	}
+	if caller == nil {
+		Forbidden(w)
+		return nil
+	}
+	return caller
+}
+
+// checkAgentNotifyScope verifies that agent callers may modify notification
+// state. Returns true if the request should proceed, false if a 403 was
+// written. User callers are not affected.
+func checkAgentNotifyScope(w http.ResponseWriter, r *http.Request) bool {
+	if agentIdent := GetAgentIdentityFromContext(r.Context()); agentIdent != nil {
+		if !agentIdent.HasScope(ScopeAgentNotify) {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden,
+				"Missing required scope: project:agent:notify", nil)
+			return false
+		}
 	}
 	return true
 }
@@ -66,19 +162,24 @@ func agentProjectAllowed(ctx context.Context, projectID string) bool {
 // handleNotifications handles GET /api/v1/notifications.
 // Lists notifications for the authenticated caller (user or agent).
 //
-// Without agentId: returns flat []Notification array (existing tray behavior).
-// With ?agentId=X: returns { userNotifications: [...], agentNotifications: [...] }.
-// Agent callers may only read their own notifications, so agentId must be
-// empty or identify the calling agent.
+// Response shape depends on the caller and the agentId filter:
+//   - user, no agentId: flat []Notification array (tray behavior).
+//   - user with ?agentId=X: { userNotifications: [...], agentNotifications: [...] }.
+//   - agent (with or without ?agentId=X): flat []Notification array of the
+//     notifications addressed to the calling agent, optionally narrowed to
+//     those about agent X. An agent never sees another subscriber's rows, so
+//     the combined shape has nothing to carry.
 func (s *Server) handleNotifications(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		MethodNotAllowed(w)
 		return
 	}
 
-	subType, subID := s.notificationCaller(r.Context())
-	if subType == "" {
-		Forbidden(w)
+	caller := s.resolveNotificationCaller(w, r)
+	if caller == nil {
+		return
+	}
+	if !checkAgentReadScope(w, r) {
 		return
 	}
 
@@ -87,35 +188,24 @@ func (s *Server) handleNotifications(w http.ResponseWriter, r *http.Request) {
 
 	agentID := r.URL.Query().Get("agentId")
 
-	if subType == store.SubscriberTypeAgent {
-		// Agents only ever see notifications addressed to themselves; the
-		// agentId filter may only name the caller.
-		if agentID != "" && !s.isCallingAgent(r.Context(), agentID, subID) {
-			Forbidden(w)
-			return
+	if caller.isAgent() || agentID == "" {
+		var notifs []store.Notification
+		var err error
+		if agentID == "" {
+			notifs, err = s.store.GetNotifications(r.Context(), caller.Type, caller.ID, onlyUnacknowledged)
+		} else {
+			notifs, err = s.store.GetNotificationsByAgent(r.Context(), agentID, caller.Type, caller.ID, onlyUnacknowledged)
 		}
-		notifs, err := s.store.GetNotifications(r.Context(), subType, subID, onlyUnacknowledged)
 		if err != nil {
 			writeErrorFromErr(w, err, "")
 			return
 		}
-		writeJSON(w, http.StatusOK, notifs)
+		writeJSON(w, http.StatusOK, caller.scopeNotifications(notifs))
 		return
 	}
 
-	if agentID == "" {
-		// Existing behaviour: flat array of user notifications
-		notifs, err := s.store.GetNotifications(r.Context(), subType, subID, onlyUnacknowledged)
-		if err != nil {
-			writeErrorFromErr(w, err, "")
-			return
-		}
-		writeJSON(w, http.StatusOK, notifs)
-		return
-	}
-
-	// Agent-scoped: return combined response
-	userNotifs, err := s.store.GetNotificationsByAgent(r.Context(), agentID, subType, subID, onlyUnacknowledged)
+	// User caller, agent-scoped: return combined response
+	userNotifs, err := s.store.GetNotificationsByAgent(r.Context(), agentID, caller.Type, caller.ID, onlyUnacknowledged)
 	if err != nil {
 		writeErrorFromErr(w, err, "")
 		return
@@ -150,9 +240,17 @@ type agentNotificationsResponse struct {
 //   - POST /api/v1/notifications/subscriptions/bulk: Bulk create subscriptions
 //   - POST /api/v1/notifications/subscriptions/bulk-delete: Bulk delete subscriptions
 func (s *Server) handleNotificationRoutes(w http.ResponseWriter, r *http.Request) {
-	subType, subID := s.notificationCaller(r.Context())
-	if subType == "" {
-		Forbidden(w)
+	caller := s.resolveNotificationCaller(w, r)
+	if caller == nil {
+		return
+	}
+	// Reads need the standard project read scope; everything else here mutates
+	// notification state.
+	if r.Method == http.MethodGet {
+		if !checkAgentReadScope(w, r) {
+			return
+		}
+	} else if !checkAgentNotifyScope(w, r) {
 		return
 	}
 
@@ -160,34 +258,51 @@ func (s *Server) handleNotificationRoutes(w http.ResponseWriter, r *http.Request
 
 	// POST /api/v1/notifications/ack-all
 	if id == "ack-all" && r.Method == http.MethodPost {
-		if err := s.store.AcknowledgeAllNotifications(r.Context(), subType, subID); err != nil {
+		// AcknowledgeAllNotifications keys on the subscriber ID alone, which
+		// for an agent would span every project that reuses its slug. There is
+		// no project-scoped variant, so agents ack individually instead.
+		if caller.isAgent() {
+			writeError(w, http.StatusBadRequest, "bad_request",
+				"agent tokens must acknowledge notifications individually", nil)
+			return
+		}
+		if err := s.store.AcknowledgeAllNotifications(r.Context(), caller.Type, caller.ID); err != nil {
 			writeErrorFromErr(w, err, "")
 			return
 		}
-		slog.Info("All notifications acknowledged", "subscriberType", subType, "subscriberID", subID)
+		slog.Info("All notifications acknowledged", "subscriberType", caller.Type, "subscriberID", caller.ID)
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 		return
 	}
 
 	// Subscription routes: /api/v1/notifications/subscriptions[/...]
 	if id == "subscriptions" {
-		s.handleSubscriptionRoutes(w, r, subType, subID, action)
+		s.handleSubscriptionRoutes(w, r, caller, action)
 		return
 	}
 
 	// Subscription template routes: /api/v1/notifications/templates[/...]
 	if id == "templates" {
-		s.handleSubscriptionTemplateRoutes(w, r, subID, action)
+		s.handleSubscriptionTemplateRoutes(w, r, caller, action)
 		return
 	}
 
 	// POST /api/v1/notifications/{id}/ack
 	if id != "" && action == "ack" && r.Method == http.MethodPost {
-		if err := s.store.AcknowledgeNotification(r.Context(), id); err != nil {
-			writeErrorFromErr(w, err, "")
+		notif, err := s.store.GetNotification(r.Context(), id)
+		if err != nil {
+			writeErrorFromErr(w, err, "Notification")
 			return
 		}
-		slog.Info("Notification acknowledged", "notificationID", id, "subscriberType", subType, "subscriberID", subID)
+		if !caller.ownsNotification(notif) {
+			Forbidden(w)
+			return
+		}
+		if err := s.store.AcknowledgeNotification(r.Context(), id); err != nil {
+			writeErrorFromErr(w, err, "Notification")
+			return
+		}
+		slog.Info("Notification acknowledged", "notificationID", id, "subscriberType", caller.Type, "subscriberID", caller.ID)
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 		return
 	}
@@ -214,7 +329,7 @@ type updateSubscriptionRequest struct {
 }
 
 // handleSubscriptionRoutes handles CRUD for notification subscriptions.
-func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request, subscriberType, subscriberID, subID string) {
+func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request, caller *notificationSubscriber, subID string) {
 	ctx := r.Context()
 
 	switch {
@@ -248,19 +363,19 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			return
 		}
 		// Agent callers may only subscribe within their own project.
-		if !agentProjectAllowed(ctx, req.ProjectID) {
+		if caller.isAgent() && req.ProjectID != caller.ProjectID {
 			Forbidden(w)
 			return
 		}
 
 		// Enforce subscription limit if configured
 		if s.config.MaxSubscriptionsPerUser > 0 {
-			existing, err := s.store.GetSubscriptionsForSubscriber(ctx, subscriberType, subscriberID)
+			existing, err := s.store.GetSubscriptionsForSubscriber(ctx, caller.Type, caller.ID)
 			if err != nil {
 				writeErrorFromErr(w, err, "")
 				return
 			}
-			if len(existing) >= s.config.MaxSubscriptionsPerUser {
+			if len(caller.scopeSubscriptions(existing)) >= s.config.MaxSubscriptionsPerUser {
 				writeError(w, http.StatusConflict, "limit_exceeded",
 					fmt.Sprintf("Maximum subscription limit reached (%d)", s.config.MaxSubscriptionsPerUser), nil)
 				return
@@ -271,19 +386,19 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			ID:                api.NewUUID(),
 			Scope:             req.Scope,
 			AgentID:           req.AgentID,
-			SubscriberType:    subscriberType,
-			SubscriberID:      subscriberID,
+			SubscriberType:    caller.Type,
+			SubscriberID:      caller.ID,
 			ProjectID:         req.ProjectID,
 			TriggerActivities: req.TriggerActivities,
-			CreatedBy:         subscriberID,
+			CreatedBy:         caller.ID,
 		}
 
 		if err := s.store.CreateNotificationSubscription(ctx, sub); err != nil {
 			if err == store.ErrAlreadyExists {
 				// Idempotent: return existing subscription
-				existing, listErr := s.store.GetSubscriptionsForSubscriber(ctx, subscriberType, subscriberID)
+				existing, listErr := s.store.GetSubscriptionsForSubscriber(ctx, caller.Type, caller.ID)
 				if listErr == nil {
-					for _, e := range existing {
+					for _, e := range caller.scopeSubscriptions(existing) {
 						if e.Scope == req.Scope && e.AgentID == req.AgentID && e.ProjectID == req.ProjectID {
 							writeJSON(w, http.StatusOK, e)
 							return
@@ -298,16 +413,17 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 		}
 
 		slog.Info("Subscription created",
-			"subscriptionID", sub.ID, "scope", sub.Scope, "subscriberType", subscriberType, "subscriberID", subscriberID)
+			"subscriptionID", sub.ID, "scope", sub.Scope, "subscriberType", caller.Type, "subscriberID", caller.ID)
 		writeJSON(w, http.StatusCreated, sub)
 
 	// GET /api/v1/notifications/subscriptions — List
 	case subID == "" && r.Method == http.MethodGet:
-		subs, err := s.store.GetSubscriptionsForSubscriber(ctx, subscriberType, subscriberID)
+		subs, err := s.store.GetSubscriptionsForSubscriber(ctx, caller.Type, caller.ID)
 		if err != nil {
 			writeErrorFromErr(w, err, "")
 			return
 		}
+		subs = caller.scopeSubscriptions(subs)
 
 		// Apply optional filters
 		projectID := r.URL.Query().Get("projectId")
@@ -316,9 +432,6 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 		}
 		agentID := r.URL.Query().Get("agentId")
 		scope := r.URL.Query().Get("scope")
-		if scope == "project" {
-			scope = "project"
-		}
 
 		filtered := make([]store.NotificationSubscription, 0)
 		for _, sub := range subs {
@@ -354,7 +467,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			writeErrorFromErr(w, err, "Subscription")
 			return
 		}
-		if sub.SubscriberType != subscriberType || sub.SubscriberID != subscriberID {
+		if !caller.ownsSubscription(sub) {
 			Forbidden(w)
 			return
 		}
@@ -377,7 +490,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 		// Return the updated subscription
 		sub.TriggerActivities = req.TriggerActivities
 		slog.Info("Subscription updated",
-			"subscriptionID", subID, "subscriberType", subscriberType, "subscriberID", subscriberID)
+			"subscriptionID", subID, "subscriberType", caller.Type, "subscriberID", caller.ID)
 		writeJSON(w, http.StatusOK, sub)
 
 	// DELETE /api/v1/notifications/subscriptions/{id} — Delete
@@ -388,7 +501,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			writeErrorFromErr(w, err, "Subscription")
 			return
 		}
-		if sub.SubscriberType != subscriberType || sub.SubscriberID != subscriberID {
+		if !caller.ownsSubscription(sub) {
 			Forbidden(w)
 			return
 		}
@@ -399,7 +512,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 		}
 
 		slog.Info("Subscription deleted",
-			"subscriptionID", subID, "subscriberType", subscriberType, "subscriberID", subscriberID)
+			"subscriptionID", subID, "subscriberType", caller.Type, "subscriberID", caller.ID)
 		w.WriteHeader(http.StatusNoContent)
 
 	// POST /api/v1/notifications/subscriptions/bulk — Bulk create
@@ -413,15 +526,26 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			writeError(w, http.StatusBadRequest, "bad_request", "Empty request array", nil)
 			return
 		}
+		// Agent callers may only subscribe within their own project. An
+		// authorization denial fails the whole request rather than silently
+		// dropping entries the way malformed items are dropped below.
+		if caller.isAgent() {
+			for _, req := range reqs {
+				if req.ProjectID != caller.ProjectID {
+					Forbidden(w)
+					return
+				}
+			}
+		}
 
 		// Enforce subscription limit if configured
 		if s.config.MaxSubscriptionsPerUser > 0 {
-			existing, err := s.store.GetSubscriptionsForSubscriber(ctx, subscriberType, subscriberID)
+			existing, err := s.store.GetSubscriptionsForSubscriber(ctx, caller.Type, caller.ID)
 			if err != nil {
 				writeErrorFromErr(w, err, "")
 				return
 			}
-			if len(existing)+len(reqs) > s.config.MaxSubscriptionsPerUser {
+			if len(caller.scopeSubscriptions(existing))+len(reqs) > s.config.MaxSubscriptionsPerUser {
 				writeError(w, http.StatusConflict, "limit_exceeded",
 					fmt.Sprintf("Bulk create would exceed subscription limit (%d)", s.config.MaxSubscriptionsPerUser), nil)
 				return
@@ -439,28 +563,23 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			if req.Scope == store.SubscriptionScopeAgent && req.AgentID == "" {
 				continue
 			}
-			// Agent callers may only subscribe within their own project.
-			if !agentProjectAllowed(ctx, req.ProjectID) {
-				continue
-			}
-
 			sub := &store.NotificationSubscription{
 				ID:                api.NewUUID(),
 				Scope:             req.Scope,
 				AgentID:           req.AgentID,
-				SubscriberType:    subscriberType,
-				SubscriberID:      subscriberID,
+				SubscriberType:    caller.Type,
+				SubscriberID:      caller.ID,
 				ProjectID:         req.ProjectID,
 				TriggerActivities: req.TriggerActivities,
-				CreatedBy:         subscriberID,
+				CreatedBy:         caller.ID,
 			}
 
 			if err := s.store.CreateNotificationSubscription(ctx, sub); err != nil {
 				if err == store.ErrAlreadyExists {
 					// Idempotent: find and return existing
-					existing, listErr := s.store.GetSubscriptionsForSubscriber(ctx, subscriberType, subscriberID)
+					existing, listErr := s.store.GetSubscriptionsForSubscriber(ctx, caller.Type, caller.ID)
 					if listErr == nil {
-						for _, e := range existing {
+						for _, e := range caller.scopeSubscriptions(existing) {
 							if e.Scope == req.Scope && e.AgentID == req.AgentID && e.ProjectID == req.ProjectID {
 								results = append(results, e)
 								break
@@ -477,7 +596,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 		}
 
 		slog.Info("Bulk subscriptions created",
-			"count", len(results), "subscriberType", subscriberType, "subscriberID", subscriberID)
+			"count", len(results), "subscriberType", caller.Type, "subscriberID", caller.ID)
 		writeJSON(w, http.StatusCreated, results)
 
 	// POST /api/v1/notifications/subscriptions/bulk-delete — Bulk delete
@@ -500,7 +619,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			if err != nil {
 				continue
 			}
-			if sub.SubscriberType != subscriberType || sub.SubscriberID != subscriberID {
+			if !caller.ownsSubscription(sub) {
 				continue
 			}
 			if err := s.store.DeleteNotificationSubscription(ctx, id); err != nil {
@@ -510,7 +629,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 		}
 
 		slog.Info("Bulk subscriptions deleted",
-			"deleted", deleted, "requested", len(req.IDs), "subscriberType", subscriberType, "subscriberID", subscriberID)
+			"deleted", deleted, "requested", len(req.IDs), "subscriberType", caller.Type, "subscriberID", caller.ID)
 		writeJSON(w, http.StatusOK, map[string]int{"deleted": deleted})
 
 	default:
@@ -543,8 +662,18 @@ func (r *createTemplateRequest) UnmarshalJSON(data []byte) error {
 }
 
 // handleSubscriptionTemplateRoutes handles CRUD for subscription templates.
-func (s *Server) handleSubscriptionTemplateRoutes(w http.ResponseWriter, r *http.Request, subscriberID, templateID string) {
+//
+// Templates are a user-facing convenience with no project containment of their
+// own (CreatedBy is a bare ID, and list/delete are not project-scoped), and
+// agents have no use for them. Agent callers are refused outright rather than
+// admitted to a surface that cannot express their containment rules.
+func (s *Server) handleSubscriptionTemplateRoutes(w http.ResponseWriter, r *http.Request, caller *notificationSubscriber, templateID string) {
 	ctx := r.Context()
+
+	if caller.isAgent() {
+		Forbidden(w)
+		return
+	}
 
 	switch {
 	// POST /api/v1/notifications/templates — Create
@@ -572,7 +701,7 @@ func (s *Server) handleSubscriptionTemplateRoutes(w http.ResponseWriter, r *http
 			Scope:             req.Scope,
 			TriggerActivities: req.TriggerActivities,
 			ProjectID:         req.ProjectID,
-			CreatedBy:         subscriberID,
+			CreatedBy:         caller.ID,
 		}
 
 		if err := s.store.CreateSubscriptionTemplate(ctx, tmpl); err != nil {
@@ -585,7 +714,7 @@ func (s *Server) handleSubscriptionTemplateRoutes(w http.ResponseWriter, r *http
 		}
 
 		slog.Info("Subscription template created",
-			"templateID", tmpl.ID, "name", tmpl.Name, "createdBy", subscriberID)
+			"templateID", tmpl.ID, "name", tmpl.Name, "createdBy", caller.ID)
 		writeJSON(w, http.StatusCreated, tmpl)
 
 	// GET /api/v1/notifications/templates — List
@@ -608,7 +737,7 @@ func (s *Server) handleSubscriptionTemplateRoutes(w http.ResponseWriter, r *http
 			writeErrorFromErr(w, err, "Template")
 			return
 		}
-		if tmpl.CreatedBy != subscriberID {
+		if tmpl.CreatedBy != caller.ID {
 			Forbidden(w)
 			return
 		}
@@ -617,7 +746,7 @@ func (s *Server) handleSubscriptionTemplateRoutes(w http.ResponseWriter, r *http
 			return
 		}
 		slog.Info("Subscription template deleted",
-			"templateID", templateID, "createdBy", subscriberID)
+			"templateID", templateID, "createdBy", caller.ID)
 		w.WriteHeader(http.StatusNoContent)
 
 	default:

--- a/pkg/hub/handlers_notifications.go
+++ b/pkg/hub/handlers_notifications.go
@@ -141,8 +141,12 @@ func (s *Server) notificationCaller(ctx context.Context) (*notificationSubscribe
 // could file a subscription in its own project that watches a foreign agent and
 // receive that agent's activity transitions. User callers are unrestricted.
 //
+// cleared memoizes agent IDs already found to be in the caller's project, so a
+// bulk request costs one lookup per distinct watched agent rather than one per
+// entry. Pass nil when there is nothing to share.
+//
 // Returns false when a response has already been written.
-func (s *Server) agentMaySubscribe(w http.ResponseWriter, r *http.Request, caller *notificationSubscriber, req *createSubscriptionRequest) bool {
+func (s *Server) agentMaySubscribe(w http.ResponseWriter, r *http.Request, caller *notificationSubscriber, req *createSubscriptionRequest, cleared map[string]bool) bool {
 	if !caller.isAgent() {
 		return true
 	}
@@ -151,6 +155,9 @@ func (s *Server) agentMaySubscribe(w http.ResponseWriter, r *http.Request, calle
 		return false
 	}
 	if req.Scope != store.SubscriptionScopeAgent || req.AgentID == "" {
+		return true
+	}
+	if cleared[req.AgentID] {
 		return true
 	}
 	target, err := s.store.GetAgent(r.Context(), req.AgentID)
@@ -167,6 +174,9 @@ func (s *Server) agentMaySubscribe(w http.ResponseWriter, r *http.Request, calle
 	if target.ProjectID != caller.ProjectID {
 		Forbidden(w)
 		return false
+	}
+	if cleared != nil {
+		cleared[req.AgentID] = true
 	}
 	return true
 }
@@ -406,7 +416,7 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 		}
 		// Agent callers may only subscribe within their own project, and may
 		// only watch agents in it.
-		if !s.agentMaySubscribe(w, r, caller, &req) {
+		if !s.agentMaySubscribe(w, r, caller, &req, nil) {
 			return
 		}
 
@@ -568,17 +578,9 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			writeError(w, http.StatusBadRequest, "bad_request", "Empty request array", nil)
 			return
 		}
-		// Agent callers may only subscribe within their own project, and may
-		// only watch agents in it. An authorization denial fails the whole
-		// request rather than silently dropping entries the way malformed
-		// items are dropped below.
-		for i := range reqs {
-			if !s.agentMaySubscribe(w, r, caller, &reqs[i]) {
-				return
-			}
-		}
-
-		// Enforce subscription limit if configured
+		// Enforce subscription limit if configured. This runs before the
+		// authorization pass below so that an oversized batch is rejected on
+		// the count alone, rather than after one agent lookup per entry.
 		if s.config.MaxSubscriptionsPerUser > 0 {
 			existing, err := s.store.GetSubscriptionsForSubscriber(ctx, caller.Type, caller.ID)
 			if err != nil {
@@ -592,6 +594,17 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 			}
 		}
 
+		// Agent callers may only subscribe within their own project, and may
+		// only watch agents in it. An authorization denial fails the whole
+		// request rather than silently dropping entries the way malformed
+		// items are dropped below.
+		cleared := make(map[string]bool)
+		for i := range reqs {
+			if !s.agentMaySubscribe(w, r, caller, &reqs[i], cleared) {
+				return
+			}
+		}
+
 		var results []store.NotificationSubscription
 		for _, req := range reqs {
 			if req.Scope != store.SubscriptionScopeAgent && req.Scope != store.SubscriptionScopeProject {
@@ -601,6 +614,13 @@ func (s *Server) handleSubscriptionRoutes(w http.ResponseWriter, r *http.Request
 				continue
 			}
 			if req.Scope == store.SubscriptionScopeAgent && req.AgentID == "" {
+				continue
+			}
+			// A project-scoped entry carrying an agentId is malformed the same
+			// way single create treats it; skipping keeps the stored row
+			// unambiguous rather than filing a project subscription that also
+			// names an agent.
+			if req.Scope == store.SubscriptionScopeProject && req.AgentID != "" {
 				continue
 			}
 			sub := &store.NotificationSubscription{

--- a/pkg/hub/handlers_notifications_test.go
+++ b/pkg/hub/handlers_notifications_test.go
@@ -1023,6 +1023,17 @@ func TestHandleSubscriptions_AgentBulkCreate(t *testing.T) {
 		assert.Equal(t, agent.ProjectID, sub.ProjectID)
 	}
 
+	// A project-scoped entry that also names an agent is malformed, and is
+	// skipped rather than stored as an ambiguous row.
+	reqs = []createSubscriptionRequest{
+		{Scope: "project", AgentID: tid("agent-watched"), ProjectID: agent.ProjectID, TriggerActivities: []string{"ERROR"}},
+	}
+	rec = doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/subscriptions/bulk", reqs, token)
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+	var skipped []store.NotificationSubscription
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&skipped))
+	assert.Empty(t, skipped)
+
 	// A foreign project anywhere in the batch fails the whole request rather
 	// than silently dropping the entry.
 	reqs = []createSubscriptionRequest{

--- a/pkg/hub/handlers_notifications_test.go
+++ b/pkg/hub/handlers_notifications_test.go
@@ -179,41 +179,17 @@ func TestHandleNotifications_AcknowledgeNotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
-func TestHandleNotifications_RejectAgentToken(t *testing.T) {
-	srv, s, _ := setupNotificationHandlerTest(t)
-	ctx := context.Background()
+func TestHandleNotifications_RejectAnonymous(t *testing.T) {
+	srv, _, _ := setupNotificationHandlerTest(t)
 
-	// Create an agent and generate a token for it
-	project := &store.Project{
-		ID:   tid("project-agent-auth"),
-		Name: "Agent Auth Project",
-		Slug: "agent-auth-project",
-	}
-	_ = s.CreateProject(ctx, project)
-
-	agent := &store.Agent{
-		ID:        tid("agent-auth-test"),
-		Slug:      "auth-agent",
-		Name:      "Auth Agent",
-		ProjectID: project.ID,
-		Phase:     string(state.PhaseRunning),
-	}
-	require.NoError(t, s.CreateAgent(ctx, agent))
-
-	tokenSvc := srv.GetAgentTokenService()
-	require.NotNil(t, tokenSvc)
-
-	agentToken, err := tokenSvc.GenerateAgentToken(agent.ID, project.ID, []AgentTokenScope{ScopeAgentStatusUpdate}, nil)
-	require.NoError(t, err)
-
-	// Try to access notifications with an agent token
+	// No identity at all: dev auth is bypassed by an (invalid) agent token.
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/notifications", nil)
-	req.Header.Set("X-Scion-Agent-Token", agentToken)
+	req.Header.Set("X-Scion-Agent-Token", "not-a-valid-token")
 
 	rec := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rec, req)
 
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.NotEqual(t, http.StatusOK, rec.Code)
 }
 
 func TestHandleNotifications_MethodNotAllowed(t *testing.T) {
@@ -540,4 +516,202 @@ func TestHandleSubscriptions_DeleteNotFound(t *testing.T) {
 
 	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/notifications/subscriptions/nonexistent-id", nil)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// =============================================================================
+// Agent-caller Tests
+//
+// Agents authenticate with an agent token and subscribe under their slug, the
+// same subscriber ID the dispatcher writes for agent subscriptions.
+// =============================================================================
+
+// setupNotificationAgentCaller creates an agent in the given project and
+// returns it together with an agent token for authenticating as that agent.
+func setupNotificationAgentCaller(t *testing.T, srv *Server, s store.Store, projectID, slug string) (*store.Agent, string) {
+	t.Helper()
+	ctx := context.Background()
+
+	agent := &store.Agent{
+		ID:        tid("agent-caller-" + slug),
+		Slug:      slug,
+		Name:      slug,
+		ProjectID: projectID,
+		Phase:     string(state.PhaseRunning),
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	tokenSvc := srv.GetAgentTokenService()
+	require.NotNil(t, tokenSvc)
+	token, err := tokenSvc.GenerateAgentToken(agent.ID, projectID, []AgentTokenScope{ScopeAgentStatusUpdate}, nil)
+	require.NoError(t, err)
+
+	return agent, token
+}
+
+func TestHandleNotifications_AgentListsOwnNotifications(t *testing.T) {
+	srv, s, _ := setupNotificationHandlerTest(t)
+	ctx := context.Background()
+
+	agent, token := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), "caller-agent")
+
+	agentSub := &store.NotificationSubscription{
+		ID:                api.NewUUID(),
+		Scope:             store.SubscriptionScopeAgent,
+		AgentID:           tid("agent-watched"),
+		SubscriberType:    store.SubscriberTypeAgent,
+		SubscriberID:      agent.Slug,
+		ProjectID:         tid("project-notif-handler"),
+		TriggerActivities: []string{"COMPLETED"},
+		CreatedAt:         time.Now(),
+		CreatedBy:         agent.Slug,
+	}
+	require.NoError(t, s.CreateNotificationSubscription(ctx, agentSub))
+
+	notif := &store.Notification{
+		ID:             api.NewUUID(),
+		SubscriptionID: agentSub.ID,
+		AgentID:        tid("agent-watched"),
+		ProjectID:      tid("project-notif-handler"),
+		SubscriberType: store.SubscriberTypeAgent,
+		SubscriberID:   agent.Slug,
+		Status:         "COMPLETED",
+		Message:        "watched-agent has reached a state of COMPLETED",
+		CreatedAt:      time.Now(),
+	}
+	require.NoError(t, s.CreateNotification(ctx, notif))
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet, "/api/v1/notifications", nil, token)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var notifs []store.Notification
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&notifs))
+	require.Len(t, notifs, 1)
+	assert.Equal(t, notif.ID, notifs[0].ID)
+	assert.Equal(t, store.SubscriberTypeAgent, notifs[0].SubscriberType)
+}
+
+func TestHandleNotifications_AgentCannotReadOtherNotifications(t *testing.T) {
+	srv, s, _ := setupNotificationHandlerTest(t)
+
+	_, token := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), "nosy-agent")
+
+	// Filtering by another agent is refused; filtering by self is allowed.
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet,
+		"/api/v1/notifications?agentId="+tid("agent-watched"), nil, token)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	rec = doRequestWithAgentToken(t, srv, http.MethodGet,
+		"/api/v1/notifications?agentId=nosy-agent", nil, token)
+	assert.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+}
+
+func TestHandleSubscriptions_AgentCreateAndList(t *testing.T) {
+	srv, s, _ := setupNotificationHandlerTest(t)
+
+	agent, token := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), "subscriber-agent")
+
+	createReq := createSubscriptionRequest{
+		Scope:             "agent",
+		AgentID:           tid("agent-watched"),
+		ProjectID:         tid("project-notif-handler"),
+		TriggerActivities: []string{"COMPLETED"},
+	}
+	rec := doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/subscriptions", createReq, token)
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var created store.NotificationSubscription
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&created))
+	assert.Equal(t, store.SubscriberTypeAgent, created.SubscriberType)
+	assert.Equal(t, agent.Slug, created.SubscriberID)
+	assert.Equal(t, agent.Slug, created.CreatedBy)
+
+	// Listing returns only the agent's own subscriptions, not the user's.
+	rec = doRequestWithAgentToken(t, srv, http.MethodGet, "/api/v1/notifications/subscriptions", nil, token)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var subs []store.NotificationSubscription
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&subs))
+	require.Len(t, subs, 1)
+	assert.Equal(t, created.ID, subs[0].ID)
+	assert.Equal(t, agent.Slug, subs[0].SubscriberID)
+}
+
+func TestHandleSubscriptions_AgentUpdateAndDeleteOwn(t *testing.T) {
+	srv, s, _ := setupNotificationHandlerTest(t)
+	ctx := context.Background()
+
+	_, token := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), "churn-agent")
+
+	createReq := createSubscriptionRequest{
+		Scope:             "project",
+		ProjectID:         tid("project-notif-handler"),
+		TriggerActivities: []string{"COMPLETED"},
+	}
+	rec := doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/subscriptions", createReq, token)
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var sub store.NotificationSubscription
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&sub))
+	require.NotEmpty(t, sub.ID)
+
+	updateReq := updateSubscriptionRequest{TriggerActivities: []string{"COMPLETED", "STALLED"}}
+	rec = doRequestWithAgentToken(t, srv, http.MethodPatch, "/api/v1/notifications/subscriptions/"+sub.ID, updateReq, token)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	stored, err := s.GetNotificationSubscription(ctx, sub.ID)
+	require.NoError(t, err)
+	assert.Contains(t, stored.TriggerActivities, "STALLED")
+
+	rec = doRequestWithAgentToken(t, srv, http.MethodDelete, "/api/v1/notifications/subscriptions/"+sub.ID, nil, token)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	_, err = s.GetNotificationSubscription(ctx, sub.ID)
+	assert.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestHandleSubscriptions_AgentCannotTouchOtherSubscriber(t *testing.T) {
+	srv, s, _ := setupNotificationHandlerTest(t)
+	ctx := context.Background()
+
+	_, token := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), "intruder-agent")
+
+	// The user subscription created by the test setup.
+	userSubs, err := s.GetSubscriptionsForSubscriber(ctx, store.SubscriberTypeUser, DevUserID)
+	require.NoError(t, err)
+	require.Len(t, userSubs, 1)
+	userSubID := userSubs[0].ID
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodDelete, "/api/v1/notifications/subscriptions/"+userSubID, nil, token)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	updateReq := updateSubscriptionRequest{TriggerActivities: []string{"ERROR"}}
+	rec = doRequestWithAgentToken(t, srv, http.MethodPatch, "/api/v1/notifications/subscriptions/"+userSubID, updateReq, token)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	// The user's subscription is untouched.
+	stored, err := s.GetNotificationSubscription(ctx, userSubID)
+	require.NoError(t, err)
+	assert.NotContains(t, stored.TriggerActivities, "ERROR")
+}
+
+func TestHandleSubscriptions_AgentCannotSubscribeOtherProject(t *testing.T) {
+	srv, s, _ := setupNotificationHandlerTest(t)
+	ctx := context.Background()
+
+	otherProject := &store.Project{
+		ID:   tid("project-other-notif"),
+		Name: "Other Project",
+		Slug: "other-notif-project",
+	}
+	require.NoError(t, s.CreateProject(ctx, otherProject))
+
+	_, token := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), "scoped-agent")
+
+	createReq := createSubscriptionRequest{
+		Scope:             "project",
+		ProjectID:         otherProject.ID,
+		TriggerActivities: []string{"COMPLETED"},
+	}
+	rec := doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/subscriptions", createReq, token)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
 }

--- a/pkg/hub/handlers_notifications_test.go
+++ b/pkg/hub/handlers_notifications_test.go
@@ -712,7 +712,7 @@ func TestHandleNotifications_AgentCannotReachSameSlugInOtherProject(t *testing.T
 	// ack-all keys on subscriber ID alone, so it is refused for agents rather
 	// than silently acking every same-slug agent's notifications.
 	rec = doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/ack-all", nil, tokenA)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, http.StatusNotImplemented, rec.Code)
 
 	// Project B's data survived intact.
 	storedSub, err := s.GetNotificationSubscription(ctx, subB.ID)
@@ -932,6 +932,66 @@ func TestHandleSubscriptions_AgentCannotSubscribeOtherProject(t *testing.T) {
 	}
 	rec := doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/subscriptions", createReq, token)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestHandleSubscriptions_AgentCannotWatchOtherProjectAgent covers the subtler
+// half of project containment: the subscription is filed under the caller's own
+// project, but watches an agent in another one, which would relay that agent's
+// activity to the caller.
+func TestHandleSubscriptions_AgentCannotWatchOtherProjectAgent(t *testing.T) {
+	srv, s, _ := setupNotificationHandlerTest(t)
+	ctx := context.Background()
+
+	otherProject := &store.Project{
+		ID:   tid("project-watch-other"),
+		Name: "Watch Other Project",
+		Slug: "watch-other-project",
+	}
+	require.NoError(t, s.CreateProject(ctx, otherProject))
+
+	foreign := &store.Agent{
+		ID:        tid("agent-foreign-watched"),
+		Slug:      "foreign-watched-agent",
+		Name:      "Foreign Watched Agent",
+		ProjectID: otherProject.ID,
+		Phase:     string(state.PhaseRunning),
+	}
+	require.NoError(t, s.CreateAgent(ctx, foreign))
+
+	agent, token := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), "watcher-agent")
+
+	// projectId is the caller's own — only the watched agent is foreign.
+	createReq := createSubscriptionRequest{
+		Scope:             "agent",
+		AgentID:           foreign.ID,
+		ProjectID:         agent.ProjectID,
+		TriggerActivities: []string{"COMPLETED"},
+	}
+	rec := doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/subscriptions", createReq, token)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	// Same via bulk, alongside an otherwise valid entry.
+	reqs := []createSubscriptionRequest{
+		{Scope: "project", ProjectID: agent.ProjectID, TriggerActivities: []string{"COMPLETED"}},
+		createReq,
+	}
+	rec = doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/subscriptions/bulk", reqs, token)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	// An unknown agent is refused the same way, without confirming it is
+	// merely absent.
+	createReq.AgentID = tid("agent-does-not-exist")
+	rec = doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/subscriptions", createReq, token)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	stored, err := s.GetSubscriptionsForSubscriber(ctx, store.SubscriberTypeAgent, agent.Slug)
+	require.NoError(t, err)
+	assert.Empty(t, stored)
+
+	// Watching an agent in the caller's own project still works.
+	createReq.AgentID = tid("agent-watched")
+	rec = doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/subscriptions", createReq, token)
+	assert.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
 }
 
 func TestHandleSubscriptions_AgentBulkCreate(t *testing.T) {

--- a/pkg/hub/handlers_notifications_test.go
+++ b/pkg/hub/handlers_notifications_test.go
@@ -663,6 +663,42 @@ func TestHandleNotifications_AgentFiltersByAgentID(t *testing.T) {
 	assert.Equal(t, aboutOther.ID, filtered[0].ID)
 }
 
+// TestHandleNotifications_AgentIDMustBeInCallerProject pins the containment
+// check on ?agentId=: an agent caller may only name an agent in its own
+// project, and an agent that does not exist is refused the same way so the
+// response is not an existence oracle.
+func TestHandleNotifications_AgentIDMustBeInCallerProject(t *testing.T) {
+	srv, s, _ := setupNotificationHandlerTest(t)
+	ctx := context.Background()
+
+	projectB := &store.Project{
+		ID:   tid("project-notif-agentid-b"),
+		Name: "Project B",
+		Slug: "project-notif-agentid-b",
+	}
+	require.NoError(t, s.CreateProject(ctx, projectB))
+
+	foreign := &store.Agent{
+		ID:        tid("agent-foreign-subject"),
+		Slug:      "foreign-subject-agent",
+		Name:      "Foreign Subject Agent",
+		ProjectID: projectB.ID,
+		Phase:     string(state.PhaseRunning),
+	}
+	require.NoError(t, s.CreateAgent(ctx, foreign))
+
+	agent, token := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), "containment-agent")
+	newAgentSubscription(t, s, agent.ProjectID, agent.Slug)
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet,
+		"/api/v1/notifications?agentId="+foreign.ID, nil, token)
+	assert.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+
+	rec = doRequestWithAgentToken(t, srv, http.MethodGet,
+		"/api/v1/notifications?agentId="+tid("agent-never-created"), nil, token)
+	assert.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
+}
+
 // TestHandleNotifications_AgentCannotReachSameSlugInOtherProject is the
 // regression test for the cross-project leak: agent slugs are unique per
 // project, so subscriber ID alone cannot distinguish two "shared-slug" agents.

--- a/pkg/hub/handlers_notifications_test.go
+++ b/pkg/hub/handlers_notifications_test.go
@@ -182,14 +182,15 @@ func TestHandleNotifications_AcknowledgeNotFound(t *testing.T) {
 func TestHandleNotifications_RejectAnonymous(t *testing.T) {
 	srv, _, _ := setupNotificationHandlerTest(t)
 
-	// No identity at all: dev auth is bypassed by an (invalid) agent token.
+	// No identity at all: dev auth is bypassed by an (invalid) agent token,
+	// which the auth middleware rejects before the handler is reached.
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/notifications", nil)
 	req.Header.Set("X-Scion-Agent-Token", "not-a-valid-token")
 
 	rec := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rec, req)
 
-	assert.NotEqual(t, http.StatusOK, rec.Code)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
 func TestHandleNotifications_MethodNotAllowed(t *testing.T) {
@@ -526,13 +527,23 @@ func TestHandleSubscriptions_DeleteNotFound(t *testing.T) {
 // =============================================================================
 
 // setupNotificationAgentCaller creates an agent in the given project and
-// returns it together with an agent token for authenticating as that agent.
+// returns it together with a baseline-role agent token for authenticating as
+// that agent.
 func setupNotificationAgentCaller(t *testing.T, srv *Server, s store.Store, projectID, slug string) (*store.Agent, string) {
+	t.Helper()
+	return setupNotificationAgentCallerWithScopes(t, srv, s, projectID, slug, ScopesForRole(AgentRoleBaseline))
+}
+
+// setupNotificationAgentCallerWithScopes is setupNotificationAgentCaller with
+// an explicit scope set, for exercising the scope gates.
+func setupNotificationAgentCallerWithScopes(t *testing.T, srv *Server, s store.Store, projectID, slug string, scopes []AgentTokenScope) (*store.Agent, string) {
 	t.Helper()
 	ctx := context.Background()
 
 	agent := &store.Agent{
-		ID:        tid("agent-caller-" + slug),
+		// Slugs are only unique per project, so the record ID has to key off
+		// both to let a test place the same slug in two projects.
+		ID:        tid("agent-caller-" + projectID + "-" + slug),
 		Slug:      slug,
 		Name:      slug,
 		ProjectID: projectID,
@@ -542,43 +553,55 @@ func setupNotificationAgentCaller(t *testing.T, srv *Server, s store.Store, proj
 
 	tokenSvc := srv.GetAgentTokenService()
 	require.NotNil(t, tokenSvc)
-	token, err := tokenSvc.GenerateAgentToken(agent.ID, projectID, []AgentTokenScope{ScopeAgentStatusUpdate}, nil)
+	token, err := tokenSvc.GenerateAgentToken(agent.ID, projectID, scopes, nil)
 	require.NoError(t, err)
 
 	return agent, token
 }
 
-func TestHandleNotifications_AgentListsOwnNotifications(t *testing.T) {
-	srv, s, _ := setupNotificationHandlerTest(t)
-	ctx := context.Background()
-
-	agent, token := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), "caller-agent")
-
-	agentSub := &store.NotificationSubscription{
+// newAgentSubscription stores a project-scoped subscription owned by the agent
+// slug in the given project, the way the dispatcher records agent subscribers.
+func newAgentSubscription(t *testing.T, s store.Store, projectID, slug string) *store.NotificationSubscription {
+	t.Helper()
+	sub := &store.NotificationSubscription{
 		ID:                api.NewUUID(),
-		Scope:             store.SubscriptionScopeAgent,
-		AgentID:           tid("agent-watched"),
+		Scope:             store.SubscriptionScopeProject,
 		SubscriberType:    store.SubscriberTypeAgent,
-		SubscriberID:      agent.Slug,
-		ProjectID:         tid("project-notif-handler"),
+		SubscriberID:      slug,
+		ProjectID:         projectID,
 		TriggerActivities: []string{"COMPLETED"},
 		CreatedAt:         time.Now(),
-		CreatedBy:         agent.Slug,
+		CreatedBy:         slug,
 	}
-	require.NoError(t, s.CreateNotificationSubscription(ctx, agentSub))
+	require.NoError(t, s.CreateNotificationSubscription(context.Background(), sub))
+	return sub
+}
 
+// newAgentNotification stores a notification addressed to the agent slug in the
+// given project.
+func newAgentNotification(t *testing.T, s store.Store, sub *store.NotificationSubscription, aboutAgentID, message string) *store.Notification {
+	t.Helper()
 	notif := &store.Notification{
 		ID:             api.NewUUID(),
-		SubscriptionID: agentSub.ID,
-		AgentID:        tid("agent-watched"),
-		ProjectID:      tid("project-notif-handler"),
+		SubscriptionID: sub.ID,
+		AgentID:        aboutAgentID,
+		ProjectID:      sub.ProjectID,
 		SubscriberType: store.SubscriberTypeAgent,
-		SubscriberID:   agent.Slug,
+		SubscriberID:   sub.SubscriberID,
 		Status:         "COMPLETED",
-		Message:        "watched-agent has reached a state of COMPLETED",
+		Message:        message,
 		CreatedAt:      time.Now(),
 	}
-	require.NoError(t, s.CreateNotification(ctx, notif))
+	require.NoError(t, s.CreateNotification(context.Background(), notif))
+	return notif
+}
+
+func TestHandleNotifications_AgentListsOwnNotifications(t *testing.T) {
+	srv, s, _ := setupNotificationHandlerTest(t)
+
+	agent, token := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), "caller-agent")
+	sub := newAgentSubscription(t, s, agent.ProjectID, agent.Slug)
+	notif := newAgentNotification(t, s, sub, tid("agent-watched"), "watched-agent has reached a state of COMPLETED")
 
 	rec := doRequestWithAgentToken(t, srv, http.MethodGet, "/api/v1/notifications", nil, token)
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
@@ -590,19 +613,206 @@ func TestHandleNotifications_AgentListsOwnNotifications(t *testing.T) {
 	assert.Equal(t, store.SubscriberTypeAgent, notifs[0].SubscriberType)
 }
 
-func TestHandleNotifications_AgentCannotReadOtherNotifications(t *testing.T) {
+// TestHandleNotifications_AgentFiltersByAgentID pins the ?agentId= behavior for
+// agent callers: it narrows the caller's own notifications to those about the
+// named agent, and never widens them to another subscriber's rows.
+func TestHandleNotifications_AgentFiltersByAgentID(t *testing.T) {
 	srv, s, _ := setupNotificationHandlerTest(t)
+	ctx := context.Background()
 
-	_, token := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), "nosy-agent")
+	other := &store.Agent{
+		ID:        tid("agent-second-watched"),
+		Slug:      "second-watched-agent",
+		Name:      "Second Watched Agent",
+		ProjectID: tid("project-notif-handler"),
+		Phase:     string(state.PhaseRunning),
+	}
+	require.NoError(t, s.CreateAgent(ctx, other))
 
-	// Filtering by another agent is refused; filtering by self is allowed.
-	rec := doRequestWithAgentToken(t, srv, http.MethodGet,
+	agent, token := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), "filter-agent")
+	sub := newAgentSubscription(t, s, agent.ProjectID, agent.Slug)
+	aboutWatched := newAgentNotification(t, s, sub, tid("agent-watched"), "about watched-agent")
+	aboutOther := newAgentNotification(t, s, sub, other.ID, "about second-watched-agent")
+
+	// Unfiltered: both of the caller's own notifications, and none of the
+	// user's (the test setup created one for DevUserID about agent-watched).
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet, "/api/v1/notifications", nil, token)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var all []store.Notification
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&all))
+	require.Len(t, all, 2)
+	for _, n := range all {
+		assert.Equal(t, agent.Slug, n.SubscriberID)
+	}
+
+	// Filtered by subject agent: a flat array narrowed to that agent.
+	rec = doRequestWithAgentToken(t, srv, http.MethodGet,
 		"/api/v1/notifications?agentId="+tid("agent-watched"), nil, token)
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var filtered []store.Notification
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&filtered))
+	require.Len(t, filtered, 1)
+	assert.Equal(t, aboutWatched.ID, filtered[0].ID)
 
 	rec = doRequestWithAgentToken(t, srv, http.MethodGet,
-		"/api/v1/notifications?agentId=nosy-agent", nil, token)
+		"/api/v1/notifications?agentId="+other.ID, nil, token)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	filtered = nil
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&filtered))
+	require.Len(t, filtered, 1)
+	assert.Equal(t, aboutOther.ID, filtered[0].ID)
+}
+
+// TestHandleNotifications_AgentCannotReachSameSlugInOtherProject is the
+// regression test for the cross-project leak: agent slugs are unique per
+// project, so subscriber ID alone cannot distinguish two "shared-slug" agents.
+func TestHandleNotifications_AgentCannotReachSameSlugInOtherProject(t *testing.T) {
+	srv, s, _ := setupNotificationHandlerTest(t)
+	ctx := context.Background()
+
+	projectB := &store.Project{
+		ID:   tid("project-notif-b"),
+		Name: "Project B",
+		Slug: "project-notif-b",
+	}
+	require.NoError(t, s.CreateProject(ctx, projectB))
+
+	const slug = "shared-slug"
+	_, tokenA := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), slug)
+	agentB, _ := setupNotificationAgentCaller(t, srv, s, projectB.ID, slug)
+
+	subB := newAgentSubscription(t, s, projectB.ID, slug)
+	notifB := newAgentNotification(t, s, subB, agentB.ID, "SECRET-PROJECT-B-CONTENT")
+
+	// Reads must not cross the project boundary.
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet, "/api/v1/notifications", nil, tokenA)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.NotContains(t, rec.Body.String(), "SECRET-PROJECT-B-CONTENT")
+
+	rec = doRequestWithAgentToken(t, srv, http.MethodGet, "/api/v1/notifications/subscriptions", nil, tokenA)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var subs []store.NotificationSubscription
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&subs))
+	assert.Empty(t, subs)
+
+	// Writes must not either, even with the ID in hand.
+	rec = doRequestWithAgentToken(t, srv, http.MethodDelete,
+		"/api/v1/notifications/subscriptions/"+subB.ID, nil, tokenA)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	rec = doRequestWithAgentToken(t, srv, http.MethodPatch,
+		"/api/v1/notifications/subscriptions/"+subB.ID,
+		updateSubscriptionRequest{TriggerActivities: []string{"ERROR"}}, tokenA)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	rec = doRequestWithAgentToken(t, srv, http.MethodPost,
+		"/api/v1/notifications/"+notifB.ID+"/ack", nil, tokenA)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	// ack-all keys on subscriber ID alone, so it is refused for agents rather
+	// than silently acking every same-slug agent's notifications.
+	rec = doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/ack-all", nil, tokenA)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// Project B's data survived intact.
+	storedSub, err := s.GetNotificationSubscription(ctx, subB.ID)
+	require.NoError(t, err)
+	assert.NotContains(t, storedSub.TriggerActivities, "ERROR")
+	storedNotif, err := s.GetNotification(ctx, notifB.ID)
+	require.NoError(t, err)
+	assert.False(t, storedNotif.Acknowledged)
+}
+
+func TestHandleNotifications_AgentAcknowledgesOnlyOwnNotifications(t *testing.T) {
+	srv, s, userNotifID := setupNotificationHandlerTest(t)
+	ctx := context.Background()
+
+	agent, token := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), "acking-agent")
+	sub := newAgentSubscription(t, s, agent.ProjectID, agent.Slug)
+	own := newAgentNotification(t, s, sub, tid("agent-watched"), "for the acking agent")
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/"+own.ID+"/ack", nil, token)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	stored, err := s.GetNotification(ctx, own.ID)
+	require.NoError(t, err)
+	assert.True(t, stored.Acknowledged)
+
+	// The user's notification is off limits even though its ID is known.
+	rec = doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/"+userNotifID+"/ack", nil, token)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	stored, err = s.GetNotification(ctx, userNotifID)
+	require.NoError(t, err)
+	assert.False(t, stored.Acknowledged)
+}
+
+// TestHandleNotifications_AgentScopeGates checks that the notification surface
+// honors agent token scopes the way every other agent-callable handler does.
+func TestHandleNotifications_AgentScopeGates(t *testing.T) {
+	srv, s, _ := setupNotificationHandlerTest(t)
+	projectID := tid("project-notif-handler")
+
+	// readonly: reads allowed, writes refused.
+	_, roToken := setupNotificationAgentCallerWithScopes(t, srv, s, projectID, "readonly-agent",
+		ScopesForRole(AgentRoleReadOnly))
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet, "/api/v1/notifications", nil, roToken)
 	assert.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	rec = doRequestWithAgentToken(t, srv, http.MethodGet, "/api/v1/notifications/subscriptions", nil, roToken)
+	assert.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	createReq := createSubscriptionRequest{
+		Scope:             "project",
+		ProjectID:         projectID,
+		TriggerActivities: []string{"COMPLETED"},
+	}
+	rec = doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/subscriptions", createReq, roToken)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), string(ScopeAgentNotify))
+
+	// No read scope: reads refused too.
+	_, narrowToken := setupNotificationAgentCallerWithScopes(t, srv, s, projectID, "narrow-agent",
+		[]AgentTokenScope{ScopeAgentStatusUpdate})
+
+	rec = doRequestWithAgentToken(t, srv, http.MethodGet, "/api/v1/notifications", nil, narrowToken)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), string(ScopeProjectRead))
+}
+
+// TestHandleSubscriptionTemplates_RejectsAgents pins the decision to keep agents
+// off the template routes, which have no project containment of their own.
+func TestHandleSubscriptionTemplates_RejectsAgents(t *testing.T) {
+	srv, s, _ := setupNotificationHandlerTest(t)
+	ctx := context.Background()
+
+	tmpl := &store.SubscriptionTemplate{
+		ID:                api.NewUUID(),
+		Name:              "user-template",
+		Scope:             store.SubscriptionScopeProject,
+		TriggerActivities: []string{"COMPLETED"},
+		ProjectID:         tid("project-notif-handler"),
+		CreatedBy:         DevUserID,
+	}
+	require.NoError(t, s.CreateSubscriptionTemplate(ctx, tmpl))
+
+	_, token := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), "template-agent")
+
+	rec := doRequestWithAgentToken(t, srv, http.MethodGet, "/api/v1/notifications/templates", nil, token)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	createReq := createTemplateRequest{
+		Name:              "agent-template",
+		Scope:             store.SubscriptionScopeProject,
+		TriggerActivities: []string{"COMPLETED"},
+		ProjectID:         tid("project-notif-handler"),
+	}
+	rec = doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/templates", createReq, token)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	rec = doRequestWithAgentToken(t, srv, http.MethodDelete, "/api/v1/notifications/templates/"+tmpl.ID, nil, token)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	_, err := s.GetSubscriptionTemplate(ctx, tmpl.ID)
+	assert.NoError(t, err)
 }
 
 func TestHandleSubscriptions_AgentCreateAndList(t *testing.T) {
@@ -688,6 +898,14 @@ func TestHandleSubscriptions_AgentCannotTouchOtherSubscriber(t *testing.T) {
 	rec = doRequestWithAgentToken(t, srv, http.MethodPatch, "/api/v1/notifications/subscriptions/"+userSubID, updateReq, token)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 
+	// Bulk delete refuses it too, without reporting it as deleted.
+	rec = doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/subscriptions/bulk-delete",
+		map[string][]string{"ids": {userSubID}}, token)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var deleted map[string]int
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&deleted))
+	assert.Equal(t, 0, deleted["deleted"])
+
 	// The user's subscription is untouched.
 	stored, err := s.GetNotificationSubscription(ctx, userSubID)
 	require.NoError(t, err)
@@ -714,4 +932,55 @@ func TestHandleSubscriptions_AgentCannotSubscribeOtherProject(t *testing.T) {
 	}
 	rec := doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/subscriptions", createReq, token)
 	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestHandleSubscriptions_AgentBulkCreate(t *testing.T) {
+	srv, s, _ := setupNotificationHandlerTest(t)
+	ctx := context.Background()
+
+	otherProject := &store.Project{
+		ID:   tid("project-bulk-other"),
+		Name: "Bulk Other Project",
+		Slug: "bulk-other-project",
+	}
+	require.NoError(t, s.CreateProject(ctx, otherProject))
+
+	agent, token := setupNotificationAgentCaller(t, srv, s, tid("project-notif-handler"), "bulk-agent")
+
+	reqs := []createSubscriptionRequest{
+		{Scope: "project", ProjectID: agent.ProjectID, TriggerActivities: []string{"COMPLETED"}},
+		{Scope: "agent", AgentID: tid("agent-watched"), ProjectID: agent.ProjectID, TriggerActivities: []string{"STALLED"}},
+	}
+	rec := doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/subscriptions/bulk", reqs, token)
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+
+	var created []store.NotificationSubscription
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&created))
+	require.Len(t, created, 2)
+	for _, sub := range created {
+		assert.Equal(t, store.SubscriberTypeAgent, sub.SubscriberType)
+		assert.Equal(t, agent.Slug, sub.SubscriberID)
+		assert.Equal(t, agent.ProjectID, sub.ProjectID)
+	}
+
+	// A foreign project anywhere in the batch fails the whole request rather
+	// than silently dropping the entry.
+	reqs = []createSubscriptionRequest{
+		{Scope: "project", ProjectID: agent.ProjectID, TriggerActivities: []string{"ERROR"}},
+		{Scope: "project", ProjectID: otherProject.ID, TriggerActivities: []string{"ERROR"}},
+	}
+	rec = doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/subscriptions/bulk", reqs, token)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+
+	stored, err := s.GetSubscriptionsForSubscriber(ctx, store.SubscriberTypeAgent, agent.Slug)
+	require.NoError(t, err)
+	assert.Len(t, stored, 2)
+
+	// Bulk delete removes the agent's own subscriptions.
+	rec = doRequestWithAgentToken(t, srv, http.MethodPost, "/api/v1/notifications/subscriptions/bulk-delete",
+		map[string][]string{"ids": {created[0].ID, created[1].ID}}, token)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var deleted map[string]int
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&deleted))
+	assert.Equal(t, 2, deleted["deleted"])
 }

--- a/pkg/store/entadapter/notification_store.go
+++ b/pkg/store/entadapter/notification_store.go
@@ -462,6 +462,19 @@ func (s *NotificationStore) GetNotificationsByAgent(ctx context.Context, agentID
 	return notifsToStore(rows), nil
 }
 
+// GetNotification returns a single notification by ID.
+func (s *NotificationStore) GetNotification(ctx context.Context, id string) (*store.Notification, error) {
+	uid, err := parseGetID(id)
+	if err != nil {
+		return nil, err
+	}
+	row, err := s.client.Notification.Get(ctx, uid)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	return entNotifToStore(row), nil
+}
+
 // AcknowledgeNotification marks a notification as acknowledged.
 func (s *NotificationStore) AcknowledgeNotification(ctx context.Context, id string) error {
 	uid, err := parseUUID(id)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1032,6 +1032,10 @@ type NotificationStore interface {
 	// Results are ordered by created_at DESC.
 	GetNotificationsByAgent(ctx context.Context, agentID, subscriberType, subscriberID string, onlyUnacknowledged bool) ([]Notification, error)
 
+	// GetNotification returns a single notification by ID.
+	// Returns ErrNotFound if the notification doesn't exist.
+	GetNotification(ctx context.Context, id string) (*Notification, error)
+
 	// AcknowledgeNotification marks a notification as acknowledged.
 	// Returns ErrNotFound if the notification doesn't exist.
 	AcknowledgeNotification(ctx context.Context, id string) error


### PR DESCRIPTION
## Summary
- Agents can now list, create, update, and delete their own notification subscriptions (previously 403)
- Agent subscriber identity qualified by (project, slug) to prevent cross-project data leaks
- Scope checks gate reads on project:read and writes on project:agent:notify
- Subscription create validates watched agent belongs to caller's project
- Single-notification ack now requires ownership
- Agent callers refused on subscription template routes
- ack-all returns 501 for agent callers

Fixes ptone/scion#579

## Test plan
- [x] Agent can list own notifications and subscriptions
- [x] Agent can create, update, delete own subscriptions
- [x] Same-slug agents in different projects cannot see each other's data
- [x] Readonly-scoped token cannot create subscriptions
- [x] Agent cannot watch a foreign-project agent
- [x] Agent refused on template routes
- [x] Ack requires ownership
- [x] Anonymous requests get 401
- [x] Bulk create validates all entries before writing