### PR TITLE
fix: strip secret config keys from file-based plugin config

### DIFF
--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -296,7 +296,9 @@ func ResolvePluginConfig(configFile string, inlineConfig map[string]string) (map
 	// Warn so that a credential disappearing from the resolved config is
 	// traceable to the strip rather than surfacing as "bot_token is required".
 	if stripped := stripSecretKeysInPlace(fileConfig); len(stripped) > 0 {
-		warnStrippedFileSecretsOnce(configFile, stripped)
+		// provider.Path() is the resolved path — tilde and relative forms of the
+		// same file must not warn twice or log an ambiguous location.
+		warnStrippedFileSecretsOnce(provider.Path(), stripped)
 	}
 
 	// File is the base for non-wiring keys.

--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -254,14 +254,18 @@ var warnedFileSecrets sync.Map
 
 // warnStrippedFileSecretsOnce logs the stripped-secret warning the first time a
 // given config file yields a given set of stripped keys. A later edit that
-// introduces a different secret key warns again.
-func warnStrippedFileSecretsOnce(configFile string, stripped []string) {
-	key := configFile + "\x00" + strings.Join(stripped, ",")
+// introduces a different secret key warns again. resolvedPath must be the
+// provider's resolved path, so that tilde and relative spellings of one file
+// share a dedup key and log an unambiguous location.
+func warnStrippedFileSecretsOnce(resolvedPath string, stripped []string) {
+	key := resolvedPath + "\x00" + strings.Join(stripped, ",")
 	if _, seen := warnedFileSecrets.LoadOrStore(key, struct{}{}); seen {
 		return
 	}
-	slog.Warn("secret keys ignored in plugin config file — store them in the secret backend instead",
-		"keys", stripped, "config_file", configFile)
+	// Startup migration copies these into the secret backend, which is
+	// authoritative — the stale file copy is what needs removing.
+	slog.Warn("secret keys in plugin config file are ignored — the secret backend is authoritative; remove them from the config file",
+		"keys", stripped, "config_file", resolvedPath)
 }
 
 // ResolvePluginConfig builds the config map for a plugin with consistent precedence.
@@ -318,8 +322,10 @@ func ResolvePluginConfig(configFile string, inlineConfig map[string]string) (map
 		}
 	}
 	if len(deprecated) > 0 {
+		// Resolved path, matching the stripped-secret warning above — two lines
+		// about one file should not show two different config_file values.
 		slog.Warn("inline config keys ignored because config_file is set — move them to the config file",
-			"keys", deprecated, "config_file", configFile)
+			"keys", deprecated, "config_file", provider.Path())
 	}
 
 	return merged, nil

--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	yamlv3 "gopkg.in/yaml.v3"
@@ -220,25 +221,43 @@ var backendSecretKeys = []string{
 	SecretA2AAPIKey,
 }
 
+// stripSecretKeys removes credential entries from a plugin config map, covering
+// both secret config keys ("bot_token") and backend secret key names
+// ("TELEGRAM_BOT_TOKEN"), so that the secret backend stays authoritative.
+// The map is modified in place; the removed key names are returned sorted.
+func stripSecretKeys(cfg map[string]string) []string {
+	var stripped []string
+	for k := range cfg {
+		if secretConfigKeys[k] {
+			stripped = append(stripped, k)
+			delete(cfg, k)
+		}
+	}
+	for _, sk := range backendSecretKeys {
+		for _, k := range []string{sk, strings.ToLower(sk)} {
+			if _, ok := cfg[k]; ok {
+				stripped = append(stripped, k)
+				delete(cfg, k)
+			}
+		}
+	}
+	slices.Sort(stripped)
+	return stripped
+}
+
 // ResolvePluginConfig builds the config map for a plugin with consistent precedence.
 // If configFile is set, the file is the source of truth for non-wiring keys.
 // Inline config is only used for wiring keys or as fallback when no config_file exists.
 // Secret config keys (bot_token, signing_key, etc.) are always stripped from both
 // inline and file config so that the secret backend takes precedence.
 func ResolvePluginConfig(configFile string, inlineConfig map[string]string) (map[string]string, error) {
-	// Build a clean copy of inline config with secret keys stripped.
+	// Build a clean copy of inline config with secret keys stripped; the
+	// caller's map must not be mutated.
 	cleanedInline := make(map[string]string, len(inlineConfig))
 	for k, v := range inlineConfig {
-		if secretConfigKeys[k] {
-			continue
-		}
 		cleanedInline[k] = v
 	}
-	// Also strip backend key names (same filtering applied to file config).
-	for _, sk := range backendSecretKeys {
-		delete(cleanedInline, sk)
-		delete(cleanedInline, strings.ToLower(sk))
-	}
+	stripSecretKeys(cleanedInline)
 
 	if configFile == "" {
 		return cleanedInline, nil
@@ -254,17 +273,12 @@ func ResolvePluginConfig(configFile string, inlineConfig map[string]string) (map
 		return nil, err
 	}
 
-	// Filter backend secret key names from file config.
-	for _, sk := range backendSecretKeys {
-		delete(fileConfig, sk)
-		delete(fileConfig, strings.ToLower(sk))
-	}
-
-	// Strip secret config keys from file config (same treatment as inline config).
-	for k := range fileConfig {
-		if secretConfigKeys[k] {
-			delete(fileConfig, k)
-		}
+	// Strip secret keys from file config (same treatment as inline config).
+	// Warn so that a credential disappearing from the resolved config is
+	// traceable to the strip rather than surfacing as "bot_token is required".
+	if stripped := stripSecretKeys(fileConfig); len(stripped) > 0 {
+		slog.Warn("secret keys ignored in plugin config file — store them in the secret backend instead",
+			"keys", stripped, "config_file", configFile)
 	}
 
 	// File is the base for non-wiring keys.

--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 
 	yamlv3 "gopkg.in/yaml.v3"
 )
@@ -221,11 +222,12 @@ var backendSecretKeys = []string{
 	SecretA2AAPIKey,
 }
 
-// stripSecretKeys removes credential entries from a plugin config map, covering
-// both secret config keys ("bot_token") and backend secret key names
+// stripSecretKeysInPlace removes credential entries from a plugin config map,
+// covering both secret config keys ("bot_token") and backend secret key names
 // ("TELEGRAM_BOT_TOKEN"), so that the secret backend stays authoritative.
 // The map is modified in place; the removed key names are returned sorted.
-func stripSecretKeys(cfg map[string]string) []string {
+// Callers holding a map they do not own must pass a copy.
+func stripSecretKeysInPlace(cfg map[string]string) []string {
 	var stripped []string
 	for k := range cfg {
 		if secretConfigKeys[k] {
@@ -245,6 +247,23 @@ func stripSecretKeys(cfg map[string]string) []string {
 	return stripped
 }
 
+// warnedFileSecrets records which (config file, stripped keys) combinations have
+// already been warned about. ResolvePluginConfig runs on request-serving paths,
+// so warning on every call would let a client drive unbounded log volume.
+var warnedFileSecrets sync.Map
+
+// warnStrippedFileSecretsOnce logs the stripped-secret warning the first time a
+// given config file yields a given set of stripped keys. A later edit that
+// introduces a different secret key warns again.
+func warnStrippedFileSecretsOnce(configFile string, stripped []string) {
+	key := configFile + "\x00" + strings.Join(stripped, ",")
+	if _, seen := warnedFileSecrets.LoadOrStore(key, struct{}{}); seen {
+		return
+	}
+	slog.Warn("secret keys ignored in plugin config file — store them in the secret backend instead",
+		"keys", stripped, "config_file", configFile)
+}
+
 // ResolvePluginConfig builds the config map for a plugin with consistent precedence.
 // If configFile is set, the file is the source of truth for non-wiring keys.
 // Inline config is only used for wiring keys or as fallback when no config_file exists.
@@ -257,7 +276,7 @@ func ResolvePluginConfig(configFile string, inlineConfig map[string]string) (map
 	for k, v := range inlineConfig {
 		cleanedInline[k] = v
 	}
-	stripSecretKeys(cleanedInline)
+	stripSecretKeysInPlace(cleanedInline)
 
 	if configFile == "" {
 		return cleanedInline, nil
@@ -276,9 +295,8 @@ func ResolvePluginConfig(configFile string, inlineConfig map[string]string) (map
 	// Strip secret keys from file config (same treatment as inline config).
 	// Warn so that a credential disappearing from the resolved config is
 	// traceable to the strip rather than surfacing as "bot_token is required".
-	if stripped := stripSecretKeys(fileConfig); len(stripped) > 0 {
-		slog.Warn("secret keys ignored in plugin config file — store them in the secret backend instead",
-			"keys", stripped, "config_file", configFile)
+	if stripped := stripSecretKeysInPlace(fileConfig); len(stripped) > 0 {
+		warnStrippedFileSecretsOnce(configFile, stripped)
 	}
 
 	// File is the base for non-wiring keys.

--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -223,8 +223,8 @@ var backendSecretKeys = []string{
 // ResolvePluginConfig builds the config map for a plugin with consistent precedence.
 // If configFile is set, the file is the source of truth for non-wiring keys.
 // Inline config is only used for wiring keys or as fallback when no config_file exists.
-// Secret config keys (bot_token, signing_key, etc.) are always stripped from inline
-// config so that the secret backend takes precedence.
+// Secret config keys (bot_token, signing_key, etc.) are always stripped from both
+// inline and file config so that the secret backend takes precedence.
 func ResolvePluginConfig(configFile string, inlineConfig map[string]string) (map[string]string, error) {
 	// Build a clean copy of inline config with secret keys stripped.
 	cleanedInline := make(map[string]string, len(inlineConfig))
@@ -258,6 +258,13 @@ func ResolvePluginConfig(configFile string, inlineConfig map[string]string) (map
 	for _, sk := range backendSecretKeys {
 		delete(fileConfig, sk)
 		delete(fileConfig, strings.ToLower(sk))
+	}
+
+	// Strip secret config keys from file config (same treatment as inline config).
+	for k := range fileConfig {
+		if secretConfigKeys[k] {
+			delete(fileConfig, k)
+		}
 	}
 
 	// File is the base for non-wiring keys.

--- a/pkg/config/integration_config_test.go
+++ b/pkg/config/integration_config_test.go
@@ -254,6 +254,12 @@ func TestResolvePluginConfig_SecretKeysStrippedFromInline(t *testing.T) {
 	if result["mode"] != "plugin" {
 		t.Errorf("wiring key should be preserved: got %q", result["mode"])
 	}
+	// Callers pass live maps (entry.Config from in-memory settings). Stripping
+	// the original would erase the credential from settings and risk writing
+	// the loss back to settings.yaml.
+	if _, ok := inline["bot_token"]; !ok {
+		t.Error("ResolvePluginConfig must not mutate the caller's inline map")
+	}
 }
 
 func TestResolvePluginConfig_SecretKeysStrippedWithConfigFile(t *testing.T) {
@@ -343,6 +349,16 @@ func TestResolvePluginConfig_SecretKeysStrippedFromConfigFileWarns(t *testing.T)
 	}
 	if strings.Contains(logged, "secret-from-file") {
 		t.Errorf("warning must not leak the credential value, got: %s", logged)
+	}
+
+	// ResolvePluginConfig runs on request-serving paths; repeat calls must not
+	// let a client drive unbounded log volume.
+	buf.Reset()
+	if _, err := ResolvePluginConfig(path, nil); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("repeat resolve should not warn again, got: %s", buf.String())
 	}
 }
 

--- a/pkg/config/integration_config_test.go
+++ b/pkg/config/integration_config_test.go
@@ -15,9 +15,12 @@
 package config
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -286,8 +289,9 @@ func TestResolvePluginConfig_SecretKeysStrippedFromConfigFile(t *testing.T) {
 	path := filepath.Join(dir, "plugin.yaml")
 	p, _ := NewYAMLConfigProvider(path)
 	if err := p.Save(context.Background(), map[string]string{
-		"bot_token":    "secret-from-file",
-		"inbound_mode": "poll",
+		"bot_token":          "secret-from-file",
+		"TELEGRAM_BOT_TOKEN": "backend-name-from-file",
+		"inbound_mode":       "poll",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -300,8 +304,45 @@ func TestResolvePluginConfig_SecretKeysStrippedFromConfigFile(t *testing.T) {
 	if _, ok := result["bot_token"]; ok {
 		t.Error("secret config key bot_token should be stripped from config file")
 	}
+	if _, ok := result["TELEGRAM_BOT_TOKEN"]; ok {
+		t.Error("backend secret key name should be stripped from config file")
+	}
 	if result["inbound_mode"] != "poll" {
 		t.Errorf("file non-secret key should be present: got %q", result["inbound_mode"])
+	}
+}
+
+func TestResolvePluginConfig_SecretKeysStrippedFromConfigFileWarns(t *testing.T) {
+	// A credential silently vanishing from the resolved config is the failure
+	// mode this warning exists to prevent — assert it actually fires.
+	var buf bytes.Buffer
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(oldLogger)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plugin.yaml")
+	p, _ := NewYAMLConfigProvider(path)
+	if err := p.Save(context.Background(), map[string]string{
+		"bot_token":    "secret-from-file",
+		"inbound_mode": "poll",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ResolvePluginConfig(path, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "level=WARN") || !strings.Contains(logged, "bot_token") {
+		t.Errorf("expected a WARN naming the stripped key, got: %s", logged)
+	}
+	if !strings.Contains(logged, path) {
+		t.Errorf("expected the warning to name the config file %q, got: %s", path, logged)
+	}
+	if strings.Contains(logged, "secret-from-file") {
+		t.Errorf("warning must not leak the credential value, got: %s", logged)
 	}
 }
 

--- a/pkg/config/integration_config_test.go
+++ b/pkg/config/integration_config_test.go
@@ -362,6 +362,42 @@ func TestResolvePluginConfig_SecretKeysStrippedFromConfigFileWarns(t *testing.T)
 	}
 }
 
+func TestResolvePluginConfig_StrippedSecretWarningDedupesByResolvedPath(t *testing.T) {
+	// "~/.scion/plugin.yaml", "plugin.yaml" and the absolute path all name the
+	// same file; the warning should fire once, against the resolved path.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, GlobalDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	abs := filepath.Join(dir, "plugin.yaml")
+	p, _ := NewYAMLConfigProvider(abs)
+	if err := p.Save(context.Background(), map[string]string{
+		"bot_token": "secret-from-file",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(oldLogger)
+
+	for _, spelling := range []string{abs, "~/" + GlobalDir + "/plugin.yaml", "plugin.yaml"} {
+		if _, err := ResolvePluginConfig(spelling, nil); err != nil {
+			t.Fatalf("resolve %q: %v", spelling, err)
+		}
+	}
+
+	if got := strings.Count(buf.String(), "level=WARN"); got != 1 {
+		t.Errorf("expected exactly 1 warning across path spellings, got %d: %s", got, buf.String())
+	}
+	if !strings.Contains(buf.String(), abs) {
+		t.Errorf("warning should name the resolved path %q, got: %s", abs, buf.String())
+	}
+}
+
 func TestResolvePluginConfig_BackendKeyNamesStrippedFromBothSources(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "plugin.yaml")

--- a/pkg/config/integration_config_test.go
+++ b/pkg/config/integration_config_test.go
@@ -281,6 +281,30 @@ func TestResolvePluginConfig_SecretKeysStrippedWithConfigFile(t *testing.T) {
 	}
 }
 
+func TestResolvePluginConfig_SecretKeysStrippedFromConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plugin.yaml")
+	p, _ := NewYAMLConfigProvider(path)
+	if err := p.Save(context.Background(), map[string]string{
+		"bot_token":    "secret-from-file",
+		"inbound_mode": "poll",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ResolvePluginConfig(path, map[string]string{"mode": "plugin"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := result["bot_token"]; ok {
+		t.Error("secret config key bot_token should be stripped from config file")
+	}
+	if result["inbound_mode"] != "poll" {
+		t.Errorf("file non-secret key should be present: got %q", result["inbound_mode"])
+	}
+}
+
 func TestResolvePluginConfig_BackendKeyNamesStrippedFromBothSources(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "plugin.yaml")


### PR DESCRIPTION
## Problem

`ResolvePluginConfig` (`pkg/config/integration_config.go`) stripped secret config keys
(`bot_token`, `signing_key`, etc.) from **inline** config but not from the per-plugin
YAML **config file**.

## Depends on

The `migratePluginSecrets` file-config support change must land first.

## Fix

- `stripSecretKeysInPlace` replaces four stripping loops with one helper
- Inline config copied before stripping (callers pass live maps)
- Warning fires once per (resolved path, keys) pair via sync.Map

## Tests

4 new test cases, all mutation-tested. go build, go test, go vet, gofmt clean.

## Known limitation

Runtime activation without restart skips boot-time migration. Follow-up tracked.