### PR TITLE
fix: migrate secrets before stripping in runtime activation path

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -58,6 +58,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/runtimebroker"
 	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/secretmigration"
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/store/entadapter"
@@ -1212,7 +1213,8 @@ func migrateStore(ctx context.Context, cfg *config.GlobalConfig, s *entadapter.C
 // safe because all guarded boot migrations are idempotent: each one checks
 // whether its work has already been done (e.g. MigrateStorageOnFirstBoot
 // checks for existing namespaced objects, BootstrapBundledResources uses
-// SkipIfAnyExist, migratePluginSecrets checks for existing secret values)
+// SkipIfAnyExist, secretmigration.MigratePluginSecrets checks for existing
+// secret values)
 // and no-ops if so. The winning replica does the work; the others skip it
 // here and will see the completed state on their next access.
 func runWithAdvisoryLock(ctx context.Context, s store.Store, key store.AdvisoryLockKey, label string, fn func()) {
@@ -2572,7 +2574,7 @@ func initPluginManager(ctx context.Context, secretBackend secret.SecretBackend, 
 	if secretBackend != nil {
 		runWithAdvisoryLock(ctx, dataStore, store.LockInlineSecretsMigration, "plugin secrets migration", func() {
 			for name, entry := range vs.Server.Plugins.Broker {
-				migratePluginSecrets(ctx, secretBackend, name, entry.Config, entry.ConfigFile)
+				secretmigration.MigratePluginSecrets(ctx, secretBackend, name, entry.Config, entry.ConfigFile)
 			}
 		})
 	}
@@ -2852,113 +2854,6 @@ func requireImageRegistryForBroker() error {
 		"  Option 1: scion config set --global image_registry <your-registry>\n" +
 		"  Option 2: export SCION_IMAGE_REGISTRY=<your-registry>\n\n" +
 		"See image-build/README.md for instructions on building and pushing images")
-}
-
-// migratePluginSecrets performs a one-shot migration of secret config keys found
-// in the raw plugin config into the secret backend. Both sources of raw config
-// are considered: the inline map in settings.yaml and the per-plugin YAML file
-// referenced by config_file.
-//
-// The two sources need migrating for different reasons:
-//
-//   - Inline settings.yaml: ResolvePluginConfig strips secret config keys
-//     (bot_token, signing_key, ...) from inline config, so without migration the
-//     credential never reaches the plugin.
-//   - Per-plugin config file: these keys are NOT stripped and do reach the plugin,
-//     so nothing breaks today. Migrating them puts every plugin credential under
-//     the secret backend's lifecycle — rotation, auditing, scoped access — instead
-//     of leaving copies scattered across plaintext YAML on disk.
-//
-// When a secret key is present in both sources the config file value wins — see
-// pluginSecretMigrationSource.
-//
-// Known limitation (no code change here — this is the existing precedence):
-// migrating a key out of a config file does not deactivate the file copy. Because
-// injectPluginSecretsIntoConfig only fills in keys the merged config leaves empty,
-// a value still present in the config file continues to win over the backend copy,
-// which stays inert until the operator removes the key from the file. An operator
-// who later rotates the secret in the backend will keep running on the stale file
-// value. The log line below tells them which file to clean up; note that it prints
-// configFile as written in settings.yaml, so a relative or "~/"-prefixed path is
-// shown unresolved.
-//
-// The same divergence bites in the other direction: the migration never refreshes
-// a secret that already exists in the backend, so an operator who rotates the
-// credential in the config file and later removes the key — as the log advises —
-// drops the plugin back onto the stale backend value. Whichever copy the operator
-// stops maintaining, the two must be reconciled by hand.
-func migratePluginSecrets(ctx context.Context, sb secret.SecretBackend, pluginName string, inlineConfig map[string]string, configFile string) {
-	mappings, ok := config.PluginSecretKeyMap[pluginName]
-	if !ok {
-		return
-	}
-
-	fileConfig := loadPluginConfigFileForMigration(pluginName, configFile)
-
-	hubID := sb.HubID()
-	for _, m := range mappings {
-		val, source := pluginSecretMigrationSource(m.ConfigKey, inlineConfig, fileConfig, configFile)
-		if val == "" {
-			continue
-		}
-		existing, err := sb.Get(ctx, m.SecretKey, store.ScopeHub, hubID)
-		if err != nil && !errors.Is(err, store.ErrNotFound) {
-			log.Printf("Warning: failed to check secret backend for %s (plugin %q), skipping migration: %v", m.ConfigKey, pluginName, err)
-			continue
-		}
-		if existing != nil && existing.Value != "" {
-			continue
-		}
-		_, _, err = sb.Set(ctx, &secret.SetSecretInput{
-			Name:          m.SecretKey,
-			Value:         val,
-			SecretType:    secret.TypeVariable,
-			InjectionMode: "as_needed",
-			Scope:         store.ScopeHub,
-			ScopeID:       hubID,
-			// Only the file name goes into backend metadata — a full host path
-			// would leak the operator's username and directory layout.
-			Description: fmt.Sprintf("Auto-migrated from %s for plugin %s", filepath.Base(source), pluginName),
-		})
-		if err != nil {
-			log.Printf("Warning: failed to migrate secret %s for plugin %q: %v", m.ConfigKey, pluginName, err)
-			continue
-		}
-		log.Printf("Migrated %s to secret backend for plugin %q — remove it from %s", m.ConfigKey, pluginName, source)
-	}
-}
-
-// pluginSecretMigrationSource picks which raw value to migrate for one secret
-// config key, and returns a label naming where it came from for logging.
-//
-// The per-plugin config file wins over inline config. That is the opposite of
-// config.LoadPluginConfigFile's merge order, and deliberately so: when
-// config_file is set, ResolvePluginConfig drops every secret config key from
-// inline config and takes the file's value, so the file holds the credential the
-// plugin is actually running on. Migrating the inline value instead would put a
-// different — possibly stale — credential in the backend, and the plugin would
-// silently switch to it once the operator cleaned the key out of the file.
-func pluginSecretMigrationSource(configKey string, inlineConfig, fileConfig map[string]string, configFile string) (value, source string) {
-	if v := fileConfig[configKey]; v != "" {
-		return v, configFile
-	}
-	return inlineConfig[configKey], "settings.yaml"
-}
-
-// loadPluginConfigFileForMigration reads the raw per-plugin YAML config file so
-// migratePluginSecrets can see secrets that live only in that file. A missing
-// file yields an empty map; any load failure is logged and treated as empty so
-// migration still proceeds for inline config.
-func loadPluginConfigFileForMigration(pluginName, configFile string) map[string]string {
-	if configFile == "" {
-		return nil
-	}
-	fileConfig, err := config.LoadPluginConfigFile(configFile, nil)
-	if err != nil {
-		log.Printf("Warning: failed to read config file %q for plugin %q during secret migration: %v", configFile, pluginName, err)
-		return nil
-	}
-	return fileConfig
 }
 
 // stripSecretKeys returns a copy of the config map with all secret config keys removed.

--- a/cmd/server_foreground_pluginsecrets_test.go
+++ b/cmd/server_foreground_pluginsecrets_test.go
@@ -30,14 +30,12 @@ import (
 // fakeSecretBackend is an in-memory secret.SecretBackend for migration tests.
 // Only Get, Set and HubID are exercised by secretmigration.MigratePluginSecrets.
 type fakeSecretBackend struct {
-	hubID        string
-	values       map[string]string
-	descriptions map[string]string
-	sets         int
+	hubID  string
+	values map[string]string
 }
 
 func newFakeSecretBackend() *fakeSecretBackend {
-	return &fakeSecretBackend{hubID: "hub-1", values: map[string]string{}, descriptions: map[string]string{}}
+	return &fakeSecretBackend{hubID: "hub-1", values: map[string]string{}}
 }
 
 func (f *fakeSecretBackend) HubID() string { return f.hubID }
@@ -51,8 +49,6 @@ func (f *fakeSecretBackend) Get(_ context.Context, name, _, _ string) (*secret.S
 }
 
 func (f *fakeSecretBackend) Set(_ context.Context, in *secret.SetSecretInput) (bool, *secret.SecretMeta, error) {
-	f.sets++
-	f.descriptions[in.Name] = in.Description
 	_, existed := f.values[in.Name]
 	f.values[in.Name] = in.Value
 	return !existed, &secret.SecretMeta{Name: in.Name}, nil

--- a/cmd/server_foreground_pluginsecrets_test.go
+++ b/cmd/server_foreground_pluginsecrets_test.go
@@ -20,7 +20,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
@@ -29,7 +28,7 @@ import (
 )
 
 // fakeSecretBackend is an in-memory secret.SecretBackend for migration tests.
-// Only Get, Set and HubID are exercised by migratePluginSecrets.
+// Only Get, Set and HubID are exercised by secretmigration.MigratePluginSecrets.
 type fakeSecretBackend struct {
 	hubID        string
 	values       map[string]string
@@ -73,16 +72,6 @@ func (f *fakeSecretBackend) Resolve(context.Context, string, string, string, *se
 	return nil, nil
 }
 
-// writePluginConfigFile writes a per-plugin YAML config file and returns its path.
-func writePluginConfigFile(t *testing.T, contents string) string {
-	t.Helper()
-	path := filepath.Join(t.TempDir(), "scion-telegram.yaml")
-	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
-		t.Fatalf("write config file: %v", err)
-	}
-	return path
-}
-
 // captureLog collects everything written to the standard logger while fn runs.
 func captureLog(t *testing.T, fn func()) string {
 	t.Helper()
@@ -92,150 +81,6 @@ func captureLog(t *testing.T, fn func()) string {
 	defer log.SetOutput(prev)
 	fn()
 	return buf.String()
-}
-
-func TestMigratePluginSecrets_FromConfigFile(t *testing.T) {
-	sb := newFakeSecretBackend()
-	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\ninbound_mode: \"webhook\"\n")
-
-	migratePluginSecrets(context.Background(), sb, "telegram", nil, cfgFile)
-
-	if got := sb.values[config.SecretTelegramBotToken]; got != "file-token" {
-		t.Errorf("expected bot_token from config file to be migrated, got %q", got)
-	}
-}
-
-// The secret description must name the config file without exposing the host
-// path, which would leak the operator's username and directory layout.
-func TestMigratePluginSecrets_DescriptionOmitsHostPath(t *testing.T) {
-	sb := newFakeSecretBackend()
-	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\n")
-
-	migratePluginSecrets(context.Background(), sb, "telegram", nil, cfgFile)
-
-	desc := sb.descriptions[config.SecretTelegramBotToken]
-	if !strings.Contains(desc, "scion-telegram.yaml") {
-		t.Errorf("expected description to name the config file, got %q", desc)
-	}
-	if strings.Contains(desc, filepath.Dir(cfgFile)) {
-		t.Errorf("description must not contain the host path, got %q", desc)
-	}
-}
-
-func TestMigratePluginSecrets_FromInlineConfig(t *testing.T) {
-	sb := newFakeSecretBackend()
-	inline := map[string]string{"bot_token": "inline-token"}
-
-	migratePluginSecrets(context.Background(), sb, "telegram", inline, "")
-
-	if got := sb.values[config.SecretTelegramBotToken]; got != "inline-token" {
-		t.Errorf("expected inline bot_token to be migrated, got %q", got)
-	}
-}
-
-// When config_file is set, ResolvePluginConfig runs the plugin on the file's
-// value, so that is the credential the backend must receive.
-func TestMigratePluginSecrets_ConfigFileWinsOverInline(t *testing.T) {
-	sb := newFakeSecretBackend()
-	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\n")
-	inline := map[string]string{"bot_token": "inline-token", "webhook_secret": "inline-secret"}
-
-	migratePluginSecrets(context.Background(), sb, "telegram", inline, cfgFile)
-
-	if got := sb.values[config.SecretTelegramBotToken]; got != "file-token" {
-		t.Errorf("expected config file value to win, got %q", got)
-	}
-	// Keys absent from the file still migrate from inline config.
-	if got := sb.values[config.SecretTelegramWebhookKey]; got != "inline-secret" {
-		t.Errorf("expected webhook_secret from inline config, got %q", got)
-	}
-}
-
-// An empty value in the config file is not a value — inline is used instead.
-func TestMigratePluginSecrets_EmptyConfigFileValueFallsBackToInline(t *testing.T) {
-	sb := newFakeSecretBackend()
-	cfgFile := writePluginConfigFile(t, "bot_token: \"\"\n")
-	inline := map[string]string{"bot_token": "inline-token"}
-
-	migratePluginSecrets(context.Background(), sb, "telegram", inline, cfgFile)
-
-	if got := sb.values[config.SecretTelegramBotToken]; got != "inline-token" {
-		t.Errorf("expected fallback to inline value, got %q", got)
-	}
-}
-
-// Backend-style key names (TELEGRAM_BOT_TOKEN) are stripped from file config by
-// LoadPluginConfigFile, so they are not a migration source — only the plugin
-// config key (bot_token) is.
-func TestMigratePluginSecrets_IgnoresBackendKeyNameInConfigFile(t *testing.T) {
-	sb := newFakeSecretBackend()
-	cfgFile := writePluginConfigFile(t, config.SecretTelegramBotToken+": \"backend-style-token\"\n")
-
-	migratePluginSecrets(context.Background(), sb, "telegram", nil, cfgFile)
-
-	if sb.sets != 0 {
-		t.Errorf("expected no migration from a backend-style key, got %d Set calls", sb.sets)
-	}
-}
-
-func TestMigratePluginSecrets_MissingConfigFile(t *testing.T) {
-	sb := newFakeSecretBackend()
-	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
-	inline := map[string]string{"bot_token": "inline-token"}
-
-	migratePluginSecrets(context.Background(), sb, "telegram", inline, missing)
-
-	if got := sb.values[config.SecretTelegramBotToken]; got != "inline-token" {
-		t.Errorf("missing config file should not block inline migration, got %q", got)
-	}
-}
-
-func TestMigratePluginSecrets_DoesNotOverwriteExisting(t *testing.T) {
-	sb := newFakeSecretBackend()
-	sb.values[config.SecretTelegramBotToken] = "already-migrated"
-	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\n")
-
-	migratePluginSecrets(context.Background(), sb, "telegram", map[string]string{"bot_token": "inline-token"}, cfgFile)
-
-	if got := sb.values[config.SecretTelegramBotToken]; got != "already-migrated" {
-		t.Errorf("existing secret must not be overwritten, got %q", got)
-	}
-	if sb.sets != 0 {
-		t.Errorf("expected no Set calls, got %d", sb.sets)
-	}
-}
-
-func TestMigratePluginSecrets_UnknownPluginNoOp(t *testing.T) {
-	sb := newFakeSecretBackend()
-	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\n")
-
-	migratePluginSecrets(context.Background(), sb, "not-a-known-plugin", map[string]string{"bot_token": "x"}, cfgFile)
-
-	if sb.sets != 0 {
-		t.Errorf("expected no migration for unknown plugin, got %d Set calls", sb.sets)
-	}
-}
-
-func TestMigratePluginSecrets_MalformedConfigFileFallsBackToInline(t *testing.T) {
-	sb := newFakeSecretBackend()
-	// bot_token appears only in the file, webhook_secret only inline: if the file
-	// parsed, bot_token would migrate too.
-	cfgFile := writePluginConfigFile(t, "bot_token: \"file-token\"\nwebhook_secret: [unterminated\n")
-	inline := map[string]string{"webhook_secret": "inline-secret"}
-
-	out := captureLog(t, func() {
-		migratePluginSecrets(context.Background(), sb, "telegram", inline, cfgFile)
-	})
-
-	if got := sb.values[config.SecretTelegramWebhookKey]; got != "inline-secret" {
-		t.Errorf("malformed config file should not block inline migration, got %q", got)
-	}
-	if got, ok := sb.values[config.SecretTelegramBotToken]; ok {
-		t.Errorf("unparseable config file must yield no file values, got %q", got)
-	}
-	if !strings.Contains(out, "failed to read config file") {
-		t.Errorf("expected a warning about the unreadable config file, got log: %q", out)
-	}
 }
 
 // initPluginManager must run the migration for a plugin whose only raw config is

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -34,6 +34,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/integrationupdate"
 	"github.com/GoogleCloudPlatform/scion/pkg/eventbus"
 	"github.com/GoogleCloudPlatform/scion/pkg/plugin"
+	"github.com/GoogleCloudPlatform/scion/pkg/secretmigration"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
@@ -1321,6 +1322,13 @@ func installedPluginSettingsEntry(name string) *config.V1PluginEntry {
 // map that server startup builds — file settings, secret-backend secrets, and
 // hub wiring credentials — so the plugin's Configure call succeeds on load.
 func (s *Server) activateInstalledIntegration(ctx context.Context, mgr IntegrationManager, name string, entry *config.V1PluginEntry) error {
+	// Migrate raw credentials into the secret backend before
+	// ResolvePluginConfig strips them, mirroring what the server boot path
+	// does in initPluginManager. Without this, a plugin installed and
+	// activated without a restart loses any secret its operator put in
+	// settings.yaml. A nil backend is a no-op.
+	secretmigration.MigratePluginSecrets(ctx, s.GetSecretBackend(), name, entry.Config, entry.ConfigFile)
+
 	merged, err := config.ResolvePluginConfig(entry.ConfigFile, entry.Config)
 	if err != nil {
 		slog.Warn("Failed to resolve config file for plugin activation", "plugin", name, "error", err)

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -1322,6 +1322,13 @@ func installedPluginSettingsEntry(name string) *config.V1PluginEntry {
 // map that server startup builds — file settings, secret-backend secrets, and
 // hub wiring credentials — so the plugin's Configure call succeeds on load.
 func (s *Server) activateInstalledIntegration(ctx context.Context, mgr IntegrationManager, name string, entry *config.V1PluginEntry) error {
+	// Every current caller checks entry before calling, but the signature
+	// accepts a pointer, so fail loudly rather than panicking deep inside the
+	// activation sequence if a future one forgets.
+	if entry == nil {
+		return fmt.Errorf("cannot activate integration %q: entry is nil", name)
+	}
+
 	// Migrate raw credentials into the secret backend before
 	// ResolvePluginConfig strips them, mirroring what the server boot path
 	// does in initPluginManager. Without this, a plugin installed and

--- a/pkg/hub/handlers_integrations_activate_secrets_test.go
+++ b/pkg/hub/handlers_integrations_activate_secrets_test.go
@@ -16,6 +16,7 @@ package hub
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -222,6 +223,20 @@ func TestGetIntegration_DoesNotMigrateSecrets(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
+
+	// Positive assertion first: chat_id is a non-secret key that only exists in
+	// the config file, so seeing it proves the handler actually resolved the
+	// file. Without this the no-write assertion below could pass simply because
+	// the read path never ran.
+	var detail IntegrationDetail
+	if err := json.Unmarshal(rr.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := detail.Settings["chat_id"]; got != "42" {
+		t.Fatalf("chat_id in response = %q, want %q — the config file was not "+
+			"resolved, so the no-write assertion below proves nothing", got, "42")
+	}
+
 	if len(sb.sets) != 0 {
 		t.Errorf("GET must not write to the secret backend, got %+v", sb.sets)
 	}
@@ -239,8 +254,15 @@ func TestLoadTeamsConfig_DoesNotMigrateSecrets(t *testing.T) {
 	}
 	mgr.plugins["teams"] = map[string]string{"config_file": configFile}
 
-	if _, err := srv.loadTeamsConfig(); err != nil {
+	cfg, err := srv.loadTeamsConfig()
+	if err != nil {
 		t.Fatalf("loadTeamsConfig: %v", err)
+	}
+	// Positive assertion first: without it this test would pass vacuously if
+	// loadTeamsConfig stopped reading the config file at all.
+	if got := cfg["app_id"]; got != "abc" {
+		t.Fatalf("app_id = %q, want %q — the config file was not read, so the "+
+			"no-write assertion below proves nothing", got, "abc")
 	}
 	if len(sb.sets) != 0 {
 		t.Errorf("manifest generation must not write to the secret backend, got %+v", sb.sets)

--- a/pkg/hub/handlers_integrations_activate_secrets_test.go
+++ b/pkg/hub/handlers_integrations_activate_secrets_test.go
@@ -1,0 +1,248 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// migrationSecretBackend is an in-memory secret backend that records writes,
+// used to observe whether a code path migrates plugin secrets.
+type migrationSecretBackend struct {
+	values map[string]string
+	sets   []secret.SetSecretInput
+}
+
+func newMigrationSecretBackend() *migrationSecretBackend {
+	return &migrationSecretBackend{values: make(map[string]string)}
+}
+
+func (m *migrationSecretBackend) Get(_ context.Context, name, _, _ string) (*secret.SecretWithValue, error) {
+	v, ok := m.values[name]
+	if !ok {
+		return nil, store.ErrNotFound
+	}
+	return &secret.SecretWithValue{SecretMeta: secret.SecretMeta{Name: name}, Value: v}, nil
+}
+
+func (m *migrationSecretBackend) Set(_ context.Context, in *secret.SetSecretInput) (bool, *secret.SecretMeta, error) {
+	m.sets = append(m.sets, *in)
+	m.values[in.Name] = in.Value
+	return true, nil, nil
+}
+
+func (m *migrationSecretBackend) Delete(context.Context, string, string, string) error { return nil }
+
+func (m *migrationSecretBackend) List(context.Context, secret.Filter) ([]secret.SecretMeta, error) {
+	return nil, nil
+}
+
+func (m *migrationSecretBackend) GetMeta(_ context.Context, name, _, _ string) (*secret.SecretMeta, error) {
+	if _, ok := m.values[name]; !ok {
+		return nil, store.ErrNotFound
+	}
+	return &secret.SecretMeta{Name: name}, nil
+}
+
+func (m *migrationSecretBackend) Resolve(context.Context, string, string, string, *secret.ResolveOpts) ([]secret.SecretWithValue, error) {
+	return nil, nil
+}
+
+func (m *migrationSecretBackend) HubID() string { return "test-hub" }
+
+// newActivationServer returns a Server wired with a mock plugin manager and
+// the given secret backend, plus a temporary HOME so plugin dir resolution
+// stays inside the test sandbox.
+func newActivationServer(t *testing.T, sb secret.SecretBackend) (*Server, *mockIntegrationManager) {
+	t.Helper()
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".scion"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr := newMockIntegrationManager()
+	srv := &Server{}
+	srv.pluginManager = mgr
+	srv.secretBackend = sb
+	return srv, mgr
+}
+
+// TestActivateInstalledIntegration_MigratesInlineSecret pins the bug from
+// ptone/scion#1017: a user who put bot_token in settings.yaml and activated
+// the plugin from the admin UI without restarting had the token stripped by
+// ResolvePluginConfig and never written to the backend.
+func TestActivateInstalledIntegration_MigratesInlineSecret(t *testing.T) {
+	sb := newMigrationSecretBackend()
+	srv, mgr := newActivationServer(t, sb)
+
+	entry := &config.V1PluginEntry{
+		Path:   "./telegram",
+		Config: map[string]string{"bot_token": "inline-token", "mode": "plugin"},
+	}
+
+	if err := srv.activateInstalledIntegration(context.Background(), mgr, "telegram", entry); err != nil {
+		t.Fatalf("activateInstalledIntegration: %v", err)
+	}
+
+	if got := sb.values[config.SecretTelegramBotToken]; got != "inline-token" {
+		t.Errorf("%s in backend = %q, want %q — the inline secret was not migrated",
+			config.SecretTelegramBotToken, got, "inline-token")
+	}
+
+	// The activated plugin must still receive the token: migration happens
+	// before stripping, and the value is read back out of the backend.
+	if got := mgr.plugins["telegram"]["bot_token"]; got != "inline-token" {
+		t.Errorf("bot_token passed to LoadOne = %q, want %q", got, "inline-token")
+	}
+}
+
+func TestActivateInstalledIntegration_MigratesConfigFileSecret(t *testing.T) {
+	sb := newMigrationSecretBackend()
+	srv, mgr := newActivationServer(t, sb)
+
+	configFile := filepath.Join(t.TempDir(), "scion-telegram.yaml")
+	if err := os.WriteFile(configFile, []byte("bot_token: file-token\nchat_id: \"42\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	entry := &config.V1PluginEntry{Path: "./telegram", ConfigFile: configFile}
+
+	if err := srv.activateInstalledIntegration(context.Background(), mgr, "telegram", entry); err != nil {
+		t.Fatalf("activateInstalledIntegration: %v", err)
+	}
+
+	if got := sb.values[config.SecretTelegramBotToken]; got != "file-token" {
+		t.Errorf("%s in backend = %q, want %q — the config-file secret was not migrated",
+			config.SecretTelegramBotToken, got, "file-token")
+	}
+}
+
+func TestActivateInstalledIntegration_DoesNotOverwriteMigratedSecret(t *testing.T) {
+	sb := newMigrationSecretBackend()
+	sb.values[config.SecretTelegramBotToken] = "backend-token"
+	srv, mgr := newActivationServer(t, sb)
+
+	entry := &config.V1PluginEntry{
+		Path:   "./telegram",
+		Config: map[string]string{"bot_token": "stale-inline-token"},
+	}
+
+	if err := srv.activateInstalledIntegration(context.Background(), mgr, "telegram", entry); err != nil {
+		t.Fatalf("activateInstalledIntegration: %v", err)
+	}
+
+	if len(sb.sets) != 0 {
+		t.Errorf("expected no backend writes when the secret already exists, got %+v", sb.sets)
+	}
+	if got := sb.values[config.SecretTelegramBotToken]; got != "backend-token" {
+		t.Errorf("backend value = %q, want the existing %q preserved", got, "backend-token")
+	}
+	// The backend copy is authoritative once it exists.
+	if got := mgr.plugins["telegram"]["bot_token"]; got != "backend-token" {
+		t.Errorf("bot_token passed to LoadOne = %q, want %q", got, "backend-token")
+	}
+}
+
+func TestActivateInstalledIntegration_NoSecretBackendIsNoOp(t *testing.T) {
+	// No backend configured: activation must still proceed without panicking.
+	srv, mgr := newActivationServer(t, nil)
+
+	entry := &config.V1PluginEntry{
+		Path:   "./telegram",
+		Config: map[string]string{"bot_token": "inline-token", "mode": "plugin"},
+	}
+
+	if err := srv.activateInstalledIntegration(context.Background(), mgr, "telegram", entry); err != nil {
+		t.Fatalf("activateInstalledIntegration: %v", err)
+	}
+	if len(mgr.loadOneCalls) != 1 {
+		t.Errorf("expected the plugin to be loaded once, got %v", mgr.loadOneCalls)
+	}
+}
+
+func TestActivateInstalledIntegration_UnknownPluginDoesNotMigrate(t *testing.T) {
+	sb := newMigrationSecretBackend()
+	srv, mgr := newActivationServer(t, sb)
+
+	entry := &config.V1PluginEntry{
+		Path:   "./custom",
+		Config: map[string]string{"bot_token": "inline-token"},
+	}
+
+	if err := srv.activateInstalledIntegration(context.Background(), mgr, "custom-broker", entry); err != nil {
+		t.Fatalf("activateInstalledIntegration: %v", err)
+	}
+
+	if len(sb.sets) != 0 {
+		t.Errorf("expected no migration for a plugin with no secret key mapping, got %+v", sb.sets)
+	}
+}
+
+// TestGetIntegration_DoesNotMigrateSecrets guards the boundary: reading an
+// integration must never write to the secret backend. Migration belongs to
+// activation, not to inspection.
+func TestGetIntegration_DoesNotMigrateSecrets(t *testing.T) {
+	sb := newMigrationSecretBackend()
+	srv, mgr := newActivationServer(t, sb)
+
+	configFile := filepath.Join(t.TempDir(), "scion-telegram.yaml")
+	if err := os.WriteFile(configFile, []byte("bot_token: file-token\nchat_id: \"42\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	mgr.plugins["telegram"] = map[string]string{"config_file": configFile, "bot_token": "runtime-token"}
+
+	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/telegram", nil)
+	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	rr := httptest.NewRecorder()
+	srv.handleAdminIntegrationByName(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(sb.sets) != 0 {
+		t.Errorf("GET must not write to the secret backend, got %+v", sb.sets)
+	}
+}
+
+// TestLoadTeamsConfig_DoesNotMigrateSecrets covers the other read-only
+// ResolvePluginConfig caller (Teams manifest generation).
+func TestLoadTeamsConfig_DoesNotMigrateSecrets(t *testing.T) {
+	sb := newMigrationSecretBackend()
+	srv, mgr := newActivationServer(t, sb)
+
+	configFile := filepath.Join(t.TempDir(), "scion-teams.yaml")
+	if err := os.WriteFile(configFile, []byte("app_secret: file-secret\napp_id: abc\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	mgr.plugins["teams"] = map[string]string{"config_file": configFile}
+
+	if _, err := srv.loadTeamsConfig(); err != nil {
+		t.Fatalf("loadTeamsConfig: %v", err)
+	}
+	if len(sb.sets) != 0 {
+		t.Errorf("manifest generation must not write to the secret backend, got %+v", sb.sets)
+	}
+}

--- a/pkg/hub/handlers_integrations_activate_secrets_test.go
+++ b/pkg/hub/handlers_integrations_activate_secrets_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
@@ -180,6 +181,27 @@ func TestActivateInstalledIntegration_NoSecretBackendIsNoOp(t *testing.T) {
 	}
 	if len(mgr.loadOneCalls) != 1 {
 		t.Errorf("expected the plugin to be loaded once, got %v", mgr.loadOneCalls)
+	}
+}
+
+// A nil entry must be rejected up front rather than panicking part-way through
+// activation, which could leave the plugin manager holding partial state.
+func TestActivateInstalledIntegration_NilEntryReturnsError(t *testing.T) {
+	sb := newMigrationSecretBackend()
+	srv, mgr := newActivationServer(t, sb)
+
+	err := srv.activateInstalledIntegration(context.Background(), mgr, "telegram", nil)
+	if err == nil {
+		t.Fatal("expected an error for a nil entry, got nil")
+	}
+	if !strings.Contains(err.Error(), "telegram") {
+		t.Errorf("error = %q, want it to name the integration", err)
+	}
+	if len(mgr.loadOneCalls) != 0 {
+		t.Errorf("expected no load attempt for a nil entry, got %v", mgr.loadOneCalls)
+	}
+	if len(sb.sets) != 0 {
+		t.Errorf("expected no backend writes for a nil entry, got %+v", sb.sets)
 	}
 }
 

--- a/pkg/secretmigration/secretmigration.go
+++ b/pkg/secretmigration/secretmigration.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package secretmigration performs the one-shot migration of plugin
+// credentials found in raw configuration (settings.yaml inline config and
+// per-plugin YAML config files) into the secret backend.
+//
+// It lives in its own package because two unrelated call paths need it: the
+// server boot path in cmd/, which migrates every registered plugin before
+// loading them, and the hub's runtime activation path, which migrates a single
+// plugin when an operator activates it from the admin UI. Both must run the
+// migration *before* config.ResolvePluginConfig strips secret keys, otherwise
+// the credential is dropped and never reaches the backend.
+package secretmigration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// MigratePluginSecrets performs a one-shot migration of the secret config keys
+// declared in config.PluginSecretKeyMap for pluginName into the secret backend.
+// Both sources of raw config are considered: the inline map from settings.yaml
+// and, when configFile is set, the per-plugin YAML file it points at.
+//
+// config.ResolvePluginConfig strips secret config keys (bot_token,
+// signing_key, ...) from *both* sources, so for both of them the credential
+// only reaches the plugin if it has been migrated first — the backend is the
+// authoritative store, and injectPluginSecretsIntoConfig fills the stripped key
+// back in from there. Migrating is therefore not a hygiene improvement; it is
+// what keeps a plugin able to start.
+//
+// When a secret key is present in both sources the config file value wins — see
+// migrationSource.
+//
+// Existing backend values are never overwritten: this seeds the backend, it does
+// not rotate it. That has a consequence worth knowing about. Once a key has been
+// migrated, editing it in settings.yaml or the config file has no effect at all,
+// because the raw value is stripped during resolution and the backend copy is
+// what the plugin receives. An operator who rotates the credential in YAML and
+// sees no change is hitting this; rotation must happen in the backend. The log
+// line below names the file the value was taken from so it can be cleaned up.
+//
+// Calling this is safe without external locking. The semantics are seed-only: a
+// key that already holds a value is left alone, and two writers racing an
+// unseeded key both derive their value from the same config, so either ordering
+// yields the same result. The Get-then-Set is a TOCTOU, but a benign one — the
+// worst outcome is a redundant backend version holding the same value. The boot
+// path still takes an advisory lock, to avoid replicas repeating the work rather
+// than for correctness; the runtime activation path calls this without one.
+//
+// A nil backend, an unknown plugin, and an unreadable config file are all no-ops
+// rather than errors — migration is best-effort and must never block plugin
+// startup or activation.
+func MigratePluginSecrets(ctx context.Context, sb secret.SecretBackend, pluginName string, inlineConfig map[string]string, configFile string) {
+	if sb == nil {
+		return
+	}
+
+	mappings, ok := config.PluginSecretKeyMap[pluginName]
+	if !ok {
+		return
+	}
+
+	fileConfig := loadConfigFile(pluginName, configFile)
+
+	hubID := sb.HubID()
+	for _, m := range mappings {
+		val, source := migrationSource(m.ConfigKey, inlineConfig, fileConfig, configFile)
+		if val == "" {
+			continue
+		}
+		existing, err := sb.Get(ctx, m.SecretKey, store.ScopeHub, hubID)
+		if err != nil && !errors.Is(err, store.ErrNotFound) {
+			slog.Warn("failed to check secret backend, skipping migration",
+				"config_key", m.ConfigKey, "plugin", pluginName, "error", err)
+			continue
+		}
+		if existing != nil && existing.Value != "" {
+			continue
+		}
+		if _, _, err := sb.Set(ctx, &secret.SetSecretInput{
+			Name:          m.SecretKey,
+			Value:         val,
+			SecretType:    secret.TypeVariable,
+			InjectionMode: "as_needed",
+			Scope:         store.ScopeHub,
+			ScopeID:       hubID,
+			// Only the file name goes into backend metadata — a full host path
+			// would leak the operator's username and directory layout.
+			Description: fmt.Sprintf("Auto-migrated from %s for plugin %s", filepath.Base(source), pluginName),
+		}); err != nil {
+			slog.Warn("failed to migrate secret to backend",
+				"config_key", m.ConfigKey, "plugin", pluginName, "error", err)
+			continue
+		}
+		// The log carries the full source path, unlike the description: an
+		// operator being told to clean up a file needs to know which one, and
+		// this goes to their own logs rather than into backend metadata. The
+		// path is printed as written in settings.yaml, so a relative or
+		// "~/"-prefixed form is shown unresolved.
+		slog.Info("migrated plugin secret to the secret backend — remove it from the source config",
+			"config_key", m.ConfigKey, "plugin", pluginName, "source", source)
+	}
+}
+
+// migrationSource picks which raw value to migrate for one secret config key,
+// and returns a label naming where it came from.
+//
+// The per-plugin config file wins over inline config. That is the opposite of
+// config.LoadPluginConfigFile's merge order, and deliberately so: when
+// config_file is set, config.ResolvePluginConfig ignores non-wiring inline keys
+// entirely and resolves the plugin from the file, so the file holds the
+// credential the plugin is actually running on. Migrating the inline value
+// instead would seed the backend with a different — possibly stale — credential
+// that the plugin would then run on, since the backend copy is what gets
+// injected once both raw copies are stripped.
+func migrationSource(configKey string, inlineConfig, fileConfig map[string]string, configFile string) (value, source string) {
+	if v := fileConfig[configKey]; v != "" {
+		return v, configFile
+	}
+	return inlineConfig[configKey], "settings.yaml"
+}
+
+// loadConfigFile reads the raw per-plugin YAML config file so
+// MigratePluginSecrets can see secrets that live only in that file. A missing
+// file yields an empty map; any load failure is logged and treated as empty so
+// migration still proceeds for inline config.
+func loadConfigFile(pluginName, configFile string) map[string]string {
+	if configFile == "" {
+		return nil
+	}
+	fileConfig, err := config.LoadPluginConfigFile(configFile, nil)
+	if err != nil {
+		slog.Warn("failed to read config file during secret migration, migrating inline config only",
+			"plugin", pluginName, "config_file", configFile, "error", err)
+		return nil
+	}
+	return fileConfig
+}

--- a/pkg/secretmigration/secretmigration_test.go
+++ b/pkg/secretmigration/secretmigration_test.go
@@ -1,0 +1,376 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secretmigration
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// fakeBackend is an in-memory secret.SecretBackend that records writes.
+type fakeBackend struct {
+	values  map[string]secret.SecretWithValue
+	sets    []secret.SetSecretInput
+	getErr  error // returned by Get for any key when non-nil
+	setErr  error // returned by Set when non-nil
+	getKeys []string
+}
+
+func newFakeBackend() *fakeBackend {
+	return &fakeBackend{values: make(map[string]secret.SecretWithValue)}
+}
+
+func (f *fakeBackend) seed(name, value string) {
+	f.values[name] = secret.SecretWithValue{
+		SecretMeta: secret.SecretMeta{Name: name},
+		Value:      value,
+	}
+}
+
+func (f *fakeBackend) Get(_ context.Context, name, _, _ string) (*secret.SecretWithValue, error) {
+	f.getKeys = append(f.getKeys, name)
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	sv, ok := f.values[name]
+	if !ok {
+		return nil, store.ErrNotFound
+	}
+	return &sv, nil
+}
+
+func (f *fakeBackend) Set(_ context.Context, in *secret.SetSecretInput) (bool, *secret.SecretMeta, error) {
+	if f.setErr != nil {
+		return false, nil, f.setErr
+	}
+	f.sets = append(f.sets, *in)
+	f.values[in.Name] = secret.SecretWithValue{
+		SecretMeta: secret.SecretMeta{Name: in.Name, Description: in.Description},
+		Value:      in.Value,
+	}
+	return true, nil, nil
+}
+
+func (f *fakeBackend) Delete(context.Context, string, string, string) error { return nil }
+
+func (f *fakeBackend) List(context.Context, secret.Filter) ([]secret.SecretMeta, error) {
+	return nil, nil
+}
+
+func (f *fakeBackend) GetMeta(context.Context, string, string, string) (*secret.SecretMeta, error) {
+	return nil, nil
+}
+
+func (f *fakeBackend) Resolve(context.Context, string, string, string, *secret.ResolveOpts) ([]secret.SecretWithValue, error) {
+	return nil, nil
+}
+
+func (f *fakeBackend) HubID() string { return "test-hub" }
+
+// writeConfigFile writes a per-plugin YAML config file and returns its path.
+func writeConfigFile(t *testing.T, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+	return path
+}
+
+// captureLog collects everything slog writes while fn runs. The default slog
+// handler routes through the standard logger, so redirecting that captures both.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(prev)
+	fn()
+	return buf.String()
+}
+
+func TestMigratePluginSecrets_InlineSecretMigrated(t *testing.T) {
+	sb := newFakeBackend()
+
+	MigratePluginSecrets(context.Background(), sb, "telegram",
+		map[string]string{"bot_token": "inline-token", "mode": "plugin"}, "")
+
+	got, ok := sb.values[config.SecretTelegramBotToken]
+	if !ok {
+		t.Fatalf("expected %s to be written to the backend, got keys %v",
+			config.SecretTelegramBotToken, sb.values)
+	}
+	if got.Value != "inline-token" {
+		t.Errorf("migrated value = %q, want %q", got.Value, "inline-token")
+	}
+	if len(sb.sets) != 1 {
+		t.Fatalf("expected exactly 1 Set call, got %d", len(sb.sets))
+	}
+	in := sb.sets[0]
+	if in.Scope != store.ScopeHub || in.ScopeID != "test-hub" {
+		t.Errorf("secret written to scope %q/%q, want %q/%q", in.Scope, in.ScopeID, store.ScopeHub, "test-hub")
+	}
+	if in.SecretType != secret.TypeVariable {
+		t.Errorf("SecretType = %q, want %q", in.SecretType, secret.TypeVariable)
+	}
+	if !strings.Contains(in.Description, "settings.yaml") {
+		t.Errorf("Description = %q, want it to name the inline source", in.Description)
+	}
+}
+
+func TestMigratePluginSecrets_ConfigFileSecretMigrated(t *testing.T) {
+	sb := newFakeBackend()
+	configFile := writeConfigFile(t, "scion-telegram.yaml", "bot_token: file-token\nchat_id: \"42\"\n")
+
+	MigratePluginSecrets(context.Background(), sb, "telegram", nil, configFile)
+
+	got, ok := sb.values[config.SecretTelegramBotToken]
+	if !ok {
+		t.Fatalf("expected %s to be written to the backend", config.SecretTelegramBotToken)
+	}
+	if got.Value != "file-token" {
+		t.Errorf("migrated value = %q, want %q", got.Value, "file-token")
+	}
+	if !strings.Contains(sb.sets[0].Description, "scion-telegram.yaml") {
+		t.Errorf("Description = %q, want it to name the source file", sb.sets[0].Description)
+	}
+	// The description must not leak the operator's home directory layout.
+	if strings.Contains(sb.sets[0].Description, string(filepath.Separator)) {
+		t.Errorf("Description = %q, want base name only, not a host path", sb.sets[0].Description)
+	}
+}
+
+// The two sinks have opposite requirements: the operator-facing log must name
+// the full path so the file can be found, while the persisted backend
+// description must not, because it would leak the operator's username and
+// directory layout to anyone who can read secret metadata.
+func TestMigratePluginSecrets_LogsFullPathButDescriptionOmitsIt(t *testing.T) {
+	sb := newFakeBackend()
+	configFile := writeConfigFile(t, "scion-telegram.yaml", "bot_token: \"file-token\"\n")
+
+	out := captureLog(t, func() {
+		MigratePluginSecrets(context.Background(), sb, "telegram", nil, configFile)
+	})
+
+	if !strings.Contains(out, configFile) {
+		t.Errorf("expected the migration log to name the full path %q, got: %q", configFile, out)
+	}
+	desc := sb.sets[0].Description
+	if !strings.Contains(desc, "scion-telegram.yaml") {
+		t.Errorf("Description = %q, want it to name the config file", desc)
+	}
+	if strings.Contains(desc, filepath.Dir(configFile)) {
+		t.Errorf("Description = %q, must not contain the host path %q", desc, filepath.Dir(configFile))
+	}
+}
+
+func TestMigratePluginSecrets_ConfigFileWinsOverInline(t *testing.T) {
+	// When config_file is set, ResolvePluginConfig drops secret keys from
+	// inline config and the plugin runs on the file's value — so the file's
+	// value is what must reach the backend.
+	sb := newFakeBackend()
+	configFile := writeConfigFile(t, "scion-telegram.yaml", "bot_token: file-token\n")
+
+	MigratePluginSecrets(context.Background(), sb, "telegram",
+		map[string]string{"bot_token": "inline-token"}, configFile)
+
+	if got := sb.values[config.SecretTelegramBotToken].Value; got != "file-token" {
+		t.Errorf("migrated value = %q, want the config file value %q", got, "file-token")
+	}
+}
+
+func TestMigratePluginSecrets_EmptyFileValueFallsBackToInline(t *testing.T) {
+	sb := newFakeBackend()
+	configFile := writeConfigFile(t, "scion-telegram.yaml", "bot_token: \"\"\nchat_id: \"42\"\n")
+
+	MigratePluginSecrets(context.Background(), sb, "telegram",
+		map[string]string{"bot_token": "inline-token"}, configFile)
+
+	if got := sb.values[config.SecretTelegramBotToken].Value; got != "inline-token" {
+		t.Errorf("migrated value = %q, want the inline value %q", got, "inline-token")
+	}
+}
+
+func TestMigratePluginSecrets_AlreadyMigratedNotOverwritten(t *testing.T) {
+	sb := newFakeBackend()
+	sb.seed(config.SecretTelegramBotToken, "backend-token")
+
+	MigratePluginSecrets(context.Background(), sb, "telegram",
+		map[string]string{"bot_token": "inline-token"}, "")
+
+	if len(sb.sets) != 0 {
+		t.Errorf("expected no writes when the secret already exists, got %+v", sb.sets)
+	}
+	if got := sb.values[config.SecretTelegramBotToken].Value; got != "backend-token" {
+		t.Errorf("backend value = %q, want the existing %q to be preserved", got, "backend-token")
+	}
+}
+
+func TestMigratePluginSecrets_EmptyBackendValueIsMigrated(t *testing.T) {
+	// A secret that exists but holds an empty value is not a real credential;
+	// migration should fill it.
+	sb := newFakeBackend()
+	sb.seed(config.SecretTelegramBotToken, "")
+
+	MigratePluginSecrets(context.Background(), sb, "telegram",
+		map[string]string{"bot_token": "inline-token"}, "")
+
+	if got := sb.values[config.SecretTelegramBotToken].Value; got != "inline-token" {
+		t.Errorf("backend value = %q, want %q", got, "inline-token")
+	}
+}
+
+func TestMigratePluginSecrets_NilBackendIsNoOp(t *testing.T) {
+	// Must not panic when no secret backend is configured.
+	MigratePluginSecrets(context.Background(), nil, "telegram",
+		map[string]string{"bot_token": "inline-token"}, "")
+}
+
+func TestMigratePluginSecrets_UnknownPluginIsNoOp(t *testing.T) {
+	sb := newFakeBackend()
+
+	MigratePluginSecrets(context.Background(), sb, "not-a-known-plugin",
+		map[string]string{"bot_token": "inline-token"}, "")
+
+	if len(sb.sets) != 0 {
+		t.Errorf("expected no writes for an unknown plugin, got %+v", sb.sets)
+	}
+	if len(sb.getKeys) != 0 {
+		t.Errorf("expected the backend not to be consulted, got Gets for %v", sb.getKeys)
+	}
+}
+
+func TestMigratePluginSecrets_NoSecretsInConfigIsNoOp(t *testing.T) {
+	sb := newFakeBackend()
+
+	MigratePluginSecrets(context.Background(), sb, "telegram",
+		map[string]string{"mode": "plugin", "path": "./telegram"}, "")
+
+	if len(sb.sets) != 0 {
+		t.Errorf("expected no writes when config holds no secrets, got %+v", sb.sets)
+	}
+}
+
+func TestMigratePluginSecrets_MissingConfigFileStillMigratesInline(t *testing.T) {
+	sb := newFakeBackend()
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+
+	MigratePluginSecrets(context.Background(), sb, "telegram",
+		map[string]string{"bot_token": "inline-token"}, missing)
+
+	if got := sb.values[config.SecretTelegramBotToken].Value; got != "inline-token" {
+		t.Errorf("migrated value = %q, want %q", got, "inline-token")
+	}
+}
+
+func TestMigratePluginSecrets_MalformedConfigFileStillMigratesInline(t *testing.T) {
+	sb := newFakeBackend()
+	// bot_token appears only in the file and webhook_secret only inline: if the
+	// file parsed, bot_token would migrate too.
+	configFile := writeConfigFile(t, "scion-telegram.yaml",
+		"bot_token: \"file-token\"\nwebhook_secret: [unterminated\n")
+
+	out := captureLog(t, func() {
+		MigratePluginSecrets(context.Background(), sb, "telegram",
+			map[string]string{"webhook_secret": "inline-secret"}, configFile)
+	})
+
+	if got := sb.values[config.SecretTelegramWebhookKey].Value; got != "inline-secret" {
+		t.Errorf("migrated value = %q, want the inline fallback %q", got, "inline-secret")
+	}
+	if _, ok := sb.values[config.SecretTelegramBotToken]; ok {
+		t.Errorf("an unparseable config file must yield no file values, got %q",
+			sb.values[config.SecretTelegramBotToken].Value)
+	}
+	if !strings.Contains(out, "failed to read config file") {
+		t.Errorf("expected a warning about the unreadable config file, got log: %q", out)
+	}
+	// The operator needs the path to know which file to fix, so the warning
+	// carries the full path even though the backend description does not.
+	if !strings.Contains(out, configFile) {
+		t.Errorf("expected the warning to name the full config file path %q, got log: %q", configFile, out)
+	}
+}
+
+func TestMigratePluginSecrets_BackendKeyNameInFileIsNotASource(t *testing.T) {
+	// TELEGRAM_BOT_TOKEN is the backend key name, not a plugin config key.
+	// LoadPluginConfigFile strips it, so it must not act as a migration source.
+	sb := newFakeBackend()
+	configFile := writeConfigFile(t, "scion-telegram.yaml", "TELEGRAM_BOT_TOKEN: file-token\n")
+
+	MigratePluginSecrets(context.Background(), sb, "telegram", nil, configFile)
+
+	if len(sb.sets) != 0 {
+		t.Errorf("expected no writes for a backend-style key, got %+v", sb.sets)
+	}
+}
+
+func TestMigratePluginSecrets_GetErrorSkipsWrite(t *testing.T) {
+	// A backend that cannot be read must not be overwritten blindly — the
+	// existing value is unknown and could be clobbered.
+	sb := newFakeBackend()
+	sb.getErr = errors.New("backend unavailable")
+
+	MigratePluginSecrets(context.Background(), sb, "telegram",
+		map[string]string{"bot_token": "inline-token"}, "")
+
+	if len(sb.sets) != 0 {
+		t.Errorf("expected no writes when the backend read fails, got %+v", sb.sets)
+	}
+}
+
+func TestMigratePluginSecrets_SetErrorDoesNotStopRemainingKeys(t *testing.T) {
+	sb := newFakeBackend()
+	sb.setErr = errors.New("write rejected")
+
+	// Both telegram keys are present; a failure on the first must not abort
+	// the second. Neither is stored, but both must have been attempted.
+	MigratePluginSecrets(context.Background(), sb, "telegram",
+		map[string]string{"bot_token": "t", "webhook_secret": "w"}, "")
+
+	if len(sb.getKeys) != 2 {
+		t.Errorf("expected both mapped keys to be attempted, got Gets for %v", sb.getKeys)
+	}
+}
+
+func TestMigratePluginSecrets_MultipleKeysForPlugin(t *testing.T) {
+	sb := newFakeBackend()
+
+	MigratePluginSecrets(context.Background(), sb, "slack", map[string]string{
+		"bot_token":      "xoxb-1",
+		"app_token":      "xapp-1",
+		"signing_secret": "sign-1",
+	}, "")
+
+	for key, want := range map[string]string{
+		config.SecretSlackBotToken:      "xoxb-1",
+		config.SecretSlackAppToken:      "xapp-1",
+		config.SecretSlackSigningSecret: "sign-1",
+	} {
+		if got := sb.values[key].Value; got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+}

--- a/pkg/secretmigration/secretmigration_test.go
+++ b/pkg/secretmigration/secretmigration_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -99,14 +100,35 @@ func writeConfigFile(t *testing.T, name, contents string) string {
 	return path
 }
 
-// captureLog collects everything slog writes while fn runs. The default slog
-// handler routes through the standard logger, so redirecting that captures both.
+// captureLog collects everything the code under test logs while fn runs, via
+// either slog or the standard logger.
+//
+// Redirecting slog explicitly rather than relying on its default handler
+// routing through the standard logger means the capture keeps working if this
+// package's logging is reconfigured. Note the format that implies: assertions
+// see slog's text form (`level=WARN msg="..." key=value`), not the standard
+// logger's.
+//
+// slog.SetDefault has the side effect of rewiring the standard logger's output
+// and clearing its flags, so all three are snapshotted and restored together —
+// restoring them in the wrong order leaves log.Flags() at 0 for the rest of the
+// run. This mutates process-global state, so callers must not use t.Parallel.
 func captureLog(t *testing.T, fn func()) string {
 	t.Helper()
 	var buf bytes.Buffer
-	prev := log.Writer()
+
+	prevDefault := slog.Default()
+	prevWriter := log.Writer()
+	prevFlags := log.Flags()
+	defer func() {
+		slog.SetDefault(prevDefault)
+		log.SetOutput(prevWriter)
+		log.SetFlags(prevFlags)
+	}()
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
 	log.SetOutput(&buf)
-	defer log.SetOutput(prev)
+
 	fn()
 	return buf.String()
 }
@@ -306,6 +328,12 @@ func TestMigratePluginSecrets_MalformedConfigFileStillMigratesInline(t *testing.
 	}
 	if !strings.Contains(out, "failed to read config file") {
 		t.Errorf("expected a warning about the unreadable config file, got log: %q", out)
+	}
+	// `level=WARN` is the slog text handler's form and is absent from the
+	// standard logger's, so this also proves captureLog's slog redirection is
+	// what caught the line rather than the default routing happening to work.
+	if !strings.Contains(out, "level=WARN") {
+		t.Errorf("expected the line to be logged at WARN via slog, got log: %q", out)
 	}
 	// The operator needs the path to know which file to fix, so the warning
 	// carries the full path even though the backend description does not.


### PR DESCRIPTION
## Problem

The boot-time plugin startup path calls MigratePluginSecrets before ResolvePluginConfig,
so secrets are copied to the backend before stripping removes them from config maps.
The runtime activation path (activateInstalledIntegration) calls ResolvePluginConfig
directly without migrating first.

After upstream #1183, this gap widened from inline-only to file-config too.

## Fix

New pkg/secretmigration package. Both boot and activation paths call it.

## Tests

Bug-pinning + unit + read-only guards. All clean.