### PR TITLE
fix: prevent admin_emails from overriding UI-promoted user roles

### DIFF
--- a/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
+++ b/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
@@ -116,7 +116,7 @@ Provisioning in proxy mode works identically to OAuth — lazy, allow-list-gated
 - **`open`**: any verified email is allowed.
 - **`domain_restricted`**: email domain must be in `authorized_domains`.
 - **`invite_only`**: email must be pre-registered (via admin invite-code flow).
-- Emails in `admin_emails` are always allowed and auto-promoted to admin role.
+- Emails in `admin_emails` are always allowed and auto-promoted to admin role. The list only promotes: removing an email from it does not demote a user who is already an admin — use the admin UI to demote.
 - If not permitted, the request returns **403**.
 - Suspended users are rejected even though IAP authenticates them upstream.
 

--- a/docs-site/src/content/docs/reference/server-config.md
+++ b/docs-site/src/content/docs/reference/server-config.md
@@ -59,7 +59,7 @@ Controls the central Hub API server.
 | `gcp_iam_deny_unknown_policy` | string | `"fail-open"` | Behavior when Policy Troubleshooter cannot evaluate deny policies (e.g. if the Hub lacks org-level reviewer roles). Supported values: `"fail-open"` (allow if no explicit deny is found; default) or `"fail-closed"` (treat as indeterminate and deny). |
 | `read_timeout` | duration | `"30s"` | HTTP read timeout. |
 | `write_timeout` | duration | `"60s"` | HTTP write timeout. |
-| `admin_emails` | list | `[]` | List of emails granted super-admin access. Additive only: listed users are promoted to admin on login, but the list never demotes a user who holds admin in the database (e.g. promoted from the admin UI). Demotion is an explicit admin action. |
+| `admin_emails` | list | `[]` | List of emails granted super-admin access. Additive only: listed users are promoted to admin on login, but the list never demotes or rewrites a role already stored in the database (e.g. `admin` or `viewer` set from the admin UI). Changing a role is an explicit admin action. |
 | `soft_delete_retention` | duration | | Duration to retain soft-deleted agents (e.g., `"72h"`). |
 | `soft_delete_retain_files` | bool | `false` | Preserve workspace files during the soft-delete period. |
 | `cors` | object | | CORS configuration (see below). |

--- a/docs-site/src/content/docs/reference/server-config.md
+++ b/docs-site/src/content/docs/reference/server-config.md
@@ -59,7 +59,7 @@ Controls the central Hub API server.
 | `gcp_iam_deny_unknown_policy` | string | `"fail-open"` | Behavior when Policy Troubleshooter cannot evaluate deny policies (e.g. if the Hub lacks org-level reviewer roles). Supported values: `"fail-open"` (allow if no explicit deny is found; default) or `"fail-closed"` (treat as indeterminate and deny). |
 | `read_timeout` | duration | `"30s"` | HTTP read timeout. |
 | `write_timeout` | duration | `"60s"` | HTTP write timeout. |
-| `admin_emails` | list | `[]` | List of emails granted super-admin access. |
+| `admin_emails` | list | `[]` | List of emails granted super-admin access. Additive only: listed users are promoted to admin on login, but the list never demotes a user who holds admin in the database (e.g. promoted from the admin UI). Demotion is an explicit admin action. |
 | `soft_delete_retention` | duration | | Duration to retain soft-deleted agents (e.g., `"72h"`). |
 | `soft_delete_retain_files` | bool | `false` | Preserve workspace files during the soft-delete period. |
 | `cors` | object | | CORS configuration (see below). |

--- a/pkg/hub/attachments_agent_test.go
+++ b/pkg/hub/attachments_agent_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_sqlite
+
 package hub
 
 import (

--- a/pkg/hub/attachments_dm_test.go
+++ b/pkg/hub/attachments_dm_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_sqlite
+
 package hub
 
 import (

--- a/pkg/hub/attachments_staging_test.go
+++ b/pkg/hub/attachments_staging_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_sqlite
+
 package hub
 
 import (

--- a/pkg/hub/auth_test.go
+++ b/pkg/hub/auth_test.go
@@ -645,6 +645,29 @@ func TestDetermineUserRole(t *testing.T) {
 			currentRole: "admin",
 			expected:    "admin",
 		},
+		{
+			// Regression: config must not rewrite a UI-set viewer to member.
+			name:        "viewer is preserved",
+			email:       "viewer@example.com",
+			adminEmails: []string{"admin@example.com"},
+			currentRole: "viewer",
+			expected:    "viewer",
+		},
+		{
+			name:        "viewer with empty admin emails is preserved",
+			email:       "viewer@example.com",
+			adminEmails: nil,
+			currentRole: "viewer",
+			expected:    "viewer",
+		},
+		{
+			// Config always promotes, even over an established role.
+			name:        "viewer in admin emails is promoted to admin",
+			email:       "viewer@example.com",
+			adminEmails: []string{"viewer@example.com"},
+			currentRole: "viewer",
+			expected:    "admin",
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/hub/auth_test.go
+++ b/pkg/hub/auth_test.go
@@ -586,3 +586,74 @@ func TestIsEmailAuthorized(t *testing.T) {
 		})
 	}
 }
+
+func TestDetermineUserRole(t *testing.T) {
+	tests := []struct {
+		name        string
+		email       string
+		adminEmails []string
+		currentRole string
+		expected    string
+	}{
+		{
+			name:        "in admin emails is admin",
+			email:       "admin@example.com",
+			adminEmails: []string{"admin@example.com"},
+			currentRole: "member",
+			expected:    "admin",
+		},
+		{
+			name:        "in admin emails promotes new user",
+			email:       "admin@example.com",
+			adminEmails: []string{"admin@example.com"},
+			currentRole: "",
+			expected:    "admin",
+		},
+		{
+			name:        "admin emails match is case insensitive",
+			email:       "Admin@Example.com",
+			adminEmails: []string{"admin@example.com"},
+			currentRole: "",
+			expected:    "admin",
+		},
+		{
+			name:        "not in admin emails and member stays member",
+			email:       "user@example.com",
+			adminEmails: []string{"admin@example.com"},
+			currentRole: "member",
+			expected:    "member",
+		},
+		{
+			name:        "new user with no admin emails is member",
+			email:       "user@example.com",
+			adminEmails: nil,
+			currentRole: "",
+			expected:    "member",
+		},
+		{
+			// Regression: config must never demote a UI-promoted admin.
+			name:        "not in admin emails but already admin stays admin",
+			email:       "ui-admin@example.com",
+			adminEmails: []string{"admin@example.com"},
+			currentRole: "admin",
+			expected:    "admin",
+		},
+		{
+			name:        "already admin with empty admin emails stays admin",
+			email:       "ui-admin@example.com",
+			adminEmails: nil,
+			currentRole: "admin",
+			expected:    "admin",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := determineUserRole(tc.email, tc.adminEmails, tc.currentRole)
+			if got != tc.expected {
+				t.Errorf("determineUserRole(%q, %v, %q) = %q, expected %q",
+					tc.email, tc.adminEmails, tc.currentRole, got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/hub/events.go
+++ b/pkg/hub/events.go
@@ -87,8 +87,8 @@ func (noopEventPublisher) PublishDispatchDone(_ context.Context, _ string)      
 func (noopEventPublisher) PublishChatTopicEvent(_ context.Context, _ string, _ string, _ WebChatTopic) {
 }
 func (noopEventPublisher) PublishChatReadStateEvent(_ context.Context, _, _, _ string) {}
-func (noopEventPublisher) PublishRaw(_ string, _ interface{}) {}
-func (noopEventPublisher) Close()                             {}
+func (noopEventPublisher) PublishRaw(_ string, _ interface{})                          {}
+func (noopEventPublisher) Close()                                                      {}
 
 // Subscribe on the no-op publisher returns a nil channel (which blocks forever
 // on receive) and a no-op unsubscribe. Callers that need real subscriptions

--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -476,7 +476,7 @@ func (s *Server) handleAuthRefresh(w http.ResponseWriter, r *http.Request) {
 				"email", claims.Email, "error", err)
 		}
 	}
-	if user != nil && user.Status == "suspended" {
+	if user != nil && user.Status == store.UserStatusSuspended {
 		slog.Warn("Refresh rejected: user is suspended", "email", claims.Email, "user_id", user.ID)
 		writeError(w, http.StatusForbidden, ErrCodeForbidden,
 			"user account is suspended", nil)
@@ -492,8 +492,15 @@ func (s *Server) handleAuthRefresh(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Prefer the freshly-read user's ID: on delete-and-recreate of the same
+	// email, the token's ID refers to the dead record.
+	userID := claims.UserID
+	if user != nil {
+		userID = user.ID
+	}
+
 	accessToken, refreshToken, expiresIn, err := s.userTokenService.GenerateTokenPair(
-		claims.UserID, claims.Email, claims.DisplayName, role, claims.ClientType,
+		userID, claims.Email, claims.DisplayName, role, claims.ClientType,
 	)
 	if err != nil {
 		InternalError(w)

--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -488,7 +488,10 @@ func (s *Server) handleAuthRefresh(w http.ResponseWriter, r *http.Request) {
 		// Persist the role change
 		if user != nil && user.Role != role {
 			user.Role = role
-			_ = s.store.UpdateUser(r.Context(), user)
+			if err := s.store.UpdateUser(r.Context(), user); err != nil {
+				slog.Error("Failed to persist role change on token refresh",
+					"email", claims.Email, "error", err)
+			}
 		}
 	}
 

--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -451,16 +451,38 @@ func (s *Server) handleAuthRefresh(w http.ResponseWriter, r *http.Request) {
 
 	// Re-evaluate admin status on token refresh. The stored role is the source
 	// of truth for UI-granted promotions; admin_emails can only add to it.
+	//
+	// storedRole deliberately starts empty rather than at claims.Role: if the
+	// store cannot be read we fall back to config-only evaluation instead of
+	// trusting the token's own role claim, which would let a stale admin claim
+	// renew itself indefinitely through the rotating refresh chain.
 	role := claims.Role
-	currentRole := role
+	storedRole := ""
 	var user *store.User
 	if s.store != nil {
-		if u, err := s.store.GetUserByEmail(r.Context(), claims.Email); err == nil {
+		u, err := s.store.GetUserByEmail(r.Context(), claims.Email)
+		switch {
+		case err == nil:
 			user = u
-			currentRole = u.Role
+			storedRole = u.Role
+		case errors.Is(err, store.ErrNotFound):
+			// The user no longer exists — refuse to mint a new token pair.
+			slog.Warn("Refresh rejected: user no longer exists", "email", claims.Email)
+			writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized,
+				"invalid refresh token", nil)
+			return
+		default:
+			slog.Warn("Refresh: user lookup failed, falling back to config-only role",
+				"email", claims.Email, "error", err)
 		}
 	}
-	if newRole := s.getUserRole(claims.Email, currentRole); role != newRole {
+	if user != nil && user.Status == "suspended" {
+		slog.Warn("Refresh rejected: user is suspended", "email", claims.Email, "user_id", user.ID)
+		writeError(w, http.StatusForbidden, ErrCodeForbidden,
+			"user account is suspended", nil)
+		return
+	}
+	if newRole := s.getUserRole(claims.Email, storedRole); role != newRole {
 		slog.Info("User role changed on token refresh", "email", claims.Email, "old_role", role, "new_role", newRole)
 		role = newRole
 		// Persist the role change
@@ -1399,10 +1421,11 @@ func isEmailAuthorized(email string, authorizedDomains []string, adminEmails []s
 // role they currently hold.
 //
 // The adminEmails config list is additive-only: it acts as a floor, not a
-// ceiling. A user is "admin" if their email is in adminEmails OR if they are
-// already an admin (for example, promoted through the admin UI). Config can
-// therefore promote a user, but it never demotes one — demotion is an explicit
-// admin action through the UI/API.
+// ceiling. A user is "admin" if their email is in adminEmails, so config always
+// promotes. Otherwise any role the user already holds is preserved verbatim —
+// including "viewer" and any role added in future — so config never demotes or
+// rewrites a role set through the admin UI/API. Only a user with no stored role
+// (that is, one that does not exist yet) defaults to "member".
 //
 // currentRole is the user's role as stored in the database; pass "" for a user
 // that does not exist yet.
@@ -1413,8 +1436,8 @@ func determineUserRole(email string, adminEmails []string, currentRole string) s
 			return "admin"
 		}
 	}
-	if currentRole == "admin" {
-		return "admin"
+	if currentRole != "" {
+		return currentRole
 	}
 	return "member"
 }

--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -449,13 +449,22 @@ func (s *Server) handleAuthRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Re-evaluate admin status on token refresh
+	// Re-evaluate admin status on token refresh. The stored role is the source
+	// of truth for UI-granted promotions; admin_emails can only add to it.
 	role := claims.Role
-	if newRole := s.getUserRole(claims.Email); role != newRole {
+	currentRole := role
+	var user *store.User
+	if s.store != nil {
+		if u, err := s.store.GetUserByEmail(r.Context(), claims.Email); err == nil {
+			user = u
+			currentRole = u.Role
+		}
+	}
+	if newRole := s.getUserRole(claims.Email, currentRole); role != newRole {
 		slog.Info("User role changed on token refresh", "email", claims.Email, "old_role", role, "new_role", newRole)
 		role = newRole
 		// Persist the role change
-		if user, err := s.store.GetUserByEmail(r.Context(), claims.Email); err == nil && user.Role != role {
+		if user != nil && user.Role != role {
 			user.Role = role
 			_ = s.store.UpdateUser(r.Context(), user)
 		}
@@ -1210,7 +1219,7 @@ func (s *Server) provisionUser(ctx context.Context, info *ExternalUserInfo) (*st
 			Email:       info.Email,
 			DisplayName: info.DisplayName,
 			AvatarURL:   info.AvatarURL,
-			Role:        s.getUserRole(info.Email),
+			Role:        s.getUserRole(info.Email, ""),
 			Status:      "active",
 			Created:     time.Now(),
 			LastLogin:   time.Now(),
@@ -1236,7 +1245,7 @@ func (s *Server) provisionUser(ctx context.Context, info *ExternalUserInfo) (*st
 				user.AvatarURL = info.AvatarURL
 			}
 			user.LastLogin = time.Now()
-			user.Role = s.getUserRole(info.Email)
+			user.Role = s.getUserRole(info.Email, user.Role)
 			LogInviteAudit(ctx, s.auditLogger, InviteAuditUserActivated, info.Email, "", user.ID, info.Email, nil)
 		} else {
 			// Update last login and backfill profile
@@ -1248,7 +1257,7 @@ func (s *Server) provisionUser(ctx context.Context, info *ExternalUserInfo) (*st
 				user.DisplayName = info.DisplayName
 			}
 			// Re-evaluate admin status on every login
-			if newRole := s.getUserRole(info.Email); user.Role != newRole {
+			if newRole := s.getUserRole(info.Email, user.Role); user.Role != newRole {
 				slog.Info("User role changed on login", "email", info.Email, "old_role", user.Role, "new_role", newRole)
 				user.Role = newRole
 			}
@@ -1386,21 +1395,33 @@ func isEmailAuthorized(email string, authorizedDomains []string, adminEmails []s
 	return false
 }
 
-// determineUserRole returns the role for a user based on their email.
-// Returns "admin" if the email is in the adminEmails list, otherwise "member".
-func determineUserRole(email string, adminEmails []string) string {
+// determineUserRole returns the role for a user based on their email and the
+// role they currently hold.
+//
+// The adminEmails config list is additive-only: it acts as a floor, not a
+// ceiling. A user is "admin" if their email is in adminEmails OR if they are
+// already an admin (for example, promoted through the admin UI). Config can
+// therefore promote a user, but it never demotes one — demotion is an explicit
+// admin action through the UI/API.
+//
+// currentRole is the user's role as stored in the database; pass "" for a user
+// that does not exist yet.
+func determineUserRole(email string, adminEmails []string, currentRole string) string {
 	emailLower := strings.ToLower(email)
 	for _, adminEmail := range adminEmails {
 		if strings.ToLower(adminEmail) == emailLower {
 			return "admin"
 		}
 	}
+	if currentRole == "admin" {
+		return "admin"
+	}
 	return "member"
 }
 
 // (s *Server) getUserRole is a convenience method to determine role using server config.
-func (s *Server) getUserRole(email string) string {
-	return determineUserRole(email, s.config.AdminEmails)
+func (s *Server) getUserRole(email, currentRole string) string {
+	return determineUserRole(email, s.config.AdminEmails, currentRole)
 }
 
 // handleInviteRedeem handles POST /api/v1/auth/invite/redeem.

--- a/pkg/hub/handlers_auth_test.go
+++ b/pkg/hub/handlers_auth_test.go
@@ -448,6 +448,54 @@ func TestAuthRefreshRoleReevaluation(t *testing.T) {
 			t.Fatalf("expected status 403 for suspended user, got %d: %s", rec.Code, rec.Body.String())
 		}
 	})
+
+	t.Run("store error degrades to config-only role", func(t *testing.T) {
+		// A transient store failure must not let the token's own role claim
+		// stand in for the stored role: the refresh chain rotates, so trusting
+		// claims.Role here would let a stale admin renew itself indefinitely.
+		// The handler falls back to config-only evaluation instead.
+		srv, s := testServer(t)
+		ctx := context.Background()
+
+		user := &store.User{
+			ID:      tid("user_store_error"),
+			Email:   "store-error@example.com",
+			Role:    "admin",
+			Status:  "active",
+			Created: time.Now(),
+		}
+		if err := s.CreateUser(ctx, user); err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+		srv.config.AdminEmails = nil
+
+		// Token carries the admin role the user currently holds in the store.
+		_, refreshToken, _, err := srv.userTokenService.GenerateTokenPair(
+			user.ID, user.Email, user.DisplayName, "admin", ClientTypeWeb,
+		)
+		if err != nil {
+			t.Fatalf("failed to generate tokens: %v", err)
+		}
+
+		// The lookup now fails for a reason other than "not found" — a DB blip
+		// rather than an offboarded user.
+		srv.store = &failingUserLookupStore{Store: s, err: errors.New("database is locked")}
+
+		if role := refresh(t, srv, refreshToken); role != "member" {
+			t.Errorf("expected refreshed token role 'member' (config-only fallback), got %q", role)
+		}
+	})
+}
+
+// failingUserLookupStore wraps a store and makes the by-email user lookup fail
+// with a non-ErrNotFound error, simulating a transient database failure.
+type failingUserLookupStore struct {
+	store.Store
+	err error
+}
+
+func (f *failingUserLookupStore) GetUserByEmail(context.Context, string) (*store.User, error) {
+	return nil, f.err
 }
 
 func TestAuthValidate(t *testing.T) {

--- a/pkg/hub/handlers_auth_test.go
+++ b/pkg/hub/handlers_auth_test.go
@@ -201,6 +201,138 @@ func TestAuthMe(t *testing.T) {
 	}
 }
 
+// TestAuthRefreshRoleReevaluation covers the role re-evaluation that happens on
+// every token refresh. The admin_emails config is additive-only: it promotes,
+// but it never demotes a user who holds admin in the store.
+func TestAuthRefreshRoleReevaluation(t *testing.T) {
+	refresh := func(t *testing.T, srv *Server, refreshToken string) string {
+		t.Helper()
+		rec := doRequest(t, srv, http.MethodPost, "/api/v1/auth/refresh",
+			AuthRefreshRequest{RefreshToken: refreshToken})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp AuthRefreshResponse
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+		claims, err := srv.userTokenService.ValidateUserToken(resp.AccessToken)
+		if err != nil {
+			t.Fatalf("failed to validate refreshed access token: %v", err)
+		}
+		return claims.Role
+	}
+
+	t.Run("UI-promoted admin keeps admin role", func(t *testing.T) {
+		srv, s := testServer(t)
+		ctx := context.Background()
+
+		// User is admin in the store (promoted via the admin UI) but is not
+		// listed in admin_emails.
+		user := &store.User{
+			ID:      tid("user_ui_admin"),
+			Email:   "ui-admin@example.com",
+			Role:    "admin",
+			Status:  "active",
+			Created: time.Now(),
+		}
+		if err := s.CreateUser(ctx, user); err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+		srv.config.AdminEmails = nil
+
+		_, refreshToken, _, err := srv.userTokenService.GenerateTokenPair(
+			user.ID, user.Email, user.DisplayName, user.Role, ClientTypeWeb,
+		)
+		if err != nil {
+			t.Fatalf("failed to generate tokens: %v", err)
+		}
+
+		if role := refresh(t, srv, refreshToken); role != "admin" {
+			t.Errorf("expected refreshed token role 'admin', got %q", role)
+		}
+
+		stored, err := s.GetUserByEmail(ctx, user.Email)
+		if err != nil {
+			t.Fatalf("user not found: %v", err)
+		}
+		if stored.Role != "admin" {
+			t.Errorf("expected stored role 'admin', got %q", stored.Role)
+		}
+	})
+
+	t.Run("admin emails promotes member on refresh", func(t *testing.T) {
+		srv, s := testServer(t)
+		ctx := context.Background()
+
+		user := &store.User{
+			ID:      tid("user_promoted"),
+			Email:   "promoted@example.com",
+			Role:    "member",
+			Status:  "active",
+			Created: time.Now(),
+		}
+		if err := s.CreateUser(ctx, user); err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+		srv.config.AdminEmails = []string{"promoted@example.com"}
+
+		_, refreshToken, _, err := srv.userTokenService.GenerateTokenPair(
+			user.ID, user.Email, user.DisplayName, user.Role, ClientTypeWeb,
+		)
+		if err != nil {
+			t.Fatalf("failed to generate tokens: %v", err)
+		}
+
+		if role := refresh(t, srv, refreshToken); role != "admin" {
+			t.Errorf("expected refreshed token role 'admin', got %q", role)
+		}
+
+		stored, err := s.GetUserByEmail(ctx, user.Email)
+		if err != nil {
+			t.Fatalf("user not found: %v", err)
+		}
+		if stored.Role != "admin" {
+			t.Errorf("expected stored role 'admin', got %q", stored.Role)
+		}
+	})
+
+	t.Run("UI demotion is reflected in refreshed token", func(t *testing.T) {
+		srv, s := testServer(t)
+		ctx := context.Background()
+
+		user := &store.User{
+			ID:      tid("user_demoted"),
+			Email:   "demoted@example.com",
+			Role:    "admin",
+			Status:  "active",
+			Created: time.Now(),
+		}
+		if err := s.CreateUser(ctx, user); err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+		srv.config.AdminEmails = nil
+
+		// Token still carries the stale "admin" role.
+		_, refreshToken, _, err := srv.userTokenService.GenerateTokenPair(
+			user.ID, user.Email, user.DisplayName, "admin", ClientTypeWeb,
+		)
+		if err != nil {
+			t.Fatalf("failed to generate tokens: %v", err)
+		}
+
+		// Explicit demotion through the admin UI/API.
+		user.Role = "member"
+		if err := s.UpdateUser(ctx, user); err != nil {
+			t.Fatalf("failed to demote user: %v", err)
+		}
+
+		if role := refresh(t, srv, refreshToken); role != "member" {
+			t.Errorf("expected refreshed token role 'member', got %q", role)
+		}
+	})
+}
+
 func TestAuthValidate(t *testing.T) {
 	srv, _ := testServer(t)
 
@@ -640,13 +772,16 @@ func TestProvisionUser(t *testing.T) {
 		}
 	})
 
-	t.Run("demotes admin to member when removed from admin emails", func(t *testing.T) {
+	// admin_emails is additive-only: it can promote a user to admin but must
+	// never demote one. A user promoted through the admin UI (or an admin whose
+	// email was removed from the config) keeps their role across logins.
+	t.Run("keeps admin role when not in admin emails", func(t *testing.T) {
 		srv, s := testServer(t)
 
-		// Pre-create user as admin
+		// Pre-create user as admin (e.g. promoted via the admin UI)
 		original := &store.User{
 			ID:      generateID(),
-			Email:   "former-admin@example.com",
+			Email:   "ui-admin@example.com",
 			Role:    "admin",
 			Status:  "active",
 			Created: time.Now(),
@@ -658,23 +793,82 @@ func TestProvisionUser(t *testing.T) {
 		// Admin emails list does NOT include this user
 		srv.config.AdminEmails = []string{"other-admin@example.com"}
 
-		info := &ExternalUserInfo{Email: "former-admin@example.com"}
+		info := &ExternalUserInfo{Email: "ui-admin@example.com"}
+		user, err := srv.provisionUser(ctx, info)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if user.Role != "admin" {
+			t.Errorf("expected role 'admin' to be retained, got %q", user.Role)
+		}
+
+		// Verify persisted in store
+		stored, err := s.GetUserByEmail(ctx, "ui-admin@example.com")
+		if err != nil {
+			t.Fatalf("user not found in store: %v", err)
+		}
+		if stored.Role != "admin" {
+			t.Errorf("expected stored role 'admin', got %q", stored.Role)
+		}
+	})
+
+	t.Run("keeps member role when not in admin emails", func(t *testing.T) {
+		srv, s := testServer(t)
+
+		original := &store.User{
+			ID:      generateID(),
+			Email:   "plain-member@example.com",
+			Role:    "member",
+			Status:  "active",
+			Created: time.Now(),
+		}
+		if err := s.CreateUser(ctx, original); err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+
+		srv.config.AdminEmails = []string{"other-admin@example.com"}
+
+		info := &ExternalUserInfo{Email: "plain-member@example.com"}
 		user, err := srv.provisionUser(ctx, info)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
 		if user.Role != "member" {
-			t.Errorf("expected role 'member' after demotion, got %q", user.Role)
+			t.Errorf("expected role 'member', got %q", user.Role)
+		}
+	})
+
+	t.Run("respects UI demotion of a config-less admin", func(t *testing.T) {
+		srv, s := testServer(t)
+
+		original := &store.User{
+			ID:      generateID(),
+			Email:   "demoted@example.com",
+			Role:    "admin",
+			Status:  "active",
+			Created: time.Now(),
+		}
+		if err := s.CreateUser(ctx, original); err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+		srv.config.AdminEmails = nil
+
+		// Explicit demotion through the admin UI/API writes "member" to the DB.
+		original.Role = "member"
+		if err := s.UpdateUser(ctx, original); err != nil {
+			t.Fatalf("failed to demote user: %v", err)
 		}
 
-		// Verify persisted in store
-		stored, err := s.GetUserByEmail(ctx, "former-admin@example.com")
+		info := &ExternalUserInfo{Email: "demoted@example.com"}
+		user, err := srv.provisionUser(ctx, info)
 		if err != nil {
-			t.Fatalf("user not found in store: %v", err)
+			t.Fatalf("unexpected error: %v", err)
 		}
-		if stored.Role != "member" {
-			t.Errorf("expected stored role 'member', got %q", stored.Role)
+
+		if user.Role != "member" {
+			t.Errorf("expected demotion to stick, got role %q", user.Role)
 		}
 	})
 

--- a/pkg/hub/handlers_auth_test.go
+++ b/pkg/hub/handlers_auth_test.go
@@ -331,6 +331,123 @@ func TestAuthRefreshRoleReevaluation(t *testing.T) {
 			t.Errorf("expected refreshed token role 'member', got %q", role)
 		}
 	})
+
+	t.Run("UI-set viewer keeps viewer role", func(t *testing.T) {
+		srv, s := testServer(t)
+		ctx := context.Background()
+
+		user := &store.User{
+			ID:      tid("user_viewer"),
+			Email:   "viewer@example.com",
+			Role:    "viewer",
+			Status:  "active",
+			Created: time.Now(),
+		}
+		if err := s.CreateUser(ctx, user); err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+		srv.config.AdminEmails = nil
+
+		_, refreshToken, _, err := srv.userTokenService.GenerateTokenPair(
+			user.ID, user.Email, user.DisplayName, user.Role, ClientTypeWeb,
+		)
+		if err != nil {
+			t.Fatalf("failed to generate tokens: %v", err)
+		}
+
+		if role := refresh(t, srv, refreshToken); role != "viewer" {
+			t.Errorf("expected refreshed token role 'viewer', got %q", role)
+		}
+
+		stored, err := s.GetUserByEmail(ctx, user.Email)
+		if err != nil {
+			t.Fatalf("user not found: %v", err)
+		}
+		if stored.Role != "viewer" {
+			t.Errorf("expected stored role 'viewer', got %q", stored.Role)
+		}
+	})
+
+	t.Run("deleted admin cannot refresh into admin", func(t *testing.T) {
+		srv, s := testServer(t)
+		ctx := context.Background()
+
+		user := &store.User{
+			ID:      tid("user_deleted"),
+			Email:   "deleted-admin@example.com",
+			Role:    "admin",
+			Status:  "active",
+			Created: time.Now(),
+		}
+		if err := s.CreateUser(ctx, user); err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+		srv.config.AdminEmails = nil
+
+		// Token carries the admin role the user held before offboarding.
+		_, refreshToken, _, err := srv.userTokenService.GenerateTokenPair(
+			user.ID, user.Email, user.DisplayName, "admin", ClientTypeWeb,
+		)
+		if err != nil {
+			t.Fatalf("failed to generate tokens: %v", err)
+		}
+
+		if err := s.DeleteUser(ctx, user.ID); err != nil {
+			t.Fatalf("failed to delete user: %v", err)
+		}
+
+		rec := doRequest(t, srv, http.MethodPost, "/api/v1/auth/refresh",
+			AuthRefreshRequest{RefreshToken: refreshToken})
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("expected status 401 for deleted user, got %d: %s", rec.Code, rec.Body.String())
+		}
+
+		// Belt and braces: even if the handler were changed to keep issuing
+		// tokens, it must never hand back the admin role from the claim.
+		if rec.Code == http.StatusOK {
+			var resp AuthRefreshResponse
+			if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			claims, err := srv.userTokenService.ValidateUserToken(resp.AccessToken)
+			if err != nil {
+				t.Fatalf("failed to validate refreshed access token: %v", err)
+			}
+			if claims.Role == "admin" {
+				t.Error("deleted user retained admin role from the JWT claim")
+			}
+		}
+	})
+
+	t.Run("suspended user cannot refresh", func(t *testing.T) {
+		srv, s := testServer(t)
+		ctx := context.Background()
+
+		user := &store.User{
+			ID:      tid("user_suspended"),
+			Email:   "suspended@example.com",
+			Role:    "admin",
+			Status:  "suspended",
+			Created: time.Now(),
+		}
+		if err := s.CreateUser(ctx, user); err != nil {
+			t.Fatalf("failed to create user: %v", err)
+		}
+		srv.config.AdminEmails = nil
+
+		_, refreshToken, _, err := srv.userTokenService.GenerateTokenPair(
+			user.ID, user.Email, user.DisplayName, "admin", ClientTypeWeb,
+		)
+		if err != nil {
+			t.Fatalf("failed to generate tokens: %v", err)
+		}
+
+		rec := doRequest(t, srv, http.MethodPost, "/api/v1/auth/refresh",
+			AuthRefreshRequest{RefreshToken: refreshToken})
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("expected status 403 for suspended user, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
 }
 
 func TestAuthValidate(t *testing.T) {

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -1478,10 +1478,22 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 				currentRole, _ := session.Values[sessKeyUserRole].(string)
 				// The stored role is the source of truth: it carries UI-granted
 				// promotions (and demotions) that the config list knows nothing
-				// about. Fall back to the session role if it can't be read.
+				// about. If it can't be read we deliberately fall back to the
+				// session role, preserving the status quo rather than extending
+				// privilege: unlike a refresh token, the session cookie is not
+				// re-minted here, so a transient read failure cannot lengthen
+				// the life of a stale role.
 				storedRole := currentRole
+				// A nil store is fatal further down this middleware (see the
+				// check before proxy provisioning), but this branch returns
+				// before reaching it, so the guard is load-bearing here.
 				if ws.store != nil {
 					if u, err := ws.store.GetUserByEmail(r.Context(), email); err == nil {
+						if u.Status == "suspended" {
+							ws.logger().Warn("Proxy auth: session user is suspended", "email", email, "user_id", u.ID)
+							http.Error(w, "access denied: user account is suspended", http.StatusForbidden)
+							return
+						}
 						storedRole = u.Role
 					}
 				}

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -1509,6 +1509,8 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 					default:
 						// Transient read failure — keep the status quo (see
 						// the storedRole comment above).
+						ws.logger().Warn("Proxy auth: user lookup failed, falling back to session role",
+							"email", email, "error", err)
 					}
 				}
 				expectedRole := determineUserRole(email, ws.config.AdminEmails, storedRole)

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -1476,7 +1476,16 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 			email, _ := session.Values[sessKeyUserEmail].(string)
 			if email != "" {
 				currentRole, _ := session.Values[sessKeyUserRole].(string)
-				expectedRole := determineUserRole(email, ws.config.AdminEmails)
+				// The stored role is the source of truth: it carries UI-granted
+				// promotions (and demotions) that the config list knows nothing
+				// about. Fall back to the session role if it can't be read.
+				storedRole := currentRole
+				if ws.store != nil {
+					if u, err := ws.store.GetUserByEmail(r.Context(), email); err == nil {
+						storedRole = u.Role
+					}
+				}
+				expectedRole := determineUserRole(email, ws.config.AdminEmails, storedRole)
 				if currentRole == expectedRole {
 					// Role unchanged — inject user into context and proceed
 					// without saving session (avoids redundant write).
@@ -1563,7 +1572,7 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 		}
 		if err != nil {
 			// User not found — create new user
-			role := determineUserRole(proxyUser.Email, ws.config.AdminEmails)
+			role := determineUserRole(proxyUser.Email, ws.config.AdminEmails, "")
 			user = &store.User{
 				ID:          generateID(),
 				Email:       proxyUser.Email,
@@ -1593,7 +1602,7 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 				user.DisplayName = proxyUser.DisplayName
 			}
 			// Re-evaluate admin status on every login (matches handleOAuthCallback / provisionUser)
-			if newRole := determineUserRole(proxyUser.Email, ws.config.AdminEmails); user.Role != newRole {
+			if newRole := determineUserRole(proxyUser.Email, ws.config.AdminEmails, user.Role); user.Role != newRole {
 				ws.logger().Info("User role changed on proxy login", "email", proxyUser.Email, "old_role", user.Role, "new_role", newRole)
 				user.Role = newRole
 			}
@@ -1847,7 +1856,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		// Create new user (only reachable in open/domain_restricted modes;
 		// in invite_only mode, checkUserAuthorized already confirmed a User record exists)
-		role := determineUserRole(userInfo.Email, ws.config.AdminEmails)
+		role := determineUserRole(userInfo.Email, ws.config.AdminEmails, "")
 		user = &store.User{
 			ID:          generateID(),
 			Email:       userInfo.Email,
@@ -1884,7 +1893,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 				user.AvatarURL = userInfo.AvatarURL
 			}
 			user.LastLogin = time.Now()
-			user.Role = determineUserRole(userInfo.Email, ws.config.AdminEmails)
+			user.Role = determineUserRole(userInfo.Email, ws.config.AdminEmails, user.Role)
 			// Log the activation via slog (WebServer does not have a structured
 			// audit logger; the hub.Server audit path covers API/CLI auth).
 			ws.logger().Info("invite audit: user_activated", "email", userInfo.Email, "user_id", user.ID)
@@ -1898,7 +1907,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 				user.DisplayName = userInfo.DisplayName
 			}
 			// Re-evaluate admin status on every login
-			newRole := determineUserRole(userInfo.Email, ws.config.AdminEmails)
+			newRole := determineUserRole(userInfo.Email, ws.config.AdminEmails, user.Role)
 			if user.Role != newRole {
 				ws.logger().Info("User role changed on login", "email", userInfo.Email, "old_role", user.Role, "new_role", newRole)
 				user.Role = newRole

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -1488,13 +1488,27 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 				// check before proxy provisioning), but this branch returns
 				// before reaching it, so the guard is load-bearing here.
 				if ws.store != nil {
-					if u, err := ws.store.GetUserByEmail(r.Context(), email); err == nil {
-						if u.Status == "suspended" {
+					u, err := ws.store.GetUserByEmail(r.Context(), email)
+					switch {
+					case err == nil:
+						if u.Status == store.UserStatusSuspended {
 							ws.logger().Warn("Proxy auth: session user is suspended", "email", email, "user_id", u.ID)
 							http.Error(w, "access denied: user account is suspended", http.StatusForbidden)
 							return
 						}
 						storedRole = u.Role
+					case errors.Is(err, store.ErrNotFound):
+						// Definitive answer: the account is gone. Unlike a
+						// transient read failure, this must not fall back to
+						// the session role — that would let a deleted user
+						// keep a UI-granted admin role for the remaining life
+						// of their session cookie.
+						ws.logger().Warn("Proxy auth: session user no longer exists", "email", email)
+						http.Error(w, "access denied: user account no longer exists", http.StatusForbidden)
+						return
+					default:
+						// Transient read failure — keep the status quo (see
+						// the storedRole comment above).
 					}
 				}
 				expectedRole := determineUserRole(email, ws.config.AdminEmails, storedRole)

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -3017,6 +3017,75 @@ func TestProxyAuthMiddleware_ExistingSession_SuspendedUserRejected(t *testing.T)
 	assert.Equal(t, http.StatusForbidden, rec2.Code, "suspended user should be rejected with 403")
 }
 
+func TestProxyAuthMiddleware_ExistingSession_DeletedUserRejected(t *testing.T) {
+	// Deleting a user must take effect on their next request. Because the
+	// stored role is now the source of truth, a deleted user whose session
+	// cookie carries a UI-granted admin role would otherwise keep that role
+	// for the remaining life of the cookie — the ordinary offboarding path.
+	// ErrNotFound is a definitive answer, not the transient read failure that
+	// justifies falling back to the session role.
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject: "12345",
+			Email:   "user@example.com",
+			Domain:  "example.com",
+		},
+	}
+
+	st := newProxyAuthStore()
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+		AdminEmails:        []string{}, // not an admin by config
+	})
+	ws.SetStore(st)
+
+	handler := ws.Handler()
+
+	// First request: provisions the user as member and establishes the session.
+	req1 := httptest.NewRequest("GET", "/projects", nil)
+	req1.Header.Set("Accept", "text/html")
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+
+	require.NotEqual(t, http.StatusForbidden, rec1.Code, "active user should not be rejected")
+	cookies := rec1.Result().Cookies()
+	require.NotEmpty(t, cookies, "session cookie should be set")
+
+	// Admin promotes the user through the UI, so the session picks up admin.
+	created, err := st.GetUserByEmail(context.Background(), "user@example.com")
+	require.NoError(t, err)
+	created.Role = "admin"
+	require.NoError(t, st.UpdateUser(context.Background(), created))
+
+	req2 := httptest.NewRequest("GET", "/projects", nil)
+	req2.Header.Set("Accept", "text/html")
+	for _, c := range cookies {
+		req2.AddCookie(c)
+	}
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+
+	adminCookies := rec2.Result().Cookies()
+	require.NotEmpty(t, adminCookies, "session should be re-set with the admin role")
+
+	// The user is offboarded: deleted from the store entirely.
+	delete(st.users, created.ID)
+	_, err = st.GetUserByEmail(context.Background(), "user@example.com")
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	// Replaying the still-valid admin session cookie must now be rejected.
+	req3 := httptest.NewRequest("GET", "/projects", nil)
+	req3.Header.Set("Accept", "text/html")
+	for _, c := range adminCookies {
+		req3.AddCookie(c)
+	}
+	rec3 := httptest.NewRecorder()
+	handler.ServeHTTP(rec3, req3)
+
+	assert.Equal(t, http.StatusForbidden, rec3.Code, "deleted user should be rejected with 403")
+}
+
 func TestProxyAuthMiddleware_ExistingSession_NoUpdateWhenRoleUnchanged(t *testing.T) {
 	// When the session role already matches the expected role, the session
 	// should NOT be re-saved (no Set-Cookie header emitted).

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -2966,6 +2966,57 @@ func TestProxyAuthMiddleware_ExistingSession_PicksUpUIPromotion(t *testing.T) {
 	assert.True(t, sessionUpdated, "session cookie should be re-set after UI promotion")
 }
 
+func TestProxyAuthMiddleware_ExistingSession_SuspendedUserRejected(t *testing.T) {
+	// Suspending a user through the admin UI must take effect on their next
+	// request rather than at session expiry: the session cookie lives for 24h,
+	// so without the store check a suspended user would keep full web access
+	// for the rest of that window.
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject: "12345",
+			Email:   "user@example.com",
+			Domain:  "example.com",
+		},
+	}
+
+	st := newProxyAuthStore()
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+		AdminEmails:        []string{},
+	})
+	ws.SetStore(st)
+
+	handler := ws.Handler()
+
+	// First request: provisions the user and establishes the session.
+	req1 := httptest.NewRequest("GET", "/projects", nil)
+	req1.Header.Set("Accept", "text/html")
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+
+	require.NotEqual(t, http.StatusForbidden, rec1.Code, "active user should not be rejected")
+	cookies := rec1.Result().Cookies()
+	require.NotEmpty(t, cookies, "session cookie should be set")
+
+	// Admin suspends the user through the UI (writes to the store).
+	created, err := st.GetUserByEmail(context.Background(), "user@example.com")
+	require.NoError(t, err)
+	created.Status = "suspended"
+	require.NoError(t, st.UpdateUser(context.Background(), created))
+
+	// Replaying the still-valid session cookie must now be rejected.
+	req2 := httptest.NewRequest("GET", "/projects", nil)
+	req2.Header.Set("Accept", "text/html")
+	for _, c := range cookies {
+		req2.AddCookie(c)
+	}
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+
+	assert.Equal(t, http.StatusForbidden, rec2.Code, "suspended user should be rejected with 403")
+}
+
 func TestProxyAuthMiddleware_ExistingSession_NoUpdateWhenRoleUnchanged(t *testing.T) {
 	// When the session role already matches the expected role, the session
 	// should NOT be re-saved (no Set-Cookie header emitted).

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -2631,13 +2631,14 @@ func TestProxyAuthMiddleware_ExistingSession_SkipsVerification(t *testing.T) {
 	_ = callCount
 }
 
-func TestProxyAuthMiddleware_DemotesAdminWhenRemovedFromList(t *testing.T) {
-	// An existing admin user whose email is no longer in AdminEmails
-	// should be demoted to "member" on next proxy-authenticated request.
+func TestProxyAuthMiddleware_KeepsAdminWhenNotInList(t *testing.T) {
+	// AdminEmails is additive-only: an existing admin user whose email is not
+	// in AdminEmails (e.g. promoted through the admin UI) keeps the admin role
+	// on the next proxy-authenticated request.
 	mockAuth := &mockProxyAuthenticator{
 		user: &ProxyUserInfo{
 			Subject: "99",
-			Email:   "former-admin@example.com",
+			Email:   "ui-admin@example.com",
 			Domain:  "example.com",
 		},
 	}
@@ -2646,7 +2647,7 @@ func TestProxyAuthMiddleware_DemotesAdminWhenRemovedFromList(t *testing.T) {
 	// Pre-create user as admin
 	adminUser := &store.User{
 		ID:      "u-admin-proxy",
-		Email:   "former-admin@example.com",
+		Email:   "ui-admin@example.com",
 		Role:    "admin",
 		Status:  "active",
 		Created: time.Now(),
@@ -2656,7 +2657,7 @@ func TestProxyAuthMiddleware_DemotesAdminWhenRemovedFromList(t *testing.T) {
 	ws := newTestWebServer(t, WebServerConfig{
 		AuthMode:           "proxy",
 		ProxyAuthenticator: mockAuth,
-		// AdminEmails does NOT include former-admin@example.com
+		// AdminEmails does NOT include ui-admin@example.com
 		AdminEmails: []string{"other-admin@example.com"},
 	})
 	ws.SetStore(st)
@@ -2667,11 +2668,11 @@ func TestProxyAuthMiddleware_DemotesAdminWhenRemovedFromList(t *testing.T) {
 
 	ws.Handler().ServeHTTP(rec, req)
 
-	// Verify user was demoted
-	updated, err := st.GetUserByEmail(context.Background(), "former-admin@example.com")
+	// Verify user kept the admin role
+	updated, err := st.GetUserByEmail(context.Background(), "ui-admin@example.com")
 	assert.NoError(t, err)
-	assert.Equal(t, "member", updated.Role,
-		"admin user should be demoted to member when removed from admin emails list")
+	assert.Equal(t, "admin", updated.Role,
+		"admin_emails must not demote an admin granted through the UI")
 }
 
 func TestProxyAuthMiddleware_PromotesToAdminWhenAddedToList(t *testing.T) {
@@ -2784,10 +2785,10 @@ func TestProxyAuthMiddleware_ExistingSession_ReEvaluatesRoleOnPromotion(t *testi
 	assert.True(t, sessionUpdated, "session cookie should be re-set after role change")
 }
 
-func TestProxyAuthMiddleware_ExistingSession_ReEvaluatesRoleOnDemotion(t *testing.T) {
+func TestProxyAuthMiddleware_ExistingSession_ReEvaluatesRoleOnUIDemotion(t *testing.T) {
 	// A user with an existing session (role=admin) should be demoted to
-	// member when their email is removed from AdminEmails — even though
-	// the session already exists.
+	// member when an admin demotes them through the UI — even though the
+	// session already exists. Config removal alone never demotes.
 	mockAuth := &mockProxyAuthenticator{
 		user: &ProxyUserInfo{
 			Subject: "12345",
@@ -2822,8 +2823,10 @@ func TestProxyAuthMiddleware_ExistingSession_ReEvaluatesRoleOnDemotion(t *testin
 	require.NoError(t, err)
 	assert.Equal(t, "admin", created.Role)
 
-	// Now remove user from admin list (simulates config change)
+	// Remove from the config list AND demote through the UI (explicit action).
 	ws.config.AdminEmails = []string{}
+	created.Role = "member"
+	require.NoError(t, st.UpdateUser(context.Background(), created))
 
 	// Second request: re-uses the session cookie
 	req2 := httptest.NewRequest("GET", "/projects", nil)
@@ -2849,6 +2852,118 @@ func TestProxyAuthMiddleware_ExistingSession_ReEvaluatesRoleOnDemotion(t *testin
 		}
 	}
 	assert.True(t, sessionUpdated, "session cookie should be re-set after role demotion")
+}
+
+func TestProxyAuthMiddleware_ExistingSession_KeepsRoleWhenRemovedFromList(t *testing.T) {
+	// Removing an email from AdminEmails must not demote a user who is admin
+	// in the store: the session keeps the admin role.
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject: "12345",
+			Email:   "admin@example.com",
+			Domain:  "example.com",
+		},
+	}
+
+	st := newProxyAuthStore()
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+		AdminEmails:        []string{"admin@example.com"},
+	})
+	ws.SetStore(st)
+
+	handler := ws.Handler()
+
+	// First request: creates session with role=admin
+	req1 := httptest.NewRequest("GET", "/projects", nil)
+	req1.Header.Set("Accept", "text/html")
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+
+	cookies := rec1.Result().Cookies()
+	require.NotEmpty(t, cookies, "session cookie should be set")
+
+	created, err := st.GetUserByEmail(context.Background(), "admin@example.com")
+	require.NoError(t, err)
+	require.Equal(t, "admin", created.Role)
+
+	// Config change only — no UI demotion.
+	ws.config.AdminEmails = []string{}
+
+	req2 := httptest.NewRequest("GET", "/projects", nil)
+	req2.Header.Set("Accept", "text/html")
+	for _, c := range cookies {
+		req2.AddCookie(c)
+	}
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+
+	// Role unchanged, so the session must not be re-written.
+	for _, c := range rec2.Result().Cookies() {
+		assert.NotEqual(t, webSessionName, c.Name,
+			"session should not be re-saved when the role is unchanged")
+	}
+
+	unchanged, err := st.GetUserByEmail(context.Background(), "admin@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "admin", unchanged.Role, "stored role should stay admin")
+}
+
+func TestProxyAuthMiddleware_ExistingSession_PicksUpUIPromotion(t *testing.T) {
+	// A user promoted to admin through the UI while holding a session should
+	// see the new role on their next request: the store is the source of truth.
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject: "12345",
+			Email:   "user@example.com",
+			Domain:  "example.com",
+		},
+	}
+
+	st := newProxyAuthStore()
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+		AdminEmails:        []string{},
+	})
+	ws.SetStore(st)
+
+	handler := ws.Handler()
+
+	// First request: creates session with role=member
+	req1 := httptest.NewRequest("GET", "/projects", nil)
+	req1.Header.Set("Accept", "text/html")
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, req1)
+
+	cookies := rec1.Result().Cookies()
+	require.NotEmpty(t, cookies, "session cookie should be set")
+
+	created, err := st.GetUserByEmail(context.Background(), "user@example.com")
+	require.NoError(t, err)
+	require.Equal(t, "member", created.Role)
+
+	// Admin promotes the user through the UI (writes to the store).
+	created.Role = "admin"
+	require.NoError(t, st.UpdateUser(context.Background(), created))
+
+	req2 := httptest.NewRequest("GET", "/projects", nil)
+	req2.Header.Set("Accept", "text/html")
+	for _, c := range cookies {
+		req2.AddCookie(c)
+	}
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req2)
+
+	var sessionUpdated bool
+	for _, c := range rec2.Result().Cookies() {
+		if c.Name == webSessionName {
+			sessionUpdated = true
+			break
+		}
+	}
+	assert.True(t, sessionUpdated, "session cookie should be re-set after UI promotion")
 }
 
 func TestProxyAuthMiddleware_ExistingSession_NoUpdateWhenRoleUnchanged(t *testing.T) {

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -1733,14 +1733,14 @@ type MessageFilter struct {
 	// the sender_id UUID column), this matches the human-readable
 	// sender label. Useful for finding messages from agents that were
 	// persisted before SenderID was reliably populated.
-	Sender    string
-	OnlyUnread    bool      // Only unread messages
-	Type          string    // Filter by message type
-	Channel       string    // Filter by channel (e.g. "web", "discord")
-	ThreadID      string    // Filter by thread_id (wave-2 conversation key)
-	Visibility    []string  // Filter to listed visibility levels
-	Before        time.Time // Upper bound for created_at (exclusive)
-	After         time.Time // Lower bound for created_at (exclusive)
+	Sender     string
+	OnlyUnread bool      // Only unread messages
+	Type       string    // Filter by message type
+	Channel    string    // Filter by channel (e.g. "web", "discord")
+	ThreadID   string    // Filter by thread_id (wave-2 conversation key)
+	Visibility []string  // Filter to listed visibility levels
+	Before     time.Time // Upper bound for created_at (exclusive)
+	After      time.Time // Lower bound for created_at (exclusive)
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Fixes a bug where determineUserRole() silently reverted UI-granted role changes on every login/refresh.

- admin_emails now acts as a floor, not a ceiling (additive-only)
- All UI-set roles (admin, viewer) preserved across logins/refreshes
- Deleted users get 401/403, suspended users get 403
- Token refresh and proxy-auth now read stored role from DB

Key files: pkg/hub/handlers_auth.go, pkg/hub/web.go + tests.
642 of 726 added lines are tests, mutation-verified.

Relates to ptone/scion#1020
