### PR TITLE
fix: gofmt and build-tag fixes for pkg/hub and pkg/store

### DIFF
--- a/pkg/hub/attachments_agent_test.go
+++ b/pkg/hub/attachments_agent_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_sqlite
+
 package hub
 
 import (

--- a/pkg/hub/attachments_dm_test.go
+++ b/pkg/hub/attachments_dm_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_sqlite
+
 package hub
 
 import (

--- a/pkg/hub/attachments_staging_test.go
+++ b/pkg/hub/attachments_staging_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_sqlite
+
 package hub
 
 import (

--- a/pkg/hub/events.go
+++ b/pkg/hub/events.go
@@ -87,8 +87,8 @@ func (noopEventPublisher) PublishDispatchDone(_ context.Context, _ string)      
 func (noopEventPublisher) PublishChatTopicEvent(_ context.Context, _ string, _ string, _ WebChatTopic) {
 }
 func (noopEventPublisher) PublishChatReadStateEvent(_ context.Context, _, _, _ string) {}
-func (noopEventPublisher) PublishRaw(_ string, _ interface{}) {}
-func (noopEventPublisher) Close()                             {}
+func (noopEventPublisher) PublishRaw(_ string, _ interface{})                          {}
+func (noopEventPublisher) Close()                                                      {}
 
 // Subscribe on the no-op publisher returns a nil channel (which blocks forever
 // on receive) and a no-op unsubscribe. Callers that need real subscriptions

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -1733,14 +1733,14 @@ type MessageFilter struct {
 	// the sender_id UUID column), this matches the human-readable
 	// sender label. Useful for finding messages from agents that were
 	// persisted before SenderID was reliably populated.
-	Sender    string
-	OnlyUnread    bool      // Only unread messages
-	Type          string    // Filter by message type
-	Channel       string    // Filter by channel (e.g. "web", "discord")
-	ThreadID      string    // Filter by thread_id (wave-2 conversation key)
-	Visibility    []string  // Filter to listed visibility levels
-	Before        time.Time // Upper bound for created_at (exclusive)
-	After         time.Time // Lower bound for created_at (exclusive)
+	Sender     string
+	OnlyUnread bool      // Only unread messages
+	Type       string    // Filter by message type
+	Channel    string    // Filter by channel (e.g. "web", "discord")
+	ThreadID   string    // Filter by thread_id (wave-2 conversation key)
+	Visibility []string  // Filter to listed visibility levels
+	Before     time.Time // Upper bound for created_at (exclusive)
+	After      time.Time // Lower bound for created_at (exclusive)
 }
 
 // =============================================================================


### PR DESCRIPTION
Upstream main is red on Format Check (gofmt: pkg/hub/events.go, pkg/store/models.go) and Vet Code (missing //go:build !no_sqlite tags in pkg/hub attachments test files). Formatting and build-tag fixes only - no logic changes.