### PR TITLE
docs: nightly documentation update for Aug 15

### DIFF
--- a/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
+++ b/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
@@ -116,9 +116,9 @@ Provisioning in proxy mode works identically to OAuth — lazy, allow-list-gated
 - **`open`**: any verified email is allowed.
 - **`domain_restricted`**: email domain must be in `authorized_domains`.
 - **`invite_only`**: email must be pre-registered (via admin invite-code flow).
-- Emails in `admin_emails` are always allowed and auto-promoted to admin role. The list only promotes: removing an email from it does not demote a user who is already an admin — use the admin UI to demote.
-- If not permitted, the request returns **403**.
-- Suspended users are rejected even though IAP authenticates them upstream.
+- **Additive-Only `admin_emails` Floor**: Emails in the `admin_emails` configuration are granted the `admin` role automatically. This setting is strictly additive (acts as a floor, not a ceiling): it never overwrites or demotes roles that have been explicitly promoted or changed via the Admin UI/API, which are stored in the database and preserved verbatim across logins/refreshes.
+- If not permitted, the request returns **403**. Deleted users are rejected with **401** or **403**, and suspended users are rejected with **403** (even though upstream IAP may authenticate them).
+- **Database-Backed Token Refresh**: The token refresh endpoint reads the user's active role directly from the database rather than relying on stale session cache, ensuring UI-based role promotions take effect immediately.
 
 A **60-second resolution cache** (keyed by verified email) avoids a database lookup on every request. The JWT signature is verified on every request — only the provisioning/store lookup is cached.
 

--- a/docs-site/src/content/docs/hosted/ha/permissions.md
+++ b/docs-site/src/content/docs/hosted/ha/permissions.md
@@ -145,6 +145,7 @@ To make the service account lifecycle transparent and auditable for users and ad
 - **Tiered Role Badges**: The agents list and agent detail pages display visible role badges (`none`, `readonly`, `baseline`, or `full`) highlighting the active execution role of each running container.
 - **GCP Identity Card**: The agent detail view features an interactive **GCP Identity Card**. In all authentication modes, it displays the bound service account email, verification status (e.g. `verified` or `failed`), and the corresponding GCP project ID.
 - **Service Account Status Manager**: Within project settings, owners can view registered service accounts, check their live Policy Troubleshooter verification status, and manually trigger verification probes.
+- **Zero-Reload Service Account Dropdown Sync**: The UI dispatches custom events (`sa-list-changed`) across components upon SA registration, verification, minting, or deletion, instantly updating default service account selection dropdowns without a full-page reload, and automatically clears the default SA selection if the selected SA is deleted.
 
 ---
 
@@ -174,7 +175,7 @@ Agents are assigned one of four named roles, each mapping to a fixed set of JWT 
 | :--- | :--- | :--- |
 | `none` | *None* | No access to the Hub API (runs with no authorization claims). |
 | `readonly` | `project:read` | Can view and query project state, but cannot report status, register port forwards, or manage other agents. |
-| `baseline` | `project:read`<br>`agent:status:update`<br>`agent:token:refresh`<br>`project:agent:notify`<br>`agent:port:forward` | Standard execution permissions. Allows the agent to report progress, refresh its token, register reverse-proxied port forwards, and send notifications. |
+| `baseline` | `project:read`<br>`agent:status:update`<br>`agent:token:refresh`<br>`project:agent:notify`<br>`agent:port:forward` | Standard execution permissions. Allows the agent to report progress, refresh its token, register reverse-proxied port forwards, send notifications, and manage its own notification subscriptions. |
 | `full` | *All baseline scopes* +<br>`project:agent:create`<br>`project:agent:lifecycle`<br>`project:secret:read` | Complete agent control. Allows spawning child (sub) agents, managing their lifecycles, and reading project-scoped secrets from the secret backend. |
 
 #### Two-Gate Authority Lattice

--- a/docs-site/src/content/docs/hosted/user/messaging.md
+++ b/docs-site/src/content/docs/hosted/user/messaging.md
@@ -19,15 +19,18 @@ Scion features an interactive, top-level **Native Web Chat** interface in the We
 ### Core Layout & Navigation
 
 - **Project-Scoped Spaces & Shared Threads**: Chat is organized into distinct spaces scoped to specific Projects. Within a project-scoped space, users and agents participate in shared discussion threads, creating focused hubs of collaboration.
-- **Direct Messaging (DMs)**: In addition to collaborative project spaces, the chat interface supports 1-on-1 Direct Messages. This includes both **human-to-human (H2H)** communication between team members and **human-to-agent (H2A)** chats. DMs are structured as a "global pair"—a single, consolidated thread per participant pair.
+- **Direct Messaging (DMs)**: In addition to collaborative project spaces, the chat interface supports robust 1-on-1 Direct Messages (DMs). This includes both **human-to-human (H2H)** communication between team members and **human-to-agent (H2A)** chats, backed by deep DM routing and persistence fixes. DMs are structured as a "global pair"—a single, consolidated thread per participant pair.
 - **Members Sidebar, Presence & Typing**: A right-hand members sidebar lists all participants in the active project space or DM. This includes real-time online **presence indicators** (active, away, offline) and live **typing indicators** to show when a team member or agent is actively composing a message.
-- **The Thread Rail**: A left-hand navigation sidebar lists all active chat spaces, threads, and DMs. Unread badges ("unread dots") update in real-time as messages arrive, instantly alerting you to new activity requiring attention.
+- **The Thread Rail & Mobile Swipe Navigation**: A left-hand navigation sidebar lists all active chat spaces, threads, and DMs. On mobile viewports, the rail supports native **swipe gestures** for fluid, app-like drawer navigation.
 - **Chat/Log Toggle**: Located on the main `scion-chat-thread` panel, this toggle lets you switch between a clean, dialogue-focused **Chat** view and a live **Execution Log** stream for that agent.
 - **Zero-Reload Navigation**: Move between threads, project spaces, and configuration pages instantly with deep-linking support and no full-page reloads, ensuring no interruption to your active chat context or log streams.
+- **Markdown & Rich Rendering**: Chat messages support fully-featured real-time **Markdown rendering** inside chat bubbles (including syntax-highlighted code fences, tables, and nested lists) for highly readable development chats.
+- **iOS & Platform Tailoring**: The layout incorporates specific styling adjustments for iOS devices, delivering polished rendering and input behavior under Safari and other mobile browsers.
 - **Attachments, Search & Notifications**:
-  - **Attachments**: The chat composer supports file and image uploads, allowing users to send documents or visual context directly to threads.
+  - **Attachments & Image Overlay**: The chat composer supports file and image uploads, allowing users to send documents or visual context directly to threads. Uploaded images feature an interactive, full-screen **image overlay viewer** with smooth zoom controls.
   - **Search**: Built-in chat search lets you quickly query across historical messages and active threads to find crucial context.
   - **Notifications**: Integrated chat-specific notifications, including native browser push notifications and persistent unread counts, ensure you stay informed of incoming messages.
+- **Config Toggle**: Top-level native chat can be turned on or off globally by administrators using a single configuration key (`web.native_chat` feature flag) or via the Admin interface.
 
 ### Three-State Visibility Filtering
 
@@ -142,10 +145,15 @@ When an agent signals `WAITING_FOR_INPUT` (by calling `sciontool status ask_user
 * **Parent Agent Role**: If you are the parent agent that created the waiting agent, you may be the intended respondent. Use `scion message agent:<name>` to reply with the answer.
 * **Peer Agent Rule**: Unrelated peer agents should **NOT** reply to `input-needed` notifications. Answering a peer's input prompt wastes context tokens, causes false loop signals, and violates project-scoped boundaries. To request a peer's input, always send an explicit `instruction` instead.
 
-### 3. Subscription Management and the `--notify` Deprecation
+### 3. Subscription Management and Agent Self-Service
 
 * **Automatic Subscription**: The `--notify` flag on `scion start` is **deprecated**. When you start a sub-agent, Scion automatically registers your subscription via creation ancestry.
 * **Explicit Messaging Subscription**: Use the `--notify` flag on `scion message` only when you need to subscribe to notifications from a peer agent that you did *not* create.
+* **Agent Self-Service Subscriptions**: Running agents in Hosted mode are empowered to programmatically manage their own notification subscriptions. Previously restricted to administrative users (returning a `403 Forbidden` for agents), agents with appropriate API credentials can now perform the following operations:
+  - **CRUD Operations**: Live agents can list, create, update, and delete their own subscriptions via the Hub API or client utilities.
+  - **Identity Qualification**: To prevent cross-project security leaks, every subscription request is qualified by the agent's specific `(project, slug)` coordinates.
+  - **Granular Scopes**: Authorization gates require the agent token to hold the `project:read` scope for reading subscriptions and the `project:agent:notify` scope for writing (creating, updating, or deleting) subscriptions.
+  - **Ownership Constraints**: Acknowledging notifications or modifying/deleting existing subscriptions strictly requires ownership validation, meaning an agent can only modify or acknowledge subscriptions that target or belong to itself.
 
 ### 4. Sleep Anti-Pattern & Polling
 

--- a/docs-site/src/content/docs/hosted/user/secrets.md
+++ b/docs-site/src/content/docs/hosted/user/secrets.md
@@ -314,6 +314,14 @@ When GCP Secret Manager is configured, Scion uses a **hybrid storage** model:
 
 ## Technical Details
 
+### Automatic Plugin Secret Migration & Safety (Hub Integrations)
+
+For external messaging integrations (such as Discord, Telegram, or Google Chat) that run as Hub-level message broker plugins, Scion implements an automatic, secure secret migration and stripping pipeline to keep sensitive bot tokens and API keys out of plaintext configuration files:
+
+- **Automatic One-Shot Migration**: When starting up or activating a plugin (e.g., via the runtime activation path in `activateInstalledIntegration`), the Hub automatically scans the integration's configuration—including per-plugin external configuration files and inline config blocks. Any discovered secret keys are automatically migrated into the configured secure **Secrets Backend** (such as GCP Secret Manager).
+- **Copy-Before-Strip Safety**: After migrating the secrets, Scion strips the raw values in-place from the integration's file-based and inline configurations (`stripSecretKeysInPlace`) using a secure copy-before-strip helper to avoid any risk of partial writes or configuration corruption, while deduplicating warning logs.
+- **Boot and Activation Consistency**: This migration-and-strip sequence runs consistently during both the Hub's boot-up routine and dynamic runtime integration activation, ensuring that secrets are never stored or exposed in plaintext configs.
+
 ### Resolution Hierarchy
 When an agent starts, the Runtime Broker requests a "Resolved Environment" from the Hub. The Hub merges secret values in this order (last one wins for the same key):
 1. Hub Secrets (global defaults)

--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -387,7 +387,7 @@ Manages connection to and interaction with a Scion Hub. Authentication lives und
     - `revoke <token-id>`: Revoke a token (remains visible in listings as revoked).
     - `delete <token-id>`: Permanently delete a token.
 - `scion hub status`: Show the current Hub connection status.
-- `scion hub notifications`: Retrieve a list of recent system notifications and agent alerts.
+- `scion hub notifications`: **Deprecated**. This command has been moved to the top-level `scion notifications` command group.
 - `scion hub link`: Link the current local project to the Hub.
 - `scion hub unlink`: Unlink the current project from the Hub locally.
 - `scion hub projects`: List all projects registered on the Hub.
@@ -411,6 +411,25 @@ Manages connection to and interaction with a Scion Hub. Authentication lives und
         - Flags: `--name`, `--script`, `--description`.
     - `activate <id-or-slug>`: Mark an archived hook as active (archives any currently active hub-scoped hook).
     - `delete <id-or-slug>` (alias `rm`, `remove`): Delete an archived hook. Active hooks cannot be deleted.
+
+## Notification Management
+
+### `scion notifications`
+
+Manages notifications and notification subscriptions. Requires Hub mode.
+
+- `scion notifications`: List your recent unacknowledged notifications.
+    - Flags: `--all` (include acknowledged notifications), `--json` (format output as JSON).
+- `scion notifications ack [id]`: Acknowledge one or all notifications.
+    - Flags: `--all` (acknowledge all unacknowledged notifications).
+- `scion notifications subscribe`: Subscribe to notifications for a specific agent or all agents in a project.
+    - Flags: `--agent <name-or-id>` (subscribe to specific agent), `--project <name>` (specify project, inferred from context if omitted), `--triggers <triggers>` (comma-separated list of trigger activities, default: `COMPLETED,WAITING_FOR_INPUT,LIMITS_EXCEEDED`).
+- `scion notifications unsubscribe <id>`: Remove a subscription.
+    - Flags: `--all` (remove all subscriptions in the project), `--project <name>`.
+- `scion notifications update <id>`: Update a subscription's trigger activities.
+    - Flags: `--triggers <triggers>` (comma-separated list of triggers).
+- `scion notifications subscriptions`: List your active notification subscriptions.
+    - Flags: `--project <name>` (filter by project), `--json` (format output as JSON).
 
 ## Infrastructure
 


### PR DESCRIPTION
## Summary
Changelog-driven documentation updates for the 2026-08-15 release.

### Changes
- messaging.md: Web chat post-Wave-2 (mobile swipe, attachments, markdown, image overlay, iOS, config toggle)
- secrets.md: Plugin secret management migration notes
- cli.md: Agent notification subscription management commands
- permissions.md: Admin role persistence fix (admin_emails as additive floor)
- auth-proxy-iap.md: SA list sync improvements

5 files, 45 insertions, 9 deletions

Tracking: ptone/scion#1025
