### PR TITLE
feat(server): warn when IAP audience looks like a bootstrap placeholder

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -998,6 +998,18 @@ func validateHostedHAPreflight(cfg *config.GlobalConfig) error {
 	// a trailing slash would pass preflight but cause a runtime audience
 	// mismatch in IAP token verification.
 	cfg.Auth.Proxy.IAP.Audience = proxyAudience
+	// The GKE + GCLB bootstrap flow deliberately allows a placeholder audience
+	// on the first deploy, because the backend-service ID only exists once the
+	// ingress has reconciled.  Preflight stays non-fatal for that case, but an
+	// operator who never completes the follow-up upgrade would otherwise get a
+	// hub that looks healthy and 401s every real request.
+	if isLikelyPlaceholderAudience(proxyAudience) {
+		log.Printf("WARNING: IAP audience %q looks like a bootstrap placeholder. "+
+			"IAP token validation will FAIL on real requests until a valid "+
+			"backend-service audience is configured. After your ingress "+
+			"reconciles, update auth.proxy.iap.audience with the real "+
+			"backend-service ID and restart.", proxyAudience)
+	}
 
 	if cfg.Auth.Transport == nil {
 		return fmt.Errorf("hosted HA deployment requires server.auth.transport; do not use server.transport")
@@ -1045,6 +1057,36 @@ func isSupportedIAPAudience(audience string) bool {
 		parts[1] == "projects" && parts[2] != "" &&
 		parts[3] == "global" &&
 		parts[4] == "backendServices" && parts[5] != "" {
+		return true
+	}
+	return false
+}
+
+// isLikelyPlaceholderAudience returns true when a GCLB audience looks
+// synthetic — e.g. all-zero project numbers, backend-service ID "0", or other
+// patterns that indicate a bootstrap placeholder rather than a real
+// backend-service audience.
+//
+// Only the GCLB format is inspected.  Cloud Run audiences are knowable before
+// the first deploy, so they never need a placeholder.
+func isLikelyPlaceholderAudience(audience string) bool {
+	parts := strings.Split(strings.TrimSpace(audience), "/")
+	if len(parts) != 6 || parts[4] != "backendServices" {
+		return false
+	}
+	projectNumber := parts[2]
+	backendServiceID := parts[5]
+
+	// Backend-service ID "0" is the canonical placeholder.
+	if backendServiceID == "0" {
+		return true
+	}
+	// An all-zeros project number (any length) is synthetic.
+	if projectNumber != "" && strings.Trim(projectNumber, "0") == "" {
+		return true
+	}
+	// Well-known dummy project numbers.
+	if projectNumber == "123456789" {
 		return true
 	}
 	return false

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1077,8 +1077,8 @@ func isLikelyPlaceholderAudience(audience string) bool {
 	projectNumber := parts[2]
 	backendServiceID := parts[5]
 
-	// Backend-service ID "0" is the canonical placeholder.
-	if backendServiceID == "0" {
+	// Backend-service ID "0" (or any all-zeros string) is the canonical placeholder.
+	if backendServiceID != "" && strings.Trim(backendServiceID, "0") == "" {
 		return true
 	}
 	// An all-zeros project number (any length) is synthetic.

--- a/cmd/server_ha_preflight_test.go
+++ b/cmd/server_ha_preflight_test.go
@@ -278,6 +278,7 @@ func TestIsLikelyPlaceholderAudience(t *testing.T) {
 	}{
 		{"canonical placeholder", "/projects/000000000/global/backendServices/0", true},
 		{"zero backend ID", "/projects/486315127503/global/backendServices/0", true},
+		{"padded zero backend service ID", "/projects/486315127503/global/backendServices/000000", true},
 		{"all-zeros project", "/projects/000000000/global/backendServices/12345", true},
 		{"all-zeros project short", "/projects/0/global/backendServices/12345", true},
 		{"dummy project number", "/projects/123456789/global/backendServices/12345", true},

--- a/cmd/server_ha_preflight_test.go
+++ b/cmd/server_ha_preflight_test.go
@@ -123,10 +123,15 @@ func TestValidateHostedHAPreflightRejectsUnsafeBackends(t *testing.T) {
 func TestValidateHostedHAPreflightAcceptsGCLBAudience(t *testing.T) {
 	withHostedHAGuards(t)
 	cfg := validHostedHAConfig()
-	cfg.Auth.Proxy.IAP.Audience = "/projects/123456789/global/backendServices/987654321"
+	cfg.Auth.Proxy.IAP.Audience = "/projects/486315127503/global/backendServices/987654321"
 	cfg.Auth.Transport.OIDCAudience = cfg.Auth.Proxy.IAP.Audience
 
-	require.NoError(t, validateHostedHAPreflight(cfg))
+	var err error
+	logged := captureLog(t, func() {
+		err = validateHostedHAPreflight(cfg)
+	})
+	require.NoError(t, err)
+	require.NotContains(t, logged, "looks like a bootstrap placeholder")
 }
 
 func TestValidateHostedHAPreflightRequiresSessionSecret(t *testing.T) {
@@ -298,5 +303,13 @@ func TestValidateHostedHAPreflightAcceptsPlaceholderGCLBAudience(t *testing.T) {
 	cfg.Auth.Proxy.IAP.Audience = "/projects/000000000/global/backendServices/0"
 	cfg.Auth.Transport.OIDCAudience = cfg.Auth.Proxy.IAP.Audience
 
-	require.NoError(t, validateHostedHAPreflight(cfg))
+	// Non-fatality alone is not the contract: the operator must also be told
+	// the deployment will 401 until the real backend-service ID is wired in.
+	var err error
+	logged := captureLog(t, func() {
+		err = validateHostedHAPreflight(cfg)
+	})
+	require.NoError(t, err)
+	require.Contains(t, logged, "looks like a bootstrap placeholder")
+	require.Contains(t, logged, cfg.Auth.Proxy.IAP.Audience)
 }

--- a/cmd/server_ha_preflight_test.go
+++ b/cmd/server_ha_preflight_test.go
@@ -264,3 +264,39 @@ func TestIAPAudienceShape(t *testing.T) {
 	require.True(t, isSupportedIAPAudience("/projects/123/global/backendServices/456"))
 	require.False(t, isSupportedIAPAudience(strings.TrimSpace("")))
 }
+
+func TestIsLikelyPlaceholderAudience(t *testing.T) {
+	tests := []struct {
+		name     string
+		audience string
+		want     bool
+	}{
+		{"canonical placeholder", "/projects/000000000/global/backendServices/0", true},
+		{"zero backend ID", "/projects/486315127503/global/backendServices/0", true},
+		{"all-zeros project", "/projects/000000000/global/backendServices/12345", true},
+		{"all-zeros project short", "/projects/0/global/backendServices/12345", true},
+		{"dummy project number", "/projects/123456789/global/backendServices/12345", true},
+		{"real audience", "/projects/486315127503/global/backendServices/987654321", false},
+		{"cloud run (not checked)", "/projects/123/locations/us-central1/services/scion-hub", false},
+		{"cloud run with dummy project (not checked)", "/projects/123456789/locations/us-central1/services/scion-hub", false},
+		{"empty", "", false},
+		{"malformed", "/projects//global/backendServices/12345", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isLikelyPlaceholderAudience(tt.audience))
+		})
+	}
+}
+
+// A placeholder audience is intentionally non-fatal: it is the supported GKE
+// bootstrap path, where the real backend-service ID does not exist until the
+// ingress has reconciled.
+func TestValidateHostedHAPreflightAcceptsPlaceholderGCLBAudience(t *testing.T) {
+	withHostedHAGuards(t)
+	cfg := validHostedHAConfig()
+	cfg.Auth.Proxy.IAP.Audience = "/projects/000000000/global/backendServices/0"
+	cfg.Auth.Transport.OIDCAudience = cfg.Auth.Proxy.IAP.Audience
+
+	require.NoError(t, validateHostedHAPreflight(cfg))
+}


### PR DESCRIPTION
Detect synthetic-looking GCLB IAP audiences at startup and log a WARNING so operators know their hub will 401 real requests until the real backend-service ID is configured.

Supports the GKE two-step bootstrap flow: deploy with placeholder audience -> ingress reconciles -> operator upgrades with real audience.

Ref: ptone/scion#1068