### PR TITLE
fix(server): accept truthy env values for boolean server flags

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -89,7 +90,7 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 	// 3. Resolve admin mode settings
 	adminMode := cfg.AdminMode
 	if v := os.Getenv("SCION_SERVER_ADMIN_MODE"); v != "" {
-		adminMode = v == "true" || v == "1" || v == "yes"
+		adminMode = parseBoolEnv("SCION_SERVER_ADMIN_MODE")
 	}
 	maintenanceMessage := cfg.MaintenanceMessage
 	if v := os.Getenv("SCION_SERVER_MAINTENANCE_MESSAGE"); v != "" {
@@ -260,7 +261,7 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 		}
 
 		// Wire hub OTel tracing export to Cloud Trace.
-		if os.Getenv("SCION_TRACING_ENABLED") == "true" && cfg.Hub.GCPProjectID != "" {
+		if parseBoolEnv("SCION_TRACING_ENABLED") && cfg.Hub.GCPProjectID != "" {
 			tp, tpErr := hubtracing.NewTracerProvider(ctx, cfg.Hub.GCPProjectID,
 				hubtracing.WithHubID(hubSrv.HubID()),
 				hubtracing.WithHubName(cfg.Hub.ResolveHubName()),
@@ -701,7 +702,7 @@ func warnShadowedBrokerEnv(ctx context.Context, w brokerEnvShadowWarner) {
 
 // initServerLogging initializes all logging subsystems and returns cleanup functions.
 func initServerLogging(cmd *cobra.Command) (cleanups []func(), requestLogger *slog.Logger, messageLogger *slog.Logger, err error) {
-	useGCP := os.Getenv("SCION_LOG_GCP") == "true"
+	useGCP := parseBoolEnv("SCION_LOG_GCP")
 	if os.Getenv("K_SERVICE") != "" {
 		useGCP = true
 	}
@@ -1463,6 +1464,22 @@ func resolveSessionSecret() string {
 	return secret
 }
 
+// parseBoolEnv reports whether the named environment variable is set to a
+// truthy value. It accepts every spelling strconv.ParseBool understands
+// (1, t, T, true, TRUE, True) plus the operator-friendly yes/y/on, matched
+// case-insensitively. Unset, empty, and unparseable values are false.
+func parseBoolEnv(key string) bool {
+	v := os.Getenv(key)
+	if b, err := strconv.ParseBool(v); err == nil {
+		return b
+	}
+	switch strings.ToLower(v) {
+	case "yes", "y", "on":
+		return true
+	}
+	return false
+}
+
 // initHubServer creates and configures the Hub server.
 func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store, entClient *ent.Client, hubEndpoint, devAuthToken string, adminEmailList []string, adminMode bool, maintenanceMessage string, requestLogger, messageLogger *slog.Logger, globalDir string, pluginMgr *scionplugin.Manager, secretBackend secret.SecretBackend) (*hub.Server, error) {
 	hubCfg := hub.ServerConfig{
@@ -1559,7 +1576,7 @@ func initHubServer(ctx context.Context, cfg *config.GlobalConfig, s store.Store,
 		// (which would invalidate every live token after, e.g., a redeploy onto a
 		// new host that changed the HubID). Operators enabling this must supply a
 		// session secret or pre-provision the signing keys.
-		RequireStableSigningKey: os.Getenv("SCION_REQUIRE_STABLE_SIGNING_KEY") == "true",
+		RequireStableSigningKey: parseBoolEnv("SCION_REQUIRE_STABLE_SIGNING_KEY"),
 		OIDCLogin:               cfg.OIDCLogin,
 		OIDCConfig:              cfg.OIDC,
 		Federation:              cfg.Federation,

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1465,15 +1465,17 @@ func resolveSessionSecret() string {
 }
 
 // parseBoolEnv reports whether the named environment variable is set to a
-// truthy value. It accepts every spelling strconv.ParseBool understands
-// (1, t, T, true, TRUE, True) plus the operator-friendly yes/y/on, matched
-// case-insensitively. Unset, empty, and unparseable values are false.
+// truthy value. Leading/trailing whitespace is stripped (file-mounted
+// secrets often include a trailing newline). It accepts every spelling
+// strconv.ParseBool understands (1, t, true, TRUE, True, etc.) plus the
+// operator-friendly yes/y/on, all case-insensitively. Unset, empty, and
+// unparseable values are false.
 func parseBoolEnv(key string) bool {
-	v := os.Getenv(key)
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
 	if b, err := strconv.ParseBool(v); err == nil {
 		return b
 	}
-	switch strings.ToLower(v) {
+	switch v {
 	case "yes", "y", "on":
 		return true
 	}

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1468,17 +1468,31 @@ func resolveSessionSecret() string {
 // truthy value. Leading/trailing whitespace is stripped (file-mounted
 // secrets often include a trailing newline). It accepts every spelling
 // strconv.ParseBool understands (1, t, true, TRUE, True, etc.) plus the
-// operator-friendly yes/y/on, all case-insensitively. Unset, empty, and
-// unparseable values are false.
+// operator-friendly yes/y/on (and their no/n/off counterparts), all
+// case-insensitively. Unset, empty, and
+// unparseable values are false, but an unparseable non-empty value also logs
+// a warning so a typo does not silently disable a feature the operator meant
+// to turn on.
+//
+// The warning uses the stdlib logger because parseBoolEnv runs during
+// initServerLogging, before the slog loggers are wired.
 func parseBoolEnv(key string) bool {
 	v := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	if v == "" {
+		return false
+	}
 	if b, err := strconv.ParseBool(v); err == nil {
 		return b
 	}
 	switch v {
 	case "yes", "y", "on":
 		return true
+	case "no", "n", "off":
+		// Recognized as an explicit "disabled" spelling: false, but no warning.
+		return false
 	}
+	log.Printf("WARNING: environment variable %s=%q is not a recognized boolean value; treating as false. "+
+		"Accepted truthy values: true, 1, t, yes, y, on (case-insensitive, whitespace-trimmed).", key, os.Getenv(key))
 	return false
 }
 

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -89,7 +89,7 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 
 	// 3. Resolve admin mode settings
 	adminMode := cfg.AdminMode
-	if v := os.Getenv("SCION_SERVER_ADMIN_MODE"); v != "" {
+	if os.Getenv("SCION_SERVER_ADMIN_MODE") != "" {
 		adminMode = parseBoolEnv("SCION_SERVER_ADMIN_MODE")
 	}
 	maintenanceMessage := cfg.MaintenanceMessage

--- a/cmd/server_foreground_boolenv_test.go
+++ b/cmd/server_foreground_boolenv_test.go
@@ -24,16 +24,37 @@ import (
 // operator who set the variable to "1" or "TRUE" silently got the disabled
 // path while believing the key was pinned across HA replicas.
 
-func TestRequireStableSigningKeyAcceptsTruthyValues(t *testing.T) {
-	for _, val := range []string{"true", "TRUE", "True", "1", "t", "T", "yes", "YES", "on", "ON"} {
-		t.Run(val, func(t *testing.T) {
-			t.Setenv("SCION_REQUIRE_STABLE_SIGNING_KEY", val)
+func TestParseBoolEnvAcceptsTruthyValues(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+	}{
+		{"true", "true"},
+		{"TRUE", "TRUE"},
+		{"True", "True"},
+		{"TrUe", "TrUe"},
+		{"1", "1"},
+		{"t", "t"},
+		{"T", "T"},
+		{"yes", "yes"},
+		{"YES", "YES"},
+		{"on", "on"},
+		{"ON", "ON"},
+		{"leading space", " true"},
+		{"trailing space", "true "},
+		{"trailing newline", "true\n"},
+		{"padded 1", " 1 "},
+		{"padded yes", " yes "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SCION_REQUIRE_STABLE_SIGNING_KEY", tc.val)
 			require.True(t, parseBoolEnv("SCION_REQUIRE_STABLE_SIGNING_KEY"))
 		})
 	}
 }
 
-func TestRequireStableSigningKeyRejectsFalsyValues(t *testing.T) {
+func TestParseBoolEnvRejectsFalsyValues(t *testing.T) {
 	for _, val := range []string{"false", "FALSE", "0", "f", "no", "off", "", "maybe"} {
 		t.Run(val, func(t *testing.T) {
 			t.Setenv("SCION_REQUIRE_STABLE_SIGNING_KEY", val)

--- a/cmd/server_foreground_boolenv_test.go
+++ b/cmd/server_foreground_boolenv_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The signing-key gate used to compare against the exact string "true", so an
+// operator who set the variable to "1" or "TRUE" silently got the disabled
+// path while believing the key was pinned across HA replicas.
+
+func TestRequireStableSigningKeyAcceptsTruthyValues(t *testing.T) {
+	for _, val := range []string{"true", "TRUE", "True", "1", "t", "T", "yes", "YES", "on", "ON"} {
+		t.Run(val, func(t *testing.T) {
+			t.Setenv("SCION_REQUIRE_STABLE_SIGNING_KEY", val)
+			require.True(t, parseBoolEnv("SCION_REQUIRE_STABLE_SIGNING_KEY"))
+		})
+	}
+}
+
+func TestRequireStableSigningKeyRejectsFalsyValues(t *testing.T) {
+	for _, val := range []string{"false", "FALSE", "0", "f", "no", "off", "", "maybe"} {
+		t.Run(val, func(t *testing.T) {
+			t.Setenv("SCION_REQUIRE_STABLE_SIGNING_KEY", val)
+			require.False(t, parseBoolEnv("SCION_REQUIRE_STABLE_SIGNING_KEY"))
+		})
+	}
+}
+
+func TestParseBoolEnvUnsetIsFalse(t *testing.T) {
+	require.False(t, parseBoolEnv("SCION_BOOL_ENV_THAT_IS_NOT_SET"))
+}

--- a/cmd/server_foreground_boolenv_test.go
+++ b/cmd/server_foreground_boolenv_test.go
@@ -38,6 +38,8 @@ func TestParseBoolEnvAcceptsTruthyValues(t *testing.T) {
 		{"T", "T"},
 		{"yes", "yes"},
 		{"YES", "YES"},
+		{"lowercase y", "y"},
+		{"uppercase Y", "Y"},
 		{"on", "on"},
 		{"ON", "ON"},
 		{"leading space", " true"},
@@ -55,7 +57,7 @@ func TestParseBoolEnvAcceptsTruthyValues(t *testing.T) {
 }
 
 func TestParseBoolEnvRejectsFalsyValues(t *testing.T) {
-	for _, val := range []string{"false", "FALSE", "0", "f", "no", "off", "", "maybe"} {
+	for _, val := range []string{"false", "FALSE", "0", "f", "no", "n", "N", "off", "OFF", "", "maybe"} {
 		t.Run(val, func(t *testing.T) {
 			t.Setenv("SCION_REQUIRE_STABLE_SIGNING_KEY", val)
 			require.False(t, parseBoolEnv("SCION_REQUIRE_STABLE_SIGNING_KEY"))
@@ -65,4 +67,32 @@ func TestParseBoolEnvRejectsFalsyValues(t *testing.T) {
 
 func TestParseBoolEnvUnsetIsFalse(t *testing.T) {
 	require.False(t, parseBoolEnv("SCION_BOOL_ENV_THAT_IS_NOT_SET"))
+}
+
+// A value like "enabled" reads as an intent to turn the feature on. Falling
+// back to false is the safe behaviour, but it must be visible to the operator.
+func TestParseBoolEnvWarnsOnUnrecognizedValue(t *testing.T) {
+	t.Setenv("SCION_REQUIRE_STABLE_SIGNING_KEY", "enabled")
+	var result bool
+	logged := captureLog(t, func() {
+		result = parseBoolEnv("SCION_REQUIRE_STABLE_SIGNING_KEY")
+	})
+	require.False(t, result)
+	require.Contains(t, logged, "not a recognized boolean value")
+	require.Contains(t, logged, "SCION_REQUIRE_STABLE_SIGNING_KEY")
+	require.Contains(t, logged, `"enabled"`)
+}
+
+// Recognized values — truthy, falsy, or empty — are not a misconfiguration, so
+// they must stay silent.
+func TestParseBoolEnvNoWarningOnRecognizedValues(t *testing.T) {
+	for _, val := range []string{"", "  ", "true", "false", "1", "0", "yes", "off"} {
+		t.Run(val, func(t *testing.T) {
+			t.Setenv("SCION_REQUIRE_STABLE_SIGNING_KEY", val)
+			logged := captureLog(t, func() {
+				parseBoolEnv("SCION_REQUIRE_STABLE_SIGNING_KEY")
+			})
+			require.Empty(t, logged)
+		})
+	}
 }


### PR DESCRIPTION
Replace strict == "true" comparison with parseBoolEnv helper for 4 boolean env vars (SCION_REQUIRE_STABLE_SIGNING_KEY, SCION_SERVER_ADMIN_MODE, SCION_TRACING_ENABLED, SCION_LOG_GCP). Accepts all strconv.ParseBool spellings plus yes/y/on, case-insensitively, with whitespace trimming. Warns on unrecognized non-empty values instead of silently defaulting to false.

Ref: ptone/scion#1080