### PR TITLE
fix: do not require IAP for hosted HA preflight

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1402,17 +1402,13 @@ func resolveHubEndpoint(cfg *config.GlobalConfig, brokerSettings *config.Setting
 
 	// In hosted mode with IAP authentication, derive the Cloud Run URL from
 	// the IAP audience. This prevents the localhost:8080 fallback which is
-	// unreachable from GKE-dispatched agents.
+	// unreachable from GKE-dispatched agents. GCLB/GKE audiences carry no
+	// routing information and cannot be converted to a URL, so they fall
+	// through to the HA warning below.
 	if hostedMode && cfg.Auth.Proxy != nil && cfg.Auth.Proxy.IAP != nil && cfg.Auth.Proxy.IAP.Audience != "" {
 		if cloudRunURL := iapAudienceToCloudRunURL(cfg.Auth.Proxy.IAP.Audience); cloudRunURL != "" {
 			log.Printf("Hub endpoint derived from IAP audience: %s", cloudRunURL)
 			return cloudRunURL
-		}
-		// GCLB/GKE audiences cannot be used to derive a URL; warn if no
-		// explicit base URL was provided (all earlier return paths above
-		// would have caught an explicit one).
-		if isSupportedIAPAudience(strings.TrimRight(strings.TrimSpace(cfg.Auth.Proxy.IAP.Audience), "/")) {
-			log.Println("Warning: GKE/GCLB IAP audience detected but SCION_SERVER_BASE_URL not set; hub endpoint will fall back to localhost which is likely unreachable from dispatched agents")
 		}
 	}
 
@@ -1421,6 +1417,14 @@ func resolveHubEndpoint(cfg *config.GlobalConfig, brokerSettings *config.Setting
 		port = webPort
 	}
 	hubEndpoint := fmt.Sprintf("http://localhost:%d", port)
+	// Any hosted multi-instance deployment reaching this fallback has no
+	// usable public URL: dispatched agents would resolve the loopback address
+	// inside their own container. This is not specific to IAP — a GCLB
+	// audience cannot be converted to a URL, and a hub doing its own
+	// OAuth/OIDC has no audience to derive one from at all.
+	if hostedHAGuardsRequired(cfg) {
+		log.Printf("Warning: hosted HA deployment has no explicit hub base URL; falling back to %s, which is unreachable from dispatched agents. Set SCION_SERVER_BASE_URL or server.hub.public_url.", hubEndpoint)
+	}
 	if enableDebug {
 		log.Printf("Auto-computed hub endpoint for combo mode: %s", hubEndpoint)
 	}

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -949,10 +949,17 @@ func validateHostedBasic(cfg *config.GlobalConfig) {
 	}
 }
 
+// validateHostedHAPreflight fails startup closed when a hosted multi-instance
+// deployment is configured in a way that is not HA-safe.  It has two parts:
+// universal HA consistency checks that apply to every multi-instance
+// deployment regardless of auth mode, and IAP checks that apply only when IAP
+// is the auth frontend (auth.mode=proxy).
 func validateHostedHAPreflight(cfg *config.GlobalConfig) error {
 	if !hostedHAGuardsRequired(cfg) {
 		return nil
 	}
+
+	// --- Universal HA consistency checks (all auth modes) ---
 
 	// Require an explicitly configured hub_id so all instances share the same
 	// GCS prefix, secret scopes, and DB lookups. Without this, each Cloud Run
@@ -977,59 +984,63 @@ func validateHostedHAPreflight(cfg *config.GlobalConfig) error {
 		return fmt.Errorf("hosted HA deployment requires a durable session/signing secret; set --session-secret or SCION_SERVER_SESSION_SECRET")
 	}
 
-	if cfg.Auth.Mode != "proxy" {
-		return fmt.Errorf("hosted HA deployment requires server.auth.mode=proxy for IAP authentication; got %q", cfg.Auth.Mode)
-	}
-	if cfg.Auth.Proxy == nil || cfg.Auth.Proxy.Provider != "iap" {
-		provider := ""
-		if cfg.Auth.Proxy != nil {
-			provider = cfg.Auth.Proxy.Provider
+	// --- IAP-specific validation (proxy mode only) ---
+	// When auth.mode is not "proxy", the hub handles authentication directly
+	// (OAuth/OIDC). Cross-replica session consistency is provided by the
+	// shared session secret (checked above) and stateless encrypted cookies.
+	// No IAP infrastructure config is needed, so IAP is not required for HA.
+	if cfg.Auth.Mode == "proxy" {
+		if cfg.Auth.Proxy == nil || cfg.Auth.Proxy.Provider != "iap" {
+			provider := ""
+			if cfg.Auth.Proxy != nil {
+				provider = cfg.Auth.Proxy.Provider
+			}
+			return fmt.Errorf("hosted HA deployment requires server.auth.proxy.provider=iap; got %q", provider)
 		}
-		return fmt.Errorf("hosted HA deployment requires server.auth.proxy.provider=iap; got %q", provider)
-	}
-	if cfg.Auth.Proxy.IAP == nil || strings.TrimSpace(cfg.Auth.Proxy.IAP.Audience) == "" {
-		return fmt.Errorf("hosted HA deployment requires server.auth.proxy.iap.audience")
-	}
-	proxyAudience := strings.TrimRight(strings.TrimSpace(cfg.Auth.Proxy.IAP.Audience), "/")
-	if !isSupportedIAPAudience(proxyAudience) {
-		return fmt.Errorf("hosted HA deployment requires a supported IAP audience: Cloud Run (/projects/<number>/locations/<region>/services/<service>) or GCLB (/projects/<number>/global/backendServices/<id>); got %q", proxyAudience)
-	}
-	// Normalize the audience in-place so downstream consumers (IAP JWT
-	// validation, endpoint derivation) see the trimmed value.  Without this
-	// a trailing slash would pass preflight but cause a runtime audience
-	// mismatch in IAP token verification.
-	cfg.Auth.Proxy.IAP.Audience = proxyAudience
-	// The GKE + GCLB bootstrap flow deliberately allows a placeholder audience
-	// on the first deploy, because the backend-service ID only exists once the
-	// ingress has reconciled.  Preflight stays non-fatal for that case, but an
-	// operator who never completes the follow-up upgrade would otherwise get a
-	// hub that looks healthy and 401s every real request.
-	if isLikelyPlaceholderAudience(proxyAudience) {
-		log.Printf("WARNING: IAP audience %q looks like a bootstrap placeholder. "+
-			"IAP token validation will FAIL on real requests until a valid "+
-			"backend-service audience is configured. After your ingress "+
-			"reconciles, update auth.proxy.iap.audience with the real "+
-			"backend-service ID and restart.", proxyAudience)
-	}
+		if cfg.Auth.Proxy.IAP == nil || strings.TrimSpace(cfg.Auth.Proxy.IAP.Audience) == "" {
+			return fmt.Errorf("hosted HA deployment requires server.auth.proxy.iap.audience")
+		}
+		proxyAudience := strings.TrimRight(strings.TrimSpace(cfg.Auth.Proxy.IAP.Audience), "/")
+		if !isSupportedIAPAudience(proxyAudience) {
+			return fmt.Errorf("hosted HA deployment requires a supported IAP audience: Cloud Run (/projects/<number>/locations/<region>/services/<service>) or GCLB (/projects/<number>/global/backendServices/<id>); got %q", proxyAudience)
+		}
+		// Normalize the audience in-place so downstream consumers (IAP JWT
+		// validation, endpoint derivation) see the trimmed value.  Without this
+		// a trailing slash would pass preflight but cause a runtime audience
+		// mismatch in IAP token verification.
+		cfg.Auth.Proxy.IAP.Audience = proxyAudience
+		// The GKE + GCLB bootstrap flow deliberately allows a placeholder audience
+		// on the first deploy, because the backend-service ID only exists once the
+		// ingress has reconciled.  Preflight stays non-fatal for that case, but an
+		// operator who never completes the follow-up upgrade would otherwise get a
+		// hub that looks healthy and 401s every real request.
+		if isLikelyPlaceholderAudience(proxyAudience) {
+			log.Printf("WARNING: IAP audience %q looks like a bootstrap placeholder. "+
+				"IAP token validation will FAIL on real requests until a valid "+
+				"backend-service audience is configured. After your ingress "+
+				"reconciles, update auth.proxy.iap.audience with the real "+
+				"backend-service ID and restart.", proxyAudience)
+		}
 
-	if cfg.Auth.Transport == nil {
-		return fmt.Errorf("hosted HA deployment requires server.auth.transport; do not use server.transport")
-	}
-	if cfg.Auth.Transport.Mode != "iap" {
-		return fmt.Errorf("hosted HA deployment requires server.auth.transport.mode=iap; got %q", cfg.Auth.Transport.Mode)
-	}
-	transportAudience := strings.TrimRight(strings.TrimSpace(cfg.Auth.Transport.OIDCAudience), "/")
-	if transportAudience == "" {
-		return fmt.Errorf("hosted HA deployment requires server.auth.transport.oidc_audience")
-	}
-	// Note: transport.oidc_audience and proxy.iap.audience are intentionally
-	// allowed to differ. proxy.iap.audience is the IAP audience resource path
-	// (Cloud Run or GCLB) used for validating incoming IAP-signed JWTs, while
-	// transport.oidc_audience is the audience minted into OIDC tokens for
-	// dispatched agents (typically the IAP OAuth client ID). IAP requires
-	// the OAuth client ID format for token validation, not the resource path.
-	if strings.TrimSpace(cfg.Auth.Transport.PlatformAuthSA) == "" {
-		return fmt.Errorf("hosted HA deployment requires server.auth.transport.platform_auth_sa")
+		if cfg.Auth.Transport == nil {
+			return fmt.Errorf("hosted HA deployment requires server.auth.transport; do not use server.transport")
+		}
+		if cfg.Auth.Transport.Mode != "iap" {
+			return fmt.Errorf("hosted HA deployment requires server.auth.transport.mode=iap; got %q", cfg.Auth.Transport.Mode)
+		}
+		transportAudience := strings.TrimRight(strings.TrimSpace(cfg.Auth.Transport.OIDCAudience), "/")
+		if transportAudience == "" {
+			return fmt.Errorf("hosted HA deployment requires server.auth.transport.oidc_audience")
+		}
+		// Note: transport.oidc_audience and proxy.iap.audience are intentionally
+		// allowed to differ. proxy.iap.audience is the IAP audience resource path
+		// (Cloud Run or GCLB) used for validating incoming IAP-signed JWTs, while
+		// transport.oidc_audience is the audience minted into OIDC tokens for
+		// dispatched agents (typically the IAP OAuth client ID). IAP requires
+		// the OAuth client ID format for token validation, not the resource path.
+		if strings.TrimSpace(cfg.Auth.Transport.PlatformAuthSA) == "" {
+			return fmt.Errorf("hosted HA deployment requires server.auth.transport.platform_auth_sa")
+		}
 	}
 
 	return nil

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1032,6 +1032,10 @@ func validateHostedHAPreflight(cfg *config.GlobalConfig) error {
 		if transportAudience == "" {
 			return fmt.Errorf("hosted HA deployment requires server.auth.transport.oidc_audience")
 		}
+		// Normalize in-place so downstream consumers (token minting,
+		// validation) see the trimmed value — matching the proxy audience
+		// normalization above.
+		cfg.Auth.Transport.OIDCAudience = transportAudience
 		// Note: transport.oidc_audience and proxy.iap.audience are intentionally
 		// allowed to differ. proxy.iap.audience is the IAP audience resource path
 		// (Cloud Run or GCLB) used for validating incoming IAP-signed JWTs, while

--- a/cmd/server_foreground_test.go
+++ b/cmd/server_foreground_test.go
@@ -166,4 +166,13 @@ func TestValidateHostedHAPreflight(t *testing.T) {
 		assert.Equal(t, "/projects/123/global/backendServices/456", cfg.Auth.Proxy.IAP.Audience,
 			"preflight should strip trailing slash so downstream IAP validation uses the canonical audience")
 	})
+
+	t.Run("transport audience is normalized in config", func(t *testing.T) {
+		withHostedHAGuards(t)
+		cfg := validHostedHAConfig()
+		cfg.Auth.Transport.OIDCAudience = "  123-abc.apps.googleusercontent.com/  "
+		require.NoError(t, validateHostedHAPreflight(cfg))
+		assert.Equal(t, "123-abc.apps.googleusercontent.com", cfg.Auth.Transport.OIDCAudience,
+			"preflight should trim the transport audience so downstream token minting uses the canonical value")
+	})
 }

--- a/cmd/server_ha_preflight_test.go
+++ b/cmd/server_ha_preflight_test.go
@@ -178,12 +178,10 @@ func TestValidateHostedHAPreflightSkippedForNonHA(t *testing.T) {
 	require.NoError(t, validateHostedHAPreflight(&cfg))
 }
 
-// TestValidateHostedHAPreflightAcceptsOAuthMode covers the core of #1087: IAP
-// is not required for HA. A hub that authenticates users itself (OAuth/OIDC)
-// starts in HA as long as the universal consistency checks are satisfied.
-func TestValidateHostedHAPreflightAcceptsOAuthMode(t *testing.T) {
-	withHostedHAGuards(t)
-
+// validHostedHAOAuthConfig is the HA-safe counterpart of validHostedHAConfig
+// for a hub that authenticates users itself: every universal check is
+// satisfied and no IAP configuration is present.
+func validHostedHAOAuthConfig() *config.GlobalConfig {
 	cfg := config.DefaultGlobalConfig()
 	cfg.Mode = "hosted"
 	cfg.Hub.HubID = "scion-hub"
@@ -192,8 +190,16 @@ func TestValidateHostedHAPreflightAcceptsOAuthMode(t *testing.T) {
 	cfg.Storage.Provider = "gcs"
 	cfg.Storage.Bucket = "scion-prod-artifacts"
 	cfg.Auth.Mode = "oauth"
+	return &cfg
+}
 
-	require.NoError(t, validateHostedHAPreflight(&cfg), "oauth mode should pass HA preflight when universal checks are satisfied")
+// TestValidateHostedHAPreflightAcceptsOAuthMode covers the core of #1087: IAP
+// is not required for HA. A hub that authenticates users itself (OAuth/OIDC)
+// starts in HA as long as the universal consistency checks are satisfied.
+func TestValidateHostedHAPreflightAcceptsOAuthMode(t *testing.T) {
+	withHostedHAGuards(t)
+
+	require.NoError(t, validateHostedHAPreflight(validHostedHAOAuthConfig()), "oauth mode should pass HA preflight when universal checks are satisfied")
 }
 
 // TestValidateHostedHAPreflightStillRequiresIAPForProxy pins the other half of
@@ -210,20 +216,79 @@ func TestValidateHostedHAPreflightStillRequiresIAPForProxy(t *testing.T) {
 	require.Contains(t, err.Error(), "requires server.auth.proxy.provider=iap")
 }
 
-// TestValidateHostedHAPreflightEnforcesUniversalForOAuth checks that skipping
-// the IAP block does not skip the universal checks.  Postgres makes this an HA
-// deployment; hub_id is missing, so preflight must still reject it.
+// TestValidateHostedHAPreflightEnforcesUniversalForOAuth pins every universal
+// check against oauth mode. Without a case per check, a universal check could
+// be nested under the proxy guard by accident and the suite would stay green:
+// the proxy-mode tests would still exercise it, and the oauth tests would only
+// notice the one check they happen to break.
 func TestValidateHostedHAPreflightEnforcesUniversalForOAuth(t *testing.T) {
-	withHostedHAGuards(t)
+	tests := []struct {
+		name    string
+		mutate  func(t *testing.T, cfg *config.GlobalConfig)
+		wantErr string
+	}{
+		{
+			name: "missing hub_id",
+			mutate: func(t *testing.T, cfg *config.GlobalConfig) {
+				cfg.Hub.HubID = ""
+			},
+			wantErr: "requires an explicit server.hub.hub_id",
+		},
+		{
+			name: "sqlite",
+			mutate: func(t *testing.T, cfg *config.GlobalConfig) {
+				cfg.Database.Driver = "sqlite"
+				// Postgres is what marks this deployment HA, so removing it
+				// would also skip preflight entirely. K_SERVICE keeps
+				// isHADeployment true and isolates the driver check.
+				t.Setenv("K_SERVICE", "scion-hub")
+			},
+			wantErr: "requires server.database.driver=postgres",
+		},
+		{
+			name: "empty postgres dsn",
+			mutate: func(t *testing.T, cfg *config.GlobalConfig) {
+				cfg.Database.URL = ""
+			},
+			wantErr: "requires server.database.url",
+		},
+		{
+			name: "local storage",
+			mutate: func(t *testing.T, cfg *config.GlobalConfig) {
+				cfg.Storage.Provider = "local"
+				cfg.Storage.Bucket = ""
+			},
+			wantErr: "requires server.storage.provider=gcs",
+		},
+		{
+			name: "gcs without bucket",
+			mutate: func(t *testing.T, cfg *config.GlobalConfig) {
+				cfg.Storage.Bucket = ""
+			},
+			wantErr: "requires server.storage.provider=gcs",
+		},
+		{
+			name: "missing session secret",
+			mutate: func(t *testing.T, cfg *config.GlobalConfig) {
+				webSessionSecret = ""
+				t.Setenv("SCION_SERVER_SESSION_SECRET", "")
+				t.Setenv("SESSION_SECRET", "")
+			},
+			wantErr: "durable session/signing secret",
+		},
+	}
 
-	cfg := config.DefaultGlobalConfig()
-	cfg.Mode = "hosted"
-	cfg.Database.Driver = "postgres"
-	cfg.Auth.Mode = "oauth"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withHostedHAGuards(t)
+			cfg := validHostedHAOAuthConfig()
+			tt.mutate(t, cfg)
 
-	err := validateHostedHAPreflight(&cfg)
-	require.Error(t, err, "universal checks should still enforce for oauth mode")
-	require.Contains(t, err.Error(), "requires an explicit server.hub.hub_id")
+			err := validateHostedHAPreflight(cfg)
+			require.Error(t, err, "universal checks should still enforce for oauth mode")
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
 }
 
 func TestIsHADeployment(t *testing.T) {

--- a/cmd/server_ha_preflight_test.go
+++ b/cmd/server_ha_preflight_test.go
@@ -178,6 +178,54 @@ func TestValidateHostedHAPreflightSkippedForNonHA(t *testing.T) {
 	require.NoError(t, validateHostedHAPreflight(&cfg))
 }
 
+// TestValidateHostedHAPreflightAcceptsOAuthMode covers the core of #1087: IAP
+// is not required for HA. A hub that authenticates users itself (OAuth/OIDC)
+// starts in HA as long as the universal consistency checks are satisfied.
+func TestValidateHostedHAPreflightAcceptsOAuthMode(t *testing.T) {
+	withHostedHAGuards(t)
+
+	cfg := config.DefaultGlobalConfig()
+	cfg.Mode = "hosted"
+	cfg.Hub.HubID = "scion-hub"
+	cfg.Database.Driver = "postgres"
+	cfg.Database.URL = "postgres://scion:secret@localhost/scionhub"
+	cfg.Storage.Provider = "gcs"
+	cfg.Storage.Bucket = "scion-prod-artifacts"
+	cfg.Auth.Mode = "oauth"
+
+	require.NoError(t, validateHostedHAPreflight(&cfg), "oauth mode should pass HA preflight when universal checks are satisfied")
+}
+
+// TestValidateHostedHAPreflightStillRequiresIAPForProxy pins the other half of
+// the split: proxy mode keeps every IAP requirement it has today.
+func TestValidateHostedHAPreflightStillRequiresIAPForProxy(t *testing.T) {
+	withHostedHAGuards(t)
+
+	cfg := validHostedHAConfig()
+	cfg.Auth.Proxy = nil
+	cfg.Auth.Transport = nil
+
+	err := validateHostedHAPreflight(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "iap")
+}
+
+// TestValidateHostedHAPreflightEnforcesUniversalForOAuth checks that skipping
+// the IAP block does not skip the universal checks.  Postgres makes this an HA
+// deployment; hub_id is missing, so preflight must still reject it.
+func TestValidateHostedHAPreflightEnforcesUniversalForOAuth(t *testing.T) {
+	withHostedHAGuards(t)
+
+	cfg := config.DefaultGlobalConfig()
+	cfg.Mode = "hosted"
+	cfg.Database.Driver = "postgres"
+	cfg.Auth.Mode = "oauth"
+
+	err := validateHostedHAPreflight(&cfg)
+	require.Error(t, err, "universal checks should still enforce for oauth mode")
+	require.Contains(t, err.Error(), "requires an explicit server.hub.hub_id")
+}
+
 func TestIsHADeployment(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/server_ha_preflight_test.go
+++ b/cmd/server_ha_preflight_test.go
@@ -207,7 +207,7 @@ func TestValidateHostedHAPreflightStillRequiresIAPForProxy(t *testing.T) {
 
 	err := validateHostedHAPreflight(cfg)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "iap")
+	require.Contains(t, err.Error(), "requires server.auth.proxy.provider=iap")
 }
 
 // TestValidateHostedHAPreflightEnforcesUniversalForOAuth checks that skipping

--- a/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
+++ b/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
@@ -94,7 +94,7 @@ During startup in Hosted HA mode, Scion performs strict preflight checks to vali
    - For **Cloud Run** audiences, Scion can automatically derive the Hub's public URL format from the audience.
    - For **GCLB/GKE** backend-service audiences, Scion *cannot* automatically derive the public endpoint URL because a backend service ID does not contain regional or routing information. You **must explicitly configure the public URL** using the `SCION_SERVER_BASE_URL` environment variable (or `server.hub.public_url` / `SCION_SERVER_HUB_PUBLIC_URL`). If missing, Scion will log a warning at startup and fall back to `localhost`, which is likely unreachable from dispatched agents:
      ```
-     Warning: GKE/GCLB IAP audience detected but SCION_SERVER_BASE_URL not set; hub endpoint will fall back to localhost which is likely unreachable from dispatched agents
+     Warning: hosted HA deployment has no explicit hub base URL; falling back to http://localhost:8080, which is unreachable from dispatched agents. Set SCION_SERVER_BASE_URL or server.hub.public_url.
      ```
 :::
 


### PR DESCRIPTION
## Summary

Split validateHostedHAPreflight into universal HA checks and IAP-specific checks. OAuth/OIDC-direct HA now works.

Related: ptone/scion#1087