### PR TITLE
fix(hub): handle gke-shared-volume in readiness check and hub project paths

### DIFF
--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -65,7 +65,7 @@ Brokers maintain a persistent outbound WebSocket connection to the Hub. The Hub 
 
 ## System Health Endpoints (Hub)
 - `GET /healthz`: Basic liveness check. If a reverse proxy intercepts this with a non-JSON response, the client gracefully falls back to `/health`.
-- `GET /readyz`: Readiness check verifying database connectivity.
+- `GET /readyz`: Readiness check verifying database connectivity and, when a non-`local` workspace storage backend is configured, that its mount is available. Kubernetes and Cloud Run readiness probes must target this endpoint rather than `/healthz`, which always returns `200`.
 - `GET /health`: Legacy/alternative liveness check endpoint.
 
 ## Communication Patterns

--- a/docs-site/src/content/docs/reference/server-config.md
+++ b/docs-site/src/content/docs/reference/server-config.md
@@ -211,9 +211,9 @@ Configures the backend and mount settings for storing and managing agent workspa
 | `nfs.storage_class` | string | | The Kubernetes StorageClass name used to dynamically allocate volumes on GKE. |
 | `nfs.subpath_root` | string | `"projects"` | The default base folder name within the share for project workspaces. |
 | `nfs.shares` | list of objects | `[]` | List of NFS share objects. Each share requires: `id` (stable ID), `server` (IP address or hostname), `export` (exported path, e.g., `/scion-workspaces`), and optional `pv_name` (for GKE). |
-| `cloudrun_volume.volume_name` | string | | The name of the platform volume declared in the Cloud Run service specification. |
+| `cloudrun_volume.volume_name` | string | | The name of the platform volume declared in the Cloud Run service specification. The Hub resolves workspaces under `/mnt/<volume_name>`, which is where Cloud Run mounts a declared volume. |
 | `cloudrun_volume.subpath_root` | string | `"projects"` | Sub-directory prefix within the Cloud Run volume. |
-| `gke_shared_volume.volume_name` | string | | The K8s volume name referencing the persistent volume claim (PVC). |
+| `gke_shared_volume.volume_name` | string | | The K8s volume name referencing the persistent volume claim (PVC). **The pod spec must mount that volume at `/mnt/<volume_name>`**: the Hub derives every workspace path from it, and a pod that mounts the PVC elsewhere fails readiness (`GET /readyz` returns `503`) rather than writing workspaces to ephemeral container storage. |
 | `gke_shared_volume.pv_claim_name` | string | | The name of the GKE-managed PVC bound to the shared storage backend (e.g. Filestore). |
 | `gke_shared_volume.subpath_root` | string | `"projects"` | Sub-directory prefix within the GKE volume. |
 

--- a/pkg/hub/handlers_health.go
+++ b/pkg/hub/handlers_health.go
@@ -165,25 +165,42 @@ func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 			//
 			// This is not free, and the cost is not local. GetHealthInfo marks
 			// the whole response "degraded" on any non-healthy check value,
-			// and four consumers compare the composite status to "healthy"
-			// exactly. Setting this key therefore also:
-			//   - makes waitForServerReady (cmd/server_daemon.go) never return
-			//     true, so `scion server start` reports a 20s timeout on a
-			//     server that is up;
-			//   - leaves WebRunning/HubRunning false in `scion server status`,
-			//     which then reports the web frontend and hub API as not
-			//     detected;
-			//   - fails the `grep '"status":"healthy"'` in
-			//     scripts/starter-hub/gce-start-hub.sh, whose local and remote
-			//     health checks both exit 1;
-			//   - renders the red "unhealthy" style in the diagnostics UI,
-			//     which has no degraded class.
-			// That coupling is pre-existing and tracked in ptone/scion#1094;
-			// it is tolerated here because this branch is unreachable on the
+			// and five consumers compare that composite status to "healthy"
+			// exactly. Four consequences, listed most reachable first — this
+			// key is only ever set under a gke-shared-volume config, so a
+			// consumer's exposure depends on which deployments carry one:
+			//   - the diagnostics UI renders the red "unhealthy" style, having
+			//     no degraded class. This is the one that actually happens on a
+			//     GKE hub with this backend;
+			//   - on a workstation configured with this backend, and only
+			//     there: waitForServerReady (cmd/server_daemon.go) never
+			//     returns true, so `scion server start` stalls for its full 20s
+			//     wait and then skips the browser open with "server not yet
+			//     ready" — in an interactive non-headless terminal with web
+			//     enabled — and `scion server status` leaves WebRunning false,
+			//     reporting the web frontend as not detected. HubRunning
+			//     survives either way: the :9810 standalone fallback parses the
+			//     body without comparing the status, so a degraded standalone
+			//     hub still reads as running;
+			//   - scripts/starter-hub/gce-start-hub.sh greps for
+			//     '"status":"healthy"' and exits 1 on both its health checks.
+			//     The settings.yaml that script writes declares no
+			//     workspace_storage, and the script health-checks only the hub
+			//     it just deployed, so this clause bites only where an operator
+			//     supplies that config out of band — via the hub.env
+			//     EnvironmentFile, say, whose SCION_ overrides were not traced.
+			// The fifth comparator, handlers_health_summary.go:126, propagates
+			// degraded correctly, because the health dashboard does have a
+			// degraded class. Counted, not damage.
+			//
+			// That coupling is pre-existing and tracked in ptone/scion#1094.
+			// Tolerated here because this branch is unreachable on the
 			// platforms we ship — os.Stat always yields a *syscall.Stat_t on
 			// linux and darwin, and a container whose root cannot be stat'ed
-			// has larger problems. If it ever does become reachable, prefer
-			// logging over a check-map entry.
+			// has larger problems. Note that hedge is a PLATFORM one: if it
+			// stops holding, the consequences above go live on their own
+			// reachability, not on this one. If it ever does become reachable,
+			// prefer logging over a check-map entry.
 			checks["workspace_storage_mount_verification"] = "unavailable: could not compare filesystem device IDs"
 		}
 		checks["workspace_storage"] = "healthy"

--- a/pkg/hub/handlers_health.go
+++ b/pkg/hub/handlers_health.go
@@ -199,9 +199,9 @@ func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 			//     it just deployed, so this clause bites only where an operator
 			//     supplies that config out of band — via the hub.env
 			//     EnvironmentFile, say, whose SCION_ overrides were not traced.
-			// The fifth comparator, handlers_health_summary.go:126, propagates
-			// degraded correctly, because the health dashboard does have a
-			// degraded class. Counted, not damage.
+			// The fifth comparator, handleHealthSummary, propagates degraded
+			// correctly, because the health dashboard does have a degraded
+			// class. Counted, not damage.
 			//
 			// That coupling is pre-existing and tracked in ptone/scion#1094.
 			// Tolerated here because this branch is unreachable on the

--- a/pkg/hub/handlers_health.go
+++ b/pkg/hub/handlers_health.go
@@ -177,11 +177,15 @@ func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 			//     returns true, so `scion server start` stalls for its full 20s
 			//     wait and then skips the browser open with "server not yet
 			//     ready" — in an interactive non-headless terminal with web
-			//     enabled — and `scion server status` leaves WebRunning false,
-			//     reporting the web frontend as not detected. HubRunning
-			//     survives either way: the :9810 standalone fallback parses the
-			//     body without comparing the status, so a degraded standalone
-			//     hub still reads as running;
+			//     enabled — and `scion server status` leaves WebRunning and
+			//     HubRunning both false, reporting the web frontend and the hub
+			//     API as not detected. Both, and the hub half is the one worth
+			//     spelling out: a workstation enables web by default
+			//     (cmd/server_config.go), so the hub is mounted on the web port
+			//     rather than binding :9810 (cmd/server_foreground.go), and the
+			//     status command's :9810 fallback — which would otherwise leave
+			//     HubRunning true, since it parses the body without comparing
+			//     the status — has nothing to connect to here;
 			//   - scripts/starter-hub/gce-start-hub.sh greps for
 			//     '"status":"healthy"' and exits 1 on both its health checks.
 			//     The settings.yaml that script writes declares no

--- a/pkg/hub/handlers_health.go
+++ b/pkg/hub/handlers_health.go
@@ -98,8 +98,9 @@ func (h *HealthResponse) HealthStatus() string {
 }
 
 // checkWorkspaceStorageHealth verifies that the configured workspace storage
-// backend is accessible. For NFS and Cloud Run volume backends, it stats the
-// mount point to confirm it is present. For local storage, no check is needed.
+// backend is accessible. For NFS, Cloud Run volume and GKE shared volume
+// backends, it stats the mount point to confirm it is present. For local
+// storage, no check is needed.
 func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 	wsCfg := s.config.WorkspaceStorageConfig
 	if wsCfg == nil || wsCfg.Backend == "" || wsCfg.Backend == "local" {
@@ -116,6 +117,15 @@ func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 	case "cloudrun-volume":
 		if wsCfg.CloudRunVolume != nil && wsCfg.CloudRunVolume.VolumeName != "" {
 			mountPath = filepath.Join("/mnt", wsCfg.CloudRunVolume.VolumeName)
+		}
+	case "gke-shared-volume":
+		// The PVC is mounted into the pod at /mnt/<volume_name>, mirroring the
+		// Cloud Run volume convention. V1GKESharedVolumeConfig carries no mount
+		// path of its own — PVClaimName names the PVC and SubPathRoot is the
+		// prefix *within* the volume — so the volume name is what identifies
+		// the mount point.
+		if wsCfg.GKESharedVolume != nil && wsCfg.GKESharedVolume.VolumeName != "" {
+			mountPath = filepath.Join("/mnt", wsCfg.GKESharedVolume.VolumeName)
 		}
 	}
 

--- a/pkg/hub/handlers_health.go
+++ b/pkg/hub/handlers_health.go
@@ -170,10 +170,14 @@ func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 			// key is only ever set under a gke-shared-volume config, so a
 			// consumer's exposure depends on which deployments carry one:
 			//   - the diagnostics UI styles it unhealthy and labels it
-			//     "degraded": with no degraded class, anything but healthy takes
-			//     the red style (diagnostics.ts:294-298) while the label prints
-			//     the raw status (:299-303). This is the one that actually
-			//     happens on a GKE hub with this backend;
+			//     "degraded": renderStatusBanner in diagnostics.ts has no
+			//     degraded class, so degraded falls through its statusClass
+			//     ternary to the red unhealthy style, and through its
+			//     statusLabel ternary to printing the raw status. Not "anything
+			//     but healthy is red" — unknown has its own neutral class, and
+			//     it is what the banner shows before the health fetch resolves.
+			//     This is the one that actually happens on a GKE hub with this
+			//     backend;
 			//   - on a workstation configured with this backend, and only
 			//     there: waitForServerReady (cmd/server_daemon.go) never
 			//     returns true, so `scion server start` stalls for its full 20s

--- a/pkg/hub/handlers_health.go
+++ b/pkg/hub/handlers_health.go
@@ -164,11 +164,10 @@ func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 			// and would 503 the pod on any suffix.
 			//
 			// This is not free, and the cost is not local. GetHealthInfo marks
-			// the whole response "degraded" on any non-healthy check value,
-			// and five consumers compare that composite status to "healthy"
-			// exactly. Four consequences, listed most reachable first — this
-			// key is only ever set under a gke-shared-volume config, so a
-			// consumer's exposure depends on which deployments carry one:
+			// the whole response "degraded" on any non-healthy check value, and
+			// six comparators downstream test for "healthy" exactly. Four
+			// consequences, most reachable first; this key is set only under a
+			// gke-shared-volume config, so exposure depends on the deployment:
 			//   - the diagnostics UI styles it unhealthy and labels it
 			//     "degraded": renderStatusBanner in diagnostics.ts has no
 			//     degraded class, so degraded falls through its statusClass
@@ -199,9 +198,9 @@ func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 			//     it just deployed, so this clause bites only where an operator
 			//     supplies that config out of band — via the hub.env
 			//     EnvironmentFile, say, whose SCION_ overrides were not traced.
-			// The fifth comparator, handleHealthSummary, propagates degraded
-			// correctly, because the health dashboard does have a degraded
-			// class. Counted, not damage.
+			// The other two only forward degraded: WebServer.handleHealthz into
+			// the web composite at /healthz, handleHealthSummary into the health
+			// dashboard, which does have a degraded class. Counted, not damage.
 			//
 			// That coupling is pre-existing and tracked in ptone/scion#1094.
 			// Tolerated here because this branch is unreachable on the

--- a/pkg/hub/handlers_health.go
+++ b/pkg/hub/handlers_health.go
@@ -125,8 +125,9 @@ func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 	// hung NFS mount. A stuck stat call would otherwise hang the health
 	// endpoint indefinitely, taking down readiness probes.
 	type statResult struct {
-		err     error
-		mounted bool
+		err          error
+		mounted      bool
+		determinable bool
 	}
 	ch := make(chan statResult, 1)
 	go func() {
@@ -135,11 +136,11 @@ func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 			ch <- statResult{err: err}
 			return
 		}
-		mounted := true
+		mounted, determinable := true, true
 		if requireMount {
-			mounted = isMountedVolume(fi, containerRootPath)
+			mounted, determinable = isMountedVolume(fi, containerRootPath)
 		}
-		ch <- statResult{mounted: mounted}
+		ch <- statResult{mounted: mounted, determinable: determinable}
 	}()
 
 	select {
@@ -151,6 +152,16 @@ func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 		if !res.mounted {
 			checks["workspace_storage"] = "unhealthy: mount path is not a mounted volume"
 			return
+		}
+		if !res.determinable {
+			// The mount could not be verified, so the storage check passed by
+			// default and the silent-ephemeral-storage failure is possible
+			// again. Readiness stays green deliberately — an unenforceable
+			// check must not take a pod out of service — but the operator gets
+			// a distinct signal instead of an indistinguishable "healthy":
+			// this entry marks the overall health status degraded, while
+			// handleReadyz only consults workspace_storage.
+			checks["workspace_storage_mount_verification"] = "unavailable: could not compare filesystem device IDs"
 		}
 		checks["workspace_storage"] = "healthy"
 	case <-time.After(2 * time.Second):

--- a/pkg/hub/handlers_health.go
+++ b/pkg/hub/handlers_health.go
@@ -158,9 +158,32 @@ func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 			// default and the silent-ephemeral-storage failure is possible
 			// again. Readiness stays green deliberately — an unenforceable
 			// check must not take a pod out of service — but the operator gets
-			// a distinct signal instead of an indistinguishable "healthy":
-			// this entry marks the overall health status degraded, while
-			// handleReadyz only consults workspace_storage.
+			// a distinct signal instead of an indistinguishable "healthy". A
+			// separate key rather than a qualified workspace_storage value,
+			// because handleReadyz compares that value to "healthy" exactly
+			// and would 503 the pod on any suffix.
+			//
+			// This is not free, and the cost is not local. GetHealthInfo marks
+			// the whole response "degraded" on any non-healthy check value,
+			// and four consumers compare the composite status to "healthy"
+			// exactly. Setting this key therefore also:
+			//   - makes waitForServerReady (cmd/server_daemon.go) never return
+			//     true, so `scion server start` reports a 20s timeout on a
+			//     server that is up;
+			//   - leaves WebRunning/HubRunning false in `scion server status`,
+			//     which then reports the web frontend and hub API as not
+			//     detected;
+			//   - fails the `grep '"status":"healthy"'` in
+			//     scripts/starter-hub/gce-start-hub.sh, whose local and remote
+			//     health checks both exit 1;
+			//   - renders the red "unhealthy" style in the diagnostics UI,
+			//     which has no degraded class.
+			// That coupling is pre-existing and tracked in ptone/scion#1094;
+			// it is tolerated here because this branch is unreachable on the
+			// platforms we ship — os.Stat always yields a *syscall.Stat_t on
+			// linux and darwin, and a container whose root cannot be stat'ed
+			// has larger problems. If it ever does become reachable, prefer
+			// logging over a check-map entry.
 			checks["workspace_storage_mount_verification"] = "unavailable: could not compare filesystem device IDs"
 		}
 		checks["workspace_storage"] = "healthy"

--- a/pkg/hub/handlers_health.go
+++ b/pkg/hub/handlers_health.go
@@ -112,22 +112,44 @@ func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 		return
 	}
 
+	// For the GKE shared volume, presence of the directory is not enough. The
+	// pod spec has to mount the PVC at the path derived from the volume name,
+	// and nothing enforces that it did; when it did not, the hub creates that
+	// directory itself on the container overlay the first time a project is
+	// written. Requiring the path to be a mounted volume keeps a
+	// wrongly-mounted deployment permanently unready instead of letting it
+	// latch healthy over ephemeral storage. See isMountedVolume.
+	requireMount := wsCfg.Backend == "gke-shared-volume"
+
 	// Wrap os.Stat in a goroutine with a timeout to prevent blocking on a
 	// hung NFS mount. A stuck stat call would otherwise hang the health
 	// endpoint indefinitely, taking down readiness probes.
 	type statResult struct {
-		err error
+		err     error
+		mounted bool
 	}
 	ch := make(chan statResult, 1)
 	go func() {
-		_, err := os.Stat(mountPath)
-		ch <- statResult{err: err}
+		fi, err := os.Stat(mountPath)
+		if err != nil {
+			ch <- statResult{err: err}
+			return
+		}
+		mounted := true
+		if requireMount {
+			mounted = isMountedVolume(fi, containerRootPath)
+		}
+		ch <- statResult{mounted: mounted}
 	}()
 
 	select {
 	case res := <-ch:
 		if res.err != nil {
 			checks["workspace_storage"] = "unhealthy: mount not available"
+			return
+		}
+		if !res.mounted {
+			checks["workspace_storage"] = "unhealthy: mount path is not a mounted volume"
 			return
 		}
 		checks["workspace_storage"] = "healthy"

--- a/pkg/hub/handlers_health.go
+++ b/pkg/hub/handlers_health.go
@@ -169,9 +169,11 @@ func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 			// exactly. Four consequences, listed most reachable first — this
 			// key is only ever set under a gke-shared-volume config, so a
 			// consumer's exposure depends on which deployments carry one:
-			//   - the diagnostics UI renders the red "unhealthy" style, having
-			//     no degraded class. This is the one that actually happens on a
-			//     GKE hub with this backend;
+			//   - the diagnostics UI styles it unhealthy and labels it
+			//     "degraded": with no degraded class, anything but healthy takes
+			//     the red style (diagnostics.ts:294-298) while the label prints
+			//     the raw status (:299-303). This is the one that actually
+			//     happens on a GKE hub with this backend;
 			//   - on a workstation configured with this backend, and only
 			//     there: waitForServerReady (cmd/server_daemon.go) never
 			//     returns true, so `scion server start` stalls for its full 20s

--- a/pkg/hub/handlers_health.go
+++ b/pkg/hub/handlers_health.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"net/http"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
@@ -107,28 +106,7 @@ func (s *Server) checkWorkspaceStorageHealth(checks map[string]string) {
 		return // Local storage — no health check needed
 	}
 
-	var mountPath string
-	switch wsCfg.Backend {
-	case "nfs":
-		if wsCfg.NFS != nil && len(wsCfg.NFS.Shares) > 0 {
-			share := wsCfg.NFS.Shares[0]
-			mountPath = filepath.Join(wsCfg.NFS.MountRoot, share.ID)
-		}
-	case "cloudrun-volume":
-		if wsCfg.CloudRunVolume != nil && wsCfg.CloudRunVolume.VolumeName != "" {
-			mountPath = filepath.Join("/mnt", wsCfg.CloudRunVolume.VolumeName)
-		}
-	case "gke-shared-volume":
-		// The PVC is mounted into the pod at /mnt/<volume_name>, mirroring the
-		// Cloud Run volume convention. V1GKESharedVolumeConfig carries no mount
-		// path of its own — PVClaimName names the PVC and SubPathRoot is the
-		// prefix *within* the volume — so the volume name is what identifies
-		// the mount point.
-		if wsCfg.GKESharedVolume != nil && wsCfg.GKESharedVolume.VolumeName != "" {
-			mountPath = filepath.Join("/mnt", wsCfg.GKESharedVolume.VolumeName)
-		}
-	}
-
+	mountPath := workspaceMountRoot(wsCfg)
 	if mountPath == "" {
 		checks["workspace_storage"] = "unhealthy: mount path not configured"
 		return

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -2625,10 +2625,11 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 	// the population that has an entry here — so evicting before that call
 	// would reliably reinstate the entry it just removed, not occasionally.
 	// The invariant is about resolutions, not reads: the eviction has to
-	// follow the last hubManagedProjectPath call for this slug. Plain reads
-	// after it are harmless and there are several — the project-configs
-	// cleanup below and two log lines — because none of them resolves a path,
-	// and only a resolution re-records.
+	// follow the last hubManagedProjectPath call for this slug. The
+	// project-configs cleanup below reads the slug three times after it —
+	// its guard, the marker, and the failure log — and all three are
+	// harmless, because none of them resolves a path and only a resolution
+	// re-records.
 	s.warnedEphemeralProjects.Delete(project.Slug)
 
 	// Clean up the project-configs directory (~/.scion/project-configs/<slug>__<short-uuid>/).

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -2501,7 +2501,8 @@ func (s *Server) migrateProjectSlug(ctx context.Context, project *store.Project,
 	// As in deleteProject, this has to be the last read of oldSlug. The
 	// hubManagedProjectPath(oldSlug) call above re-records it on
 	// gke-shared-volume, where that resolution takes the warning path, so an
-	// eviction placed before it is undone by it.
+	// eviction placed before it is undone by it. Best-effort even here: a
+	// resolution already in flight on another goroutine can re-insert it.
 	s.warnedEphemeralProjects.Delete(oldSlug)
 }
 

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -2493,6 +2493,12 @@ func (s *Server) migrateProjectSlug(ctx context.Context, project *store.Project,
 			}
 		}
 	}
+
+	// The old slug is now unreachable, so its ephemeral-path warning
+	// suppression can never be consulted again — drop it. This has to run
+	// after the hubManagedProjectPath(oldSlug) call above, which can itself
+	// re-record oldSlug as warned.
+	s.warnedEphemeralProjects.Delete(oldSlug)
 }
 
 func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string) {
@@ -2601,6 +2607,10 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 		}
 	}
 	s.webdavLocks.Delete(id)
+	// Same reason, keyed by slug rather than ID: drop the once-per-project
+	// ephemeral-path warning suppression so a slug that is deleted and later
+	// recreated warns again instead of inheriting the old suppression.
+	s.warnedEphemeralProjects.Delete(project.Slug)
 
 	// Clean up the project-configs directory (~/.scion/project-configs/<slug>__<short-uuid>/).
 	// This stores external settings, templates, and agent homes for both

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -2628,8 +2628,8 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 	// follow the last hubManagedProjectPath call for this slug. The
 	// project-configs cleanup below reads the slug three times after it —
 	// its guard, the marker, and the failure log — and all three are
-	// harmless, because none of them resolves a path and only a resolution
-	// re-records.
+	// harmless, because none of them calls hubManagedProjectPath, and only
+	// that resolution re-records.
 	s.warnedEphemeralProjects.Delete(project.Slug)
 
 	// Clean up the project-configs directory (~/.scion/project-configs/<slug>__<short-uuid>/).

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -747,9 +747,7 @@ func (s *Server) hubManagedProjectPath(slug string) (string, error) {
 
 	// --- NFS backend ---
 	if wsCfg != nil && wsCfg.Backend == "nfs" && wsCfg.NFS != nil && len(wsCfg.NFS.Shares) > 0 {
-		share := wsCfg.NFS.Shares[0]
-		mountBase := filepath.Join(wsCfg.NFS.MountRoot, share.ID)
-		nfsPath := filepath.Join(mountBase, "hub-projects", slug)
+		nfsPath := filepath.Join(workspaceMountRoot(wsCfg), "hub-projects", slug)
 		if hasWorkspaceContent(nfsPath) {
 			return nfsPath, nil
 		}
@@ -762,12 +760,15 @@ func (s *Server) hubManagedProjectPath(slug string) (string, error) {
 	}
 
 	// --- Cloud Run volume backend ---
+	// Unlike the GKE branch below, this one does not require a non-empty
+	// volume name: guarding it would change where existing Cloud Run
+	// deployments look for content, which needs its own migration (#1073).
 	if wsCfg != nil && wsCfg.Backend == "cloudrun-volume" && wsCfg.CloudRunVolume != nil {
 		subPathRoot := wsCfg.CloudRunVolume.SubPathRoot
 		if subPathRoot == "" {
 			subPathRoot = "projects"
 		}
-		crPath := filepath.Join("/mnt", wsCfg.CloudRunVolume.VolumeName, subPathRoot, "hub-projects", slug)
+		crPath := filepath.Join(volumeMountBase, wsCfg.CloudRunVolume.VolumeName, subPathRoot, "hub-projects", slug)
 		if hasWorkspaceContent(crPath) {
 			return crPath, nil
 		}
@@ -779,25 +780,28 @@ func (s *Server) hubManagedProjectPath(slug string) (string, error) {
 	}
 
 	// --- GKE shared volume backend ---
-	// The PVC is mounted into the pod at /mnt/<volume_name>, the same
-	// convention checkWorkspaceStorageHealth probes for readiness. VolumeName
-	// is required: without it there is no mount point to build a path from, so
-	// the config is treated as unset and this falls through to the local path —
-	// a deployment in that state fails its readiness check anyway.
-	if wsCfg != nil && wsCfg.Backend == "gke-shared-volume" && wsCfg.GKESharedVolume != nil && wsCfg.GKESharedVolume.VolumeName != "" {
-		subPathRoot := wsCfg.GKESharedVolume.SubPathRoot
-		if subPathRoot == "" {
-			subPathRoot = "projects"
-		}
-		gkePath := filepath.Join("/mnt", wsCfg.GKESharedVolume.VolumeName, subPathRoot, "hub-projects", slug)
-		if hasWorkspaceContent(gkePath) {
+	// The mount root comes from workspaceMountRoot, the same resolver
+	// checkWorkspaceStorageHealth probes for readiness, so the two cannot
+	// drift. An empty root means no volume name was configured: there is no
+	// mount point to build a path from, so the config is treated as unset and
+	// this falls through to the local path. A deployment in that state fails
+	// its readiness check and never serves.
+	if wsCfg != nil && wsCfg.Backend == "gke-shared-volume" {
+		if mountRoot := workspaceMountRoot(wsCfg); mountRoot != "" {
+			subPathRoot := wsCfg.GKESharedVolume.SubPathRoot
+			if subPathRoot == "" {
+				subPathRoot = "projects"
+			}
+			gkePath := filepath.Join(mountRoot, subPathRoot, "hub-projects", slug)
+			if hasWorkspaceContent(gkePath) {
+				return gkePath, nil
+			}
+			// Fallback: check legacy local path
+			if localPath, err := localProjectPath(slug); err == nil && hasWorkspaceContent(localPath) {
+				return localPath, nil
+			}
 			return gkePath, nil
 		}
-		// Fallback: check legacy local path
-		if localPath, err := localProjectPath(slug); err == nil && hasWorkspaceContent(localPath) {
-			return localPath, nil
-		}
-		return gkePath, nil
 	}
 
 	// --- Default: local ephemeral path (existing behavior) ---

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -798,6 +798,11 @@ func (s *Server) hubManagedProjectPath(slug string) (string, error) {
 			}
 			// Fallback: check legacy local path
 			if localPath, err := localProjectPath(slug); err == nil && hasWorkspaceContent(localPath) {
+				// Worth saying out loud: on GKE the local path is always pod
+				// ephemeral storage, so this content disappears on the next
+				// reschedule and the project silently moves to the volume.
+				s.projectsLogger().Warn("hub-managed project served from ephemeral local path; gke-shared-volume mount has no content yet",
+					"slug", slug, "local_path", localPath, "volume_path", gkePath)
 				return localPath, nil
 			}
 			return gkePath, nil

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -733,11 +733,11 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 // It prefers projects/<slug> and falls back to groves/<slug> for backward compatibility
 // with workspaces created before the grove-to-project rename.
 //
-// When the server has a workspace storage config with backend "nfs" or
-// "cloudrun-volume", the NFS/volume-backed path is returned instead.
-// A backward-compatible fallback checks the NFS path first, then the
-// legacy local path, so existing local deployments continue to work
-// when NFS is first configured.
+// When the server has a workspace storage config with backend "nfs",
+// "cloudrun-volume" or "gke-shared-volume", the durable volume-backed path is
+// returned instead. A backward-compatible fallback checks the durable path
+// first, then the legacy local path, so existing local deployments continue to
+// work when durable storage is first configured.
 func (s *Server) hubManagedProjectPath(slug string) (string, error) {
 	if err := validateProjectSlug(slug); err != nil {
 		return "", err
@@ -776,6 +776,28 @@ func (s *Server) hubManagedProjectPath(slug string) (string, error) {
 			return localPath, nil
 		}
 		return crPath, nil
+	}
+
+	// --- GKE shared volume backend ---
+	// The PVC is mounted into the pod at /mnt/<volume_name>, the same
+	// convention checkWorkspaceStorageHealth probes for readiness. VolumeName
+	// is required: without it there is no mount point to build a path from, so
+	// the config is treated as unset and this falls through to the local path —
+	// a deployment in that state fails its readiness check anyway.
+	if wsCfg != nil && wsCfg.Backend == "gke-shared-volume" && wsCfg.GKESharedVolume != nil && wsCfg.GKESharedVolume.VolumeName != "" {
+		subPathRoot := wsCfg.GKESharedVolume.SubPathRoot
+		if subPathRoot == "" {
+			subPathRoot = "projects"
+		}
+		gkePath := filepath.Join("/mnt", wsCfg.GKESharedVolume.VolumeName, subPathRoot, "hub-projects", slug)
+		if hasWorkspaceContent(gkePath) {
+			return gkePath, nil
+		}
+		// Fallback: check legacy local path
+		if localPath, err := localProjectPath(slug); err == nil && hasWorkspaceContent(localPath) {
+			return localPath, nil
+		}
+		return gkePath, nil
 	}
 
 	// --- Default: local ephemeral path (existing behavior) ---

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -801,8 +801,7 @@ func (s *Server) hubManagedProjectPath(slug string) (string, error) {
 				// Worth saying out loud: on GKE the local path is always pod
 				// ephemeral storage, so this content disappears on the next
 				// reschedule and the project silently moves to the volume.
-				s.projectsLogger().Warn("hub-managed project served from ephemeral local path; gke-shared-volume mount has no content yet",
-					"slug", slug, "local_path", localPath, "volume_path", gkePath)
+				s.warnEphemeralProjectPath(slug, localPath, gkePath)
 				return localPath, nil
 			}
 			return gkePath, nil

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -2498,10 +2498,13 @@ func (s *Server) migrateProjectSlug(ctx context.Context, project *store.Project,
 	// suppression can never be consulted again — drop it, or a later project
 	// reusing the slug inherits the suppression and never warns.
 	//
-	// As in deleteProject, this has to be the last read of oldSlug. The
-	// hubManagedProjectPath(oldSlug) call above re-records it on
-	// gke-shared-volume, where that resolution takes the warning path, so an
-	// eviction placed before it is undone by it. Best-effort even here: a
+	// As in deleteProject, the invariant is that this follows the last
+	// hubManagedProjectPath(oldSlug) call, not that it follows the last read
+	// of oldSlug — reads that resolve no path cannot re-record. That call
+	// above re-records it on gke-shared-volume, where the resolution takes
+	// the warning path, so an eviction placed before it is undone by it.
+	// Nothing reads oldSlug after this point today, but that is incidental;
+	// the resolution is the thing to order against. Best-effort even here: a
 	// resolution already in flight on another goroutine can re-insert it.
 	s.warnedEphemeralProjects.Delete(oldSlug)
 }
@@ -2621,7 +2624,11 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 	// fallback and warns, and a project served from that fallback is exactly
 	// the population that has an entry here — so evicting before that call
 	// would reliably reinstate the entry it just removed, not occasionally.
-	// The eviction has to be the last read of the slug, not the first.
+	// The invariant is about resolutions, not reads: the eviction has to
+	// follow the last hubManagedProjectPath call for this slug. Plain reads
+	// after it are harmless and there are several — the project-configs
+	// cleanup below and two log lines — because none of them resolves a path,
+	// and only a resolution re-records.
 	s.warnedEphemeralProjects.Delete(project.Slug)
 
 	// Clean up the project-configs directory (~/.scion/project-configs/<slug>__<short-uuid>/).

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -2495,9 +2495,13 @@ func (s *Server) migrateProjectSlug(ctx context.Context, project *store.Project,
 	}
 
 	// The old slug is now unreachable, so its ephemeral-path warning
-	// suppression can never be consulted again — drop it. This has to run
-	// after the hubManagedProjectPath(oldSlug) call above, which can itself
-	// re-record oldSlug as warned.
+	// suppression can never be consulted again — drop it, or a later project
+	// reusing the slug inherits the suppression and never warns.
+	//
+	// As in deleteProject, this has to be the last read of oldSlug. The
+	// hubManagedProjectPath(oldSlug) call above re-records it on
+	// gke-shared-volume, where that resolution takes the warning path, so an
+	// eviction placed before it is undone by it.
 	s.warnedEphemeralProjects.Delete(oldSlug)
 }
 
@@ -2610,6 +2614,13 @@ func (s *Server) deleteProject(w http.ResponseWriter, r *http.Request, id string
 	// Same reason, keyed by slug rather than ID: drop the once-per-project
 	// ephemeral-path warning suppression so a slug that is deleted and later
 	// recreated warns again instead of inheriting the old suppression.
+	//
+	// Order matters, and not marginally. The hubManagedProjectPath call above
+	// can re-record this slug: on gke-shared-volume it takes the legacy-local
+	// fallback and warns, and a project served from that fallback is exactly
+	// the population that has an entry here — so evicting before that call
+	// would reliably reinstate the entry it just removed, not occasionally.
+	// The eviction has to be the last read of the slug, not the first.
 	s.warnedEphemeralProjects.Delete(project.Slug)
 
 	// Clean up the project-configs directory (~/.scion/project-configs/<slug>__<short-uuid>/).

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -786,7 +786,7 @@ func (s *Server) hubManagedProjectPath(slug string) (string, error) {
 	// mount point to build a path from, so the config is treated as unset and
 	// this falls through to the local path. A deployment in that state fails
 	// its readiness check and never serves.
-	if wsCfg != nil && wsCfg.Backend == "gke-shared-volume" {
+	if wsCfg != nil && wsCfg.Backend == "gke-shared-volume" && wsCfg.GKESharedVolume != nil {
 		if mountRoot := workspaceMountRoot(wsCfg); mountRoot != "" {
 			subPathRoot := wsCfg.GKESharedVolume.SubPathRoot
 			if subPathRoot == "" {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -891,6 +891,11 @@ type Server struct {
 	// chatLinkStore is the DB-backed chat link code store (nil when entClient is nil).
 	// When non-nil, Telegram/Discord/Teams link services delegate to it.
 	chatLinkStore *ChatLinkStore
+
+	// warnedEphemeralProjects holds the project slugs already reported as being
+	// served from ephemeral local storage, keeping that warning to one line per
+	// slug on a request path. See warnEphemeralProjectPath.
+	warnedEphemeralProjects sync.Map
 }
 
 // groupsLogger returns the groups subsystem logger, falling back to

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -263,9 +263,10 @@ type ServerConfig struct {
 	Mode string
 
 	// WorkspaceStorageConfig selects the workspace storage backend for
-	// hub-managed project workspaces. When Backend is "nfs" or
-	// "cloudrun-volume", hubManagedProjectPath returns a path on the
-	// configured durable mount instead of the node-local home directory.
+	// hub-managed project workspaces. When Backend is "nfs",
+	// "cloudrun-volume" or "gke-shared-volume", hubManagedProjectPath returns
+	// a path on the configured durable mount instead of the node-local home
+	// directory.
 	// Nil or Backend=="" / "local" preserves the legacy ephemeral behavior.
 	WorkspaceStorageConfig *config.V1WorkspaceStorageConfig
 

--- a/pkg/hub/workspace_storage.go
+++ b/pkg/hub/workspace_storage.go
@@ -15,7 +15,9 @@
 package hub
 
 import (
+	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 )
@@ -26,6 +28,10 @@ import (
 // the same for the GKE shared volume PVC, since nothing in the config surface
 // can express any other location. Overridden by tests.
 var volumeMountBase = "/mnt"
+
+// containerRootPath is the container root filesystem, used as the reference
+// device for isMountedVolume. Overridden by tests.
+var containerRootPath = "/"
 
 // workspaceMountRoot returns the absolute path at which the configured
 // workspace storage backend is mounted, or "" when the config does not name
@@ -57,4 +63,51 @@ func workspaceMountRoot(wsCfg *config.V1WorkspaceStorageConfig) string {
 	}
 
 	return ""
+}
+
+// isMountedVolume reports whether path lives on a filesystem other than the
+// container root — that is, whether a volume is actually mounted there.
+//
+// Presence alone does not answer that question. The hub image declares no USER
+// and runs as root, so when the volume is mounted somewhere other than the
+// expected path, initHubManagedProject's MkdirAll happily creates the
+// directory on the container's ephemeral overlay. From then on a plain
+// os.Stat succeeds and readiness would report healthy forever while every
+// project tree is written to storage that vanishes on reschedule. Comparing
+// device IDs distinguishes the two: a directory created on the overlay shares
+// the root filesystem's device, a mounted volume does not.
+//
+// The comparison is against the container root rather than the path's parent
+// so that a deployment mounting the volume one level up — at volumeMountBase
+// itself, with a subPath — is still recognized as mounted. Writes in that
+// layout do land in the volume.
+//
+// When device IDs are unavailable (a platform without syscall.Stat_t), this
+// returns true: an unenforceable check must not fail readiness.
+func isMountedVolume(fi os.FileInfo, rootPath string) bool {
+	dev, ok := deviceID(fi)
+	if !ok {
+		return true
+	}
+
+	rootFI, err := os.Stat(rootPath)
+	if err != nil {
+		return true
+	}
+	rootDev, ok := deviceID(rootFI)
+	if !ok {
+		return true
+	}
+
+	return dev != rootDev
+}
+
+// deviceID returns the filesystem device ID for fi, and whether it could be
+// determined.
+func deviceID(fi os.FileInfo) (uint64, bool) {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return uint64(st.Dev), true
 }

--- a/pkg/hub/workspace_storage.go
+++ b/pkg/hub/workspace_storage.go
@@ -111,3 +111,19 @@ func deviceID(fi os.FileInfo) (uint64, bool) {
 	}
 	return uint64(st.Dev), true
 }
+
+// warnEphemeralProjectPath reports, once per slug, that a hub-managed project
+// is being served from the pod's local disk because the shared volume has no
+// content for it yet.
+//
+// Once per slug rather than once per call: hubManagedProjectPath is on the
+// WebDAV, clone and cache request paths, so a deployment sitting in this state
+// would otherwise emit a line per request for as long as it runs. The
+// condition is a property of the deployment, not of the request.
+func (s *Server) warnEphemeralProjectPath(slug, localPath, volumePath string) {
+	if _, alreadyWarned := s.warnedEphemeralProjects.LoadOrStore(slug, struct{}{}); alreadyWarned {
+		return
+	}
+	s.projectsLogger().Warn("hub-managed project served from ephemeral local path; gke-shared-volume mount has no content yet",
+		"slug", slug, "local_path", localPath, "volume_path", volumePath)
+}

--- a/pkg/hub/workspace_storage.go
+++ b/pkg/hub/workspace_storage.go
@@ -82,24 +82,31 @@ func workspaceMountRoot(wsCfg *config.V1WorkspaceStorageConfig) string {
 // itself, with a subPath — is still recognized as mounted. Writes in that
 // layout do land in the volume.
 //
-// When device IDs are unavailable (a platform without syscall.Stat_t), this
-// returns true: an unenforceable check must not fail readiness.
-func isMountedVolume(fi os.FileInfo, rootPath string) bool {
+// The second return reports whether the answer could be established at all.
+// When it is false the first return is true, because an unenforceable check
+// must not fail readiness — but the caller is expected to surface the fact,
+// since that state silently reinstates the bug this function exists to catch.
+// It happens when a FileInfo does not carry a unix stat (a fake FileInfo or a
+// filesystem implementation outside package os) or when the container root
+// cannot be stat'ed. Note this file needs syscall.Stat_t at compile time and
+// so builds only on unix targets, which is everything build-release.yml ships;
+// on a platform without that type it would not compile rather than fail open.
+func isMountedVolume(fi os.FileInfo, rootPath string) (mounted, determinable bool) {
 	dev, ok := deviceID(fi)
 	if !ok {
-		return true
+		return true, false
 	}
 
 	rootFI, err := os.Stat(rootPath)
 	if err != nil {
-		return true
+		return true, false
 	}
 	rootDev, ok := deviceID(rootFI)
 	if !ok {
-		return true
+		return true, false
 	}
 
-	return dev != rootDev
+	return dev != rootDev, true
 }
 
 // deviceID returns the filesystem device ID for fi, and whether it could be

--- a/pkg/hub/workspace_storage.go
+++ b/pkg/hub/workspace_storage.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"path/filepath"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+)
+
+// volumeMountBase is the directory under which platform-managed workspace
+// volumes are mounted into the hub container. Cloud Run mounts a declared
+// volume at /mnt/<volume_name>; a Kubernetes pod spec must be written to do
+// the same for the GKE shared volume PVC, since nothing in the config surface
+// can express any other location. Overridden by tests.
+var volumeMountBase = "/mnt"
+
+// workspaceMountRoot returns the absolute path at which the configured
+// workspace storage backend is mounted, or "" when the config does not name
+// one. It is the single place the mount location is derived, so the readiness
+// check and hub-managed project paths cannot drift apart.
+//
+// For the volume backends the mount root is <volumeMountBase>/<volume_name>;
+// the volume name is what identifies the mount point, since neither
+// V1CloudRunVolumeConfig nor V1GKESharedVolumeConfig has a mount path field
+// (PVClaimName names the PVC and SubPathRoot is a prefix within the volume).
+func workspaceMountRoot(wsCfg *config.V1WorkspaceStorageConfig) string {
+	if wsCfg == nil {
+		return ""
+	}
+
+	switch wsCfg.Backend {
+	case "nfs":
+		if wsCfg.NFS != nil && len(wsCfg.NFS.Shares) > 0 {
+			return filepath.Join(wsCfg.NFS.MountRoot, wsCfg.NFS.Shares[0].ID)
+		}
+	case "cloudrun-volume":
+		if wsCfg.CloudRunVolume != nil && wsCfg.CloudRunVolume.VolumeName != "" {
+			return filepath.Join(volumeMountBase, wsCfg.CloudRunVolume.VolumeName)
+		}
+	case "gke-shared-volume":
+		if wsCfg.GKESharedVolume != nil && wsCfg.GKESharedVolume.VolumeName != "" {
+			return filepath.Join(volumeMountBase, wsCfg.GKESharedVolume.VolumeName)
+		}
+	}
+
+	return ""
+}

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -798,6 +798,166 @@ func TestCheckWorkspaceStorageHealth_MountPathPerBackend(t *testing.T) {
 	}
 }
 
+// setContainerRootPath overrides the reference path isMountedVolume compares
+// device IDs against. Pointing it at a temp directory makes anything created
+// under that directory look like it lives on the container root filesystem.
+func setContainerRootPath(t *testing.T, dir string) {
+	t.Helper()
+	prev := containerRootPath
+	containerRootPath = dir
+	t.Cleanup(func() { containerRootPath = prev })
+}
+
+// distinctDeviceDir returns a fresh directory on a filesystem other than the
+// one containerRootPath lives on — a stand-in for a real volume mount — or
+// skips the test when the sandbox has no second filesystem to offer.
+func distinctDeviceDir(t *testing.T) string {
+	t.Helper()
+
+	rootFI, err := os.Stat(containerRootPath)
+	require.NoError(t, err)
+	rootDev, ok := deviceID(rootFI)
+	if !ok {
+		t.Skip("device IDs unavailable on this platform")
+	}
+
+	for _, candidate := range []string{"/dev/shm", "/run", "/tmp", os.TempDir()} {
+		fi, err := os.Stat(candidate)
+		if err != nil {
+			continue
+		}
+		dev, ok := deviceID(fi)
+		if !ok || dev == rootDev {
+			continue
+		}
+		dir, err := os.MkdirTemp(candidate, "scion-mount-")
+		if err != nil {
+			continue
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(dir) })
+		return dir
+	}
+
+	t.Skip("no filesystem distinct from the container root is available")
+	return ""
+}
+
+// TestCheckWorkspaceStorageHealth_GKEOverlayDirIsUnhealthy is the regression
+// test for the self-latching readiness check.
+//
+// Nothing forces a Kubernetes pod spec to mount the PVC at /mnt/<volume_name>.
+// When it does not, the hub — running as root — creates that directory itself
+// on the container overlay the first time a project is written. Readiness must
+// keep reporting unhealthy in that state; if it flips to healthy, the pod
+// serves every project tree from ephemeral disk and the failure is silent.
+func TestCheckWorkspaceStorageHealth_GKEOverlayDirIsUnhealthy(t *testing.T) {
+	srv, _ := testServer(t)
+
+	mountBase := t.TempDir()
+	setVolumeMountBase(t, mountBase)
+	// Same filesystem as the "container root", i.e. an overlay directory.
+	setContainerRootPath(t, mountBase)
+	require.NoError(t, os.MkdirAll(filepath.Join(mountBase, "workspace-vol"), 0755))
+
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "gke-shared-volume",
+		GKESharedVolume: &config.V1GKESharedVolumeConfig{
+			VolumeName:  "workspace-vol",
+			PVClaimName: "scion-workspaces",
+		},
+	}
+
+	checks := make(map[string]string)
+	srv.checkWorkspaceStorageHealth(checks)
+	assert.Equal(t, "unhealthy: mount path is not a mounted volume", checks["workspace_storage"])
+}
+
+// The same condition must keep the pod out of the load balancer, not merely
+// annotate /healthz.
+func TestReadiness_GKEOverlayDirNotReady(t *testing.T) {
+	srv, _ := testServer(t)
+
+	mountBase := t.TempDir()
+	setVolumeMountBase(t, mountBase)
+	setContainerRootPath(t, mountBase)
+	require.NoError(t, os.MkdirAll(filepath.Join(mountBase, "workspace-vol"), 0755))
+
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend:         "gke-shared-volume",
+		GKESharedVolume: &config.V1GKESharedVolumeConfig{VolumeName: "workspace-vol"},
+	}
+
+	rec := doRequest(t, srv, http.MethodGet, "/readyz", nil)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "not_ready", resp["status"])
+	assert.Contains(t, resp["reason"], "workspace storage")
+}
+
+// A correctly mounted volume — a filesystem of its own — is healthy.
+func TestCheckWorkspaceStorageHealth_GKEMountedVolumeIsHealthy(t *testing.T) {
+	srv, _ := testServer(t)
+
+	mountDir := distinctDeviceDir(t)
+	setVolumeMountBase(t, filepath.Dir(mountDir))
+
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "gke-shared-volume",
+		GKESharedVolume: &config.V1GKESharedVolumeConfig{
+			VolumeName:  filepath.Base(mountDir),
+			PVClaimName: "scion-workspaces",
+		},
+	}
+
+	checks := make(map[string]string)
+	srv.checkWorkspaceStorageHealth(checks)
+	assert.Equal(t, "healthy", checks["workspace_storage"])
+}
+
+// A chart may mount the PVC one level up — at the mount base itself, with a
+// subPath — so that <base>/<volume_name> is a directory inside the volume
+// rather than the mount point. Writes there still land in the volume, so this
+// must read as healthy. Comparing against the container root rather than the
+// path's parent is what makes that work.
+func TestCheckWorkspaceStorageHealth_GKEVolumeMountedAtBaseIsHealthy(t *testing.T) {
+	srv, _ := testServer(t)
+
+	mountDir := distinctDeviceDir(t)
+	setVolumeMountBase(t, mountDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(mountDir, "workspace-vol"), 0755))
+
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend:         "gke-shared-volume",
+		GKESharedVolume: &config.V1GKESharedVolumeConfig{VolumeName: "workspace-vol"},
+	}
+
+	checks := make(map[string]string)
+	srv.checkWorkspaceStorageHealth(checks)
+	assert.Equal(t, "healthy", checks["workspace_storage"])
+}
+
+// The mount requirement is confined to the GKE backend: Cloud Run mounts the
+// volume itself, and changing what its deployments report is out of scope.
+func TestCheckWorkspaceStorageHealth_CloudRunPlainDirIsHealthy(t *testing.T) {
+	srv, _ := testServer(t)
+
+	mountBase := t.TempDir()
+	setVolumeMountBase(t, mountBase)
+	setContainerRootPath(t, mountBase)
+	require.NoError(t, os.MkdirAll(filepath.Join(mountBase, "workspace-vol"), 0755))
+
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend:        "cloudrun-volume",
+		CloudRunVolume: &config.V1CloudRunVolumeConfig{VolumeName: "workspace-vol"},
+	}
+
+	checks := make(map[string]string)
+	srv.checkWorkspaceStorageHealth(checks)
+	assert.Equal(t, "healthy", checks["workspace_storage"])
+}
+
 // ============================================================================
 // Integration Test: Write → Verify → Simulated Restart
 // ============================================================================

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -317,6 +317,19 @@ func TestServerHubManagedProjectPath_NFSPrefersNFSWhenBothExist(t *testing.T) {
 	assert.Equal(t, nfsDir, path)
 }
 
+// setVolumeMountBase points the platform volume mount base at dir for the
+// duration of the test, so a test can create the mount root that a real
+// deployment gets from Cloud Run or a Kubernetes pod spec. Tests in this
+// package do not run in parallel, so mutating the package-level seam is safe.
+func setVolumeMountBase(t *testing.T, dir string) {
+	t.Helper()
+	prev := volumeMountBase
+	volumeMountBase = dir
+	t.Cleanup(func() { volumeMountBase = prev })
+}
+
+// This test pins the literal default mount root: a deployment gets
+// /mnt/<volume_name> and the chart must mount the PVC there.
 func TestServerHubManagedProjectPath_GKESharedVolume(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
@@ -357,13 +370,75 @@ func TestServerHubManagedProjectPath_GKESharedVolumeCustomSubPath(t *testing.T) 
 	assert.Equal(t, expected, path)
 }
 
+// Content on the volume wins over content in the legacy local path. This is
+// the case that discriminates: without the gke branch the local path is
+// returned and the project is served from ephemeral disk.
+func TestServerHubManagedProjectPath_GKESharedVolumePrefersVolumeWhenBothExist(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	mountBase := t.TempDir()
+	setVolumeMountBase(t, mountBase)
+
+	slug := "gke-both-project"
+
+	localDir := filepath.Join(tmpHome, ".scion", "projects", slug)
+	require.NoError(t, os.MkdirAll(localDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, "local.txt"), []byte("local"), 0644))
+
+	volumeDir := filepath.Join(mountBase, "workspace-vol", "projects", "hub-projects", slug)
+	require.NoError(t, os.MkdirAll(volumeDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(volumeDir, "volume.txt"), []byte("volume"), 0644))
+
+	srv, _ := testServer(t)
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "gke-shared-volume",
+		GKESharedVolume: &config.V1GKESharedVolumeConfig{
+			VolumeName:  "workspace-vol",
+			PVClaimName: "scion-workspaces",
+		},
+	}
+
+	path, err := srv.hubManagedProjectPath(slug)
+	require.NoError(t, err)
+	assert.Equal(t, volumeDir, path)
+}
+
+// A project with no content on the volume yet resolves to the volume, not to
+// the local path — new projects are created on durable storage.
+func TestServerHubManagedProjectPath_GKESharedVolumeEmptyVolumeStillWins(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	mountBase := t.TempDir()
+	setVolumeMountBase(t, mountBase)
+	require.NoError(t, os.MkdirAll(filepath.Join(mountBase, "workspace-vol"), 0755))
+
+	srv, _ := testServer(t)
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend:         "gke-shared-volume",
+		GKESharedVolume: &config.V1GKESharedVolumeConfig{VolumeName: "workspace-vol"},
+	}
+
+	path, err := srv.hubManagedProjectPath("new-project")
+	require.NoError(t, err)
+
+	expected := filepath.Join(mountBase, "workspace-vol", "projects", "hub-projects", "new-project")
+	assert.Equal(t, expected, path)
+}
+
 func TestServerHubManagedProjectPath_GKESharedVolumeFallbackToLocal(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
+	mountBase := t.TempDir()
+	setVolumeMountBase(t, mountBase)
+	// The volume is mounted and empty: a deployment that predates it still has
+	// its content on the local path.
+	require.NoError(t, os.MkdirAll(filepath.Join(mountBase, "workspace-vol"), 0755))
+
 	slug := "gke-fallback-project"
 
-	// Content exists in the local path only (deployment predating the volume)
 	localDir := filepath.Join(tmpHome, ".scion", "projects", slug)
 	require.NoError(t, os.MkdirAll(localDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(localDir, "existing.txt"), []byte("data"), 0644))
@@ -372,7 +447,7 @@ func TestServerHubManagedProjectPath_GKESharedVolumeFallbackToLocal(t *testing.T
 	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
 		Backend: "gke-shared-volume",
 		GKESharedVolume: &config.V1GKESharedVolumeConfig{
-			VolumeName: "absent-workspace-vol",
+			VolumeName: "workspace-vol",
 		},
 	}
 
@@ -388,6 +463,9 @@ func TestServerHubManagedProjectPath_GKESharedVolumeMissingVolumeName(t *testing
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
+	mountBase := t.TempDir()
+	setVolumeMountBase(t, mountBase)
+
 	srv, _ := testServer(t)
 	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
 		Backend:         "gke-shared-volume",
@@ -399,6 +477,77 @@ func TestServerHubManagedProjectPath_GKESharedVolumeMissingVolumeName(t *testing
 
 	expected := filepath.Join(tmpHome, ".scion", "projects", "my-project")
 	assert.Equal(t, expected, path)
+}
+
+// TestWorkspaceMountRoot covers the single resolver both the readiness check
+// and the hub-managed project path derive the mount location from.
+func TestWorkspaceMountRoot(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.V1WorkspaceStorageConfig
+		want string
+	}{
+		{name: "nil config", cfg: nil, want: ""},
+		{name: "local backend", cfg: &config.V1WorkspaceStorageConfig{Backend: "local"}, want: ""},
+		{
+			name: "nfs joins mount root and first share",
+			cfg: &config.V1WorkspaceStorageConfig{
+				Backend: "nfs",
+				NFS: &config.V1NFSConfig{
+					MountRoot: "/mnt/nfs",
+					Shares:    []config.V1NFSShare{{ID: "share1"}, {ID: "share2"}},
+				},
+			},
+			want: "/mnt/nfs/share1",
+		},
+		{
+			name: "nfs without shares",
+			cfg: &config.V1WorkspaceStorageConfig{
+				Backend: "nfs",
+				NFS:     &config.V1NFSConfig{MountRoot: "/mnt/nfs"},
+			},
+			want: "",
+		},
+		{
+			name: "cloudrun-volume mounts under /mnt",
+			cfg: &config.V1WorkspaceStorageConfig{
+				Backend:        "cloudrun-volume",
+				CloudRunVolume: &config.V1CloudRunVolumeConfig{VolumeName: "scion-workspaces"},
+			},
+			want: "/mnt/scion-workspaces",
+		},
+		{
+			name: "gke-shared-volume mounts under /mnt",
+			cfg: &config.V1WorkspaceStorageConfig{
+				Backend: "gke-shared-volume",
+				GKESharedVolume: &config.V1GKESharedVolumeConfig{
+					VolumeName:  "scion-workspaces",
+					PVClaimName: "scion-workspaces-pvc",
+					SubPathRoot: "projects",
+				},
+			},
+			want: "/mnt/scion-workspaces",
+		},
+		{
+			name: "gke-shared-volume without a volume name",
+			cfg: &config.V1WorkspaceStorageConfig{
+				Backend:         "gke-shared-volume",
+				GKESharedVolume: &config.V1GKESharedVolumeConfig{PVClaimName: "scion-workspaces-pvc"},
+			},
+			want: "",
+		},
+		{
+			name: "unknown backend",
+			cfg:  &config.V1WorkspaceStorageConfig{Backend: "some-future-backend"},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, workspaceMountRoot(tt.cfg))
+		})
+	}
 }
 
 func TestServerHubManagedProjectPath_EmptySlugError(t *testing.T) {

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -1207,3 +1207,49 @@ func TestWebDAVSafetyGate_ReadMethodsAllowed(t *testing.T) {
 	assert.NotEqual(t, http.StatusServiceUnavailable, rec.Code,
 		"WebDAV PROPFIND should not be blocked on Cloud Run")
 }
+
+// The ephemeral-path warning is suppressed per slug for the life of the
+// process, so the suppression has to be dropped when the slug goes away.
+// Otherwise a slug that is deleted and recreated — or reused by a different
+// project — silently inherits the old suppression and never warns, on a
+// deployment that is still writing to ephemeral storage.
+func TestWarnEphemeralProjectPath_SuppressionClearedOnProjectDelete(t *testing.T) {
+	srv, _ := testServer(t)
+	logs := captureProjectsLog(t, srv)
+
+	project, _ := createTestHubManagedProject(t, srv, "Ephemeral Warn Delete")
+
+	srv.warnEphemeralProjectPath(project.Slug, "/local", "/mnt/vol")
+	srv.warnEphemeralProjectPath(project.Slug, "/local", "/mnt/vol")
+	require.Equal(t, 1, strings.Count(logs.String(), "served from ephemeral local path"),
+		"the warning is suppressed after the first call")
+
+	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/projects/"+project.ID, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code, "body: %s", rec.Body.String())
+
+	// The slug is recreated and hits the same fallback.
+	srv.warnEphemeralProjectPath(project.Slug, "/local", "/mnt/vol")
+	assert.Equal(t, 2, strings.Count(logs.String(), "served from ephemeral local path"),
+		"deleting the project should clear its warning suppression")
+}
+
+// A renamed project keeps its state under the new slug; the old slug is
+// unreachable, so its suppression entry is dead weight that would also
+// mis-suppress the old slug if it were later reused by another project.
+func TestWarnEphemeralProjectPath_SuppressionClearedOnSlugMigration(t *testing.T) {
+	srv, _ := testServer(t)
+	logs := captureProjectsLog(t, srv)
+
+	project, _ := createTestHubManagedProject(t, srv, "Ephemeral Warn Rename")
+	oldSlug := project.Slug
+
+	srv.warnEphemeralProjectPath(oldSlug, "/local", "/mnt/vol")
+	require.Equal(t, 1, strings.Count(logs.String(), "served from ephemeral local path"))
+
+	project.Slug = oldSlug + "-renamed"
+	srv.migrateProjectSlug(t.Context(), project, oldSlug)
+
+	srv.warnEphemeralProjectPath(oldSlug, "/local", "/mnt/vol")
+	assert.Equal(t, 2, strings.Count(logs.String(), "served from ephemeral local path"),
+		"migrating away from a slug should clear its warning suppression")
+}

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1236,20 +1237,58 @@ func TestWarnEphemeralProjectPath_SuppressionClearedOnProjectDelete(t *testing.T
 // A renamed project keeps its state under the new slug; the old slug is
 // unreachable, so its suppression entry is dead weight that would also
 // mis-suppress the old slug if it were later reused by another project.
+//
+// Configured against gke-shared-volume on purpose. migrateProjectSlug resolves
+// the old slug itself, and under any other backend that resolution never
+// reaches the warning — so the cleanup could be placed before it, be dead
+// wrong, and still pass. The assertion immediately after the migration is what
+// pins the ordering: the migration's own resolution must find the suppression
+// still in place.
 func TestWarnEphemeralProjectPath_SuppressionClearedOnSlugMigration(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	mountBase := t.TempDir()
+	setVolumeMountBase(t, mountBase)
+	require.NoError(t, os.MkdirAll(filepath.Join(mountBase, "workspace-vol"), 0755))
+
 	srv, _ := testServer(t)
 	logs := captureProjectsLog(t, srv)
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend:         "gke-shared-volume",
+		GKESharedVolume: &config.V1GKESharedVolumeConfig{VolumeName: "workspace-vol"},
+	}
 
-	project, _ := createTestHubManagedProject(t, srv, "Ephemeral Warn Rename")
-	oldSlug := project.Slug
+	oldSlug := "rename-ephemeral"
+	newSlug := oldSlug + "-renamed"
+	localDir := filepath.Join(tmpHome, ".scion", "projects", oldSlug)
+	seedLocal := func() {
+		require.NoError(t, os.MkdirAll(localDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(localDir, "existing.txt"), []byte("data"), 0644))
+	}
+	seedLocal()
 
-	srv.warnEphemeralProjectPath(oldSlug, "/local", "/mnt/vol")
+	path, err := srv.hubManagedProjectPath(oldSlug)
+	require.NoError(t, err)
+	require.Equal(t, localDir, path)
 	require.Equal(t, 1, strings.Count(logs.String(), "served from ephemeral local path"))
 
-	project.Slug = oldSlug + "-renamed"
-	srv.migrateProjectSlug(t.Context(), project, oldSlug)
+	srv.migrateProjectSlug(t.Context(), &store.Project{
+		ID:   "rename-ephemeral-project",
+		Name: "Ephemeral Warn Rename",
+		Slug: newSlug,
+	}, oldSlug)
 
-	srv.warnEphemeralProjectPath(oldSlug, "/local", "/mnt/vol")
+	// The migration resolves the old slug on its way to renaming the directory.
+	// That resolution must still be suppressed, which is only true if the
+	// suppression is dropped after it rather than before.
+	assert.Equal(t, 1, strings.Count(logs.String(), "served from ephemeral local path"),
+		"the migration's own path resolution must not re-warn, and must not re-record the slug")
+
+	// The slug is now free and taken by another project with local content.
+	seedLocal()
+	_, err = srv.hubManagedProjectPath(oldSlug)
+	require.NoError(t, err)
 	assert.Equal(t, 2, strings.Count(logs.String(), "served from ephemeral local path"),
 		"migrating away from a slug should clear its warning suppression")
 }

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -303,6 +303,90 @@ func TestServerHubManagedProjectPath_NFSPrefersNFSWhenBothExist(t *testing.T) {
 	assert.Equal(t, nfsDir, path)
 }
 
+func TestServerHubManagedProjectPath_GKESharedVolume(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	srv, _ := testServer(t)
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "gke-shared-volume",
+		GKESharedVolume: &config.V1GKESharedVolumeConfig{
+			VolumeName:  "workspace-vol",
+			PVClaimName: "scion-workspaces",
+		},
+	}
+
+	path, err := srv.hubManagedProjectPath("my-project")
+	require.NoError(t, err)
+
+	expected := filepath.Join("/mnt", "workspace-vol", "projects", "hub-projects", "my-project")
+	assert.Equal(t, expected, path)
+}
+
+func TestServerHubManagedProjectPath_GKESharedVolumeCustomSubPath(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	srv, _ := testServer(t)
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "gke-shared-volume",
+		GKESharedVolume: &config.V1GKESharedVolumeConfig{
+			VolumeName:  "workspace-vol",
+			SubPathRoot: "custom-root",
+		},
+	}
+
+	path, err := srv.hubManagedProjectPath("my-project")
+	require.NoError(t, err)
+
+	expected := filepath.Join("/mnt", "workspace-vol", "custom-root", "hub-projects", "my-project")
+	assert.Equal(t, expected, path)
+}
+
+func TestServerHubManagedProjectPath_GKESharedVolumeFallbackToLocal(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	slug := "gke-fallback-project"
+
+	// Content exists in the local path only (deployment predating the volume)
+	localDir := filepath.Join(tmpHome, ".scion", "projects", slug)
+	require.NoError(t, os.MkdirAll(localDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, "existing.txt"), []byte("data"), 0644))
+
+	srv, _ := testServer(t)
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "gke-shared-volume",
+		GKESharedVolume: &config.V1GKESharedVolumeConfig{
+			VolumeName: "absent-workspace-vol",
+		},
+	}
+
+	path, err := srv.hubManagedProjectPath(slug)
+	require.NoError(t, err)
+	assert.Equal(t, localDir, path)
+}
+
+// A gke-shared-volume config without a volume name has no mount point to build
+// a path from, so it is treated as unset and falls through to the local path.
+// Such a deployment fails its readiness check, so it never serves traffic.
+func TestServerHubManagedProjectPath_GKESharedVolumeMissingVolumeName(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	srv, _ := testServer(t)
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend:         "gke-shared-volume",
+		GKESharedVolume: &config.V1GKESharedVolumeConfig{PVClaimName: "scion-workspaces"},
+	}
+
+	path, err := srv.hubManagedProjectPath("my-project")
+	require.NoError(t, err)
+
+	expected := filepath.Join(tmpHome, ".scion", "projects", "my-project")
+	assert.Equal(t, expected, path)
+}
+
 func TestServerHubManagedProjectPath_EmptySlugError(t *testing.T) {
 	srv, _ := testServer(t)
 

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -465,7 +465,7 @@ func TestServerHubManagedProjectPath_GKESharedVolumeFallbackToLocal(t *testing.T
 	// unfixed code, which returns the same local path without ever consulting
 	// the volume — so asserting on it is what makes this test discriminate,
 	// and it is also the only coverage the warning has.
-	assert.Contains(t, logs.String(), "served from ephemeral local path")
+	assert.Equal(t, 1, countWarningsForSlug(logs, slug))
 	assert.Contains(t, logs.String(), filepath.Join(mountBase, "workspace-vol"))
 
 	// Repeated resolutions must not repeat the warning: this runs on the
@@ -474,7 +474,7 @@ func TestServerHubManagedProjectPath_GKESharedVolumeFallbackToLocal(t *testing.T
 		_, err := srv.hubManagedProjectPath(slug)
 		require.NoError(t, err)
 	}
-	assert.Equal(t, 1, strings.Count(logs.String(), "served from ephemeral local path"))
+	assert.Equal(t, 1, countEphemeralWarnings(logs))
 
 	// A second project must still get its own warning. Suppression is per
 	// project, not per process: with a single shared key the first project to
@@ -490,9 +490,9 @@ func TestServerHubManagedProjectPath_GKESharedVolumeFallbackToLocal(t *testing.T
 		require.NoError(t, err)
 		assert.Equal(t, otherLocalDir, otherPath)
 	}
-	assert.Equal(t, 2, strings.Count(logs.String(), "served from ephemeral local path"))
-	assert.Equal(t, 1, strings.Count(logs.String(), "slug="+slug+" "))
-	assert.Equal(t, 1, strings.Count(logs.String(), "slug="+otherSlug))
+	assert.Equal(t, 2, countEphemeralWarnings(logs))
+	assert.Equal(t, 1, countWarningsForSlug(logs, slug))
+	assert.Equal(t, 1, countWarningsForSlug(logs, otherSlug))
 }
 
 // A gke-shared-volume config without a volume name has no mount point to build
@@ -835,6 +835,43 @@ func TestCheckWorkspaceStorageHealth_MountPathPerBackend(t *testing.T) {
 			assert.Equal(t, tt.want, checks["workspace_storage"])
 		})
 	}
+}
+
+// ephemeralWarnMessage is the message logged by warnEphemeralProjectPath.
+const ephemeralWarnMessage = "hub-managed project served from ephemeral local path"
+
+// countEphemeralWarnings returns how many ephemeral-path warnings were logged,
+// and countWarningsForSlug how many of those name the given slug.
+//
+// Parsed per line and per attribute rather than matched as a substring: a
+// substring match for `slug=<name> ` depends on slog attribute ORDER, so
+// reordering the attrs in warnEphemeralProjectPath would silently make these
+// assertions count zero and pass. An assertion whose whole job is to not pass
+// vacuously must not be the thing that quietly stops matching.
+func countEphemeralWarnings(logs *bytes.Buffer) int {
+	return countWarningsForSlug(logs, "")
+}
+
+func countWarningsForSlug(logs *bytes.Buffer, slug string) int {
+	n := 0
+	for _, line := range strings.Split(logs.String(), "\n") {
+		if !strings.Contains(line, ephemeralWarnMessage) {
+			continue
+		}
+		if slug == "" {
+			n++
+			continue
+		}
+		for _, field := range strings.Fields(line) {
+			if key, value, found := strings.Cut(field, "="); found && key == "slug" {
+				if strings.Trim(value, `"`) == slug {
+					n++
+				}
+				break
+			}
+		}
+	}
+	return n
 }
 
 // captureProjectsLog redirects the projects subsystem logger into a buffer the
@@ -1250,7 +1287,7 @@ func TestWarnEphemeralProjectPath_SuppressionClearedOnProjectDelete(t *testing.T
 	path, err := srv.hubManagedProjectPath(project.Slug)
 	require.NoError(t, err)
 	require.Equal(t, localDir, path)
-	require.Equal(t, 1, strings.Count(logs.String(), "served from ephemeral local path"))
+	require.Equal(t, 1, countWarningsForSlug(logs, project.Slug))
 
 	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/projects/"+project.ID, nil)
 	require.Equal(t, http.StatusNoContent, rec.Code, "body: %s", rec.Body.String())
@@ -1258,14 +1295,14 @@ func TestWarnEphemeralProjectPath_SuppressionClearedOnProjectDelete(t *testing.T
 	// The delete resolves the slug once more to find the directory to remove.
 	// That resolution must still be suppressed, which is only true if the
 	// eviction runs after it.
-	assert.Equal(t, 1, strings.Count(logs.String(), "served from ephemeral local path"),
+	assert.Equal(t, 1, countWarningsForSlug(logs, project.Slug),
 		"the delete's own path resolution must not re-warn, and must not re-record the slug")
 
 	// The slug is now free and taken by a new project with local content.
 	seedLocal()
 	_, err = srv.hubManagedProjectPath(project.Slug)
 	require.NoError(t, err)
-	assert.Equal(t, 2, strings.Count(logs.String(), "served from ephemeral local path"),
+	assert.Equal(t, 2, countWarningsForSlug(logs, project.Slug),
 		"deleting the project should clear its warning suppression")
 }
 
@@ -1306,7 +1343,7 @@ func TestWarnEphemeralProjectPath_SuppressionClearedOnSlugMigration(t *testing.T
 	path, err := srv.hubManagedProjectPath(oldSlug)
 	require.NoError(t, err)
 	require.Equal(t, localDir, path)
-	require.Equal(t, 1, strings.Count(logs.String(), "served from ephemeral local path"))
+	require.Equal(t, 1, countWarningsForSlug(logs, oldSlug))
 
 	srv.migrateProjectSlug(t.Context(), &store.Project{
 		ID:   "rename-ephemeral-project",
@@ -1317,13 +1354,13 @@ func TestWarnEphemeralProjectPath_SuppressionClearedOnSlugMigration(t *testing.T
 	// The migration resolves the old slug on its way to renaming the directory.
 	// That resolution must still be suppressed, which is only true if the
 	// suppression is dropped after it rather than before.
-	assert.Equal(t, 1, strings.Count(logs.String(), "served from ephemeral local path"),
+	assert.Equal(t, 1, countWarningsForSlug(logs, oldSlug),
 		"the migration's own path resolution must not re-warn, and must not re-record the slug")
 
 	// The slug is now free and taken by another project with local content.
 	seedLocal()
 	_, err = srv.hubManagedProjectPath(oldSlug)
 	require.NoError(t, err)
-	assert.Equal(t, 2, strings.Count(logs.String(), "served from ephemeral local path"),
+	assert.Equal(t, 2, countWarningsForSlug(logs, oldSlug),
 		"migrating away from a slug should clear its warning suppression")
 }

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -80,6 +80,20 @@ func TestWorkspaceWriteBlocked_CloudRunVolumeOnCloudRun(t *testing.T) {
 	assert.False(t, srv.workspaceWriteBlocked())
 }
 
+func TestWorkspaceWriteBlocked_GKESharedVolumeOnCloudRun(t *testing.T) {
+	srv, _ := testServer(t)
+	t.Setenv("K_SERVICE", "hub-service")
+
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend: "gke-shared-volume",
+		GKESharedVolume: &config.V1GKESharedVolumeConfig{
+			VolumeName:  "workspace-vol",
+			PVClaimName: "scion-workspaces",
+		},
+	}
+	assert.False(t, srv.workspaceWriteBlocked())
+}
+
 func TestWorkspaceWriteBlocked_NotOnCloudRun(t *testing.T) {
 	srv, _ := testServer(t)
 

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -1214,22 +1214,57 @@ func TestWebDAVSafetyGate_ReadMethodsAllowed(t *testing.T) {
 // Otherwise a slug that is deleted and recreated — or reused by a different
 // project — silently inherits the old suppression and never warns, on a
 // deployment that is still writing to ephemeral storage.
+//
+// Configured against gke-shared-volume on purpose, and asserted immediately
+// after the delete returns. deleteProject resolves the slug itself on its way
+// to removing the directory; under any other backend that resolution never
+// reaches the warning, and an eviction placed before it would pass. Totals at
+// the end of the test cannot tell the two placements apart, because a
+// misplaced eviction is followed by a warn that re-records the slug and
+// suppresses the later one — same count, opposite behavior.
 func TestWarnEphemeralProjectPath_SuppressionClearedOnProjectDelete(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	mountBase := t.TempDir()
+	setVolumeMountBase(t, mountBase)
+	require.NoError(t, os.MkdirAll(filepath.Join(mountBase, "workspace-vol"), 0755))
+
 	srv, _ := testServer(t)
 	logs := captureProjectsLog(t, srv)
 
-	project, _ := createTestHubManagedProject(t, srv, "Ephemeral Warn Delete")
+	// Created before the backend is configured, so its content is on the local
+	// path — the legacy deployment this fallback exists for.
+	project, localDir := createTestHubManagedProject(t, srv, "Ephemeral Warn Delete")
+	seedLocal := func() {
+		require.NoError(t, os.MkdirAll(localDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(localDir, "existing.txt"), []byte("data"), 0644))
+	}
+	seedLocal()
 
-	srv.warnEphemeralProjectPath(project.Slug, "/local", "/mnt/vol")
-	srv.warnEphemeralProjectPath(project.Slug, "/local", "/mnt/vol")
-	require.Equal(t, 1, strings.Count(logs.String(), "served from ephemeral local path"),
-		"the warning is suppressed after the first call")
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend:         "gke-shared-volume",
+		GKESharedVolume: &config.V1GKESharedVolumeConfig{VolumeName: "workspace-vol"},
+	}
+
+	path, err := srv.hubManagedProjectPath(project.Slug)
+	require.NoError(t, err)
+	require.Equal(t, localDir, path)
+	require.Equal(t, 1, strings.Count(logs.String(), "served from ephemeral local path"))
 
 	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/projects/"+project.ID, nil)
 	require.Equal(t, http.StatusNoContent, rec.Code, "body: %s", rec.Body.String())
 
-	// The slug is recreated and hits the same fallback.
-	srv.warnEphemeralProjectPath(project.Slug, "/local", "/mnt/vol")
+	// The delete resolves the slug once more to find the directory to remove.
+	// That resolution must still be suppressed, which is only true if the
+	// eviction runs after it.
+	assert.Equal(t, 1, strings.Count(logs.String(), "served from ephemeral local path"),
+		"the delete's own path resolution must not re-warn, and must not re-record the slug")
+
+	// The slug is now free and taken by a new project with local content.
+	seedLocal()
+	_, err = srv.hubManagedProjectPath(project.Slug)
+	require.NoError(t, err)
 	assert.Equal(t, 2, strings.Count(logs.String(), "served from ephemeral local path"),
 		"deleting the project should clear its warning suppression")
 }

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/stretchr/testify/assert"
@@ -966,6 +967,78 @@ func TestCheckWorkspaceStorageHealth_GKEVolumeMountedAtBaseIsHealthy(t *testing.
 	checks := make(map[string]string)
 	srv.checkWorkspaceStorageHealth(checks)
 	assert.Equal(t, "healthy", checks["workspace_storage"])
+}
+
+// statlessFileInfo is an os.FileInfo whose Sys() carries no unix stat, which is
+// what a filesystem implementation outside package os hands back.
+type statlessFileInfo struct{}
+
+func (statlessFileInfo) Name() string       { return "workspace-vol" }
+func (statlessFileInfo) Size() int64        { return 0 }
+func (statlessFileInfo) Mode() os.FileMode  { return os.ModeDir | 0755 }
+func (statlessFileInfo) ModTime() time.Time { return time.Time{} }
+func (statlessFileInfo) IsDir() bool        { return true }
+func (statlessFileInfo) Sys() any           { return nil }
+
+// The three branches where the device comparison cannot be made are
+// unreachable on every platform this repo ships, which is exactly why they need
+// tests: nothing else will ever exercise them. They must fail open — refusing
+// readiness on a check that cannot be enforced would take a working pod out of
+// service — and they must say so, which is the second return.
+func TestIsMountedVolume_FailsOpenWhenUndeterminable(t *testing.T) {
+	dir := t.TempDir()
+	realFI, err := os.Stat(dir)
+	require.NoError(t, err)
+
+	t.Run("file info carries no unix stat", func(t *testing.T) {
+		mounted, determinable := isMountedVolume(statlessFileInfo{}, dir)
+		assert.True(t, mounted)
+		assert.False(t, determinable)
+	})
+
+	t.Run("container root cannot be stat'ed", func(t *testing.T) {
+		mounted, determinable := isMountedVolume(realFI, filepath.Join(dir, "absent-root"))
+		assert.True(t, mounted)
+		assert.False(t, determinable)
+	})
+
+	t.Run("a determinable comparison reports so", func(t *testing.T) {
+		mounted, determinable := isMountedVolume(realFI, dir)
+		assert.False(t, mounted, "a directory compared against itself shares its device")
+		assert.True(t, determinable)
+	})
+}
+
+// Failing open leaves the pod ready — deliberately — but it also reinstates the
+// failure mode the mount check exists to catch, so it must not be reported as
+// an ordinary "healthy". The distinct entry marks overall health degraded while
+// leaving readiness alone.
+func TestCheckWorkspaceStorageHealth_GKEUnverifiableMountStaysReady(t *testing.T) {
+	srv, _ := testServer(t)
+
+	mountBase := t.TempDir()
+	setVolumeMountBase(t, mountBase)
+	setContainerRootPath(t, filepath.Join(mountBase, "absent-root"))
+	require.NoError(t, os.MkdirAll(filepath.Join(mountBase, "workspace-vol"), 0755))
+
+	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
+		Backend:         "gke-shared-volume",
+		GKESharedVolume: &config.V1GKESharedVolumeConfig{VolumeName: "workspace-vol"},
+	}
+
+	checks := make(map[string]string)
+	srv.checkWorkspaceStorageHealth(checks)
+	assert.Equal(t, "healthy", checks["workspace_storage"])
+	assert.Contains(t, checks["workspace_storage_mount_verification"], "unavailable")
+
+	rec := doRequest(t, srv, http.MethodGet, "/readyz", nil)
+	assert.Equal(t, http.StatusOK, rec.Code, "an unenforceable check must not take the pod out of service")
+
+	rec = doRequest(t, srv, http.MethodGet, "/healthz", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp HealthResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "degraded", resp.Status, "the operator needs to see that the mount was never verified")
 }
 
 // The mount requirement is confined to the GKE backend: Cloud Run mounts the

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -474,6 +474,24 @@ func TestServerHubManagedProjectPath_GKESharedVolumeFallbackToLocal(t *testing.T
 		require.NoError(t, err)
 	}
 	assert.Equal(t, 1, strings.Count(logs.String(), "served from ephemeral local path"))
+
+	// A second project must still get its own warning. Suppression is per
+	// project, not per process: with a single shared key the first project to
+	// resolve would silence every other one, and every assertion above would
+	// still pass. This is the assertion that separates the two.
+	otherSlug := "gke-fallback-project-2"
+	otherLocalDir := filepath.Join(tmpHome, ".scion", "projects", otherSlug)
+	require.NoError(t, os.MkdirAll(otherLocalDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(otherLocalDir, "existing.txt"), []byte("data"), 0644))
+
+	for range 3 {
+		otherPath, err := srv.hubManagedProjectPath(otherSlug)
+		require.NoError(t, err)
+		assert.Equal(t, otherLocalDir, otherPath)
+	}
+	assert.Equal(t, 2, strings.Count(logs.String(), "served from ephemeral local path"))
+	assert.Equal(t, 1, strings.Count(logs.String(), "slug="+slug+" "))
+	assert.Equal(t, 1, strings.Count(logs.String(), "slug="+otherSlug))
 }
 
 // A gke-shared-volume config without a volume name has no mount point to build

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -17,11 +17,14 @@
 package hub
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
@@ -444,6 +447,7 @@ func TestServerHubManagedProjectPath_GKESharedVolumeFallbackToLocal(t *testing.T
 	require.NoError(t, os.WriteFile(filepath.Join(localDir, "existing.txt"), []byte("data"), 0644))
 
 	srv, _ := testServer(t)
+	logs := captureProjectsLog(t, srv)
 	srv.config.WorkspaceStorageConfig = &config.V1WorkspaceStorageConfig{
 		Backend: "gke-shared-volume",
 		GKESharedVolume: &config.V1GKESharedVolumeConfig{
@@ -454,6 +458,21 @@ func TestServerHubManagedProjectPath_GKESharedVolumeFallbackToLocal(t *testing.T
 	path, err := srv.hubManagedProjectPath(slug)
 	require.NoError(t, err)
 	assert.Equal(t, localDir, path)
+
+	// The warning is the only thing that distinguishes this fallback from the
+	// unfixed code, which returns the same local path without ever consulting
+	// the volume — so asserting on it is what makes this test discriminate,
+	// and it is also the only coverage the warning has.
+	assert.Contains(t, logs.String(), "served from ephemeral local path")
+	assert.Contains(t, logs.String(), filepath.Join(mountBase, "workspace-vol"))
+
+	// Repeated resolutions must not repeat the warning: this runs on the
+	// WebDAV, clone and cache paths.
+	for range 3 {
+		_, err := srv.hubManagedProjectPath(slug)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, 1, strings.Count(logs.String(), "served from ephemeral local path"))
 }
 
 // A gke-shared-volume config without a volume name has no mount point to build
@@ -796,6 +815,17 @@ func TestCheckWorkspaceStorageHealth_MountPathPerBackend(t *testing.T) {
 			assert.Equal(t, tt.want, checks["workspace_storage"])
 		})
 	}
+}
+
+// captureProjectsLog redirects the projects subsystem logger into a buffer the
+// test can assert on.
+func captureProjectsLog(t *testing.T, srv *Server) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := srv.projectsLog
+	srv.projectsLog = slog.New(slog.NewTextHandler(buf, nil))
+	t.Cleanup(func() { srv.projectsLog = prev })
+	return buf
 }
 
 // setContainerRootPath overrides the reference path isMountedVolume compares

--- a/pkg/hub/workspace_storage_test.go
+++ b/pkg/hub/workspace_storage_test.go
@@ -427,6 +427,130 @@ func TestReadiness_NFSAvailable(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// TestCheckWorkspaceStorageHealth_MountPathPerBackend covers mount path
+// resolution for every backend.
+//
+// The Cloud Run and GKE volume backends resolve a path under /mnt, which a test
+// cannot create, so those cases assert the distinction between "mount path not
+// configured" (no path resolved at all — the gke-shared-volume bug) and "mount
+// not available" (a path was resolved and stat'ed). The NFS backend, whose
+// mount root is configurable, covers the healthy path above.
+func TestCheckWorkspaceStorageHealth_MountPathPerBackend(t *testing.T) {
+	srv, _ := testServer(t)
+
+	mountRoot := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(mountRoot, "share1"), 0755))
+
+	tests := []struct {
+		name string
+		cfg  *config.V1WorkspaceStorageConfig
+		want string // expected checks["workspace_storage"]; "" means no entry
+	}{
+		{
+			name: "nil config records no check",
+			cfg:  nil,
+			want: "",
+		},
+		{
+			name: "local backend records no check",
+			cfg:  &config.V1WorkspaceStorageConfig{Backend: "local"},
+			want: "",
+		},
+		{
+			name: "empty backend records no check",
+			cfg:  &config.V1WorkspaceStorageConfig{Backend: ""},
+			want: "",
+		},
+		{
+			name: "nfs with a mounted share is healthy",
+			cfg: &config.V1WorkspaceStorageConfig{
+				Backend: "nfs",
+				NFS: &config.V1NFSConfig{
+					MountRoot: mountRoot,
+					Shares:    []config.V1NFSShare{{ID: "share1", Server: "10.0.0.2", Export: "/scion"}},
+				},
+			},
+			want: "healthy",
+		},
+		{
+			name: "nfs with a missing share reports mount unavailable",
+			cfg: &config.V1WorkspaceStorageConfig{
+				Backend: "nfs",
+				NFS: &config.V1NFSConfig{
+					MountRoot: mountRoot,
+					Shares:    []config.V1NFSShare{{ID: "absent-share", Server: "10.0.0.2", Export: "/scion"}},
+				},
+			},
+			want: "unhealthy: mount not available",
+		},
+		{
+			name: "nfs without shares reports mount path not configured",
+			cfg: &config.V1WorkspaceStorageConfig{
+				Backend: "nfs",
+				NFS:     &config.V1NFSConfig{MountRoot: mountRoot},
+			},
+			want: "unhealthy: mount path not configured",
+		},
+		{
+			name: "cloudrun-volume with a volume name resolves a mount path",
+			cfg: &config.V1WorkspaceStorageConfig{
+				Backend:        "cloudrun-volume",
+				CloudRunVolume: &config.V1CloudRunVolumeConfig{VolumeName: "scion-absent-cloudrun-vol"},
+			},
+			want: "unhealthy: mount not available",
+		},
+		{
+			name: "cloudrun-volume without a volume name reports mount path not configured",
+			cfg: &config.V1WorkspaceStorageConfig{
+				Backend:        "cloudrun-volume",
+				CloudRunVolume: &config.V1CloudRunVolumeConfig{},
+			},
+			want: "unhealthy: mount path not configured",
+		},
+		{
+			name: "gke-shared-volume with a volume name resolves a mount path",
+			cfg: &config.V1WorkspaceStorageConfig{
+				Backend: "gke-shared-volume",
+				GKESharedVolume: &config.V1GKESharedVolumeConfig{
+					VolumeName:  "scion-absent-gke-vol",
+					PVClaimName: "scion-workspaces",
+					SubPathRoot: "projects",
+				},
+			},
+			want: "unhealthy: mount not available",
+		},
+		{
+			// The mount path keys off VolumeName, not PVClaimName.
+			name: "gke-shared-volume without a volume name reports mount path not configured",
+			cfg: &config.V1WorkspaceStorageConfig{
+				Backend:         "gke-shared-volume",
+				GKESharedVolume: &config.V1GKESharedVolumeConfig{PVClaimName: "scion-workspaces"},
+			},
+			want: "unhealthy: mount path not configured",
+		},
+		{
+			name: "gke-shared-volume without a config block reports mount path not configured",
+			cfg:  &config.V1WorkspaceStorageConfig{Backend: "gke-shared-volume"},
+			want: "unhealthy: mount path not configured",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv.config.WorkspaceStorageConfig = tt.cfg
+
+			checks := make(map[string]string)
+			srv.checkWorkspaceStorageHealth(checks)
+
+			if tt.want == "" {
+				assert.NotContains(t, checks, "workspace_storage")
+				return
+			}
+			assert.Equal(t, tt.want, checks["workspace_storage"])
+		})
+	}
+}
+
 // ============================================================================
 // Integration Test: Write → Verify → Simulated Restart
 // ============================================================================

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -67,7 +67,8 @@ type ResolvedWorkspace struct {
 	// SharedDirs maps shared-dir name → resolved path info.
 	SharedDirs map[string]ResolvedSharedDir
 
-	// Backend identifies which backend produced this resolution ("local" or "nfs").
+	// Backend identifies which backend produced this resolution: "local",
+	// "nfs", "cloudrun-volume" or "gke-shared-volume".
 	Backend string
 }
 

--- a/pkg/runtime/interface.go
+++ b/pkg/runtime/interface.go
@@ -56,9 +56,10 @@ type RunConfig struct {
 	Project              string   // Project name (e.g., "global" or "my-project")
 	ProjectID            string   // Project ID (e.g., "550e8400-e29b-41d4-a716-446655440000")
 
-	// WorkspaceBackendName is "local" or "nfs", set by the workspace backend
-	// selector. Used to branch UID/GID injection and skip per-start chown
-	// when NFS (N1-5).
+	// WorkspaceBackendName is the name of the backend chosen by the workspace
+	// backend selector: "local", "nfs", "cloudrun-volume" or
+	// "gke-shared-volume". Used to branch UID/GID injection and skip per-start
+	// chown when NFS (N1-5); the branches below key on "nfs" only.
 	WorkspaceBackendName string
 	// NFSUID and NFSGID are the stable, node-independent UID/GID for NFS-backed
 	// workspaces. Advertised as SCION_HOST_UID/GID when WorkspaceBackendName is "nfs"

--- a/pkg/sciontool/telemetry/pipeline_health_test.go
+++ b/pkg/sciontool/telemetry/pipeline_health_test.go
@@ -13,19 +13,25 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
+// Receiver ports in these tests are always 0 so the kernel assigns a free
+// port. A hardcoded port here is unsafe even if nothing else in the tree uses
+// it: `go test ./...` runs package binaries in parallel, and any port in the
+// local ephemeral range (32768-60999 on Linux) can already be held as the
+// source port of an outbound connection made by a sibling test binary, which
+// makes Start fail with "bind: address already in use".
 func TestPipeline_HealthGauge_Registers(t *testing.T) {
 	clearTelemetryEnv()
 	t.Setenv(EnvEnabled, "true")
 	t.Setenv(EnvCloudEnabled, "false")
-	t.Setenv(EnvGRPCPort, "54401")
-	t.Setenv(EnvHTTPPort, "54402")
+	t.Setenv(EnvGRPCPort, "0")
+	t.Setenv(EnvHTTPPort, "0")
 	defer clearTelemetryEnv()
 
 	cfg := &Config{
 		Enabled:       true,
 		CloudEnabled:  false,
-		GRPCPort:      54401,
-		HTTPPort:      54402,
+		GRPCPort:      0,
+		HTTPPort:      0,
 		CloudProvider: "",
 	}
 	pipeline := NewWithConfig(cfg)
@@ -55,14 +61,14 @@ func TestPipeline_HealthGauge_StopsOnStop(t *testing.T) {
 	clearTelemetryEnv()
 	t.Setenv(EnvEnabled, "true")
 	t.Setenv(EnvCloudEnabled, "false")
-	t.Setenv(EnvGRPCPort, "54403")
-	t.Setenv(EnvHTTPPort, "54404")
+	t.Setenv(EnvGRPCPort, "0")
+	t.Setenv(EnvHTTPPort, "0")
 	defer clearTelemetryEnv()
 
 	cfg := &Config{
 		Enabled:  true,
-		GRPCPort: 54403,
-		HTTPPort: 54404,
+		GRPCPort: 0,
+		HTTPPort: 0,
 	}
 	pipeline := NewWithConfig(cfg)
 	if pipeline == nil {
@@ -92,8 +98,8 @@ func TestPipeline_HealthGauge_StopsOnStop(t *testing.T) {
 func TestPipeline_ExportErrors_NilCounter(t *testing.T) {
 	cfg := &Config{
 		Enabled:  true,
-		GRPCPort: 54405,
-		HTTPPort: 54406,
+		GRPCPort: 0,
+		HTTPPort: 0,
 	}
 	pipeline := NewWithConfig(cfg)
 	if pipeline == nil {


### PR DESCRIPTION
Two hub-side switches on `wsCfg.Backend` never learned about the `gke-shared-volume` workspace backend.

`checkWorkspaceStorageHealth` fell through, leaving `mountPath` empty, so `/readyz` 503'd permanently: the pod never becomes Ready and a GCLB ingress never gets a healthy backend.

`hubManagedProjectPath` fell through to `localProjectPath`, so hub project trees landed on node-local ephemeral storage and were lost on reschedule.

They ship together deliberately. Fixing readiness alone converts a loud failure into silent data loss.

Both resolve `/mnt/<volume_name>`, mirroring `cloudrun-volume`; the config has no mount-path field. Readiness additionally requires the mount root to be a real mount (`st_dev` vs container root), so a directory created on the overlay cannot latch readiness healthy.

Testing: `go test ./pkg/hub/ -count=1` untagged passes. CI `make test-fast` uses `-tags no_sqlite`, which excludes these tests, so the untagged run is the evidence.

Fixes ptone/scion#1067, ptone/scion#1069.