### PR TITLE
docs: weekly release notes for Aug 10-16, 2026

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -97,6 +97,7 @@ export default defineConfig({
 							label: 'Release Notes',
 							items: [
 								{ label: 'Overview', slug: 'release-notes' },
+								{ label: 'Aug 10 -- 16', slug: 'release-notes/2026-08-10' },
 								{ label: 'Aug 3 -- 9', slug: 'release-notes/2026-08-03' },
 								{ label: 'Jul 27 -- Aug 2', slug: 'release-notes/2026-07-27' },
 								{ label: 'Jul 19 -- 25', slug: 'release-notes/2026-07-19' },

--- a/docs-site/src/content/docs/release-notes.md
+++ b/docs-site/src/content/docs/release-notes.md
@@ -4,14 +4,15 @@ title: Release Notes
 
 Scion release notes are published weekly.
 
-## Latest: Week of August 3 -- 9, 2026
+## Latest: Week of August 10 -- 16, 2026
 
-This week marked a massive leap forward for Scion's production readiness, headlined by an end-to-end security and identity federation overhaul that includes OIDC provider capabilities, tiered agent authorization roles, and multi-issuer OIDC logins. Alongside these security enhancements, the platform introduced a comprehensive observability suite featuring real-time diagnostic logs, active health-monitoring alerts, and server-side OTel tracing. Additionally, a redesigned user onboarding flow and major high-availability updates to the A2A Protocol Bridge solidify Scion's capability to run at enterprise scale.
+August 10–16, 2026, marked a landmark week for Scion's communication capabilities, highlighted by the feature-complete launch of native web chat and major bidirectional messaging integrations for Microsoft Teams and Google Chat. Alongside these messaging breakthroughs, the platform received significant hardening for multi-instance high availability (HA) on Cloud Run and robust GCP service account IAM security authorization gates.
 
-[Read the full release notes for this week ->](/scion/release-notes/2026-08-03/)
+[Read the full release notes for this week ->](/scion/release-notes/2026-08-10/)
 
 ## Previous Weeks
 
+- [Week of August 3 -- 9, 2026](/scion/release-notes/2026-08-03/)
 - [Week of July 27 -- August 2, 2026](/scion/release-notes/2026-07-27/)
 - [Week of July 19--25, 2026](/scion/release-notes/2026-07-19/)
 - [Week of July 12--19, 2026](/scion/release-notes/2026-07-12/)

--- a/docs-site/src/content/docs/release-notes/2026-08-10.md
+++ b/docs-site/src/content/docs/release-notes/2026-08-10.md
@@ -1,14 +1,14 @@
 ---
 title: "Week of August 10 -- 16, 2026"
 ---
-August 10–16, 2026, marked a landmark week for Scion’s communication capabilities, highlighted by the feature-complete launch of native web chat and major bidirectional messaging integrations for Microsoft Teams and Google Chat. Alongside these messaging breakthroughs, the platform received significant hardening for multi-instance high availability (HA) on Cloud Run and robust GCP service account IAM security authorization gates. Users also benefit from a highly refined administrative UX, featuring a unified agent creation flow and complete on-demand Runtimes & Profiles management.
+August 10–16, 2026, marked a landmark week for Scion's communication capabilities, highlighted by the feature-complete launch of native web chat and major bidirectional messaging integrations for Microsoft Teams and Google Chat. Alongside these messaging breakthroughs, the platform received significant hardening for multi-instance high availability (HA) on Cloud Run and robust GCP service account IAM security authorization gates. Users also benefit from a highly refined administrative UX, featuring a unified agent creation flow and complete on-demand Runtimes & Profiles management.
 
 ---
 
 ## Highlights
 
 ### 1. A Complete Native Web Chat Experience
-This week, the native web chat went from initial database schemas and Server-Sent Event (SSE) foundations to a feature-complete collaborative environment. Following Phase 0 and 1, the rollout introduced real-time log-chat toggles, conversational visibility filters, autocomplete @-mentions, and a dedicated top-level application shell. The launch was completed in Wave 2 and its subsequent iterations with project-scoped collaborative spaces, direct messages, user presence indicators, search capabilities, and extensive mobile optimizations.
+This week, the native web chat went from initial database schemas and Server-Sent Event (SSE) foundations to a feature-complete collaborative environment. Following Phases 0 and 1, the rollout introduced real-time log-chat toggles, conversational visibility filters, autocomplete @-mentions, and a dedicated top-level application shell. The launch was completed in Wave 2 and its subsequent iterations with project-scoped collaborative spaces, direct messages, user presence indicators, search capabilities, and extensive mobile optimizations.
 
 ### 2. Sweeping Platform Integrations with Microsoft Teams and Google Chat
 Platform reach expanded significantly with a comprehensive bidirectional Microsoft Teams chat integration, which provides robust bot command matching and full Azure AD authentication across channel contexts. Alongside Teams, the Google Chat plugin received major enhancements, adding Cloud Pub/Sub ingress support for firewall-restricted setups, queue-based message deduplication, and bidirectional attachment processing up to 25 MB.
@@ -47,5 +47,5 @@ To support production high availability on multi-instance Cloud Run deployments,
 
 ## 🛠️ Developer Experience
 - **Case Collision Resolution:** Resolved a file casing conflict between `AGENTS.md` and `agents.md` that broke checkouts on macOS and Windows by merging them into a single uppercase file and correcting all references (#1153).
-- **Robust Lint Filtering:** Switched linter checks to a git-based `--new-from-merge-base=origin/main` filter, bypassing GitHub's 20,000-line API diff limitation and resolving pre-existing issues from blocking pull requests (#1174).
+- **Robust Lint Filtering:** Switched linter checks to a git-based `--new-from-merge-base=origin/main` filter, bypassing GitHub's 20,000-line API diff limitation and preventing pre-existing issues from blocking pull requests (#1174).
 - **Self-Policing Harness Names:** Introduced a compile-time test to guarantee that embedded harnesses in Go match actual directory files, preventing manual index out-of-sync bugs (#1176).

--- a/docs-site/src/content/docs/release-notes/2026-08-10.md
+++ b/docs-site/src/content/docs/release-notes/2026-08-10.md
@@ -1,0 +1,51 @@
+---
+title: "Week of August 10 -- 16, 2026"
+---
+August 10–16, 2026, marked a landmark week for Scion’s communication capabilities, highlighted by the feature-complete launch of native web chat and major bidirectional messaging integrations for Microsoft Teams and Google Chat. Alongside these messaging breakthroughs, the platform received significant hardening for multi-instance high availability (HA) on Cloud Run and robust GCP service account IAM security authorization gates. Users also benefit from a highly refined administrative UX, featuring a unified agent creation flow and complete on-demand Runtimes & Profiles management.
+
+---
+
+## Highlights
+
+### 1. A Complete Native Web Chat Experience
+This week, the native web chat went from initial database schemas and Server-Sent Event (SSE) foundations to a feature-complete collaborative environment. Following Phase 0 and 1, the rollout introduced real-time log-chat toggles, conversational visibility filters, autocomplete @-mentions, and a dedicated top-level application shell. The launch was completed in Wave 2 and its subsequent iterations with project-scoped collaborative spaces, direct messages, user presence indicators, search capabilities, and extensive mobile optimizations.
+
+### 2. Sweeping Platform Integrations with Microsoft Teams and Google Chat
+Platform reach expanded significantly with a comprehensive bidirectional Microsoft Teams chat integration, which provides robust bot command matching and full Azure AD authentication across channel contexts. Alongside Teams, the Google Chat plugin received major enhancements, adding Cloud Pub/Sub ingress support for firewall-restricted setups, queue-based message deduplication, and bidirectional attachment processing up to 25 MB.
+
+### 3. Multi-Instance Stability and Hardened IAM Security for High Availability
+To support production high availability on multi-instance Cloud Run deployments, we migrated key ephemeral state, such as HMAC replay nonces and account-link codes, to persistent database tables. This infrastructure was fortified with GCP Policy Troubleshooter v3 `actAs` authorization gates to restrict service account usage, and project-isolated checks on the agent deletion API to guarantee tenant security.
+
+---
+
+## 💬 Native Web Chat
+- **End-to-End Collaborative Chat Workspace:** Shipped a feature-complete native web chat interface that evolved from early database schemas and SSE event streams into a fully collaborative space. Key features include a real-time Chat/Log interface toggle, three-state conversational visibility filters, keyboard-navigated autocomplete @-mentions, project-scoped collaborative spaces, direct messaging, real-time presence/typing indicators, search, and attachment support (#1137, #1138, #1144, #1151, #1152, #1156, #1157, #1170).
+- **Mobile Navigation and Refinements:** Polished the mobile client experience with gesture-based swipe navigation, inline markdown rendering, image overlay capabilities, and dedicated iOS layout fixes, verified by over 250 passing frontend tests (#1185).
+
+## 🔌 Chat Integration Plugins
+- **Bidirectional Microsoft Teams Integration:** Delivered a comprehensive bidirectional chat integration plugin comprising over 14,000 lines of code across 40 files. The integration supports Azure AD OAuth2/JWT authentication, Adaptive Card layouts, SQLite and PostgreSQL database persistence, bot commands, profile identity linking, and a dedicated setup UI with downloadable app manifests (#1106, #1123, #1127, #1128).
+- **Expanded Google Chat Enhancements:** Introduced major updates to the Google Chat plugin, adding thread-level default agent routing, queue-backed message deduplication, Cloud Pub/Sub ingress for firewall-restricted environments, bidirectional 25 MB attachments, and a collection of interactive admin commands (#1114, #1115, #1116, #1117, #1118, #1119, #1120, #1121).
+
+## 🛡️ Security & Identity
+- **GCP Service Account IAM Authorization Gates:** Implemented GCP Policy Troubleshooter v3 `actAs` verification in fail-closed mode for all caller types, backed by a cached permission checker, to securely gate service account delegation and project-default service account assignment (#1034).
+- **Project-Isolated Agent Deletion:** Hardened the agent deletion endpoint to enforce strict project boundaries and require the `ScopeAgentLifecycle` scope, resolving a vulnerability where any valid agent JWT could delete arbitrary agents across the entire hub (#1097).
+- **Agent Notification Self-Service:** Authorized agents to manage their own notification subscriptions within their project boundaries under scoped permissions (`project:read`, `project:agent:notify`), preventing cross-project information leakage (#1182).
+- **Federation Auth and OIDC Discovery:** Added external OIDC login provider support to the web UI and deployed OIDC discovery and JWKS proxy endpoints on the A2A bridge to facilitate secure token validation behind IAP gateways (#1131, #1133, #1147).
+- **Workload Identity Federation Guide:** Shipped a comprehensive guide on GCP-to-AWS Workload Identity Federation, featuring trust policy configurations, OIDC provider gotchas, and multi-credential troubleshooting strategies (#1186).
+
+## ⚙️ Hub Infrastructure & HA Stability
+- **Multi-Instance Cloud Run Optimization:** Solved concurrency and state-drift race conditions at `min-instances=2` by moving the HMAC nonce replay cache and messaging account-link codes to Postgres tables, pinning the unique `hubID`, utilizing advisory database locks during boot migrations, and sharing OIDC signing keys via CAS database writes (#1134, #1135, #1136, #1139).
+- **Durable Workspace Storage:** Rolled out scalable NFS workspace storage backed by a new `workspace_storage.backend` config pivot, introducing a 503 safety gate on write endpoints when Cloud Run instances lose connection to the storage backend (#1148).
+- **Layer-1 Settings Integration:** Configured container runtimes, hardware profiles, and harness configurations as Layer-1 settings persisted as JSONB in the database, directly wire-routing them to runtime broker agent dispatch (#1145, #1167).
+- **Persistent User Role Alignment:** Fixed an authentication regression to ensure UI-promoted user roles are preserved on subsequent logins instead of being silently reverted by static file-based `admin_emails` configurations (#1187).
+
+## 🖥️ Administrative UI & UX
+- **Unified Single-Page Agent Creation:** Merged the previous two-phase agent creation and configuration workflows into a single-page form with a collapsible advanced settings disclosure containing five distinct tabs, eliminating multi-step round-trips (#1107).
+- **On-Demand Runtimes & Profiles Management:** Added a CRUD configuration tab to the Admin dashboard, allowing administrators to edit Docker/Podman/K8s runtimes, modify resource limit profiles, and edit harness configuration JSON strings in-place (#1155).
+- **Identity & Role Visibility:** Added color-coded role badges (Full, Baseline, Read-Only, None) and expanded GCP service account detail cards on the Agent detail page for better security visibility (#1104).
+- **Dynamic Credential Synchronization:** Wired custom `sa-list-changed` events to instantly sync service account lists and clear deleted credentials from the default SA dropdown without requiring a full page refresh (#1178).
+
+## 🛠️ Developer Experience
+- **Case Collision Resolution:** Resolved a file casing conflict between `AGENTS.md` and `agents.md` that broke checkouts on macOS and Windows by merging them into a single uppercase file and correcting all references (#1153).
+- **Robust Lint Filtering:** Switched linter checks to a git-based `--new-from-merge-base=origin/main` filter, bypassing GitHub's 20,000-line API diff limitation and resolving pre-existing issues from blocking pull requests (#1174).
+- **Self-Policing Harness Names:** Introduced a compile-time test to guarantee that embedded harnesses in Go match actual directory files, preventing manual index out-of-sync bugs (#1176).


### PR DESCRIPTION
## Summary
Weekly release notes for August 10-16, 2026.

Highlights: native web chat feature-complete launch, Microsoft Teams and Google Chat integrations, multi-instance HA hardening and GCP SA IAM gates.

New per-week page, updated index, sidebar entry. 3 files, 56 insertions.

Tracking: ptone/scion#1113
