### PR TITLE
fix(web-chat): Phase 0 correctness — scrollback, scroll-to-bottom, presence, rate limit

### DIFF
--- a/pkg/hub/chat_notifications_test.go
+++ b/pkg/hub/chat_notifications_test.go
@@ -467,3 +467,69 @@ type mockPresenceChecker struct {
 func (m *mockPresenceChecker) IsUserActive(userID string) bool {
 	return m.activeUsers[userID]
 }
+
+// ---------------------------------------------------------------------------
+// Tests: presence wiring on the Server (#1032)
+// ---------------------------------------------------------------------------
+
+// The notifier used to be constructed with a nil PresenceChecker, which falls
+// back to NoOpPresenceChecker and reports every user as absent — so the
+// "don't interrupt someone who is already looking at chat" suppression never
+// fired. The mocked-checker tests above could not catch that: only the real
+// server wiring can. Note the construction order this depends on —
+// SetWebChatStore runs before InitPresenceManager on the startup path, so the
+// checker has to resolve the presence manager lazily.
+func TestServer_ChatNotifier_UsesServerPresence(t *testing.T) {
+	srv, st := testServer(t)
+	ctx := context.Background()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	wcs := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, wcs.Init())
+
+	// Startup order: the webchat store (and with it the notifier) is wired
+	// first, the presence manager second.
+	srv.SetWebChatStore(wcs)
+	srv.InitPresenceManager()
+	t.Cleanup(srv.StopPresenceManager)
+
+	cn := srv.getChatNotifier()
+	require.NotNil(t, cn, "expected a chat notifier after SetWebChatStore")
+
+	viewer := api.NewUUID()
+	absent := api.NewUUID()
+
+	// The viewer is actively using chat; the other user is not.
+	srv.presenceManager.Heartbeat(ctx, viewer, "Active Viewer", nil)
+	require.True(t, srv.presenceManager.IsUserActive(viewer))
+	require.False(t, srv.presenceManager.IsUserActive(absent))
+
+	cn.NotifyDMReceived(ctx, viewer, "Sender", "dm:user:"+api.NewUUID()+":user:"+viewer, "hello", "")
+	cn.NotifyDMReceived(ctx, absent, "Sender", "dm:user:"+api.NewUUID()+":user:"+absent, "hello", "")
+
+	viewerNotifs, err := st.GetNotifications(ctx, store.SubscriberTypeUser, viewer, false)
+	require.NoError(t, err)
+	assert.Empty(t, viewerNotifs, "an actively present user must not be notified")
+
+	absentNotifs, err := st.GetNotifications(ctx, store.SubscriberTypeUser, absent, false)
+	require.NoError(t, err)
+	assert.Len(t, absentNotifs, 1, "an absent user must still be notified")
+}
+
+// A presence manager that has never seen a heartbeat for the user, and a nil
+// manager (no InitPresenceManager, e.g. in tests or a trimmed deployment),
+// must both report absent so notifications keep flowing.
+func TestPresenceManager_IsUserActive(t *testing.T) {
+	var nilPM *PresenceManager
+	assert.False(t, nilPM.IsUserActive("user-1"))
+
+	pm := NewPresenceManager(NewChannelEventPublisher(), nil)
+	t.Cleanup(pm.Stop)
+
+	assert.False(t, pm.IsUserActive("user-1"))
+	pm.Heartbeat(context.Background(), "user-1", "User One", nil)
+	assert.True(t, pm.IsUserActive("user-1"))
+	assert.False(t, pm.IsUserActive("user-2"))
+}

--- a/pkg/hub/chat_ratelimit.go
+++ b/pkg/hub/chat_ratelimit.go
@@ -336,20 +336,27 @@ func (l *chatSendLimiter) Allow(senderID string, class chatSenderClass) chatSend
 // when the limiter has no positive rate at all — an empty rate map means "no
 // limiting configured", the same as a nil limiter, and nothing in production
 // constructs one. The caller must hold l.mu.
+//
+// Capacity is floored at one token. A sub-1/minute rate would otherwise cap the
+// bucket below the single token a send costs, so it could never accumulate
+// enough to allow one — a permanent block rather than a slow drip. Flooring the
+// capacity leaves the refill rate untouched: the sender still waits 1/perMinute
+// minutes between sends, but the send eventually happens.
 func (l *chatSendLimiter) refillLocked(senderID string, class chatSenderClass, now time.Time) *chatSendBucket {
 	perMinute := l.limitFor(class)
 	if perMinute <= 0 {
 		return nil
 	}
+	capacity := math.Max(1, perMinute)
 
 	key := class.keyPrefix() + senderID
 	b, ok := l.buckets[key]
 	if !ok {
-		b = &chatSendBucket{tokens: perMinute, last: now}
+		b = &chatSendBucket{tokens: capacity, last: now}
 		l.buckets[key] = b
 		return b
 	}
-	b.tokens = math.Min(perMinute, b.tokens+now.Sub(b.last).Seconds()*perMinute/60)
+	b.tokens = math.Min(capacity, b.tokens+now.Sub(b.last).Seconds()*perMinute/60)
 	b.last = now
 	return b
 }

--- a/pkg/hub/chat_ratelimit.go
+++ b/pkg/hub/chat_ratelimit.go
@@ -92,17 +92,26 @@ const (
 	chatSenderHuman chatSenderClass = iota
 	chatSenderAgent
 	chatSenderAgentMirror
+
+	// chatSenderClassCount is one past the last class, not a class itself.
+	// The startup check walks the enum with it, so a class added above is
+	// checked without anyone having to remember a separate list.
+	chatSenderClassCount
 )
 
-// keyPrefix namespaces a class's buckets.
+// keyPrefix namespaces a class's buckets. An unrecognised class gets its own
+// namespace rather than sharing a real one, so it can neither drain nor be
+// drained by a legitimate sender that happens to have the same ID.
 func (c chatSenderClass) keyPrefix() string {
 	switch c {
+	case chatSenderHuman:
+		return "user:"
 	case chatSenderAgent:
 		return "agent:"
 	case chatSenderAgentMirror:
 		return "agent-mirror:"
 	default:
-		return "user:"
+		return "unknown-class:"
 	}
 }
 
@@ -158,9 +167,15 @@ type chatSendLimiter struct {
 	buckets   map[string]*chatSendBucket
 	lastSweep time.Time
 
-	// ratesPerMinute is the allowance per rate class. A missing class, or a
-	// rate of zero or less, disables limiting for that class.
+	// ratesPerMinute is the allowance per rate class. Every class the
+	// production limiter can see has an entry (enforced at construction by
+	// validateChatSendRates); a class without one is not unlimited, it falls
+	// back to strictestRate. See limitFor.
 	ratesPerMinute map[chatSenderClass]float64
+
+	// strictestRate is the smallest configured allowance, used for any class
+	// with no rate of its own.
+	strictestRate float64
 
 	// now is the clock, injectable so tests can exhaust and refill a bucket
 	// without sleeping a real minute.
@@ -174,33 +189,76 @@ func newChatSendLimiter() *chatSendLimiter {
 
 // newChatSendLimiterWithClock creates a limiter with the production limits
 // and an injectable clock.
+//
+// It panics if a class has no rate. That is a programming error, not a runtime
+// condition: it is deterministic, it fires the first time a Server is
+// constructed (so any test catches it), and the alternative — starting up with
+// a class nobody is limiting — is exactly the silent failure this check
+// exists to prevent.
 func newChatSendLimiterWithClock(now func() time.Time) *chatSendLimiter {
-	return newChatSendLimiterWithRates(map[chatSenderClass]float64{
+	rates := map[chatSenderClass]float64{
 		chatSenderHuman:       chatSendHumanRatePerMinute,
 		chatSenderAgent:       chatSendAgentRatePerMinute,
 		chatSenderAgentMirror: chatSendAgentMirrorRatePerMinute,
-	}, now)
+	}
+	if err := validateChatSendRates(rates); err != nil {
+		panic(err)
+	}
+	return newChatSendLimiterWithRates(rates, now)
+}
+
+// validateChatSendRates reports whether every sender class has a positive
+// allowance. A class added to the enum without a rate would otherwise be
+// limited at the strictest rate instead of its own, which is safe but not what
+// the author meant — better to hear about it at startup.
+func validateChatSendRates(ratesPerMinute map[chatSenderClass]float64) error {
+	for class := chatSenderClass(0); class < chatSenderClassCount; class++ {
+		if ratesPerMinute[class] <= 0 {
+			return fmt.Errorf("chat send limiter: sender class %d has no positive rate configured", class)
+		}
+	}
+	return nil
 }
 
 // newChatSendLimiterWithRates creates a limiter with explicit limits and clock.
+// It is the test seam: production goes through newChatSendLimiterWithClock,
+// which additionally requires every class to be configured. A class omitted
+// here is limited at the strictest rate given, never left unlimited.
 func newChatSendLimiterWithRates(ratesPerMinute map[chatSenderClass]float64, now func() time.Time) *chatSendLimiter {
 	if now == nil {
 		now = time.Now
+	}
+	strictest := 0.0
+	for _, rate := range ratesPerMinute {
+		if rate > 0 && (strictest == 0 || rate < strictest) {
+			strictest = rate
+		}
 	}
 	return &chatSendLimiter{
 		buckets:        make(map[string]*chatSendBucket),
 		lastSweep:      now(),
 		ratesPerMinute: ratesPerMinute,
+		strictestRate:  strictest,
 		now:            now,
 	}
 }
 
 // limitFor returns the per-minute allowance for a rate class.
+//
+// A class with no rate of its own falls back to the strictest configured rate.
+// It deliberately does not fall back to "unlimited": a rate limiter is a
+// security control and fail-open is the wrong default for one, however
+// unreachable the path looks today. It equally does not deny outright, which
+// would turn a future missing rate into a total outage of the send path — the
+// strictest known rate closes the bypass without that risk.
 func (l *chatSendLimiter) limitFor(class chatSenderClass) float64 {
 	if l == nil {
 		return 0
 	}
-	return l.ratesPerMinute[class]
+	if rate, ok := l.ratesPerMinute[class]; ok && rate > 0 {
+		return rate
+	}
+	return l.strictestRate
 }
 
 // chatSendDecision is the outcome of a rate-limit check.
@@ -275,7 +333,9 @@ func (l *chatSendLimiter) Allow(senderID string, class chatSenderClass) chatSend
 
 // refillLocked returns the sender's bucket for a class, creating it if needed
 // and crediting the tokens accrued since it was last touched. It returns nil
-// when the class is unlimited. The caller must hold l.mu.
+// when the limiter has no positive rate at all — an empty rate map means "no
+// limiting configured", the same as a nil limiter, and nothing in production
+// constructs one. The caller must hold l.mu.
 func (l *chatSendLimiter) refillLocked(senderID string, class chatSenderClass, now time.Time) *chatSendBucket {
 	perMinute := l.limitFor(class)
 	if perMinute <= 0 {

--- a/pkg/hub/chat_ratelimit.go
+++ b/pkg/hub/chat_ratelimit.go
@@ -22,12 +22,20 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 )
 
 // Per-sender send limits for chat messages (#1054). Without them a single
 // looping agent can fill a thread faster than any reader can scroll, and the
 // cost lands on every consumer of that thread: the store, the SSE fan-out and
 // the notification pipeline.
+//
+// THE ENFORCED CEILING IS THE AGGREGATE PER SENDER: 30/min for a human,
+// 60/min for an agent, whatever the caller puts in the request body. Class
+// sub-limits below are reservations carved out of that aggregate, never extra
+// budget — a send is charged to its class bucket *and* to the sender's
+// aggregate bucket, and is refused if either is empty.
 //
 // The limits are per sender, not global: a busy fleet of many agents is normal
 // traffic, a single sender emitting more than one message per second is not.
@@ -39,22 +47,27 @@ import (
 // deliberately scoped to the chat send paths and should stay consistent with
 // whatever that work lands.
 const (
-	// chatSendHumanRatePerMinute is the sustained send rate allowed for a
-	// single human sender.
+	// chatSendHumanRatePerMinute is the total send rate allowed for a single
+	// human sender.
 	chatSendHumanRatePerMinute = 30
 
-	// chatSendAgentRatePerMinute is the sustained send rate allowed for a
-	// single agent's own messages to humans. Agents legitimately send more
-	// than humans (status reports, replies to several recipients), so they
-	// get a higher ceiling.
+	// chatSendAgentRatePerMinute is the total send rate allowed for a single
+	// agent, across every kind of traffic it produces. Agents legitimately
+	// send more than humans (status reports, replies to several recipients),
+	// so they get a higher ceiling.
 	chatSendAgentRatePerMinute = 60
 
-	// chatSendAgentMirrorRatePerMinute is the sustained rate allowed for an
-	// agent's automatic assistant-reply transcript mirror. Same ceiling as
-	// the agent's own messages, but a separate bucket: the mirror is machine
-	// generated and must not be able to spend the allowance an agent needs
-	// for a completion report or a blocker escalation.
-	chatSendAgentMirrorRatePerMinute = 60
+	// chatSendAgentMirrorRatePerMinute is the share of an agent's aggregate
+	// allowance that the automatic assistant-reply transcript mirror may
+	// consume. It is a sub-cap inside chatSendAgentRatePerMinute, not an
+	// addition to it: the mirror is machine generated and must not be able to
+	// spend the whole allowance an agent needs for a completion report or a
+	// blocker escalation, but it cannot raise the agent's total either.
+	//
+	// Sized so a flooding mirror always leaves at least
+	// chatSendAgentRatePerMinute - chatSendAgentMirrorRatePerMinute of
+	// headroom for the agent's own messages.
+	chatSendAgentMirrorRatePerMinute = 30
 
 	// chatSendLimiterIdleTTL is how long an untouched bucket is kept before
 	// being evicted. It also bounds how often the sweep runs.
@@ -70,6 +83,9 @@ const (
 // that share an ID cannot drain each other's allowance and — more
 // importantly — an agent's automatic transcript mirror cannot starve the
 // messages that agent writes itself.
+//
+// A class that is not its own aggregate (see aggregate) is a reservation
+// inside another class's ceiling rather than a ceiling of its own.
 type chatSenderClass int
 
 const (
@@ -90,13 +106,43 @@ func (c chatSenderClass) keyPrefix() string {
 	}
 }
 
-// chatSenderClassFor maps an authenticated identity to its rate class.
-// Anything that is not an agent is rated as a human.
-func chatSenderClassFor(ident Identity) chatSenderClass {
-	if ident != nil && ident.Type() == "agent" {
+// aggregate returns the class holding the sender's real ceiling. The mirror
+// spends an agent's allowance, so its aggregate is the agent class; every
+// other class is its own aggregate.
+//
+// This is what makes the traffic class safe to derive from a caller-supplied
+// field: whichever class a sender claims, the same aggregate bucket is
+// charged, so relabelling traffic cannot buy a second allowance. It can only
+// move the sender into a *smaller* reservation.
+func (c chatSenderClass) aggregate() chatSenderClass {
+	if c == chatSenderAgentMirror {
 		return chatSenderAgent
 	}
-	return chatSenderHuman
+	return c
+}
+
+// chatSenderClassForMessageType maps an outbound message type to its traffic
+// class. Only the transcript mirror's own type gets the mirror reservation;
+// every other type — including one this build does not recognise — is charged
+// as an agent-authored message, so an unfamiliar label can never be used to
+// claim a reservation it is not entitled to.
+//
+// The class is only ever a reservation *within* the sender's aggregate
+// allowance (see aggregate), so a sender cannot gain budget by choosing a
+// class either way.
+func chatSenderClassForMessageType(msgType string) chatSenderClass {
+	if msgType == messages.TypeAssistantReply {
+		return chatSenderAgentMirror
+	}
+	return chatSenderAgent
+}
+
+// noun describes a class in a rate-limit error message.
+func (c chatSenderClass) noun() string {
+	if c == chatSenderAgentMirror {
+		return "assistant-reply messages"
+	}
+	return "messages"
 }
 
 // chatSendBucket is one sender's token bucket.
@@ -157,22 +203,32 @@ func (l *chatSendLimiter) limitFor(class chatSenderClass) float64 {
 	return l.ratesPerMinute[class]
 }
 
-// Allow consumes one token for the sender and reports whether the send may
-// proceed. When it may not, the returned duration is how long the caller
-// should wait before retrying — suitable for a Retry-After header.
+// chatSendDecision is the outcome of a rate-limit check.
+type chatSendDecision struct {
+	// Allowed reports whether the send may proceed.
+	Allowed bool
+	// RetryAfter is how long to wait before retrying. When both the
+	// aggregate bucket and the class reservation are empty it is the longer
+	// of the two waits. Zero when Allowed.
+	RetryAfter time.Duration
+	// Limit is the per-minute allowance of the bucket that refused, and
+	// LimitClass is the class that bucket belongs to, so the error can name
+	// the limit the sender actually hit. Zero when Allowed.
+	Limit      float64
+	LimitClass chatSenderClass
+}
+
+// Allow consumes one token from the sender's aggregate bucket and one from
+// the class reservation (when the class is not its own aggregate), and
+// reports whether the send may proceed. It is refused if either bucket is
+// empty, and nothing is consumed from either when it is refused.
 //
 // A nil limiter allows everything: limiting is a protection, not a
 // correctness requirement, and a hand-constructed Server must still work.
-func (l *chatSendLimiter) Allow(senderID string, class chatSenderClass) (bool, time.Duration) {
+func (l *chatSendLimiter) Allow(senderID string, class chatSenderClass) chatSendDecision {
 	if l == nil {
-		return true, 0
+		return chatSendDecision{Allowed: true}
 	}
-
-	perMinute := l.limitFor(class)
-	if perMinute <= 0 {
-		return true, 0
-	}
-	perSecond := perMinute / 60
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -180,25 +236,62 @@ func (l *chatSendLimiter) Allow(senderID string, class chatSenderClass) (bool, t
 	now := l.now()
 	l.sweepLocked(now)
 
+	aggregate := l.refillLocked(senderID, class.aggregate(), now)
+	var reservation *chatSendBucket
+	if class != class.aggregate() {
+		reservation = l.refillLocked(senderID, class, now)
+	}
+
+	// Refuse if either bucket is empty, reporting whichever has the longer
+	// wait: that is the one the sender actually has to wait out.
+	decision := chatSendDecision{Allowed: true}
+	consider := func(b *chatSendBucket, c chatSenderClass) {
+		if b == nil || b.tokens >= 1 {
+			return
+		}
+		perMinute := l.limitFor(c)
+		wait := time.Duration((1 - b.tokens) / (perMinute / 60) * float64(time.Second))
+		if wait < time.Second {
+			wait = time.Second
+		}
+		if decision.Allowed || wait > decision.RetryAfter {
+			decision = chatSendDecision{RetryAfter: wait, Limit: perMinute, LimitClass: c}
+		}
+	}
+	consider(aggregate, class.aggregate())
+	consider(reservation, class)
+	if !decision.Allowed {
+		return decision
+	}
+
+	if aggregate != nil {
+		aggregate.tokens--
+	}
+	if reservation != nil {
+		reservation.tokens--
+	}
+	return decision
+}
+
+// refillLocked returns the sender's bucket for a class, creating it if needed
+// and crediting the tokens accrued since it was last touched. It returns nil
+// when the class is unlimited. The caller must hold l.mu.
+func (l *chatSendLimiter) refillLocked(senderID string, class chatSenderClass, now time.Time) *chatSendBucket {
+	perMinute := l.limitFor(class)
+	if perMinute <= 0 {
+		return nil
+	}
+
 	key := class.keyPrefix() + senderID
 	b, ok := l.buckets[key]
 	if !ok {
 		b = &chatSendBucket{tokens: perMinute, last: now}
 		l.buckets[key] = b
-	} else {
-		b.tokens = math.Min(perMinute, b.tokens+now.Sub(b.last).Seconds()*perSecond)
-		b.last = now
+		return b
 	}
-
-	if b.tokens < 1 {
-		wait := time.Duration((1 - b.tokens) / perSecond * float64(time.Second))
-		if wait < time.Second {
-			wait = time.Second
-		}
-		return false, wait
-	}
-	b.tokens--
-	return true, 0
+	b.tokens = math.Min(perMinute, b.tokens+now.Sub(b.last).Seconds()*perMinute/60)
+	b.last = now
+	return b
 }
 
 // sweepLocked evicts idle buckets. It runs at most once per idle TTL, or
@@ -239,15 +332,17 @@ func (l *chatSendLimiter) sweepLocked(now time.Time) {
 // caller must stop. The error is deliberately explicit rather than a silent
 // drop, so an agent that hits the limit can back off and resend (#1054).
 func (s *Server) allowChatSend(w http.ResponseWriter, senderID string, class chatSenderClass) bool {
-	allowed, retryAfter := s.chatSendLimiter.Allow(senderID, class)
-	if allowed {
+	decision := s.chatSendLimiter.Allow(senderID, class)
+	if decision.Allowed {
 		return true
 	}
 
-	seconds := int(math.Ceil(retryAfter.Seconds()))
+	seconds := int(math.Ceil(decision.RetryAfter.Seconds()))
 	w.Header().Set("Retry-After", strconv.Itoa(seconds))
+	// The delay goes in the body as well as the header: no current client
+	// reads Retry-After, so the message text is what a sending agent sees.
 	writeError(w, http.StatusTooManyRequests, ErrCodeRateLimited,
-		fmt.Sprintf("send rate limit exceeded (%d messages per minute); retry in %ds",
-			int(s.chatSendLimiter.limitFor(class)), seconds), nil)
+		fmt.Sprintf("send rate limit exceeded (%d %s per minute); retry in %ds",
+			int(decision.Limit), decision.LimitClass.noun(), seconds), nil)
 	return false
 }

--- a/pkg/hub/chat_ratelimit.go
+++ b/pkg/hub/chat_ratelimit.go
@@ -44,9 +44,17 @@ const (
 	chatSendHumanRatePerMinute = 30
 
 	// chatSendAgentRatePerMinute is the sustained send rate allowed for a
-	// single agent. Agents legitimately send more than humans (status
-	// reports, replies to several recipients), so they get a higher ceiling.
+	// single agent's own messages to humans. Agents legitimately send more
+	// than humans (status reports, replies to several recipients), so they
+	// get a higher ceiling.
 	chatSendAgentRatePerMinute = 60
+
+	// chatSendAgentMirrorRatePerMinute is the sustained rate allowed for an
+	// agent's automatic assistant-reply transcript mirror. Same ceiling as
+	// the agent's own messages, but a separate bucket: the mirror is machine
+	// generated and must not be able to spend the allowance an agent needs
+	// for a completion report or a blocker escalation.
+	chatSendAgentMirrorRatePerMinute = 60
 
 	// chatSendLimiterIdleTTL is how long an untouched bucket is kept before
 	// being evicted. It also bounds how often the sweep runs.
@@ -57,15 +65,30 @@ const (
 	chatSendLimiterMaxBuckets = 10000
 )
 
-// chatSenderClass distinguishes the rate classes. Buckets are keyed by class
-// as well as ID so a user and an agent that share an ID cannot drain each
-// other's allowance.
+// chatSenderClass distinguishes both who is sending and what kind of traffic
+// it is. Buckets are keyed by class as well as by ID, so a user and an agent
+// that share an ID cannot drain each other's allowance and — more
+// importantly — an agent's automatic transcript mirror cannot starve the
+// messages that agent writes itself.
 type chatSenderClass int
 
 const (
 	chatSenderHuman chatSenderClass = iota
 	chatSenderAgent
+	chatSenderAgentMirror
 )
+
+// keyPrefix namespaces a class's buckets.
+func (c chatSenderClass) keyPrefix() string {
+	switch c {
+	case chatSenderAgent:
+		return "agent:"
+	case chatSenderAgentMirror:
+		return "agent-mirror:"
+	default:
+		return "user:"
+	}
+}
 
 // chatSenderClassFor maps an authenticated identity to its rate class.
 // Anything that is not an agent is rated as a human.
@@ -89,8 +112,9 @@ type chatSendLimiter struct {
 	buckets   map[string]*chatSendBucket
 	lastSweep time.Time
 
-	humanPerMinute float64
-	agentPerMinute float64
+	// ratesPerMinute is the allowance per rate class. A missing class, or a
+	// rate of zero or less, disables limiting for that class.
+	ratesPerMinute map[chatSenderClass]float64
 
 	// now is the clock, injectable so tests can exhaust and refill a bucket
 	// without sleeping a real minute.
@@ -99,20 +123,28 @@ type chatSendLimiter struct {
 
 // newChatSendLimiter creates a limiter with the production limits.
 func newChatSendLimiter() *chatSendLimiter {
-	return newChatSendLimiterWithRates(chatSendHumanRatePerMinute, chatSendAgentRatePerMinute, time.Now)
+	return newChatSendLimiterWithClock(time.Now)
 }
 
-// newChatSendLimiterWithRates creates a limiter with explicit limits and
-// clock. A rate of zero or less disables limiting for that class.
-func newChatSendLimiterWithRates(humanPerMinute, agentPerMinute float64, now func() time.Time) *chatSendLimiter {
+// newChatSendLimiterWithClock creates a limiter with the production limits
+// and an injectable clock.
+func newChatSendLimiterWithClock(now func() time.Time) *chatSendLimiter {
+	return newChatSendLimiterWithRates(map[chatSenderClass]float64{
+		chatSenderHuman:       chatSendHumanRatePerMinute,
+		chatSenderAgent:       chatSendAgentRatePerMinute,
+		chatSenderAgentMirror: chatSendAgentMirrorRatePerMinute,
+	}, now)
+}
+
+// newChatSendLimiterWithRates creates a limiter with explicit limits and clock.
+func newChatSendLimiterWithRates(ratesPerMinute map[chatSenderClass]float64, now func() time.Time) *chatSendLimiter {
 	if now == nil {
 		now = time.Now
 	}
 	return &chatSendLimiter{
 		buckets:        make(map[string]*chatSendBucket),
 		lastSweep:      now(),
-		humanPerMinute: humanPerMinute,
-		agentPerMinute: agentPerMinute,
+		ratesPerMinute: ratesPerMinute,
 		now:            now,
 	}
 }
@@ -122,10 +154,7 @@ func (l *chatSendLimiter) limitFor(class chatSenderClass) float64 {
 	if l == nil {
 		return 0
 	}
-	if class == chatSenderAgent {
-		return l.agentPerMinute
-	}
-	return l.humanPerMinute
+	return l.ratesPerMinute[class]
 }
 
 // Allow consumes one token for the sender and reports whether the send may
@@ -139,10 +168,7 @@ func (l *chatSendLimiter) Allow(senderID string, class chatSenderClass) (bool, t
 		return true, 0
 	}
 
-	perMinute, prefix := l.limitFor(class), "user:"
-	if class == chatSenderAgent {
-		prefix = "agent:"
-	}
+	perMinute := l.limitFor(class)
 	if perMinute <= 0 {
 		return true, 0
 	}
@@ -154,7 +180,7 @@ func (l *chatSendLimiter) Allow(senderID string, class chatSenderClass) (bool, t
 	now := l.now()
 	l.sweepLocked(now)
 
-	key := prefix + senderID
+	key := class.keyPrefix() + senderID
 	b, ok := l.buckets[key]
 	if !ok {
 		b = &chatSendBucket{tokens: perMinute, last: now}

--- a/pkg/hub/chat_ratelimit.go
+++ b/pkg/hub/chat_ratelimit.go
@@ -1,0 +1,227 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// Per-sender send limits for chat messages (#1054). Without them a single
+// looping agent can fill a thread faster than any reader can scroll, and the
+// cost lands on every consumer of that thread: the store, the SSE fan-out and
+// the notification pipeline.
+//
+// The limits are per sender, not global: a busy fleet of many agents is normal
+// traffic, a single sender emitting more than one message per second is not.
+// Bucket capacity equals the per-minute allowance, so a burst (an agent
+// reporting completion to a dozen recipients at once, a human pasting a series
+// of messages) passes untouched and only sustained flooding is throttled.
+//
+// Hub-wide rate limiting is tracked separately in issue #302; these limits are
+// deliberately scoped to the chat send paths and should stay consistent with
+// whatever that work lands.
+const (
+	// chatSendHumanRatePerMinute is the sustained send rate allowed for a
+	// single human sender.
+	chatSendHumanRatePerMinute = 30
+
+	// chatSendAgentRatePerMinute is the sustained send rate allowed for a
+	// single agent. Agents legitimately send more than humans (status
+	// reports, replies to several recipients), so they get a higher ceiling.
+	chatSendAgentRatePerMinute = 60
+
+	// chatSendLimiterIdleTTL is how long an untouched bucket is kept before
+	// being evicted. It also bounds how often the sweep runs.
+	chatSendLimiterIdleTTL = 10 * time.Minute
+
+	// chatSendLimiterMaxBuckets caps the tracked senders so the map cannot
+	// grow without bound. Reaching it forces an immediate sweep.
+	chatSendLimiterMaxBuckets = 10000
+)
+
+// chatSenderClass distinguishes the rate classes. Buckets are keyed by class
+// as well as ID so a user and an agent that share an ID cannot drain each
+// other's allowance.
+type chatSenderClass int
+
+const (
+	chatSenderHuman chatSenderClass = iota
+	chatSenderAgent
+)
+
+// chatSenderClassFor maps an authenticated identity to its rate class.
+// Anything that is not an agent is rated as a human.
+func chatSenderClassFor(ident Identity) chatSenderClass {
+	if ident != nil && ident.Type() == "agent" {
+		return chatSenderAgent
+	}
+	return chatSenderHuman
+}
+
+// chatSendBucket is one sender's token bucket.
+type chatSendBucket struct {
+	tokens float64
+	last   time.Time // last time this bucket was touched
+}
+
+// chatSendLimiter is a per-sender token-bucket limiter for the chat send
+// paths. It is safe for concurrent use.
+type chatSendLimiter struct {
+	mu        sync.Mutex
+	buckets   map[string]*chatSendBucket
+	lastSweep time.Time
+
+	humanPerMinute float64
+	agentPerMinute float64
+
+	// now is the clock, injectable so tests can exhaust and refill a bucket
+	// without sleeping a real minute.
+	now func() time.Time
+}
+
+// newChatSendLimiter creates a limiter with the production limits.
+func newChatSendLimiter() *chatSendLimiter {
+	return newChatSendLimiterWithRates(chatSendHumanRatePerMinute, chatSendAgentRatePerMinute, time.Now)
+}
+
+// newChatSendLimiterWithRates creates a limiter with explicit limits and
+// clock. A rate of zero or less disables limiting for that class.
+func newChatSendLimiterWithRates(humanPerMinute, agentPerMinute float64, now func() time.Time) *chatSendLimiter {
+	if now == nil {
+		now = time.Now
+	}
+	return &chatSendLimiter{
+		buckets:        make(map[string]*chatSendBucket),
+		lastSweep:      now(),
+		humanPerMinute: humanPerMinute,
+		agentPerMinute: agentPerMinute,
+		now:            now,
+	}
+}
+
+// limitFor returns the per-minute allowance for a rate class.
+func (l *chatSendLimiter) limitFor(class chatSenderClass) float64 {
+	if l == nil {
+		return 0
+	}
+	if class == chatSenderAgent {
+		return l.agentPerMinute
+	}
+	return l.humanPerMinute
+}
+
+// Allow consumes one token for the sender and reports whether the send may
+// proceed. When it may not, the returned duration is how long the caller
+// should wait before retrying — suitable for a Retry-After header.
+//
+// A nil limiter allows everything: limiting is a protection, not a
+// correctness requirement, and a hand-constructed Server must still work.
+func (l *chatSendLimiter) Allow(senderID string, class chatSenderClass) (bool, time.Duration) {
+	if l == nil {
+		return true, 0
+	}
+
+	perMinute, prefix := l.limitFor(class), "user:"
+	if class == chatSenderAgent {
+		prefix = "agent:"
+	}
+	if perMinute <= 0 {
+		return true, 0
+	}
+	perSecond := perMinute / 60
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	l.sweepLocked(now)
+
+	key := prefix + senderID
+	b, ok := l.buckets[key]
+	if !ok {
+		b = &chatSendBucket{tokens: perMinute, last: now}
+		l.buckets[key] = b
+	} else {
+		b.tokens = math.Min(perMinute, b.tokens+now.Sub(b.last).Seconds()*perSecond)
+		b.last = now
+	}
+
+	if b.tokens < 1 {
+		wait := time.Duration((1 - b.tokens) / perSecond * float64(time.Second))
+		if wait < time.Second {
+			wait = time.Second
+		}
+		return false, wait
+	}
+	b.tokens--
+	return true, 0
+}
+
+// sweepLocked evicts idle buckets. It runs at most once per idle TTL, or
+// immediately when the map has hit its cap. The caller must hold l.mu.
+func (l *chatSendLimiter) sweepLocked(now time.Time) {
+	atCap := len(l.buckets) >= chatSendLimiterMaxBuckets
+	if !atCap && now.Sub(l.lastSweep) < chatSendLimiterIdleTTL {
+		return
+	}
+	l.lastSweep = now
+
+	for k, b := range l.buckets {
+		if now.Sub(b.last) >= chatSendLimiterIdleTTL {
+			delete(l.buckets, k)
+		}
+	}
+	if len(l.buckets) < chatSendLimiterMaxBuckets {
+		return
+	}
+
+	// Still at the cap with every bucket recently active: drop the
+	// least-recently-used half rather than the whole map, so a burst of new
+	// senders cannot reset the limits of the busiest ones.
+	keys := make([]string, 0, len(l.buckets))
+	for k := range l.buckets {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return l.buckets[keys[i]].last.Before(l.buckets[keys[j]].last)
+	})
+	for _, k := range keys[:len(keys)/2] {
+		delete(l.buckets, k)
+	}
+}
+
+// allowChatSend applies the per-sender send limit. When the sender is over
+// its limit it writes a 429 with a Retry-After header and returns false; the
+// caller must stop. The error is deliberately explicit rather than a silent
+// drop, so an agent that hits the limit can back off and resend (#1054).
+func (s *Server) allowChatSend(w http.ResponseWriter, senderID string, class chatSenderClass) bool {
+	allowed, retryAfter := s.chatSendLimiter.Allow(senderID, class)
+	if allowed {
+		return true
+	}
+
+	seconds := int(math.Ceil(retryAfter.Seconds()))
+	w.Header().Set("Retry-After", strconv.Itoa(seconds))
+	writeError(w, http.StatusTooManyRequests, ErrCodeRateLimited,
+		fmt.Sprintf("send rate limit exceeded (%d messages per minute); retry in %ds",
+			int(s.chatSendLimiter.limitFor(class)), seconds), nil)
+	return false
+}

--- a/pkg/hub/chat_ratelimit_test.go
+++ b/pkg/hub/chat_ratelimit_test.go
@@ -16,6 +16,7 @@ package hub
 
 import (
 	"fmt"
+	"math"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -157,12 +158,20 @@ func TestChatSendLimiter_MirrorReservationDoesNotStarveAgentMessages(t *testing.
 		t.Errorf("refused by class %v, want the mirror reservation: the aggregate still has room", decision.LimitClass)
 	}
 
-	// The mirror spent 2 of the aggregate 4, so 2 remain for the agent's own
-	// messages — the reservation caps the mirror, not the agent.
+	// The mirror spent 2 of the aggregate 4, so exactly 2 remain for the
+	// agent's own messages: the reservation caps the mirror, and what the
+	// mirror spent still came out of the one shared ceiling.
 	for i := range 2 {
 		if !lim.Allow("a1", chatSenderAgent).Allowed {
 			t.Errorf("agent-authored send %d refused: a flooding mirror must leave headroom", i+1)
 		}
+	}
+	decision = lim.Allow("a1", chatSenderAgent)
+	if decision.Allowed {
+		t.Fatal("the third agent-authored send should be refused: the mirror's 2 sends came out of the same aggregate 4")
+	}
+	if decision.LimitClass != chatSenderAgent {
+		t.Errorf("refused by class %v, want the agent aggregate", decision.LimitClass)
 	}
 }
 
@@ -222,6 +231,54 @@ func TestChatSenderClassForMessageType(t *testing.T) {
 		if got := chatSenderClassForMessageType(tc.msgType); got != tc.want {
 			t.Errorf("chatSenderClassForMessageType(%q) = %v, want %v", tc.msgType, got, tc.want)
 		}
+	}
+}
+
+// A class the limiter has no rate for must not be waved through. Unreachable
+// today — only three classes are constructed — but fail-open is the wrong
+// default for a rate limiter, and this is the branch a future class lands in.
+func TestChatSendLimiter_UnknownClassIsLimitedAtTheStrictestRate(t *testing.T) {
+	clock := newTestClock()
+	lim := newChatSendLimiterWithClock(clock.Now)
+
+	const unknown = chatSenderClass(99)
+	strictest := math.Min(chatSendHumanRatePerMinute, chatSendAgentMirrorRatePerMinute)
+	if got := lim.limitFor(unknown); got != strictest {
+		t.Fatalf("limitFor(unknown) = %v, want the strictest configured rate %v", got, strictest)
+	}
+
+	allowed := 0
+	for range 200 {
+		if lim.Allow("prober", unknown).Allowed {
+			allowed++
+		}
+	}
+	if float64(allowed) != strictest {
+		t.Errorf("an unknown class got %d sends through, want the strictest rate %v", allowed, strictest)
+	}
+
+	// And it does not share a bucket with a real class of the same sender ID.
+	if !lim.Allow("prober", chatSenderHuman).Allowed {
+		t.Error("a human sender must not be throttled by traffic in an unrecognised class")
+	}
+}
+
+// The production rates must cover every class in the enum. A class added
+// without a rate should fail loudly at startup rather than quietly being
+// limited at somebody else's number.
+func TestChatSendLimiter_ProductionRatesCoverEveryClass(t *testing.T) {
+	lim := newChatSendLimiter()
+	for class := chatSenderClass(0); class < chatSenderClassCount; class++ {
+		if got := lim.limitFor(class); got <= 0 {
+			t.Errorf("sender class %d has no positive rate (%v)", class, got)
+		}
+	}
+
+	if err := validateChatSendRates(map[chatSenderClass]float64{
+		chatSenderHuman: chatSendHumanRatePerMinute,
+		chatSenderAgent: chatSendAgentRatePerMinute,
+	}); err == nil {
+		t.Error("a rate map missing a class must be rejected, not accepted and silently back-filled")
 	}
 }
 

--- a/pkg/hub/chat_ratelimit_test.go
+++ b/pkg/hub/chat_ratelimit_test.go
@@ -15,10 +15,13 @@
 package hub
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 )
 
 // testClock is a manually advanced clock so limiter tests can exhaust and
@@ -51,26 +54,29 @@ func TestChatSendLimiter_BurstThenRefusesUntilRefill(t *testing.T) {
 	lim := newChatSendLimiterWithClock(clock.Now)
 
 	for i := range chatSendHumanRatePerMinute {
-		if allowed, _ := lim.Allow("u1", chatSenderHuman); !allowed {
+		if !lim.Allow("u1", chatSenderHuman).Allowed {
 			t.Fatalf("send %d of the first 30 was refused; the whole minute's allowance should burst", i+1)
 		}
 	}
 
-	allowed, retryAfter := lim.Allow("u1", chatSenderHuman)
-	if allowed {
+	decision := lim.Allow("u1", chatSenderHuman)
+	if decision.Allowed {
 		t.Fatal("the 31st send in the same instant should be refused")
 	}
-	if retryAfter < time.Second {
-		t.Errorf("retryAfter = %v, want at least 1s so Retry-After is a usable number", retryAfter)
+	if decision.RetryAfter < time.Second {
+		t.Errorf("RetryAfter = %v, want at least 1s so Retry-After is a usable number", decision.RetryAfter)
+	}
+	if decision.Limit != chatSendHumanRatePerMinute {
+		t.Errorf("Limit = %v, want the human limit %d so the error names the limit that was hit", decision.Limit, chatSendHumanRatePerMinute)
 	}
 
 	// At 30/min a token accrues every 2 seconds.
 	clock.Advance(time.Second)
-	if allowed, _ := lim.Allow("u1", chatSenderHuman); allowed {
+	if lim.Allow("u1", chatSenderHuman).Allowed {
 		t.Error("half a token later the sender should still be refused")
 	}
 	clock.Advance(time.Second)
-	if allowed, _ := lim.Allow("u1", chatSenderHuman); !allowed {
+	if !lim.Allow("u1", chatSenderHuman).Allowed {
 		t.Error("a full token later the sender should be allowed again")
 	}
 
@@ -78,11 +84,11 @@ func TestChatSendLimiter_BurstThenRefusesUntilRefill(t *testing.T) {
 	// an hour's worth of sends.
 	clock.Advance(time.Hour)
 	for i := range chatSendHumanRatePerMinute {
-		if allowed, _ := lim.Allow("u1", chatSenderHuman); !allowed {
+		if !lim.Allow("u1", chatSenderHuman).Allowed {
 			t.Fatalf("send %d after a long idle was refused", i+1)
 		}
 	}
-	if allowed, _ := lim.Allow("u1", chatSenderHuman); allowed {
+	if lim.Allow("u1", chatSenderHuman).Allowed {
 		t.Error("a long idle should refill at most one burst, not more")
 	}
 }
@@ -97,19 +103,19 @@ func TestChatSendLimiter_BucketsAreScopedToSenderAndClass(t *testing.T) {
 	}, clock.Now)
 
 	for range 2 {
-		if allowed, _ := lim.Allow("shared-id", chatSenderHuman); !allowed {
+		if !lim.Allow("shared-id", chatSenderHuman).Allowed {
 			t.Fatal("the human's own allowance should not be exhausted yet")
 		}
 	}
-	if allowed, _ := lim.Allow("shared-id", chatSenderHuman); allowed {
+	if lim.Allow("shared-id", chatSenderHuman).Allowed {
 		t.Fatal("the human is over its limit and should be refused")
 	}
 
-	if allowed, _ := lim.Allow("someone-else", chatSenderHuman); !allowed {
+	if !lim.Allow("someone-else", chatSenderHuman).Allowed {
 		t.Error("a different sender must not be throttled by the flooder")
 	}
 	for i := range 3 {
-		if allowed, _ := lim.Allow("shared-id", chatSenderAgent); !allowed {
+		if !lim.Allow("shared-id", chatSenderAgent).Allowed {
 			t.Errorf("agent send %d refused: the agent class has its own bucket and a higher limit", i+1)
 		}
 	}
@@ -124,32 +130,97 @@ func TestChatSendLimiter_ProductionLimits(t *testing.T) {
 	if got := lim.limitFor(chatSenderAgent); got != 60 {
 		t.Errorf("agent limit = %v, want 60/min", got)
 	}
-	if got := lim.limitFor(chatSenderAgentMirror); got != 60 {
-		t.Errorf("assistant-reply mirror limit = %v, want 60/min", got)
+	if got := lim.limitFor(chatSenderAgentMirror); got != 30 {
+		t.Errorf("assistant-reply mirror limit = %v, want 30/min (a reservation inside the agent's 60)", got)
 	}
 }
 
-// An agent's transcript mirror and its own messages are counted separately,
-// so neither can spend the other's allowance.
-func TestChatSendLimiter_MirrorAndAgentTrafficHaveSeparateBuckets(t *testing.T) {
+// The mirror's sub-cap is a reservation inside the agent's ceiling: it bounds
+// the mirror without shrinking what the agent itself may send.
+func TestChatSendLimiter_MirrorReservationDoesNotStarveAgentMessages(t *testing.T) {
 	clock := newTestClock()
 	lim := newChatSendLimiterWithRates(map[chatSenderClass]float64{
-		chatSenderAgent:       2,
+		chatSenderAgent:       4,
 		chatSenderAgentMirror: 2,
 	}, clock.Now)
 
 	for range 2 {
-		if allowed, _ := lim.Allow("a1", chatSenderAgentMirror); !allowed {
-			t.Fatal("the mirror's own allowance should not be exhausted yet")
+		if !lim.Allow("a1", chatSenderAgentMirror).Allowed {
+			t.Fatal("the mirror's own reservation should not be exhausted yet")
 		}
 	}
-	if allowed, _ := lim.Allow("a1", chatSenderAgentMirror); allowed {
-		t.Fatal("the mirror is over its limit and should be refused")
+	decision := lim.Allow("a1", chatSenderAgentMirror)
+	if decision.Allowed {
+		t.Fatal("the mirror is over its reservation and should be refused")
+	}
+	if decision.LimitClass != chatSenderAgentMirror {
+		t.Errorf("refused by class %v, want the mirror reservation: the aggregate still has room", decision.LimitClass)
 	}
 
+	// The mirror spent 2 of the aggregate 4, so 2 remain for the agent's own
+	// messages — the reservation caps the mirror, not the agent.
 	for i := range 2 {
-		if allowed, _ := lim.Allow("a1", chatSenderAgent); !allowed {
-			t.Errorf("agent-authored send %d refused: the mirror must not spend this allowance", i+1)
+		if !lim.Allow("a1", chatSenderAgent).Allowed {
+			t.Errorf("agent-authored send %d refused: a flooding mirror must leave headroom", i+1)
+		}
+	}
+}
+
+// With the mirror idle, agent-authored sends may use the whole aggregate
+// allowance: the sub-cap must not silently become the agent's ceiling.
+func TestChatSendLimiter_AgentMayUseFullAggregateWhenMirrorIdle(t *testing.T) {
+	clock := newTestClock()
+	lim := newChatSendLimiterWithClock(clock.Now)
+
+	for i := range chatSendAgentRatePerMinute {
+		if !lim.Allow("a1", chatSenderAgent).Allowed {
+			t.Fatalf("agent-authored send %d of %d refused; the full aggregate should be available", i+1, chatSendAgentRatePerMinute)
+		}
+	}
+	if lim.Allow("a1", chatSenderAgent).Allowed {
+		t.Error("the aggregate ceiling should be reached after the whole allowance is spent")
+	}
+}
+
+// The ceiling is the aggregate per sender, whatever class the traffic claims:
+// an agent that relabels its sends cannot buy a second allowance (#1054).
+func TestChatSendLimiter_RelabellingCannotExceedAggregate(t *testing.T) {
+	clock := newTestClock()
+	lim := newChatSendLimiterWithClock(clock.Now)
+
+	// Alternate the two classes the outbound path can reach, in one instant,
+	// exactly as a caller flipping req.Type would.
+	classes := []chatSenderClass{chatSenderAgent, chatSenderAgentMirror}
+	allowed := 0
+	for i := range 4 * chatSendAgentRatePerMinute {
+		if lim.Allow("a1", classes[i%len(classes)]).Allowed {
+			allowed++
+		}
+	}
+
+	if allowed != chatSendAgentRatePerMinute {
+		t.Errorf("relabelling agent got %d sends through, want exactly the aggregate %d/min", allowed, chatSendAgentRatePerMinute)
+	}
+}
+
+// Only the transcript mirror's own type gets the mirror reservation. Defence
+// in depth: the class comes from a caller-supplied field, so an unfamiliar
+// label must never land in the cheaper bucket (#1054).
+func TestChatSenderClassForMessageType(t *testing.T) {
+	tests := []struct {
+		msgType string
+		want    chatSenderClass
+	}{
+		{messages.TypeAssistantReply, chatSenderAgentMirror},
+		{messages.TypeInputNeeded, chatSenderAgent},
+		{messages.TypeInstruction, chatSenderAgent},
+		{"", chatSenderAgent},
+		{"not-a-real-type", chatSenderAgent},
+		{"Assistant-Reply", chatSenderAgent},
+	}
+	for _, tc := range tests {
+		if got := chatSenderClassForMessageType(tc.msgType); got != tc.want {
+			t.Errorf("chatSenderClassForMessageType(%q) = %v, want %v", tc.msgType, got, tc.want)
 		}
 	}
 }
@@ -174,12 +245,66 @@ func TestChatSendLimiter_EvictsIdleBuckets(t *testing.T) {
 	}
 }
 
+// The threat the idle sweep does not cover: a caller minting fresh sender IDs
+// faster than the TTL. The hard cap is the only thing bounding memory then,
+// and it must not hand a flooder a way to reset its own bucket by churning
+// IDs around it.
+func TestChatSendLimiter_HardCapBoundsMemoryAndKeepsFloodersThrottled(t *testing.T) {
+	clock := newTestClock()
+	lim := newChatSendLimiterWithClock(clock.Now)
+
+	// Exhaust one agent's aggregate allowance.
+	for range chatSendAgentRatePerMinute {
+		lim.Allow("flooder", chatSenderAgent)
+	}
+	if lim.Allow("flooder", chatSenderAgent).Allowed {
+		t.Fatal("the flooder should be over its limit before the churn starts")
+	}
+
+	// Mint far more senders than the cap, well inside the idle TTL so the
+	// TTL sweep evicts nothing and only the hard cap can bound the map. The
+	// clock creeps forward so "least recently used" is meaningful, but by far
+	// less than the second it takes the flooder to earn one token back.
+	const extra = 2000
+	peak := 0
+	for i := range chatSendLimiterMaxBuckets + extra {
+		lim.Allow(fmt.Sprintf("churn-%d", i), chatSenderAgent)
+		if got := len(lim.buckets); got > peak {
+			peak = got
+		}
+		if got := len(lim.buckets); got > chatSendLimiterMaxBuckets {
+			t.Fatalf("tracked buckets = %d after %d senders, want at most the cap %d", got, i+1, chatSendLimiterMaxBuckets)
+		}
+		// Keep the flooder active, as a real flooder would be.
+		if i%500 == 0 {
+			clock.Advance(time.Millisecond)
+			lim.Allow("flooder", chatSenderAgent)
+		}
+	}
+
+	if peak < chatSendLimiterMaxBuckets {
+		t.Fatalf("peak tracked buckets = %d, never reached the cap %d: the test did not exercise the hard-cap branch", peak, chatSendLimiterMaxBuckets)
+	}
+	if got := len(lim.buckets); got >= chatSendLimiterMaxBuckets {
+		t.Errorf("tracked buckets = %d after the churn, want the cap %d to have forced an eviction", got, chatSendLimiterMaxBuckets)
+	}
+
+	// The flooder stayed active throughout, so eviction must not have dropped
+	// it: churning sender IDs is not a way to buy a fresh allowance.
+	if _, ok := lim.buckets["agent:flooder"]; !ok {
+		t.Fatal("the active flooder's bucket was evicted; churning IDs would reset its limit")
+	}
+	if lim.Allow("flooder", chatSenderAgent).Allowed {
+		t.Error("the flooder is still over its limit and must stay refused after the eviction")
+	}
+}
+
 // A nil limiter allows everything rather than panicking: limiting is a
 // protection, not a correctness requirement.
 func TestChatSendLimiter_NilAllows(t *testing.T) {
 	var lim *chatSendLimiter
-	if allowed, retryAfter := lim.Allow("u1", chatSenderHuman); !allowed || retryAfter != 0 {
-		t.Errorf("nil limiter returned (%v, %v), want (true, 0)", allowed, retryAfter)
+	if decision := lim.Allow("u1", chatSenderHuman); !decision.Allowed || decision.RetryAfter != 0 {
+		t.Errorf("nil limiter returned %+v, want allowed with no retry delay", decision)
 	}
 }
 
@@ -198,7 +323,7 @@ func TestChatSendLimiter_ConcurrentSendersGetExactlyTheAllowance(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if ok, _ := lim.Allow("flooder", chatSenderAgent); ok {
+			if lim.Allow("flooder", chatSenderAgent).Allowed {
 				allowed.Add(1)
 			}
 		}()

--- a/pkg/hub/chat_ratelimit_test.go
+++ b/pkg/hub/chat_ratelimit_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// testClock is a manually advanced clock so limiter tests can exhaust and
+// refill a bucket without sleeping a real minute.
+type testClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newTestClock() *testClock {
+	return &testClock{now: time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *testClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *testClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// A sender gets a full minute's allowance as burst, then is refused until
+// tokens refill — the refusal carries a usable retry delay.
+func TestChatSendLimiter_BurstThenRefusesUntilRefill(t *testing.T) {
+	clock := newTestClock()
+	lim := newChatSendLimiterWithRates(30, 60, clock.Now)
+
+	for i := range chatSendHumanRatePerMinute {
+		if allowed, _ := lim.Allow("u1", chatSenderHuman); !allowed {
+			t.Fatalf("send %d of the first 30 was refused; the whole minute's allowance should burst", i+1)
+		}
+	}
+
+	allowed, retryAfter := lim.Allow("u1", chatSenderHuman)
+	if allowed {
+		t.Fatal("the 31st send in the same instant should be refused")
+	}
+	if retryAfter < time.Second {
+		t.Errorf("retryAfter = %v, want at least 1s so Retry-After is a usable number", retryAfter)
+	}
+
+	// At 30/min a token accrues every 2 seconds.
+	clock.Advance(time.Second)
+	if allowed, _ := lim.Allow("u1", chatSenderHuman); allowed {
+		t.Error("half a token later the sender should still be refused")
+	}
+	clock.Advance(time.Second)
+	if allowed, _ := lim.Allow("u1", chatSenderHuman); !allowed {
+		t.Error("a full token later the sender should be allowed again")
+	}
+
+	// Refill is capped at the burst size: idling for an hour does not bank
+	// an hour's worth of sends.
+	clock.Advance(time.Hour)
+	for i := range chatSendHumanRatePerMinute {
+		if allowed, _ := lim.Allow("u1", chatSenderHuman); !allowed {
+			t.Fatalf("send %d after a long idle was refused", i+1)
+		}
+	}
+	if allowed, _ := lim.Allow("u1", chatSenderHuman); allowed {
+		t.Error("a long idle should refill at most one burst, not more")
+	}
+}
+
+// One flooding sender must not spend anybody else's allowance, and the two
+// rate classes are tracked separately even for the same ID.
+func TestChatSendLimiter_BucketsAreScopedToSenderAndClass(t *testing.T) {
+	clock := newTestClock()
+	lim := newChatSendLimiterWithRates(2, 3, clock.Now)
+
+	for range 2 {
+		if allowed, _ := lim.Allow("shared-id", chatSenderHuman); !allowed {
+			t.Fatal("the human's own allowance should not be exhausted yet")
+		}
+	}
+	if allowed, _ := lim.Allow("shared-id", chatSenderHuman); allowed {
+		t.Fatal("the human is over its limit and should be refused")
+	}
+
+	if allowed, _ := lim.Allow("someone-else", chatSenderHuman); !allowed {
+		t.Error("a different sender must not be throttled by the flooder")
+	}
+	for i := range 3 {
+		if allowed, _ := lim.Allow("shared-id", chatSenderAgent); !allowed {
+			t.Errorf("agent send %d refused: the agent class has its own bucket and a higher limit", i+1)
+		}
+	}
+}
+
+// The limits shipped to production are the ones issue #1054 asks for.
+func TestChatSendLimiter_ProductionLimits(t *testing.T) {
+	lim := newChatSendLimiter()
+	if got := lim.limitFor(chatSenderHuman); got != 30 {
+		t.Errorf("human limit = %v, want 30/min", got)
+	}
+	if got := lim.limitFor(chatSenderAgent); got != 60 {
+		t.Errorf("agent limit = %v, want 60/min", got)
+	}
+}
+
+// Bucket state is bounded: senders that stop sending are forgotten.
+func TestChatSendLimiter_EvictsIdleBuckets(t *testing.T) {
+	clock := newTestClock()
+	lim := newChatSendLimiterWithRates(30, 60, clock.Now)
+
+	for _, id := range []string{"a", "b", "c"} {
+		lim.Allow(id, chatSenderHuman)
+	}
+	if got := len(lim.buckets); got != 3 {
+		t.Fatalf("tracked buckets = %d, want 3", got)
+	}
+
+	clock.Advance(chatSendLimiterIdleTTL + time.Minute)
+	lim.Allow("d", chatSenderHuman)
+
+	if got := len(lim.buckets); got != 1 {
+		t.Errorf("tracked buckets = %d, want 1 (only the active sender survives the sweep)", got)
+	}
+}
+
+// A nil limiter allows everything rather than panicking: limiting is a
+// protection, not a correctness requirement.
+func TestChatSendLimiter_NilAllows(t *testing.T) {
+	var lim *chatSendLimiter
+	if allowed, retryAfter := lim.Allow("u1", chatSenderHuman); !allowed || retryAfter != 0 {
+		t.Errorf("nil limiter returned (%v, %v), want (true, 0)", allowed, retryAfter)
+	}
+}
+
+// Concurrent senders hitting one bucket hand out exactly the allowance — no
+// more (the point of the limit) and no fewer (run with -race).
+func TestChatSendLimiter_ConcurrentSendersGetExactlyTheAllowance(t *testing.T) {
+	clock := newTestClock()
+	const limit = 20
+	lim := newChatSendLimiterWithRates(limit, limit, clock.Now)
+
+	var allowed atomic.Int64
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if ok, _ := lim.Allow("flooder", chatSenderAgent); ok {
+				allowed.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := allowed.Load(); got != limit {
+		t.Errorf("allowed %d of 100 concurrent sends, want exactly %d", got, limit)
+	}
+}

--- a/pkg/hub/chat_ratelimit_test.go
+++ b/pkg/hub/chat_ratelimit_test.go
@@ -294,6 +294,46 @@ func TestChatSendLimiter_ProductionRatesCoverEveryClass(t *testing.T) {
 	}
 }
 
+// A rate below one per minute throttles, it does not lock the sender out.
+// Capacity tracked the rate, so a 0.5/min bucket could hold at most half the
+// single token a send costs and no amount of waiting ever bought one: the
+// sender was refused forever. Capacity is floored at one token so the slow
+// rate becomes a slow drip.
+func TestChatSendLimiter_SubOnePerMinuteRateStillEventuallyAllows(t *testing.T) {
+	clock := newTestClock()
+	lim := newChatSendLimiterWithRates(map[chatSenderClass]float64{
+		chatSenderHuman:       0.5,
+		chatSenderAgent:       0.5,
+		chatSenderAgentMirror: 0.5,
+	}, clock.Now)
+
+	if !lim.Allow("u1", chatSenderHuman).Allowed {
+		t.Fatal("the first send at 0.5/min was refused; a fresh bucket must hold at least the one token a send costs")
+	}
+	if lim.Allow("u1", chatSenderHuman).Allowed {
+		t.Fatal("the second send in the same instant should be refused at 0.5/min")
+	}
+
+	// At 0.5/min a token accrues every two minutes.
+	clock.Advance(time.Minute)
+	if lim.Allow("u1", chatSenderHuman).Allowed {
+		t.Error("half a token later the sender should still be refused")
+	}
+	clock.Advance(time.Minute)
+	if !lim.Allow("u1", chatSenderHuman).Allowed {
+		t.Error("two minutes on, a full token has accrued and the send should be allowed")
+	}
+
+	// The floor is a floor, not a new burst size: idling does not bank sends.
+	clock.Advance(time.Hour)
+	if !lim.Allow("u1", chatSenderHuman).Allowed {
+		t.Fatal("the sender should be allowed after a long idle")
+	}
+	if lim.Allow("u1", chatSenderHuman).Allowed {
+		t.Error("a long idle should refill at most one token, not a burst")
+	}
+}
+
 // Bucket state is bounded: senders that stop sending are forgotten.
 func TestChatSendLimiter_EvictsIdleBuckets(t *testing.T) {
 	clock := newTestClock()

--- a/pkg/hub/chat_ratelimit_test.go
+++ b/pkg/hub/chat_ratelimit_test.go
@@ -16,7 +16,6 @@ package hub
 
 import (
 	"fmt"
-	"math"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -242,7 +241,20 @@ func TestChatSendLimiter_UnknownClassIsLimitedAtTheStrictestRate(t *testing.T) {
 	lim := newChatSendLimiterWithClock(clock.Now)
 
 	const unknown = chatSenderClass(99)
-	strictest := math.Min(chatSendHumanRatePerMinute, chatSendAgentMirrorRatePerMinute)
+	// Derive the expectation from the rate set the limiter was actually built
+	// with, not from a hand-picked subset of the constants: a test that decides
+	// for itself which rates count drifts from production the day one of the
+	// others becomes the smallest, and fails for a reason that reads like a bug
+	// in the limiter.
+	strictest := 0.0
+	for _, rate := range lim.ratesPerMinute {
+		if strictest == 0 || rate < strictest {
+			strictest = rate
+		}
+	}
+	if strictest == 0 {
+		t.Fatal("the production limiter was built with no rates at all")
+	}
 	if got := lim.limitFor(unknown); got != strictest {
 		t.Fatalf("limitFor(unknown) = %v, want the strictest configured rate %v", got, strictest)
 	}

--- a/pkg/hub/chat_ratelimit_test.go
+++ b/pkg/hub/chat_ratelimit_test.go
@@ -48,7 +48,7 @@ func (c *testClock) Advance(d time.Duration) {
 // tokens refill — the refusal carries a usable retry delay.
 func TestChatSendLimiter_BurstThenRefusesUntilRefill(t *testing.T) {
 	clock := newTestClock()
-	lim := newChatSendLimiterWithRates(30, 60, clock.Now)
+	lim := newChatSendLimiterWithClock(clock.Now)
 
 	for i := range chatSendHumanRatePerMinute {
 		if allowed, _ := lim.Allow("u1", chatSenderHuman); !allowed {
@@ -91,7 +91,10 @@ func TestChatSendLimiter_BurstThenRefusesUntilRefill(t *testing.T) {
 // rate classes are tracked separately even for the same ID.
 func TestChatSendLimiter_BucketsAreScopedToSenderAndClass(t *testing.T) {
 	clock := newTestClock()
-	lim := newChatSendLimiterWithRates(2, 3, clock.Now)
+	lim := newChatSendLimiterWithRates(map[chatSenderClass]float64{
+		chatSenderHuman: 2,
+		chatSenderAgent: 3,
+	}, clock.Now)
 
 	for range 2 {
 		if allowed, _ := lim.Allow("shared-id", chatSenderHuman); !allowed {
@@ -121,12 +124,40 @@ func TestChatSendLimiter_ProductionLimits(t *testing.T) {
 	if got := lim.limitFor(chatSenderAgent); got != 60 {
 		t.Errorf("agent limit = %v, want 60/min", got)
 	}
+	if got := lim.limitFor(chatSenderAgentMirror); got != 60 {
+		t.Errorf("assistant-reply mirror limit = %v, want 60/min", got)
+	}
+}
+
+// An agent's transcript mirror and its own messages are counted separately,
+// so neither can spend the other's allowance.
+func TestChatSendLimiter_MirrorAndAgentTrafficHaveSeparateBuckets(t *testing.T) {
+	clock := newTestClock()
+	lim := newChatSendLimiterWithRates(map[chatSenderClass]float64{
+		chatSenderAgent:       2,
+		chatSenderAgentMirror: 2,
+	}, clock.Now)
+
+	for range 2 {
+		if allowed, _ := lim.Allow("a1", chatSenderAgentMirror); !allowed {
+			t.Fatal("the mirror's own allowance should not be exhausted yet")
+		}
+	}
+	if allowed, _ := lim.Allow("a1", chatSenderAgentMirror); allowed {
+		t.Fatal("the mirror is over its limit and should be refused")
+	}
+
+	for i := range 2 {
+		if allowed, _ := lim.Allow("a1", chatSenderAgent); !allowed {
+			t.Errorf("agent-authored send %d refused: the mirror must not spend this allowance", i+1)
+		}
+	}
 }
 
 // Bucket state is bounded: senders that stop sending are forgotten.
 func TestChatSendLimiter_EvictsIdleBuckets(t *testing.T) {
 	clock := newTestClock()
-	lim := newChatSendLimiterWithRates(30, 60, clock.Now)
+	lim := newChatSendLimiterWithClock(clock.Now)
 
 	for _, id := range []string{"a", "b", "c"} {
 		lim.Allow(id, chatSenderHuman)
@@ -157,7 +188,9 @@ func TestChatSendLimiter_NilAllows(t *testing.T) {
 func TestChatSendLimiter_ConcurrentSendersGetExactlyTheAllowance(t *testing.T) {
 	clock := newTestClock()
 	const limit = 20
-	lim := newChatSendLimiterWithRates(limit, limit, clock.Now)
+	lim := newChatSendLimiterWithRates(map[chatSenderClass]float64{
+		chatSenderAgent: limit,
+	}, clock.Now)
 
 	var allowed atomic.Int64
 	var wg sync.WaitGroup

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -64,19 +64,29 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Per-sender send limit (#1054). This is the path a looping agent floods a
-	// thread through, so the limit has to live here and not only on the
-	// browser send path. The response is an explicit 429 with Retry-After
-	// rather than a silent drop, so a caller can back off and resend.
-	if !s.allowChatSend(w, agentIdent.ID(), chatSenderAgent) {
-		return
-	}
-
 	var req OutboundMessageRequest
 	if err := readJSON(r, &req); err != nil {
 		BadRequest(w, "Invalid request body: "+err.Error())
 		return
 	}
+
+	// Per-sender send limit (#1054). This is the path a looping agent floods a
+	// thread through, so the limit has to live here and not only on the
+	// browser send path. The response is an explicit 429 with Retry-After
+	// rather than a silent drop, so a caller can back off and resend.
+	//
+	// The automatic assistant-reply transcript mirror (posted by the agent
+	// hook, not written by the agent) is limited in its own bucket: it is
+	// still part of the flood vector, but it must not be able to spend the
+	// allowance the agent needs for a completion report or an escalation.
+	sendClass := chatSenderAgent
+	if req.Type == messages.TypeAssistantReply {
+		sendClass = chatSenderAgentMirror
+	}
+	if !s.allowChatSend(w, agentIdent.ID(), sendClass) {
+		return
+	}
+
 	if req.Msg == "" {
 		ValidationError(w, "msg is required", nil)
 		return

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -84,16 +84,14 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 	// not written by the agent — cannot spend the whole allowance the agent
 	// needs for a completion report or an escalation. The class only ever
 	// selects a reservation inside the agent's single aggregate ceiling, so a
-	// caller cannot buy extra allowance by relabelling its traffic.
+	// caller cannot buy extra allowance by relabelling its traffic. A type
+	// this build does not recognise is classified as ordinary agent traffic
+	// and still accepted, exactly as before: tightening the type contract on
+	// the wire is a compatibility change and is tracked separately.
 	//
 	// Charged before the payload is validated: a flood of malformed sends is
 	// still a flood.
 	if !s.allowChatSend(w, agentIdent.ID(), chatSenderClassForMessageType(req.Type)) {
-		return
-	}
-
-	if err := messages.ValidateType(req.Type); err != nil {
-		ValidationError(w, err.Error(), nil)
 		return
 	}
 

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -64,6 +64,14 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Per-sender send limit (#1054). This is the path a looping agent floods a
+	// thread through, so the limit has to live here and not only on the
+	// browser send path. The response is an explicit 429 with Retry-After
+	// rather than a silent drop, so a caller can back off and resend.
+	if !s.allowChatSend(w, agentIdent.ID(), chatSenderAgent) {
+		return
+	}
+
 	var req OutboundMessageRequest
 	if err := readJSON(r, &req); err != nil {
 		BadRequest(w, "Invalid request body: "+err.Error())

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -70,20 +70,30 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	if req.Type == "" {
+		req.Type = "input-needed"
+	}
+
 	// Per-sender send limit (#1054). This is the path a looping agent floods a
 	// thread through, so the limit has to live here and not only on the
 	// browser send path. The response is an explicit 429 with Retry-After
 	// rather than a silent drop, so a caller can back off and resend.
 	//
-	// The automatic assistant-reply transcript mirror (posted by the agent
-	// hook, not written by the agent) is limited in its own bucket: it is
-	// still part of the flood vector, but it must not be able to spend the
-	// allowance the agent needs for a completion report or an escalation.
-	sendClass := chatSenderAgent
-	if req.Type == messages.TypeAssistantReply {
-		sendClass = chatSenderAgentMirror
+	// The traffic class is derived from the (now defaulted) message type so the
+	// automatic assistant-reply transcript mirror — posted by the agent hook,
+	// not written by the agent — cannot spend the whole allowance the agent
+	// needs for a completion report or an escalation. The class only ever
+	// selects a reservation inside the agent's single aggregate ceiling, so a
+	// caller cannot buy extra allowance by relabelling its traffic.
+	//
+	// Charged before the payload is validated: a flood of malformed sends is
+	// still a flood.
+	if !s.allowChatSend(w, agentIdent.ID(), chatSenderClassForMessageType(req.Type)) {
+		return
 	}
-	if !s.allowChatSend(w, agentIdent.ID(), sendClass) {
+
+	if err := messages.ValidateType(req.Type); err != nil {
+		ValidationError(w, err.Error(), nil)
 		return
 	}
 
@@ -94,9 +104,6 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 	if msgLen := utf8.RuneCountInString(req.Msg); msgLen > messages.MaxMessageLength {
 		ValidationError(w, fmt.Sprintf("message exceeds %d character limit (current: %d chars). Consider splitting into multiple messages using multiple scion message invocations", messages.MaxMessageLength, msgLen), nil)
 		return
-	}
-	if req.Type == "" {
-		req.Type = "input-needed"
 	}
 
 	// Validate and default visibility.

--- a/pkg/hub/handlers_agent_messaging_test.go
+++ b/pkg/hub/handlers_agent_messaging_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/go-jose/go-jose/v4/jwt"
 )
@@ -35,9 +36,16 @@ import (
 // postOutbound sends one agent→human message as the given agent.
 func postOutbound(t *testing.T, srv *Server, projectID, agentID, msg string) *httptest.ResponseRecorder {
 	t.Helper()
+	return postOutboundTyped(t, srv, projectID, agentID, msg, "")
+}
+
+// postOutboundTyped sends one agent→human message of a specific message type.
+func postOutboundTyped(t *testing.T, srv *Server, projectID, agentID, msg, msgType string) *httptest.ResponseRecorder {
+	t.Helper()
 	body, _ := json.Marshal(OutboundMessageRequest{
 		Recipient: "user:human@example.com",
 		Msg:       msg,
+		Type:      msgType,
 	})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+agentID+"/outbound-message", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -95,8 +103,7 @@ func TestOutboundMessage_RateLimitsFloodingAgent(t *testing.T) {
 	// Production limits, test clock: the real 60/min ceiling without a real
 	// minute of waiting.
 	clock := newTestClock()
-	srv.chatSendLimiter = newChatSendLimiterWithRates(
-		chatSendHumanRatePerMinute, chatSendAgentRatePerMinute, clock.Now)
+	srv.chatSendLimiter = newChatSendLimiterWithClock(clock.Now)
 
 	for i := range chatSendAgentRatePerMinute {
 		if rr := postOutbound(t, srv, project.ID, flooder, "spam"); rr.Code != http.StatusOK {
@@ -125,5 +132,63 @@ func TestOutboundMessage_RateLimitsFloodingAgent(t *testing.T) {
 	clock.Advance(time.Second)
 	if rr := postOutbound(t, srv, project.ID, flooder, "after backoff"); rr.Code != http.StatusOK {
 		t.Errorf("expected the send to succeed after backing off, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// The automatic assistant-reply transcript mirror shares an agent with the
+// messages the agent writes itself, but not a bucket: a chatty agent whose
+// mirror is over its limit can still deliver a completion report or a blocker
+// escalation. Low-value traffic must not starve high-value traffic.
+func TestOutboundMessage_TranscriptMirrorDoesNotStarveAgentMessages(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "mirror-project",
+		Slug:       "mirror-project",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	if err := s.CreateUser(ctx, &store.User{
+		ID:          api.NewUUID(),
+		Email:       "human@example.com",
+		DisplayName: "Human",
+	}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	agent := &store.Agent{
+		ID:         api.NewUUID(),
+		Name:       "chatty",
+		Slug:       "chatty",
+		ProjectID:  project.ID,
+		Phase:      "running",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	clock := newTestClock()
+	srv.chatSendLimiter = newChatSendLimiterWithClock(clock.Now)
+
+	// Exhaust the mirror's allowance with hook-posted assistant replies.
+	for i := range chatSendAgentMirrorRatePerMinute {
+		rr := postOutboundTyped(t, srv, project.ID, agent.ID, "mirrored transcript", messages.TypeAssistantReply)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("mirror send %d: expected 200, got %d: %s", i+1, rr.Code, rr.Body.String())
+		}
+	}
+	rr := postOutboundTyped(t, srv, project.ID, agent.ID, "mirrored transcript", messages.TypeAssistantReply)
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("the mirror is over its limit and should be refused, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// The agent's own message to a human is unaffected.
+	if rr := postOutbound(t, srv, project.ID, agent.ID, "task complete"); rr.Code != http.StatusOK {
+		t.Fatalf("the agent's own message must not be starved by its transcript mirror: got %d: %s",
+			rr.Code, rr.Body.String())
 	}
 }

--- a/pkg/hub/handlers_agent_messaging_test.go
+++ b/pkg/hub/handlers_agent_messaging_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/go-jose/go-jose/v4/jwt"
+)
+
+// postOutbound sends one agent→human message as the given agent.
+func postOutbound(t *testing.T, srv *Server, projectID, agentID, msg string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(OutboundMessageRequest{
+		Recipient: "user:human@example.com",
+		Msg:       msg,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+agentID+"/outbound-message", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithIdentity(req.Context(), &agentIdentityWrapper{&AgentTokenClaims{
+		Claims:    jwt.Claims{Subject: agentID},
+		ProjectID: projectID,
+	}}))
+
+	rr := httptest.NewRecorder()
+	srv.handleAgentOutboundMessage(rr, req, agentID)
+	return rr
+}
+
+// An agent stuck in a loop is cut off with an explicit, retryable 429 — the
+// flood vector issue #1054 is actually about. The limit is per sender, so a
+// second agent going about its business is untouched.
+func TestOutboundMessage_RateLimitsFloodingAgent(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "flood-project",
+		Slug:       "flood-project",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	if err := s.CreateUser(ctx, &store.User{
+		ID:          api.NewUUID(),
+		Email:       "human@example.com",
+		DisplayName: "Human",
+	}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	newAgent := func(name string) string {
+		a := &store.Agent{
+			ID:         api.NewUUID(),
+			Name:       name,
+			Slug:       name,
+			ProjectID:  project.ID,
+			Phase:      "running",
+			Visibility: store.VisibilityPrivate,
+		}
+		if err := s.CreateAgent(ctx, a); err != nil {
+			t.Fatalf("CreateAgent: %v", err)
+		}
+		return a.ID
+	}
+	flooder := newAgent("flooder")
+	bystander := newAgent("bystander")
+
+	// Production limits, test clock: the real 60/min ceiling without a real
+	// minute of waiting.
+	clock := newTestClock()
+	srv.chatSendLimiter = newChatSendLimiterWithRates(
+		chatSendHumanRatePerMinute, chatSendAgentRatePerMinute, clock.Now)
+
+	for i := range chatSendAgentRatePerMinute {
+		if rr := postOutbound(t, srv, project.ID, flooder, "spam"); rr.Code != http.StatusOK {
+			t.Fatalf("send %d: expected 200, got %d: %s", i+1, rr.Code, rr.Body.String())
+		}
+	}
+
+	rr := postOutbound(t, srv, project.ID, flooder, "one too many")
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("send %d: expected 429, got %d: %s",
+			chatSendAgentRatePerMinute+1, rr.Code, rr.Body.String())
+	}
+	retryAfter := rr.Header().Get("Retry-After")
+	if secs, err := strconv.Atoi(retryAfter); err != nil || secs < 1 {
+		t.Errorf("Retry-After = %q, want a positive number of seconds so the agent can back off", retryAfter)
+	}
+	if !strings.Contains(rr.Body.String(), ErrCodeRateLimited) {
+		t.Errorf("expected a %q error code in the body, got %s", ErrCodeRateLimited, rr.Body.String())
+	}
+
+	if rr := postOutbound(t, srv, project.ID, bystander, "unrelated report"); rr.Code != http.StatusOK {
+		t.Errorf("a second agent must not be throttled by the flooder: got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// The refusal is transient: at 60/min a token accrues every second.
+	clock.Advance(time.Second)
+	if rr := postOutbound(t, srv, project.ID, flooder, "after backoff"); rr.Code != http.StatusOK {
+		t.Errorf("expected the send to succeed after backing off, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/pkg/hub/handlers_agent_messaging_test.go
+++ b/pkg/hub/handlers_agent_messaging_test.go
@@ -123,6 +123,11 @@ func TestOutboundMessage_RateLimitsFloodingAgent(t *testing.T) {
 	if !strings.Contains(rr.Body.String(), ErrCodeRateLimited) {
 		t.Errorf("expected a %q error code in the body, got %s", ErrCodeRateLimited, rr.Body.String())
 	}
+	// No current client reads Retry-After, so the delay in the message text is
+	// what a sending agent actually sees. Assert it as well as the header.
+	if want := "retry in " + retryAfter + "s"; !strings.Contains(rr.Body.String(), want) {
+		t.Errorf("expected the body to carry the retry delay %q, got %s", want, rr.Body.String())
+	}
 
 	if rr := postOutbound(t, srv, project.ID, bystander, "unrelated report"); rr.Code != http.StatusOK {
 		t.Errorf("a second agent must not be throttled by the flooder: got %d: %s", rr.Code, rr.Body.String())
@@ -135,10 +140,70 @@ func TestOutboundMessage_RateLimitsFloodingAgent(t *testing.T) {
 	}
 }
 
-// The automatic assistant-reply transcript mirror shares an agent with the
-// messages the agent writes itself, but not a bucket: a chatty agent whose
-// mirror is over its limit can still deliver a completion report or a blocker
-// escalation. Low-value traffic must not starve high-value traffic.
+// An unrecognised message type is charged as ordinary agent traffic and then
+// rejected: the class must be picked from the closed enum, not from whatever
+// the caller puts in the body, and a flood of malformed sends is still a flood
+// (#1054).
+func TestOutboundMessage_UnknownTypeIsChargedThenRejected(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "type-project",
+		Slug:       "type-project",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	if err := s.CreateUser(ctx, &store.User{
+		ID:          api.NewUUID(),
+		Email:       "human@example.com",
+		DisplayName: "Human",
+	}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	agent := &store.Agent{
+		ID:         api.NewUUID(),
+		Name:       "mislabeller",
+		Slug:       "mislabeller",
+		ProjectID:  project.ID,
+		Phase:      "running",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	clock := newTestClock()
+	srv.chatSendLimiter = newChatSendLimiterWithClock(clock.Now)
+
+	rr := postOutboundTyped(t, srv, project.ID, agent.ID, "mislabelled", "not-a-real-type")
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for an unknown message type, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// It cost a token from the agent's aggregate allowance, not from the
+	// cheaper mirror reservation.
+	if got := srv.chatSendLimiter.buckets["agent:"+agent.ID].tokens; got != chatSendAgentRatePerMinute-1 {
+		t.Errorf("agent bucket = %v tokens, want %v: the send must be charged to the agent aggregate",
+			got, chatSendAgentRatePerMinute-1)
+	}
+	if _, ok := srv.chatSendLimiter.buckets["agent-mirror:"+agent.ID]; ok {
+		t.Error("an unknown type must not be classified as transcript-mirror traffic")
+	}
+}
+
+// The automatic assistant-reply transcript mirror shares the agent's single
+// aggregate allowance with the messages the agent writes itself, but it may
+// only spend its own reservation of it: a chatty agent whose mirror is
+// flooding can still deliver a completion report or a blocker escalation. Low
+// value traffic must not starve high-value traffic.
+//
+// The mirror is driven well past the aggregate ceiling here, not merely up to
+// its reservation — otherwise the test would pass even with no reservation at
+// all and would prove nothing about starvation.
 func TestOutboundMessage_TranscriptMirrorDoesNotStarveAgentMessages(t *testing.T) {
 	srv, s := testServer(t)
 	ctx := context.Background()
@@ -174,16 +239,22 @@ func TestOutboundMessage_TranscriptMirrorDoesNotStarveAgentMessages(t *testing.T
 	clock := newTestClock()
 	srv.chatSendLimiter = newChatSendLimiterWithClock(clock.Now)
 
-	// Exhaust the mirror's allowance with hook-posted assistant replies.
-	for i := range chatSendAgentMirrorRatePerMinute {
+	// Flood with hook-posted assistant replies, twice the agent's whole
+	// aggregate allowance. Only the mirror's reservation may get through.
+	accepted := 0
+	for range 2 * chatSendAgentRatePerMinute {
 		rr := postOutboundTyped(t, srv, project.ID, agent.ID, "mirrored transcript", messages.TypeAssistantReply)
-		if rr.Code != http.StatusOK {
-			t.Fatalf("mirror send %d: expected 200, got %d: %s", i+1, rr.Code, rr.Body.String())
+		switch rr.Code {
+		case http.StatusOK:
+			accepted++
+		case http.StatusTooManyRequests:
+		default:
+			t.Fatalf("mirror send: expected 200 or 429, got %d: %s", rr.Code, rr.Body.String())
 		}
 	}
-	rr := postOutboundTyped(t, srv, project.ID, agent.ID, "mirrored transcript", messages.TypeAssistantReply)
-	if rr.Code != http.StatusTooManyRequests {
-		t.Fatalf("the mirror is over its limit and should be refused, got %d: %s", rr.Code, rr.Body.String())
+	if accepted != chatSendAgentMirrorRatePerMinute {
+		t.Fatalf("the flooding mirror got %d sends through, want exactly its reservation of %d",
+			accepted, chatSendAgentMirrorRatePerMinute)
 	}
 
 	// The agent's own message to a human is unaffected.

--- a/pkg/hub/handlers_agent_messaging_test.go
+++ b/pkg/hub/handlers_agent_messaging_test.go
@@ -140,11 +140,12 @@ func TestOutboundMessage_RateLimitsFloodingAgent(t *testing.T) {
 	}
 }
 
-// An unrecognised message type is charged as ordinary agent traffic and then
-// rejected: the class must be picked from the closed enum, not from whatever
-// the caller puts in the body, and a flood of malformed sends is still a flood
-// (#1054).
-func TestOutboundMessage_UnknownTypeIsChargedThenRejected(t *testing.T) {
+// An unrecognised message type is charged as ordinary agent traffic: the
+// class must come from the closed enum, not from whatever the caller puts in
+// the body, so an unfamiliar label cannot buy the cheaper mirror reservation.
+// The send itself is still accepted, as it is today — tightening the type
+// contract on the wire is a separate compatibility change (#1054).
+func TestOutboundMessage_UnknownTypeIsChargedAsAgentTraffic(t *testing.T) {
 	srv, s := testServer(t)
 	ctx := context.Background()
 
@@ -180,8 +181,8 @@ func TestOutboundMessage_UnknownTypeIsChargedThenRejected(t *testing.T) {
 	srv.chatSendLimiter = newChatSendLimiterWithClock(clock.Now)
 
 	rr := postOutboundTyped(t, srv, project.ID, agent.ID, "mislabelled", "not-a-real-type")
-	if rr.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for an unknown message type, got %d: %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected an unknown message type to be accepted as before, got %d: %s", rr.Code, rr.Body.String())
 	}
 
 	// It cost a token from the agent's aggregate allowance, not from the

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -1180,6 +1180,11 @@ func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, p
 // ---------------------------------------------------------------------------
 
 // handleConversationHistory handles GET /api/v1/chat/conversations/{key}/messages.
+//
+// Query params:
+//   - limit: page size (default 50, max 200)
+//   - cursor: keyset pagination cursor from the previous page's nextCursor (optional)
+//   - visibility: repeatable visibility filter (optional)
 func (s *Server) handleConversationHistory(w http.ResponseWriter, r *http.Request, key string) {
 	user := GetUserIdentityFromContext(r.Context())
 	if user == nil {
@@ -1243,8 +1248,12 @@ func (s *Server) handleConversationHistory(w http.ResponseWriter, r *http.Reques
 	}
 
 	opts := store.ListOptions{
-		Limit:  limit,
-		Cursor: q.Get("before"),
+		Limit: limit,
+		// Keyset pagination cursor. The client sends the opaque `nextCursor`
+		// from the previous page back as `cursor` (see chat-thread.ts
+		// fetchHistoryV2); reading any other parameter name silently drops it
+		// and every page returns the newest messages again (#1027).
+		Cursor: q.Get("cursor"),
 	}
 
 	result, err := s.store.ListMessages(ctx, filter, opts)

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -729,6 +729,14 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 		}
 	}
 
+	// --- Rate limit (#1054) ---
+	// After authorization so an unauthorized caller cannot consume a
+	// legitimate sender's allowance, and before the body is read so a flood
+	// costs the hub as little as possible.
+	if !s.allowChatSend(w, user.ID(), chatSenderClassFor(user)) {
+		return
+	}
+
 	// --- Validate body ---
 	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
 	var body struct {

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -733,7 +733,11 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 	// After authorization so an unauthorized caller cannot consume a
 	// legitimate sender's allowance, and before the body is read so a flood
 	// costs the hub as little as possible.
-	if !s.allowChatSend(w, user.ID(), chatSenderClassFor(user)) {
+	//
+	// Always the human class: this handler rejects anything that is not a
+	// UserIdentity above, which is exactly why agent senders need their own
+	// limit on the outbound-message path.
+	if !s.allowChatSend(w, user.ID(), chatSenderHuman) {
 		return
 	}
 

--- a/pkg/hub/handlers_chat_v2_test.go
+++ b/pkg/hub/handlers_chat_v2_test.go
@@ -2309,8 +2309,7 @@ func TestChatV2_Send_RateLimitsFloodingHuman(t *testing.T) {
 	// Production limits, test clock: the real 30/min ceiling without a real
 	// minute of waiting.
 	clock := newTestClock()
-	srv.chatSendLimiter = newChatSendLimiterWithRates(
-		chatSendHumanRatePerMinute, chatSendAgentRatePerMinute, clock.Now)
+	srv.chatSendLimiter = newChatSendLimiterWithClock(clock.Now)
 
 	path := "/api/v1/chat/conversations/" + tid("topic-ratelimit") + "/messages"
 	for i := range chatSendHumanRatePerMinute {

--- a/pkg/hub/handlers_chat_v2_test.go
+++ b/pkg/hub/handlers_chat_v2_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -2285,5 +2286,59 @@ func TestChatV2_History_CursorPaginatesToOlderMessages(t *testing.T) {
 	}
 	if third.NextCursor != "" {
 		t.Errorf("third page: expected no nextCursor, got %q", third.NextCursor)
+	}
+}
+
+// A human sender that floods a thread is cut off with a retryable 429 rather
+// than being allowed to fill the conversation, and the cut-off lifts as soon
+// as tokens refill (#1054).
+func TestChatV2_Send_RateLimitsFloodingHuman(t *testing.T) {
+	srv, _, wcs, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        tid("topic-ratelimit"),
+		ProjectID: proj.ID,
+		Name:      "flooded",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	// Production limits, test clock: the real 30/min ceiling without a real
+	// minute of waiting.
+	clock := newTestClock()
+	srv.chatSendLimiter = newChatSendLimiterWithRates(
+		chatSendHumanRatePerMinute, chatSendAgentRatePerMinute, clock.Now)
+
+	path := "/api/v1/chat/conversations/" + tid("topic-ratelimit") + "/messages"
+	for i := range chatSendHumanRatePerMinute {
+		rec := doRequest(t, srv, http.MethodPost, path, map[string]string{"content": "flood"})
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("send %d: expected 201, got %d: %s", i+1, rec.Code, rec.Body.String())
+		}
+	}
+
+	rec := doRequest(t, srv, http.MethodPost, path, map[string]string{"content": "one too many"})
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("send %d: expected 429, got %d: %s",
+			chatSendHumanRatePerMinute+1, rec.Code, rec.Body.String())
+	}
+	retryAfter := rec.Header().Get("Retry-After")
+	if retryAfter == "" {
+		t.Error("a rate-limited send must say when to retry (Retry-After header missing)")
+	} else if secs, err := strconv.Atoi(retryAfter); err != nil || secs < 1 {
+		t.Errorf("Retry-After = %q, want a positive number of seconds", retryAfter)
+	}
+	if !strings.Contains(rec.Body.String(), ErrCodeRateLimited) {
+		t.Errorf("expected a %q error code in the body, got %s", ErrCodeRateLimited, rec.Body.String())
+	}
+
+	// The refusal is transient: at 30/min a token accrues every 2 seconds.
+	clock.Advance(2 * time.Second)
+	rec = doRequest(t, srv, http.MethodPost, path, map[string]string{"content": "after backoff"})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected the send to succeed after backing off, got %d: %s", rec.Code, rec.Body.String())
 	}
 }

--- a/pkg/hub/handlers_chat_v2_test.go
+++ b/pkg/hub/handlers_chat_v2_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"slices"
@@ -2158,5 +2159,131 @@ func TestChatV2_ClearTopicDefaultAgent(t *testing.T) {
 	}
 	if other.DefaultAgent != "reviewer" {
 		t.Errorf("unrelated topic default changed: got %q", other.DefaultAgent)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// History pagination (#1027)
+// ---------------------------------------------------------------------------
+
+// seedHistoryMessages inserts n web-channel messages into the given thread,
+// one second apart so the keyset ordering (created DESC, id DESC) is stable.
+// It returns the message contents in chronological order (oldest first).
+func seedHistoryMessages(t *testing.T, s store.Store, projectID, threadID string, n int) []string {
+	t.Helper()
+	ctx := context.Background()
+	base := time.Now().UTC().Add(-time.Duration(n) * time.Second)
+	contents := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		content := fmt.Sprintf("message-%03d", i)
+		msg := &store.Message{
+			ID:        tid(threadID + "-msg-" + content),
+			ProjectID: projectID,
+			Sender:    "user:dev",
+			SenderID:  DevUserID,
+			Recipient: "thread:" + threadID,
+			Msg:       content,
+			Type:      messages.TypeChat,
+			Channel:   "web",
+			ThreadID:  threadID,
+			CreatedAt: base.Add(time.Duration(i) * time.Second),
+		}
+		if err := s.CreateMessage(ctx, msg); err != nil {
+			t.Fatalf("CreateMessage(%s): %v", content, err)
+		}
+		contents = append(contents, content)
+	}
+	return contents
+}
+
+// The client sends the pagination cursor as ?cursor= (chat-thread.ts
+// fetchHistoryV2). When the handler read a different parameter the cursor was
+// silently dropped and every page returned the same newest window, so
+// scrollback never advanced past the first page (#1027). Paginating twice is
+// the only way to catch that: a single-page assertion passes either way.
+func TestChatV2_History_CursorPaginatesToOlderMessages(t *testing.T) {
+	srv, s, wcs, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	topicID := tid("topic-history-paginate")
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        topicID,
+		ProjectID: proj.ID,
+		Name:      "history-paginate",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	// More than one default page (50) so a second page must exist.
+	const total = 120
+	seedHistoryMessages(t, s, proj.ID, topicID, total)
+
+	fetch := func(cursor string) chatHistoryResponse {
+		t.Helper()
+		path := "/api/v1/chat/conversations/" + topicID + "/messages?limit=50"
+		if cursor != "" {
+			path += "&cursor=" + url.QueryEscape(cursor)
+		}
+		rec := doRequest(t, srv, http.MethodGet, path, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET %s: expected 200, got %d: %s", path, rec.Code, rec.Body.String())
+		}
+		var resp chatHistoryResponse
+		if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return resp
+	}
+
+	first := fetch("")
+	if len(first.Messages) != 50 {
+		t.Fatalf("first page: got %d messages, want 50", len(first.Messages))
+	}
+	if first.NextCursor == "" {
+		t.Fatalf("first page: expected a nextCursor with %d messages seeded", total)
+	}
+	// Newest first: the last seeded message heads the first page.
+	if got, want := first.Messages[0].Msg, fmt.Sprintf("message-%03d", total-1); got != want {
+		t.Errorf("first page head = %q, want %q", got, want)
+	}
+
+	second := fetch(first.NextCursor)
+	if len(second.Messages) != 50 {
+		t.Fatalf("second page: got %d messages, want 50", len(second.Messages))
+	}
+
+	// The second page must be disjoint from the first...
+	firstIDs := make(map[string]bool, len(first.Messages))
+	for _, m := range first.Messages {
+		firstIDs[m.ID] = true
+	}
+	for _, m := range second.Messages {
+		if firstIDs[m.ID] {
+			t.Fatalf("second page repeats message %q from the first page — cursor was ignored", m.Msg)
+		}
+	}
+
+	// ...and strictly older than it.
+	oldestOnFirst := first.Messages[len(first.Messages)-1].CreatedAt
+	newestOnSecond := second.Messages[0].CreatedAt
+	if !newestOnSecond.Before(oldestOnFirst) {
+		t.Errorf("second page is not older: newest=%s, oldest on first page=%s", newestOnSecond, oldestOnFirst)
+	}
+	if got, want := second.Messages[0].Msg, fmt.Sprintf("message-%03d", total-51); got != want {
+		t.Errorf("second page head = %q, want %q", got, want)
+	}
+
+	// A third page walks the tail: 120 seeded, 100 consumed, 20 left.
+	third := fetch(second.NextCursor)
+	if len(third.Messages) != 20 {
+		t.Fatalf("third page: got %d messages, want 20", len(third.Messages))
+	}
+	if got, want := third.Messages[len(third.Messages)-1].Msg, "message-000"; got != want {
+		t.Errorf("third page tail = %q, want %q (oldest message unreachable)", got, want)
+	}
+	if third.NextCursor != "" {
+		t.Errorf("third page: expected no nextCursor, got %q", third.NextCursor)
 	}
 }

--- a/pkg/hub/handlers_chat_v2_test.go
+++ b/pkg/hub/handlers_chat_v2_test.go
@@ -2333,6 +2333,11 @@ func TestChatV2_Send_RateLimitsFloodingHuman(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), ErrCodeRateLimited) {
 		t.Errorf("expected a %q error code in the body, got %s", ErrCodeRateLimited, rec.Body.String())
 	}
+	// The delay belongs in the body as well as the header: no current client
+	// reads Retry-After, so the message text is the signal that gets seen.
+	if want := "retry in " + retryAfter + "s"; !strings.Contains(rec.Body.String(), want) {
+		t.Errorf("expected the body to carry the retry delay %q, got %s", want, rec.Body.String())
+	}
 
 	// The refusal is transient: at 30/min a token accrues every 2 seconds.
 	clock.Advance(2 * time.Second)

--- a/pkg/hub/notifications.go
+++ b/pkg/hub/notifications.go
@@ -517,9 +517,10 @@ const (
 // currently viewing the chat UI). When a user is actively present, DM
 // notifications are suppressed to avoid interrupting them.
 //
-// W5 will implement a real presence map; until then a nil PresenceChecker
-// (or the NoOpPresenceChecker) treats every user as absent, which means
-// DM notifications always fire — the conservative default.
+// The server satisfies this with its PresenceManager (see
+// serverPresenceChecker). A nil PresenceChecker (or the NoOpPresenceChecker)
+// treats every user as absent, which means DM notifications always fire —
+// the conservative default.
 type PresenceChecker interface {
 	// IsUserActive returns true if the user is actively present
 	// (heartbeat within the presence window).
@@ -527,7 +528,7 @@ type PresenceChecker interface {
 }
 
 // NoOpPresenceChecker always returns false (user is not active).
-// Used as the default when W5 presence is not yet available.
+// Used as the default when no presence source is wired in.
 type NoOpPresenceChecker struct{}
 
 // IsUserActive always returns false — the user is assumed absent.

--- a/pkg/hub/presence.go
+++ b/pkg/hub/presence.go
@@ -178,6 +178,16 @@ func (pm *PresenceManager) GetState(userID string) PresenceState {
 	return entry.state
 }
 
+// IsUserActive implements PresenceChecker: it reports whether the user has
+// heartbeated within the presence window. A nil manager reports every user as
+// absent, which is the conservative answer — notifications still fire.
+func (pm *PresenceManager) IsUserActive(userID string) bool {
+	if pm == nil {
+		return false
+	}
+	return pm.GetState(userID) == PresenceActive
+}
+
 // GetAllStates returns a map of userID -> presence state for all tracked users.
 func (pm *PresenceManager) GetAllStates() map[string]string {
 	pm.mu.RLock()

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1892,8 +1892,11 @@ func (s *Server) GetMessageBrokerProxy() *MessageBrokerProxy {
 func (s *Server) SetWebChatStore(wcs WebChatStore) {
 	s.mu.Lock()
 	s.webChatStore = wcs
-	// Initialize ChatNotifier with the store; presence checker is nil (W5 stub).
-	s.chatNotifier = NewChatNotifier(s.store, s.events, wcs, nil, s.messageLog)
+	// Initialize ChatNotifier with the store. Presence is resolved lazily
+	// through the server (see serverPresenceChecker): the presence manager is
+	// created by InitPresenceManager, which runs after this on the current
+	// startup path, and a snapshot taken here would pin a nil checker.
+	s.chatNotifier = NewChatNotifier(s.store, s.events, wcs, serverPresenceChecker{s}, s.messageLog)
 	// Wire into existing broker proxy if already started (startup order varies).
 	if s.messageBrokerProxy != nil {
 		s.messageBrokerProxy.chatNotifier = s.chatNotifier
@@ -1914,6 +1917,28 @@ func (s *Server) getChatNotifier() *ChatNotifier {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.chatNotifier
+}
+
+// serverPresenceChecker adapts the server's presence manager to the
+// PresenceChecker interface, resolving it at call time rather than at
+// construction time. Startup wires the webchat store (and with it the
+// ChatNotifier) before InitPresenceManager runs, so a checker captured up
+// front would be permanently absent-reporting — the defect this replaces.
+type serverPresenceChecker struct {
+	srv *Server
+}
+
+// IsUserActive reports whether the user is currently present, or false while
+// no presence manager exists (before InitPresenceManager, or in deployments
+// that never start one).
+func (c serverPresenceChecker) IsUserActive(userID string) bool {
+	if c.srv == nil {
+		return false
+	}
+	c.srv.mu.RLock()
+	pm := c.srv.presenceManager
+	c.srv.mu.RUnlock()
+	return pm.IsUserActive(userID)
 }
 
 // InitPresenceManager creates and starts the presence manager for real-time

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -757,6 +757,10 @@ type Server struct {
 	// Single-node only; see design §4.5 HA limitation.
 	presenceManager *PresenceManager
 
+	// Per-sender token-bucket limiter for the chat send paths (#1054).
+	// Set once in New and read without the lock; nil-safe.
+	chatSendLimiter *chatSendLimiter
+
 	// Channel registry for external notification delivery (nil = disabled)
 	channelRegistry *ChannelRegistry
 
@@ -993,6 +997,9 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 
 	// Initialize GCP token metrics
 	srv.gcpTokenMetrics = NewGCPTokenMetrics()
+
+	// Per-sender chat send rate limiter (#1054).
+	srv.chatSendLimiter = newChatSendLimiter()
 
 	ctx := context.Background()
 

--- a/web/src/components/shared/chat/chat-thread.test.ts
+++ b/web/src/components/shared/chat/chat-thread.test.ts
@@ -438,6 +438,18 @@ describe('scion-chat-thread initial scroll position', () => {
     return el;
   }
 
+  /**
+   * Let a background history refetch run to completion, including the scroll
+   * it defers behind updateComplete. The macrotask flushes are what make the
+   * difference: the refetch chain resolves over several microtask turns, so
+   * awaiting updateComplete alone looks before anything could have happened.
+   */
+  async function flushRefetch(el: ScionChatThread): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await el.updateComplete;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
   function scrollContainer(el: ScionChatThread): HTMLElement {
     const node = el.shadowRoot?.querySelector('.messages-scroll') as HTMLElement | null;
     if (!node) throw new Error('scroll container not rendered');
@@ -517,10 +529,25 @@ describe('scion-chat-thread initial scroll position', () => {
     // A message arrives on the SSE stream and triggers a background refetch.
     emitChatMessage({ threadId: CONVERSATION_KEY, id: 'm4' });
     await vi.waitFor(() => expect(historyCalls()).toBeGreaterThan(0));
-    await el.updateComplete;
-    await Promise.resolve();
+    // Drain the whole refetch chain — apiFetch promise, .json(), the merge and
+    // the deferred updateComplete.then() — before looking. A single microtask
+    // is not enough: the assertion would run before a scroll could have
+    // happened and would pass with the pinnedToBottom guard deleted.
+    await flushRefetch(el);
 
     expect(scrollWrites.filter((w) => w.top === SCROLL_HEIGHT)).toEqual([]);
+
+    // Positive control, same flush sequence: with the user re-pinned the very
+    // same event must produce a scroll. Without this, a future change to the
+    // timing above silently returns the negative assertion to vacuity.
+    (el as unknown as { pinnedToBottom: boolean }).pinnedToBottom = true;
+    emitChatMessage({ threadId: CONVERSATION_KEY, id: 'm5' });
+    await flushRefetch(el);
+
+    expect(
+      scrollWrites.filter((w) => w.top === SCROLL_HEIGHT),
+      'the flush must be long enough for a scroll to land when the user is pinned'
+    ).not.toEqual([]);
   });
 
   it('scrolls back to the bottom when the user asks to jump to latest', async () => {

--- a/web/src/components/shared/chat/chat-thread.test.ts
+++ b/web/src/components/shared/chat/chat-thread.test.ts
@@ -477,7 +477,11 @@ describe('scion-chat-thread initial scroll position', () => {
       },
       set(this: HTMLElement, value: number) {
         scrollTops.set(this, value);
-        if (this.classList.contains('messages-scroll')) {
+        // isConnected keeps a detached element's late scroll out of the shared
+        // recorder: the setter lives on the prototype, so an element torn down
+        // by a previous test can still write here if its refetch chain lands
+        // afterwards, and the positive control would count it as its own.
+        if (this.classList.contains('messages-scroll') && this.isConnected) {
           scrollWrites.push({
             top: value,
             messagesRendered: this.querySelectorAll('scion-chat-message').length,
@@ -527,8 +531,11 @@ describe('scion-chat-thread initial scroll position', () => {
     scrollWrites = [];
 
     // A message arrives on the SSE stream and triggers a background refetch.
+    // Wait for the *next* history call: the mount already made one, so waiting
+    // for any call at all would be satisfied before the emit is even handled.
+    const before = historyCalls();
     emitChatMessage({ threadId: CONVERSATION_KEY, id: 'm4' });
-    await vi.waitFor(() => expect(historyCalls()).toBeGreaterThan(0));
+    await vi.waitFor(() => expect(historyCalls()).toBeGreaterThan(before));
     // Drain the whole refetch chain — apiFetch promise, .json(), the merge and
     // the deferred updateComplete.then() — before looking. A single microtask
     // is not enough: the assertion would run before a scroll could have
@@ -547,8 +554,9 @@ describe('scion-chat-thread initial scroll position', () => {
     const el = await mountWithHistory();
     scrollWrites = [];
 
+    const before = historyCalls();
     emitChatMessage({ threadId: CONVERSATION_KEY, id: 'm5' });
-    await vi.waitFor(() => expect(historyCalls()).toBeGreaterThan(0));
+    await vi.waitFor(() => expect(historyCalls()).toBeGreaterThan(before));
     await flushRefetch(el);
 
     expect(

--- a/web/src/components/shared/chat/chat-thread.test.ts
+++ b/web/src/components/shared/chat/chat-thread.test.ts
@@ -536,12 +536,19 @@ describe('scion-chat-thread initial scroll position', () => {
     await flushRefetch(el);
 
     expect(scrollWrites.filter((w) => w.top === SCROLL_HEIGHT)).toEqual([]);
+  });
 
-    // Positive control, same flush sequence: with the user re-pinned the very
-    // same event must produce a scroll. Without this, a future change to the
-    // timing above silently returns the negative assertion to vacuity.
-    (el as unknown as { pinnedToBottom: boolean }).pinnedToBottom = true;
+  // Positive control for the test above. It has to run on its own element:
+  // sharing one with the negative phase lets that phase's still-in-flight
+  // refetch land inside this window, so the control passes on someone else's
+  // scroll and stops noticing whether flushRefetch is long enough. Keep the
+  // flush sequence identical to the negative case — that is the whole point.
+  it('positive control: a pinned user IS scrolled by the same refetch', async () => {
+    const el = await mountWithHistory();
+    scrollWrites = [];
+
     emitChatMessage({ threadId: CONVERSATION_KEY, id: 'm5' });
+    await vi.waitFor(() => expect(historyCalls()).toBeGreaterThan(0));
     await flushRefetch(el);
 
     expect(

--- a/web/src/components/shared/chat/chat-thread.test.ts
+++ b/web/src/components/shared/chat/chat-thread.test.ts
@@ -24,6 +24,8 @@
  *  2. SSE `chat-message-received` events belong to every conversation the user
  *     can see; the thread must only refetch for its own conversation, and
  *     concurrent refetches must collapse into a single in-flight request.
+ *  3. The scroll to the newest message must happen after the loaded messages
+ *     have rendered, and must not override a deliberate user scroll.
  */
 
 // @vitest-environment happy-dom
@@ -372,5 +374,170 @@ describe('scion-chat-thread typing self-filter', () => {
     await el.updateComplete;
 
     expect(el.shadowRoot?.querySelector('.typing-indicator')).not.toBeNull();
+  });
+});
+
+/**
+ * Opening a thread landed the user on the oldest message: the scroll ran in a
+ * `finally` block without awaiting `updateComplete`, so `scrollToBottom` read
+ * the DOM before the loaded messages had rendered — while the thread still
+ * showed the loading spinner the scroll container did not even exist, and the
+ * scroll was a silent no-op.
+ */
+describe('scion-chat-thread initial scroll position', () => {
+  // happy-dom performs no layout: every element reports zero size, so the
+  // geometry the component reads has to be supplied by the test.
+  const SCROLL_HEIGHT = 1000;
+  const CLIENT_HEIGHT = 300;
+
+  /** Each write to the scroll container's scrollTop, with the DOM it saw. */
+  let scrollWrites: { top: number; messagesRendered: number; renderPending: boolean }[] = [];
+  let scrollTops: WeakMap<HTMLElement, number>;
+
+  /** The thread element owning a node inside its shadow root. */
+  function hostOf(node: HTMLElement): (ScionChatThread & { isUpdatePending: boolean }) | null {
+    const root = node.getRootNode();
+    const host = (root as ShadowRoot).host as unknown;
+    return (host ?? null) as (ScionChatThread & { isUpdatePending: boolean }) | null;
+  }
+  const originalScrollTop = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'scrollTop');
+  const originalScrollHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'scrollHeight'
+  );
+  const originalClientHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'clientHeight'
+  );
+
+  const HISTORY = [
+    { id: 'm1', sender: 'them@example.com', msg: 'oldest', createdAt: '2026-01-01T00:00:00Z' },
+    { id: 'm2', sender: 'them@example.com', msg: 'middle', createdAt: '2026-01-01T00:01:00Z' },
+    { id: 'm3', sender: 'them@example.com', msg: 'newest', createdAt: '2026-01-01T00:02:00Z' },
+  ];
+
+  function history(): Response {
+    return {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ items: HISTORY }),
+    } as unknown as Response;
+  }
+
+  /** Mount a v2 thread and wait for its history to render. */
+  async function mountWithHistory(): Promise<ScionChatThread> {
+    const el = document.createElement('scion-chat-thread') as ScionChatThread;
+    el.conversationKey = CONVERSATION_KEY;
+    document.body.appendChild(el);
+    await vi.waitFor(() =>
+      expect(el.shadowRoot?.querySelectorAll('scion-chat-message').length).toBe(HISTORY.length)
+    );
+    await el.updateComplete;
+    // Let the deferred (post-render) scroll run.
+    await Promise.resolve();
+    return el;
+  }
+
+  function scrollContainer(el: ScionChatThread): HTMLElement {
+    const node = el.shadowRoot?.querySelector('.messages-scroll') as HTMLElement | null;
+    if (!node) throw new Error('scroll container not rendered');
+    return node;
+  }
+
+  beforeEach(() => {
+    apiFetch.mockReset();
+    apiFetch.mockImplementation(() => Promise.resolve(history()));
+    scrollWrites = [];
+    scrollTops = new WeakMap();
+
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => SCROLL_HEIGHT,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get: () => CLIENT_HEIGHT,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'scrollTop', {
+      configurable: true,
+      get(this: HTMLElement) {
+        return scrollTops.get(this) ?? 0;
+      },
+      set(this: HTMLElement, value: number) {
+        scrollTops.set(this, value);
+        if (this.classList.contains('messages-scroll')) {
+          scrollWrites.push({
+            top: value,
+            messagesRendered: this.querySelectorAll('scion-chat-message').length,
+            renderPending: hostOf(this)?.isUpdatePending ?? false,
+          });
+        }
+      },
+    });
+  });
+
+  afterEach(() => {
+    for (const [prop, descriptor] of [
+      ['scrollTop', originalScrollTop],
+      ['scrollHeight', originalScrollHeight],
+      ['clientHeight', originalClientHeight],
+    ] as const) {
+      if (descriptor) {
+        Object.defineProperty(HTMLElement.prototype, prop, descriptor);
+      } else {
+        delete (HTMLElement.prototype as unknown as Record<string, unknown>)[prop];
+      }
+    }
+    document.body.innerHTML = '';
+  });
+
+  it('scrolls to the newest message only after the loaded messages have rendered', async () => {
+    await mountWithHistory();
+
+    const last = scrollWrites.at(-1);
+    expect(last, 'expected a scroll to the bottom after the initial load').toBeDefined();
+    expect(last?.top).toBe(SCROLL_HEIGHT);
+    // The scroll must see the populated list, not the loading placeholder.
+    expect(last?.messagesRendered).toBe(HISTORY.length);
+    // And it must not run while a render is still queued — that is the read of
+    // stale geometry the bug was made of.
+    expect(scrollWrites.filter((w) => w.renderPending)).toEqual([]);
+  });
+
+  it('does not yank back a user who scrolled away while a load was in flight', async () => {
+    const el = await mountWithHistory();
+    const container = scrollContainer(el);
+
+    // The user scrolls up to read older messages.
+    container.scrollTop = 0;
+    container.dispatchEvent(new Event('scroll'));
+    await el.updateComplete;
+    scrollWrites = [];
+
+    // A message arrives on the SSE stream and triggers a background refetch.
+    emitChatMessage({ threadId: CONVERSATION_KEY, id: 'm4' });
+    await vi.waitFor(() => expect(historyCalls()).toBeGreaterThan(0));
+    await el.updateComplete;
+    await Promise.resolve();
+
+    expect(scrollWrites.filter((w) => w.top === SCROLL_HEIGHT)).toEqual([]);
+  });
+
+  it('scrolls back to the bottom when the user asks to jump to latest', async () => {
+    const el = await mountWithHistory();
+    const container = scrollContainer(el);
+
+    container.scrollTop = 0;
+    container.dispatchEvent(new Event('scroll'));
+    await el.updateComplete;
+    scrollWrites = [];
+
+    const jump = el.shadowRoot?.querySelector('.jump-btn') as HTMLElement | null;
+    expect(jump, 'jump-to-latest pill should be shown once scrolled away').not.toBeNull();
+    jump?.click();
+    await el.updateComplete;
+    await Promise.resolve();
+
+    expect(scrollWrites.at(-1)?.top).toBe(SCROLL_HEIGHT);
   });
 });

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -668,7 +668,7 @@ export class ScionChatThread extends LitElement {
     } finally {
       if (currentId === this.fetchId) {
         this.loading = false;
-        this.scrollToBottom();
+        this.scrollToBottomAfterRender();
       }
     }
   }
@@ -732,7 +732,7 @@ export class ScionChatThread extends LitElement {
       this.error = err instanceof Error ? err.message : 'Failed to load messages';
     } finally {
       this.loading = false;
-      this.scrollToBottom();
+      this.scrollToBottomAfterRender();
     }
   }
 
@@ -871,11 +871,8 @@ export class ScionChatThread extends LitElement {
     this.eventSource.addEventListener('message', (event: Event) => {
       try {
         const msg = JSON.parse((event as MessageEvent).data as string) as Message;
-        const wasPinned = this.pinnedToBottom;
         this.mergeMessages([msg]);
-        if (wasPinned) {
-          void this.updateComplete.then(() => this.scrollToBottom());
-        }
+        this.scrollToBottomAfterRender();
       } catch {
         // Skip unparseable entries
       }
@@ -927,7 +924,7 @@ export class ScionChatThread extends LitElement {
       this.error = err instanceof Error ? err.message : 'Failed to load messages';
     } finally {
       this.loading = false;
-      this.scrollToBottom();
+      this.scrollToBottomAfterRender();
     }
   }
 
@@ -1146,11 +1143,8 @@ export class ScionChatThread extends LitElement {
       }
     }
 
-    const wasPinned = this.pinnedToBottom;
     this.mergeMessages(items);
-    if (wasPinned) {
-      void this.updateComplete.then(() => this.scrollToBottom());
-    }
+    this.scrollToBottomAfterRender();
     // Advance read watermark if applicable
     this.maybeAdvanceReadWatermark();
   }
@@ -1565,9 +1559,27 @@ export class ScionChatThread extends LitElement {
     }
   }
 
+  /**
+   * Scroll to the newest message once the pending render has committed.
+   *
+   * scrollToBottom() reads scrollHeight synchronously, so calling it directly
+   * after a load reads the height of the still-empty (or stale) container and
+   * leaves the user parked at the top of the real list (#1028). Awaiting
+   * updateComplete lets Lit commit the newly loaded messages first.
+   *
+   * The deferred scroll respects pinnedToBottom: if the user scrolled away
+   * while the load was in flight, it is skipped rather than yanking them back.
+   */
+  private scrollToBottomAfterRender(): void {
+    void this.updateComplete.then(() => {
+      if (!this.pinnedToBottom) return;
+      this.scrollToBottom();
+    });
+  }
+
   private handleJumpToLatest(): void {
     this.pinnedToBottom = true;
-    this.scrollToBottom();
+    this.scrollToBottomAfterRender();
   }
 
   /** Focus the composer textarea when clicking the message area background. */

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -1569,12 +1569,18 @@ export class ScionChatThread extends LitElement {
    *
    * The deferred scroll respects pinnedToBottom: if the user scrolled away
    * while the load was in flight, it is skipped rather than yanking them back.
+   *
+   * updateComplete rejects when a reactive update throws, so the chain is
+   * caught: a failed render should not also surface as an unhandled rejection,
+   * and there is nothing to scroll to in that case anyway.
    */
   private scrollToBottomAfterRender(): void {
-    void this.updateComplete.then(() => {
-      if (!this.pinnedToBottom) return;
-      this.scrollToBottom();
-    });
+    void this.updateComplete
+      .then(() => {
+        if (!this.pinnedToBottom) return;
+        this.scrollToBottom();
+      })
+      .catch(() => {});
   }
 
   private handleJumpToLatest(): void {


### PR DESCRIPTION
## Summary
- Fix scrollback pagination no-op: client sent cursor param, server read before param (ptone/scion#1027)
- Fix threads opening at oldest message instead of newest (ptone/scion#1028)
- Wire real PresenceChecker into ChatNotifier instead of nil (ptone/scion#1032)
- Add per-sender token-bucket rate limiting on chat send and agent outbound paths (ptone/scion#1054)

## Test plan
- Pagination test exercises scrollback past 50 messages
- Scroll-to-bottom verified with updateComplete await before scrollHeight read
- Presence checker suppression test for active viewers
- Rate limiter tests for human and agent limits with 429 response