### PR TITLE
fix: uptime check content matcher never fails on degraded status

### DIFF
--- a/deploy/monitoring/uptime-checks.yaml
+++ b/deploy/monitoring/uptime-checks.yaml
@@ -40,9 +40,16 @@ uptimeChecks:
       useSsl: true
       validateSsl: true
       requestMethod: GET
+    # Match the top-level "status" field exactly. A substring match on
+    # "healthy" would also succeed against "unhealthy" (which appears in the
+    # per-check detail fields) and against a "degraded" response that still
+    # reports some checks as "healthy".
     contentMatchers:
       - content: "healthy"
-        matcher: CONTAINS_STRING
+        matcher: MATCHES_JSON_PATH
+        jsonPathMatcher:
+          jsonPath: "$.status"
+          jsonMatcher: EXACT_MATCH
     period: "60s"              # Check every 1 minute
     timeout: "10s"
     notificationChannels:
@@ -97,9 +104,15 @@ uptimeChecks:
       port: 8080
       useSsl: false
       requestMethod: GET
+    # Match the top-level "status" field exactly. See the Hub /healthz note
+    # above: a substring match on "healthy" also succeeds against "unhealthy"
+    # and against a "degraded" response carrying healthy sub-checks.
     contentMatchers:
       - content: "healthy"
-        matcher: CONTAINS_STRING
+        matcher: MATCHES_JSON_PATH
+        jsonPathMatcher:
+          jsonPath: "$.status"
+          jsonMatcher: EXACT_MATCH
     # Internal checks use a longer period since the Broker is not user-facing.
     period: "300s"             # Check every 5 minutes
     timeout: "10s"


### PR DESCRIPTION
The /healthz uptime checks could never fail.

Root cause: the top-level failure value is `degraded`, not `unhealthy`, and a degraded response with any passing sub-check still contains the literal string `healthy`. The CONTAINS_STRING matcher therefore matched on success and failure alike. Both /healthz handlers return HTTP 200 even when degraded, so the content matcher was the only failure signal, and it was blind.

Fix: MATCHES_JSON_PATH + EXACT_MATCH on $.status. Verified against the direct hub/broker handlers and the composite web response (which uses `ok` for the web sub-object, so any substring or prefix anchor would have failed permanently there). Schema field names confirmed against the Cloud Monitoring v3 API.

Files: monitoring/uptime-checks.yaml (lines 44, 101).

Follow-up: ptone/scion#1130 -- /readyz has the same class of defect, `ready` being a substring of `not_ready`. Lower severity because 503 also fires. Identical fix applies.