### PR TITLE
fix: --harness flag should default to empty in create command

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -328,7 +328,7 @@ func init() {
 	createCmd.Flags().StringVarP(&workspace, "workspace", "w", "", "Host path or project-relative subdirectory to mount as /workspace")
 	createCmd.Flags().StringVar(&runtimeBrokerID, "broker", "", "Preferred runtime broker ID or name")
 	createCmd.Flags().StringVar(&harnessConfigFlag, "harness-config", "", "Named harness configuration to use")
-	createCmd.Flags().StringVar(&harnessConfigFlag, "harness", "h", "Named harness configuration to use (alias for --harness-config)")
+	createCmd.Flags().StringVar(&harnessConfigFlag, "harness", "", "Named harness configuration to use (alias for --harness-config)")
 
 	createCmd.Flags().StringVar(&harnessAuthFlag, "harness-auth", "", "Override auth method for the harness (api-key, oauth-token, auth-file, vertex-ai)")
 

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -44,6 +44,16 @@ func (s createTestState) restore() {
 	noHub = s.noHub
 }
 
+func TestCreateCmd_HarnessFlagDefaultsToEmpty(t *testing.T) {
+	// Regression test: the --harness flag on createCmd must default to ""
+	// (not "h"). Previously StringVar was called with "h" as the default
+	// value instead of the empty string, causing harnessConfigFlag to be
+	// non-empty even when neither --harness nor --harness-config was passed.
+	f := createCmd.Flags().Lookup("harness")
+	require.NotNil(t, f, "--harness flag must be registered on createCmd")
+	assert.Equal(t, "", f.DefValue, "--harness default value must be empty string")
+}
+
 func TestCreateAgent_DuplicateReturnsError(t *testing.T) {
 	orig := saveCreateTestState()
 	defer orig.restore()

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
 // createTestState captures and restores package-level vars for test isolation.
 type createTestState struct {
 	home        string

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+
 // createTestState captures and restores package-level vars for test isolation.
 type createTestState struct {
 	home        string


### PR DESCRIPTION
The --harness flag on `scion create` declared its default as the loop variable `h`
instead of an empty string, so the created agent recorded a bogus harness name.

Change: cmd/create.go:331 StringVar default changed from `h` to `""`, matching the
equivalent flag registration in cmd/start.go:57.

Test: adds TestCreateCmd_HarnessFlagDefaultsToEmpty as a regression guard.

CI green on 3dc5a60c (Build and Test, golangci-lint).
