### PR TITLE
ci: add shellcheck gate and fix existing findings

### DIFF
--- a/.design/walkthroughs/web-nats-server.sh
+++ b/.design/walkthroughs/web-nats-server.sh
@@ -102,7 +102,7 @@ check_nats() {
     else
         # Extract host:port from the URL for a basic TCP probe
         local host_port
-        host_port=$(echo "${NATS_URL}" | sed 's|nats://||')
+        host_port="${NATS_URL#nats://}"
         if curl -s --connect-timeout 2 "telnet://${host_port}" >/dev/null 2>&1; then
             ok "NATS appears reachable at ${host_port}"
         else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,57 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           args: '--new-from-merge-base=origin/main'
+
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+          shellcheck --version
+
+      # Positive control -- this gate is not a no-op.
+      #
+      # Before it was added, scripts/hub-env-integration-test.sh:328 and
+      # scripts/hub-secret-integration-test.sh:329 both read:
+      #
+      #     GROVE_ID=$($SCION config get grove_id 2>/dev/null || "")
+      #
+      # The `|| ""` runs the empty string as a command name -- SC2286, an
+      # error-severity finding. (The intended form, `|| echo ""`, appears two
+      # lines below in both files.) Re-introducing that `|| ""` makes this step
+      # exit 1, which is how you can confirm the job catches real defects.
+      #
+      # -x plus --source-path=SCRIPTDIR lets shellcheck follow `source` targets
+      # relative to each script's own directory, which honours the existing
+      # `# shellcheck source=` directives (e.g. image-build/scripts/lib/targets.sh
+      # and scripts/starter-hub/hub-config.sh) instead of reporting SC1091.
+      - name: Run shellcheck
+        run: |
+          checked=0
+          failed=0
+          while IFS= read -r script; do
+            checked=$((checked + 1))
+            if ! shellcheck -x --source-path=SCRIPTDIR "$script"; then
+              failed=$((failed + 1))
+            fi
+          done < <(find . -type f -name '*.sh' \
+                     -not -path './.git/*' \
+                     -not -path './vendor/*' \
+                     -not -path '*/vendor/*' \
+                     -not -path '*/node_modules/*' \
+                   | sort)
+          echo "shellcheck: $((checked - failed))/${checked} file(s) passed"
+          if [ "$checked" -eq 0 ]; then
+            echo "::error::no shell scripts found -- the file discovery is broken"
+            exit 1
+          fi
+          if [ "$failed" -gt 0 ]; then
+            echo "::error::shellcheck reported issues in ${failed} file(s)"
+            exit 1
+          fi

--- a/deploy/helm/scion-hub/tests/render-guards.sh
+++ b/deploy/helm/scion-hub/tests/render-guards.sh
@@ -78,8 +78,8 @@ render() { "$HELM" template t "$CHART" "${BASE[@]}" "$@" 2>&1; }
 reject() {
   local label="$1" want="$2"; shift 2
   executed=$((executed + 1))
-  local out; out="$(render "$@")"
-  if [ $? -eq 0 ]; then
+  local out
+  if out="$(render "$@")"; then
     echo "FAIL  rendered but must reject: ${label}"; failed=$((failed + 1)); return
   fi
   case "$out" in
@@ -103,8 +103,8 @@ reject() {
 accept() {
   local label="$1"; shift
   executed=$((executed + 1))
-  local out; out="$(render "$@")"
-  if [ $? -eq 0 ]; then
+  local out
+  if out="$(render "$@")"; then
     echo "ok    accepted: ${label}"
   else
     echo "FAIL  rejected but must accept: ${label}"

--- a/deploy/helm/scion-hub/tests/reserved-flags.sh
+++ b/deploy/helm/scion-hub/tests/reserved-flags.sh
@@ -47,7 +47,7 @@ BASE=(--set image.repository=r --set hub.hubId=h)
 # "Nothing was analysed" is a THIRD outcome, distinct from clean and from failing,
 # and it exits 2 with the other harness errors rather than 1.
 _missing=""
-for _t in "$HELM"; do command -v "$_t" >/dev/null 2>&1 || _missing="${_missing} ${_t}"; done
+command -v "$HELM" >/dev/null 2>&1 || _missing="${_missing} ${HELM}"
 if [ -n "$_missing" ]; then
   echo "HARNESS ERROR: required tool(s) not on PATH:${_missing}"
   echo "NOTHING WAS ANALYSED. This is not a passing run, and it is NOT a chart failure."
@@ -140,8 +140,7 @@ reject() {
   # is what an exit-status check could never distinguish - and both present, or
   # the naive form alone, means the message format moved under us.
   naive="hub.args may not contain --${lower}:"
-  out="$("$HELM" template t "$CHART" "${BASE[@]}" --set-json "hub.args=[\"--$1\"]" 2>&1)"
-  if [ $? -eq 0 ]; then
+  if out="$("$HELM" template t "$CHART" "${BASE[@]}" --set-json "hub.args=[\"--$1\"]" 2>&1)"; then
     echo "FAIL  accepted but must reject: --$1"; failed=$((failed + 1)); return
   fi
   # gd-p1-dev's guard, checked first because it is the more specific failure: a

--- a/deploy/helm/scion-hub/tests/verify-failopen.sh
+++ b/deploy/helm/scion-hub/tests/verify-failopen.sh
@@ -83,7 +83,7 @@ bad()  { executed=$((executed+1)); failed=$((failed+1)); echo "FAIL  STEP $1"; }
 
 # --- 1. clean tree from git archive, outside the author's working copy -------
 TREE="$(mktemp -d)"
-trap 'rm -rf "$TREE"' EXIT
+trap '[ -n "${TREE:-}" ] && rm -rf "$TREE"' EXIT
 if git -C "$REPO" archive "$SHA" | tar -x -C "$TREE" 2>/dev/null && [ -f "$TREE/deploy/helm/scion-hub/tests/run-all.sh" ]; then
   step "1 git archive $SHA -> clean tree ($TREE)"
 else
@@ -120,7 +120,7 @@ fi
 # --- 4. a REAL assertion failure AND a short run, together -------------------
 # Both must be reported. The count inequality must fire ALONGSIDE the failure,
 # not be short-circuited by it. That short-circuit is the 60b2912 defect.
-M="$(mktemp -d)"; trap 'rm -rf "$TREE" "$M"' EXIT
+M="$(mktemp -d)"; trap '[ -n "${TREE:-}" ] && rm -rf "$TREE"; [ -n "${M:-}" ] && rm -rf "$M"' EXIT
 cp -r "$TREE/deploy/helm/scion-hub" "$M/chart"
 # (i) real assertion failure: break the chart so a render guard genuinely fails
 rm -f "$M/chart/templates/service.yaml"
@@ -161,11 +161,11 @@ fi
 # The required outcome is the one the two exit codes exist for: a red chart and
 # an INTACT check set, correctly distinguished. So exit 1, and the total is
 # either complete or flagged - a short total sitting beside meta 0 is the defect.
-M5="$(mktemp -d)"; trap 'rm -rf "$TREE" "$M" "$M5"' EXIT
+M5="$(mktemp -d)"; trap '[ -n "${TREE:-}" ] && rm -rf "$TREE"; [ -n "${M:-}" ] && rm -rf "$M"; [ -n "${M5:-}" ] && rm -rf "$M5"' EXIT
 cp -r "$TREE/deploy/helm/scion-hub" "$M5/chart"
 # One assertion made genuinely red, by flipping the value it expects. Nothing
 # else touched: no count changed, no assertion removed, the chart is untouched.
-python3 - "$M5/chart/tests/update-strategy.sh" <<'PY'
+if ! python3 - "$M5/chart/tests/update-strategy.sh" <<'PY'
 import sys
 p=sys.argv[1]; L=open(p).read().split('\n')
 for i,l in enumerate(L):
@@ -175,7 +175,7 @@ else:
     sys.exit("MUTATION TARGET NOT FOUND")
 open(p,'w').write('\n'.join(L))
 PY
-if [ $? -ne 0 ]; then
+then
   echo "HARNESS ERROR: step 5 could not induce its mutation; the target line has moved."
   echo "NOTHING WAS VERIFIED for step 5. Fix the mutation, do not drop the step."
   exit 2

--- a/docs-site/check-d2.sh
+++ b/docs-site/check-d2.sh
@@ -36,7 +36,10 @@ trap 'rm -rf "$tmpdir"' EXIT
 failed=0
 checked=0
 
-for mdfile in $(grep -rl '```d2' "$CONTENT_DIR" --include='*.md' --include='*.mdx'); do
+# Iterate via a while-loop rather than `for f in $(grep ...)` so that filenames
+# containing whitespace are handled correctly. The inner loop below redirects
+# its own stdin from "$mdfile", so it does not consume this one.
+while IFS= read -r mdfile; do
   block=0
   in_d2=false
 
@@ -64,7 +67,7 @@ for mdfile in $(grep -rl '```d2' "$CONTENT_DIR" --include='*.md' --include='*.md
       echo "$line" >> "$outfile"
     fi
   done < "$mdfile"
-done
+done < <(grep -rl '```d2' "$CONTENT_DIR" --include='*.md' --include='*.mdx')
 
 echo ""
 echo "Checked $checked d2 block(s), $failed failure(s)."

--- a/docs-site/check-d2.sh
+++ b/docs-site/check-d2.sh
@@ -25,13 +25,18 @@ CONTENT_DIR="${1:-src/content}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
+if [ ! -d "$CONTENT_DIR" ]; then
+  echo "error: content directory '$CONTENT_DIR' not found" >&2
+  exit 1
+fi
+
 if ! command -v d2 &>/dev/null; then
   echo "error: d2 is not installed (https://d2lang.com/install)" >&2
   exit 1
 fi
 
 tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
+trap '[ -n "${tmpdir:-}" ] && rm -rf "$tmpdir"' EXIT
 
 failed=0
 checked=0

--- a/hack/dist.sh
+++ b/hack/dist.sh
@@ -82,7 +82,7 @@ function publish() {
     SHORT_HASH=$(git -C "${PROJECT_ROOT}" rev-parse --short HEAD)
     LDFLAGS=$(bash "${SCRIPT_DIR}/version.sh")
     BUILD_DIR=$(mktemp -d)
-    trap 'rm -rf "${BUILD_DIR}"' EXIT
+    trap '[ -n "${BUILD_DIR:-}" ] && rm -rf "${BUILD_DIR}"' EXIT
 
     echo "Commit: ${SHORT_HASH}"
     echo "Build dir: ${BUILD_DIR}"

--- a/hack/dist.sh
+++ b/hack/dist.sh
@@ -82,7 +82,7 @@ function publish() {
     SHORT_HASH=$(git -C "${PROJECT_ROOT}" rev-parse --short HEAD)
     LDFLAGS=$(bash "${SCRIPT_DIR}/version.sh")
     BUILD_DIR=$(mktemp -d)
-    trap "rm -rf ${BUILD_DIR}" EXIT
+    trap 'rm -rf "${BUILD_DIR}"' EXIT
 
     echo "Commit: ${SHORT_HASH}"
     echo "Build dir: ${BUILD_DIR}"

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -78,7 +78,7 @@ PLATFORM=$(detect_platform)
 INSTALL_DIR=$(detect_install_dir)
 VERSION="${SCION_VERSION:-latest}"
 TMPDIR=$(mktemp -d)
-trap 'rm -rf "${TMPDIR}"' EXIT
+trap '[ -n "${TMPDIR:-}" ] && rm -rf "${TMPDIR}"' EXIT
 
 echo "Scion CLI Installer"
 echo "  Platform:  ${PLATFORM}"

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -78,7 +78,7 @@ PLATFORM=$(detect_platform)
 INSTALL_DIR=$(detect_install_dir)
 VERSION="${SCION_VERSION:-latest}"
 TMPDIR=$(mktemp -d)
-trap "rm -rf ${TMPDIR}" EXIT
+trap 'rm -rf "${TMPDIR}"' EXIT
 
 echo "Scion CLI Installer"
 echo "  Platform:  ${PLATFORM}"

--- a/hack/test_oauth.sh
+++ b/hack/test_oauth.sh
@@ -18,7 +18,7 @@
 set -e
 
 TEST_TMP=$(mktemp -d)
-trap 'rm -rf "$TEST_TMP"' EXIT
+trap '[ -n "${TEST_TMP:-}" ] && rm -rf "$TEST_TMP"' EXIT
 
 echo "Using temporary directory: $TEST_TMP"
 

--- a/hack/test_oauth.sh
+++ b/hack/test_oauth.sh
@@ -17,7 +17,6 @@
 
 set -e
 
-REPO_ROOT=$(pwd)
 TEST_TMP=$(mktemp -d)
 trap 'rm -rf "$TEST_TMP"' EXIT
 

--- a/image-build/scripts/builders/cloud-build.sh
+++ b/image-build/scripts/builders/cloud-build.sh
@@ -21,6 +21,7 @@
 # and per-image step ordering are concerns of the static cloudbuild-*.yaml
 # files that ship alongside this script.
 
+# shellcheck disable=SC2034 # sourced by build-images.sh, which reads BUILDER_MODE
 BUILDER_MODE="target"
 
 builder_check() {

--- a/image-build/scripts/builders/local-docker.sh
+++ b/image-build/scripts/builders/local-docker.sh
@@ -17,6 +17,7 @@
 #
 # Implements the per-image builder contract on top of `docker buildx`.
 
+# shellcheck disable=SC2034 # sourced by build-images.sh, which reads BUILDER_MODE
 BUILDER_MODE="per-image"
 BUILDX_INSTANCE="scion-builder"
 

--- a/image-build/scripts/builders/local-podman.sh
+++ b/image-build/scripts/builders/local-podman.sh
@@ -19,6 +19,7 @@
 # values are rejected with an actionable error (QEMU binfmt setup is the
 # user's responsibility and must be opted into deliberately).
 
+# shellcheck disable=SC2034 # sourced by build-images.sh, which reads BUILDER_MODE
 BUILDER_MODE="per-image"
 
 builder_check() {
@@ -35,7 +36,7 @@ builder_prepare() {
 
 # See local-docker.sh for the flag contract.
 builder_build() {
-  local image_name="" context_dir="" dockerfile="" tags="" platforms="" push="false" load="false"
+  local image_name="" context_dir="" dockerfile="" tags="" platforms="" push="false"
   local -a build_args=()
 
   while [[ $# -gt 0 ]]; do
@@ -47,7 +48,7 @@ builder_build() {
       --platforms)   platforms="$2"; shift 2 ;;
       --build-arg)   build_args+=("$2"); shift 2 ;;
       --push)        push="$2"; shift 2 ;;
-      --load)        load="$2"; shift 2 ;;
+      --load)        shift 2 ;;  # accepted for CLI parity; --load is implicit for podman
       *) echo "local-podman: unknown builder_build flag: $1" >&2; return 1 ;;
     esac
   done

--- a/image-build/scripts/lib/targets.sh
+++ b/image-build/scripts/lib/targets.sh
@@ -64,6 +64,7 @@ ALL_STEP_IDS+=(
 
 # All known target names. Used by the orchestrator's --help and --target
 # validation.
+# shellcheck disable=SC2034 # sourced library; ALL_TARGETS is read by build-images.sh
 ALL_TARGETS=(
   core-base
   thick-prep

--- a/scripts/hub-env-integration-test.sh
+++ b/scripts/hub-env-integration-test.sh
@@ -325,7 +325,7 @@ setup_test_grove() {
     fi
 
     # Extract the grove ID for later use
-    GROVE_ID=$($SCION config get grove_id 2>/dev/null || "")
+    GROVE_ID=$($SCION config get grove_id 2>/dev/null || echo "")
     if [[ -z "$GROVE_ID" ]]; then
         # Fall back to reading settings.yaml directly
         GROVE_ID=$(grep 'grove_id:' "$grove_dir/.scion/settings.yaml" 2>/dev/null | awk '{print $2}' || echo "")

--- a/scripts/hub-secret-integration-test.sh
+++ b/scripts/hub-secret-integration-test.sh
@@ -326,7 +326,7 @@ setup_test_grove() {
     fi
 
     # Extract the grove ID for later use
-    GROVE_ID=$($SCION config get grove_id 2>/dev/null || "")
+    GROVE_ID=$($SCION config get grove_id 2>/dev/null || echo "")
     if [[ -z "$GROVE_ID" ]]; then
         # Fall back to reading settings.yaml directly
         GROVE_ID=$(grep 'grove_id:' "$grove_dir/.scion/settings.yaml" 2>/dev/null | awk '{print $2}' || echo "")

--- a/scripts/pr-deps.sh
+++ b/scripts/pr-deps.sh
@@ -41,11 +41,15 @@
 set -euo pipefail
 
 # --- Colors ---
+# shellcheck disable=SC2034 # part of the standard colour palette, kept complete
 RED='\033[0;31m'
+# shellcheck disable=SC2034 # part of the standard colour palette, kept complete
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
+# shellcheck disable=SC2034 # part of the standard colour palette, kept complete
 CYAN='\033[0;36m'
 BOLD='\033[1m'
+# shellcheck disable=SC2034 # part of the standard colour palette, kept complete
 DIM='\033[2m'
 RESET='\033[0m'
 
@@ -225,14 +229,14 @@ infer_dependencies() {
     # that i depends on (i.e., whose tip is an ancestor of i's tip)
     local -a ancestors_of
     for ((i = 0; i < count; i++)); do
-        ancestors_of[$i]=""
+        ancestors_of[i]=""
         for ((j = 0; j < count; j++)); do
             if [ "$i" -eq "$j" ]; then
                 continue
             fi
             # Is j's tip an ancestor of i's tip? If so, i depends on j.
             if git merge-base --is-ancestor "${ref_arr[$j]}" "${ref_arr[$i]}" 2>/dev/null; then
-                ancestors_of[$i]="${ancestors_of[$i]} $j"
+                ancestors_of[i]="${ancestors_of[i]} $j"
             fi
         done
     done

--- a/scripts/pr-deps.sh
+++ b/scripts/pr-deps.sh
@@ -465,7 +465,7 @@ cmd_files() {
     # Fetch file lists into a temp dir (one file per PR)
     local tmpdir
     tmpdir=$(mktemp -d)
-    trap 'rm -rf "$tmpdir"' EXIT
+    trap '[ -n "${tmpdir:-}" ] && rm -rf "$tmpdir"' EXIT
 
     for num in $pr_numbers; do
         # shellcheck disable=SC2086

--- a/scripts/starter-hub/gce-certs.sh
+++ b/scripts/starter-hub/gce-certs.sh
@@ -18,6 +18,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hub-config.sh
 source "${SCRIPT_DIR}/hub-config.sh"
 
 DOMAIN="${CERT_DOMAIN}"

--- a/scripts/starter-hub/gce-demo-cluster.sh
+++ b/scripts/starter-hub/gce-demo-cluster.sh
@@ -18,6 +18,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hub-config.sh
 source "${SCRIPT_DIR}/hub-config.sh"
 
 function delete_resources() {
@@ -54,7 +55,7 @@ if ! gcloud container clusters describe "${CLUSTER_NAME}" --region "${REGION}" -
         --region "${REGION}" \
         --project "${PROJECT_ID}" \
         --release-channel "regular" \
-        --labels=env=${HUB_NAME},project=scion,type=scion-hub-cluster
+        --labels=env="${HUB_NAME}",project=scion,type=scion-hub-cluster
 else
     echo "Cluster '${CLUSTER_NAME}' already exists."
 fi

--- a/scripts/starter-hub/gce-demo-deploy.sh
+++ b/scripts/starter-hub/gce-demo-deploy.sh
@@ -18,6 +18,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hub-config.sh
 source "${SCRIPT_DIR}/hub-config.sh"
 
 echo "=== Scion Hub Full Deployment: ${HUB_NAME} ==="

--- a/scripts/starter-hub/gce-demo-preflight.sh
+++ b/scripts/starter-hub/gce-demo-preflight.sh
@@ -26,6 +26,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hub-config.sh
 source "${SCRIPT_DIR}/hub-config.sh"
 
 # ---------------------------------------------------------------------------

--- a/scripts/starter-hub/gce-demo-provision.sh
+++ b/scripts/starter-hub/gce-demo-provision.sh
@@ -18,6 +18,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hub-config.sh
 source "${SCRIPT_DIR}/hub-config.sh"
 
 if [[ -z "$PROJECT_ID" ]]; then
@@ -106,7 +107,7 @@ if [[ "${INSTANCE_EXISTS}" == "false" ]]; then
             echo "2) Medium (~50 agents)     - n2-standard-16 (16 vCPU, 64GB)"
             echo "3) Large  (100s of agents) - n2-standard-32 (32 vCPU, 128GB)"
             echo "4) XLarge (~1000 agents)   - n2-standard-128 (128 vCPU, 512GB)"
-            read -p "Select [1-4]: " SIZE_CHOICE
+            read -r -p "Select [1-4]: " SIZE_CHOICE
         fi
 
         case $SIZE_CHOICE in
@@ -124,7 +125,7 @@ fi
 # Prompt for cluster (only when GKE is enabled)
 if [[ "${ENABLE_GKE}" == "true" ]]; then
     if [[ -z "${CREATE_CLUSTER:-}" ]]; then
-        read -p "Create GKE cluster for agents? [y/N]: " CLUSTER_CHOICE
+        read -r -p "Create GKE cluster for agents? [y/N]: " CLUSTER_CHOICE
         if [[ "${CLUSTER_CHOICE,,}" == "y" ]]; then
             CREATE_CLUSTER="true"
         else
@@ -217,8 +218,8 @@ if [[ "${INSTANCE_EXISTS}" == "false" ]]; then
         --service-account="${SERVICE_ACCOUNT_EMAIL}" \
         --scopes=https://www.googleapis.com/auth/cloud-platform \
         --tags=https-server,scion-hub \
-        --labels=env=${HUB_NAME},project=scion,type=scion-hub \
-        --create-disk=auto-delete=yes,boot=yes,device-name=${INSTANCE_NAME},image=projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts,mode=rw,size=200,type=projects/${PROJECT_ID}/zones/${ZONE}/diskTypes/pd-balanced \
+        --labels=env="${HUB_NAME}",project=scion,type=scion-hub \
+        --create-disk=auto-delete=yes,boot=yes,device-name="${INSTANCE_NAME}",image=projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts,mode=rw,size=200,type=projects/"${PROJECT_ID}"/zones/"${ZONE}"/diskTypes/pd-balanced \
         --metadata-from-file=user-data="${CLOUD_INIT_FILE}"
 else
     echo "Skipping instance creation (already exists)."

--- a/scripts/starter-hub/gce-demo-provision.sh
+++ b/scripts/starter-hub/gce-demo-provision.sh
@@ -218,9 +218,9 @@ if [[ "${INSTANCE_EXISTS}" == "false" ]]; then
         --service-account="${SERVICE_ACCOUNT_EMAIL}" \
         --scopes=https://www.googleapis.com/auth/cloud-platform \
         --tags=https-server,scion-hub \
-        --labels=env="${HUB_NAME}",project=scion,type=scion-hub \
-        --create-disk=auto-delete=yes,boot=yes,device-name="${INSTANCE_NAME}",image=projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts,mode=rw,size=200,type=projects/"${PROJECT_ID}"/zones/"${ZONE}"/diskTypes/pd-balanced \
-        --metadata-from-file=user-data="${CLOUD_INIT_FILE}"
+        --labels="env=${HUB_NAME},project=scion,type=scion-hub" \
+        --create-disk="auto-delete=yes,boot=yes,device-name=${INSTANCE_NAME},image=projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts,mode=rw,size=200,type=projects/${PROJECT_ID}/zones/${ZONE}/diskTypes/pd-balanced" \
+        --metadata-from-file="user-data=${CLOUD_INIT_FILE}"
 else
     echo "Skipping instance creation (already exists)."
 fi

--- a/scripts/starter-hub/gce-demo-setup-repo.sh
+++ b/scripts/starter-hub/gce-demo-setup-repo.sh
@@ -18,6 +18,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hub-config.sh
 source "${SCRIPT_DIR}/hub-config.sh"
 
 REPO="${GITHUB_REPO}"

--- a/scripts/starter-hub/gce-demo-telemetry-sa.sh
+++ b/scripts/starter-hub/gce-demo-telemetry-sa.sh
@@ -31,6 +31,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hub-config.sh
 source "${SCRIPT_DIR}/hub-config.sh"
 
 SA_NAME="scion-telemetry-writer"

--- a/scripts/starter-hub/gce-setup-nats.sh
+++ b/scripts/starter-hub/gce-setup-nats.sh
@@ -23,6 +23,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hub-config.sh
 source "${SCRIPT_DIR}/hub-config.sh"
 
 # --- Create systemd unit file ---
@@ -76,6 +77,7 @@ gcloud compute scp "$TMP_CONF" "${INSTANCE_NAME}:/tmp/nats-server.conf" --zone="
 rm "$TMP_SERVICE" "$TMP_CONF"
 
 # --- Install and configure on instance ---
+# shellcheck disable=SC2016 # remote script: $vars must expand on the remote host, not locally
 gcloud compute ssh "${INSTANCE_NAME}" --zone="${ZONE}" --command '
     set -euo pipefail
 

--- a/scripts/starter-hub/gce-start-hub.sh
+++ b/scripts/starter-hub/gce-start-hub.sh
@@ -126,7 +126,7 @@ if $FULL_DEPLOY; then
 
     # Prepare all temp files locally
     UPLOAD_DIR=$(mktemp -d)
-    trap 'rm -rf "$UPLOAD_DIR"' EXIT
+    trap '[ -n "${UPLOAD_DIR:-}" ] && rm -rf "$UPLOAD_DIR"' EXIT
 
     # hub.env
     HAS_HUB_ENV=false

--- a/scripts/starter-hub/gce-start-hub.sh
+++ b/scripts/starter-hub/gce-start-hub.sh
@@ -25,6 +25,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hub-config.sh
 source "${SCRIPT_DIR}/hub-config.sh"
 
 DOMAIN="${HUB_DOMAIN}"
@@ -125,7 +126,7 @@ if $FULL_DEPLOY; then
 
     # Prepare all temp files locally
     UPLOAD_DIR=$(mktemp -d)
-    trap "rm -rf $UPLOAD_DIR" EXIT
+    trap 'rm -rf "$UPLOAD_DIR"' EXIT
 
     # hub.env
     HAS_HUB_ENV=false
@@ -241,6 +242,7 @@ if $FULL_DEPLOY; then
         echo "  -> Installed hub.env"'
     fi
 
+    # shellcheck disable=SC2016 # remote script: $vars must expand on the remote host, not locally
     FULL_REMOTE_COMMANDS='
     # Place uploaded config files
     echo ""
@@ -322,6 +324,7 @@ fi
 
 FULL_POST_INSTALL_COMMANDS=""
 if $FULL_DEPLOY; then
+    # shellcheck disable=SC2016 # remote script: $vars must expand on the remote host, not locally
     FULL_POST_INSTALL_COMMANDS='
     # Update systemd unit file if changed
     echo ""
@@ -396,6 +399,7 @@ fi
 
 step "Remote: pull, build, restart..."
 
+# shellcheck disable=SC2016 # remote script: $vars must expand on the remote host, not locally
 gcloud compute ssh "${INSTANCE_NAME}" --zone="${ZONE}" --command '
     set -euo pipefail
     RESET_DB='"${RESET_DB}"'

--- a/scripts/template-integration-test.sh
+++ b/scripts/template-integration-test.sh
@@ -34,6 +34,11 @@
 #   --help           Show this help message
 #
 
+# shellcheck disable=SC2155
+# SC2155 (declare and assign separately) is intentionally disabled for this file.
+# Under `set -e`, splitting `local x=$(curl ...)` would make the script abort on the
+# first failed request. This suite deliberately masks the exit status so it can
+# inspect the response body and emit a proper `log_error` diagnostic instead.
 set -e
 
 # Colors for output
@@ -733,9 +738,11 @@ test_cli_commands() {
 
     # Test CLI.3: Modify template locally and push changes
     log_info "Test CLI.3: scion template push (after modification)..."
-    echo "" >> "$grove_template_dir/agents.md"
-    echo "## Updated" >> "$grove_template_dir/agents.md"
-    echo "- Added by integration test push verification" >> "$grove_template_dir/agents.md"
+    {
+        echo ""
+        echo "## Updated"
+        echo "- Added by integration test push verification"
+    } >> "$grove_template_dir/agents.md"
 
     if $TEST_DIR/scion template push "$template_name" \
         --hub "$hub_url" 2>&1; then

--- a/scripts/vm-pulse.sh
+++ b/scripts/vm-pulse.sh
@@ -50,7 +50,8 @@ print_header "SCHEDULER & THREAD DENSITY"
 check_tool "vmstat" && vmstat 1 3
 
 echo -e "\n${BOLD}Total Daemon Threads (dockerd/containerd):${NC}"
-ps -eLo comm,pid | grep -E 'dockerd|containerd' | wc -l
+# shellcheck disable=SC2009 # counting threads (ps -eLo); pgrep cannot count threads
+ps -eLo comm,pid | grep -cE 'dockerd|containerd'
 
 echo -e "\n${BOLD}Top 10 Thread-Heavy Processes:${NC}"
 ps -eo nlwp,pid,args --sort=-nlwp | head -n 11


### PR DESCRIPTION
Adds a standalone `shellcheck` job to .github/workflows/ci.yml and clears every finding across the repository's 49 shell scripts (10,073 lines).

Baseline before this change: 25/49 files clean, 24/49 with findings
(85 total: 2 error, 51 warning, 32 note). After: 49/49 clean.

Real defects fixed:

- SC2286 (error, x2) in scripts/hub-env-integration-test.sh:328 and scripts/hub-secret-integration-test.sh:329. `GROVE_ID=$(... || "")` executes the empty string as a command name; the intended form (`|| echo ""`) already appears two lines below in both files.
- SC2013 in docs-site/check-d2.sh: `for f in $(grep -rl ...)` word-split on filenames containing spaces. Now a `while read` loop, verified against a filename with a space.
- SC2064 (x3): `trap "rm -rf ${DIR}" EXIT` expanded at trap-definition time rather than at signal time. Now single-quoted.
- SC2086 (x5): unquoted expansions in gcloud --labels and --create-disk.
- SC2162 (x2): `read` without -r mangled backslashes in interactive prompts.
- SC2034: removed a dead REPO_ROOT in hack/test_oauth.sh and an unused `load` variable in local-podman.sh (--load is implicit for podman).
- SC2004, SC2126, SC2129, SC2001: arithmetic and redirect cleanups.

Suppressions, each documented inline with its rationale:

- SC2016 (x7): remote scripts sent over `gcloud compute ssh`, where `$vars` must expand on the remote host rather than locally.
- SC2034 (x5): BUILDER_MODE/ALL_TARGETS are read by the parent that sources these library files; plus four colour-palette constants kept complete.
- SC2155 (x38, file-level in scripts/template-integration-test.sh): under `set -e`, splitting `local x=$(curl ...)` would abort the suite on the first failed request. It deliberately masks exit status so it can inspect the response body and emit a proper log_error diagnostic.

SC1091 is resolved rather than suppressed: the job runs shellcheck with `-x --source-path=SCRIPTDIR`, so `# shellcheck source=` directives resolve relative to each script's own directory and the sourced libraries are actually checked.

The job carries a positive-control comment naming the SC2286 defect above, so a reader can confirm the gate catches real errors. Verified by re-introducing that `|| ""`: the step reports 48/49 and exits 1.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
