### PR TITLE
cmd: accept repeated values for five string-slice flags

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1525,3 +1525,26 @@ func printAutoResolvedBroker(ctx context.Context, hubCtx *HubContext, flagBroker
 		statusf("Using default broker %s\n", resp.Agent.RuntimeBrokerID)
 	}
 }
+
+// splitCommaList normalises a repeatable string-slice flag into a flat list of
+// values. Each occurrence of the flag is additionally split on commas, so the
+// historical comma-separated form and the repeatable form are both accepted and
+// may be freely mixed:
+//
+//	--scopes a,b            -> ["a", "b"]
+//	--scopes a --scopes b   -> ["a", "b"]
+//	--scopes a,b --scopes c -> ["a", "b", "c"]
+//
+// Surrounding whitespace is trimmed and empty entries are dropped.
+func splitCommaList(values []string) []string {
+	var out []string
+	for _, v := range values {
+		for _, part := range strings.Split(v, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				out = append(out, part)
+			}
+		}
+	}
+	return out
+}

--- a/cmd/hub_token.go
+++ b/cmd/hub_token.go
@@ -133,7 +133,7 @@ Examples:
 var (
 	tokenCreateName    string
 	tokenCreateProject string
-	tokenCreateScopes  string
+	tokenCreateScopes  []string
 	tokenCreateExpires string
 	tokenListProject   string
 )
@@ -151,7 +151,7 @@ func init() {
 	_ = hubTokenCreateCmd.Flags().MarkDeprecated("grove", "use --project instead")
 	_ = hubTokenCreateCmd.Flags().MarkHidden("grove")
 
-	hubTokenCreateCmd.Flags().StringVar(&tokenCreateScopes, "scopes", "", "Comma-separated list of scopes (required)")
+	hubTokenCreateCmd.Flags().StringArrayVar(&tokenCreateScopes, "scopes", nil, "Scope to grant (required, repeatable; also accepts a comma-separated list)")
 	hubTokenCreateCmd.Flags().StringVar(&tokenCreateExpires, "expires", "", "Expiry duration (e.g., 30d, 90d, 1y) or RFC 3339 date (default: 90d)")
 
 	_ = hubTokenCreateCmd.MarkFlagRequired("name")
@@ -190,9 +190,9 @@ func runTokenCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to resolve project %q: %w", tokenCreateProject, err)
 	}
 
-	scopes := strings.Split(tokenCreateScopes, ",")
-	for i := range scopes {
-		scopes[i] = strings.TrimSpace(scopes[i])
+	scopes := splitCommaList(tokenCreateScopes)
+	if len(scopes) == 0 {
+		return fmt.Errorf("--scopes must specify at least one scope")
 	}
 
 	var expiresAt *time.Time

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -138,8 +138,11 @@ Examples:
 			return fmt.Errorf("--notify cannot be combined with --broadcast or --all")
 		}
 
-		// Validate --cc restrictions
-		if len(msgCC) > 0 {
+		// Validate --cc restrictions: parse first so empty-string values
+		// (e.g. --cc "") are handled correctly instead of triggering
+		// false-positive validation errors.
+		parsedCC := parseCCFlag(msgCC)
+		if len(parsedCC) > 0 {
 			if msgBroadcast || msgAll {
 				return fmt.Errorf("--cc cannot be combined with --broadcast or --all")
 			}
@@ -272,7 +275,7 @@ Examples:
 		}
 
 		// --cc requires Hub mode
-		if len(msgCC) > 0 && hubCtx == nil {
+		if len(parsedCC) > 0 && hubCtx == nil {
 			return fmt.Errorf("--cc requires Hub mode (use 'scion hub enable' first)")
 		}
 

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -47,7 +47,7 @@ var msgNotify bool
 var msgWake bool
 var msgChannel string
 var msgThreadID string
-var msgCC string
+var msgCC []string
 
 // messageCmd represents the message command
 var messageCmd = &cobra.Command{
@@ -139,7 +139,7 @@ Examples:
 		}
 
 		// Validate --cc restrictions
-		if msgCC != "" {
+		if len(msgCC) > 0 {
 			if msgBroadcast || msgAll {
 				return fmt.Errorf("--cc cannot be combined with --broadcast or --all")
 			}
@@ -272,7 +272,7 @@ Examples:
 		}
 
 		// --cc requires Hub mode
-		if msgCC != "" && hubCtx == nil {
+		if len(msgCC) > 0 && hubCtx == nil {
 			return fmt.Errorf("--cc requires Hub mode (use 'scion hub enable' first)")
 		}
 
@@ -913,9 +913,10 @@ func extractMentions(text string) []string {
 	return messages.ExtractMentions(text)
 }
 
-// parseCCFlag delegates to the shared messages.ParseCCFlag.
-func parseCCFlag(cc string) []string {
-	return messages.ParseCCFlag(cc)
+// parseCCFlag delegates to the shared messages.ParseCCFlags. The --cc flag is
+// repeatable and each occurrence may itself be a comma-separated list.
+func parseCCFlag(cc []string) []string {
+	return messages.ParseCCFlags(cc)
 }
 
 // maxMentionRecipients is an alias for the shared constant.
@@ -1015,7 +1016,7 @@ func init() {
 	messageCmd.Flags().BoolVarP(&msgWake, "wake", "w", false, "Resume a suspended agent before delivering the message")
 	messageCmd.Flags().StringVar(&msgChannel, "channel", "", "Target a specific message channel (e.g. telegram, gchat, web)")
 	messageCmd.Flags().StringVar(&msgThreadID, "thread-id", "", "Target a specific thread within the channel")
-	messageCmd.Flags().StringVar(&msgCC, "cc", "", "CC additional agents (comma-separated names); each receives a mention notification")
+	messageCmd.Flags().StringArrayVar(&msgCC, "cc", nil, "CC an additional agent (repeatable; also accepts a comma-separated list); each receives a mention notification")
 	messageCmd.AddCommand(messageChannelsCmd)
 	rootCmd.AddCommand(messageCmd)
 }

--- a/cmd/message_test.go
+++ b/cmd/message_test.go
@@ -1661,43 +1661,65 @@ func TestExtractMentions_Basic(t *testing.T) {
 func TestParseCCFlag(t *testing.T) {
 	tests := []struct {
 		name string
-		cc   string
+		cc   []string
 		want []string
 	}{
 		{
 			name: "empty",
-			cc:   "",
+			cc:   nil,
+			want: nil,
+		},
+		{
+			name: "single empty string",
+			cc:   []string{""},
 			want: nil,
 		},
 		{
 			name: "single name",
-			cc:   "alice",
+			cc:   []string{"alice"},
 			want: []string{"alice"},
 		},
 		{
 			name: "multiple names",
-			cc:   "alice,bob,charlie",
+			cc:   []string{"alice,bob,charlie"},
 			want: []string{"alice", "bob", "charlie"},
 		},
 		{
 			name: "whitespace trimmed",
-			cc:   " alice , bob , charlie ",
+			cc:   []string{" alice , bob , charlie "},
 			want: []string{"alice", "bob", "charlie"},
 		},
 		{
 			name: "empty entries skipped",
-			cc:   "alice,,bob",
+			cc:   []string{"alice,,bob"},
 			want: []string{"alice", "bob"},
 		},
 		{
 			name: "duplicates removed",
-			cc:   "alice,bob,alice",
+			cc:   []string{"alice,bob,alice"},
 			want: []string{"alice", "bob"},
 		},
 		{
 			name: "case insensitive dedup",
-			cc:   "Alice,alice",
+			cc:   []string{"Alice,alice"},
 			want: []string{"Alice"},
+		},
+		{
+			// The repeatable form: previously only the last occurrence
+			// survived, so "alice" was silently dropped.
+			name: "repeated flag accumulates",
+			cc:   []string{"alice", "bob"},
+			want: []string{"alice", "bob"},
+		},
+		{
+			name: "repeated and comma forms mixed",
+			cc:   []string{"alice,bob", "charlie"},
+			want: []string{"alice", "bob", "charlie"},
+		},
+		{
+			name: "dedup across occurrences",
+			cc:   []string{"alice", "Alice", "bob"},
+			want: []string{"alice", "bob"},
 		},
 	}
 
@@ -1733,7 +1755,7 @@ func TestSendMessageViaHub_MentionFanOut(t *testing.T) {
 
 	// Reset CC flag
 	origCC := msgCC
-	msgCC = ""
+	msgCC = nil
 	defer func() { msgCC = origCC }()
 
 	err = sendMessageViaHub(hubCtx, "primary-agent", "hey @mentioned-agent check this", false, false, false, false, false)
@@ -1777,7 +1799,7 @@ func TestSendMessageViaHub_MentionDedup(t *testing.T) {
 	}
 
 	origCC := msgCC
-	msgCC = ""
+	msgCC = nil
 	defer func() { msgCC = origCC }()
 
 	// Primary recipient is also @mentioned in body — should be deduplicated
@@ -1812,7 +1834,7 @@ func TestSendMessageViaHub_UnknownMentionWarns(t *testing.T) {
 	}
 
 	origCC := msgCC
-	msgCC = ""
+	msgCC = nil
 	defer func() { msgCC = origCC }()
 
 	// @nonexistent doesn't match any agent — should warn but not fail
@@ -1847,7 +1869,7 @@ func TestSendMessageViaHub_CCFlag(t *testing.T) {
 	}
 
 	origCC := msgCC
-	msgCC = "cc-agent-1,cc-agent-2"
+	msgCC = []string{"cc-agent-1", "cc-agent-2"}
 	defer func() { msgCC = origCC }()
 
 	err = sendMessageViaHub(hubCtx, "primary-agent", "check this out", false, false, false, false, false)
@@ -1890,7 +1912,7 @@ func TestSendMessageViaHub_CCAndMentionCombined(t *testing.T) {
 	}
 
 	origCC := msgCC
-	msgCC = "cc-agent"
+	msgCC = []string{"cc-agent"}
 	defer func() { msgCC = origCC }()
 
 	// Both @mention in body and --cc flag
@@ -1927,7 +1949,7 @@ func TestSendMessageViaHub_CCDedupWithMention(t *testing.T) {
 	}
 
 	origCC := msgCC
-	msgCC = "shared-agent"
+	msgCC = []string{"shared-agent"}
 	defer func() { msgCC = origCC }()
 
 	// Same agent in both @mention and --cc — should only get one mention
@@ -1962,7 +1984,7 @@ func TestSendMessageViaHub_NoMentionsInBody(t *testing.T) {
 	}
 
 	origCC := msgCC
-	msgCC = ""
+	msgCC = nil
 	defer func() { msgCC = origCC }()
 
 	// No mentions in body, no --cc — only primary should be sent
@@ -1997,7 +2019,7 @@ func TestSendGroupMessageViaHub_MentionFanOut(t *testing.T) {
 
 	// Reset CC flag
 	origCC := msgCC
-	msgCC = ""
+	msgCC = nil
 	defer func() { msgCC = origCC }()
 
 	recipients := []messages.GroupRecipient{
@@ -2038,7 +2060,7 @@ func TestSendGroupMessageViaHub_MentionFanOut(t *testing.T) {
 func TestCCFlagValidation(t *testing.T) {
 	tests := []struct {
 		name      string
-		cc        string
+		cc        []string
 		broadcast bool
 		all       bool
 		raw       bool
@@ -2049,37 +2071,37 @@ func TestCCFlagValidation(t *testing.T) {
 	}{
 		{
 			name:      "cc with broadcast",
-			cc:        "agent-a",
+			cc:        []string{"agent-a"},
 			broadcast: true,
 			wantErr:   "--cc cannot be combined with --broadcast or --all",
 		},
 		{
 			name:    "cc with all",
-			cc:      "agent-a",
+			cc:      []string{"agent-a"},
 			all:     true,
 			wantErr: "--cc cannot be combined with --broadcast or --all",
 		},
 		{
 			name:    "cc with raw",
-			cc:      "agent-a",
+			cc:      []string{"agent-a"},
 			raw:     true,
 			wantErr: "--cc cannot be combined with --raw",
 		},
 		{
 			name:      "cc with user recipient",
-			cc:        "agent-a",
+			cc:        []string{"agent-a"},
 			userRecip: true,
 			wantErr:   "--cc cannot be used with user recipients",
 		},
 		{
 			name:    "cc with --in scheduling",
-			cc:      "agent-a",
+			cc:      []string{"agent-a"},
 			in:      "5m",
 			wantErr: "--cc cannot be combined with --in or --at",
 		},
 		{
 			name:    "cc with --at scheduling",
-			cc:      "agent-a",
+			cc:      []string{"agent-a"},
 			at:      "2026-01-01 12:00",
 			wantErr: "--cc cannot be combined with --in or --at",
 		},

--- a/cmd/notifications.go
+++ b/cmd/notifications.go
@@ -34,12 +34,12 @@ var (
 
 	subscribeAgent    string
 	subscribeProject  string
-	subscribeTriggers string
+	subscribeTriggers []string
 
 	unsubscribeAll     bool
 	unsubscribeProject string
 
-	updateTriggers string
+	updateTriggers []string
 
 	subscriptionsProject string
 	subscriptionsJSON    bool
@@ -165,7 +165,7 @@ func init() {
 	notificationsSubscribeCmd.Flags().StringVar(&subscribeProject, "grove", "", "Deprecated alias for --project")
 	_ = notificationsSubscribeCmd.Flags().MarkDeprecated("grove", "use --project instead")
 	_ = notificationsSubscribeCmd.Flags().MarkHidden("grove")
-	notificationsSubscribeCmd.Flags().StringVar(&subscribeTriggers, "triggers", "", "Comma-separated trigger activities (default: COMPLETED,WAITING_FOR_INPUT,LIMITS_EXCEEDED)")
+	notificationsSubscribeCmd.Flags().StringArrayVar(&subscribeTriggers, "triggers", nil, "Trigger activity (repeatable; also accepts a comma-separated list) (default: COMPLETED,WAITING_FOR_INPUT,LIMITS_EXCEEDED)")
 
 	// Unsubscribe flags
 	notificationsUnsubscribeCmd.Flags().BoolVar(&unsubscribeAll, "all", false, "Remove all subscriptions in the project")
@@ -175,7 +175,7 @@ func init() {
 	_ = notificationsUnsubscribeCmd.Flags().MarkHidden("grove")
 
 	// Update flags
-	notificationsUpdateCmd.Flags().StringVar(&updateTriggers, "triggers", "", "Comma-separated trigger activities (required)")
+	notificationsUpdateCmd.Flags().StringArrayVar(&updateTriggers, "triggers", nil, "Trigger activity (required, repeatable; also accepts a comma-separated list)")
 	_ = notificationsUpdateCmd.MarkFlagRequired("triggers")
 
 	// Subscriptions list flags
@@ -357,11 +357,8 @@ func runNotificationsSubscribe(cmd *cobra.Command, args []string) error {
 
 	// Parse triggers
 	triggers := defaultTriggers
-	if subscribeTriggers != "" {
-		triggers = strings.Split(subscribeTriggers, ",")
-		for i := range triggers {
-			triggers[i] = strings.TrimSpace(triggers[i])
-		}
+	if parsed := splitCommaList(subscribeTriggers); len(parsed) > 0 {
+		triggers = parsed
 	}
 
 	req := &hubclient.CreateSubscriptionRequest{
@@ -402,11 +399,7 @@ func runNotificationsUpdate(cmd *cobra.Command, args []string) error {
 
 	subID := args[0]
 
-	triggers := strings.Split(updateTriggers, ",")
-	for i := range triggers {
-		triggers[i] = strings.TrimSpace(triggers[i])
-	}
-
+	triggers := splitCommaList(updateTriggers)
 	if len(triggers) == 0 {
 		return fmt.Errorf("--triggers must specify at least one trigger activity")
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -46,8 +46,9 @@ var (
 	// Auto-provide flag for runtime broker
 	serverAutoProvide bool
 
-	// Admin emails for bootstrapping - comma-separated list
-	adminEmails string
+	// Admin emails for bootstrapping - repeatable, each value may be a
+	// comma-separated list
+	adminEmails []string
 
 	// Web frontend flags
 	enableWeb        bool
@@ -276,7 +277,7 @@ func init() {
 	serverStartCmd.Flags().StringVar(&webBaseURL, "base-url", "", "Public base URL for OAuth redirects (e.g., https://scion.example.com)")
 
 	// Admin bootstrap flags
-	serverStartCmd.Flags().StringVar(&adminEmails, "admin-emails", "", "Comma-separated list of email addresses to auto-promote to admin role")
+	serverStartCmd.Flags().StringArrayVar(&adminEmails, "admin-emails", nil, "Email address to auto-promote to admin role (repeatable; also accepts a comma-separated list)")
 
 	// Stop flags
 	serverStopCmd.Flags().BoolVar(&stopForce, "force", false, "Kill any process listening on the server ports, even without a PID file")

--- a/cmd/server_daemon.go
+++ b/cmd/server_daemon.go
@@ -134,7 +134,11 @@ func buildDaemonStartArgs(cmd *cobra.Command) []string {
 		daemonArgs = append(daemonArgs, fmt.Sprintf("--base-url=%s", webBaseURL))
 	}
 	if cmd.Flags().Changed("admin-emails") {
-		daemonArgs = append(daemonArgs, fmt.Sprintf("--admin-emails=%s", adminEmails))
+		// Forwarded as a single comma-joined value rather than repeated flags:
+		// the daemon argv is persisted to server-args.json for restart, and the
+		// one-arg form keeps that file byte-compatible with existing installs.
+		// The flag still accepts a comma-separated list, so this round-trips.
+		daemonArgs = append(daemonArgs, fmt.Sprintf("--admin-emails=%s", strings.Join(adminEmails, ",")))
 	}
 	if globalMode {
 		daemonArgs = append(daemonArgs, "--global")

--- a/cmd/server_daemon_test.go
+++ b/cmd/server_daemon_test.go
@@ -72,12 +72,14 @@ func TestBuildDaemonStartArgsForwardsExplicitFlags(t *testing.T) {
 	resetServerFlags()
 	// Globals resetServerFlags doesn't cover:
 	noAutoMigrate, enableTestLogin, simulateRemoteBroker = false, false, false
-	templateCacheDir, webAssetsDir, webBaseURL, adminEmails = "", "", "", ""
+	templateCacheDir, webAssetsDir, webBaseURL = "", "", ""
+	adminEmails = nil
 	templateCacheMax, globalMode = 0, false
 	defer func() {
 		resetServerFlags()
 		noAutoMigrate, enableTestLogin, simulateRemoteBroker = false, false, false
-		templateCacheDir, webAssetsDir, webBaseURL, adminEmails = "", "", "", ""
+		templateCacheDir, webAssetsDir, webBaseURL = "", "", ""
+		adminEmails = nil
 		templateCacheMax, globalMode = 0, false
 	}()
 
@@ -95,7 +97,7 @@ func TestBuildDaemonStartArgsForwardsExplicitFlags(t *testing.T) {
 	f.StringVar(&webAssetsDir, "web-assets-dir", "", "")
 	f.StringVar(&webSessionSecret, "session-secret", "", "")
 	f.StringVar(&webBaseURL, "base-url", "", "")
-	f.StringVar(&adminEmails, "admin-emails", "", "")
+	f.StringArrayVar(&adminEmails, "admin-emails", nil, "")
 
 	c.SetArgs([]string{
 		"--hosted=false",     // explicit mode disable must survive the re-exec

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1398,15 +1398,8 @@ func iapAudienceToCloudRunURL(audience string) string {
 
 // parseAdminEmails parses admin emails from the flag or config.
 func parseAdminEmails(cfg *config.GlobalConfig) []string {
-	var adminEmailList []string
-	if adminEmails != "" {
-		for _, email := range strings.Split(adminEmails, ",") {
-			email = strings.TrimSpace(email)
-			if email != "" {
-				adminEmailList = append(adminEmailList, email)
-			}
-		}
-	} else if len(cfg.Hub.AdminEmails) > 0 {
+	adminEmailList := splitCommaList(adminEmails)
+	if len(adminEmailList) == 0 && len(cfg.Hub.AdminEmails) > 0 {
 		adminEmailList = cfg.Hub.AdminEmails
 	}
 	if len(adminEmailList) > 0 {
@@ -2109,18 +2102,11 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 
 	// Resolve authorized domains and admin email list for the web server
 	var webAuthorizedDomains []string
-	var webAdminEmails []string
 	if len(cfg.Auth.AuthorizedDomains) > 0 {
 		webAuthorizedDomains = cfg.Auth.AuthorizedDomains
 	}
-	if adminEmails != "" {
-		for _, email := range strings.Split(adminEmails, ",") {
-			email = strings.TrimSpace(email)
-			if email != "" {
-				webAdminEmails = append(webAdminEmails, email)
-			}
-		}
-	} else if len(cfg.Hub.AdminEmails) > 0 {
+	webAdminEmails := splitCommaList(adminEmails)
+	if len(webAdminEmails) == 0 && len(cfg.Hub.AdminEmails) > 0 {
 		webAdminEmails = cfg.Hub.AdminEmails
 	}
 

--- a/pkg/messages/mentions.go
+++ b/pkg/messages/mentions.go
@@ -81,6 +81,18 @@ func ParseCCFlag(cc string) []string {
 	return names
 }
 
+// ParseCCFlags parses a repeatable --cc flag into a slice of agent names.
+// Each occurrence may itself be a comma-separated list, so the historical
+// comma-separated form and the repeatable form are both accepted and may be
+// mixed. Names are whitespace-trimmed and de-duplicated case-insensitively
+// across all occurrences, preserving first-seen order.
+func ParseCCFlags(cc []string) []string {
+	if len(cc) == 0 {
+		return nil
+	}
+	return ParseCCFlag(strings.Join(cc, ","))
+}
+
 // AgentInfo holds the minimal agent data needed for mention resolution.
 type AgentInfo struct {
 	Slug string


### PR DESCRIPTION
Five flags were declared with StringVar, so passing the flag more than once kept only the last occurrence and silently discarded the earlier ones:

  --admin-emails  (server start)
  --cc            (message)
  --scopes        (hub token create)
  --triggers      (notifications subscribe)
  --triggers      (notifications update)

All five are semantically lists and were already documented as comma-separated. Switch them to StringArrayVar so repeating the flag accumulates, matching the existing repeatable-flag idiom used by --label, --exclude and --attach.

The comma-separated form is retained. A new splitCommaList helper splits each occurrence on commas, so the historical form, the repeatable form, and a mix of the two all work. This keeps existing command lines, scripts and stored server args working unchanged.

Downstream updates:
  - parseAdminEmails and initWebServer use splitCommaList instead of an inline strings.Split.
  - buildDaemonStartArgs joins the values back into a single --admin-emails=a,b argument, keeping server-args.json byte-compatible with existing installs.
  - runTokenCreate, runNotificationsSubscribe and runNotificationsUpdate use splitCommaList.
  - parseCCFlag takes []string and delegates to a new messages.ParseCCFlags, which preserves case-insensitive dedup across all occurrences.

Two empty-value edge cases change, both toward stricter validation: --scopes "" now reports a clear error instead of sending a single empty scope, and the previously unreachable "--triggers must specify at least one trigger activity" check in notifications update now fires instead of sending an empty trigger.

Tests: TestParseCCFlag gains cases for the repeated, mixed and cross-occurrence-dedup forms.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
