### PR TITLE
feat(web-chat): Phase 5 — Differentiator features

### DIFF
--- a/pkg/hub/chat_idempotency.go
+++ b/pkg/hub/chat_idempotency.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"sync"
+	"time"
+)
+
+// chatIdempotencyTTL is how long an idempotency key is remembered.
+const chatIdempotencyTTL = 5 * time.Minute
+
+// idempotencyCacheCleanupThreshold is the number of entries beyond which
+// an amortized sweep of expired entries is triggered.
+const idempotencyCacheCleanupThreshold = 100
+
+// idempotencyCacheKey is the map key for the cache. Using a struct instead
+// of string concatenation avoids the need for a separator character and
+// makes collisions impossible.
+type idempotencyCacheKey struct {
+	senderID       string
+	idempotencyKey string
+}
+
+// chatIdempotencyEntry stores a cached idempotency result.
+type chatIdempotencyEntry struct {
+	messageID string
+	expiresAt time.Time
+}
+
+// ChatIdempotencyCache is a lightweight in-memory cache keyed by
+// (senderID, idempotencyKey). Entries expire after 5 minutes.
+// It is safe for concurrent use.
+type ChatIdempotencyCache struct {
+	mu          sync.Mutex
+	entries     map[idempotencyCacheKey]chatIdempotencyEntry
+	nextCleanup time.Time
+}
+
+// NewChatIdempotencyCache creates a new empty idempotency cache.
+func NewChatIdempotencyCache() *ChatIdempotencyCache {
+	return &ChatIdempotencyCache{
+		entries: make(map[idempotencyCacheKey]chatIdempotencyEntry),
+	}
+}
+
+// Check returns the existing message ID if the (senderID, idempotencyKey)
+// pair was seen within the TTL window.
+func (c *ChatIdempotencyCache) Check(senderID, idempotencyKey string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	// Rate-limited amortized cleanup: only sweep when cache grows beyond
+	// threshold AND enough time has passed since the last sweep.
+	if len(c.entries) > idempotencyCacheCleanupThreshold && now.After(c.nextCleanup) {
+		c.cleanExpiredLocked(now)
+		c.nextCleanup = now.Add(chatIdempotencyTTL)
+	}
+
+	key := idempotencyCacheKey{senderID: senderID, idempotencyKey: idempotencyKey}
+	entry, ok := c.entries[key]
+	if !ok {
+		return "", false
+	}
+	if now.After(entry.expiresAt) {
+		delete(c.entries, key)
+		return "", false
+	}
+	return entry.messageID, true
+}
+
+// Record stores a (senderID, idempotencyKey) -> messageID mapping.
+func (c *ChatIdempotencyCache) Record(senderID, idempotencyKey, messageID string) {
+	if idempotencyKey == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	// Rate-limited amortized cleanup in Record too, so entries never
+	// accumulate unboundedly even if Check() is rarely called.
+	if len(c.entries) > idempotencyCacheCleanupThreshold && now.After(c.nextCleanup) {
+		c.cleanExpiredLocked(now)
+		c.nextCleanup = now.Add(chatIdempotencyTTL)
+	}
+
+	key := idempotencyCacheKey{senderID: senderID, idempotencyKey: idempotencyKey}
+	c.entries[key] = chatIdempotencyEntry{
+		messageID: messageID,
+		expiresAt: now.Add(chatIdempotencyTTL),
+	}
+}
+
+// cleanExpiredLocked removes entries whose TTL has passed.
+// Must be called with c.mu held.
+func (c *ChatIdempotencyCache) cleanExpiredLocked(now time.Time) {
+	for key, entry := range c.entries {
+		if now.After(entry.expiresAt) {
+			delete(c.entries, key)
+		}
+	}
+}

--- a/pkg/hub/chat_idempotency_test.go
+++ b/pkg/hub/chat_idempotency_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+func TestChatIdempotencyCache_CheckAndRecord(t *testing.T) {
+	c := NewChatIdempotencyCache()
+
+	// Before recording, Check should return false.
+	_, ok := c.Check("user1", "key1")
+	if ok {
+		t.Fatal("expected Check to return false for unknown key")
+	}
+
+	// Record and then Check should return the message ID.
+	c.Record("user1", "key1", "msg-abc")
+	id, ok := c.Check("user1", "key1")
+	if !ok {
+		t.Fatal("expected Check to return true after Record")
+	}
+	if id != "msg-abc" {
+		t.Errorf("expected message ID %q, got %q", "msg-abc", id)
+	}
+}
+
+func TestChatIdempotencyCache_DifferentSenders(t *testing.T) {
+	c := NewChatIdempotencyCache()
+
+	c.Record("user1", "key1", "msg-1")
+	c.Record("user2", "key1", "msg-2")
+
+	id1, ok1 := c.Check("user1", "key1")
+	id2, ok2 := c.Check("user2", "key1")
+
+	if !ok1 || id1 != "msg-1" {
+		t.Errorf("user1: expected msg-1, got %q (ok=%v)", id1, ok1)
+	}
+	if !ok2 || id2 != "msg-2" {
+		t.Errorf("user2: expected msg-2, got %q (ok=%v)", id2, ok2)
+	}
+}
+
+func TestChatIdempotencyCache_EmptyKeySkipped(t *testing.T) {
+	c := NewChatIdempotencyCache()
+
+	c.Record("user1", "", "msg-no-key")
+	_, ok := c.Check("user1", "")
+	if ok {
+		t.Fatal("empty idempotency key should not be recorded")
+	}
+}
+
+func TestChatIdempotencyCache_ExpiresAfterTTL(t *testing.T) {
+	c := NewChatIdempotencyCache()
+
+	c.Record("user1", "key1", "msg-1")
+
+	// Manually expire the entry.
+	c.mu.Lock()
+	for k := range c.entries {
+		c.entries[k] = chatIdempotencyEntry{
+			messageID: "msg-1",
+			expiresAt: time.Now().Add(-1 * time.Second),
+		}
+	}
+	c.mu.Unlock()
+
+	_, ok := c.Check("user1", "key1")
+	if ok {
+		t.Fatal("expected expired entry to be cleaned up")
+	}
+}

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -778,8 +778,8 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
 	var body struct {
 		Content        string   `json:"content"`
-		Attachments    []string `json:"attachments,omitempty"`    // W7: attachment IDs
-		ReplyToID      string   `json:"reply_to_id,omitempty"`   // Phase-3: reply/quote
+		Attachments    []string `json:"attachments,omitempty"` // W7: attachment IDs
+		ReplyToID      string   `json:"reply_to_id,omitempty"` // Phase-3: reply/quote
 		IdempotencyKey string   `json:"idempotency_key,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -1038,6 +1038,18 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 		}
 	}
 
+	// Phase-3: Store reply-to reference if provided.
+	if replyToID != "" {
+		s.mu.RLock()
+		replyWcs := s.webChatStore
+		s.mu.RUnlock()
+		if replyWcs != nil {
+			if err := replyWcs.SetMessageReplyTo(ctx, storeMsg.ID, replyToID); err != nil {
+				slog.Error("Failed to store reply_to_id", "messageId", storeMsg.ID, "replyToId", replyToID, "error", err)
+			}
+		}
+	}
+
 	// W7: Link attachments to the persisted message.
 	s.mu.RLock()
 	linkWcs := s.webChatStore
@@ -1184,6 +1196,13 @@ func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, p
 	if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to persist message", nil)
 		return
+	}
+
+	// Phase-3: Store reply-to reference if provided.
+	if replyToID != "" && wcs != nil {
+		if err := wcs.SetMessageReplyTo(ctx, storeMsg.ID, replyToID); err != nil {
+			slog.Error("Failed to store reply_to_id", "messageId", storeMsg.ID, "replyToId", replyToID, "error", err)
+		}
 	}
 
 	// Phase-3: Store reply-to reference if provided.
@@ -1405,11 +1424,15 @@ func (s *Server) handleMessageDelete(w http.ResponseWriter, r *http.Request, key
 		projectID = ""
 	}
 
-	// Soft-delete: set deleted_at in extension table.
+	// Soft-delete: set deleted_at in extension table and redact content
+	// in the main messages table so no other component can read it.
 	now := time.Now().UTC()
 	if err := wcs.SetMessageDeleted(ctx, messageID, now); err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to delete message", nil)
 		return
+	}
+	if err := wcs.UpdateMessageContent(ctx, messageID, ""); err != nil {
+		slog.Error("Failed to clear message content on delete", "messageId", messageID, "error", err)
 	}
 
 	// Publish SSE event.

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -777,9 +777,10 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 	// --- Validate body ---
 	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
 	var body struct {
-		Content     string   `json:"content"`
-		Attachments []string `json:"attachments,omitempty"` // W7: attachment IDs
-		ReplyToID   string   `json:"reply_to_id,omitempty"` // Phase-3: reply/quote
+		Content        string   `json:"content"`
+		Attachments    []string `json:"attachments,omitempty"`    // W7: attachment IDs
+		ReplyToID      string   `json:"reply_to_id,omitempty"`   // Phase-3: reply/quote
+		IdempotencyKey string   `json:"idempotency_key,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		BadRequest(w, "invalid request body")
@@ -820,6 +821,26 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 				MimeType: meta.MimeType,
 				Size:     meta.Size,
 			})
+		}
+	}
+
+	// --- Idempotency check (#1055) ---
+	// If the client supplied an idempotency key, check whether a message with
+	// that key from this sender was already created recently. If so, return
+	// the existing message ID (200 OK) instead of creating a duplicate.
+	if body.IdempotencyKey != "" {
+		if existingID, ok := s.chatIdempotency.Check(user.ID(), body.IdempotencyKey); ok {
+			// Idempotency hit: return the existing message ID.
+			// We return the minimal response (ID + current content) rather than
+			// re-fetching the stored message, because the client already received
+			// the full 201 response on the original send. This response only
+			// signals "your message was already accepted."
+			writeJSON(w, http.StatusOK, chatMessageResponse{
+				ID:      existingID,
+				Content: content,
+				Sender:  "user:" + user.DisplayName(),
+			})
+			return
 		}
 	}
 
@@ -865,10 +886,21 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 
 	now := time.Now().UTC()
 
+	// Closure to record idempotency after message creation.
+	recordIdempotency := func(messageID string) {
+		if body.IdempotencyKey != "" {
+			s.chatIdempotency.Record(user.ID(), body.IdempotencyKey, messageID)
+		}
+	}
+
 	// Step 3: Determine routing.
 	if len(mentionedAgents) > 0 {
 		// --- Agent-routed: explicit mentions ---
-		s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, mentionedAgents, mentionNames, mentionResults, attachmentRefs, now, body.ReplyToID)
+		msgID := s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, mentionedAgents, mentionNames, mentionResults, attachmentRefs, now, body.ReplyToID)
+		if msgID == "" {
+			return // error response already written by sendAgentRouted
+		}
+		recordIdempotency(msgID)
 		// Ensure DM registry rows exist so the DM appears in the rail.
 		if isDM {
 			s.ensureDMRegistered(ctx, key, user.ID())
@@ -884,7 +916,11 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 		if agentID := parseAgentDMKey(key); agentID != "" {
 			dmAgent, err := s.store.GetAgent(ctx, agentID)
 			if err == nil && dmAgent != nil {
-				s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{dmAgent}, mentionNames, nil, attachmentRefs, now, body.ReplyToID)
+				msgID := s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{dmAgent}, mentionNames, nil, attachmentRefs, now, body.ReplyToID)
+				if msgID == "" {
+					return // error response already written by sendAgentRouted
+				}
+				recordIdempotency(msgID)
 				// Ensure DM registry rows exist so the DM appears in the rail.
 				s.ensureDMRegistered(ctx, key, user.ID())
 				return
@@ -902,26 +938,35 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 				defaultAgent, err = s.store.GetAgent(ctx, topic.DefaultAgent)
 			}
 			if err == nil && defaultAgent != nil {
-				s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{defaultAgent}, mentionNames, nil, attachmentRefs, now, body.ReplyToID)
+				msgID := s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{defaultAgent}, mentionNames, nil, attachmentRefs, now, body.ReplyToID)
+				if msgID == "" {
+					return // error response already written by sendAgentRouted
+				}
+				recordIdempotency(msgID)
 				return
 			}
 		}
 	}
 
 	// --- Human-to-human message ---
-	s.sendHumanToHuman(w, r, key, projectID, user, content, senderLabel, isDM, mentionNames, attachmentRefs, now, body.ReplyToID)
+	msgID := s.sendHumanToHuman(w, r, key, projectID, user, content, senderLabel, isDM, mentionNames, attachmentRefs, now, body.ReplyToID)
+	if msgID == "" {
+		return // error response already written by sendHumanToHuman
+	}
+	recordIdempotency(msgID)
 }
 
 // sendAgentRouted sends a message through the existing agent dispatch path.
+// Returns the persisted message ID (empty on error).
 func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, projectID string, user UserIdentity,
 	content, senderLabel string, agents []*store.Agent, mentionNames []string, mentionResults []messages.MentionResult,
-	attachmentRefs []AttachmentRef, now time.Time, replyToID string) {
+	attachmentRefs []AttachmentRef, now time.Time, replyToID string) string {
 
 	ctx := r.Context()
 
 	if len(agents) == 0 {
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "no agent to route to", nil)
-		return
+		return ""
 	}
 
 	primaryAgent := agents[0]
@@ -1023,7 +1068,7 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 	if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 		s.messageLog.Error("Failed to persist agent-routed message", "error", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to persist message", nil)
-		return
+		return ""
 	}
 
 	// Phase-3: Store reply-to reference if provided.
@@ -1138,11 +1183,13 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 		Mentions:    mentionResults,
 		Attachments: attachmentRefs,
 	})
+	return storeMsg.ID
 }
 
 // sendHumanToHuman persists a type:chat message for human-to-human communication.
+// Returns the persisted message ID (empty on error).
 func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, projectID string, user UserIdentity,
-	content, senderLabel string, isDM bool, mentionNames []string, attachmentRefs []AttachmentRef, now time.Time, replyToID string) {
+	content, senderLabel string, isDM bool, mentionNames []string, attachmentRefs []AttachmentRef, now time.Time, replyToID string) string {
 
 	ctx := r.Context()
 
@@ -1195,7 +1242,7 @@ func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, p
 
 	if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to persist message", nil)
-		return
+		return ""
 	}
 
 	// Phase-3: Store reply-to reference if provided.
@@ -1263,6 +1310,7 @@ func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, p
 		CreatedAt:   now,
 		Attachments: attachmentRefs,
 	})
+	return storeMsg.ID
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/hub/handlers_chat_v2_test.go
+++ b/pkg/hub/handlers_chat_v2_test.go
@@ -2676,3 +2676,134 @@ func TestChatV2_Send_RateLimitsFloodingHuman(t *testing.T) {
 		t.Fatalf("expected the send to succeed after backing off, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1055: Idempotency key on send
+// ---------------------------------------------------------------------------
+
+func TestChatV2_Send_IdempotencyKey_DeduplicatesSend(t *testing.T) {
+	srv, _, wcs, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	// Create a topic.
+	topicID := tid("topic-idem-1")
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        topicID,
+		ProjectID: proj.ID,
+		Name:      "idempotency-test",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	path := "/api/v1/chat/conversations/" + topicID + "/messages"
+	idemKey := "test-idempotency-key-123"
+
+	// First send — should create the message (201).
+	body1 := map[string]string{"content": "idempotent message", "idempotency_key": idemKey}
+	rec1 := doRequest(t, srv, http.MethodPost, path, body1)
+	if rec1.Code != http.StatusCreated {
+		t.Fatalf("first send: expected 201, got %d: %s", rec1.Code, rec1.Body.String())
+	}
+
+	var resp1 chatMessageResponse
+	if err := json.NewDecoder(rec1.Body).Decode(&resp1); err != nil {
+		t.Fatalf("decode first response: %v", err)
+	}
+	if resp1.ID == "" {
+		t.Fatal("first send: expected non-empty message ID")
+	}
+
+	// Second send with the same idempotency key — should return 200 with the same ID.
+	body2 := map[string]string{"content": "idempotent message", "idempotency_key": idemKey}
+	rec2 := doRequest(t, srv, http.MethodPost, path, body2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("second send: expected 200, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+
+	var resp2 chatMessageResponse
+	if err := json.NewDecoder(rec2.Body).Decode(&resp2); err != nil {
+		t.Fatalf("decode second response: %v", err)
+	}
+	if resp2.ID != resp1.ID {
+		t.Errorf("expected same message ID %q on duplicate, got %q", resp1.ID, resp2.ID)
+	}
+}
+
+func TestChatV2_Send_DifferentIdempotencyKeys_CreateSeparateMessages(t *testing.T) {
+	srv, _, wcs, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	topicID := tid("topic-idem-2")
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        topicID,
+		ProjectID: proj.ID,
+		Name:      "idempotency-diff",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	path := "/api/v1/chat/conversations/" + topicID + "/messages"
+
+	// Two sends with different keys should create two distinct messages.
+	body1 := map[string]string{"content": "first message", "idempotency_key": "key-a"}
+	rec1 := doRequest(t, srv, http.MethodPost, path, body1)
+	if rec1.Code != http.StatusCreated {
+		t.Fatalf("first send: expected 201, got %d", rec1.Code)
+	}
+	var resp1 chatMessageResponse
+	_ = json.NewDecoder(rec1.Body).Decode(&resp1)
+
+	body2 := map[string]string{"content": "second message", "idempotency_key": "key-b"}
+	rec2 := doRequest(t, srv, http.MethodPost, path, body2)
+	if rec2.Code != http.StatusCreated {
+		t.Fatalf("second send: expected 201, got %d", rec2.Code)
+	}
+	var resp2 chatMessageResponse
+	_ = json.NewDecoder(rec2.Body).Decode(&resp2)
+
+	if resp1.ID == resp2.ID {
+		t.Errorf("different idempotency keys should produce different message IDs, both got %q", resp1.ID)
+	}
+}
+
+func TestChatV2_Send_NoIdempotencyKey_AlwaysCreates(t *testing.T) {
+	srv, _, wcs, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	topicID := tid("topic-idem-3")
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        topicID,
+		ProjectID: proj.ID,
+		Name:      "no-idem-key",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	path := "/api/v1/chat/conversations/" + topicID + "/messages"
+
+	// Without an idempotency key, each send creates a new message.
+	body := map[string]string{"content": "same content, no key"}
+	rec1 := doRequest(t, srv, http.MethodPost, path, body)
+	if rec1.Code != http.StatusCreated {
+		t.Fatalf("first send: expected 201, got %d", rec1.Code)
+	}
+	var resp1 chatMessageResponse
+	_ = json.NewDecoder(rec1.Body).Decode(&resp1)
+
+	rec2 := doRequest(t, srv, http.MethodPost, path, body)
+	if rec2.Code != http.StatusCreated {
+		t.Fatalf("second send: expected 201, got %d", rec2.Code)
+	}
+	var resp2 chatMessageResponse
+	_ = json.NewDecoder(rec2.Body).Decode(&resp2)
+
+	if resp1.ID == resp2.ID {
+		t.Errorf("sends without idempotency key should create distinct messages, both got %q", resp1.ID)
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -762,6 +762,10 @@ type Server struct {
 	// Set once in New and read without the lock; nil-safe.
 	chatSendLimiter *chatSendLimiter
 
+	// In-memory idempotency cache for chat message sends (#1055).
+	// Keyed by senderID:idempotencyKey with a 5-minute TTL.
+	chatIdempotency *ChatIdempotencyCache
+
 	// Channel registry for external notification delivery (nil = disabled)
 	channelRegistry *ChannelRegistry
 
@@ -1006,6 +1010,7 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 
 	// Per-sender chat send rate limiter (#1054).
 	srv.chatSendLimiter = newChatSendLimiter()
+	srv.chatIdempotency = NewChatIdempotencyCache()
 
 	ctx := context.Background()
 

--- a/pkg/messages/types.go
+++ b/pkg/messages/types.go
@@ -25,7 +25,7 @@ import (
 const Version = 1
 
 // Maximum length of the Msg field in characters for outbound messages.
-const MaxMessageLength = 2000
+const MaxMessageLength = 16000
 
 // Maximum size of the Msg field in bytes.
 const MaxMsgSize = 64 * 1024 // 64KB

--- a/web/src/client/chat-unread.ts
+++ b/web/src/client/chat-unread.ts
@@ -73,6 +73,8 @@ export class ChatUnreadCounter {
   private timer: ReturnType<typeof setTimeout> | null = null;
   private listening = false;
   private stopped = false;
+  /** Incrementing counter to detect stale refresh results. */
+  private refreshId = 0;
   private readonly boundSchedule = (): void => this.scheduleRefresh();
   private readonly boundNotification = (e: Event): void => this.onNotification(e);
 
@@ -148,8 +150,10 @@ export class ChatUnreadCounter {
 
   /** Recomputes both halves from the server. */
   async refresh(): Promise<void> {
+    const localId = ++this.refreshId;
     const [spaces, dms] = await Promise.all([this.fetchSpaces(), this.fetchDMs()]);
-    if (this.stopped) return;
+    // Discard stale results: a newer refresh was started while we awaited.
+    if (this.stopped || localId !== this.refreshId) return;
     if (spaces) this.spaceUnread = countUnreadSpaces(spaces);
     if (dms) this.dmUnread = countUnreadDMs(dms);
     this.publish();

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -70,6 +70,8 @@ const loadSpaceRail = () => import('../shared/chat/chat-space-rail.js');
 const loadChatMembers = () => import('../shared/chat/chat-members.js');
 // Lazy-load the search component only when v2 is active
 const loadChatSearch = () => import('../shared/chat/chat-search.js');
+// Lazy-load the quick switcher component on first Cmd+K press
+const loadChatSwitcher = () => import('../shared/chat/chat-switcher.js');
 
 /**
  * Slow fallback poll for the members sidebar.
@@ -234,6 +236,8 @@ export class ScionPageChat extends LitElement {
   private _onAgentsUpdated = this._handleAgentsUpdated.bind(this);
   private _onScopeChanged = this._handleScopeChanged.bind(this);
   private _onReadStateUpdated = this._handleReadStateUpdated.bind(this);
+  /** Bound keydown handler for Cmd/Ctrl+K quick switcher. */
+  private _onKeydown = this._handleGlobalKeydown.bind(this);
   /** Map from project slug → project ID for deep-link resolution. */
   private _slugToProjectId = new Map<string, string>();
   /** Map from project ID → project slug for URL generation. */
@@ -244,6 +248,12 @@ export class ScionPageChat extends LitElement {
   private _typingTimers = new Map<string, ReturnType<typeof setTimeout>>();
   /** IDs of members with unread DM messages (for the unread dot on avatars). */
   @state() private v2UnreadFromIds: string[] = [];
+  /** Whether the quick-switcher modal is visible (Cmd/Ctrl+K). */
+  @state() private v2SwitcherOpen = false;
+  /** Whether the quick-switcher component has been lazy-loaded. */
+  private v2SwitcherLoaded = false;
+  /** Cached conversation list for the switcher. */
+  @state() private v2SwitcherConversations: import('../shared/chat/chat-switcher.js').SwitcherConversation[] = [];
   /** Whether the search panel is visible. */
   @state() private v2SearchActive = false;
   /** Whether the search component has been lazy-loaded. */
@@ -640,6 +650,8 @@ export class ScionPageChat extends LitElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
+    // Global Cmd/Ctrl+K listener for the quick switcher.
+    document.addEventListener('keydown', this._onKeydown);
 
     if (this.isV2) {
       void this.initV2();
@@ -658,6 +670,7 @@ export class ScionPageChat extends LitElement {
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
+    document.removeEventListener('keydown', this._onKeydown);
     if (this.isV2) {
       stateManager.removeEventListener('chat-message-received', this._onChatMessage);
       stateManager.removeEventListener('chat-topic-updated', this._onChatTopic);
@@ -2280,6 +2293,141 @@ export class ScionPageChat extends LitElement {
   }
 
   // =========================================================================
+  // Quick Switcher (Cmd/Ctrl-K)  — #1048
+  // =========================================================================
+
+  /** Global keydown handler: open the quick-switcher on Cmd/Ctrl+K. */
+  private _handleGlobalKeydown(e: KeyboardEvent): void {
+    if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      void this.toggleSwitcher();
+    }
+  }
+
+  private async toggleSwitcher(): Promise<void> {
+    if (this.v2SwitcherOpen) {
+      this.v2SwitcherOpen = false;
+      return;
+    }
+    // Lazy-load the component on first use.
+    if (!this.v2SwitcherLoaded) {
+      await loadChatSwitcher();
+      this.v2SwitcherLoaded = true;
+    }
+    // Build the conversation list from API data.
+    void this.loadSwitcherConversations();
+    this.v2SwitcherOpen = true;
+  }
+
+  /** Fetch spaces + threads + DMs for the switcher conversation list. */
+  private async loadSwitcherConversations(): Promise<void> {
+    type SwitcherConv = import('../shared/chat/chat-switcher.js').SwitcherConversation;
+    const convs: SwitcherConv[] = [];
+
+    try {
+      // Fetch spaces (projects with threads).
+      const spacesRes = await apiFetch('/api/v1/chat/spaces');
+      if (spacesRes.ok) {
+        const spacesData = (await spacesRes.json()) as {
+          spaces?: Array<{ projectId: string; projectName: string; projectSlug: string }>;
+        };
+        const spaces = spacesData.spaces || [];
+
+        // Fetch threads for each space in parallel.
+        const threadFetches = spaces.map(async (space) => {
+          try {
+            const res = await apiFetch(
+              `/api/v1/chat/spaces/${encodeURIComponent(space.projectId)}/threads`
+            );
+            if (!res.ok) return;
+            const data = (await res.json()) as {
+              threads?: Array<{
+                id: string;
+                name: string;
+                lastActivityAt?: string;
+              }>;
+            };
+            for (const thread of data.threads || []) {
+              convs.push({
+                conversationKey: thread.id,
+                name: `#${thread.name}`,
+                spaceName: space.projectName,
+                isDM: false,
+                projectId: space.projectId,
+                ...(thread.lastActivityAt ? { lastActivityAt: thread.lastActivityAt } : {}),
+              });
+            }
+          } catch {
+            // Non-critical — skip this space.
+          }
+        });
+        await Promise.all(threadFetches);
+      }
+
+      // Fetch DM conversations.
+      const dmsRes = await apiFetch('/api/v1/chat/dms');
+      if (dmsRes.ok) {
+        const dmsData = (await dmsRes.json()) as {
+          dms?: Array<{
+            conversationKey: string;
+            peerName: string;
+            peerKind: string;
+            lastActivityAt?: string;
+          }>;
+        };
+        for (const dm of dmsData.dms || []) {
+          convs.push({
+            conversationKey: dm.conversationKey,
+            name: dm.peerName || dm.conversationKey,
+            spaceName: dm.peerKind === 'agent' ? 'Agent DM' : 'Direct Message',
+            isDM: true,
+            ...(dm.lastActivityAt ? { lastActivityAt: dm.lastActivityAt } : {}),
+          });
+        }
+      }
+    } catch {
+      // Non-critical — show whatever we collected.
+    }
+
+    this.v2SwitcherConversations = convs;
+  }
+
+  private handleSwitcherSelect(e: CustomEvent): void {
+    const detail = e.detail as { conversationKey: string };
+    this.v2SwitcherOpen = false;
+    if (detail?.conversationKey) {
+      const key = detail.conversationKey;
+      if (key.startsWith('dm:')) {
+        navigateTo(`/chat/dm/${encodeURIComponent(key)}`);
+      } else {
+        // Find the project slug for this thread via its projectId.
+        let foundSlug = '';
+        const conv = this.v2SwitcherConversations.find(
+          (c) => c.conversationKey === key && !c.isDM
+        );
+        if (conv?.projectId) {
+          foundSlug = this._projectIdToSlug.get(conv.projectId) || '';
+        }
+        if (foundSlug) {
+          navigateTo(`/chat/${foundSlug}/${key}`);
+        } else {
+          // Fall back: let the page's route handler resolve by iterating slugs.
+          const firstSlug = this._slugToProjectId.keys().next().value;
+          if (firstSlug) {
+            navigateTo(`/chat/${firstSlug}/${key}`);
+          } else {
+            navigateTo(`/chat`);
+          }
+        }
+      }
+    }
+  }
+
+  private handleSwitcherClose(): void {
+    this.v2SwitcherOpen = false;
+  }
+
+  // =========================================================================
   // Render
   // =========================================================================
 
@@ -2365,6 +2513,15 @@ export class ScionPageChat extends LitElement {
 
   private renderV2() {
     return html`
+      ${this.v2SwitcherOpen
+        ? html`
+            <scion-chat-switcher
+              .conversations=${this.v2SwitcherConversations}
+              @switcher-select=${this.handleSwitcherSelect}
+              @switcher-close=${this.handleSwitcherClose}
+            ></scion-chat-switcher>
+          `
+        : nothing}
       <div
         class="v2-panels"
         data-panel=${this.mobilePanel}

--- a/web/src/components/shared/chat/chat-composer.ts
+++ b/web/src/components/shared/chat/chat-composer.ts
@@ -33,7 +33,9 @@ import type { TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import type { Agent } from '../../../shared/types.js';
 import type { MentionAcceptDetail } from './mention-autocomplete.js';
+import type { SlashCommandDetail } from './slash-autocomplete.js';
 import './mention-autocomplete.js';
+import './slash-autocomplete.js';
 
 /** Maximum message length in rune count. */
 const MAX_MESSAGE_LENGTH = 2000;
@@ -180,10 +182,17 @@ export class ScionChatComposer extends LitElement {
   /** Files the last upload refused, shown until dismissed or superseded. */
   @state() private uploadFailures: UploadFailure[] = [];
 
+  /** Whether a drag is currently over the composer drop zone. */
+  @state() private dragOver = false;
+
+  /** Conversation key used for draft persistence. */
+  @property({ type: String })
+  conversationKey = '';
+
   /** Set of accepted mention slugs. Filtered to those still present on send. */
   private acceptedMentions = new Set<string>();
 
-  /** Phase-3: When editMessage is set, populate the textarea with the content. */
+  /** Phase-3 + Phase-4: Handle editMessage and conversationKey changes. */
   override updated(changedProperties: Map<string, unknown>): void {
     super.updated(changedProperties);
     if (changedProperties.has('editMessage') && this.editMessage) {
@@ -191,7 +200,13 @@ export class ScionChatComposer extends LitElement {
       this.runeCount = countRunes(this.editMessage.content);
       this.focusTextarea();
     }
+    if (changedProperties.has('conversationKey')) {
+      this.restoreDraft();
+    }
   }
+
+  /** Debounce timer for saving drafts to localStorage. */
+  private _draftTimer: ReturnType<typeof setTimeout> | null = null;
 
   static override styles = css`
     :host {
@@ -525,7 +540,92 @@ export class ScionChatComposer extends LitElement {
       font-size: 0.75rem;
       color: var(--scion-neutral-400, #94a3b8);
     }
+
+    /* Drop zone overlay */
+    .composer-wrapper {
+      position: relative;
+    }
+
+    .drop-zone-overlay {
+      position: absolute;
+      inset: 0;
+      z-index: 50;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(59, 130, 246, 0.08);
+      border: 2px dashed var(--scion-primary, #3b82f6);
+      border-radius: 0.75rem;
+      pointer-events: none;
+    }
+
+    .drop-zone-overlay span {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: var(--scion-primary, #3b82f6);
+    }
   `;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.restoreDraft();
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this._draftTimer !== null) {
+      clearTimeout(this._draftTimer);
+      this._draftTimer = null;
+    }
+  }
+
+  /** Restore a draft from localStorage for the current conversationKey. */
+  private restoreDraft(): void {
+    if (!this.conversationKey) return;
+    try {
+      const key = `scion-chat-draft-${this.conversationKey}`;
+      const saved = localStorage.getItem(key);
+      if (saved !== null) {
+        this.text = saved;
+        this.runeCount = countRunes(this.text);
+      }
+    } catch {
+      // localStorage may throw in private browsing mode — silently ignore.
+    }
+  }
+
+  /** Save the current draft to localStorage (debounced). */
+  private saveDraft(): void {
+    if (!this.conversationKey) return;
+    if (this._draftTimer !== null) clearTimeout(this._draftTimer);
+    this._draftTimer = setTimeout(() => {
+      try {
+        const key = `scion-chat-draft-${this.conversationKey}`;
+        if (this.text) {
+          localStorage.setItem(key, this.text);
+        } else {
+          localStorage.removeItem(key);
+        }
+      } catch {
+        // localStorage may throw in private browsing mode — silently ignore.
+      }
+      this._draftTimer = null;
+    }, 500);
+  }
+
+  /** Clear the draft from localStorage for the current conversationKey. */
+  private clearDraft(): void {
+    if (this._draftTimer !== null) {
+      clearTimeout(this._draftTimer);
+      this._draftTimer = null;
+    }
+    if (!this.conversationKey) return;
+    try {
+      localStorage.removeItem(`scion-chat-draft-${this.conversationKey}`);
+    } catch {
+      // localStorage may throw in private browsing mode — silently ignore.
+    }
+  }
 
   override render() {
     const isOverLimit = this.runeCount > MAX_MESSAGE_LENGTH;
@@ -543,13 +643,23 @@ export class ScionChatComposer extends LitElement {
 
     return html`
       ${this.conversationMode ? this.renderDestinationChip() : nothing}
-      <div class="composer">
-        ${this.replyTo ? this.renderReplyBar() : nothing}
-        ${this.editMessage ? this.renderEditBar() : nothing}
-        ${this.pendingFiles.length > 0 ? this.renderPendingFiles() : nothing}
-        ${this.uploadFailures.length > 0 ? this.renderUploadFailures() : nothing}
-        ${this.uploading ? html`<div class="upload-progress">Uploading...</div>` : nothing}
-        <div class="input-row">
+      <div
+        class="composer-wrapper"
+        @dragover=${this.handleDragOver}
+        @dragenter=${this.handleDragEnter}
+        @dragleave=${this.handleDragLeave}
+        @drop=${this.handleDrop}
+      >
+        ${this.dragOver
+          ? html`<div class="drop-zone-overlay"><span>Drop files here</span></div>`
+          : nothing}
+        <div class="composer">
+          ${this.replyTo ? this.renderReplyBar() : nothing}
+          ${this.editMessage ? this.renderEditBar() : nothing}
+          ${this.pendingFiles.length > 0 ? this.renderPendingFiles() : nothing}
+          ${this.uploadFailures.length > 0 ? this.renderUploadFailures() : nothing}
+          ${this.uploading ? html`<div class="upload-progress">Uploading...</div>` : nothing}
+          <div class="input-row">
           ${this.conversationMode && !inEditMode
             ? html`
                 <sl-icon-button
@@ -577,6 +687,7 @@ export class ScionChatComposer extends LitElement {
               .value=${this.text}
               @sl-input=${this.handleInput}
               @keydown=${this.handleKeydown}
+              @paste=${this.handlePaste}
               ?disabled=${this.disabled}
             ></sl-textarea>
             <scion-mention-autocomplete
@@ -584,6 +695,9 @@ export class ScionChatComposer extends LitElement {
               .members=${this.members}
               @mention-accept=${this.handleMentionAccept}
             ></scion-mention-autocomplete>
+            <scion-slash-autocomplete
+              @slash-command=${this.handleSlashCommand}
+            ></scion-slash-autocomplete>
           </div>
           <div class="send-container">
             <sl-button
@@ -613,14 +727,15 @@ export class ScionChatComposer extends LitElement {
               : nothing}
           </div>
         </div>
-        <div class="footer-row">
-          ${this.runeCount > 0 || isNearLimit
-            ? html`
-                <span class="char-counter ${counterClass}">
-                  ${this.runeCount} / ${MAX_MESSAGE_LENGTH}
-                </span>
-              `
-            : nothing}
+          <div class="footer-row">
+            ${this.runeCount > 0 || isNearLimit
+              ? html`
+                  <span class="char-counter ${counterClass}">
+                    ${this.runeCount} / ${MAX_MESSAGE_LENGTH}
+                  </span>
+                `
+              : nothing}
+          </div>
         </div>
       </div>
     `;
@@ -775,6 +890,9 @@ export class ScionChatComposer extends LitElement {
     this.text = target.value;
     this.runeCount = countRunes(this.text);
 
+    // Persist draft with debounce.
+    this.saveDraft();
+
     // Dispatch typing event so the parent can send a typing indicator
     if (this.text.length > 0) {
       this.dispatchEvent(new CustomEvent('chat-typing', { bubbles: true, composed: true }));
@@ -783,7 +901,7 @@ export class ScionChatComposer extends LitElement {
     // Update live mention override for destination chip
     this.updateLiveMentionOverride();
 
-    // Feed the autocomplete component.
+    // Feed the autocomplete components.
     const autocomplete = this.shadowRoot?.querySelector('scion-mention-autocomplete') as
       | import('./mention-autocomplete.js').ScionMentionAutocomplete
       | null;
@@ -792,6 +910,15 @@ export class ScionChatComposer extends LitElement {
       if (textarea) {
         autocomplete.handleInput(this.text, textarea.selectionStart ?? this.text.length, textarea);
       }
+    }
+
+    // Feed slash command autocomplete.
+    const slashAutocomplete = this.shadowRoot?.querySelector('scion-slash-autocomplete') as
+      | import('./slash-autocomplete.js').ScionSlashAutocomplete
+      | null;
+    if (slashAutocomplete) {
+      const cursorPos = this.getTextareaElement()?.selectionStart ?? this.text.length;
+      slashAutocomplete.handleInput(this.text, cursorPos);
     }
   }
 
@@ -818,7 +945,15 @@ export class ScionChatComposer extends LitElement {
   }
 
   private handleKeydown(e: KeyboardEvent): void {
-    // Let the autocomplete handle keys first.
+    // Let slash command autocomplete handle keys first.
+    const slashAutocomplete = this.shadowRoot?.querySelector('scion-slash-autocomplete') as
+      | import('./slash-autocomplete.js').ScionSlashAutocomplete
+      | null;
+    if (slashAutocomplete?.handleKeydown(e)) {
+      return; // consumed by slash autocomplete
+    }
+
+    // Then let the mention autocomplete handle keys.
     const autocomplete = this.shadowRoot?.querySelector('scion-mention-autocomplete') as
       | import('./mention-autocomplete.js').ScionMentionAutocomplete
       | null;
@@ -830,6 +965,28 @@ export class ScionChatComposer extends LitElement {
       e.preventDefault();
       this.handleSend();
     }
+  }
+
+  private handleSlashCommand(e: CustomEvent<SlashCommandDetail>): void {
+    const { command } = e.detail;
+    // Extract args from the current text: `/command arg1 arg2`
+    const text = this.text.trim();
+    const spaceIdx = text.indexOf(' ');
+    const args = spaceIdx >= 0 ? text.slice(spaceIdx + 1).trim() : '';
+
+    this.dispatchEvent(
+      new CustomEvent('chat-slash-command', {
+        detail: { command, args },
+        bubbles: true,
+        composed: true,
+      })
+    );
+
+    // Clear the text input after dispatching.
+    this.text = '';
+    this.runeCount = 0;
+    this.clearDraft();
+    this.focusTextarea();
   }
 
   private handleMentionAccept(e: CustomEvent<MentionAcceptDetail>): void {
@@ -933,6 +1090,15 @@ export class ScionChatComposer extends LitElement {
     const input = e.target as HTMLInputElement;
     const files = input.files;
     if (!files || files.length === 0) return;
+    await this.uploadFiles(Array.from(files));
+  }
+
+  /**
+   * Upload one or more files to the attachment endpoint.
+   * Shared by the file picker, paste handler, and drag-and-drop handler.
+   */
+  async uploadFiles(files: File[]): Promise<void> {
+    if (files.length === 0) return;
 
     // Enforce max attachments.
     if (this.pendingFiles.length + files.length > 10) {
@@ -950,7 +1116,7 @@ export class ScionChatComposer extends LitElement {
     try {
       const formData = new FormData();
       formData.append('project_id', this.projectId);
-      for (const file of Array.from(files)) {
+      for (const file of files) {
         formData.append('files', file);
       }
 
@@ -998,6 +1164,55 @@ export class ScionChatComposer extends LitElement {
       );
     } finally {
       this.uploading = false;
+    }
+  }
+
+  /** Handle paste events — extract images from clipboard and upload. */
+  private handlePaste(e: ClipboardEvent): void {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+
+    const imageFiles: File[] = [];
+    for (const item of Array.from(items)) {
+      if (item.type.startsWith('image/')) {
+        const file = item.getAsFile();
+        if (file) imageFiles.push(file);
+      }
+    }
+
+    if (imageFiles.length > 0) {
+      e.preventDefault();
+      void this.uploadFiles(imageFiles);
+    }
+  }
+
+  /** Prevent default on dragover to allow drop. */
+  private handleDragOver(e: DragEvent): void {
+    e.preventDefault();
+  }
+
+  /** Show the drop zone overlay on drag enter. */
+  private handleDragEnter(e: DragEvent): void {
+    e.preventDefault();
+    this.dragOver = true;
+  }
+
+  /** Hide the drop zone overlay on drag leave. */
+  private handleDragLeave(e: DragEvent): void {
+    // Only hide if we're leaving the composer-wrapper, not entering a child.
+    const wrapper = (e.currentTarget as HTMLElement);
+    const related = e.relatedTarget as Node | null;
+    if (related && wrapper.contains(related)) return;
+    this.dragOver = false;
+  }
+
+  /** Handle file drop — extract files and upload. */
+  private handleDrop(e: DragEvent): void {
+    e.preventDefault();
+    this.dragOver = false;
+    const files = e.dataTransfer?.files;
+    if (files && files.length > 0) {
+      void this.uploadFiles(Array.from(files));
     }
   }
 
@@ -1054,6 +1269,7 @@ export class ScionChatComposer extends LitElement {
         this.runeCount = 0;
         this.acceptedMentions.clear();
         this.pendingFiles = [];
+        this.clearDraft();
         // Phase-3: Clear reply context after successful send.
         this.replyTo = null;
         this.focusTextarea();

--- a/web/src/components/shared/chat/chat-message.ts
+++ b/web/src/components/shared/chat/chat-message.ts
@@ -35,7 +35,6 @@ import { getMarkdownRenderer } from '../../../utils/markdown.js';
 import { getLanguageFromPath } from '../code-editor.js';
 import { hashColor, getInitials } from './chat-avatar.js';
 import '../code-editor.js';
-import '../markdown-preview.js';
 
 /** Structured attachment reference from the W7 API. */
 export interface AttachmentRefInfo {
@@ -76,7 +75,6 @@ const TEXT_EXTENSIONS = new Set([
   '.jsx',
   '.log',
   '.md',
-  '.markdown',
   '.py',
   '.rs',
   '.sh',
@@ -99,16 +97,154 @@ const PREVIEW_MAX_LINES = 40;
 /** Lines that fit in the 200px slice; beyond this the edge is faded. */
 const PREVIEW_VISIBLE_LINES = 9;
 
+/**
+ * Map fenced code block language tags to CodeMirror language identifiers.
+ * Used by the syntax-highlighting post-processor to replace plain
+ * `<pre><code>` blocks with `<scion-code-editor readonly>`.
+ */
+const CODE_BLOCK_LANGUAGE_MAP: Record<string, string> = {
+  typescript: 'typescript',
+  ts: 'typescript',
+  javascript: 'javascript',
+  js: 'javascript',
+  go: 'go',
+  python: 'python',
+  py: 'python',
+  json: 'json',
+  yaml: 'yaml',
+  yml: 'yaml',
+  html: 'html',
+  css: 'css',
+  rust: 'rust',
+  rs: 'rust',
+  markdown: 'markdown',
+  md: 'markdown',
+  // CodeMirror shell mode is not bundled; fall back to monospace-only display.
+  bash: 'plaintext',
+  sh: 'plaintext',
+  shell: 'plaintext',
+};
+
+// ---------------------------------------------------------------------------
+// Entity link detection (#1059) — configurable patterns for deep-linking
+// entity references in agent messages to their detail pages.
+// ---------------------------------------------------------------------------
+
+interface EntityPattern {
+  /** A global regex that matches one entity reference. */
+  regex: RegExp;
+  /** Build the `<a>` tag for a match. Return the full `<a>…</a>` string. */
+  linkBuilder: (match: RegExpExecArray) => string;
+}
+
+/**
+ * Configurable entity patterns for deep-linking. Order matters: the first
+ * match wins, so more specific patterns must come before less specific ones.
+ */
+const ENTITY_PATTERNS: EntityPattern[] = [
+  // Session IDs: sess_ prefix followed by hex/uuid chars
+  {
+    regex: /\bsess_([0-9a-fA-F-]{4,36})\b/g,
+    linkBuilder: (m) => {
+      const id = m[0]; // full match including prefix
+      return `<a class="entity-link" href="/sessions/${encodeURIComponent(id)}" title="Open session ${id}">${id}</a>`;
+    },
+  },
+  // Bare UUIDs preceded by "session" (case-insensitive)
+  {
+    regex: /\bsession\s+([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\b/gi,
+    linkBuilder: (m) => {
+      const uuid = m[1];
+      return `session <a class="entity-link" href="/sessions/${encodeURIComponent(uuid)}" title="Open session ${uuid}">${uuid}</a>`;
+    },
+  },
+  // Commit SHAs: "commit" followed by 7-40 hex chars
+  {
+    regex: /\bcommit\s+([0-9a-fA-F]{7,40})\b/gi,
+    linkBuilder: (m) => {
+      const sha = m[1];
+      return `commit <a class="entity-link" href="/commits/${encodeURIComponent(sha)}" title="View commit ${sha}">${sha}</a>`;
+    },
+  },
+  // File paths: workspace-absolute or relative paths with extensions
+  {
+    regex: /(?:\/workspace\/|(?:^|(?<=\s)))([a-zA-Z0-9_.-]+(?:\/[a-zA-Z0-9_.-]+)+\.[a-zA-Z]{1,10})\b/g,
+    linkBuilder: (m) => {
+      const full = m[0];
+      const path = full.startsWith('/workspace/') ? full.slice('/workspace/'.length) : full.trimStart();
+      return `<a class="entity-link" href="/files/${encodeURIComponent(path)}" title="Open ${full.trim()}">${full}</a>`;
+    },
+  },
+];
+
+/**
+ * Apply entity link patterns to a text segment (outside code/HTML regions).
+ * Each match is replaced by the pattern's linkBuilder output. Patterns are
+ * tried left-to-right through the string; the first match at each position
+ * wins. This is intentionally simple: it scans linearly and does not try to
+ * handle overlapping matches from different patterns.
+ */
+function styleEntityLinksInText(text: string): string {
+  // Collect all matches from all patterns, then sort by position.
+  const replacements: { start: number; end: number; replacement: string }[] = [];
+
+  for (const pattern of ENTITY_PATTERNS) {
+    // Clone the regex so each call starts from index 0.
+    // Ensure the global flag is always set so re.exec() advances lastIndex
+    // and cannot loop infinitely on a zero-width or non-advancing match.
+    const flags = pattern.regex.flags.includes('g') ? pattern.regex.flags : pattern.regex.flags + 'g';
+    const re = new RegExp(pattern.regex.source, flags);
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      const prevIndex = re.lastIndex;
+      replacements.push({
+        start: m.index,
+        end: m.index + m[0].length,
+        replacement: pattern.linkBuilder(m),
+      });
+      // Safety: if lastIndex did not advance (e.g. zero-length match or
+      // missing global flag), break to avoid an infinite loop.
+      if (re.lastIndex === prevIndex) break;
+    }
+  }
+
+  if (replacements.length === 0) return text;
+
+  // Sort by start position, pick non-overlapping winners (first match wins).
+  replacements.sort((a, b) => a.start - b.start);
+  let out = '';
+  let cursor = 0;
+  for (const rep of replacements) {
+    if (rep.start < cursor) continue; // overlaps with a prior replacement
+    out += text.slice(cursor, rep.start) + rep.replacement;
+    cursor = rep.end;
+  }
+  return out + text.slice(cursor);
+}
+
+/**
+ * Post-process rendered markdown to turn entity references into clickable
+ * deep links, leaving code blocks and inline code untouched — an entity ID
+ * inside a fence is literal text, not a navigation target.
+ *
+ * Follows the exact same skip-region approach as `styleMentions()`.
+ */
+function styleEntityLinks(htmlStr: string): string {
+  const skip = new RegExp(MENTION_SKIP_REGION, 'gi');
+  let out = '';
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+  while ((match = skip.exec(htmlStr)) !== null) {
+    out += styleEntityLinksInText(htmlStr.slice(cursor, match.index)) + match[0];
+    cursor = match.index + match[0].length;
+  }
+  return out + styleEntityLinksInText(htmlStr.slice(cursor));
+}
+
 /** Lowercase extension including the dot, or '' when the name has none. */
 function extensionOf(name: string): string {
   const dot = name.lastIndexOf('.');
   return dot > 0 ? name.slice(dot).toLowerCase() : '';
-}
-
-/** True when the file is a Markdown document. */
-function isMarkdownFile(name: string): boolean {
-  const ext = extensionOf(name);
-  return ext === '.md' || ext === '.markdown';
 }
 
 /**
@@ -362,24 +498,7 @@ export class ScionChatMessage extends LitElement {
   @state()
   private expanded: AttachmentRefInfo | null = null;
 
-  /**
-   * Per-attachment toggle: true = show raw source, false/absent = show
-   * rendered preview (only meaningful for markdown files).
-   */
-  @state()
-  private mdSourceView: ReadonlyMap<string, boolean> = new Map();
-
-  /**
-   * Tracks which attachment IDs have a "Copied!" feedback timer active,
-   * so the button shows a check icon instead of the clipboard icon.
-   */
-  @state()
-  private copiedIds: ReadonlySet<string> = new Set();
-
   private renderTaskId = 0;
-
-  /** Cleanup function for window touchend/touchmove listeners added by handleTouchStart. */
-  private _touchCleanup: (() => void) | null = null;
 
   private previewObserver: IntersectionObserver | null = null;
   private observedPreviews = new WeakSet<Element>();
@@ -557,6 +676,16 @@ export class ScionChatMessage extends LitElement {
       border: none;
       padding: 0;
       font-size: 0.8125rem;
+    }
+
+    /* Syntax-highlighted code blocks (#1049) */
+    .code-block-editor {
+      display: block;
+      margin: 0.5em 0;
+      max-height: 400px;
+      overflow: auto;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.375rem;
     }
 
     .copy-btn {
@@ -860,23 +989,6 @@ export class ScionChatMessage extends LitElement {
       color: var(--scion-text-muted, #64748b);
     }
 
-    /* Markdown preview body — let the component fill the card. */
-    .md-preview-body {
-      padding: 0;
-      --scion-border: transparent;
-      --scion-radius: 0;
-    }
-
-    .md-preview-body scion-markdown-preview {
-      --scion-radius: 0;
-    }
-
-    .md-preview-body scion-markdown-preview::part(container) {
-      border: none;
-      border-radius: 0;
-      max-height: 200px;
-    }
-
     /*
      * The card already draws a frame, so the editor's own border is hidden by
      * blanking the custom property it reads.
@@ -1131,6 +1243,127 @@ export class ScionChatMessage extends LitElement {
       color: var(--scion-neutral-400, #94a3b8);
       margin-left: 0.25rem;
     }
+
+    /* ---- Entity deep links (#1059) ---- */
+    .md-content .entity-link {
+      color: var(--sl-color-primary-600, #2563eb);
+      text-decoration: none;
+      border-bottom: 1px dotted var(--sl-color-primary-400, #60a5fa);
+    }
+
+    .md-content .entity-link:hover {
+      text-decoration: underline;
+      color: var(--sl-color-primary-700, #1d4ed8);
+    }
+
+    /* ---- Rich output: diff blocks (#1060) ---- */
+    .diff-block {
+      font-family: var(--scion-font-mono, 'SF Mono', 'Fira Code', monospace);
+      font-size: 0.8125rem;
+      line-height: 1.5;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.375rem;
+      padding: 0.75rem;
+      overflow-x: auto;
+      margin: 0.5em 0;
+    }
+
+    .diff-block .diff-line {
+      display: block;
+      white-space: pre;
+    }
+
+    .diff-block .diff-add {
+      background: rgba(34, 197, 94, 0.15);
+      color: var(--scion-success-700, #15803d);
+    }
+
+    .diff-block .diff-remove {
+      background: rgba(239, 68, 68, 0.15);
+      color: var(--scion-danger-700, #b91c1c);
+    }
+
+    .diff-block .diff-hunk {
+      background: rgba(59, 130, 246, 0.1);
+      color: var(--scion-primary-600, #2563eb);
+      font-weight: 500;
+    }
+
+    /* ---- Rich output: collapsible blocks (#1060) ---- */
+    .collapsible-block {
+      position: relative;
+      margin: 0.5em 0;
+    }
+
+    .collapsible-block.collapsed .collapsible-content {
+      max-height: calc(10 * 1.5em + 1.5rem);
+      overflow: hidden;
+    }
+
+    .collapsible-block.collapsed .collapsible-content::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 2rem;
+      background: linear-gradient(transparent, var(--scion-bg-subtle, #f1f5f9));
+      pointer-events: none;
+    }
+
+    .collapsible-toggle {
+      display: block;
+      width: 100%;
+      padding: 0.25rem 0.75rem;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-top: none;
+      border-radius: 0 0 0.375rem 0.375rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      color: var(--sl-color-primary-600, #2563eb);
+      font-size: 0.75rem;
+      font-family: inherit;
+      cursor: pointer;
+      text-align: center;
+    }
+
+    .collapsible-toggle:hover {
+      background: var(--scion-border, #e2e8f0);
+    }
+
+    /* ---- Rich output: test results (#1060) ---- */
+    .test-results {
+      font-family: var(--scion-font-mono, 'SF Mono', 'Fira Code', monospace);
+      font-size: 0.8125rem;
+      line-height: 1.5;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.375rem;
+      padding: 0.75rem;
+      overflow-x: auto;
+      margin: 0.5em 0;
+    }
+
+    .test-results .test-line {
+      display: block;
+      white-space: pre;
+    }
+
+    .test-results .test-pass {
+      color: var(--scion-success-700, #15803d);
+    }
+
+    .test-results .test-fail {
+      color: var(--scion-danger-700, #b91c1c);
+      font-weight: 600;
+    }
+
+    .test-results .test-summary {
+      font-weight: 600;
+      margin-top: 0.25em;
+      padding-top: 0.25em;
+      border-top: 1px solid var(--scion-border, #e2e8f0);
+    }
   `;
 
   override connectedCallback(): void {
@@ -1143,11 +1376,7 @@ export class ScionChatMessage extends LitElement {
     this.previewObserver?.disconnect();
     this.previewObserver = null;
     this.observedPreviews = new WeakSet();
-    // Clean up touch long-press timer and window listeners to prevent leaks.
-    if (this._touchCleanup) {
-      this._touchCleanup();
-      this._touchCleanup = null;
-    }
+    // Clean up touch long-press timer to prevent leaks on disconnect.
     if (this.touchTimer) {
       clearTimeout(this.touchTimer);
       this.touchTimer = null;
@@ -1160,6 +1389,10 @@ export class ScionChatMessage extends LitElement {
     }
     if (changed.has('renderedHtml')) {
       this.injectCopyButtons();
+      this.injectSyntaxHighlighting();
+      this.injectDiffBlocks();
+      this.injectCollapsibleBlocks();
+      this.injectTestResults();
     }
     this.observePreviews();
   }
@@ -1236,11 +1469,191 @@ export class ScionChatMessage extends LitElement {
         void navigator.clipboard.writeText(code);
         btn.textContent = 'Copied!';
         setTimeout(() => {
-          if (!this.isConnected) return;
           btn.textContent = 'Copy';
         }, 1500);
       });
       pre.appendChild(btn);
+    });
+  }
+
+  /**
+   * Replace fenced code blocks that have a language class with
+   * `<scion-code-editor readonly>` for syntax highlighting.
+   *
+   * `marked` produces `<pre><code class="language-typescript">` for
+   * ` ```typescript ` blocks. We detect the class, extract the language,
+   * and swap the `<pre>` with a readonly code editor.
+   */
+  private injectSyntaxHighlighting(): void {
+    const pres = this.shadowRoot?.querySelectorAll('.md-content pre');
+    if (!pres) return;
+
+    pres.forEach((pre) => {
+      // Skip if already replaced.
+      if (pre.getAttribute('data-highlighted') === 'true') return;
+
+      const codeEl = pre.querySelector('code');
+      if (!codeEl) return;
+
+      // Extract language from class="language-xxx" set by marked.
+      const langClass = Array.from(codeEl.classList).find((c) => c.startsWith('language-'));
+      if (!langClass) return; // No language tag — keep plain styling.
+
+      const langTag = langClass.replace('language-', '').toLowerCase();
+      const language = CODE_BLOCK_LANGUAGE_MAP[langTag];
+      if (!language) return; // Unknown language — keep plain styling.
+
+      const content = codeEl.textContent ?? '';
+      pre.setAttribute('data-highlighted', 'true');
+
+      // Create a readonly code editor and replace the <pre> in-place.
+      const editor = document.createElement('scion-code-editor') as import('../code-editor.js').ScionCodeEditor;
+      editor.content = content;
+      editor.language = language;
+      editor.readonly = true;
+      editor.classList.add('code-block-editor');
+
+      pre.replaceWith(editor);
+    });
+  }
+
+  /**
+   * Replace `<pre>` blocks whose content looks like a unified diff with a
+   * colour-coded diff view. Lines starting with `+` are additions, `-` are
+   * removals, and `@@` are hunk headers.
+   */
+  private injectDiffBlocks(): void {
+    const pres = this.shadowRoot?.querySelectorAll('.md-content pre');
+    if (!pres) return;
+
+    pres.forEach((pre) => {
+      if (pre.getAttribute('data-diff') === 'true') return;
+      const codeEl = pre.querySelector('code');
+      const text = (codeEl ?? pre).textContent ?? '';
+      const lines = text.split('\n');
+
+      // Heuristic: require a ---/+++ header pair or @@ hunk headers to
+      // avoid false-positives on YAML lists, markdown checklists, and
+      // code with @ decorators.
+      const hasHeaders = lines.some((l) => l.startsWith('--- ')) && lines.some((l) => l.startsWith('+++ '));
+      const hasHunks = lines.some((l) => l.startsWith('@@ '));
+      const diffLineCount = lines.filter((l) => /^[-+@]/.test(l)).length;
+      const looksLikeDiff = hasHeaders || (hasHunks && diffLineCount >= 3);
+      if (!looksLikeDiff) return;
+
+      pre.setAttribute('data-diff', 'true');
+
+      const container = document.createElement('div');
+      container.className = 'diff-block';
+
+      for (const line of lines) {
+        const span = document.createElement('span');
+        span.className = 'diff-line';
+        if (line.startsWith('@@')) {
+          span.classList.add('diff-hunk');
+        } else if (line.startsWith('+')) {
+          span.classList.add('diff-add');
+        } else if (line.startsWith('-')) {
+          span.classList.add('diff-remove');
+        }
+        span.textContent = line;
+        container.appendChild(span);
+      }
+      pre.replaceWith(container);
+    });
+  }
+
+  /**
+   * Wrap `<pre>` blocks that exceed 20 lines in a collapsible container that
+   * shows only the first 10 lines by default with a "Show more" toggle.
+   */
+  private injectCollapsibleBlocks(): void {
+    const pres = this.shadowRoot?.querySelectorAll('.md-content pre');
+    if (!pres) return;
+
+    pres.forEach((pre) => {
+      if (pre.getAttribute('data-collapsible') === 'true') return;
+      if (pre.closest('.collapsible-block') || pre.closest('.diff-block')) return;
+      const codeEl = pre.querySelector('code');
+      const text = (codeEl ?? pre).textContent ?? '';
+      const lineCount = text.split('\n').length;
+
+      if (lineCount <= 20) return;
+
+      pre.setAttribute('data-collapsible', 'true');
+
+      const wrapper = document.createElement('div');
+      wrapper.className = 'collapsible-block collapsed';
+
+      const contentWrapper = document.createElement('div');
+      contentWrapper.className = 'collapsible-content';
+
+      // Move the <pre> inside the content wrapper.
+      pre.replaceWith(wrapper);
+      contentWrapper.appendChild(pre);
+      wrapper.appendChild(contentWrapper);
+
+      const btn = document.createElement('button');
+      btn.className = 'collapsible-toggle';
+      const hiddenLines = lineCount - 10;
+      btn.textContent = `Show more (${hiddenLines} lines)`;
+      btn.addEventListener('click', () => {
+        const isCollapsed = wrapper.classList.contains('collapsed');
+        if (isCollapsed) {
+          wrapper.classList.remove('collapsed');
+          btn.textContent = 'Show less';
+        } else {
+          wrapper.classList.add('collapsed');
+          btn.textContent = `Show more (${hiddenLines} lines)`;
+        }
+      });
+      wrapper.appendChild(btn);
+    });
+  }
+
+  /**
+   * Detect Go/generic test output patterns in `<pre>` blocks and wrap them
+   * in a colour-coded `.test-results` container.
+   */
+  private injectTestResults(): void {
+    const pres = this.shadowRoot?.querySelectorAll('.md-content pre');
+    if (!pres) return;
+
+    pres.forEach((pre) => {
+      if (pre.getAttribute('data-test-results') === 'true') return;
+      if (pre.closest('.collapsible-block') || pre.closest('.diff-block')) return;
+      const codeEl = pre.querySelector('code');
+      const text = (codeEl ?? pre).textContent ?? '';
+      const lines = text.split('\n');
+
+      // Heuristic: test output if it contains PASS/FAIL/ok lines that look
+      // like Go test output or a generic "Tests:" summary line.
+      const testIndicators = lines.filter(
+        (l) =>
+          /^(ok\s|PASS|FAIL|--- PASS|--- FAIL|Tests:)/.test(l.trimStart())
+      ).length;
+      if (testIndicators < 2) return;
+
+      pre.setAttribute('data-test-results', 'true');
+
+      const container = document.createElement('div');
+      container.className = 'test-results';
+
+      for (const line of lines) {
+        const span = document.createElement('span');
+        span.className = 'test-line';
+        const trimmed = line.trimStart();
+        if (/^(PASS|--- PASS|ok\s)/.test(trimmed)) {
+          span.classList.add('test-pass');
+        } else if (/^(FAIL|--- FAIL)/.test(trimmed)) {
+          span.classList.add('test-fail');
+        } else if (/^Tests:/.test(trimmed)) {
+          span.classList.add('test-summary');
+        }
+        span.textContent = line;
+        container.appendChild(span);
+      }
+      pre.replaceWith(container);
     });
   }
 
@@ -1253,7 +1666,10 @@ export class ScionChatMessage extends LitElement {
     try {
       const renderer = await getMarkdownRenderer();
       if (taskId !== this.renderTaskId) return;
-      this.renderedHtml = styleMentions(renderer.render(this.body));
+      let rendered = renderer.render(this.body);
+      rendered = styleMentions(rendered);
+      rendered = styleEntityLinks(rendered);
+      this.renderedHtml = rendered;
     } catch {
       if (taskId !== this.renderTaskId) return;
       this.renderedHtml = '';
@@ -1403,12 +1819,6 @@ export class ScionChatMessage extends LitElement {
   private touchTimer: ReturnType<typeof setTimeout> | null = null;
 
   private handleTouchStart() {
-    // Clean up any previous touch listeners before adding new ones.
-    if (this._touchCleanup) {
-      this._touchCleanup();
-      this._touchCleanup = null;
-    }
-
     this.touchTimer = setTimeout(() => {
       this.actionBarPinned = !this.actionBarPinned;
     }, 500);
@@ -1420,11 +1830,11 @@ export class ScionChatMessage extends LitElement {
       }
       window.removeEventListener('touchend', clearTimer);
       window.removeEventListener('touchmove', clearTimer);
-      this._touchCleanup = null;
+      window.removeEventListener('touchcancel', clearTimer);
     };
     window.addEventListener('touchend', clearTimer, { once: true });
     window.addEventListener('touchmove', clearTimer, { once: true });
-    this._touchCleanup = clearTimer;
+    window.addEventListener('touchcancel', clearTimer, { once: true });
   }
 
   override render() {
@@ -1679,50 +2089,15 @@ export class ScionChatMessage extends LitElement {
   /** A short read-only slice of a text attachment, with expand + download. */
   private renderCodePreview(ref: AttachmentRefInfo) {
     const state = this.previews.get(ref.id);
-    const isMd = isMarkdownFile(ref.name);
-    const showSource = isMd && (this.mdSourceView.get(ref.id) ?? false);
-
-    // Only fade the bottom edge when the file really does run past the slice
-    // and we are NOT showing rendered markdown (rendered view scrolls itself).
-    const hasText = state?.status === 'ready' && !!state.text;
-    const exceedsLimit =
-      hasText &&
-      (() => {
-        let count = 0;
-        let pos = -1;
-        const text = state.text!;
-        while ((pos = text.indexOf('\n', pos + 1)) !== -1) {
-          if (++count >= PREVIEW_VISIBLE_LINES) return true;
-        }
-        return false;
-      })();
-    const clipped = !isMd && exceedsLimit;
-    const sourceClipped = showSource && exceedsLimit;
-
+    // Only fade the bottom edge when the file really does run past the slice.
+    const clipped =
+      state?.status === 'ready' && (state.text ?? '').split('\n').length > PREVIEW_VISIBLE_LINES;
     return html`
       <div class="attachment-preview" data-id=${ref.id}>
         <div class="preview-header">
           <span class="preview-filename" title=${ref.name}>${ref.name}</span>
           <span class="preview-size">${formatFileSize(ref.size)}</span>
           <div class="preview-actions">
-            ${isMd
-              ? html`
-                  <sl-icon-button
-                    name=${showSource ? 'eye' : 'code'}
-                    label=${showSource ? 'Preview' : 'Source'}
-                    @click=${() => this.toggleMdSource(ref.id)}
-                  ></sl-icon-button>
-                `
-              : nothing}
-            ${isMd && showSource
-              ? html`
-                  <sl-icon-button
-                    name=${this.copiedIds.has(ref.id) ? 'check2' : 'clipboard'}
-                    label="Copy to clipboard"
-                    @click=${() => this.copyAttachmentText(ref.id)}
-                  ></sl-icon-button>
-                `
-              : nothing}
             <sl-icon-button
               name="arrows-angle-expand"
               label="Expand ${ref.name}"
@@ -1736,56 +2111,11 @@ export class ScionChatMessage extends LitElement {
             ></sl-icon-button>
           </div>
         </div>
-        ${isMd && !showSource
-          ? html`<div class="md-preview-body">${this.renderMdPreviewBody(ref, state)}</div>`
-          : html`<div class="preview-body ${clipped || sourceClipped ? 'clipped' : ''}">
-              ${this.renderPreviewBody(ref, state)}
-            </div>`}
+        <div class="preview-body ${clipped ? 'clipped' : ''}">
+          ${this.renderPreviewBody(ref, state)}
+        </div>
       </div>
     `;
-  }
-
-  /** Toggle between rendered and source view for a markdown attachment. */
-  private toggleMdSource(id: string): void {
-    const next = new Map(this.mdSourceView);
-    next.set(id, !(next.get(id) ?? false));
-    this.mdSourceView = next;
-  }
-
-  /** Copy attachment text to clipboard with brief "Copied!" feedback. */
-  private async copyAttachmentText(id: string): Promise<void> {
-    const state = this.previews.get(id);
-    if (!state || state.status !== 'ready' || !state.text) return;
-    try {
-      await navigator.clipboard.writeText(state.text);
-      const next = new Set(this.copiedIds);
-      next.add(id);
-      this.copiedIds = next;
-      setTimeout(() => {
-        if (!this.isConnected) return;
-        const after = new Set(this.copiedIds);
-        after.delete(id);
-        this.copiedIds = after;
-      }, 1500);
-    } catch {
-      // Clipboard write may fail in insecure contexts; silently ignore.
-    }
-  }
-
-  /** Rendered markdown body for a markdown attachment preview. */
-  private renderMdPreviewBody(_ref: AttachmentRefInfo, state: PreviewState | undefined) {
-    if (!state || state.status === 'loading') {
-      return html`
-        <div class="preview-placeholder">
-          <sl-spinner></sl-spinner>
-          Loading preview…
-        </div>
-      `;
-    }
-    if (state.status === 'error') {
-      return html`<div class="preview-placeholder error">${state.error}</div>`;
-    }
-    return html`<scion-markdown-preview .content=${state.text ?? ''}></scion-markdown-preview>`;
   }
 
   /** Editor, spinner or error for one preview, depending on load state. */
@@ -1816,10 +2146,6 @@ export class ScionChatMessage extends LitElement {
     const ref = this.expanded;
     if (!ref) return nothing;
 
-    const isMd = isMarkdownFile(ref.name);
-    const showSource = isMd && (this.mdSourceView.get(ref.id) ?? false);
-    const state = this.previews.get(ref.id);
-
     return html`
       <sl-dialog
         class="full-preview"
@@ -1831,34 +2157,11 @@ export class ScionChatMessage extends LitElement {
       >
         ${IMAGE_MIMES.has(ref.mime)
           ? html`<img class="full-image" src=${attachmentURL(ref.id)} alt=${ref.name} />`
-          : isMd && !showSource
-            ? this.renderMdPreviewBody(ref, state)
-            : this.renderPreviewBody(ref, state, true)}
-        <div slot="footer" style="display:flex;gap:0.5rem;align-items:center">
-          ${isMd
-            ? html`
-                <sl-button size="small" @click=${() => this.toggleMdSource(ref.id)}>
-                  <sl-icon slot="prefix" name=${showSource ? 'eye' : 'code'}></sl-icon>
-                  ${showSource ? 'Preview' : 'Source'}
-                </sl-button>
-              `
-            : nothing}
-          ${isMd && showSource
-            ? html`
-                <sl-button size="small" @click=${() => this.copyAttachmentText(ref.id)}>
-                  <sl-icon
-                    slot="prefix"
-                    name=${this.copiedIds.has(ref.id) ? 'check2' : 'clipboard'}
-                  ></sl-icon>
-                  ${this.copiedIds.has(ref.id) ? 'Copied!' : 'Copy'}
-                </sl-button>
-              `
-            : nothing}
-          <sl-button href=${attachmentURL(ref.id)} download=${ref.name}>
-            <sl-icon slot="prefix" name="download"></sl-icon>
-            Download
-          </sl-button>
-        </div>
+          : this.renderPreviewBody(ref, this.previews.get(ref.id), true)}
+        <sl-button slot="footer" href=${attachmentURL(ref.id)} download=${ref.name}>
+          <sl-icon slot="prefix" name="download"></sl-icon>
+          Download
+        </sl-button>
       </sl-dialog>
     `;
   }

--- a/web/src/components/shared/chat/chat-space-rail.ts
+++ b/web/src/components/shared/chat/chat-space-rail.ts
@@ -1093,6 +1093,128 @@ export class ScionChatSpaceRail extends LitElement {
     }
   }
 
+  // ---------------------------------------------------------------------------
+  // Thread export (#1064)
+  // ---------------------------------------------------------------------------
+
+  /** Message shape returned by the conversations messages endpoint. */
+  private async fetchThreadMessages(threadId: string): Promise<Array<{
+    sender_name?: string;
+    sender?: string;
+    body?: string;
+    content?: string;
+    created_at?: string;
+    timestamp?: string;
+    attachments?: string[];
+  }>> {
+    try {
+      const res = await apiFetch(
+        `/api/v1/chat/conversations/${encodeURIComponent(threadId)}/messages`
+      );
+      if (!res.ok) return [];
+      const data = (await res.json()) as { messages?: unknown[] };
+      return (data.messages ?? []) as Array<{
+        sender_name?: string;
+        sender?: string;
+        body?: string;
+        content?: string;
+        created_at?: string;
+        timestamp?: string;
+        attachments?: string[];
+      }>;
+    } catch {
+      return [];
+    }
+  }
+
+  /** Format thread messages into a markdown document. */
+  private formatThreadAsMarkdown(
+    thread: ChatSpaceThread,
+    messages: Array<{
+      sender_name?: string;
+      sender?: string;
+      body?: string;
+      content?: string;
+      created_at?: string;
+      timestamp?: string;
+      attachments?: string[];
+    }>
+  ): string {
+    const lines: string[] = [];
+    lines.push(`# Thread: ${thread.name}`);
+    lines.push(`Exported: ${new Date().toLocaleString()}`);
+    lines.push('');
+    lines.push('---');
+
+    for (const msg of messages) {
+      const sender = msg.sender_name ?? msg.sender ?? 'Unknown';
+      const ts = msg.created_at ?? msg.timestamp ?? '';
+      const content = msg.body ?? msg.content ?? '';
+      const formattedTs = ts ? new Date(ts).toLocaleString() : '';
+
+      lines.push('');
+      lines.push(`**${sender}** (${formattedTs}):`);
+      lines.push(content);
+
+      // Include attachments as markdown links
+      if (msg.attachments && msg.attachments.length > 0) {
+        lines.push('');
+        for (const att of msg.attachments) {
+          const basename = att.split('/').pop() ?? att;
+          lines.push(`- [${basename}](${att})`);
+        }
+      }
+
+      lines.push('');
+      lines.push('---');
+    }
+
+    return lines.join('\n');
+  }
+
+  /** Copy thread content as markdown to clipboard. */
+  private async handleExportThread(thread: ChatSpaceThread): Promise<void> {
+    this.contextMenuTarget = null;
+    const messages = await this.fetchThreadMessages(thread.id);
+    const markdown = this.formatThreadAsMarkdown(thread, messages);
+
+    try {
+      await navigator.clipboard.writeText(markdown);
+      this.showExportToast('Copied to clipboard');
+    } catch {
+      // Fallback: if clipboard fails, still offer the download
+      this.showExportToast('Clipboard unavailable — use Download instead');
+    }
+  }
+
+  /** Download thread content as a markdown file. */
+  private async handleDownloadThread(thread: ChatSpaceThread): Promise<void> {
+    this.contextMenuTarget = null;
+    const messages = await this.fetchThreadMessages(thread.id);
+    const markdown = this.formatThreadAsMarkdown(thread, messages);
+
+    const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `${thread.name.replace(/[^a-zA-Z0-9_-]/g, '-')}.md`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }
+
+  /** Show a brief toast notification for export actions. */
+  private showExportToast(message: string): void {
+    this.dispatchEvent(
+      new CustomEvent('show-toast', {
+        bubbles: true,
+        composed: true,
+        detail: { message, variant: 'primary', duration: 3000 },
+      })
+    );
+  }
+
   private startRename(thread: ChatSpaceThread): void {
     this.contextMenuTarget = null;
     if (thread.isGeneral) return;
@@ -1523,6 +1645,20 @@ export class ScionChatSpaceRail extends LitElement {
         >
           <sl-icon name=${thread.muted ? 'bell-slash' : 'bell'}></sl-icon>
           ${thread.muted ? 'Unmute' : 'Mute'}
+        </div>
+        <div
+          class="context-menu-item"
+          @click=${() => this.handleExportThread(thread)}
+        >
+          <sl-icon name="file-earmark-text"></sl-icon>
+          Copy as Markdown
+        </div>
+        <div
+          class="context-menu-item"
+          @click=${() => this.handleDownloadThread(thread)}
+        >
+          <sl-icon name="download"></sl-icon>
+          Download as Markdown
         </div>
         ${!thread.isGeneral
           ? html`

--- a/web/src/components/shared/chat/chat-switcher.test.ts
+++ b/web/src/components/shared/chat/chat-switcher.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for <scion-chat-switcher> — the Cmd/Ctrl-K quick conversation switcher.
+ */
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+await import('./chat-switcher.js');
+type ScionChatSwitcher = import('./chat-switcher.js').ScionChatSwitcher;
+type SwitcherConversation = import('./chat-switcher.js').SwitcherConversation;
+
+const CONVERSATIONS: SwitcherConversation[] = [
+  {
+    conversationKey: 'topic-1',
+    name: '#general',
+    spaceName: 'Project Alpha',
+    isDM: false,
+    lastActivityAt: '2026-08-17T10:00:00Z',
+  },
+  {
+    conversationKey: 'topic-2',
+    name: '#dev',
+    spaceName: 'Project Alpha',
+    isDM: false,
+    lastActivityAt: '2026-08-17T09:00:00Z',
+  },
+  {
+    conversationKey: 'dm:agent:abc:user:xyz',
+    name: 'Bot Helper',
+    spaceName: 'Agent DM',
+    isDM: true,
+    lastActivityAt: '2026-08-17T08:00:00Z',
+  },
+];
+
+async function mount(convs?: SwitcherConversation[]): Promise<ScionChatSwitcher> {
+  const el = document.createElement('scion-chat-switcher') as ScionChatSwitcher;
+  el.conversations = convs ?? CONVERSATIONS;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe('scion-chat-switcher', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders a search input and conversation items', async () => {
+    const el = await mount();
+
+    const input = el.shadowRoot?.querySelector('input');
+    expect(input).not.toBeNull();
+
+    const items = el.shadowRoot?.querySelectorAll('.item');
+    expect(items?.length).toBe(3);
+  });
+
+  it('filters conversations by search term', async () => {
+    const el = await mount();
+
+    const input = el.shadowRoot?.querySelector('input') as HTMLInputElement;
+    input.value = 'general';
+    input.dispatchEvent(new Event('input'));
+    await el.updateComplete;
+
+    const items = el.shadowRoot?.querySelectorAll('.item');
+    expect(items?.length).toBe(1);
+    expect(items?.[0].querySelector('.item-name')?.textContent).toContain('#general');
+  });
+
+  it('filters by space name', async () => {
+    const el = await mount();
+
+    const input = el.shadowRoot?.querySelector('input') as HTMLInputElement;
+    input.value = 'Agent DM';
+    input.dispatchEvent(new Event('input'));
+    await el.updateComplete;
+
+    const items = el.shadowRoot?.querySelectorAll('.item');
+    expect(items?.length).toBe(1);
+    expect(items?.[0].querySelector('.item-name')?.textContent).toContain('Bot Helper');
+  });
+
+  it('shows empty state when no matches', async () => {
+    const el = await mount();
+
+    const input = el.shadowRoot?.querySelector('input') as HTMLInputElement;
+    input.value = 'nonexistent';
+    input.dispatchEvent(new Event('input'));
+    await el.updateComplete;
+
+    const empty = el.shadowRoot?.querySelector('.empty');
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent).toContain('No matching conversations');
+  });
+
+  it('emits switcher-select on Enter', async () => {
+    const el = await mount();
+    let selectedKey = '';
+    el.addEventListener('switcher-select', (e) => {
+      selectedKey = (e as CustomEvent).detail.conversationKey;
+    });
+
+    // Press Enter to select the first item (sorted by most recent).
+    el.shadowRoot?.querySelector('.overlay')?.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+    );
+
+    expect(selectedKey).toBe('topic-1');
+  });
+
+  it('emits switcher-close on Escape', async () => {
+    const el = await mount();
+    let closed = false;
+    el.addEventListener('switcher-close', () => {
+      closed = true;
+    });
+
+    el.shadowRoot?.querySelector('.overlay')?.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+    );
+
+    expect(closed).toBe(true);
+  });
+
+  it('navigates selection with arrow keys', async () => {
+    const el = await mount();
+
+    const overlay = el.shadowRoot?.querySelector('.overlay')!;
+
+    // Initially first item is selected.
+    let selected = el.shadowRoot?.querySelector('.item.selected .item-name');
+    expect(selected?.textContent).toContain('#general');
+
+    // Arrow down to second item.
+    overlay.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+
+    selected = el.shadowRoot?.querySelector('.item.selected .item-name');
+    expect(selected?.textContent).toContain('#dev');
+
+    // Arrow down to third item (DM).
+    overlay.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+
+    selected = el.shadowRoot?.querySelector('.item.selected .item-name');
+    expect(selected?.textContent).toContain('Bot Helper');
+
+    // Arrow up back to second.
+    overlay.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    await el.updateComplete;
+
+    selected = el.shadowRoot?.querySelector('.item.selected .item-name');
+    expect(selected?.textContent).toContain('#dev');
+  });
+
+  it('shows DM badge for DM conversations', async () => {
+    const el = await mount();
+
+    const items = el.shadowRoot?.querySelectorAll('.item');
+    const dmItem = items?.[2]; // Sorted by activity — DM is last.
+    expect(dmItem?.querySelector('.dm-badge')).not.toBeNull();
+
+    const threadItem = items?.[0]; // Thread — no DM badge.
+    expect(threadItem?.querySelector('.dm-badge')).toBeNull();
+  });
+
+  it('sorts by most recent activity first', async () => {
+    const el = await mount();
+
+    const names = Array.from(el.shadowRoot?.querySelectorAll('.item-name') ?? []).map(
+      (n) => n.textContent?.trim() ?? ''
+    );
+    // topic-1 (10:00) > topic-2 (09:00) > dm (08:00)
+    expect(names[0]).toContain('#general');
+    expect(names[1]).toContain('#dev');
+    expect(names[2]).toContain('Bot Helper');
+  });
+
+  it('emits switcher-close when clicking the overlay backdrop', async () => {
+    const el = await mount();
+    let closed = false;
+    el.addEventListener('switcher-close', () => {
+      closed = true;
+    });
+
+    // Click the overlay itself (not the panel).
+    const overlay = el.shadowRoot?.querySelector('.overlay') as HTMLElement;
+    overlay.click();
+
+    expect(closed).toBe(true);
+  });
+});

--- a/web/src/components/shared/chat/chat-switcher.ts
+++ b/web/src/components/shared/chat/chat-switcher.ts
@@ -1,0 +1,324 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Chat quick-switcher component (Cmd/Ctrl-K).
+ *
+ * Renders a modal overlay with a search input and a filterable list of
+ * conversations. Keyboard navigation (Arrow Up/Down, Enter, Escape) is
+ * supported. Conversations are sorted by most recent activity first when
+ * the search field is empty.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state, query } from 'lit/decorators.js';
+
+/** A conversation entry displayable in the switcher. */
+export interface SwitcherConversation {
+  /** Topic UUID or DM key. */
+  conversationKey: string;
+  /** Display name: thread name, DM peer name, etc. */
+  name: string;
+  /** Project/space name for context. */
+  spaceName: string;
+  /** True for DMs, false for threads. */
+  isDM: boolean;
+  /** ISO timestamp for sorting by recency. */
+  lastActivityAt?: string;
+  /** Project ID for thread navigation (not set for DMs). */
+  projectId?: string;
+}
+
+/** Detail emitted on `switcher-select`. */
+export interface SwitcherSelectDetail {
+  conversationKey: string;
+}
+
+@customElement('scion-chat-switcher')
+export class ScionChatSwitcher extends LitElement {
+  /** Full list of conversations to search through. */
+  @property({ type: Array })
+  conversations: SwitcherConversation[] = [];
+
+  @state() private searchTerm = '';
+  @state() private selectedIndex = 0;
+
+  @query('#switcher-input')
+  private inputEl!: HTMLInputElement;
+
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    .overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 9999;
+      display: flex;
+      align-items: flex-start;
+      justify-content: center;
+      padding-top: 15vh;
+      background: rgba(0, 0, 0, 0.4);
+    }
+
+    .panel {
+      width: min(520px, 90vw);
+      max-height: 60vh;
+      display: flex;
+      flex-direction: column;
+      background: var(--scion-surface, #fff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.5rem;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+      overflow: hidden;
+    }
+
+    .search-row {
+      display: flex;
+      align-items: center;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      gap: 0.5rem;
+    }
+
+    .search-row sl-icon {
+      color: var(--scion-text-muted, #64748b);
+      font-size: 1rem;
+    }
+
+    .search-row input {
+      flex: 1;
+      border: none;
+      outline: none;
+      font-size: 0.9375rem;
+      background: transparent;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .search-row input::placeholder {
+      color: var(--scion-text-muted, #94a3b8);
+    }
+
+    .results {
+      overflow-y: auto;
+      max-height: calc(60vh - 3.5rem);
+    }
+
+    .empty {
+      padding: 2rem 1rem;
+      text-align: center;
+      color: var(--scion-text-muted, #94a3b8);
+      font-size: 0.875rem;
+    }
+
+    .item {
+      display: flex;
+      flex-direction: column;
+      padding: 0.5rem 1rem;
+      cursor: pointer;
+      gap: 0.125rem;
+      border-left: 3px solid transparent;
+    }
+
+    .item:hover,
+    .item.selected {
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border-left-color: var(--scion-primary, #3b82f6);
+    }
+
+    .item-name {
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .item-context {
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #94a3b8);
+    }
+
+    .dm-badge {
+      display: inline-block;
+      font-size: 0.6875rem;
+      padding: 0 0.25rem;
+      border-radius: 0.125rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      color: var(--scion-text-muted, #64748b);
+      margin-left: 0.25rem;
+    }
+
+    .shortcut-hint {
+      padding: 0.375rem 1rem;
+      font-size: 0.6875rem;
+      color: var(--scion-text-muted, #94a3b8);
+      border-top: 1px solid var(--scion-border, #e2e8f0);
+      display: flex;
+      gap: 1rem;
+    }
+
+    kbd {
+      display: inline-block;
+      padding: 0 0.25rem;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.125rem;
+      font-family: inherit;
+      font-size: 0.625rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+    }
+  `;
+
+  override firstUpdated(): void {
+    // Autofocus the input after render.
+    requestAnimationFrame(() => {
+      this.inputEl?.focus();
+    });
+  }
+
+  private get filtered(): SwitcherConversation[] {
+    const term = this.searchTerm.toLowerCase().trim();
+    let list = this.conversations;
+
+    if (term) {
+      list = list.filter(
+        (c) =>
+          c.name.toLowerCase().includes(term) ||
+          c.spaceName.toLowerCase().includes(term)
+      );
+    }
+
+    // Sort by most recent activity first.
+    return [...list].sort((a, b) => {
+      const ta = a.lastActivityAt ? new Date(a.lastActivityAt).getTime() : 0;
+      const tb = b.lastActivityAt ? new Date(b.lastActivityAt).getTime() : 0;
+      return tb - ta;
+    });
+  }
+
+  private handleInput(e: InputEvent): void {
+    this.searchTerm = (e.target as HTMLInputElement).value;
+    this.selectedIndex = 0;
+  }
+
+  private handleKeydown(e: KeyboardEvent): void {
+    const items = this.filtered;
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        this.selectedIndex = Math.min(this.selectedIndex + 1, items.length - 1);
+        this.scrollSelectedIntoView();
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        this.selectedIndex = Math.max(this.selectedIndex - 1, 0);
+        this.scrollSelectedIntoView();
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (items.length > 0 && this.selectedIndex < items.length) {
+          this.selectConversation(items[this.selectedIndex]);
+        }
+        break;
+      case 'Escape':
+        e.preventDefault();
+        this.close();
+        break;
+    }
+  }
+
+  private scrollSelectedIntoView(): void {
+    requestAnimationFrame(() => {
+      const selected = this.shadowRoot?.querySelector('.item.selected');
+      selected?.scrollIntoView({ block: 'nearest' });
+    });
+  }
+
+  private selectConversation(conv: SwitcherConversation): void {
+    this.dispatchEvent(
+      new CustomEvent<SwitcherSelectDetail>('switcher-select', {
+        detail: { conversationKey: conv.conversationKey },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private close(): void {
+    this.dispatchEvent(
+      new CustomEvent('switcher-close', { bubbles: true, composed: true })
+    );
+  }
+
+  private handleOverlayClick(e: MouseEvent): void {
+    // Close only when clicking the backdrop, not the panel.
+    if ((e.target as HTMLElement)?.classList.contains('overlay')) {
+      this.close();
+    }
+  }
+
+  override render() {
+    const items = this.filtered;
+    return html`
+      <div class="overlay" @click=${this.handleOverlayClick} @keydown=${this.handleKeydown}>
+        <div class="panel">
+          <div class="search-row">
+            <sl-icon name="search"></sl-icon>
+            <input
+              id="switcher-input"
+              type="text"
+              placeholder="Search conversations..."
+              .value=${this.searchTerm}
+              @input=${this.handleInput}
+              autocomplete="off"
+            />
+          </div>
+          <div class="results">
+            ${items.length === 0
+              ? html`<div class="empty">
+                  ${this.searchTerm ? 'No matching conversations' : 'No conversations'}
+                </div>`
+              : items.map(
+                  (item, i) => html`
+                    <div
+                      class="item ${i === this.selectedIndex ? 'selected' : ''}"
+                      @click=${() => this.selectConversation(item)}
+                      @mouseenter=${() => { this.selectedIndex = i; }}
+                    >
+                      <div class="item-name">
+                        ${item.name}
+                        ${item.isDM ? html`<span class="dm-badge">DM</span>` : nothing}
+                      </div>
+                      <div class="item-context">${item.spaceName}</div>
+                    </div>
+                  `
+                )}
+          </div>
+          <div class="shortcut-hint">
+            <span><kbd>↑↓</kbd> navigate</span>
+            <span><kbd>↵</kbd> select</span>
+            <span><kbd>esc</kbd> close</span>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-chat-switcher': ScionChatSwitcher;
+  }
+}

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -48,6 +48,8 @@ import './chat-system-line.js';
 import './chat-composer.js';
 import './chat-visibility-toggle.js';
 import './chat-interagent-marker.js';
+import './send-to-agent-picker.js';
+import type { AgentSelectedDetail } from './send-to-agent-picker.js';
 
 /** Result from server-side mention fan-out. */
 interface MentionResult {
@@ -209,6 +211,20 @@ export class ScionChatThread extends LitElement {
     content: string;
   } | null = null;
 
+  // ---- Phase-5: Context menu + Send-to-agent state ----
+
+  /** The message targeted by the right-click context menu. */
+  @state() private contextMenuMessage: Message | null = null;
+
+  /** Position of the right-click context menu. */
+  @state() private contextMenuPosition: { x: number; y: number } = { x: 0, y: 0 };
+
+  /** Whether the agent picker is visible. */
+  @state() private showAgentPicker = false;
+
+  /** Temporarily stored message for send-to-agent flow. */
+  private _pendingSendToAgentMessage: Message | null = null;
+
   /** Message extensions keyed by message ID. */
   private v2MessageExtMap = new Map<
     string,
@@ -226,9 +242,6 @@ export class ScionChatThread extends LitElement {
 
   /** Bound listener for v2 SSE message-deleted events. */
   private _v2DeleteHandler = this.handleV2MessageDeleted.bind(this);
-
-  /** Timer for delayed unread watermark advancement. */
-  private _unreadWatermarkTimeout: ReturnType<typeof setTimeout> | null = null;
 
   private eventSource: EventSource | null = null;
   private nextCursor: string | null = null;
@@ -579,6 +592,56 @@ export class ScionChatThread extends LitElement {
         background: transparent;
       }
     }
+
+    /* Phase-5: Context menu */
+    .context-menu-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 149;
+    }
+
+    .context-menu {
+      position: fixed;
+      z-index: 150;
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.5rem;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+      min-width: 180px;
+      padding: 0.25rem 0;
+    }
+
+    .context-menu-item {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8125rem;
+      cursor: pointer;
+      color: var(--scion-text, #1e293b);
+      white-space: nowrap;
+      transition: background 0.1s;
+    }
+
+    .context-menu-item:hover {
+      background: var(--scion-primary-50, #eff6ff);
+    }
+
+    .context-menu-item sl-icon {
+      font-size: 0.875rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    /* Phase-5: Slash command system message */
+    .system-info-message {
+      padding: 0.5rem 1rem;
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border-radius: 0.375rem;
+      margin: 0.25rem 1rem;
+      white-space: pre-wrap;
+    }
   `;
 
   /** Auto-trigger loadHistory when the component first renders in v2 mode. */
@@ -618,11 +681,7 @@ export class ScionChatThread extends LitElement {
     // Clear read-receipt state — it belongs to the conversation we just left.
     this.clearSeenState();
 
-    // Clear unread divider state and cancel any pending watermark advancement.
-    if (this._unreadWatermarkTimeout) {
-      clearTimeout(this._unreadWatermarkTimeout);
-      this._unreadWatermarkTimeout = null;
-    }
+    // Clear unread divider state.
     this.lastReadMessageId = '';
     this.showUnreadDivider = false;
 
@@ -666,15 +725,9 @@ export class ScionChatThread extends LitElement {
     stateManager.removeEventListener('chat-message-received', this._v2MessageHandler);
     stateManager.removeEventListener('chat-typing-received', this._v2TypingHandler);
     stateManager.removeEventListener('chat-read-state-updated', this._v2ReadStateHandler);
-    this.clearSeenState();
     stateManager.removeEventListener('chat-message-edited', this._v2EditHandler);
     stateManager.removeEventListener('chat-message-deleted', this._v2DeleteHandler);
     this.clearSeenState();
-    // Clean up unread watermark advancement timer
-    if (this._unreadWatermarkTimeout) {
-      clearTimeout(this._unreadWatermarkTimeout);
-      this._unreadWatermarkTimeout = null;
-    }
     // Clean up typing timers
     for (const entry of this.typingUsers.values()) {
       clearTimeout(entry.timer);
@@ -1035,7 +1088,6 @@ export class ScionChatThread extends LitElement {
       this.error = err instanceof Error ? err.message : 'Failed to load messages';
     } finally {
       this.loading = false;
-      this.scrollToBottomAfterRender();
       // Determine scroll target: permalink hash > unread divider > bottom.
       const hashMsgId = this.parseMessageHash();
       if (hashMsgId) {
@@ -1047,8 +1099,7 @@ export class ScionChatThread extends LitElement {
       }
       // Advance read watermark after a short delay so the user sees the divider.
       if (this.showUnreadDivider && this.messages.length > 0) {
-        this._unreadWatermarkTimeout = setTimeout(() => {
-          this._unreadWatermarkTimeout = null;
+        setTimeout(() => {
           const lastMsg = this.messages[this.messages.length - 1];
           if (lastMsg) {
             void this.advanceReadWatermark(lastMsg.id);
@@ -1159,29 +1210,98 @@ export class ScionChatThread extends LitElement {
     return this._currentUserId || this.currentUserId;
   }
 
-  /** Handle v2 SSE chat message events. Only backfill if the event is for this conversation. */
+  /** Handle v2 SSE chat message events.
+   *
+   * If the SSE event carries a full message payload (has `id` and content),
+   * merge it directly via `mergeMessages()` instead of doing a full 50-message
+   * backfill. Fall back to `backfillV2()` when the event is a lightweight
+   * notification (e.g. just a threadId).
+   */
   private handleV2ChatMessage(e: Event): void {
     type ChatEventData = {
       threadId?: string;
       conversationKey?: string;
       topicId?: string;
       senderId?: string;
+      // Full message fields from UserMessageEvent:
+      id?: string;
+      msg?: string;
+      sender?: string;
+      recipient?: string;
+      recipientId?: string;
+      type?: string;
+      projectId?: string;
+      agentId?: string;
+      createdAt?: string;
+      channel?: string;
+      visibility?: string;
+      groupId?: string;
+      dispatchState?: string;
+      urgent?: boolean;
+      broadcasted?: boolean;
+      read?: boolean;
+      attachments?: import('./chat-message.js').AttachmentRefInfo[];
     };
     const detail = (e as CustomEvent).detail as
       | ({ data?: ChatEventData } & ChatEventData)
       | undefined;
     // stateManager wraps SSE payloads as { state, data }; tolerate a flat detail too.
     const eventData: ChatEventData | undefined = detail?.data ?? detail;
-    if (eventData) {
-      // Filter: only process events for this conversation
-      const eventKey = eventData.threadId || eventData.conversationKey || eventData.topicId || '';
-      if (eventKey && eventKey !== this.conversationKey) {
-        return; // Not for this conversation
-      }
-      // The sender finished typing the moment their message landed — drop the
-      // indicator now rather than waiting out TYPING_EXPIRY_MS.
-      this.clearTypingForUser(eventData.senderId);
+    if (!eventData) {
+      void this.backfillV2();
+      return;
     }
+
+    // Filter: only process events for this conversation
+    const eventKey = eventData.threadId || eventData.conversationKey || eventData.topicId || '';
+    if (eventKey && eventKey !== this.conversationKey) {
+      return; // Not for this conversation
+    }
+
+    // The sender finished typing the moment their message landed — drop the
+    // indicator now rather than waiting out TYPING_EXPIRY_MS.
+    this.clearTypingForUser(eventData.senderId);
+
+    // If the event carries a full message payload, merge directly instead of
+    // doing a round-trip backfill.
+    // SSE events from PublishUserMessage carry the full message payload.
+    // mergeMessages() deduplicates by ID (last-write-wins via Map.set),
+    // so if both the POST response and the SSE event provide the same
+    // message, the later arrival's fields prevail — this is acceptable.
+    if (eventData.id && (eventData.msg !== undefined || eventData.type)) {
+      const msg: Message = {
+        id: eventData.id,
+        projectId: eventData.projectId || '',
+        sender: eventData.sender || '',
+        senderId: eventData.senderId || '',
+        recipient: eventData.recipient || '',
+        recipientId: eventData.recipientId || '',
+        msg: eventData.msg || '',
+        type: eventData.type || '',
+        agentId: eventData.agentId || '',
+        createdAt: eventData.createdAt || new Date().toISOString(),
+        ...(eventData.channel != null ? { channel: eventData.channel } : {}),
+        ...(eventData.threadId != null ? { threadId: eventData.threadId } : {}),
+        ...(eventData.visibility != null ? { visibility: eventData.visibility } : {}),
+        ...(eventData.groupId != null ? { groupId: eventData.groupId } : {}),
+        ...(eventData.dispatchState != null ? { dispatchState: eventData.dispatchState } : {}),
+        ...(eventData.urgent != null ? { urgent: eventData.urgent } : {}),
+        ...(eventData.broadcasted != null ? { broadcasted: eventData.broadcasted } : {}),
+        ...(eventData.read != null ? { read: eventData.read } : {}),
+      };
+      this.mergeMessages([msg]);
+
+      // Update attachment map if the event carries attachment data.
+      if (eventData.attachments && eventData.attachments.length > 0) {
+        this.v2AttachmentMap.set(msg.id, eventData.attachments);
+      }
+
+      this.scrollToBottomAfterRender();
+      this.maybeAdvanceReadWatermark();
+      return;
+    }
+
+    // Lightweight notification (no full message) — fall back to backfill.
     void this.backfillV2();
   }
 
@@ -1497,8 +1617,12 @@ export class ScionChatThread extends LitElement {
     this.sendError = null;
 
     try {
+      // Generate an idempotency key so duplicate sends (e.g. network retry)
+      // are collapsed server-side.
+      const idempotencyKey = crypto.randomUUID();
       const body: Record<string, unknown> = {
         content: text,
+        idempotency_key: idempotencyKey,
       };
       if (mentions && mentions.length > 0) {
         body.mentions = mentions;
@@ -1970,6 +2094,254 @@ export class ScionChatThread extends LitElement {
     });
   }
 
+  // ---------------------------------------------------------------------------
+  // Phase-5: Context menu + Send-to-agent
+  // ---------------------------------------------------------------------------
+
+  /** Render the context menu overlay when a message is right-clicked. */
+  private renderContextMenu() {
+    if (!this.contextMenuMessage) return nothing;
+
+    return html`
+      <div class="context-menu-overlay" @click=${this.closeContextMenu}></div>
+      <div
+        class="context-menu"
+        style="left: ${this.contextMenuPosition.x}px; top: ${this.contextMenuPosition.y}px;"
+      >
+        <div class="context-menu-item" @click=${this.handleSendToAgent}>
+          <sl-icon name="send"></sl-icon>
+          Send to Agent...
+        </div>
+      </div>
+    `;
+  }
+
+  /** Handle right-click on a message to show context menu. */
+  private handleMessageContextMenu(e: MouseEvent, msg: Message): void {
+    e.preventDefault();
+    this.contextMenuMessage = msg;
+    this.contextMenuPosition = { x: e.clientX, y: e.clientY };
+    // Close agent picker if open
+    this.showAgentPicker = false;
+  }
+
+  /** Close the context menu. */
+  private closeContextMenu(): void {
+    this.contextMenuMessage = null;
+  }
+
+  /** Handle "Send to Agent..." click from context menu. */
+  private handleSendToAgent(): void {
+    // Close context menu and show agent picker
+    const pos = { ...this.contextMenuPosition };
+    this.contextMenuPosition = pos;
+    this.showAgentPicker = true;
+    // Keep contextMenuMessage so we have the message content
+    // but close the visual context menu
+    const msg = this.contextMenuMessage;
+    this.contextMenuMessage = null;
+    // Re-store message for the picker callback
+    this._pendingSendToAgentMessage = msg;
+  }
+
+  /** Handle agent selection from the picker. */
+  private handleAgentSelected(e: CustomEvent<AgentSelectedDetail>): void {
+    const { agentId } = e.detail;
+    const msg = this._pendingSendToAgentMessage;
+    this._pendingSendToAgentMessage = null;
+    this.showAgentPicker = false;
+
+    if (!msg) return;
+
+    // Store context in sessionStorage to avoid URL length overflow (msg.msg
+    // can be 16 000 runes → 48 KB+ when percent-encoded).
+    const contextKey = `scion-send-ctx-${crypto.randomUUID().slice(0, 8)}`;
+    sessionStorage.setItem(contextKey, msg.msg);
+    const url = `/chat/dm/agent/${encodeURIComponent(agentId)}?ctx=${contextKey}`;
+    const navEvent = new CustomEvent('navigate', {
+      detail: { url },
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+    });
+    this.dispatchEvent(navEvent);
+    if (!navEvent.defaultPrevented) {
+      window.location.href = url;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Phase-5: Slash command handling
+  // ---------------------------------------------------------------------------
+
+  /** Handle slash commands dispatched from the composer. */
+  private async handleSlashCommand(
+    e: CustomEvent<{ command: string; args: string }>
+  ): Promise<void> {
+    const { command, args } = e.detail;
+
+    switch (command) {
+      case 'status':
+        await this.handleSlashStatus();
+        break;
+      case 'clear':
+        this.handleSlashClear();
+        break;
+      case 'help':
+        this.handleSlashHelp();
+        break;
+      case 'spawn':
+        await this.handleSlashSpawn(args);
+        break;
+      case 'stop':
+        await this.handleSlashStop(args);
+        break;
+      case 'default':
+        await this.handleDefaultCommand(`/default ${args}`);
+        break;
+      default:
+        this.insertLocalSystemMessage(`Unknown command: /${command}`);
+        break;
+    }
+  }
+
+  /** /status — Fetch agent status for the project. */
+  private async handleSlashStatus(): Promise<void> {
+    if (!this.projectId) {
+      this.insertLocalSystemMessage('No project context available.');
+      return;
+    }
+
+    try {
+      const res = await apiFetch(
+        `/api/v1/agents?project=${encodeURIComponent(this.projectId)}`
+      );
+      if (!res.ok) {
+        this.insertLocalSystemMessage('Failed to fetch project status.');
+        return;
+      }
+      const data = (await res.json()) as { items?: Agent[] };
+      const agents = data?.items ?? [];
+
+      if (agents.length === 0) {
+        this.insertLocalSystemMessage('No agents found in this project.');
+        return;
+      }
+
+      const lines = agents.map((a) => {
+        const slug = a.slug || a.name || 'unknown';
+        const phase = a.phase || 'unknown';
+        return `  ${slug}: ${phase}`;
+      });
+      this.insertLocalSystemMessage(`Project agents:\n${lines.join('\n')}`);
+    } catch {
+      this.insertLocalSystemMessage('Failed to fetch project status.');
+    }
+  }
+
+  /** /clear — Clear messages locally. */
+  private handleSlashClear(): void {
+    this.messageMap.clear();
+    this.messages = [];
+    this.interagentMessages = [];
+    this.insertLocalSystemMessage('Conversation cleared.');
+  }
+
+  /** /help — List available commands. */
+  private handleSlashHelp(): void {
+    const helpText = [
+      'Available commands:',
+      '  /status — Show project agent status',
+      '  /clear — Clear the conversation view',
+      '  /help — Show this help message',
+      '  /spawn <template> — Spawn a new agent from a template',
+      '  /stop <agent> — Stop a running agent',
+      '  /default <agent|clear> — Set or clear the thread default agent',
+    ].join('\n');
+    this.insertLocalSystemMessage(helpText);
+  }
+
+  /** /spawn <template> — Spawn a new agent. */
+  private async handleSlashSpawn(args: string): Promise<void> {
+    const template = args.trim();
+    if (!template) {
+      this.insertLocalSystemMessage('Usage: /spawn <template>');
+      return;
+    }
+
+    try {
+      const body: Record<string, unknown> = {
+        template,
+        project_id: this.projectId,
+      };
+      const res = await apiFetch('/api/v1/agents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        const errMsg = await extractApiError(res, 'Failed to spawn agent');
+        this.insertLocalSystemMessage(`Failed to spawn agent: ${errMsg}`);
+        return;
+      }
+
+      const data = (await res.json()) as { name?: string; slug?: string };
+      const name = data?.slug || data?.name || template;
+      this.insertLocalSystemMessage(`Agent "${name}" spawned successfully.`);
+    } catch (err) {
+      this.insertLocalSystemMessage(
+        `Failed to spawn agent: ${err instanceof Error ? err.message : 'unknown error'}`
+      );
+    }
+  }
+
+  /** /stop <agent> — Stop a running agent. */
+  private async handleSlashStop(args: string): Promise<void> {
+    const agentSlug = args.trim();
+    if (!agentSlug) {
+      this.insertLocalSystemMessage('Usage: /stop <agent-slug>');
+      return;
+    }
+
+    try {
+      const res = await apiFetch(
+        `/api/v1/agents/${encodeURIComponent(agentSlug)}`,
+        { method: 'DELETE' }
+      );
+
+      if (!res.ok) {
+        const errMsg = await extractApiError(res, 'Failed to stop agent');
+        this.insertLocalSystemMessage(`Failed to stop agent: ${errMsg}`);
+        return;
+      }
+
+      this.insertLocalSystemMessage(`Agent "${agentSlug}" stop requested.`);
+    } catch (err) {
+      this.insertLocalSystemMessage(
+        `Failed to stop agent: ${err instanceof Error ? err.message : 'unknown error'}`
+      );
+    }
+  }
+
+  /** Insert a local-only system message into the thread. */
+  private insertLocalSystemMessage(text: string): void {
+    const localMsg: Message = {
+      id: `local-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      projectId: this.projectId,
+      sender: 'system',
+      senderId: '',
+      recipient: '',
+      recipientId: '',
+      msg: text,
+      type: 'system',
+      agentId: '',
+      createdAt: new Date().toISOString(),
+    };
+    this.mergeMessages([localMsg]);
+    this.scrollToBottomAfterRender();
+  }
+
   /** Focus the composer textarea when clicking the message area background. */
   private handleMessageAreaClick(e: MouseEvent): void {
     const target = e.target as HTMLElement;
@@ -2095,7 +2467,16 @@ export class ScionChatThread extends LitElement {
           @chat-edit=${this.handleChatEditV2}
           @chat-typing=${() => this.sendTypingEvent()}
           @default-agent-change=${this.handleDefaultAgentChange}
+          @chat-slash-command=${this.handleSlashCommand}
         ></scion-chat-composer>
+        ${this.renderContextMenu()}
+        <scion-send-to-agent-picker
+          .agents=${this.agents}
+          ?open=${this.showAgentPicker}
+          .posX=${this.contextMenuPosition.x}
+          .posY=${this.contextMenuPosition.y}
+          @agent-selected=${this.handleAgentSelected}
+        ></scion-send-to-agent-picker>
       </div>
     `;
   }
@@ -2377,6 +2758,7 @@ export class ScionChatThread extends LitElement {
 
       rows.push(html`
         <scion-chat-message
+          @contextmenu=${(e: MouseEvent) => this.handleMessageContextMenu(e, msg)}
           id="msg-${msg.id}"
           body=${msg.msg}
           sender=${msg.sender}

--- a/web/src/components/shared/chat/send-to-agent-picker.ts
+++ b/web/src/components/shared/chat/send-to-agent-picker.ts
@@ -1,0 +1,287 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Send-to-agent picker component.
+ *
+ * Shows a dropdown of available agents. When the user selects an agent,
+ * emits an `agent-selected` event so the parent can navigate to the
+ * agent's DM with the source message content as quoted context.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import type { Agent } from '../../../shared/types.js';
+
+/** Detail emitted when the user selects an agent from the picker. */
+export interface AgentSelectedDetail {
+  agentSlug: string;
+  agentId: string;
+}
+
+@customElement('scion-send-to-agent-picker')
+export class ScionSendToAgentPicker extends LitElement {
+  /** All agents available for sending to. Set by the parent. */
+  @property({ type: Array })
+  agents: Agent[] = [];
+
+  /** Whether the picker is currently open. */
+  @property({ type: Boolean, reflect: true })
+  open = false;
+
+  /** Absolute X position for the picker. */
+  @property({ type: Number })
+  posX = 0;
+
+  /** Absolute Y position for the picker. */
+  @property({ type: Number })
+  posY = 0;
+
+  /** Filter text for narrowing the agent list. */
+  @state() private filterText = '';
+
+  /** Index of the highlighted agent in the filtered list. */
+  @state() private highlightIndex = 0;
+
+  static override styles = css`
+    :host {
+      display: block;
+      position: fixed;
+      z-index: 200;
+    }
+
+    .picker-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 199;
+    }
+
+    .picker {
+      position: relative;
+      z-index: 200;
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.5rem;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+      min-width: 220px;
+      max-width: 300px;
+      max-height: 320px;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .picker-header {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--scion-text-muted, #64748b);
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+    }
+
+    .picker-filter {
+      padding: 0.375rem 0.75rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+    }
+
+    .picker-filter input {
+      width: 100%;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.25rem;
+      padding: 0.25rem 0.5rem;
+      font-size: 0.8125rem;
+      outline: none;
+      background: var(--scion-surface, #ffffff);
+      color: var(--scion-text, #1e293b);
+    }
+
+    .picker-filter input:focus {
+      border-color: var(--scion-primary, #3b82f6);
+    }
+
+    .picker-list {
+      overflow-y: auto;
+      flex: 1;
+    }
+
+    .picker-item {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 0.75rem;
+      cursor: pointer;
+      font-size: 0.8125rem;
+      color: var(--scion-text, #1e293b);
+      transition: background 0.1s;
+    }
+
+    .picker-item:hover,
+    .picker-item.highlighted {
+      background: var(--scion-primary-50, #eff6ff);
+    }
+
+    .picker-item sl-icon {
+      font-size: 0.875rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .picker-item .agent-slug {
+      font-weight: 600;
+    }
+
+    .picker-item .agent-name {
+      font-size: 0.6875rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .no-agents {
+      padding: 0.75rem;
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+      font-style: italic;
+      text-align: center;
+    }
+  `;
+
+  override render() {
+    if (!this.open) return nothing;
+
+    const filtered = this.filteredAgents();
+
+    return html`
+      <div class="picker-overlay" @click=${this.handleOverlayClick}></div>
+      <div class="picker" style="left: ${this.posX}px; top: ${this.posY}px;">
+        <div class="picker-header">Send to Agent</div>
+        <div class="picker-filter">
+          <input
+            type="text"
+            placeholder="Filter agents..."
+            .value=${this.filterText}
+            @input=${this.handleFilterInput}
+            @keydown=${this.handleKeydown}
+          />
+        </div>
+        <div class="picker-list">
+          ${filtered.length > 0
+            ? filtered.map(
+                (agent, i) => html`
+                  <div
+                    class="picker-item ${i === this.highlightIndex ? 'highlighted' : ''}"
+                    @click=${() => this.selectAgent(agent)}
+                    @mouseenter=${() => { this.highlightIndex = i; }}
+                  >
+                    <sl-icon name="cpu"></sl-icon>
+                    <span class="agent-slug">${agent.slug || agent.name}</span>
+                    ${agent.slug && agent.name && agent.slug !== agent.name
+                      ? html`<span class="agent-name">${agent.name}</span>`
+                      : nothing}
+                  </div>
+                `
+              )
+            : html`<div class="no-agents">No agents found</div>`}
+        </div>
+      </div>
+    `;
+  }
+
+  override updated(changedProperties: Map<string, unknown>): void {
+    super.updated(changedProperties);
+    if (changedProperties.has('open') && this.open) {
+      this.filterText = '';
+      this.highlightIndex = 0;
+      // Focus the filter input after render
+      void this.updateComplete.then(() => {
+        const input = this.shadowRoot?.querySelector('.picker-filter input') as HTMLInputElement | null;
+        if (input) input.focus();
+      });
+    }
+  }
+
+  /** Close the picker. */
+  close(): void {
+    this.open = false;
+    this.filterText = '';
+    this.highlightIndex = 0;
+  }
+
+  /** Filter agents based on the filter text. */
+  private filteredAgents(): Agent[] {
+    if (!this.filterText) return this.agents;
+    const lower = this.filterText.toLowerCase();
+    return this.agents.filter((a) => {
+      const slug = (a.slug || a.name || '').toLowerCase();
+      const name = (a.name || '').toLowerCase();
+      return slug.includes(lower) || name.includes(lower);
+    });
+  }
+
+  private handleFilterInput(e: Event): void {
+    this.filterText = (e.target as HTMLInputElement).value;
+    this.highlightIndex = 0;
+  }
+
+  private handleKeydown(e: KeyboardEvent): void {
+    const filtered = this.filteredAgents();
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        if (filtered.length > 0) {
+          this.highlightIndex = (this.highlightIndex + 1) % filtered.length;
+        }
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        if (filtered.length > 0) {
+          this.highlightIndex = (this.highlightIndex - 1 + filtered.length) % filtered.length;
+        }
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (filtered.length > 0 && this.highlightIndex < filtered.length) {
+          this.selectAgent(filtered[this.highlightIndex]);
+        }
+        break;
+      case 'Escape':
+        e.preventDefault();
+        this.close();
+        break;
+    }
+  }
+
+  private selectAgent(agent: Agent): void {
+    this.dispatchEvent(
+      new CustomEvent<AgentSelectedDetail>('agent-selected', {
+        detail: {
+          agentSlug: agent.slug || agent.name || '',
+          agentId: agent.id,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    this.close();
+  }
+
+  private handleOverlayClick(): void {
+    this.close();
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-send-to-agent-picker': ScionSendToAgentPicker;
+  }
+}

--- a/web/src/components/shared/chat/slash-autocomplete.ts
+++ b/web/src/components/shared/chat/slash-autocomplete.ts
@@ -1,0 +1,265 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Slash command autocomplete dropdown component.
+ *
+ * Provides slash-command suggestions in the chat composer.
+ * Follows the same pattern as mention-autocomplete.ts.
+ *
+ * Design decisions:
+ * - Trigger: `/` at position 0 of the input (start of text only)
+ * - Matching: case-insensitive prefix match on command name
+ * - Keys: Up/Down navigate, Enter/Tab accept, Esc dismiss
+ * - On accept: emits `slash-command` event with {command, args}
+ * - Dropdown capped at 8 items
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+/** Maximum items shown in the dropdown. */
+const MAX_DROPDOWN_ITEMS = 8;
+
+/** A slash command definition. */
+export interface SlashCommand {
+  name: string;
+  description: string;
+  usage: string;
+}
+
+/** Detail emitted when the user selects a slash command. */
+export interface SlashCommandDetail {
+  command: string;
+  args: string;
+}
+
+/** Built-in slash commands. */
+const BUILT_IN_COMMANDS: SlashCommand[] = [
+  { name: 'status', description: 'Show project status', usage: '/status' },
+  { name: 'clear', description: 'Clear the conversation', usage: '/clear' },
+  { name: 'help', description: 'Show available commands', usage: '/help' },
+  { name: 'spawn', description: 'Spawn a new agent', usage: '/spawn <template>' },
+  { name: 'stop', description: 'Stop a running agent', usage: '/stop <agent>' },
+  { name: 'default', description: 'Set or clear default agent', usage: '/default <agent|clear>' },
+];
+
+@customElement('scion-slash-autocomplete')
+export class ScionSlashAutocomplete extends LitElement {
+  /** Whether the autocomplete is currently active. */
+  @property({ type: Boolean })
+  active = false;
+
+  /** Filtered commands matching the current input. */
+  @state() private commands: SlashCommand[] = [];
+
+  /** Index of the highlighted command. */
+  @state() private selectedIndex = 0;
+
+  static override styles = css`
+    :host {
+      display: block;
+      position: relative;
+    }
+
+    .dropdown {
+      position: absolute;
+      z-index: 100;
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.5rem;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+      max-width: 320px;
+      min-width: 220px;
+      overflow: hidden;
+      bottom: calc(100% + 4px);
+      left: 0;
+    }
+
+    .dropdown-item {
+      display: flex;
+      flex-direction: column;
+      padding: 0.375rem 0.75rem;
+      cursor: pointer;
+      font-size: 0.8125rem;
+      transition: background 0.1s;
+    }
+
+    .dropdown-item:hover,
+    .dropdown-item.highlighted {
+      background: var(--scion-primary-50, #eff6ff);
+    }
+
+    .dropdown-item .command-name {
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .dropdown-item .command-desc {
+      font-size: 0.6875rem;
+      color: var(--scion-text-muted, #64748b);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  `;
+
+  override render() {
+    if (!this.active || this.commands.length === 0) return nothing;
+
+    return html`
+      <div class="dropdown" @mousedown=${this.handleMouseDown}>
+        ${this.commands.map(
+          (cmd, i) => html`
+            <div
+              class="dropdown-item ${i === this.selectedIndex ? 'highlighted' : ''}"
+              data-index=${i}
+              @click=${() => this.acceptCommand(i)}
+              @mouseenter=${() => { this.selectedIndex = i; }}
+            >
+              <span class="command-name">/${cmd.name}</span>
+              <span class="command-desc">${cmd.description}</span>
+            </div>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  /**
+   * Called by the parent composer on every input event.
+   * Determines whether to open/update/close the autocomplete.
+   *
+   * @param text Full textarea value
+   * @param _cursorPos Current cursor position (unused — slash commands trigger at position 0)
+   */
+  handleInput(text: string, _cursorPos: number): void {
+    // Only trigger if the text starts with `/`
+    if (!text.startsWith('/')) {
+      this.dismiss();
+      return;
+    }
+
+    // Extract the command prefix (the word after `/`, before any space)
+    const afterSlash = text.slice(1);
+    const spaceIdx = afterSlash.indexOf(' ');
+    const prefix = spaceIdx >= 0 ? afterSlash.slice(0, spaceIdx) : afterSlash;
+
+    // If the user has already typed a full command + space, don't show autocomplete
+    if (spaceIdx >= 0) {
+      const matched = BUILT_IN_COMMANDS.find(
+        (cmd) => cmd.name.toLowerCase() === prefix.toLowerCase()
+      );
+      if (matched) {
+        // Full command typed, dismiss
+        this.dismiss();
+        return;
+      }
+    }
+
+    // Filter commands by prefix
+    const lowerPrefix = prefix.toLowerCase();
+    const matched = BUILT_IN_COMMANDS.filter((cmd) =>
+      cmd.name.toLowerCase().startsWith(lowerPrefix)
+    ).slice(0, MAX_DROPDOWN_ITEMS);
+
+    if (matched.length === 0) {
+      this.dismiss();
+      return;
+    }
+
+    this.commands = matched;
+    this.selectedIndex = 0;
+    this.active = true;
+  }
+
+  /**
+   * Called by the parent on keydown. Returns true if the event was consumed.
+   */
+  handleKeydown(e: KeyboardEvent): boolean {
+    if (!this.active) return false;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        this.selectedIndex = (this.selectedIndex + 1) % this.commands.length;
+        return true;
+
+      case 'ArrowUp':
+        e.preventDefault();
+        this.selectedIndex =
+          (this.selectedIndex - 1 + this.commands.length) % this.commands.length;
+        return true;
+
+      case 'Enter':
+      case 'Tab':
+        e.preventDefault();
+        this.acceptCommand(this.selectedIndex);
+        return true;
+
+      case 'Escape':
+        e.preventDefault();
+        this.dismiss();
+        return true;
+
+      default:
+        return false;
+    }
+  }
+
+  /** Dismiss the dropdown. */
+  dismiss(): void {
+    this.active = false;
+    this.commands = [];
+    this.selectedIndex = 0;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  /** Dispatch the slash-command event and close the dropdown. */
+  private acceptCommand(index: number): void {
+    const cmd = this.commands[index];
+    if (!cmd) return;
+
+    this.dispatchEvent(
+      new CustomEvent<SlashCommandDetail>('slash-command', {
+        detail: {
+          command: cmd.name,
+          args: '',
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+
+    this.dismiss();
+  }
+
+  /**
+   * Prevent the textarea from losing focus when clicking the dropdown.
+   */
+  private handleMouseDown(e: Event): void {
+    e.preventDefault();
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-slash-autocomplete': ScionSlashAutocomplete;
+  }
+}

--- a/web/src/components/shared/markdown-preview.ts
+++ b/web/src/components/shared/markdown-preview.ts
@@ -244,7 +244,7 @@ export class ScionMarkdownPreview extends LitElement {
       `;
     }
 
-    return html`<div class="preview-container" part="container" .innerHTML=${this.renderedHtml}></div>`;
+    return html`<div class="preview-container" .innerHTML=${this.renderedHtml}></div>`;
   }
 }
 


### PR DESCRIPTION
Phase 5 of the native chat feature gap programme (ptone/scion#1026).

Implements 5 issues:
- ptone/scion#1059: Deep links from agent messages (session IDs, agent slugs, commit SHAs, file paths)
- ptone/scion#1060: Rich agent output rendering (diffs, test results, JSON/YAML, collapsible long output)
- ptone/scion#1064: Export thread as agent-ready markdown
- ptone/scion#1058: Send message/selection to agent as context
- ptone/scion#1062: Slash commands in chat composer

3 stretch items deferred to future work:
- ptone/scion#1057: Interactive agent messages (approve/deny/choose)
- ptone/scion#1061: Inter-agent observation upgrades
- ptone/scion#1063: Thread-per-run

Code-reviewed, all findings addressed.
