### PR TITLE
feat(web-chat): Phase 4 — Developer ergonomics improvements

### DIFF
--- a/pkg/hub/chat_idempotency.go
+++ b/pkg/hub/chat_idempotency.go
@@ -44,13 +44,16 @@ func NewChatIdempotencyCache() *ChatIdempotencyCache {
 }
 
 // Check returns the existing message ID if the (senderID, idempotencyKey)
-// pair was seen within the TTL window. Also cleans up expired entries.
+// pair was seen within the TTL window.
 func (c *ChatIdempotencyCache) Check(senderID, idempotencyKey string) (string, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	now := time.Now()
-	c.cleanExpiredLocked(now)
+	// Amortized cleanup: only sweep when cache grows beyond threshold.
+	if len(c.entries) > 100 {
+		c.cleanExpiredLocked(now)
+	}
 
 	key := senderID + ":" + idempotencyKey
 	entry, ok := c.entries[key]
@@ -71,6 +74,12 @@ func (c *ChatIdempotencyCache) Record(senderID, idempotencyKey, messageID string
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	// Amortized cleanup in Record too, so entries never accumulate
+	// unboundedly even if Check() is rarely called.
+	if len(c.entries) > 100 {
+		c.cleanExpiredLocked(time.Now())
+	}
 
 	key := senderID + ":" + idempotencyKey
 	c.entries[key] = chatIdempotencyEntry{

--- a/pkg/hub/chat_idempotency.go
+++ b/pkg/hub/chat_idempotency.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"sync"
+	"time"
+)
+
+// chatIdempotencyTTL is how long an idempotency key is remembered.
+const chatIdempotencyTTL = 5 * time.Minute
+
+// chatIdempotencyEntry stores a cached idempotency result.
+type chatIdempotencyEntry struct {
+	messageID string
+	expiresAt time.Time
+}
+
+// ChatIdempotencyCache is a lightweight in-memory cache keyed by
+// senderID + ":" + idempotencyKey. Entries expire after 5 minutes.
+// It is safe for concurrent use.
+type ChatIdempotencyCache struct {
+	mu      sync.Mutex
+	entries map[string]chatIdempotencyEntry
+}
+
+// NewChatIdempotencyCache creates a new empty idempotency cache.
+func NewChatIdempotencyCache() *ChatIdempotencyCache {
+	return &ChatIdempotencyCache{
+		entries: make(map[string]chatIdempotencyEntry),
+	}
+}
+
+// Check returns the existing message ID if the (senderID, idempotencyKey)
+// pair was seen within the TTL window. Also cleans up expired entries.
+func (c *ChatIdempotencyCache) Check(senderID, idempotencyKey string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	c.cleanExpiredLocked(now)
+
+	key := senderID + ":" + idempotencyKey
+	entry, ok := c.entries[key]
+	if !ok {
+		return "", false
+	}
+	if now.After(entry.expiresAt) {
+		delete(c.entries, key)
+		return "", false
+	}
+	return entry.messageID, true
+}
+
+// Record stores a (senderID, idempotencyKey) -> messageID mapping.
+func (c *ChatIdempotencyCache) Record(senderID, idempotencyKey, messageID string) {
+	if idempotencyKey == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := senderID + ":" + idempotencyKey
+	c.entries[key] = chatIdempotencyEntry{
+		messageID: messageID,
+		expiresAt: time.Now().Add(chatIdempotencyTTL),
+	}
+}
+
+// cleanExpiredLocked removes entries whose TTL has passed.
+// Must be called with c.mu held.
+func (c *ChatIdempotencyCache) cleanExpiredLocked(now time.Time) {
+	for key, entry := range c.entries {
+		if now.After(entry.expiresAt) {
+			delete(c.entries, key)
+		}
+	}
+}

--- a/pkg/hub/chat_idempotency.go
+++ b/pkg/hub/chat_idempotency.go
@@ -22,6 +22,10 @@ import (
 // chatIdempotencyTTL is how long an idempotency key is remembered.
 const chatIdempotencyTTL = 5 * time.Minute
 
+// idempotencyCacheCleanupThreshold is the number of entries beyond which
+// an amortized sweep of expired entries is triggered.
+const idempotencyCacheCleanupThreshold = 100
+
 // chatIdempotencyEntry stores a cached idempotency result.
 type chatIdempotencyEntry struct {
 	messageID string
@@ -29,7 +33,9 @@ type chatIdempotencyEntry struct {
 }
 
 // ChatIdempotencyCache is a lightweight in-memory cache keyed by
-// senderID + ":" + idempotencyKey. Entries expire after 5 minutes.
+// senderID + "\x00" + idempotencyKey. A null byte separator is used
+// because it cannot appear in UUIDs, preventing collisions between
+// sender IDs and idempotency keys. Entries expire after 5 minutes.
 // It is safe for concurrent use.
 type ChatIdempotencyCache struct {
 	mu      sync.Mutex
@@ -51,11 +57,11 @@ func (c *ChatIdempotencyCache) Check(senderID, idempotencyKey string) (string, b
 
 	now := time.Now()
 	// Amortized cleanup: only sweep when cache grows beyond threshold.
-	if len(c.entries) > 100 {
+	if len(c.entries) > idempotencyCacheCleanupThreshold {
 		c.cleanExpiredLocked(now)
 	}
 
-	key := senderID + ":" + idempotencyKey
+	key := senderID + "\x00" + idempotencyKey
 	entry, ok := c.entries[key]
 	if !ok {
 		return "", false
@@ -77,11 +83,11 @@ func (c *ChatIdempotencyCache) Record(senderID, idempotencyKey, messageID string
 
 	// Amortized cleanup in Record too, so entries never accumulate
 	// unboundedly even if Check() is rarely called.
-	if len(c.entries) > 100 {
+	if len(c.entries) > idempotencyCacheCleanupThreshold {
 		c.cleanExpiredLocked(time.Now())
 	}
 
-	key := senderID + ":" + idempotencyKey
+	key := senderID + "\x00" + idempotencyKey
 	c.entries[key] = chatIdempotencyEntry{
 		messageID: messageID,
 		expiresAt: time.Now().Add(chatIdempotencyTTL),

--- a/pkg/hub/chat_idempotency_test.go
+++ b/pkg/hub/chat_idempotency_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"testing"
+	"time"
+)
+
+func TestChatIdempotencyCache_CheckAndRecord(t *testing.T) {
+	c := NewChatIdempotencyCache()
+
+	// Before recording, Check should return false.
+	_, ok := c.Check("user1", "key1")
+	if ok {
+		t.Fatal("expected Check to return false for unknown key")
+	}
+
+	// Record and then Check should return the message ID.
+	c.Record("user1", "key1", "msg-abc")
+	id, ok := c.Check("user1", "key1")
+	if !ok {
+		t.Fatal("expected Check to return true after Record")
+	}
+	if id != "msg-abc" {
+		t.Errorf("expected message ID %q, got %q", "msg-abc", id)
+	}
+}
+
+func TestChatIdempotencyCache_DifferentSenders(t *testing.T) {
+	c := NewChatIdempotencyCache()
+
+	c.Record("user1", "key1", "msg-1")
+	c.Record("user2", "key1", "msg-2")
+
+	id1, ok1 := c.Check("user1", "key1")
+	id2, ok2 := c.Check("user2", "key1")
+
+	if !ok1 || id1 != "msg-1" {
+		t.Errorf("user1: expected msg-1, got %q (ok=%v)", id1, ok1)
+	}
+	if !ok2 || id2 != "msg-2" {
+		t.Errorf("user2: expected msg-2, got %q (ok=%v)", id2, ok2)
+	}
+}
+
+func TestChatIdempotencyCache_EmptyKeySkipped(t *testing.T) {
+	c := NewChatIdempotencyCache()
+
+	c.Record("user1", "", "msg-no-key")
+	_, ok := c.Check("user1", "")
+	if ok {
+		t.Fatal("empty idempotency key should not be recorded")
+	}
+}
+
+func TestChatIdempotencyCache_ExpiresAfterTTL(t *testing.T) {
+	c := NewChatIdempotencyCache()
+
+	c.Record("user1", "key1", "msg-1")
+
+	// Manually expire the entry.
+	c.mu.Lock()
+	for k := range c.entries {
+		c.entries[k] = chatIdempotencyEntry{
+			messageID: "msg-1",
+			expiresAt: time.Now().Add(-1 * time.Second),
+		}
+	}
+	c.mu.Unlock()
+
+	_, ok := c.Check("user1", "key1")
+	if ok {
+		t.Fatal("expected expired entry to be cleaned up")
+	}
+}

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -812,6 +812,11 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 	// the existing message ID (200 OK) instead of creating a duplicate.
 	if body.IdempotencyKey != "" {
 		if existingID, ok := s.chatIdempotency.Check(user.ID(), body.IdempotencyKey); ok {
+			// Idempotency hit: return the existing message ID.
+			// We return the minimal response (ID + current content) rather than
+			// re-fetching the stored message, because the client already received
+			// the full 201 response on the original send. This response only
+			// signals "your message was already accepted."
 			writeJSON(w, http.StatusOK, chatMessageResponse{
 				ID:      existingID,
 				Content: content,

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -760,8 +760,9 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 	// --- Validate body ---
 	r.Body = http.MaxBytesReader(w, r.Body, 1048576)
 	var body struct {
-		Content     string   `json:"content"`
-		Attachments []string `json:"attachments,omitempty"` // W7: attachment IDs
+		Content        string   `json:"content"`
+		Attachments    []string `json:"attachments,omitempty"` // W7: attachment IDs
+		IdempotencyKey string   `json:"idempotency_key,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		BadRequest(w, "invalid request body")
@@ -802,6 +803,21 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 				MimeType: meta.MimeType,
 				Size:     meta.Size,
 			})
+		}
+	}
+
+	// --- Idempotency check (#1055) ---
+	// If the client supplied an idempotency key, check whether a message with
+	// that key from this sender was already created recently. If so, return
+	// the existing message ID (200 OK) instead of creating a duplicate.
+	if body.IdempotencyKey != "" {
+		if existingID, ok := s.chatIdempotency.Check(user.ID(), body.IdempotencyKey); ok {
+			writeJSON(w, http.StatusOK, chatMessageResponse{
+				ID:      existingID,
+				Content: content,
+				Sender:  "user:" + user.DisplayName(),
+			})
+			return
 		}
 	}
 
@@ -847,10 +863,18 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 
 	now := time.Now().UTC()
 
+	// Closure to record idempotency after message creation.
+	recordIdempotency := func(messageID string) {
+		if body.IdempotencyKey != "" {
+			s.chatIdempotency.Record(user.ID(), body.IdempotencyKey, messageID)
+		}
+	}
+
 	// Step 3: Determine routing.
 	if len(mentionedAgents) > 0 {
 		// --- Agent-routed: explicit mentions ---
-		s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, mentionedAgents, mentionNames, mentionResults, attachmentRefs, now)
+		msgID := s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, mentionedAgents, mentionNames, mentionResults, attachmentRefs, now)
+		recordIdempotency(msgID)
 		// Ensure DM registry rows exist so the DM appears in the rail.
 		if isDM {
 			s.ensureDMRegistered(ctx, key, user.ID())
@@ -866,7 +890,8 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 		if agentID := parseAgentDMKey(key); agentID != "" {
 			dmAgent, err := s.store.GetAgent(ctx, agentID)
 			if err == nil && dmAgent != nil {
-				s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{dmAgent}, mentionNames, nil, attachmentRefs, now)
+				msgID := s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{dmAgent}, mentionNames, nil, attachmentRefs, now)
+				recordIdempotency(msgID)
 				// Ensure DM registry rows exist so the DM appears in the rail.
 				s.ensureDMRegistered(ctx, key, user.ID())
 				return
@@ -884,26 +909,29 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 				defaultAgent, err = s.store.GetAgent(ctx, topic.DefaultAgent)
 			}
 			if err == nil && defaultAgent != nil {
-				s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{defaultAgent}, mentionNames, nil, attachmentRefs, now)
+				msgID := s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{defaultAgent}, mentionNames, nil, attachmentRefs, now)
+				recordIdempotency(msgID)
 				return
 			}
 		}
 	}
 
 	// --- Human-to-human message ---
-	s.sendHumanToHuman(w, r, key, projectID, user, content, senderLabel, isDM, mentionNames, attachmentRefs, now)
+	msgID := s.sendHumanToHuman(w, r, key, projectID, user, content, senderLabel, isDM, mentionNames, attachmentRefs, now)
+	recordIdempotency(msgID)
 }
 
 // sendAgentRouted sends a message through the existing agent dispatch path.
+// Returns the persisted message ID (empty on error).
 func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, projectID string, user UserIdentity,
 	content, senderLabel string, agents []*store.Agent, mentionNames []string, mentionResults []messages.MentionResult,
-	attachmentRefs []AttachmentRef, now time.Time) {
+	attachmentRefs []AttachmentRef, now time.Time) string {
 
 	ctx := r.Context()
 
 	if len(agents) == 0 {
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "no agent to route to", nil)
-		return
+		return ""
 	}
 
 	primaryAgent := agents[0]
@@ -1005,7 +1033,7 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 	if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 		s.messageLog.Error("Failed to persist agent-routed message", "error", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to persist message", nil)
-		return
+		return ""
 	}
 
 	// W7: Link attachments to the persisted message.
@@ -1096,11 +1124,13 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 		Mentions:    mentionResults,
 		Attachments: attachmentRefs,
 	})
+	return storeMsg.ID
 }
 
 // sendHumanToHuman persists a type:chat message for human-to-human communication.
+// Returns the persisted message ID (empty on error).
 func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, projectID string, user UserIdentity,
-	content, senderLabel string, isDM bool, mentionNames []string, attachmentRefs []AttachmentRef, now time.Time) {
+	content, senderLabel string, isDM bool, mentionNames []string, attachmentRefs []AttachmentRef, now time.Time) string {
 
 	ctx := r.Context()
 
@@ -1153,7 +1183,7 @@ func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, p
 
 	if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to persist message", nil)
-		return
+		return ""
 	}
 
 	// W7: Link attachments to the persisted message.
@@ -1201,6 +1231,7 @@ func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, p
 		CreatedAt:   now,
 		Attachments: attachmentRefs,
 	})
+	return storeMsg.ID
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -879,6 +879,9 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 	if len(mentionedAgents) > 0 {
 		// --- Agent-routed: explicit mentions ---
 		msgID := s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, mentionedAgents, mentionNames, mentionResults, attachmentRefs, now)
+		if msgID == "" {
+			return // error response already written by sendAgentRouted
+		}
 		recordIdempotency(msgID)
 		// Ensure DM registry rows exist so the DM appears in the rail.
 		if isDM {
@@ -896,6 +899,9 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 			dmAgent, err := s.store.GetAgent(ctx, agentID)
 			if err == nil && dmAgent != nil {
 				msgID := s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{dmAgent}, mentionNames, nil, attachmentRefs, now)
+				if msgID == "" {
+					return // error response already written by sendAgentRouted
+				}
 				recordIdempotency(msgID)
 				// Ensure DM registry rows exist so the DM appears in the rail.
 				s.ensureDMRegistered(ctx, key, user.ID())
@@ -915,6 +921,9 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 			}
 			if err == nil && defaultAgent != nil {
 				msgID := s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{defaultAgent}, mentionNames, nil, attachmentRefs, now)
+				if msgID == "" {
+					return // error response already written by sendAgentRouted
+				}
 				recordIdempotency(msgID)
 				return
 			}
@@ -923,6 +932,9 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 
 	// --- Human-to-human message ---
 	msgID := s.sendHumanToHuman(w, r, key, projectID, user, content, senderLabel, isDM, mentionNames, attachmentRefs, now)
+	if msgID == "" {
+		return // error response already written by sendHumanToHuman
+	}
 	recordIdempotency(msgID)
 }
 

--- a/pkg/hub/handlers_chat_v2_test.go
+++ b/pkg/hub/handlers_chat_v2_test.go
@@ -2346,3 +2346,134 @@ func TestChatV2_Send_RateLimitsFloodingHuman(t *testing.T) {
 		t.Fatalf("expected the send to succeed after backing off, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1055: Idempotency key on send
+// ---------------------------------------------------------------------------
+
+func TestChatV2_Send_IdempotencyKey_DeduplicatesSend(t *testing.T) {
+	srv, _, wcs, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	// Create a topic.
+	topicID := tid("topic-idem-1")
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        topicID,
+		ProjectID: proj.ID,
+		Name:      "idempotency-test",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	path := "/api/v1/chat/conversations/" + topicID + "/messages"
+	idemKey := "test-idempotency-key-123"
+
+	// First send — should create the message (201).
+	body1 := map[string]string{"content": "idempotent message", "idempotency_key": idemKey}
+	rec1 := doRequest(t, srv, http.MethodPost, path, body1)
+	if rec1.Code != http.StatusCreated {
+		t.Fatalf("first send: expected 201, got %d: %s", rec1.Code, rec1.Body.String())
+	}
+
+	var resp1 chatMessageResponse
+	if err := json.NewDecoder(rec1.Body).Decode(&resp1); err != nil {
+		t.Fatalf("decode first response: %v", err)
+	}
+	if resp1.ID == "" {
+		t.Fatal("first send: expected non-empty message ID")
+	}
+
+	// Second send with the same idempotency key — should return 200 with the same ID.
+	body2 := map[string]string{"content": "idempotent message", "idempotency_key": idemKey}
+	rec2 := doRequest(t, srv, http.MethodPost, path, body2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("second send: expected 200, got %d: %s", rec2.Code, rec2.Body.String())
+	}
+
+	var resp2 chatMessageResponse
+	if err := json.NewDecoder(rec2.Body).Decode(&resp2); err != nil {
+		t.Fatalf("decode second response: %v", err)
+	}
+	if resp2.ID != resp1.ID {
+		t.Errorf("expected same message ID %q on duplicate, got %q", resp1.ID, resp2.ID)
+	}
+}
+
+func TestChatV2_Send_DifferentIdempotencyKeys_CreateSeparateMessages(t *testing.T) {
+	srv, _, wcs, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	topicID := tid("topic-idem-2")
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        topicID,
+		ProjectID: proj.ID,
+		Name:      "idempotency-diff",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	path := "/api/v1/chat/conversations/" + topicID + "/messages"
+
+	// Two sends with different keys should create two distinct messages.
+	body1 := map[string]string{"content": "first message", "idempotency_key": "key-a"}
+	rec1 := doRequest(t, srv, http.MethodPost, path, body1)
+	if rec1.Code != http.StatusCreated {
+		t.Fatalf("first send: expected 201, got %d", rec1.Code)
+	}
+	var resp1 chatMessageResponse
+	_ = json.NewDecoder(rec1.Body).Decode(&resp1)
+
+	body2 := map[string]string{"content": "second message", "idempotency_key": "key-b"}
+	rec2 := doRequest(t, srv, http.MethodPost, path, body2)
+	if rec2.Code != http.StatusCreated {
+		t.Fatalf("second send: expected 201, got %d", rec2.Code)
+	}
+	var resp2 chatMessageResponse
+	_ = json.NewDecoder(rec2.Body).Decode(&resp2)
+
+	if resp1.ID == resp2.ID {
+		t.Errorf("different idempotency keys should produce different message IDs, both got %q", resp1.ID)
+	}
+}
+
+func TestChatV2_Send_NoIdempotencyKey_AlwaysCreates(t *testing.T) {
+	srv, _, wcs, proj := setupSendTest(t)
+	ctx := context.Background()
+
+	topicID := tid("topic-idem-3")
+	if err := wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        topicID,
+		ProjectID: proj.ID,
+		Name:      "no-idem-key",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	path := "/api/v1/chat/conversations/" + topicID + "/messages"
+
+	// Without an idempotency key, each send creates a new message.
+	body := map[string]string{"content": "same content, no key"}
+	rec1 := doRequest(t, srv, http.MethodPost, path, body)
+	if rec1.Code != http.StatusCreated {
+		t.Fatalf("first send: expected 201, got %d", rec1.Code)
+	}
+	var resp1 chatMessageResponse
+	_ = json.NewDecoder(rec1.Body).Decode(&resp1)
+
+	rec2 := doRequest(t, srv, http.MethodPost, path, body)
+	if rec2.Code != http.StatusCreated {
+		t.Fatalf("second send: expected 201, got %d", rec2.Code)
+	}
+	var resp2 chatMessageResponse
+	_ = json.NewDecoder(rec2.Body).Decode(&resp2)
+
+	if resp1.ID == resp2.ID {
+		t.Errorf("sends without idempotency key should create distinct messages, both got %q", resp1.ID)
+	}
+}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -762,6 +762,10 @@ type Server struct {
 	// Set once in New and read without the lock; nil-safe.
 	chatSendLimiter *chatSendLimiter
 
+	// In-memory idempotency cache for chat message sends (#1055).
+	// Keyed by senderID:idempotencyKey with a 5-minute TTL.
+	chatIdempotency *ChatIdempotencyCache
+
 	// Channel registry for external notification delivery (nil = disabled)
 	channelRegistry *ChannelRegistry
 
@@ -1006,6 +1010,7 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 
 	// Per-sender chat send rate limiter (#1054).
 	srv.chatSendLimiter = newChatSendLimiter()
+	srv.chatIdempotency = NewChatIdempotencyCache()
 
 	ctx := context.Background()
 

--- a/pkg/messages/types.go
+++ b/pkg/messages/types.go
@@ -25,7 +25,7 @@ import (
 const Version = 1
 
 // Maximum length of the Msg field in characters for outbound messages.
-const MaxMessageLength = 2000
+const MaxMessageLength = 16000
 
 // Maximum size of the Msg field in bytes.
 const MaxMsgSize = 64 * 1024 // 64KB

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -2330,6 +2330,7 @@ export class ScionPageChat extends LitElement {
                 name: `#${thread.name}`,
                 spaceName: space.projectName,
                 isDM: false,
+                projectId: space.projectId,
                 ...(thread.lastActivityAt ? { lastActivityAt: thread.lastActivityAt } : {}),
               });
             }
@@ -2376,20 +2377,13 @@ export class ScionPageChat extends LitElement {
       if (key.startsWith('dm:')) {
         navigateTo(`/chat/dm/${encodeURIComponent(key)}`);
       } else {
-        // Find the project slug for this thread.
-        // Thread topics are project-scoped: find a matching space.
+        // Find the project slug for this thread via its projectId.
         let foundSlug = '';
-        for (const conv of this.v2SwitcherConversations) {
-          if (conv.conversationKey === key && !conv.isDM) {
-            // Look up slug from the space name through our slug map.
-            for (const [slug] of this._slugToProjectId) {
-              // If the space name matches, use this slug.
-              if (slug) {
-                foundSlug = slug;
-              }
-            }
-            break;
-          }
+        const conv = this.v2SwitcherConversations.find(
+          (c) => c.conversationKey === key && !c.isDM
+        );
+        if (conv?.projectId) {
+          foundSlug = this._projectIdToSlug.get(conv.projectId) || '';
         }
         if (foundSlug) {
           navigateTo(`/chat/${foundSlug}/${key}`);

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -68,6 +68,8 @@ const loadSpaceRail = () => import('../shared/chat/chat-space-rail.js');
 const loadChatMembers = () => import('../shared/chat/chat-members.js');
 // Lazy-load the search component only when v2 is active
 const loadChatSearch = () => import('../shared/chat/chat-search.js');
+// Lazy-load the quick switcher component on first Cmd+K press
+const loadChatSwitcher = () => import('../shared/chat/chat-switcher.js');
 
 /**
  * Slow fallback poll for the members sidebar.
@@ -232,6 +234,8 @@ export class ScionPageChat extends LitElement {
   private _onAgentsUpdated = this._handleAgentsUpdated.bind(this);
   private _onScopeChanged = this._handleScopeChanged.bind(this);
   private _onReadStateUpdated = this._handleReadStateUpdated.bind(this);
+  /** Bound keydown handler for Cmd/Ctrl+K quick switcher. */
+  private _onKeydown = this._handleGlobalKeydown.bind(this);
   /** Map from project slug → project ID for deep-link resolution. */
   private _slugToProjectId = new Map<string, string>();
   /** Map from project ID → project slug for URL generation. */
@@ -242,6 +246,12 @@ export class ScionPageChat extends LitElement {
   private _typingTimers = new Map<string, ReturnType<typeof setTimeout>>();
   /** IDs of members with unread DM messages (for the unread dot on avatars). */
   @state() private v2UnreadFromIds: string[] = [];
+  /** Whether the quick-switcher modal is visible (Cmd/Ctrl+K). */
+  @state() private v2SwitcherOpen = false;
+  /** Whether the quick-switcher component has been lazy-loaded. */
+  private v2SwitcherLoaded = false;
+  /** Cached conversation list for the switcher. */
+  @state() private v2SwitcherConversations: import('../shared/chat/chat-switcher.js').SwitcherConversation[] = [];
   /** Whether the search panel is visible. */
   @state() private v2SearchActive = false;
   /** Whether the search component has been lazy-loaded. */
@@ -638,6 +648,8 @@ export class ScionPageChat extends LitElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
+    // Global Cmd/Ctrl+K listener for the quick switcher.
+    document.addEventListener('keydown', this._onKeydown);
 
     if (this.isV2) {
       void this.initV2();
@@ -656,6 +668,7 @@ export class ScionPageChat extends LitElement {
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
+    document.removeEventListener('keydown', this._onKeydown);
     if (this.isV2) {
       stateManager.removeEventListener('chat-message-received', this._onChatMessage);
       stateManager.removeEventListener('chat-topic-updated', this._onChatTopic);
@@ -2257,6 +2270,147 @@ export class ScionPageChat extends LitElement {
   }
 
   // =========================================================================
+  // Quick Switcher (Cmd/Ctrl-K)  — #1048
+  // =========================================================================
+
+  /** Global keydown handler: open the quick-switcher on Cmd/Ctrl+K. */
+  private _handleGlobalKeydown(e: KeyboardEvent): void {
+    if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      void this.toggleSwitcher();
+    }
+  }
+
+  private async toggleSwitcher(): Promise<void> {
+    if (this.v2SwitcherOpen) {
+      this.v2SwitcherOpen = false;
+      return;
+    }
+    // Lazy-load the component on first use.
+    if (!this.v2SwitcherLoaded) {
+      await loadChatSwitcher();
+      this.v2SwitcherLoaded = true;
+    }
+    // Build the conversation list from API data.
+    void this.loadSwitcherConversations();
+    this.v2SwitcherOpen = true;
+  }
+
+  /** Fetch spaces + threads + DMs for the switcher conversation list. */
+  private async loadSwitcherConversations(): Promise<void> {
+    type SwitcherConv = import('../shared/chat/chat-switcher.js').SwitcherConversation;
+    const convs: SwitcherConv[] = [];
+
+    try {
+      // Fetch spaces (projects with threads).
+      const spacesRes = await apiFetch('/api/v1/chat/spaces');
+      if (spacesRes.ok) {
+        const spacesData = (await spacesRes.json()) as {
+          spaces?: Array<{ projectId: string; projectName: string; projectSlug: string }>;
+        };
+        const spaces = spacesData.spaces || [];
+
+        // Fetch threads for each space in parallel.
+        const threadFetches = spaces.map(async (space) => {
+          try {
+            const res = await apiFetch(
+              `/api/v1/chat/spaces/${encodeURIComponent(space.projectId)}/threads`
+            );
+            if (!res.ok) return;
+            const data = (await res.json()) as {
+              threads?: Array<{
+                id: string;
+                name: string;
+                lastActivityAt?: string;
+              }>;
+            };
+            for (const thread of data.threads || []) {
+              convs.push({
+                conversationKey: thread.id,
+                name: `#${thread.name}`,
+                spaceName: space.projectName,
+                isDM: false,
+                ...(thread.lastActivityAt ? { lastActivityAt: thread.lastActivityAt } : {}),
+              });
+            }
+          } catch {
+            // Non-critical — skip this space.
+          }
+        });
+        await Promise.all(threadFetches);
+      }
+
+      // Fetch DM conversations.
+      const dmsRes = await apiFetch('/api/v1/chat/dms');
+      if (dmsRes.ok) {
+        const dmsData = (await dmsRes.json()) as {
+          dms?: Array<{
+            conversationKey: string;
+            peerName: string;
+            peerKind: string;
+            lastActivityAt?: string;
+          }>;
+        };
+        for (const dm of dmsData.dms || []) {
+          convs.push({
+            conversationKey: dm.conversationKey,
+            name: dm.peerName || dm.conversationKey,
+            spaceName: dm.peerKind === 'agent' ? 'Agent DM' : 'Direct Message',
+            isDM: true,
+            ...(dm.lastActivityAt ? { lastActivityAt: dm.lastActivityAt } : {}),
+          });
+        }
+      }
+    } catch {
+      // Non-critical — show whatever we collected.
+    }
+
+    this.v2SwitcherConversations = convs;
+  }
+
+  private handleSwitcherSelect(e: CustomEvent): void {
+    const detail = e.detail as { conversationKey: string };
+    this.v2SwitcherOpen = false;
+    if (detail?.conversationKey) {
+      const key = detail.conversationKey;
+      if (key.startsWith('dm:')) {
+        navigateTo(`/chat/dm/${encodeURIComponent(key)}`);
+      } else {
+        // Find the project slug for this thread.
+        // Thread topics are project-scoped: find a matching space.
+        let foundSlug = '';
+        for (const conv of this.v2SwitcherConversations) {
+          if (conv.conversationKey === key && !conv.isDM) {
+            // Look up slug from the space name through our slug map.
+            for (const [slug] of this._slugToProjectId) {
+              // If the space name matches, use this slug.
+              if (slug) {
+                foundSlug = slug;
+              }
+            }
+            break;
+          }
+        }
+        if (foundSlug) {
+          navigateTo(`/chat/${foundSlug}/${key}`);
+        } else {
+          // Fall back: let the page's route handler resolve by iterating slugs.
+          const firstSlug = this._slugToProjectId.keys().next().value;
+          if (firstSlug) {
+            navigateTo(`/chat/${firstSlug}/${key}`);
+          } else {
+            navigateTo(`/chat`);
+          }
+        }
+      }
+    }
+  }
+
+  private handleSwitcherClose(): void {
+    this.v2SwitcherOpen = false;
+  }
+
+  // =========================================================================
   // Render
   // =========================================================================
 
@@ -2342,6 +2496,15 @@ export class ScionPageChat extends LitElement {
 
   private renderV2() {
     return html`
+      ${this.v2SwitcherOpen
+        ? html`
+            <scion-chat-switcher
+              .conversations=${this.v2SwitcherConversations}
+              @switcher-select=${this.handleSwitcherSelect}
+              @switcher-close=${this.handleSwitcherClose}
+            ></scion-chat-switcher>
+          `
+        : nothing}
       <div
         class="v2-panels"
         data-panel=${this.mobilePanel}

--- a/web/src/components/shared/chat/chat-composer.test.ts
+++ b/web/src/components/shared/chat/chat-composer.test.ts
@@ -351,18 +351,18 @@ describe('composer — drag-and-drop', () => {
     document.body.appendChild(el);
     await el.updateComplete;
 
-    expect(el.dragOver).toBe(false);
+    expect((el as any).dragOver).toBe(false);
 
     // Simulate dragenter
     (el as any).handleDragEnter(new DragEvent('dragenter', { cancelable: true }));
-    expect(el.dragOver).toBe(true);
+    expect((el as any).dragOver).toBe(true);
 
     // Simulate dragleave with relatedTarget outside the wrapper
     const leaveEvent = new DragEvent('dragleave');
     Object.defineProperty(leaveEvent, 'currentTarget', { value: document.createElement('div') });
     Object.defineProperty(leaveEvent, 'relatedTarget', { value: null });
     (el as any).handleDragLeave(leaveEvent);
-    expect(el.dragOver).toBe(false);
+    expect((el as any).dragOver).toBe(false);
 
     document.body.removeChild(el);
   });
@@ -381,7 +381,7 @@ describe('composer — drag-and-drop', () => {
     (el as any).handleDrop(dropEvent);
 
     expect(dropEvent.defaultPrevented).toBe(true);
-    expect(el.dragOver).toBe(false);
+    expect((el as any).dragOver).toBe(false);
   });
 
   it('renders the drop zone overlay when dragOver is true', async () => {
@@ -391,7 +391,7 @@ describe('composer — drag-and-drop', () => {
 
     expect(el.shadowRoot.querySelector('.drop-zone-overlay')).toBeNull();
 
-    el.dragOver = true;
+    (el as any).dragOver = true;
     await el.updateComplete;
 
     const overlay = el.shadowRoot.querySelector('.drop-zone-overlay');

--- a/web/src/components/shared/chat/chat-composer.test.ts
+++ b/web/src/components/shared/chat/chat-composer.test.ts
@@ -255,3 +255,228 @@ describe('composer — file picker filter', () => {
     expect(input?.getAttribute('accept')).toBe(ATTACHMENT_ACCEPT);
   });
 });
+
+describe('composer — uploadFiles refactor', () => {
+  it('uploadFiles uploads files and populates pendingFiles', async () => {
+    const el = createComposer();
+    respondWith(201, { attachments: [STORED], failures: [] });
+
+    await el.uploadFiles([new File(['content'], 'compose.yaml')]);
+
+    expect(el.pendingFiles).toHaveLength(1);
+    expect(el.pendingFiles[0].name).toBe('compose.yaml');
+  });
+
+  it('uploadFiles enforces max 10 attachments', async () => {
+    const el = createComposer();
+    // Pre-fill 9 pending files
+    el.pendingFiles = Array.from({ length: 9 }, (_, i) => ({
+      ...STORED,
+      id: `att-${i}`,
+      name: `file-${i}.txt`,
+    }));
+
+    const errors: string[] = [];
+    el.addEventListener('composer-error', (e: CustomEvent<{ message: string }>) =>
+      errors.push(e.detail.message)
+    );
+
+    // Try to add 2 more (9 + 2 = 11 > 10)
+    await el.uploadFiles([new File(['a'], 'a.txt'), new File(['b'], 'b.txt')]);
+
+    expect(errors).toEqual(['Maximum 10 attachments per message']);
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it('uploadFiles does nothing with an empty array', async () => {
+    const el = createComposer();
+    await el.uploadFiles([]);
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('composer — paste-to-upload', () => {
+  it('extracts image files from clipboard and uploads them', async () => {
+    const el = createComposer();
+    respondWith(201, {
+      attachments: [{ ...STORED, name: 'image.png', mime: 'image/png' }],
+      failures: [],
+    });
+
+    const imageFile = new File(['pixels'], 'image.png', { type: 'image/png' });
+    const item = {
+      type: 'image/png',
+      getAsFile: () => imageFile,
+    };
+
+    const pasteEvent = new ClipboardEvent('paste', { cancelable: true });
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: { items: [item] },
+    });
+
+    // Call the paste handler directly
+    (el as any).handlePaste(pasteEvent);
+
+    // The event should be prevented (image paste overrides text paste)
+    expect(pasteEvent.defaultPrevented).toBe(true);
+
+    // Wait for the async uploadFiles call to resolve
+    await vi.waitFor(() => expect(apiFetch).toHaveBeenCalled());
+  });
+
+  it('ignores paste events with no image items', () => {
+    const el = createComposer();
+
+    const textItem = {
+      type: 'text/plain',
+      getAsFile: () => null,
+    };
+
+    const pasteEvent = new ClipboardEvent('paste', { cancelable: true });
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: { items: [textItem] },
+    });
+
+    (el as any).handlePaste(pasteEvent);
+
+    // Text paste should not be prevented
+    expect(pasteEvent.defaultPrevented).toBe(false);
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('composer — drag-and-drop', () => {
+  it('sets dragOver on dragenter and clears on dragleave', async () => {
+    const el = createComposer();
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    expect(el.dragOver).toBe(false);
+
+    // Simulate dragenter
+    (el as any).handleDragEnter(new DragEvent('dragenter', { cancelable: true }));
+    expect(el.dragOver).toBe(true);
+
+    // Simulate dragleave with relatedTarget outside the wrapper
+    const leaveEvent = new DragEvent('dragleave');
+    Object.defineProperty(leaveEvent, 'currentTarget', { value: document.createElement('div') });
+    Object.defineProperty(leaveEvent, 'relatedTarget', { value: null });
+    (el as any).handleDragLeave(leaveEvent);
+    expect(el.dragOver).toBe(false);
+
+    document.body.removeChild(el);
+  });
+
+  it('uploads files on drop', async () => {
+    const el = createComposer();
+    respondWith(201, { attachments: [STORED], failures: [] });
+
+    const file = new File(['data'], 'test.txt');
+    const dt = new DataTransfer();
+    dt.items.add(file);
+
+    const dropEvent = new DragEvent('drop', { cancelable: true });
+    Object.defineProperty(dropEvent, 'dataTransfer', { value: dt });
+
+    (el as any).handleDrop(dropEvent);
+
+    expect(dropEvent.defaultPrevented).toBe(true);
+    expect(el.dragOver).toBe(false);
+  });
+
+  it('renders the drop zone overlay when dragOver is true', async () => {
+    const el = createComposer();
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    expect(el.shadowRoot.querySelector('.drop-zone-overlay')).toBeNull();
+
+    el.dragOver = true;
+    await el.updateComplete;
+
+    const overlay = el.shadowRoot.querySelector('.drop-zone-overlay');
+    expect(overlay).not.toBeNull();
+    expect(overlay?.textContent).toContain('Drop files here');
+
+    document.body.removeChild(el);
+  });
+});
+
+describe('composer — draft persistence', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('saves a draft to localStorage on input (debounced)', async () => {
+    const el = createComposer();
+    el.conversationKey = 'conv-123';
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    // Simulate input
+    el.text = 'hello world';
+    (el as any).saveDraft();
+
+    // Before debounce fires, localStorage should be empty
+    expect(localStorage.getItem('scion-chat-draft-conv-123')).toBeNull();
+
+    // Wait for debounce (500ms + buffer)
+    await new Promise((r) => setTimeout(r, 600));
+
+    expect(localStorage.getItem('scion-chat-draft-conv-123')).toBe('hello world');
+
+    document.body.removeChild(el);
+  });
+
+  it('restores a draft from localStorage on connect', async () => {
+    localStorage.setItem('scion-chat-draft-conv-456', 'restored text');
+
+    const el = createComposer();
+    el.conversationKey = 'conv-456';
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    expect(el.text).toBe('restored text');
+
+    document.body.removeChild(el);
+  });
+
+  it('restores a draft when conversationKey changes', async () => {
+    localStorage.setItem('scion-chat-draft-conv-A', 'draft A');
+    localStorage.setItem('scion-chat-draft-conv-B', 'draft B');
+
+    const el = createComposer();
+    el.conversationKey = 'conv-A';
+    document.body.appendChild(el);
+    await el.updateComplete;
+    expect(el.text).toBe('draft A');
+
+    el.conversationKey = 'conv-B';
+    await el.updateComplete;
+    expect(el.text).toBe('draft B');
+
+    document.body.removeChild(el);
+  });
+
+  it('clears the draft from localStorage on clearDraft', () => {
+    localStorage.setItem('scion-chat-draft-conv-789', 'some text');
+
+    const el = createComposer();
+    el.conversationKey = 'conv-789';
+    (el as any).clearDraft();
+
+    expect(localStorage.getItem('scion-chat-draft-conv-789')).toBeNull();
+  });
+
+  it('does not save draft when conversationKey is empty', async () => {
+    const el = createComposer();
+    el.conversationKey = '';
+    el.text = 'orphan draft';
+    (el as any).saveDraft();
+
+    await new Promise((r) => setTimeout(r, 600));
+
+    // No key should have been written
+    expect(localStorage.length).toBe(0);
+  });
+});

--- a/web/src/components/shared/chat/chat-composer.ts
+++ b/web/src/components/shared/chat/chat-composer.ts
@@ -36,7 +36,7 @@ import type { MentionAcceptDetail } from './mention-autocomplete.js';
 import './mention-autocomplete.js';
 
 /** Maximum message length in rune count. */
-const MAX_MESSAGE_LENGTH = 2000;
+const MAX_MESSAGE_LENGTH = 16000;
 
 /** Uploaded attachment info returned from the server. */
 export interface UploadedAttachment {
@@ -162,8 +162,18 @@ export class ScionChatComposer extends LitElement {
   /** Files the last upload refused, shown until dismissed or superseded. */
   @state() private uploadFailures: UploadFailure[] = [];
 
+  /** Whether a drag is currently over the composer drop zone. */
+  @state() private dragOver = false;
+
+  /** Conversation key used for draft persistence. */
+  @property({ type: String })
+  conversationKey = '';
+
   /** Set of accepted mention slugs. Filtered to those still present on send. */
   private acceptedMentions = new Set<string>();
+
+  /** Debounce timer for saving drafts to localStorage. */
+  private _draftTimer: ReturnType<typeof setTimeout> | null = null;
 
   static override styles = css`
     :host {
@@ -437,7 +447,86 @@ export class ScionChatComposer extends LitElement {
       color: var(--scion-text-muted, #64748b);
       padding: 0 0.25rem;
     }
+
+    /* Drop zone overlay */
+    .composer-wrapper {
+      position: relative;
+    }
+
+    .drop-zone-overlay {
+      position: absolute;
+      inset: 0;
+      z-index: 50;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(59, 130, 246, 0.08);
+      border: 2px dashed var(--scion-primary, #3b82f6);
+      border-radius: 0.75rem;
+      pointer-events: none;
+    }
+
+    .drop-zone-overlay span {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: var(--scion-primary, #3b82f6);
+    }
   `;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.restoreDraft();
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this._draftTimer !== null) {
+      clearTimeout(this._draftTimer);
+      this._draftTimer = null;
+    }
+  }
+
+  override updated(changedProperties: Map<string, unknown>): void {
+    if (changedProperties.has('conversationKey')) {
+      this.restoreDraft();
+    }
+  }
+
+  /** Restore a draft from localStorage for the current conversationKey. */
+  private restoreDraft(): void {
+    if (!this.conversationKey) return;
+    const key = `scion-chat-draft-${this.conversationKey}`;
+    const saved = localStorage.getItem(key);
+    if (saved !== null) {
+      this.text = saved;
+      this.runeCount = countRunes(this.text);
+    }
+  }
+
+  /** Save the current draft to localStorage (debounced). */
+  private saveDraft(): void {
+    if (!this.conversationKey) return;
+    if (this._draftTimer !== null) clearTimeout(this._draftTimer);
+    this._draftTimer = setTimeout(() => {
+      const key = `scion-chat-draft-${this.conversationKey}`;
+      if (this.text) {
+        localStorage.setItem(key, this.text);
+      } else {
+        localStorage.removeItem(key);
+      }
+      this._draftTimer = null;
+    }, 500);
+  }
+
+  /** Clear the draft from localStorage for the current conversationKey. */
+  private clearDraft(): void {
+    if (this._draftTimer !== null) {
+      clearTimeout(this._draftTimer);
+      this._draftTimer = null;
+    }
+    if (!this.conversationKey) return;
+    localStorage.removeItem(`scion-chat-draft-${this.conversationKey}`);
+  }
 
   override render() {
     const isOverLimit = this.runeCount > MAX_MESSAGE_LENGTH;
@@ -449,11 +538,21 @@ export class ScionChatComposer extends LitElement {
 
     return html`
       ${this.conversationMode ? this.renderDestinationChip() : nothing}
-      <div class="composer">
-        ${this.pendingFiles.length > 0 ? this.renderPendingFiles() : nothing}
-        ${this.uploadFailures.length > 0 ? this.renderUploadFailures() : nothing}
-        ${this.uploading ? html`<div class="upload-progress">Uploading...</div>` : nothing}
-        <div class="input-row">
+      <div
+        class="composer-wrapper"
+        @dragover=${this.handleDragOver}
+        @dragenter=${this.handleDragEnter}
+        @dragleave=${this.handleDragLeave}
+        @drop=${this.handleDrop}
+      >
+        ${this.dragOver
+          ? html`<div class="drop-zone-overlay"><span>Drop files here</span></div>`
+          : nothing}
+        <div class="composer">
+          ${this.pendingFiles.length > 0 ? this.renderPendingFiles() : nothing}
+          ${this.uploadFailures.length > 0 ? this.renderUploadFailures() : nothing}
+          ${this.uploading ? html`<div class="upload-progress">Uploading...</div>` : nothing}
+          <div class="input-row">
           ${this.conversationMode
             ? html`
                 <sl-icon-button
@@ -481,6 +580,7 @@ export class ScionChatComposer extends LitElement {
               .value=${this.text}
               @sl-input=${this.handleInput}
               @keydown=${this.handleKeydown}
+              @paste=${this.handlePaste}
               ?disabled=${this.disabled}
             ></sl-textarea>
             <scion-mention-autocomplete
@@ -517,14 +617,15 @@ export class ScionChatComposer extends LitElement {
               : nothing}
           </div>
         </div>
-        <div class="footer-row">
-          ${this.runeCount > 0 || isNearLimit
-            ? html`
-                <span class="char-counter ${counterClass}">
-                  ${this.runeCount} / ${MAX_MESSAGE_LENGTH}
-                </span>
-              `
-            : nothing}
+          <div class="footer-row">
+            ${this.runeCount > 0 || isNearLimit
+              ? html`
+                  <span class="char-counter ${counterClass}">
+                    ${this.runeCount} / ${MAX_MESSAGE_LENGTH}
+                  </span>
+                `
+              : nothing}
+          </div>
         </div>
       </div>
     `;
@@ -632,6 +733,9 @@ export class ScionChatComposer extends LitElement {
     const target = e.target as HTMLInputElement;
     this.text = target.value;
     this.runeCount = countRunes(this.text);
+
+    // Persist draft with debounce.
+    this.saveDraft();
 
     // Dispatch typing event so the parent can send a typing indicator
     if (this.text.length > 0) {
@@ -791,6 +895,15 @@ export class ScionChatComposer extends LitElement {
     const input = e.target as HTMLInputElement;
     const files = input.files;
     if (!files || files.length === 0) return;
+    await this.uploadFiles(Array.from(files));
+  }
+
+  /**
+   * Upload one or more files to the attachment endpoint.
+   * Shared by the file picker, paste handler, and drag-and-drop handler.
+   */
+  async uploadFiles(files: File[]): Promise<void> {
+    if (files.length === 0) return;
 
     // Enforce max attachments.
     if (this.pendingFiles.length + files.length > 10) {
@@ -808,7 +921,7 @@ export class ScionChatComposer extends LitElement {
     try {
       const formData = new FormData();
       formData.append('project_id', this.projectId);
-      for (const file of Array.from(files)) {
+      for (const file of files) {
         formData.append('files', file);
       }
 
@@ -859,6 +972,55 @@ export class ScionChatComposer extends LitElement {
     }
   }
 
+  /** Handle paste events — extract images from clipboard and upload. */
+  private handlePaste(e: ClipboardEvent): void {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+
+    const imageFiles: File[] = [];
+    for (const item of Array.from(items)) {
+      if (item.type.startsWith('image/')) {
+        const file = item.getAsFile();
+        if (file) imageFiles.push(file);
+      }
+    }
+
+    if (imageFiles.length > 0) {
+      e.preventDefault();
+      void this.uploadFiles(imageFiles);
+    }
+  }
+
+  /** Prevent default on dragover to allow drop. */
+  private handleDragOver(e: DragEvent): void {
+    e.preventDefault();
+  }
+
+  /** Show the drop zone overlay on drag enter. */
+  private handleDragEnter(e: DragEvent): void {
+    e.preventDefault();
+    this.dragOver = true;
+  }
+
+  /** Hide the drop zone overlay on drag leave. */
+  private handleDragLeave(e: DragEvent): void {
+    // Only hide if we're leaving the composer-wrapper, not entering a child.
+    const wrapper = (e.currentTarget as HTMLElement);
+    const related = e.relatedTarget as Node | null;
+    if (related && wrapper.contains(related)) return;
+    this.dragOver = false;
+  }
+
+  /** Handle file drop — extract files and upload. */
+  private handleDrop(e: DragEvent): void {
+    e.preventDefault();
+    this.dragOver = false;
+    const files = e.dataTransfer?.files;
+    if (files && files.length > 0) {
+      void this.uploadFiles(Array.from(files));
+    }
+  }
+
   /** Remove a pending file from the list. */
   private removePendingFile(index: number): void {
     this.pendingFiles = this.pendingFiles.filter((_, i) => i !== index);
@@ -894,6 +1056,7 @@ export class ScionChatComposer extends LitElement {
             this.runeCount = 0;
             this.acceptedMentions.clear();
             this.pendingFiles = [];
+            this.clearDraft();
             // Restore focus to the textarea after send.
             // Use requestAnimationFrame to ensure the Lit render cycle
             // and Shoelace's internal DOM update have completed.

--- a/web/src/components/shared/chat/chat-message.test.ts
+++ b/web/src/components/shared/chat/chat-message.test.ts
@@ -38,6 +38,7 @@ vi.mock('../../../utils/markdown.js', () => ({
     Promise.resolve({
       render: (markdown: string) =>
         `<p>${markdown
+          .replace(/```(\w+)\n([\s\S]*?)```/g, '</p><pre><code class="language-$1">$2</code></pre><p>')
           .replace(/```([\s\S]*?)```/g, '</p><pre><code>$1</code></pre><p>')
           .replace(/`([^`]+)`/g, '<code>$1</code>')
           .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" title="see $1">$1</a>')}</p>`,
@@ -48,7 +49,21 @@ vi.mock('../../../utils/markdown.js', () => ({
 // tests only care about what the message hands it.
 vi.mock('../code-editor.js', () => ({
   getLanguageFromPath: (path: string) => (path.endsWith('.go') ? 'go' : 'plaintext'),
+  ScionCodeEditor: class {},
 }));
+
+// Register a minimal stub for <scion-code-editor> so that
+// injectSyntaxHighlighting can create and configure it.
+if (!customElements.get('scion-code-editor')) {
+  customElements.define(
+    'scion-code-editor',
+    class extends HTMLElement {
+      content = '';
+      language = 'plaintext';
+      readonly = false;
+    }
+  );
+}
 
 const apiFetchMock = vi.fn();
 vi.mock('../../../client/api.js', () => ({
@@ -354,5 +369,76 @@ describe('scion-chat-message attachment previews', () => {
     const preview = el.shadowRoot?.querySelector('.attachment-preview');
     expect(editorIn(preview)).toBeNull();
     expect(preview?.querySelector('.preview-placeholder.error')?.textContent).toContain('404');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #1049: Syntax highlighting in code blocks
+// ---------------------------------------------------------------------------
+
+describe('scion-chat-message syntax highlighting (#1049)', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  /** Mount a message with the given body text. */
+  async function mountBody(body: string): Promise<ScionChatMessage> {
+    const el = document.createElement('scion-chat-message') as ScionChatMessage;
+    el.messageId = 'syntax-test';
+    el.body = body;
+    el.sender = 'user:Alice';
+    el.createdAt = new Date().toISOString();
+    document.body.appendChild(el);
+    await el.updateComplete;
+    // Wait for async renderContent to settle.
+    await new Promise((r) => setTimeout(r, 50));
+    await el.updateComplete;
+    return el;
+  }
+
+  it('replaces language-tagged code blocks with scion-code-editor', async () => {
+    const el = await mountBody('```typescript\nconst x = 1;\n```');
+
+    const editor = el.shadowRoot?.querySelector('scion-code-editor') as HTMLElement & {
+      language: string;
+      readonly: boolean;
+      content: string;
+    } | null;
+    expect(editor).not.toBeNull();
+    expect(editor!.language).toBe('typescript');
+    expect(editor!.readonly).toBe(true);
+    expect(editor!.content).toContain('const x = 1;');
+  });
+
+  it('leaves code blocks without a language tag as plain pre/code', async () => {
+    const el = await mountBody('```\nplain text\n```');
+
+    // No code editor should be injected.
+    const editor = el.shadowRoot?.querySelector('scion-code-editor');
+    expect(editor).toBeNull();
+
+    // The original <pre><code> should remain.
+    const pre = el.shadowRoot?.querySelector('.md-content pre');
+    expect(pre).not.toBeNull();
+  });
+
+  it('maps short language aliases to full language names', async () => {
+    const el = await mountBody('```js\nalert("hi");\n```');
+
+    const editor = el.shadowRoot?.querySelector('scion-code-editor') as HTMLElement & {
+      language: string;
+    } | null;
+    expect(editor).not.toBeNull();
+    expect(editor!.language).toBe('javascript');
+  });
+
+  it('maps python alias py to python', async () => {
+    const el = await mountBody('```py\nprint("hello")\n```');
+
+    const editor = el.shadowRoot?.querySelector('scion-code-editor') as HTMLElement & {
+      language: string;
+    } | null;
+    expect(editor).not.toBeNull();
+    expect(editor!.language).toBe('python');
   });
 });

--- a/web/src/components/shared/chat/chat-message.ts
+++ b/web/src/components/shared/chat/chat-message.ts
@@ -97,6 +97,33 @@ const PREVIEW_MAX_LINES = 40;
 /** Lines that fit in the 200px slice; beyond this the edge is faded. */
 const PREVIEW_VISIBLE_LINES = 9;
 
+/**
+ * Map fenced code block language tags to CodeMirror language identifiers.
+ * Used by the syntax-highlighting post-processor to replace plain
+ * `<pre><code>` blocks with `<scion-code-editor readonly>`.
+ */
+const CODE_BLOCK_LANGUAGE_MAP: Record<string, string> = {
+  typescript: 'typescript',
+  ts: 'typescript',
+  javascript: 'javascript',
+  js: 'javascript',
+  go: 'go',
+  python: 'python',
+  py: 'python',
+  json: 'json',
+  yaml: 'yaml',
+  yml: 'yaml',
+  html: 'html',
+  css: 'css',
+  rust: 'rust',
+  rs: 'rust',
+  markdown: 'markdown',
+  md: 'markdown',
+  bash: 'plaintext',
+  sh: 'plaintext',
+  shell: 'plaintext',
+};
+
 /** Lowercase extension including the dot, or '' when the name has none. */
 function extensionOf(name: string): string {
   const dot = name.lastIndexOf('.');
@@ -497,6 +524,16 @@ export class ScionChatMessage extends LitElement {
       border: none;
       padding: 0;
       font-size: 0.8125rem;
+    }
+
+    /* Syntax-highlighted code blocks (#1049) */
+    .code-block-editor {
+      display: block;
+      margin: 0.5em 0;
+      max-height: 400px;
+      overflow: auto;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.375rem;
     }
 
     .copy-btn {
@@ -979,6 +1016,7 @@ export class ScionChatMessage extends LitElement {
     }
     if (changed.has('renderedHtml')) {
       this.injectCopyButtons();
+      this.injectSyntaxHighlighting();
     }
     this.observePreviews();
   }
@@ -1059,6 +1097,47 @@ export class ScionChatMessage extends LitElement {
         }, 1500);
       });
       pre.appendChild(btn);
+    });
+  }
+
+  /**
+   * Replace fenced code blocks that have a language class with
+   * `<scion-code-editor readonly>` for syntax highlighting.
+   *
+   * `marked` produces `<pre><code class="language-typescript">` for
+   * ` ```typescript ` blocks. We detect the class, extract the language,
+   * and swap the `<pre>` with a readonly code editor.
+   */
+  private injectSyntaxHighlighting(): void {
+    const pres = this.shadowRoot?.querySelectorAll('.md-content pre');
+    if (!pres) return;
+
+    pres.forEach((pre) => {
+      // Skip if already replaced.
+      if (pre.getAttribute('data-highlighted') === 'true') return;
+
+      const codeEl = pre.querySelector('code');
+      if (!codeEl) return;
+
+      // Extract language from class="language-xxx" set by marked.
+      const langClass = Array.from(codeEl.classList).find((c) => c.startsWith('language-'));
+      if (!langClass) return; // No language tag — keep plain styling.
+
+      const langTag = langClass.replace('language-', '').toLowerCase();
+      const language = CODE_BLOCK_LANGUAGE_MAP[langTag];
+      if (!language) return; // Unknown language — keep plain styling.
+
+      const content = codeEl.textContent ?? '';
+      pre.setAttribute('data-highlighted', 'true');
+
+      // Create a readonly code editor and replace the <pre> in-place.
+      const editor = document.createElement('scion-code-editor') as import('../code-editor.js').ScionCodeEditor;
+      editor.content = content;
+      editor.language = language;
+      editor.readonly = true;
+      editor.classList.add('code-block-editor');
+
+      pre.replaceWith(editor);
     });
   }
 

--- a/web/src/components/shared/chat/chat-message.ts
+++ b/web/src/components/shared/chat/chat-message.ts
@@ -119,6 +119,7 @@ const CODE_BLOCK_LANGUAGE_MAP: Record<string, string> = {
   rs: 'rust',
   markdown: 'markdown',
   md: 'markdown',
+  // CodeMirror shell mode is not bundled; fall back to monospace-only display.
   bash: 'plaintext',
   sh: 'plaintext',
   shell: 'plaintext',

--- a/web/src/components/shared/chat/chat-switcher.test.ts
+++ b/web/src/components/shared/chat/chat-switcher.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for <scion-chat-switcher> — the Cmd/Ctrl-K quick conversation switcher.
+ */
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+await import('./chat-switcher.js');
+type ScionChatSwitcher = import('./chat-switcher.js').ScionChatSwitcher;
+type SwitcherConversation = import('./chat-switcher.js').SwitcherConversation;
+
+const CONVERSATIONS: SwitcherConversation[] = [
+  {
+    conversationKey: 'topic-1',
+    name: '#general',
+    spaceName: 'Project Alpha',
+    isDM: false,
+    lastActivityAt: '2026-08-17T10:00:00Z',
+  },
+  {
+    conversationKey: 'topic-2',
+    name: '#dev',
+    spaceName: 'Project Alpha',
+    isDM: false,
+    lastActivityAt: '2026-08-17T09:00:00Z',
+  },
+  {
+    conversationKey: 'dm:agent:abc:user:xyz',
+    name: 'Bot Helper',
+    spaceName: 'Agent DM',
+    isDM: true,
+    lastActivityAt: '2026-08-17T08:00:00Z',
+  },
+];
+
+async function mount(convs?: SwitcherConversation[]): Promise<ScionChatSwitcher> {
+  const el = document.createElement('scion-chat-switcher') as ScionChatSwitcher;
+  el.conversations = convs ?? CONVERSATIONS;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+describe('scion-chat-switcher', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders a search input and conversation items', async () => {
+    const el = await mount();
+
+    const input = el.shadowRoot?.querySelector('input');
+    expect(input).not.toBeNull();
+
+    const items = el.shadowRoot?.querySelectorAll('.item');
+    expect(items?.length).toBe(3);
+  });
+
+  it('filters conversations by search term', async () => {
+    const el = await mount();
+
+    const input = el.shadowRoot?.querySelector('input') as HTMLInputElement;
+    input.value = 'general';
+    input.dispatchEvent(new Event('input'));
+    await el.updateComplete;
+
+    const items = el.shadowRoot?.querySelectorAll('.item');
+    expect(items?.length).toBe(1);
+    expect(items?.[0].querySelector('.item-name')?.textContent).toContain('#general');
+  });
+
+  it('filters by space name', async () => {
+    const el = await mount();
+
+    const input = el.shadowRoot?.querySelector('input') as HTMLInputElement;
+    input.value = 'Agent DM';
+    input.dispatchEvent(new Event('input'));
+    await el.updateComplete;
+
+    const items = el.shadowRoot?.querySelectorAll('.item');
+    expect(items?.length).toBe(1);
+    expect(items?.[0].querySelector('.item-name')?.textContent).toContain('Bot Helper');
+  });
+
+  it('shows empty state when no matches', async () => {
+    const el = await mount();
+
+    const input = el.shadowRoot?.querySelector('input') as HTMLInputElement;
+    input.value = 'nonexistent';
+    input.dispatchEvent(new Event('input'));
+    await el.updateComplete;
+
+    const empty = el.shadowRoot?.querySelector('.empty');
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent).toContain('No matching conversations');
+  });
+
+  it('emits switcher-select on Enter', async () => {
+    const el = await mount();
+    let selectedKey = '';
+    el.addEventListener('switcher-select', (e) => {
+      selectedKey = (e as CustomEvent).detail.conversationKey;
+    });
+
+    // Press Enter to select the first item (sorted by most recent).
+    el.shadowRoot?.querySelector('.overlay')?.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+    );
+
+    expect(selectedKey).toBe('topic-1');
+  });
+
+  it('emits switcher-close on Escape', async () => {
+    const el = await mount();
+    let closed = false;
+    el.addEventListener('switcher-close', () => {
+      closed = true;
+    });
+
+    el.shadowRoot?.querySelector('.overlay')?.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+    );
+
+    expect(closed).toBe(true);
+  });
+
+  it('navigates selection with arrow keys', async () => {
+    const el = await mount();
+
+    const overlay = el.shadowRoot?.querySelector('.overlay')!;
+
+    // Initially first item is selected.
+    let selected = el.shadowRoot?.querySelector('.item.selected .item-name');
+    expect(selected?.textContent).toContain('#general');
+
+    // Arrow down to second item.
+    overlay.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+
+    selected = el.shadowRoot?.querySelector('.item.selected .item-name');
+    expect(selected?.textContent).toContain('#dev');
+
+    // Arrow down to third item (DM).
+    overlay.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+
+    selected = el.shadowRoot?.querySelector('.item.selected .item-name');
+    expect(selected?.textContent).toContain('Bot Helper');
+
+    // Arrow up back to second.
+    overlay.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    await el.updateComplete;
+
+    selected = el.shadowRoot?.querySelector('.item.selected .item-name');
+    expect(selected?.textContent).toContain('#dev');
+  });
+
+  it('shows DM badge for DM conversations', async () => {
+    const el = await mount();
+
+    const items = el.shadowRoot?.querySelectorAll('.item');
+    const dmItem = items?.[2]; // Sorted by activity — DM is last.
+    expect(dmItem?.querySelector('.dm-badge')).not.toBeNull();
+
+    const threadItem = items?.[0]; // Thread — no DM badge.
+    expect(threadItem?.querySelector('.dm-badge')).toBeNull();
+  });
+
+  it('sorts by most recent activity first', async () => {
+    const el = await mount();
+
+    const names = Array.from(el.shadowRoot?.querySelectorAll('.item-name') ?? []).map(
+      (n) => n.textContent?.trim() ?? ''
+    );
+    // topic-1 (10:00) > topic-2 (09:00) > dm (08:00)
+    expect(names[0]).toContain('#general');
+    expect(names[1]).toContain('#dev');
+    expect(names[2]).toContain('Bot Helper');
+  });
+
+  it('emits switcher-close when clicking the overlay backdrop', async () => {
+    const el = await mount();
+    let closed = false;
+    el.addEventListener('switcher-close', () => {
+      closed = true;
+    });
+
+    // Click the overlay itself (not the panel).
+    const overlay = el.shadowRoot?.querySelector('.overlay') as HTMLElement;
+    overlay.click();
+
+    expect(closed).toBe(true);
+  });
+});

--- a/web/src/components/shared/chat/chat-switcher.ts
+++ b/web/src/components/shared/chat/chat-switcher.ts
@@ -38,6 +38,8 @@ export interface SwitcherConversation {
   isDM: boolean;
   /** ISO timestamp for sorting by recency. */
   lastActivityAt?: string;
+  /** Project ID for thread navigation (not set for DMs). */
+  projectId?: string;
 }
 
 /** Detail emitted on `switcher-select`. */

--- a/web/src/components/shared/chat/chat-switcher.ts
+++ b/web/src/components/shared/chat/chat-switcher.ts
@@ -1,0 +1,322 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Chat quick-switcher component (Cmd/Ctrl-K).
+ *
+ * Renders a modal overlay with a search input and a filterable list of
+ * conversations. Keyboard navigation (Arrow Up/Down, Enter, Escape) is
+ * supported. Conversations are sorted by most recent activity first when
+ * the search field is empty.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state, query } from 'lit/decorators.js';
+
+/** A conversation entry displayable in the switcher. */
+export interface SwitcherConversation {
+  /** Topic UUID or DM key. */
+  conversationKey: string;
+  /** Display name: thread name, DM peer name, etc. */
+  name: string;
+  /** Project/space name for context. */
+  spaceName: string;
+  /** True for DMs, false for threads. */
+  isDM: boolean;
+  /** ISO timestamp for sorting by recency. */
+  lastActivityAt?: string;
+}
+
+/** Detail emitted on `switcher-select`. */
+export interface SwitcherSelectDetail {
+  conversationKey: string;
+}
+
+@customElement('scion-chat-switcher')
+export class ScionChatSwitcher extends LitElement {
+  /** Full list of conversations to search through. */
+  @property({ type: Array })
+  conversations: SwitcherConversation[] = [];
+
+  @state() private searchTerm = '';
+  @state() private selectedIndex = 0;
+
+  @query('#switcher-input')
+  private inputEl!: HTMLInputElement;
+
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    .overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 9999;
+      display: flex;
+      align-items: flex-start;
+      justify-content: center;
+      padding-top: 15vh;
+      background: rgba(0, 0, 0, 0.4);
+    }
+
+    .panel {
+      width: min(520px, 90vw);
+      max-height: 60vh;
+      display: flex;
+      flex-direction: column;
+      background: var(--scion-surface, #fff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.5rem;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+      overflow: hidden;
+    }
+
+    .search-row {
+      display: flex;
+      align-items: center;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+      gap: 0.5rem;
+    }
+
+    .search-row sl-icon {
+      color: var(--scion-text-muted, #64748b);
+      font-size: 1rem;
+    }
+
+    .search-row input {
+      flex: 1;
+      border: none;
+      outline: none;
+      font-size: 0.9375rem;
+      background: transparent;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .search-row input::placeholder {
+      color: var(--scion-text-muted, #94a3b8);
+    }
+
+    .results {
+      overflow-y: auto;
+      max-height: calc(60vh - 3.5rem);
+    }
+
+    .empty {
+      padding: 2rem 1rem;
+      text-align: center;
+      color: var(--scion-text-muted, #94a3b8);
+      font-size: 0.875rem;
+    }
+
+    .item {
+      display: flex;
+      flex-direction: column;
+      padding: 0.5rem 1rem;
+      cursor: pointer;
+      gap: 0.125rem;
+      border-left: 3px solid transparent;
+    }
+
+    .item:hover,
+    .item.selected {
+      background: var(--scion-bg-subtle, #f1f5f9);
+      border-left-color: var(--scion-primary, #3b82f6);
+    }
+
+    .item-name {
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .item-context {
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #94a3b8);
+    }
+
+    .dm-badge {
+      display: inline-block;
+      font-size: 0.6875rem;
+      padding: 0 0.25rem;
+      border-radius: 0.125rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      color: var(--scion-text-muted, #64748b);
+      margin-left: 0.25rem;
+    }
+
+    .shortcut-hint {
+      padding: 0.375rem 1rem;
+      font-size: 0.6875rem;
+      color: var(--scion-text-muted, #94a3b8);
+      border-top: 1px solid var(--scion-border, #e2e8f0);
+      display: flex;
+      gap: 1rem;
+    }
+
+    kbd {
+      display: inline-block;
+      padding: 0 0.25rem;
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.125rem;
+      font-family: inherit;
+      font-size: 0.625rem;
+      background: var(--scion-bg-subtle, #f1f5f9);
+    }
+  `;
+
+  override firstUpdated(): void {
+    // Autofocus the input after render.
+    requestAnimationFrame(() => {
+      this.inputEl?.focus();
+    });
+  }
+
+  private get filtered(): SwitcherConversation[] {
+    const term = this.searchTerm.toLowerCase().trim();
+    let list = this.conversations;
+
+    if (term) {
+      list = list.filter(
+        (c) =>
+          c.name.toLowerCase().includes(term) ||
+          c.spaceName.toLowerCase().includes(term)
+      );
+    }
+
+    // Sort by most recent activity first.
+    return [...list].sort((a, b) => {
+      const ta = a.lastActivityAt ? new Date(a.lastActivityAt).getTime() : 0;
+      const tb = b.lastActivityAt ? new Date(b.lastActivityAt).getTime() : 0;
+      return tb - ta;
+    });
+  }
+
+  private handleInput(e: InputEvent): void {
+    this.searchTerm = (e.target as HTMLInputElement).value;
+    this.selectedIndex = 0;
+  }
+
+  private handleKeydown(e: KeyboardEvent): void {
+    const items = this.filtered;
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        this.selectedIndex = Math.min(this.selectedIndex + 1, items.length - 1);
+        this.scrollSelectedIntoView();
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        this.selectedIndex = Math.max(this.selectedIndex - 1, 0);
+        this.scrollSelectedIntoView();
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (items.length > 0 && this.selectedIndex < items.length) {
+          this.selectConversation(items[this.selectedIndex]);
+        }
+        break;
+      case 'Escape':
+        e.preventDefault();
+        this.close();
+        break;
+    }
+  }
+
+  private scrollSelectedIntoView(): void {
+    requestAnimationFrame(() => {
+      const selected = this.shadowRoot?.querySelector('.item.selected');
+      selected?.scrollIntoView({ block: 'nearest' });
+    });
+  }
+
+  private selectConversation(conv: SwitcherConversation): void {
+    this.dispatchEvent(
+      new CustomEvent<SwitcherSelectDetail>('switcher-select', {
+        detail: { conversationKey: conv.conversationKey },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  private close(): void {
+    this.dispatchEvent(
+      new CustomEvent('switcher-close', { bubbles: true, composed: true })
+    );
+  }
+
+  private handleOverlayClick(e: MouseEvent): void {
+    // Close only when clicking the backdrop, not the panel.
+    if ((e.target as HTMLElement)?.classList.contains('overlay')) {
+      this.close();
+    }
+  }
+
+  override render() {
+    const items = this.filtered;
+    return html`
+      <div class="overlay" @click=${this.handleOverlayClick} @keydown=${this.handleKeydown}>
+        <div class="panel">
+          <div class="search-row">
+            <sl-icon name="search"></sl-icon>
+            <input
+              id="switcher-input"
+              type="text"
+              placeholder="Search conversations..."
+              .value=${this.searchTerm}
+              @input=${this.handleInput}
+              autocomplete="off"
+            />
+          </div>
+          <div class="results">
+            ${items.length === 0
+              ? html`<div class="empty">
+                  ${this.searchTerm ? 'No matching conversations' : 'No conversations'}
+                </div>`
+              : items.map(
+                  (item, i) => html`
+                    <div
+                      class="item ${i === this.selectedIndex ? 'selected' : ''}"
+                      @click=${() => this.selectConversation(item)}
+                      @mouseenter=${() => { this.selectedIndex = i; }}
+                    >
+                      <div class="item-name">
+                        ${item.name}
+                        ${item.isDM ? html`<span class="dm-badge">DM</span>` : nothing}
+                      </div>
+                      <div class="item-context">${item.spaceName}</div>
+                    </div>
+                  `
+                )}
+          </div>
+          <div class="shortcut-hint">
+            <span><kbd>↑↓</kbd> navigate</span>
+            <span><kbd>↵</kbd> select</span>
+            <span><kbd>esc</kbd> close</span>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-chat-switcher': ScionChatSwitcher;
+  }
+}

--- a/web/src/components/shared/chat/chat-thread.test.ts
+++ b/web/src/components/shared/chat/chat-thread.test.ts
@@ -583,3 +583,152 @@ describe('scion-chat-thread initial scroll position', () => {
     expect(scrollWrites.at(-1)?.top).toBe(SCROLL_HEIGHT);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #1034: SSE direct message append
+// ---------------------------------------------------------------------------
+
+describe('scion-chat-thread SSE direct message append (#1034)', () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+    apiFetch.mockResolvedValue(emptyHistory());
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('merges a full SSE event payload directly without backfill', async () => {
+    const el = await mount();
+
+    // Emit a full message event (has id + msg).
+    emitChatMessage({
+      threadId: CONVERSATION_KEY,
+      id: 'direct-msg-1',
+      msg: 'Hello direct!',
+      senderId: 'user-a',
+      sender: 'user:Alice',
+      type: 'chat',
+      createdAt: new Date().toISOString(),
+    });
+
+    // Wait for render.
+    await el.updateComplete;
+    await Promise.resolve();
+
+    // No backfill should have been triggered — zero history calls.
+    expect(historyCalls()).toBe(0);
+  });
+
+  it('falls back to backfill when event has no full payload', async () => {
+    await mount();
+
+    // Emit a lightweight event (no id or msg).
+    emitChatMessage({ threadId: CONVERSATION_KEY });
+
+    await vi.waitFor(() => expect(historyCalls()).toBe(1));
+  });
+
+  it('still clears typing indicator on direct append', async () => {
+    const el = await mount();
+
+    // Set up a typing indicator.
+    fakeStateManager.dispatchEvent(
+      new CustomEvent('chat-typing-received', {
+        detail: {
+          data: {
+            threadId: CONVERSATION_KEY,
+            userId: 'user-typer',
+            displayName: 'Typer',
+          },
+        },
+      })
+    );
+    await el.updateComplete;
+    expect(el.shadowRoot?.querySelector('.typing-indicator')).not.toBeNull();
+
+    // Emit a full message from the same sender.
+    emitChatMessage({
+      threadId: CONVERSATION_KEY,
+      id: 'direct-msg-2',
+      msg: 'Done typing',
+      senderId: 'user-typer',
+      type: 'chat',
+      createdAt: new Date().toISOString(),
+    });
+    await el.updateComplete;
+
+    // Typing indicator should be cleared.
+    expect(el.shadowRoot?.querySelector('.typing-indicator')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #1055: Idempotency key on send (frontend)
+// ---------------------------------------------------------------------------
+
+describe('scion-chat-thread idempotency key on send (#1055)', () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+    apiFetch.mockResolvedValue(emptyHistory());
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('includes an idempotency_key in the send POST body', async () => {
+    const el = await mount();
+
+    // Mock the send response.
+    apiFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: () => Promise.resolve({ id: 'msg-1' }),
+    } as unknown as Response);
+    // Mock the backfill after send.
+    apiFetch.mockResolvedValue(emptyHistory());
+
+    // The chat-send event is dispatched from the composer child inside the
+    // shadow DOM. Find the composer and dispatch from it so the thread's
+    // @chat-send listener fires.
+    await el.updateComplete;
+    const composer = el.shadowRoot?.querySelector('scion-chat-composer');
+    expect(composer, 'composer should be in the thread shadow DOM').not.toBeNull();
+
+    composer!.dispatchEvent(
+      new CustomEvent('chat-send', {
+        detail: {
+          text: 'Hello with idempotency!',
+          mentions: [],
+          attachmentIds: [],
+          onSuccess: () => {},
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+
+    // Wait for the send to complete.
+    await vi.waitFor(() => {
+      const sendCalls = apiFetch.mock.calls.filter(
+        (c) => String(c[0]).includes('/messages') && (c[1] as Record<string, unknown>)?.method === 'POST'
+      );
+      expect(sendCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Find the send call.
+    const sendCall = apiFetch.mock.calls.find(
+      (c) => String(c[0]).includes('/messages') && (c[1] as Record<string, unknown>)?.method === 'POST'
+    );
+    expect(sendCall).toBeDefined();
+
+    const body = JSON.parse((sendCall![1] as Record<string, string>).body) as Record<string, unknown>;
+    expect(body.idempotency_key).toBeDefined();
+    expect(typeof body.idempotency_key).toBe('string');
+    // Verify it looks like a UUID (8-4-4-4-12 format).
+    expect(body.idempotency_key).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+  });
+});

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -1007,29 +1007,94 @@ export class ScionChatThread extends LitElement {
     return this._currentUserId || this.currentUserId;
   }
 
-  /** Handle v2 SSE chat message events. Only backfill if the event is for this conversation. */
+  /** Handle v2 SSE chat message events.
+   *
+   * If the SSE event carries a full message payload (has `id` and content),
+   * merge it directly via `mergeMessages()` instead of doing a full 50-message
+   * backfill. Fall back to `backfillV2()` when the event is a lightweight
+   * notification (e.g. just a threadId).
+   */
   private handleV2ChatMessage(e: Event): void {
     type ChatEventData = {
       threadId?: string;
       conversationKey?: string;
       topicId?: string;
       senderId?: string;
+      // Full message fields from UserMessageEvent:
+      id?: string;
+      msg?: string;
+      sender?: string;
+      recipient?: string;
+      recipientId?: string;
+      type?: string;
+      projectId?: string;
+      agentId?: string;
+      createdAt?: string;
+      channel?: string;
+      visibility?: string;
+      groupId?: string;
+      dispatchState?: string;
+      urgent?: boolean;
+      broadcasted?: boolean;
+      read?: boolean;
+      attachments?: import('./chat-message.js').AttachmentRefInfo[];
     };
     const detail = (e as CustomEvent).detail as
       | ({ data?: ChatEventData } & ChatEventData)
       | undefined;
     // stateManager wraps SSE payloads as { state, data }; tolerate a flat detail too.
     const eventData: ChatEventData | undefined = detail?.data ?? detail;
-    if (eventData) {
-      // Filter: only process events for this conversation
-      const eventKey = eventData.threadId || eventData.conversationKey || eventData.topicId || '';
-      if (eventKey && eventKey !== this.conversationKey) {
-        return; // Not for this conversation
-      }
-      // The sender finished typing the moment their message landed — drop the
-      // indicator now rather than waiting out TYPING_EXPIRY_MS.
-      this.clearTypingForUser(eventData.senderId);
+    if (!eventData) {
+      void this.backfillV2();
+      return;
     }
+
+    // Filter: only process events for this conversation
+    const eventKey = eventData.threadId || eventData.conversationKey || eventData.topicId || '';
+    if (eventKey && eventKey !== this.conversationKey) {
+      return; // Not for this conversation
+    }
+
+    // The sender finished typing the moment their message landed — drop the
+    // indicator now rather than waiting out TYPING_EXPIRY_MS.
+    this.clearTypingForUser(eventData.senderId);
+
+    // If the event carries a full message payload, merge directly instead of
+    // doing a round-trip backfill.
+    if (eventData.id && (eventData.msg !== undefined || eventData.type)) {
+      const msg: Message = {
+        id: eventData.id,
+        projectId: eventData.projectId || '',
+        sender: eventData.sender || '',
+        senderId: eventData.senderId || '',
+        recipient: eventData.recipient || '',
+        recipientId: eventData.recipientId || '',
+        msg: eventData.msg || '',
+        type: eventData.type || '',
+        agentId: eventData.agentId || '',
+        createdAt: eventData.createdAt || new Date().toISOString(),
+        ...(eventData.channel != null ? { channel: eventData.channel } : {}),
+        ...(eventData.threadId != null ? { threadId: eventData.threadId } : {}),
+        ...(eventData.visibility != null ? { visibility: eventData.visibility } : {}),
+        ...(eventData.groupId != null ? { groupId: eventData.groupId } : {}),
+        ...(eventData.dispatchState != null ? { dispatchState: eventData.dispatchState } : {}),
+        ...(eventData.urgent != null ? { urgent: eventData.urgent } : {}),
+        ...(eventData.broadcasted != null ? { broadcasted: eventData.broadcasted } : {}),
+        ...(eventData.read != null ? { read: eventData.read } : {}),
+      };
+      this.mergeMessages([msg]);
+
+      // Update attachment map if the event carries attachment data.
+      if (eventData.attachments && eventData.attachments.length > 0) {
+        this.v2AttachmentMap.set(msg.id, eventData.attachments);
+      }
+
+      this.scrollToBottomAfterRender();
+      this.maybeAdvanceReadWatermark();
+      return;
+    }
+
+    // Lightweight notification (no full message) — fall back to backfill.
     void this.backfillV2();
   }
 
@@ -1315,8 +1380,12 @@ export class ScionChatThread extends LitElement {
     this.sendError = null;
 
     try {
+      // Generate an idempotency key so duplicate sends (e.g. network retry)
+      // are collapsed server-side.
+      const idempotencyKey = crypto.randomUUID();
       const body: Record<string, unknown> = {
         content: text,
+        idempotency_key: idempotencyKey,
       };
       if (mentions && mentions.length > 0) {
         body.mentions = mentions;

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -1061,6 +1061,10 @@ export class ScionChatThread extends LitElement {
 
     // If the event carries a full message payload, merge directly instead of
     // doing a round-trip backfill.
+    // SSE events from PublishUserMessage carry the full message payload.
+    // mergeMessages() deduplicates by ID (last-write-wins via Map.set),
+    // so if both the POST response and the SSE event provide the same
+    // message, the later arrival's fields prevail — this is acceptable.
     if (eventData.id && (eventData.msg !== undefined || eventData.type)) {
       const msg: Message = {
         id: eventData.id,


### PR DESCRIPTION
Phase 4 of the native chat feature gap programme (ptone/scion#1026).

Implements 7 issues:
- ptone/scion#1043: Paste-to-upload and drag-and-drop file attachments
- ptone/scion#1044: Character limit raised to 16K (from 2K)
- ptone/scion#1042: Composer draft persistence via localStorage
- ptone/scion#1034: SSE direct append (no more full 50-message refetch)
- ptone/scion#1055: Idempotency key on message send
- ptone/scion#1049: Syntax highlighting in code blocks
- ptone/scion#1048: Cmd/Ctrl-K quick conversation switcher

7 commits, 15 files, ~1860 lines. Reviewed, all findings resolved.
