### PR TITLE
ci(chart): add Helm chart CI workflow

### DIFF
--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -107,6 +107,11 @@ jobs:
           echo "Rendered $(wc -l < /tmp/rendered.yaml) lines"
           echo "::endgroup::"
 
+          if [ ! -s /tmp/rendered.yaml ]; then
+            echo "::error::Helm template produced an empty file — nothing to validate"
+            exit 1
+          fi
+
           echo "::group::Kubeconform validation"
           kubeconform \
             -strict \
@@ -138,7 +143,7 @@ jobs:
           if helm template ci-schema "${CHART_DIR}" \
             -f "${CHART_DIR}/ci/values-unknown-key.yaml" \
             --namespace ci-test 2>/tmp/schema-error.txt; then
-            echo "::error::Schema validation did not reject unknown key 'auth.sessionSecret'."
+            echo "::error::Schema validation did not reject unknown key '_ciNegativeControl'."
             echo "values.schema.json declares additionalProperties: false at the root,"
             echo "so helm template with an unknown key MUST fail. It did not."
             exit 1
@@ -155,7 +160,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install yamllint
-        run: pip install yamllint
+        run: pip install yamllint==1.38.0
 
       - name: Lint chart YAML sources
         run: |

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Install Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
@@ -78,6 +80,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Install Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
@@ -126,6 +130,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Install Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
@@ -158,6 +164,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Install yamllint
         run: pip install yamllint==1.38.0

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -1,0 +1,177 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Chart CI — validates the Helm chart at deploy/helm/scion-hub.
+#
+# TRIGGER DESIGN (C7): The existing ci.yml uses `branches: [ main ]` on
+# pull_request, which filters on the PR's BASE branch, not its head. PRs based
+# on phase branches (e.g. scion/gke-chart-p1) never trigger CI because their
+# base is not main. This workflow does NOT filter by branch. It uses path
+# filtering to run only when chart files change, and it runs on pull_request
+# events regardless of which branch the PR targets. This ensures stacked PRs
+# based on phase branches still get chart CI.
+
+name: Chart CI
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'deploy/helm/scion-hub/**'
+      - '.github/workflows/chart-ci.yml'
+  pull_request:
+    paths:
+      - 'deploy/helm/scion-hub/**'
+      - '.github/workflows/chart-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  helm-lint:
+    name: Helm Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
+        with:
+          version: 'v3.17.3'
+
+      - name: Helm lint (minimal values)
+        run: helm lint --strict deploy/helm/scion-hub -f deploy/helm/scion-hub/ci/values-minimal.yaml
+
+      - name: Helm lint (cluster RBAC values)
+        run: helm lint --strict deploy/helm/scion-hub -f deploy/helm/scion-hub/ci/values-cluster-rbac.yaml
+
+  helm-template:
+    name: Helm Template (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: minimal
+            values-file: ci/values-minimal.yaml
+            release-name: ci-minimal
+          - name: cluster-rbac
+            values-file: ci/values-cluster-rbac.yaml
+            release-name: ci-cluster-rbac
+          - name: long-release-name
+            values-file: ci/values-minimal.yaml
+            # 54 characters: exercises trunc 63 in _helpers.tpl fullname
+            # (54 + "-" + "scion-hub" = 64, truncated to 63)
+            release-name: aaaaaaaaa-bbbbbbbbb-ccccccccc-ddddddddd-eeeeeeeee-ffff
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
+        with:
+          version: 'v3.17.3'
+
+      - name: Install kubeconform
+        run: |
+          curl -sSLo kubeconform.tar.gz https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar xzf kubeconform.tar.gz
+          sudo mv kubeconform /usr/local/bin/
+          kubeconform -v
+
+      - name: Render and validate
+        run: |
+          set -euo pipefail
+
+          CHART_DIR="deploy/helm/scion-hub"
+          VALUES_FILE="${CHART_DIR}/${{ matrix.values-file }}"
+          RELEASE_NAME="${{ matrix.release-name }}"
+
+          echo "::group::Helm template"
+          helm template "${RELEASE_NAME}" "${CHART_DIR}" \
+            -f "${VALUES_FILE}" \
+            --namespace ci-test \
+            > /tmp/rendered.yaml
+          echo "Rendered $(wc -l < /tmp/rendered.yaml) lines"
+          echo "::endgroup::"
+
+          echo "::group::Kubeconform validation"
+          kubeconform \
+            -strict \
+            -summary \
+            -output json \
+            /tmp/rendered.yaml
+          echo "::endgroup::"
+
+  schema-validation:
+    name: Schema Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
+        with:
+          version: 'v3.17.3'
+
+      - name: Unknown key MUST be rejected by schema
+        run: |
+          set -euo pipefail
+
+          CHART_DIR="deploy/helm/scion-hub"
+
+          # This MUST fail. If it succeeds, the schema is not enforcing
+          # additionalProperties: false and unknown keys pass silently.
+          if helm template ci-schema "${CHART_DIR}" \
+            -f "${CHART_DIR}/ci/values-unknown-key.yaml" \
+            --namespace ci-test 2>/tmp/schema-error.txt; then
+            echo "::error::Schema validation did not reject unknown key 'auth.sessionSecret'."
+            echo "values.schema.json declares additionalProperties: false at the root,"
+            echo "so helm template with an unknown key MUST fail. It did not."
+            exit 1
+          fi
+
+          echo "Schema correctly rejected unknown key. Error:"
+          head -5 /tmp/schema-error.txt
+
+  yamllint:
+    name: YAML Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Install yamllint
+        run: pip install yamllint
+
+      - name: Lint chart YAML sources
+        run: |
+          yamllint -c <(cat <<'YAMLLINT_CONFIG'
+          extends: default
+          rules:
+            line-length:
+              max: 200
+            truthy:
+              check-keys: false
+            comments:
+              min-spaces-from-content: 1
+            document-start: disable
+          YAMLLINT_CONFIG
+          ) \
+            deploy/helm/scion-hub/Chart.yaml \
+            deploy/helm/scion-hub/values.yaml \
+            deploy/helm/scion-hub/ci/*.yaml \
+            deploy/helm/scion-hub/templates/*.yaml

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -72,9 +72,9 @@ jobs:
             release-name: ci-cluster-rbac
           - name: long-release-name
             values-file: ci/values-minimal.yaml
-            # 54 characters: exercises trunc 63 in _helpers.tpl fullname
-            # (54 + "-" + "scion-hub" = 64, truncated to 63)
-            release-name: aaaaaaaaa-bbbbbbbbb-ccccccccc-ddddddddd-eeeeeeeee-ffff
+            # 53 characters (Helm max): fullname = 53 + "-" + "scion-hub" = 63,
+            # exactly at the trunc 63 boundary in _helpers.tpl.
+            release-name: aaaaaaaaa-bbbbbbbbb-ccccccccc-ddddddddd-eeeeeeeee-fff
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -159,6 +159,10 @@ jobs:
 
       - name: Lint chart YAML sources
         run: |
+          # Lint non-template YAML only. Template files (templates/*.yaml)
+          # contain Go template directives ({{ }}) which are not valid YAML
+          # and cannot be linted by yamllint. Those are validated by helm lint
+          # and helm template instead.
           yamllint -c <(cat <<'YAMLLINT_CONFIG'
           extends: default
           rules:
@@ -173,5 +177,4 @@ jobs:
           ) \
             deploy/helm/scion-hub/Chart.yaml \
             deploy/helm/scion-hub/values.yaml \
-            deploy/helm/scion-hub/ci/*.yaml \
-            deploy/helm/scion-hub/templates/*.yaml
+            deploy/helm/scion-hub/ci/*.yaml

--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -49,7 +49,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: 'v3.17.3'
 
@@ -84,7 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: 'v3.17.3'
 
@@ -134,7 +134,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
         with:
           version: 'v3.17.3'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
@@ -94,6 +96,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Go
@@ -113,6 +116,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Install shellcheck
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 permissions:
   contents: read

--- a/deploy/helm/scion-hub/ci/values-cluster-rbac.yaml
+++ b/deploy/helm/scion-hub/ci/values-cluster-rbac.yaml
@@ -1,0 +1,28 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Exercises the cluster-scoped RBAC path: runtime.listAllNamespaces renders
+# ClusterRole and ClusterRoleBinding instead of the namespaced Role/RoleBinding
+# pair, and scion-hub.clusterRoleName includes the namespace in the name to
+# prevent cross-namespace collisions.
+
+hub:
+  hubId: ci-cluster-rbac
+
+image:
+  repository: us-docker.pkg.dev/example-project/example-repo/scion-hub-gke
+  tag: ci
+
+runtime:
+  listAllNamespaces: true

--- a/deploy/helm/scion-hub/ci/values-unknown-key.yaml
+++ b/deploy/helm/scion-hub/ci/values-unknown-key.yaml
@@ -1,0 +1,32 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NEGATIVE CONTROL for schema validation (C3). This file contains a key the
+# chart does not understand. values.schema.json declares additionalProperties:
+# false at the root and at 13 nested levels, so helm template with this file
+# MUST fail. If it succeeds, the schema is not enforced.
+#
+# This file is used by chart-ci.yml to assert that unknown keys are rejected.
+# DO NOT add these keys to the schema or values.yaml.
+
+hub:
+  hubId: ci-schema-check
+
+image:
+  repository: us-docker.pkg.dev/example-project/example-repo/scion-hub-gke
+  tag: ci
+
+# This key does not exist in values.schema.json and must be rejected.
+auth:
+  sessionSecret: "this-must-be-rejected-by-the-schema"

--- a/deploy/helm/scion-hub/ci/values-unknown-key.yaml
+++ b/deploy/helm/scion-hub/ci/values-unknown-key.yaml
@@ -18,7 +18,9 @@
 # MUST fail. If it succeeds, the schema is not enforced.
 #
 # This file is used by chart-ci.yml to assert that unknown keys are rejected.
-# DO NOT add these keys to the schema or values.yaml.
+# The negative-control key uses a leading underscore, which by convention is
+# never a real chart value, making it permanently invalid regardless of future
+# schema additions.
 
 hub:
   hubId: ci-schema-check
@@ -27,6 +29,6 @@ image:
   repository: us-docker.pkg.dev/example-project/example-repo/scion-hub-gke
   tag: ci
 
-# This key does not exist in values.schema.json and must be rejected.
-auth:
-  sessionSecret: "this-must-be-rejected-by-the-schema"
+# Permanently-invalid key: leading underscore is never a chart value.
+_ciNegativeControl:
+  mustBeRejected: true


### PR DESCRIPTION
Adds a chart-aware CI gate: Helm lint, template rendering across three fixtures
(including a 53-char release name exercising the 63-byte truncation path),
kubeconform validation, values.yaml schema validation, and yamllint. Before this,
no CI job in the repo inspected the chart -- every green check on prior chart
PRs was evidence about Go code, not the chart. A negative control (deliberate
template break, committed then reverted) proves the gate can actually fail.

Also includes a separate commit removing `branches: [main]` from ci.yml's
pull_request trigger, which matched the PR's base ref and silently skipped
stacked chart PRs. Trade-off disclosed in the PR body: build-and-test,
golangci-lint and shellcheck now run on every PR regardless of base branch.
