### PR TITLE
ci(chart): correct azure/setup-helm version comment to v4.3.1

### DIFF
--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -49,7 +49,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: 'v3.17.3'
 
@@ -84,7 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: 'v3.17.3'
 
@@ -134,7 +134,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: 'v3.17.3'
 


### PR DESCRIPTION
Small follow-up to the chart CI workflow merged in #1213. That PR's SHA-fix commit
updated azure/setup-helm's pin from v4.3.0 to v4.3.1 (a benign patch bump) but kept
the comment as the generic "# v4" rather than the specific version, which is itself
a zizmor-flagged mismatch (ref-version-mismatch). This PR corrects the comment only
-- no SHA change -- to "# v4.3.1" at all three sites in chart-ci.yml.

Verified locally with zizmor v1.29.0: zero findings, exit 0.
