### PR TITLE
fix(chat): action bar UX fixes, routing header, and restore markdown preview

### DIFF
--- a/web/scripts/copy-shoelace-icons.mjs
+++ b/web/scripts/copy-shoelace-icons.mjs
@@ -147,6 +147,7 @@ const USED_ICONS = [
   'plus-lg',
   'puzzle',
   'question-circle',
+  'reply',
   'robot',
   'pause-circle',
   'search',

--- a/web/src/components/shared/chat/chat-message.ts
+++ b/web/src/components/shared/chat/chat-message.ts
@@ -35,6 +35,7 @@ import { getMarkdownRenderer } from '../../../utils/markdown.js';
 import { getLanguageFromPath } from '../code-editor.js';
 import { hashColor, getInitials } from './chat-avatar.js';
 import '../code-editor.js';
+import '../markdown-preview.js';
 
 /** Structured attachment reference from the W7 API. */
 export interface AttachmentRefInfo {
@@ -75,6 +76,7 @@ const TEXT_EXTENSIONS = new Set([
   '.jsx',
   '.log',
   '.md',
+  '.markdown',
   '.py',
   '.rs',
   '.sh',
@@ -245,6 +247,12 @@ function styleEntityLinks(htmlStr: string): string {
 function extensionOf(name: string): string {
   const dot = name.lastIndexOf('.');
   return dot > 0 ? name.slice(dot).toLowerCase() : '';
+}
+
+/** True when the file is a Markdown document. */
+function isMarkdownFile(name: string): boolean {
+  const ext = extensionOf(name);
+  return ext === '.md' || ext === '.markdown';
 }
 
 /**
@@ -497,6 +505,20 @@ export class ScionChatMessage extends LitElement {
   /** Attachment shown in the full-height overlay, if any. */
   @state()
   private expanded: AttachmentRefInfo | null = null;
+
+  /**
+   * Per-attachment toggle: true = show raw source, false/absent = show
+   * rendered preview (only meaningful for markdown files).
+   */
+  @state()
+  private mdSourceView: ReadonlyMap<string, boolean> = new Map();
+
+  /**
+   * Tracks which attachment IDs have a "Copied!" feedback timer active,
+   * so the button shows a check icon instead of the clipboard icon.
+   */
+  @state()
+  private copiedIds: ReadonlySet<string> = new Set();
 
   private renderTaskId = 0;
 
@@ -990,6 +1012,23 @@ export class ScionChatMessage extends LitElement {
       color: var(--scion-text-muted, #64748b);
     }
 
+    /* Markdown preview body — let the component fill the card. */
+    .md-preview-body {
+      padding: 0;
+      --scion-border: transparent;
+      --scion-radius: 0;
+    }
+
+    .md-preview-body scion-markdown-preview {
+      --scion-radius: 0;
+    }
+
+    .md-preview-body scion-markdown-preview::part(container) {
+      border: none;
+      border-radius: 0;
+      max-height: 200px;
+    }
+
     /*
      * The card already draws a frame, so the editor's own border is hidden by
      * blanking the custom property it reads.
@@ -1471,6 +1510,7 @@ export class ScionChatMessage extends LitElement {
         void navigator.clipboard.writeText(code);
         btn.textContent = 'Copied!';
         setTimeout(() => {
+          if (!this.isConnected) return;
           btn.textContent = 'Copy';
         }, 1500);
       });
@@ -2096,15 +2136,50 @@ export class ScionChatMessage extends LitElement {
   /** A short read-only slice of a text attachment, with expand + download. */
   private renderCodePreview(ref: AttachmentRefInfo) {
     const state = this.previews.get(ref.id);
-    // Only fade the bottom edge when the file really does run past the slice.
-    const clipped =
-      state?.status === 'ready' && (state.text ?? '').split('\n').length > PREVIEW_VISIBLE_LINES;
+    const isMd = isMarkdownFile(ref.name);
+    const showSource = isMd && (this.mdSourceView.get(ref.id) ?? false);
+
+    // Only fade the bottom edge when the file really does run past the slice
+    // and we are NOT showing rendered markdown (rendered view scrolls itself).
+    const hasText = state?.status === 'ready' && !!state.text;
+    const exceedsLimit =
+      hasText &&
+      (() => {
+        let count = 0;
+        let pos = -1;
+        const text = state.text!;
+        while ((pos = text.indexOf('\n', pos + 1)) !== -1) {
+          if (++count >= PREVIEW_VISIBLE_LINES) return true;
+        }
+        return false;
+      })();
+    const clipped = !isMd && exceedsLimit;
+    const sourceClipped = showSource && exceedsLimit;
+
     return html`
       <div class="attachment-preview" data-id=${ref.id}>
         <div class="preview-header">
           <span class="preview-filename" title=${ref.name}>${ref.name}</span>
           <span class="preview-size">${formatFileSize(ref.size)}</span>
           <div class="preview-actions">
+            ${isMd
+              ? html`
+                  <sl-icon-button
+                    name=${showSource ? 'eye' : 'code'}
+                    label=${showSource ? 'Preview' : 'Source'}
+                    @click=${() => this.toggleMdSource(ref.id)}
+                  ></sl-icon-button>
+                `
+              : nothing}
+            ${isMd && showSource
+              ? html`
+                  <sl-icon-button
+                    name=${this.copiedIds.has(ref.id) ? 'check2' : 'clipboard'}
+                    label="Copy to clipboard"
+                    @click=${() => this.copyAttachmentText(ref.id)}
+                  ></sl-icon-button>
+                `
+              : nothing}
             <sl-icon-button
               name="arrows-angle-expand"
               label="Expand ${ref.name}"
@@ -2118,11 +2193,56 @@ export class ScionChatMessage extends LitElement {
             ></sl-icon-button>
           </div>
         </div>
-        <div class="preview-body ${clipped ? 'clipped' : ''}">
-          ${this.renderPreviewBody(ref, state)}
-        </div>
+        ${isMd && !showSource
+          ? html`<div class="md-preview-body">${this.renderMdPreviewBody(ref, state)}</div>`
+          : html`<div class="preview-body ${clipped || sourceClipped ? 'clipped' : ''}">
+              ${this.renderPreviewBody(ref, state)}
+            </div>`}
       </div>
     `;
+  }
+
+  /** Toggle between rendered and source view for a markdown attachment. */
+  private toggleMdSource(id: string): void {
+    const next = new Map(this.mdSourceView);
+    next.set(id, !(next.get(id) ?? false));
+    this.mdSourceView = next;
+  }
+
+  /** Copy attachment text to clipboard with brief "Copied!" feedback. */
+  private async copyAttachmentText(id: string): Promise<void> {
+    const state = this.previews.get(id);
+    if (!state || state.status !== 'ready' || !state.text) return;
+    try {
+      await navigator.clipboard.writeText(state.text);
+      const next = new Set(this.copiedIds);
+      next.add(id);
+      this.copiedIds = next;
+      setTimeout(() => {
+        if (!this.isConnected) return;
+        const after = new Set(this.copiedIds);
+        after.delete(id);
+        this.copiedIds = after;
+      }, 1500);
+    } catch {
+      // Clipboard write may fail in insecure contexts; silently ignore.
+    }
+  }
+
+  /** Rendered markdown body for a markdown attachment preview. */
+  private renderMdPreviewBody(_ref: AttachmentRefInfo, state: PreviewState | undefined) {
+    if (!state || state.status === 'loading') {
+      return html`
+        <div class="preview-placeholder">
+          <sl-spinner></sl-spinner>
+          Loading preview…
+        </div>
+      `;
+    }
+    if (state.status === 'error') {
+      return html`<div class="preview-placeholder error">${state.error}</div>`;
+    }
+    return html`<scion-markdown-preview .content=${state.text ?? ''}></scion-markdown-preview>`;
   }
 
   /** Editor, spinner or error for one preview, depending on load state. */
@@ -2153,6 +2273,10 @@ export class ScionChatMessage extends LitElement {
     const ref = this.expanded;
     if (!ref) return nothing;
 
+    const isMd = isMarkdownFile(ref.name);
+    const showSource = isMd && (this.mdSourceView.get(ref.id) ?? false);
+    const state = this.previews.get(ref.id);
+
     return html`
       <sl-dialog
         class="full-preview"
@@ -2164,11 +2288,34 @@ export class ScionChatMessage extends LitElement {
       >
         ${IMAGE_MIMES.has(ref.mime)
           ? html`<img class="full-image" src=${attachmentURL(ref.id)} alt=${ref.name} />`
-          : this.renderPreviewBody(ref, this.previews.get(ref.id), true)}
-        <sl-button slot="footer" href=${attachmentURL(ref.id)} download=${ref.name}>
-          <sl-icon slot="prefix" name="download"></sl-icon>
-          Download
-        </sl-button>
+          : isMd && !showSource
+            ? this.renderMdPreviewBody(ref, state)
+            : this.renderPreviewBody(ref, state, true)}
+        <div slot="footer" style="display:flex;gap:0.5rem;align-items:center">
+          ${isMd
+            ? html`
+                <sl-button size="small" @click=${() => this.toggleMdSource(ref.id)}>
+                  <sl-icon slot="prefix" name=${showSource ? 'eye' : 'code'}></sl-icon>
+                  ${showSource ? 'Preview' : 'Source'}
+                </sl-button>
+              `
+            : nothing}
+          ${isMd && showSource
+            ? html`
+                <sl-button size="small" @click=${() => this.copyAttachmentText(ref.id)}>
+                  <sl-icon
+                    slot="prefix"
+                    name=${this.copiedIds.has(ref.id) ? 'check2' : 'clipboard'}
+                  ></sl-icon>
+                  ${this.copiedIds.has(ref.id) ? 'Copied!' : 'Copy'}
+                </sl-button>
+              `
+            : nothing}
+          <sl-button href=${attachmentURL(ref.id)} download=${ref.name}>
+            <sl-icon slot="prefix" name="download"></sl-icon>
+            Download
+          </sl-button>
+        </div>
       </sl-dialog>
     `;
   }

--- a/web/src/components/shared/chat/chat-message.ts
+++ b/web/src/components/shared/chat/chat-message.ts
@@ -520,6 +520,8 @@ export class ScionChatMessage extends LitElement {
   @state()
   private copiedIds: ReadonlySet<string> = new Set();
 
+  private copyTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
   private renderTaskId = 0;
 
   private previewObserver: IntersectionObserver | null = null;
@@ -1509,7 +1511,9 @@ export class ScionChatMessage extends LitElement {
         const code = pre.querySelector('code')?.textContent ?? pre.textContent ?? '';
         void navigator.clipboard.writeText(code);
         btn.textContent = 'Copied!';
-        setTimeout(() => {
+        const prev = (btn as any)._copyTimer as ReturnType<typeof setTimeout> | undefined;
+        if (prev) clearTimeout(prev);
+        (btn as any)._copyTimer = setTimeout(() => {
           if (!this.isConnected) return;
           btn.textContent = 'Copy';
         }, 1500);
@@ -2218,12 +2222,16 @@ export class ScionChatMessage extends LitElement {
       const next = new Set(this.copiedIds);
       next.add(id);
       this.copiedIds = next;
-      setTimeout(() => {
+      const existing = this.copyTimers.get(id);
+      if (existing) clearTimeout(existing);
+      const timer = setTimeout(() => {
         if (!this.isConnected) return;
         const after = new Set(this.copiedIds);
         after.delete(id);
         this.copiedIds = after;
+        this.copyTimers.delete(id);
       }, 1500);
+      this.copyTimers.set(id, timer);
     } catch {
       // Clipboard write may fail in insecure contexts; silently ignore.
     }

--- a/web/src/components/shared/chat/chat-message.ts
+++ b/web/src/components/shared/chat/chat-message.ts
@@ -548,6 +548,7 @@ export class ScionChatMessage extends LitElement {
     .bubble {
       max-width: min(70%, 600px);
       min-width: 3rem;
+      position: relative;
     }
 
     .bubble-header {
@@ -1152,7 +1153,8 @@ export class ScionChatMessage extends LitElement {
     /* ---- Phase-3: Message action bar ---- */
     .message-actions {
       position: absolute;
-      top: -0.25rem;
+      top: -12px;
+      right: 8px;
       display: flex;
       gap: 0.0625rem;
       padding: 0.125rem;
@@ -1161,30 +1163,30 @@ export class ScionChatMessage extends LitElement {
       border: 1px solid var(--scion-neutral-200, #e2e8f0);
       box-shadow: 0 1px 3px rgba(0,0,0,0.1);
       opacity: 0;
-      transition: opacity 0.15s ease;
+      visibility: hidden;
+      pointer-events: none;
+      transition: opacity 0.15s ease, visibility 0.15s ease;
       z-index: 10;
-    }
-
-    .message-wrapper.from-user .message-actions {
-      right: 1rem;
-    }
-
-    .message-wrapper.from-agent .message-actions {
-      left: 3.5rem;
     }
 
     .message-wrapper:hover .message-actions,
     .message-wrapper:focus-within .message-actions,
     .message-actions.pinned {
       opacity: 1;
+      visibility: visible;
+      pointer-events: auto;
     }
 
     @media (hover: none) {
       .message-actions {
         opacity: 0;
+        visibility: hidden;
+        pointer-events: none;
       }
       .message-actions.pinned {
         opacity: 1;
+        visibility: visible;
+        pointer-events: auto;
       }
     }
 
@@ -1710,12 +1712,14 @@ export class ScionChatMessage extends LitElement {
         <sl-icon-button
           name="reply"
           label="Reply"
+          title="Reply"
           @click=${this.handleReply}
         ></sl-icon-button>
         ${this.isOwn && this.canEdit
           ? html`<sl-icon-button
               name="pencil"
               label="Edit"
+              title="Edit"
               @click=${this.handleEdit}
             ></sl-icon-button>`
           : nothing}
@@ -1723,17 +1727,20 @@ export class ScionChatMessage extends LitElement {
           ? html`<sl-icon-button
               name="trash"
               label="Delete"
+              title="Delete"
               @click=${this.handleDelete}
             ></sl-icon-button>`
           : nothing}
         <sl-icon-button
           name="clipboard"
           label="Copy text"
+          title="Copy message"
           @click=${this.handleCopyText}
         ></sl-icon-button>
         <sl-icon-button
           name="link-45deg"
           label="Copy link"
+          title="Copy link"
           @click=${this.handleCopyLink}
         ></sl-icon-button>
       </div>
@@ -1853,7 +1860,6 @@ export class ScionChatMessage extends LitElement {
         class="message-wrapper ${dirClass}${visClass}${groupClass}"
         @touchstart=${this.handleTouchStart}
       >
-        ${!isDeleted ? this.renderActionBar() : nothing}
         ${this.showHeader && this.fromAgent
           ? html`<div class="avatar" style="background: ${this.getAvatarColor()}">
               ${this.getInitials()}
@@ -1862,6 +1868,7 @@ export class ScionChatMessage extends LitElement {
             ? html`<div class="avatar-spacer"></div>`
             : nothing}
         <div class="bubble">
+          ${!isDeleted ? this.renderActionBar() : nothing}
           ${this.visibility === 'verbose'
             ? html`
                 <span class="verbose-label">

--- a/web/src/components/shared/chat/chat-thread.test.ts
+++ b/web/src/components/shared/chat/chat-thread.test.ts
@@ -98,11 +98,11 @@ describe('scion-chat-thread route-to-agent indicator', () => {
   });
 
   /**
-   * Routing is a property of the author: every human message in a thread with a
-   * default agent was routed to that agent, whoever sent it. Agent replies were
-   * not routed anywhere.
+   * Routing uses per-message recipient data (set at send time), not the
+   * current default-agent UI state. Only messages whose `recipient` field
+   * was populated at send time show the routing header.
    */
-  it('marks all human messages as routed and no agent message', async () => {
+  it('marks only messages with a recipient as routed, not all human messages', async () => {
     apiFetch.mockResolvedValue({
       ok: true,
       status: 200,
@@ -113,6 +113,7 @@ describe('scion-chat-thread route-to-agent indicator', () => {
               id: 'm1',
               sender: 'me@example.com',
               senderId: 'user-me',
+              recipient: 'agent:coder',
               msg: 'mine',
               createdAt: '2026-01-01T00:00:00Z',
             },
@@ -120,7 +121,7 @@ describe('scion-chat-thread route-to-agent indicator', () => {
               id: 'm2',
               sender: 'them@example.com',
               senderId: 'user-them',
-              msg: 'theirs',
+              msg: 'theirs (sent before default agent set)',
               createdAt: '2026-01-01T00:01:00Z',
             },
             {
@@ -154,7 +155,8 @@ describe('scion-chat-thread route-to-agent indicator', () => {
     const routed = Array.from(el.shadowRoot?.querySelectorAll('scion-chat-message') ?? []).map(
       (m) => m.getAttribute('routedTo')
     );
-    expect(routed).toEqual(['coder', 'coder', '']);
+    // m1 has recipient=agent:coder → shows "coder"; m2 has no recipient → empty; m3 is agent → empty
+    expect(routed).toEqual(['coder', '', '']);
   });
 });
 

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -2736,11 +2736,14 @@ export class ScionChatThread extends LitElement {
           ? msg.senderId !== this.currentUserId
           : this.isSenderAgent(msg)
         : msg.senderId === this.agentId;
-      // Routing is a property of the AUTHOR, not of the viewer: every human
-      // message in a default-agent conversation was routed to that agent, and
-      // no agent message ever is. `isFromAgent` above only means "not mine",
-      // so it cannot be reused here.
+      // Routing is a property of the individual message, not the current UI
+      // default-agent state. Use the per-message `recipient` field (set at
+      // send time) so historical messages without a default agent don't
+      // retroactively show a routing header.
       const isAgentSender = this.isSenderAgent(msg);
+      const msgRoutedTo = !isAgentSender && msg.recipient
+        ? (msg.recipient.startsWith('agent:') ? msg.recipient.slice(6) : msg.recipient)
+        : '';
       const senderDisplayName = this.isV2
         ? this.getSenderDisplayName(msg)
         : isFromAgent
@@ -2779,7 +2782,7 @@ export class ScionChatThread extends LitElement {
           dispatchFailureReason=${msg.dispatchFailureReason || ''}
           .attachments=${msg.attachments || []}
           .attachmentRefs=${this.getMessageAttachmentRefs(msg.id)}
-          routedTo=${!isAgentSender && this.defaultAgent ? this.defaultAgent : ''}
+          routedTo=${msgRoutedTo}
           messageId=${msg.id}
           ?isOwn=${isOwnMessage}
           ?canEdit=${canEditDelete}

--- a/web/src/components/shared/markdown-preview.ts
+++ b/web/src/components/shared/markdown-preview.ts
@@ -244,7 +244,7 @@ export class ScionMarkdownPreview extends LitElement {
       `;
     }
 
-    return html`<div class="preview-container" .innerHTML=${this.renderedHtml}></div>`;
+    return html`<div class="preview-container" part="container" .innerHTML=${this.renderedHtml}></div>`;
   }
 }
 


### PR DESCRIPTION
- Fix action bar positioning (top-right of message bubble)
- Add missing reply icon to USED_ICONS
- Add mouseover tooltip hints to action bar buttons
- Fix dark theme bar artifact (visibility hidden when inactive)
- Fix routing header retroactive leak (use per-message recipient data)
- Restore markdown attachment preview with source/preview toggle and clipboard copy

Fixes ptone/scion#1151