### PR TITLE
fix(chat): accept all file types for attachment uploads

### DIFF
--- a/pkg/hub/attachment_classify.go
+++ b/pkg/hub/attachment_classify.go
@@ -121,14 +121,14 @@ func ClassifyAttachment(filename string, head []byte) (string, error) {
 	}
 
 	// Everything else is what the bytes say it is, checked against the
-	// allowlist. text/html and application/javascript are not on it, so a
+	// deny-list. text/html and application/javascript are refused, so a
 	// sniffed HTML or script body is refused here whatever it is called — which
 	// is the other half of the markup rule above: the extension check catches
 	// the payloads the sniff misses, the sniff catches the ones renamed .txt.
-	if AllowedMimeTypes[detected] {
-		return detected, nil
+	if IsDangerousMimeType(detected) {
+		return "", fmt.Errorf("file type %q is not accepted", detected)
 	}
-	return "", fmt.Errorf("file type %q is not accepted", detected)
+	return detected, nil
 }
 
 // isTextContentType reports whether a sniffed type means "these bytes are

--- a/pkg/hub/attachment_classify_test.go
+++ b/pkg/hub/attachment_classify_test.go
@@ -59,8 +59,8 @@ func TestClassifyAttachment_TextLikeExtensions(t *testing.T) {
 			if got != want {
 				t.Errorf("ClassifyAttachment(%q) = %q, want %q", ext, got, want)
 			}
-			if !AllowedMimeTypes[got] {
-				t.Errorf("%q classified as %q, which the allowlist rejects", ext, got)
+			if IsDangerousMimeType(got) {
+				t.Errorf("%q classified as %q, which the deny-list rejects", ext, got)
 			}
 		})
 	}
@@ -195,14 +195,43 @@ func TestAttachmentUpload_TrailingCharactersDoNotDefeatTheBlocklist(t *testing.T
 	}
 }
 
-// The allowlist entries the brief pins (D3). Nothing in this change may flip
-// them, whatever route the file arrives by.
-func TestAllowedMimeTypes_HTMLAndJavaScriptStayBlocked(t *testing.T) {
-	if AllowedMimeTypes["text/html"] {
-		t.Error("AllowedMimeTypes[text/html] is true")
+// HTML and JavaScript are on the deny-list and must never be accepted,
+// whatever route the file arrives by.
+func TestDangerousMimeTypes_HTMLAndJavaScriptStayBlocked(t *testing.T) {
+	if !IsDangerousMimeType("text/html") {
+		t.Error("text/html is not on the deny-list")
 	}
-	if AllowedMimeTypes["application/javascript"] {
-		t.Error("AllowedMimeTypes[application/javascript] is true")
+	if !IsDangerousMimeType("application/javascript") {
+		t.Error("application/javascript is not on the deny-list")
+	}
+	if !IsDangerousMimeType("text/javascript") {
+		t.Error("text/javascript is not on the deny-list")
+	}
+}
+
+// Types that were previously rejected by the allowlist should now be accepted.
+func TestClassifyAttachment_AcceptsFormerlyRejectedTypes(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		want    string
+	}{
+		// A gzip archive (.tar.gz) was the motivating case for #1156.
+		{"archive.tar.gz", []byte("\x1f\x8b\x08\x00" + strings.Repeat("\x00", 16)), "application/x-gzip"},
+		// application/octet-stream (the fallback for unknown content) should
+		// now be accepted rather than rejected.
+		{"random.bin", []byte("\x00\x01\x02\x03" + strings.Repeat("\x00", 16)), "application/octet-stream"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ClassifyAttachment(tt.name, tt.content)
+			if err != nil {
+				t.Fatalf("ClassifyAttachment(%q) rejected: %v", tt.name, err)
+			}
+			if got != tt.want {
+				t.Errorf("ClassifyAttachment(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/hub/attachments.go
+++ b/pkg/hub/attachments.go
@@ -76,7 +76,10 @@ const (
 	MaxFilenameLength = 255
 )
 
-// AllowedMimeTypes maps allowed MIME types to their canonical extensions.
+// AllowedMimeTypes is kept for backward compatibility with tests that
+// assert specific entries. New code should call IsDangerousMimeType
+// instead: the upload path now accepts everything except the deny-listed
+// types below.
 var AllowedMimeTypes = map[string]bool{
 	// Images
 	"image/jpeg": true,
@@ -89,6 +92,22 @@ var AllowedMimeTypes = map[string]bool{
 	"text/markdown":   true,
 	// Archives
 	"application/zip": true,
+}
+
+// DangerousMimeTypes lists MIME types that are rejected on upload. These
+// are the types a browser will execute or render as a top-level document
+// if they ever escape the download path. Everything else is accepted.
+var DangerousMimeTypes = map[string]bool{
+	"text/html":                true,
+	"application/javascript":   true,
+	"text/javascript":          true,
+	"application/x-javascript": true,
+}
+
+// IsDangerousMimeType reports whether a sniffed MIME type should be
+// rejected on upload.
+func IsDangerousMimeType(mime string) bool {
+	return DangerousMimeTypes[mime]
 }
 
 // DangerousExtensions lists extensions that should be rejected even if

--- a/pkg/hub/attachments.go
+++ b/pkg/hub/attachments.go
@@ -102,12 +102,14 @@ var DangerousMimeTypes = map[string]bool{
 	"application/javascript":   true,
 	"text/javascript":          true,
 	"application/x-javascript": true,
+	"application/ecmascript":   true,
+	"text/ecmascript":          true,
 }
 
 // IsDangerousMimeType reports whether a sniffed MIME type should be
 // rejected on upload.
-func IsDangerousMimeType(mime string) bool {
-	return DangerousMimeTypes[mime]
+func IsDangerousMimeType(mimeType string) bool {
+	return DangerousMimeTypes[strings.ToLower(mimeType)]
 }
 
 // DangerousExtensions lists extensions that should be rejected even if
@@ -139,6 +141,11 @@ var DangerousExtensions = map[string]bool{
 	// double-click.
 	".sh": true, ".bash": true, ".zsh": true, ".ksh": true, ".csh": true,
 	".command": true, ".desktop": true,
+	// Windows shortcut and settings files that can execute commands or modify
+	// the system on open — none has a legitimate chat attachment use.
+	".lnk": true, ".url": true, ".scf": true, ".reg": true,
+	".settingcontent-ms": true, ".cpl": true,
+	".application": true, ".appref-ms": true,
 }
 
 // attachmentExt returns the lower-cased extension that the blocklist above and

--- a/pkg/hub/attachments_test.go
+++ b/pkg/hub/attachments_test.go
@@ -526,19 +526,19 @@ func TestUploadHandler_ValidFile(t *testing.T) {
 	_, wcs, _ := testAttachmentServer(t)
 	_ = wcs
 
-	// Test MIME validation directly (handler tests require full server with
-	// store mocking; core storage is covered by LocalDiskAttachmentStore tests).
-	assert.True(t, AllowedMimeTypes["image/jpeg"])
-	assert.True(t, AllowedMimeTypes["text/plain"])
-	assert.False(t, AllowedMimeTypes["application/x-executable"])
+	// Safe MIME types are not on the deny-list.
+	assert.False(t, IsDangerousMimeType("image/jpeg"))
+	assert.False(t, IsDangerousMimeType("text/plain"))
+	assert.False(t, IsDangerousMimeType("application/x-executable"))
+	assert.False(t, IsDangerousMimeType("application/x-gzip"))
+	assert.False(t, IsDangerousMimeType("application/octet-stream"))
 }
 
 func TestUploadHandler_DisallowedMime(t *testing.T) {
-	// Verify the allowlist rejects dangerous types.
-	assert.False(t, AllowedMimeTypes["application/x-executable"])
-	assert.False(t, AllowedMimeTypes["application/x-sharedlib"])
-	assert.False(t, AllowedMimeTypes["application/javascript"])
-	assert.False(t, AllowedMimeTypes["text/html"])
+	// Verify the deny-list rejects dangerous browser-executable types.
+	assert.True(t, IsDangerousMimeType("application/javascript"))
+	assert.True(t, IsDangerousMimeType("text/html"))
+	assert.True(t, IsDangerousMimeType("text/javascript"))
 }
 
 func TestUploadHandler_MaxFiles(t *testing.T) {

--- a/web/src/components/shared/chat/chat-composer.test.ts
+++ b/web/src/components/shared/chat/chat-composer.test.ts
@@ -230,28 +230,18 @@ describe('composer — whole-request error messages', () => {
 });
 
 describe('composer — file picker filter', () => {
-  it('offers the developer formats the server now accepts', async () => {
-    for (const ext of ['.json', '.yaml', '.go', '.py', '.tsx', '.jsx', '.env', '.sql', '.md']) {
-      expect(ATTACHMENT_ACCEPT).toContain(ext);
-    }
-    expect(ATTACHMENT_ACCEPT).toContain('image/png');
-    expect(ATTACHMENT_ACCEPT).toContain('application/pdf');
+  it('ATTACHMENT_ACCEPT is empty so the picker offers all files', () => {
+    expect(ATTACHMENT_ACCEPT).toBe('');
   });
 
-  it('does not offer the blocked extensions', async () => {
-    for (const ext of ['.exe', '.bat', '.sh', '.ps1', '.jar']) {
-      expect(ATTACHMENT_ACCEPT).not.toContain(ext);
-    }
-    // .js is blocked; .jsx is not, and contains no ".js," token.
-    expect(ATTACHMENT_ACCEPT.split(',')).not.toContain('.js');
-  });
-
-  it('puts the filter on the file input', async () => {
+  it('does not restrict the file input with an accept attribute', async () => {
     const el = createComposer();
     document.body.appendChild(el);
     await el.updateComplete;
 
     const input = el.shadowRoot.querySelector('input[type="file"]');
-    expect(input?.getAttribute('accept')).toBe(ATTACHMENT_ACCEPT);
+    expect(input).toBeTruthy();
+    // No accept attribute — the server enforces the deny-list.
+    expect(input?.hasAttribute('accept')).toBe(false);
   });
 });

--- a/web/src/components/shared/chat/chat-composer.ts
+++ b/web/src/components/shared/chat/chat-composer.ts
@@ -59,24 +59,15 @@ export interface UploadFailure {
 }
 
 /**
- * What the file picker offers. The MIME types cover what browsers recognise;
- * the extensions cover the developer formats they do not, which browsers
- * report as application/octet-stream and the server classifies by content
- * (see ClassifyAttachment). Keep in step with textLikeExtensions in
- * pkg/hub/attachment_classify.go.
+ * What the file picker offers. An empty string means "all files" — the
+ * server enforces a deny-list of dangerous executable extensions (.exe,
+ * .bat, .sh, etc.) and dangerous MIME types (text/html,
+ * application/javascript), so the frontend no longer needs to duplicate
+ * that logic.  Keeping a restrictive accept list here caused file types
+ * the server would happily store (e.g. .tar.gz) to be un-selectable in
+ * the file picker (#1156).
  */
-export const ATTACHMENT_ACCEPT = [
-  'image/jpeg',
-  'image/png',
-  'image/gif',
-  'image/webp',
-  'application/pdf',
-  'application/zip',
-  '.txt,.md,.rst,.adoc,.log,.csv',
-  '.json,.yaml,.yml,.toml,.ini,.cfg,.env,.xml',
-  '.diff,.patch,.sql,.graphql,.proto',
-  '.ts,.tsx,.jsx,.py,.go,.rs,.rb,.java,.kt,.swift,.c,.cpp,.h,.hpp,.cs',
-].join(',');
+export const ATTACHMENT_ACCEPT = '';
 
 /** Event detail for the chat-send custom event. */
 export interface ChatSendDetail {
@@ -672,7 +663,6 @@ export class ScionChatComposer extends LitElement {
                 <input
                   type="file"
                   multiple
-                  accept=${ATTACHMENT_ACCEPT}
                   style="display:none"
                   @change=${this.handleFileSelected}
                 />


### PR DESCRIPTION
Switch chat attachment uploads from MIME-type allow-list to deny-list approach. Accept all file types except known-dangerous executables (.exe, .bat, .cmd, .com, .scr, .msi). Non-previewable files render as download chips.

Fixes ptone/scion#1156