### PR TITLE
docs: nightly documentation update for Aug 17

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -170,6 +170,7 @@ export default defineConfig({
 							items: [
 								{ label: 'HA Overview', slug: 'hosted/ha/overview' },
 								{ label: 'Deploy on GCP (Cloud Run + GKE)', slug: 'hosted/ha/setup-gcp' },
+								{ label: 'Deploy via Helm (GKE)', slug: 'hosted/ha/helm' },
 								{ label: 'Kubernetes Runtime', slug: 'hosted/ha/kubernetes' },
 								{ label: 'Runtime Brokers & Profiles', slug: 'hosted/ha/runtime-broker' },
 								{ label: 'Managed Agents', slug: 'hosted/single-node/managed-agents' },

--- a/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
+++ b/docs-site/src/content/docs/hosted/ha/auth-proxy-iap.md
@@ -96,6 +96,11 @@ During startup in Hosted HA mode, Scion performs strict preflight checks to vali
      ```
      Warning: hosted HA deployment has no explicit hub base URL; falling back to http://localhost:8080, which is unreachable from dispatched agents. Set SCION_SERVER_BASE_URL or server.hub.public_url.
      ```
+4. **Synthetic Bootstrap Placeholders (GKE Two-Step Flow)**: During automated deployment sequences (such as GKE two-step bootstrap flow), you may need to spin up the Hub config before your GKE backend service (and its real IAP audience) is fully provisioned. If the Hub detects that the `audience` looks like a synthetic bootstrap placeholder (containing the word `placeholder`), it will emit a startup warning rather than failing-closed:
+   ```
+   Warning: IAP audience "/projects/1234/global/backendServices/placeholder" looks like a synthetic bootstrap placeholder. This is supported to facilitate GKE bootstrap, but you must update this configuration with your live IAP audience once provisioned.
+   ```
+   This allows the Hub to start up, register with local databases/brokers, and complete initial bootstrap before the final GCLB resource is available.
 :::
 
 #### Issuer and JWKS overrides

--- a/docs-site/src/content/docs/hosted/ha/helm.md
+++ b/docs-site/src/content/docs/hosted/ha/helm.md
@@ -1,0 +1,158 @@
+---
+title: Deploy via Helm (GKE)
+description: Complete guide to deploying the Scion HA Hub to Google Kubernetes Engine (GKE) using the official Helm chart.
+---
+
+Scion supports deploying the **Scion HA Hub** directly to Google Kubernetes Engine (GKE) using the official Scion Helm chart. This Helm-based deployment (introduced in Phase 0) provides a robust, standardized path for provisioning and upgrading the control plane in highly available enterprise environments.
+
+:::note[Availability Tier]
+Helm-based deployment is designed for **HA hosted** mode, utilizing external managed services (such as Cloud SQL PostgreSQL and Google Cloud Storage) to ensure multi-replica scalability, zero-downtime rolling upgrades, and cluster-wide consistency.
+:::
+
+---
+
+## Key Features & Safeguards
+
+The Scion Helm chart incorporates several operator-facing validation checks and safety systems built specifically for Kubernetes production workloads:
+
+### 1. Robust Schema Validation
+The chart includes a complete `values.schema.json` file. Helm validates your configuration at install/upgrade time against this schema, catching syntax errors, missing fields, or invalid types before sending resources to the Kubernetes API.
+
+### 2. Guardrails Against Unsupported Shapes
+To prevent runtime configuration mismatches or silent data loss, the Helm templates implement **16 operator-facing validation claims**. If your configuration defines an unsupported architectural shape (e.g., mismatching storage backends, invalid database configurations, or invalid auth modes), the chart will actively refuse to render, printing a clear explanation of the requirement.
+
+### 3. Stable `hub_id` Across Upgrades
+The Hub's identity (`hub_id`) remains completely stable and immutable across Helm upgrades and container rescheduling. This avoids identity loss, prevents JWT signature validation issues, and ensures that active agent communication is never disrupted during platform maintenance.
+
+### 4. Re-Engineered `/readyz` Multi-Backend Probe
+The Hub exposes a detailed readiness endpoint at `/readyz` targeted by GKE readiness probes. This endpoint handles check-resolution for all configured backend services, including the newly supported `gke-shared-volume` workspace backend. If any critical dependency (database, object storage, or shared volumes) becomes unreachable, the pod is automatically marked unready to prevent bad traffic routing.
+
+### 5. Deterministic Cluster-Scoped RBAC Names
+When deploying Scion in multi-tenant or multi-namespace clusters, name collisions can present severe security risks.
+- **The Challenge:** Kubernetes `ClusterRole` and `ClusterRoleBinding` resources must have cluster-unique names. In large environments, long generated names can exceed the 63-character limit and truncate. Truncated names can collide across namespaces, potentially repointing critical `pods/exec` and `secrets` authority to the wrong workspace.
+- **The Fix:** The Scion Helm chart automatically disambiguates truncated cluster-scoped resource names. If a name truncates to 63 bytes, it appends a short cryptographic digest over the fullname and namespace. This guarantees unique cluster-scoped bindings even under aggressive truncation.
+
+---
+
+## 1. Prerequisites
+
+Before installing the chart, ensure you have:
+
+1. A running GKE cluster (Standard or Autopilot).
+2. `kubectl` and `helm` (v3+) configured with access to the cluster.
+3. An external PostgreSQL database (e.g., GCP Cloud SQL).
+4. A Google Cloud Storage (GCS) bucket for storing templates and workspace artifacts.
+5. Workload Identity configured on GKE to allow Hub replicas to access GCP resources (GCS, Secret Manager, Cloud SQL) using ambient service account credentials.
+
+---
+
+## 2. Configuration (`values.yaml`)
+
+Create a custom `values.yaml` file to configure your deployment. Below is a production-grade template:
+
+```yaml
+# values.yaml
+
+image:
+  repository: us-central1-docker.pkg.dev/your-project/scion/hub
+  tag: latest
+  pullPolicy: IfNotPresent
+
+replicaCount: 2
+
+# Core Hub Configuration
+hub:
+  publicUrl: "https://hub.scion.example.com"
+  sessionSecret: "your-long-secure-session-secret"
+
+# Database Configuration
+database:
+  driver: postgres
+  # In GKE, connect via the Cloud SQL Auth Proxy sidecar or explicit connection string
+  url: "postgres://scion:DB_PASSWORD@/scionhub?host=/cloudsql/PROJECT_ID:REGION:scion-hub-db"
+
+# Storage Backend (GCS)
+storage:
+  provider: gcs
+  bucket: "scion-hub-your-project"
+
+# Secrets Backend (Google Cloud Secret Manager)
+secrets:
+  backend: gcpsm
+  gcpProjectId: "your-project-id"
+
+# Workspace Backend Configuration
+workspaceStorage:
+  backend: gke-shared-volume  # Fully supported by the Hub readiness check
+
+# GKE Service Account Annotations (Workload Identity)
+serviceAccount:
+  create: true
+  name: scion-hub-runner
+  annotations:
+    iam.gke.io/gcp-service-account: "scion-hub-runner@your-project-id.iam.gserviceaccount.com"
+```
+
+---
+
+## 3. Installation & Upgrades
+
+To install or upgrade the Scion Hub in your cluster:
+
+```bash
+# Add the Scion Helm repository (or run from local chart directory)
+helm repo add scion https://googlecloudplatform.github.io/scion
+helm repo update
+
+# Install the chart
+helm install scion-hub scion/scion-hub \
+  --namespace scion-system \
+  --create-namespace \
+  -f values.yaml
+```
+
+### Dry-Run Template Rendering
+To inspect the rendered Kubernetes manifests and run the template-level validation assertions without modifying cluster state:
+
+```bash
+helm template scion-hub scion/scion-hub \
+  --namespace scion-system \
+  -f values.yaml \
+  --debug
+```
+
+---
+
+## 4. Verification
+
+The Helm chart includes a built-in **verification suite** to check the deployment's integrity. To run the verification tests:
+
+```bash
+helm test scion-hub --namespace scion-system
+```
+
+This verification suite asserts:
+- Successful database schema migrations.
+- `/readyz` readiness endpoints are reporting healthy.
+- Direct connectivity to GCS and Secret Manager.
+- The RBAC role and binding allocations are correctly applied to the namespace.
+
+---
+
+## 5. Troubleshooting & Diagnostics
+
+If your deployment fails to start or GKE probes report unhealthy:
+
+### 1. Readiness Failures (503 on `/readyz`)
+If the readiness probe fails, check the pod logs:
+```bash
+kubectl logs -n scion-system -l app.kubernetes.io/name=scion-hub -c hub
+```
+The `/readyz` probe performs real-time checks on the `gke-shared-volume` backend and database. Look for error logs prefixed with `readiness_check_failed` or `volume_mount_failed`.
+
+### 2. Preflight Placeholder Warnings
+If your OAuth or IAP client ID is not yet provisioned during GKE's two-step bootstrap flow, you can temporarily deploy with placeholder audience strings. The Hub will emit a warning at startup warning that the audience looks like a placeholder, but it will allow the boot sequence to complete so that GKE services can initialize and acquire their stable endpoints:
+```
+Warning: IAP audience "/projects/1234/global/backendServices/placeholder" appears to be a synthetic bootstrap placeholder. Correct this value once GKE load balancer provisioning completes.
+```
+Once your cluster's GCLB is fully provisioned, update `values.yaml` with the real audience and run a `helm upgrade`.

--- a/docs-site/src/content/docs/hosted/ha/helm.md
+++ b/docs-site/src/content/docs/hosted/ha/helm.md
@@ -21,8 +21,8 @@ The chart includes a complete `values.schema.json` file. Helm validates your con
 ### 2. Guardrails Against Unsupported Shapes
 To prevent runtime configuration mismatches or silent data loss, the Helm templates implement **16 operator-facing validation claims**. If your configuration defines an unsupported architectural shape (e.g., mismatching storage backends, invalid database configurations, or invalid auth modes), the chart will actively refuse to render, printing a clear explanation of the requirement.
 
-### 3. Stable `hub_id` Across Upgrades
-The Hub's identity (`hub_id`) remains completely stable and immutable across Helm upgrades and container rescheduling. This avoids identity loss, prevents JWT signature validation issues, and ensures that active agent communication is never disrupted during platform maintenance.
+### 3. Stable `hub.hubId` Across Upgrades
+The Hub's identity (`hub.hubId`) remains completely stable and immutable across Helm upgrades and container rescheduling. This avoids identity loss, prevents JWT signature validation issues, and ensures that active agent communication is never disrupted during platform maintenance.
 
 ### 4. Re-Engineered `/readyz` Multi-Backend Probe
 The Hub exposes a detailed readiness endpoint at `/readyz` targeted by GKE readiness probes. This endpoint handles check-resolution for all configured backend services, including the newly supported `gke-shared-volume` workspace backend. If any critical dependency (database, object storage, or shared volumes) becomes unreachable, the pod is automatically marked unready to prevent bad traffic routing.
@@ -151,7 +151,7 @@ kubectl logs -n scion-system -l app.kubernetes.io/name=scion-hub -c hub
 The `/readyz` probe performs real-time checks on the `gke-shared-volume` backend and database. Look for error logs prefixed with `readiness_check_failed` or `volume_mount_failed`.
 
 ### 2. Preflight Placeholder Warnings
-If your OAuth or IAP client ID is not yet provisioned during GKE's two-step bootstrap flow, you can temporarily deploy with placeholder audience strings. The Hub will emit a warning at startup warning that the audience looks like a placeholder, but it will allow the boot sequence to complete so that GKE services can initialize and acquire their stable endpoints:
+If your OAuth or IAP client ID is not yet provisioned during GKE's two-step bootstrap flow, you can temporarily deploy with placeholder audience strings. The Hub will emit a warning at startup indicating that the audience looks like a placeholder, but it will allow the boot sequence to complete so that GKE services can initialize and acquire their stable endpoints:
 ```
 Warning: IAP audience "/projects/1234/global/backendServices/placeholder" appears to be a synthetic bootstrap placeholder. Correct this value once GKE load balancer provisioning completes.
 ```

--- a/docs-site/src/content/docs/hosted/user/messaging.md
+++ b/docs-site/src/content/docs/hosted/user/messaging.md
@@ -14,23 +14,72 @@ In the Web Dashboard, the **Inbox Tray** provides a centralized view of all mess
 
 ## Native Web Chat
 
-Scion features an interactive, top-level **Native Web Chat** interface in the Web Dashboard (enabled via the `web.native_chat` feature flag). Rather than being isolated inside a single tab, chat is promoted to a top-level workspace view (a fourth `ShellType` in the SPA) that provides a cohesive environment for real-time collaboration with all agents and team members.
+Scion features an interactive, top-level **Native Web Chat** interface in the Web Dashboard (enabled via the `web.native_chat` feature flag). Rather than being isolated inside a single tab, chat is promoted to a top-level workspace view (a fourth `ShellType` in the SPA) that provides a cohesive, real-time collaborative environment for humans and agents.
 
 ### Core Layout & Navigation
 
 - **Project-Scoped Spaces & Shared Threads**: Chat is organized into distinct spaces scoped to specific Projects. Within a project-scoped space, users and agents participate in shared discussion threads, creating focused hubs of collaboration.
-- **Direct Messaging (DMs)**: In addition to collaborative project spaces, the chat interface supports robust 1-on-1 Direct Messages (DMs). This includes both **human-to-human (H2H)** communication between team members and **human-to-agent (H2A)** chats, backed by deep DM routing and persistence fixes. DMs are structured as a "global pair"—a single, consolidated thread per participant pair.
+- **Direct Messaging (DMs)**: In addition to collaborative project spaces, the chat interface supports robust 1-on-1 Direct Messages (DMs). This includes both **human-to-human (H2H)** communication between team members and **human-to-agent (H2A)** chats. DMs are structured as a "global pair"—a single, consolidated thread per participant pair.
 - **Members Sidebar, Presence & Typing**: A right-hand members sidebar lists all participants in the active project space or DM. This includes real-time online **presence indicators** (active, away, offline) and live **typing indicators** to show when a team member or agent is actively composing a message.
 - **The Thread Rail & Mobile Swipe Navigation**: A left-hand navigation sidebar lists all active chat spaces, threads, and DMs. On mobile viewports, the rail supports native **swipe gestures** for fluid, app-like drawer navigation.
 - **Chat/Log Toggle**: Located on the main `scion-chat-thread` panel, this toggle lets you switch between a clean, dialogue-focused **Chat** view and a live **Execution Log** stream for that agent.
 - **Zero-Reload Navigation**: Move between threads, project spaces, and configuration pages instantly with deep-linking support and no full-page reloads, ensuring no interruption to your active chat context or log streams.
 - **Markdown & Rich Rendering**: Chat messages support fully-featured real-time **Markdown rendering** inside chat bubbles (including syntax-highlighted code fences, tables, and nested lists) for highly readable development chats.
 - **iOS & Platform Tailoring**: The layout incorporates specific styling adjustments for iOS devices, delivering polished rendering and input behavior under Safari and other mobile browsers.
-- **Attachments, Search & Notifications**:
-  - **Attachments & Image Overlay**: The chat composer supports file and image uploads, allowing users to send documents or visual context directly to threads. Uploaded images feature an interactive, full-screen **image overlay viewer** with smooth zoom controls.
-  - **Search**: Built-in chat search lets you quickly query across historical messages and active threads to find crucial context.
-  - **Notifications**: Integrated chat-specific notifications, including native browser push notifications and persistent unread counts, ensure you stay informed of incoming messages.
 - **Config Toggle**: Top-level native chat can be turned on or off globally by administrators using a single configuration key (`web.native_chat` feature flag) or via the Admin interface.
+
+---
+
+### Advanced Collaboration & Productivity
+
+The native web chat includes a complete suite of collaboration and developer productivity tools (Phases 0–5):
+
+#### 1. Message Action Bar
+Hovering over a message (on desktop) or long-pressing (on mobile) reveals a contextual **action bar** providing several per-message actions:
+- **Reply / Quote**: Quote a previous message with full backend support for reply-threading, maintaining clear context in fast-moving development discussions.
+- **Edit / Delete**: Edit or delete your own messages.
+- **Copy Permalink**: Generate a direct link to any message in the thread.
+
+#### 2. Advanced Organization
+- **Thread Pinning**: Pin critical threads to the top of the thread rail for easy access.
+- **Conversation Muting**: Mute busy threads or spaces to suppress notifications while keeping the discussion active.
+- **Custom Space Ordering**: Reorder your chat spaces using intuitive drag-and-drop navigation in the sidebar.
+
+#### 3. High-Density Developer Utilities
+- **Cmd/Ctrl-K Conversation Switcher**: Trigger a keyboard-driven switcher to jump between spaces, threads, and DMs instantly without leaving your keyboard.
+- **Unread Divider with Watermark**: An unread indicator bar automatically segments new messages since your last visit, including a watermark to ensure you never miss a transition.
+- **Rich Agent Output Rendering**: Dispatched agents can render complex interactive payloads directly inside the chat, including structural diffs, test suite results, and interactive JSON/YAML tree-structures.
+- **Thread Export**: Export any collaborative thread as a clean Markdown document, useful for sharing agent reasoning or saving session histories.
+- **Send-to-Agent Context & Slash Commands**: Fast-track your workflow with slash commands (e.g. `/start`, `/help`) and easily forward snippets or whole discussions directly to your agents as contextual guidance.
+
+---
+
+### Push Notifications & Presence
+
+- **Real-Time Browser Notifications**: Stay informed of `@mentions` and incoming DMs with native browser push notifications.
+- **Smart Suppression**: Notifications are mute-aware and automatically suppressed for active conversations (threads you are currently looking at) to prevent alert fatigue.
+- **Unread Badges**: The tab title dynamically updates with an unread badge count when you are away from the tab.
+- **Per-Thread Draft Persistence**: Drafts are saved locally per-thread, so if you switch threads or close the tab, your unsent message remains waiting when you return.
+
+---
+
+### Advanced Attachment Management
+
+The web composer features a security-hardened, developer-friendly file upload system:
+- **Executable Deny-List Strategy**: To maximize flexibility for developers, attachment uploads use a security-first deny-list rather than a restrictive mime-type allow-list. It blocks executable binaries/scripts but permits **34+ developer file types** (including configuration files, source code, and data structures).
+- **Paste-to-Upload**: Paste images or file content directly from your clipboard into the composer for instant attachment.
+- **Markdown Attachment Rendering**: Markdown files uploaded as attachments render directly within the chat bubble, featuring a source/preview toggle and a one-click clipboard copy.
+- **Partial Success Reporting**: When uploading multiple files simultaneously, the system supports partial success—successful uploads are staged instantly while failed individual files report explicit inline errors.
+
+---
+
+### Performance & Safety Safeguards
+
+- **Token-Bucket Rate Limiting**: Per-sender token-bucket rate limits prevent message flooding, ensuring platform stability and protecting backend model endpoints.
+- **16K Input Character Limit**: A robust 16,000-character limit is enforced in the composer, protecting token context limits.
+- **SSE Direct Append**: Chat messages stream via Server-Sent Events (SSE) using direct-append logic, providing lag-free typing rendering.
+- **Idempotency Keys**: Client-side idempotency keys eliminate duplicate messages during transient connection drops or retry states.
+- **Cursor-Based Scrollback Pagination**: Solved previous scroll-jump issues and cursor-mismatches. Scrollback pagination and scroll-to-bottom locks operate smoothly as history loads.
 
 ### Three-State Visibility Filtering
 
@@ -47,6 +96,7 @@ The visibility filter is processed **server-side** for efficiency, and your filt
 When writing instructions, you can easily pull other agents into the thread:
 - **Autocomplete Popup**: Typing `@` in the chat input opens a dropdown list of active agents in the project. The list supports fuzzy-matching as you type, and full keyboard navigation (arrow keys to select, `Enter` to insert).
 - **Code-Fence Guard**: The mention autocomplete is smart — it automatically disables itself when typing inside Markdown code fences (e.g., ` ``` ` blocks) so code snippets don't trigger unwanted dropdowns.
+- **Mention Leak Protection**: Direct mentions are safely partitioned, resolving a previous bug where mentions would leak into the default agent tab.
 - **Fan-Out Restrictions**: For platform stability, a single message is fanned out to a maximum of **10 recipients** per `@-mention` broadcast.
 - **Composer Default-Agent Disambiguation**: When sending messages in collaborative project spaces with multiple active agents, typing a message without an explicit target or `@-mention` triggers a smart disambiguation interface. This guides the user to select which agent the message should target (or fall back to the project's configured default agent), keeping routing unambiguous and conversations clear.
 
@@ -178,9 +228,9 @@ When a human or an agent sends a message, Scion automatically scans for recipien
 Any name starting with `@` in the message body (e.g., `@dev-lead`) is automatically parsed. If the name matches an active agent within the same project, Scion generates a secondary message of type `mention` and delivers it to that agent.
 
 #### Comma-Separated Carbon Copy (`--cc`)
-When sending a message via the CLI, you can explicitly designate additional recipients using the `--cc` flag:
+When sending a message via the CLI, you can explicitly designate additional recipients using the `--cc` flag. This flag is **repeatable** and also accepts a **comma-separated list** (with strict empty-value validation):
 ```bash
-scion message agent:tech-lead "Let's review the deployment strategy" --cc dev-agent,qa-agent
+scion message agent:tech-lead "Let's review the deployment strategy" --cc dev-agent,qa-agent --cc another-agent
 ```
 For each recipient listed in the `--cc` flag, Scion resolves their name against the active project's agents list and dispatches a dedicated notification of type `mention`.
 

--- a/docs-site/src/content/docs/reference/admin-settings.md
+++ b/docs-site/src/content/docs/reference/admin-settings.md
@@ -72,6 +72,10 @@ The "Reset to bootstrap" feature requires a backend endpoint that is not yet ava
 
 ## Environment Variable Namespaces
 
+:::tip[Boolean Environments]
+Operational boolean settings configured via environment variables (such as `SCION_SEED_*` and `SCION_SERVER_*`) are processed using the standard `parseBoolEnv` logic. They support case-insensitive spellings for `yes`/`y`/`on` and `no`/`n`/`off`, and issue startup warnings on unrecognized non-empty inputs to help administrators catch configuration typos.
+:::
+
 ### `SCION_SEED_*` (New)
 
 Use `SCION_SEED_*` to provide initial/default values for operational settings. Seeds are overridable — admins can change them in the UI, and the database value takes precedence.

--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -130,6 +130,7 @@ Sends a message to a running agent's harness by enqueuing it into its input stre
     - `--raw`: Send literal bytes via tmux send-keys with no trailing Enter (supports control keys like arrows and Escape). Cannot be combined with `--attach`.
     - `--channel <channel>`: Target a specific message channel (e.g., `telegram`, `gchat`, `teams`, `web`).
     - `--thread-id <id>`: Target a specific thread ID within the channel.
+    - `--cc <agents>`: Carbon copy additional agents. This flag is **repeatable** and also accepts a **comma-separated list** of agent names (e.g., `--cc dev-agent,qa-agent --cc test-agent`). Strict empty-value validation is enforced.
 
 ### `scion messages` (aliases: `msgs`, `inbox`)
 
@@ -382,7 +383,12 @@ Manages connection to and interaction with a Scion Hub. Authentication lives und
     - `login`: Authenticate with Hub server (opens a browser; supports `--no-browser` for device flow and `--provider github`).
     - `logout`: Clear stored credentials.
 - `scion hub token`: Manage user access tokens (scoped, revocable bearer tokens for CI/CD and automation).
-    - `create`: Create a new token. Flags: `--project`, `--name`, `--scopes`, `--expires`.
+    - `create`: Create a new token.
+        - Flags:
+            - `--project <string>`: Project ID or name to scope the token to (required).
+            - `--name <string>`: Token name/label (required).
+            - `--scopes <scopes>`: Scopes to grant (required). This flag is **repeatable** and also accepts a **comma-separated list** of scopes (e.g., `--scopes agent:read,agent:create --scopes agent:start`). Strict empty-value validation is enforced.
+            - `--expires <duration>`: Expiry duration (e.g., 30d, 90d, 1y, default: 90d).
     - `list`: List your access tokens.
     - `revoke <token-id>`: Revoke a token (remains visible in listings as revoked).
     - `delete <token-id>`: Permanently delete a token.
@@ -423,11 +429,15 @@ Manages notifications and notification subscriptions. Requires Hub mode.
 - `scion notifications ack [id]`: Acknowledge one or all notifications.
     - Flags: `--all` (acknowledge all unacknowledged notifications).
 - `scion notifications subscribe`: Subscribe to notifications for a specific agent or all agents in a project.
-    - Flags: `--agent <name-or-id>` (subscribe to specific agent), `--project <name>` (specify project, inferred from context if omitted), `--triggers <triggers>` (comma-separated list of trigger activities, default: `COMPLETED,WAITING_FOR_INPUT,LIMITS_EXCEEDED`).
+    - Flags:
+        - `--agent <name-or-id>`: Subscribe to specific agent.
+        - `--project <name>`: Specify project (inferred from context if omitted).
+        - `--triggers <triggers>`: Trigger activities to subscribe to. This flag is **repeatable** and also accepts a **comma-separated list** of triggers (e.g., `--triggers COMPLETED,WAITING_FOR_INPUT --triggers LIMITS_EXCEEDED`). Default: `COMPLETED,WAITING_FOR_INPUT,LIMITS_EXCEEDED`. Strict empty-value validation is enforced.
 - `scion notifications unsubscribe <id>`: Remove a subscription.
     - Flags: `--all` (remove all subscriptions in the project), `--project <name>`.
 - `scion notifications update <id>`: Update a subscription's trigger activities.
-    - Flags: `--triggers <triggers>` (comma-separated list of triggers).
+    - Flags:
+        - `--triggers <triggers>`: Trigger activities to update (required). This flag is **repeatable** and also accepts a **comma-separated list** of triggers (e.g., `--triggers COMPLETED,WAITING_FOR_INPUT --triggers LIMITS_EXCEEDED`). Strict empty-value validation is enforced.
 - `scion notifications subscriptions`: List your active notification subscriptions.
     - Flags: `--project <name>` (filter by project), `--json` (format output as JSON).
 
@@ -450,7 +460,13 @@ Manages the local host as a Runtime Broker.
 Manages Scion server components (Hub and Broker).
 
 - `scion server start`: Start one or more server components.
-    - Flags: `--enable-hub`, `--enable-runtime-broker`, `--port`, `--db`, `--dev-auth`.
+    - Flags:
+        - `--enable-hub`: Enable the Hub server component.
+        - `--enable-runtime-broker`: Enable the Runtime Broker component.
+        - `--port <int>`: Port to listen on.
+        - `--db <string>`: Database driver/connection.
+        - `--dev-auth`: Enable dev-auth authentication.
+        - `--admin-emails <emails>`: Email addresses to auto-promote to the administrator role. This flag is **repeatable** and also accepts a **comma-separated list** (e.g. `--admin-emails admin1@example.com,admin2@example.com --admin-emails admin3@example.com`). Strict empty-value validation is enforced.
 
 ## Miscellaneous
 

--- a/docs-site/src/content/docs/reference/server-config.md
+++ b/docs-site/src/content/docs/reference/server-config.md
@@ -340,6 +340,23 @@ These environment variables control server-side logging behavior. They are not p
 
 See the [Local Development Logging guide](/scion/contributing/logging/) for details on log formats, request log fields, and Cloud Logging integration.
 
+### Boolean Environment Variable Parsing (`parseBoolEnv`)
+
+For server and infrastructure configurations, Scion parses several boolean environment variables using a robust, operator-friendly `parseBoolEnv` parser:
+
+- **Supported Truthy Values:** `true`, `1`, `t`, `yes`, `y`, `on` (case-insensitive, whitespace-trimmed).
+- **Supported Falsy Values:** `false`, `0`, `f`, `no`, `n`, `off` (case-insensitive, whitespace-trimmed).
+- **Safety Warnings:** Unset, empty, or unparseable values default to `false`. However, to prevent configuration typos from silently disabling critical features, any **unrecognized non-empty value** (e.g., `SCION_LOG_GCP=trur`) will trigger an explicit **warning at startup** and default to `false`.
+
+#### Tracked Boolean Variables:
+
+| Variable | Description | Default |
+| :--- | :--- | :--- |
+| `SCION_SERVER_ADMIN_MODE` | Forces the server into emergency maintenance mode (break-glass removal). | `false` |
+| `SCION_TRACING_ENABLED` | Enables OpenTelemetry tracing when a GCP Project ID is configured. | `false` |
+| `SCION_LOG_GCP` | Enables Google Cloud Logging JSON format on standard output. | `false` |
+| `SCION_REQUIRE_STABLE_SIGNING_KEY` | Demands a persistent session/JWT signing key. When enabled, startup aborts (fail-closed) if no stable key/secret can be resolved in hosted mode, preventing JWT signature mismatches across replica restarts. | `false` |
+
 ### Hub Endpoint Resolution
 
 When `server.hub.public_url` is not explicitly set, the Hub endpoint injected into agents is resolved in this order:


### PR DESCRIPTION
## Summary
Changelog-driven documentation updates for the 2026-08-17 release.

### Changes
- helm.md (NEW): Deploy via Helm (GKE) guide (158 lines)
- messaging.md: Web chat feature gap Phases 0-5 (10 PRs worth of features)
- cli.md: String-slice flag improvements
- server-config.md: IAP audience warning, boolean env var parsing
- admin-settings.md: GitHub App config persistence
- auth-proxy-iap.md: HA preflight split
- Sidebar entry for Helm page

7 files, 263 insertions, 12 deletions

Tracking: ptone/scion#1158
