### PR TITLE
fix(chat): scope interagent message queries by project

### DIFF
--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -1801,6 +1801,7 @@ func (s *Server) handleConversationInteragent(w http.ResponseWriter, r *http.Req
 	// Query 1: messages where the DM agent's UUID appears in sender_id
 	// or recipient_id.
 	filter := store.MessageFilter{
+		ProjectID:     agent.ProjectID,
 		ParticipantID: agentID,
 		Before:        before,
 		After:         after,
@@ -1818,9 +1819,10 @@ func (s *Server) handleConversationInteragent(w http.ResponseWriter, r *http.Req
 	// direction that ParticipantID misses for older data.
 	agentSender := "agent:" + agent.Slug
 	senderFilter := store.MessageFilter{
-		Sender: agentSender,
-		Before: before,
-		After:  after,
+		ProjectID: agent.ProjectID,
+		Sender:    agentSender,
+		Before:    before,
+		After:     after,
 	}
 	senderResult, err := s.store.ListMessages(ctx, senderFilter, opts)
 	if err != nil {


### PR DESCRIPTION
Add ProjectID filter to both interagent message query paths in the chat handler. The slug-based backward-compat query (Sender: agent:slug) returned messages from all projects with identically-named agents. Now both queries include project scoping.

Fixes ptone/scion#1161