### PR TITLE
feat: prompt user for secret scope in capture auth flow

### DIFF
--- a/cmd/sciontool/commands/secret.go
+++ b/cmd/sciontool/commands/secret.go
@@ -24,6 +24,7 @@ var (
 	secretType   string
 	secretTarget string
 	secretForce  bool
+	secretScope  string
 )
 
 var secretCmd = &cobra.Command{
@@ -34,11 +35,12 @@ var secretCmd = &cobra.Command{
 
 var secretSetCmd = &cobra.Command{
 	Use:   "set KEY VALUE",
-	Short: "Store a project-scoped secret via the Hub API",
-	Long: `Store a project-scoped secret in the Hub from within an agent container.
+	Short: "Store a secret via the Hub API",
+	Long: `Store a secret in the Hub from within an agent container.
 
-The secret is scoped to the current agent's project. Subsequent agents in the
-same project will receive this secret automatically.
+By default, the secret is scoped to the current agent's project. Subsequent
+agents in the same project will receive this secret automatically. Use
+--scope=user to store a personal credential visible only to your agents.
 
 If VALUE starts with @, the remainder is treated as a file path. The file
 contents are read and base64-encoded, and --type defaults to "file".
@@ -54,7 +56,10 @@ Examples:
   sciontool secret set MY_CERT @/tmp/cert.pem --type file --target ~/certs/cert.pem
 
   # Overwrite an existing secret
-  sciontool secret set MY_KEY "new-value" --force`,
+  sciontool secret set MY_KEY "new-value" --force
+
+  # Store a user-scoped (personal) secret
+  sciontool secret set MY_TOKEN "tok-123" --scope user`,
 	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
@@ -66,6 +71,12 @@ Examples:
 		}
 		if strings.ContainsAny(key, "= \t\n") {
 			log.Error("key cannot contain spaces, tabs, newlines, or '='")
+			os.Exit(1)
+		}
+
+		// Validate scope flag.
+		if secretScope != "" && secretScope != "project" && secretScope != "user" {
+			log.Error("--scope must be \"project\" or \"user\"")
 			os.Exit(1)
 		}
 
@@ -127,7 +138,7 @@ Examples:
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		resp, err := hubClient.SetSecret(ctx, key, value, localType, localTarget, secretForce)
+		resp, err := hubClient.SetSecret(ctx, key, value, localType, localTarget, secretScope, secretForce)
 		if err != nil {
 			log.Error("%v", err)
 			os.Exit(1)
@@ -237,4 +248,5 @@ func init() {
 	secretSetCmd.Flags().StringVar(&secretType, "type", "", "Secret type: environment (default), variable, file")
 	secretSetCmd.Flags().StringVar(&secretTarget, "target", "", "Injection target path (defaults to key for env, required for file)")
 	secretSetCmd.Flags().BoolVar(&secretForce, "force", false, "Overwrite existing secret")
+	secretSetCmd.Flags().StringVar(&secretScope, "scope", "", "Secret scope: project (default) or user")
 }

--- a/harnesses/antigravity/capture_auth.py
+++ b/harnesses/antigravity/capture_auth.py
@@ -92,7 +92,7 @@ def _validate_refresh_token(token_raw: str) -> bool:
 _AGY_TOKEN_PATH = "~/.gemini/antigravity-cli/antigravity-oauth-token"
 
 
-def _try_capture_token_file(force: bool) -> int | None:
+def _try_capture_token_file(force: bool, scope: str = "project") -> int | None:
     """Attempt to capture AGY_TOKEN directly from the known disk path.
 
     Returns an exit code on definitive result, or None to continue to keyring.
@@ -111,7 +111,8 @@ def _try_capture_token_file(force: bool) -> int | None:
         print("capture-auth: AGY_TOKEN file does not contain refresh_token", file=sys.stderr)
         return _CA_EXIT_ERROR
     cmd = ["sciontool", "secret", "set", "AGY_TOKEN", f"@{expanded}",
-           "--type", "file", "--target", _AGY_TOKEN_PATH]
+           "--type", "file", "--target", _AGY_TOKEN_PATH,
+           "--scope", scope]
     if force:
         cmd.append("--force")
     try:
@@ -130,6 +131,11 @@ def _try_capture_token_file(force: bool) -> int | None:
 
 
 def main() -> int:
+    import argparse
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--scope", choices=["project", "user"], default="project")
+    known, _ = parser.parse_known_args()
+
     rc = scion_harness.capture_auth_main()
     if rc == _CA_EXIT_OK:
         return rc
@@ -142,7 +148,7 @@ def main() -> int:
     # Synthesized default: try the well-known AGY_TOKEN path on disk even if
     # capture-auth-config.json didn't list it (e.g. missing config, staging bug).
     force = "--force" in sys.argv
-    disk_rc = _try_capture_token_file(force)
+    disk_rc = _try_capture_token_file(force, known.scope)
     if disk_rc is not None:
         return disk_rc
 
@@ -164,7 +170,8 @@ def main() -> int:
             f.write(token)
         force = "--force" in sys.argv
         cmd = ["sciontool", "secret", "set", "AGY_TOKEN", f"@{tmp_path}",
-               "--type", "file", "--target", target]
+               "--type", "file", "--target", target,
+               "--scope", known.scope]
         if force:
             cmd.append("--force")
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)

--- a/harnesses/antigravity/scion_harness.py
+++ b/harnesses/antigravity/scion_harness.py
@@ -1041,9 +1041,15 @@ _CA_EXIT_CONFLICT = 3
 def capture_auth_main(argv: list[str] | None = None) -> int:
     """Portable capture-auth logic. Returns exit code."""
     parser = argparse.ArgumentParser(
-        description="Capture auth credentials and store as project secrets"
+        description="Capture auth credentials and store as secrets"
     )
     parser.add_argument("--force", action="store_true", help="Overwrite existing secrets")
+    parser.add_argument(
+        "--scope",
+        choices=["project", "user"],
+        default="project",
+        help="Secret scope: project (default) or user",
+    )
     parser.add_argument(
         "--bundle",
         default=os.path.join(
@@ -1101,7 +1107,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
             print(f"capture-auth: {key}: source not found ({source})")
             continue
 
-        ok, err = _capture_one_cred(entry, args.force)
+        ok, err = _capture_one_cred(entry, args.force, args.scope)
         if err == "CONFLICT":
             print(f'CONFLICT: secret "{key}" already exists (use --force to overwrite)')
             conflicts += 1
@@ -1124,7 +1130,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1137,7 +1143,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | N
         return False, None
 
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
-           "--type", secret_type, "--target", target]
+           "--type", secret_type, "--target", target,
+           "--scope", scope]
     if force:
         cmd.append("--force")
 

--- a/harnesses/claude/capture_auth.py
+++ b/harnesses/claude/capture_auth.py
@@ -50,11 +50,12 @@ def _extract_oauth_from_scrollback() -> str | None:
     return None
 
 
-def _store_oauth_token(token: str) -> bool:
+def _store_oauth_token(token: str, scope: str = "project") -> bool:
     """Store a token as CLAUDE_CODE_OAUTH_TOKEN via sciontool secret set."""
     try:
         result = subprocess.run(
-            ["sciontool", "secret", "set", "CLAUDE_CODE_OAUTH_TOKEN", token],
+            ["sciontool", "secret", "set", "CLAUDE_CODE_OAUTH_TOKEN", token,
+             "--scope", scope],
             capture_output=True, text=True, timeout=10,
         )
         if result.returncode == 0:
@@ -68,10 +69,17 @@ def _store_oauth_token(token: str) -> bool:
 
 
 def main() -> int:
+    # Parse --scope from argv so we can forward it to both capture_auth_main
+    # and the Claude-specific scrollback capture.
+    import argparse
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--scope", choices=["project", "user"], default="project")
+    known, _ = parser.parse_known_args()
+
     config_rc = scion_harness.capture_auth_main()
 
     token = _extract_oauth_from_scrollback()
-    scrollback_ok = _store_oauth_token(token) if token else False
+    scrollback_ok = _store_oauth_token(token, known.scope) if token else False
 
     if config_rc == 0 or scrollback_ok:
         return 0

--- a/harnesses/claude/scion_harness.py
+++ b/harnesses/claude/scion_harness.py
@@ -1041,9 +1041,15 @@ _CA_EXIT_CONFLICT = 3
 def capture_auth_main(argv: list[str] | None = None) -> int:
     """Portable capture-auth logic. Returns exit code."""
     parser = argparse.ArgumentParser(
-        description="Capture auth credentials and store as project secrets"
+        description="Capture auth credentials and store as secrets"
     )
     parser.add_argument("--force", action="store_true", help="Overwrite existing secrets")
+    parser.add_argument(
+        "--scope",
+        choices=["project", "user"],
+        default="project",
+        help="Secret scope: project (default) or user",
+    )
     parser.add_argument(
         "--bundle",
         default=os.path.join(
@@ -1101,7 +1107,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
             print(f"capture-auth: {key}: source not found ({source})")
             continue
 
-        ok, err = _capture_one_cred(entry, args.force)
+        ok, err = _capture_one_cred(entry, args.force, args.scope)
         if err == "CONFLICT":
             print(f'CONFLICT: secret "{key}" already exists (use --force to overwrite)')
             conflicts += 1
@@ -1124,7 +1130,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1137,7 +1143,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | N
         return False, None
 
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
-           "--type", secret_type, "--target", target]
+           "--type", secret_type, "--target", target,
+           "--scope", scope]
     if force:
         cmd.append("--force")
 

--- a/harnesses/codex/scion_harness.py
+++ b/harnesses/codex/scion_harness.py
@@ -1041,9 +1041,15 @@ _CA_EXIT_CONFLICT = 3
 def capture_auth_main(argv: list[str] | None = None) -> int:
     """Portable capture-auth logic. Returns exit code."""
     parser = argparse.ArgumentParser(
-        description="Capture auth credentials and store as project secrets"
+        description="Capture auth credentials and store as secrets"
     )
     parser.add_argument("--force", action="store_true", help="Overwrite existing secrets")
+    parser.add_argument(
+        "--scope",
+        choices=["project", "user"],
+        default="project",
+        help="Secret scope: project (default) or user",
+    )
     parser.add_argument(
         "--bundle",
         default=os.path.join(
@@ -1101,7 +1107,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
             print(f"capture-auth: {key}: source not found ({source})")
             continue
 
-        ok, err = _capture_one_cred(entry, args.force)
+        ok, err = _capture_one_cred(entry, args.force, args.scope)
         if err == "CONFLICT":
             print(f'CONFLICT: secret "{key}" already exists (use --force to overwrite)')
             conflicts += 1
@@ -1124,7 +1130,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1137,7 +1143,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | N
         return False, None
 
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
-           "--type", secret_type, "--target", target]
+           "--type", secret_type, "--target", target,
+           "--scope", scope]
     if force:
         cmd.append("--force")
 

--- a/harnesses/copilot/capture_auth.py
+++ b/harnesses/copilot/capture_auth.py
@@ -28,7 +28,7 @@ _COPILOT_CONFIG = os.path.join(
 )
 
 
-def _capture_config_json(force: bool = False) -> bool:
+def _capture_config_json(force: bool = False, scope: str = "project") -> bool:
     """Capture ~/.copilot/config.json as a COPILOT_CONFIG file secret."""
     if not os.path.isfile(_COPILOT_CONFIG):
         print(
@@ -43,6 +43,7 @@ def _capture_config_json(force: bool = False) -> bool:
         f"@{_COPILOT_CONFIG}",
         "--type", "file",
         "--target", _COPILOT_CONFIG,
+        "--scope", scope,
     ]
     if force:
         cmd.append("--force")
@@ -71,10 +72,15 @@ def _capture_config_json(force: bool = False) -> bool:
 
 
 if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--scope", choices=["project", "user"], default="project")
+    known, _ = parser.parse_known_args()
+
     rc = scion_harness.capture_auth_main()
 
     force = "--force" in sys.argv
-    config_ok = _capture_config_json(force)
+    config_ok = _capture_config_json(force, known.scope)
 
     if rc != 0 and config_ok:
         sys.exit(0)

--- a/harnesses/copilot/scion_harness.py
+++ b/harnesses/copilot/scion_harness.py
@@ -1041,9 +1041,15 @@ _CA_EXIT_CONFLICT = 3
 def capture_auth_main(argv: list[str] | None = None) -> int:
     """Portable capture-auth logic. Returns exit code."""
     parser = argparse.ArgumentParser(
-        description="Capture auth credentials and store as project secrets"
+        description="Capture auth credentials and store as secrets"
     )
     parser.add_argument("--force", action="store_true", help="Overwrite existing secrets")
+    parser.add_argument(
+        "--scope",
+        choices=["project", "user"],
+        default="project",
+        help="Secret scope: project (default) or user",
+    )
     parser.add_argument(
         "--bundle",
         default=os.path.join(
@@ -1101,7 +1107,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
             print(f"capture-auth: {key}: source not found ({source})")
             continue
 
-        ok, err = _capture_one_cred(entry, args.force)
+        ok, err = _capture_one_cred(entry, args.force, args.scope)
         if err == "CONFLICT":
             print(f'CONFLICT: secret "{key}" already exists (use --force to overwrite)')
             conflicts += 1
@@ -1124,7 +1130,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1137,7 +1143,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | N
         return False, None
 
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
-           "--type", secret_type, "--target", target]
+           "--type", secret_type, "--target", target,
+           "--scope", scope]
     if force:
         cmd.append("--force")
 

--- a/harnesses/gemini-cli/scion_harness.py
+++ b/harnesses/gemini-cli/scion_harness.py
@@ -1041,9 +1041,15 @@ _CA_EXIT_CONFLICT = 3
 def capture_auth_main(argv: list[str] | None = None) -> int:
     """Portable capture-auth logic. Returns exit code."""
     parser = argparse.ArgumentParser(
-        description="Capture auth credentials and store as project secrets"
+        description="Capture auth credentials and store as secrets"
     )
     parser.add_argument("--force", action="store_true", help="Overwrite existing secrets")
+    parser.add_argument(
+        "--scope",
+        choices=["project", "user"],
+        default="project",
+        help="Secret scope: project (default) or user",
+    )
     parser.add_argument(
         "--bundle",
         default=os.path.join(
@@ -1101,7 +1107,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
             print(f"capture-auth: {key}: source not found ({source})")
             continue
 
-        ok, err = _capture_one_cred(entry, args.force)
+        ok, err = _capture_one_cred(entry, args.force, args.scope)
         if err == "CONFLICT":
             print(f'CONFLICT: secret "{key}" already exists (use --force to overwrite)')
             conflicts += 1
@@ -1124,7 +1130,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1137,7 +1143,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | N
         return False, None
 
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
-           "--type", secret_type, "--target", target]
+           "--type", secret_type, "--target", target,
+           "--scope", scope]
     if force:
         cmd.append("--force")
 

--- a/harnesses/hermes/scion_harness.py
+++ b/harnesses/hermes/scion_harness.py
@@ -1041,9 +1041,15 @@ _CA_EXIT_CONFLICT = 3
 def capture_auth_main(argv: list[str] | None = None) -> int:
     """Portable capture-auth logic. Returns exit code."""
     parser = argparse.ArgumentParser(
-        description="Capture auth credentials and store as project secrets"
+        description="Capture auth credentials and store as secrets"
     )
     parser.add_argument("--force", action="store_true", help="Overwrite existing secrets")
+    parser.add_argument(
+        "--scope",
+        choices=["project", "user"],
+        default="project",
+        help="Secret scope: project (default) or user",
+    )
     parser.add_argument(
         "--bundle",
         default=os.path.join(
@@ -1101,7 +1107,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
             print(f"capture-auth: {key}: source not found ({source})")
             continue
 
-        ok, err = _capture_one_cred(entry, args.force)
+        ok, err = _capture_one_cred(entry, args.force, args.scope)
         if err == "CONFLICT":
             print(f'CONFLICT: secret "{key}" already exists (use --force to overwrite)')
             conflicts += 1
@@ -1124,7 +1130,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1137,7 +1143,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | N
         return False, None
 
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
-           "--type", secret_type, "--target", target]
+           "--type", secret_type, "--target", target,
+           "--scope", scope]
     if force:
         cmd.append("--force")
 

--- a/harnesses/opencode/capture_auth.py
+++ b/harnesses/opencode/capture_auth.py
@@ -28,7 +28,7 @@ _OPENCODE_AUTH = os.path.join(
 )
 
 
-def _capture_auth_json(quiet: bool = False) -> bool:
+def _capture_auth_json(quiet: bool = False, scope: str = "project") -> bool:
     """Capture ~/.local/share/opencode/auth.json as an OPENCODE_AUTH file secret.
 
     Uses --force unconditionally: capture_auth_main() may have already set
@@ -50,6 +50,7 @@ def _capture_auth_json(quiet: bool = False) -> bool:
         "--type", "file",
         "--target", _OPENCODE_AUTH,
         "--force",
+        "--scope", scope,
     ]
 
     try:
@@ -71,9 +72,14 @@ def _capture_auth_json(quiet: bool = False) -> bool:
 
 
 if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--scope", choices=["project", "user"], default="project")
+    known, _ = parser.parse_known_args()
+
     rc = scion_harness.capture_auth_main()
 
-    auth_ok = _capture_auth_json(quiet=(rc == 0))
+    auth_ok = _capture_auth_json(quiet=(rc == 0), scope=known.scope)
 
     if rc != 0 and auth_ok:
         sys.exit(0)

--- a/harnesses/opencode/scion_harness.py
+++ b/harnesses/opencode/scion_harness.py
@@ -1041,9 +1041,15 @@ _CA_EXIT_CONFLICT = 3
 def capture_auth_main(argv: list[str] | None = None) -> int:
     """Portable capture-auth logic. Returns exit code."""
     parser = argparse.ArgumentParser(
-        description="Capture auth credentials and store as project secrets"
+        description="Capture auth credentials and store as secrets"
     )
     parser.add_argument("--force", action="store_true", help="Overwrite existing secrets")
+    parser.add_argument(
+        "--scope",
+        choices=["project", "user"],
+        default="project",
+        help="Secret scope: project (default) or user",
+    )
     parser.add_argument(
         "--bundle",
         default=os.path.join(
@@ -1101,7 +1107,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
             print(f"capture-auth: {key}: source not found ({source})")
             continue
 
-        ok, err = _capture_one_cred(entry, args.force)
+        ok, err = _capture_one_cred(entry, args.force, args.scope)
         if err == "CONFLICT":
             print(f'CONFLICT: secret "{key}" already exists (use --force to overwrite)')
             conflicts += 1
@@ -1124,7 +1130,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1137,7 +1143,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | N
         return False, None
 
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
-           "--type", secret_type, "--target", target]
+           "--type", secret_type, "--target", target,
+           "--scope", scope]
     if force:
         cmd.append("--force")
 

--- a/harnesses/scion_harness.py
+++ b/harnesses/scion_harness.py
@@ -1040,9 +1040,15 @@ _CA_EXIT_CONFLICT = 3
 def capture_auth_main(argv: list[str] | None = None) -> int:
     """Portable capture-auth logic. Returns exit code."""
     parser = argparse.ArgumentParser(
-        description="Capture auth credentials and store as project secrets"
+        description="Capture auth credentials and store as secrets"
     )
     parser.add_argument("--force", action="store_true", help="Overwrite existing secrets")
+    parser.add_argument(
+        "--scope",
+        choices=["project", "user"],
+        default="project",
+        help="Secret scope: project (default) or user",
+    )
     parser.add_argument(
         "--bundle",
         default=os.path.join(
@@ -1100,7 +1106,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
             print(f"capture-auth: {key}: source not found ({source})")
             continue
 
-        ok, err = _capture_one_cred(entry, args.force)
+        ok, err = _capture_one_cred(entry, args.force, args.scope)
         if err == "CONFLICT":
             print(f'CONFLICT: secret "{key}" already exists (use --force to overwrite)')
             conflicts += 1
@@ -1123,7 +1129,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1136,7 +1142,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool) -> tuple[bool, str | N
         return False, None
 
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
-           "--type", secret_type, "--target", target]
+           "--type", secret_type, "--target", target,
+           "--scope", scope]
     if force:
         cmd.append("--force")
 

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -1010,7 +1010,7 @@ func (s *Server) handleAgentSecrets(w http.ResponseWriter, r *http.Request, agen
 		}
 		scopeID = agentIdent.OriginUserID()
 		if scopeID == "" {
-			ValidationError(w, "agent token lacks user context required for user-scoped secrets", nil)
+			writeError(w, http.StatusForbidden, ErrCodeForbidden, "agent token lacks user context required for user-scoped secrets", nil)
 			return
 		}
 	default:
@@ -1151,6 +1151,7 @@ func (s *Server) validateAgentSecretAccess(w http.ResponseWriter, r *http.Reques
 
 // agentGetSecret handles GET /api/v1/agents/{agentID}/secrets/{key}.
 // Returns the secret value (base64-encoded) along with type and target metadata.
+// Supports both project-scoped and user-scoped secrets via the ?scope= query parameter.
 func (s *Server) agentGetSecret(w http.ResponseWriter, r *http.Request, agentID, key string) {
 	ctx := r.Context()
 
@@ -1160,16 +1161,45 @@ func (s *Server) agentGetSecret(w http.ResponseWriter, r *http.Request, agentID,
 		return
 	}
 
+	// Determine scope and scopeID.
+	scope := r.URL.Query().Get("scope")
+	if scope == "" {
+		scope = store.ScopeProject
+	}
+	var scopeID string
+	switch scope {
+	case store.ScopeProject:
+		scopeID = projectID
+	case store.ScopeUser:
+		agentIdent := GetAgentIdentityFromContext(ctx)
+		if agentIdent == nil {
+			writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "This endpoint requires agent authentication", nil)
+			return
+		}
+		scopeID = agentIdent.OriginUserID()
+		if scopeID == "" {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden, "agent token lacks user context required for user-scoped secrets", nil)
+			return
+		}
+	default:
+		ValidationError(w, "scope must be \"project\" or \"user\"", map[string]interface{}{
+			"field":   "scope",
+			"value":   scope,
+			"allowed": []string{"project", "user"},
+		})
+		return
+	}
+
 	// Retrieve the secret including its value.
-	secretVal, err := s.secretBackend.Get(ctx, key, store.ScopeProject, projectID)
+	secretVal, err := s.secretBackend.Get(ctx, key, scope, scopeID)
 	if err != nil {
-		LogAgentSecretRead(ctx, s.auditLogger, agentID, projectID, key, false, err.Error())
+		LogAgentSecretRead(ctx, s.auditLogger, agentID, scopeID, key, false, err.Error())
 		writeErrorFromErr(w, err, "")
 		return
 	}
 
 	// Audit log the successful read.
-	LogAgentSecretRead(ctx, s.auditLogger, agentID, projectID, key, true, "")
+	LogAgentSecretRead(ctx, s.auditLogger, agentID, scopeID, key, true, "")
 
 	writeJSON(w, http.StatusOK, AgentGetSecretResponse{
 		Key:    secretVal.Name,
@@ -1180,7 +1210,9 @@ func (s *Server) agentGetSecret(w http.ResponseWriter, r *http.Request, agentID,
 }
 
 // agentListSecrets handles GET /api/v1/agents/{agentID}/secrets (no key).
-// Returns metadata for all secrets in the agent's project (no values).
+// Returns metadata for secrets accessible to the agent.
+// Supports both project-scoped and user-scoped secrets via the ?scope= query parameter.
+// When no scope is specified, secrets from both project and user scopes are returned.
 func (s *Server) agentListSecrets(w http.ResponseWriter, r *http.Request, agentID string) {
 	ctx := r.Context()
 
@@ -1189,17 +1221,82 @@ func (s *Server) agentListSecrets(w http.ResponseWriter, r *http.Request, agentI
 		return
 	}
 
-	metas, err := s.secretBackend.List(ctx, secret.Filter{
-		Scope:   store.ScopeProject,
-		ScopeID: projectID,
-	})
-	if err != nil {
-		writeErrorFromErr(w, err, "")
+	scope := r.URL.Query().Get("scope")
+
+	// Collect secrets based on requested scope.
+	var allMetas []secret.SecretMeta
+
+	switch scope {
+	case "": // No scope filter: include both project and user secrets.
+		projectMetas, err := s.secretBackend.List(ctx, secret.Filter{
+			Scope:   store.ScopeProject,
+			ScopeID: projectID,
+		})
+		if err != nil {
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		allMetas = append(allMetas, projectMetas...)
+
+		// Include user-scoped secrets if agent has user context.
+		agentIdent := GetAgentIdentityFromContext(ctx)
+		if agentIdent != nil {
+			if userID := agentIdent.OriginUserID(); userID != "" {
+				userMetas, err := s.secretBackend.List(ctx, secret.Filter{
+					Scope:   store.ScopeUser,
+					ScopeID: userID,
+				})
+				if err != nil {
+					writeErrorFromErr(w, err, "")
+					return
+				}
+				allMetas = append(allMetas, userMetas...)
+			}
+		}
+
+	case store.ScopeProject:
+		metas, err := s.secretBackend.List(ctx, secret.Filter{
+			Scope:   store.ScopeProject,
+			ScopeID: projectID,
+		})
+		if err != nil {
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		allMetas = metas
+
+	case store.ScopeUser:
+		agentIdent := GetAgentIdentityFromContext(ctx)
+		if agentIdent == nil {
+			writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "This endpoint requires agent authentication", nil)
+			return
+		}
+		userID := agentIdent.OriginUserID()
+		if userID == "" {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden, "agent token lacks user context required for user-scoped secrets", nil)
+			return
+		}
+		metas, err := s.secretBackend.List(ctx, secret.Filter{
+			Scope:   store.ScopeUser,
+			ScopeID: userID,
+		})
+		if err != nil {
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		allMetas = metas
+
+	default:
+		ValidationError(w, "scope must be \"project\" or \"user\"", map[string]interface{}{
+			"field":   "scope",
+			"value":   scope,
+			"allowed": []string{"project", "user"},
+		})
 		return
 	}
 
-	secrets := make([]AgentSecretMeta, len(metas))
-	for i, m := range metas {
+	secrets := make([]AgentSecretMeta, len(allMetas))
+	for i, m := range allMetas {
 		secrets[i] = AgentSecretMeta{
 			Key:    m.Name,
 			Type:   m.SecretType,

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -887,6 +887,7 @@ type AgentSetSecretRequest struct {
 	Type     string `json:"type,omitempty"`     // environment (default), variable, file
 	Target   string `json:"target,omitempty"`   // Injection target path
 	Force    bool   `json:"force,omitempty"`    // Overwrite existing secret
+	Scope    string `json:"scope,omitempty"`    // "project" (default) or "user"
 }
 
 // AgentSetSecretResponse is returned on successful agent secret creation.
@@ -992,6 +993,35 @@ func (s *Server) handleAgentSecrets(w http.ResponseWriter, r *http.Request, agen
 		return
 	}
 
+	// Determine scope and scopeID.
+	scope := req.Scope
+	if scope == "" {
+		scope = store.ScopeProject
+	}
+	var scopeID string
+	switch scope {
+	case store.ScopeProject:
+		scopeID = projectID
+	case store.ScopeUser:
+		agentIdent := GetAgentIdentityFromContext(ctx)
+		if agentIdent == nil {
+			writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "This endpoint requires agent authentication", nil)
+			return
+		}
+		scopeID = agentIdent.OriginUserID()
+		if scopeID == "" {
+			ValidationError(w, "agent token lacks user context required for user-scoped secrets", nil)
+			return
+		}
+	default:
+		ValidationError(w, "scope must be \"project\" or \"user\"", map[string]interface{}{
+			"field":   "scope",
+			"value":   scope,
+			"allowed": []string{"project", "user"},
+		})
+		return
+	}
+
 	var decoded []byte
 	if req.Encoding == "raw" {
 		// Caller explicitly opted in to raw text — store the value as-is.
@@ -1051,9 +1081,9 @@ func (s *Server) handleAgentSecrets(w http.ResponseWriter, r *http.Request, agen
 	// Note: the backend's UpsertSecret has the same check-then-write pattern
 	// internally, so this is consistent with the existing TOCTOU window.
 	if !req.Force {
-		_, err := s.secretBackend.GetMeta(ctx, key, store.ScopeProject, projectID)
+		_, err := s.secretBackend.GetMeta(ctx, key, scope, scopeID)
 		if err == nil {
-			Conflict(w, fmt.Sprintf("Secret %q already exists at project scope. Use force=true to overwrite.", key))
+			Conflict(w, fmt.Sprintf("Secret %q already exists at %s scope. Use force=true to overwrite.", key, scope))
 			return
 		}
 		if !errors.Is(err, store.ErrNotFound) {
@@ -1067,8 +1097,8 @@ func (s *Server) handleAgentSecrets(w http.ResponseWriter, r *http.Request, agen
 		Value:      string(decoded),
 		SecretType: secretType,
 		Target:     target,
-		Scope:      store.ScopeProject,
-		ScopeID:    projectID,
+		Scope:      scope,
+		ScopeID:    scopeID,
 		CreatedBy:  fmt.Sprintf("agent:%s", agentID),
 		UpdatedBy:  fmt.Sprintf("agent:%s", agentID),
 	}
@@ -1082,8 +1112,8 @@ func (s *Server) handleAgentSecrets(w http.ResponseWriter, r *http.Request, agen
 	if created {
 		writeJSON(w, http.StatusCreated, AgentSetSecretResponse{
 			Key:     key,
-			Scope:   store.ScopeProject,
-			ScopeID: projectID,
+			Scope:   scope,
+			ScopeID: scopeID,
 		})
 	} else {
 		w.WriteHeader(http.StatusNoContent)

--- a/pkg/hubclient/secrets.go
+++ b/pkg/hubclient/secrets.go
@@ -89,12 +89,13 @@ type SetSecretResponse struct {
 }
 
 // AgentSetSecretRequest is the request for setting a secret via the agent-scoped endpoint.
-// Unlike SetSecretRequest, scope is derived from the agent's JWT — no scope/scopeID needed.
+// Scope defaults to "project" (derived from JWT); set to "user" for personal credentials.
 type AgentSetSecretRequest struct {
 	Value  string `json:"value"`            // Required: base64-encoded secret value
 	Type   string `json:"type,omitempty"`   // Secret type: environment (default), variable, file
 	Target string `json:"target,omitempty"` // Projection target (defaults to key)
 	Force  bool   `json:"force,omitempty"`  // Overwrite existing secret
+	Scope  string `json:"scope,omitempty"`  // "project" (default) or "user"
 }
 
 // AgentSetSecretResponse is the response from the agent-scoped set endpoint.

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -385,6 +385,7 @@ type SetSecretRequest struct {
 	Type   string `json:"type,omitempty"`
 	Target string `json:"target,omitempty"`
 	Force  bool   `json:"force,omitempty"`
+	Scope  string `json:"scope,omitempty"`
 }
 
 // SetSecretResponse is the response from the agent secret creation endpoint.
@@ -505,9 +506,10 @@ func (c *Client) absoluteURL(path string) string {
 	return strings.TrimSuffix(c.hubURL, "/") + path
 }
 
-// SetSecret stores a project-scoped secret via the Hub API.
-// The value should already be base64-encoded.
-func (c *Client) SetSecret(ctx context.Context, key, value, secretType, target string, force bool) (*SetSecretResponse, error) {
+// SetSecret stores a secret via the Hub API.
+// The value should already be base64-encoded. Scope selects project (default)
+// or user; an empty scope is treated as "project".
+func (c *Client) SetSecret(ctx context.Context, key, value, secretType, target, scope string, force bool) (*SetSecretResponse, error) {
 	if !c.IsConfigured() {
 		return nil, fmt.Errorf("hub client not configured (is SCION_HUB_ENDPOINT set?)")
 	}
@@ -520,6 +522,7 @@ func (c *Client) SetSecret(ctx context.Context, key, value, secretType, target s
 		Type:   secretType,
 		Target: target,
 		Force:  force,
+		Scope:  scope,
 	}
 
 	body, err := json.Marshal(reqBody)

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -558,7 +558,10 @@ func (c *Client) SetSecret(ctx context.Context, key, value, secretType, target, 
 		}
 		return &result, nil
 	case http.StatusNoContent:
-		return &SetSecretResponse{Key: key, Scope: "project"}, nil
+		if scope == "" {
+			scope = "project"
+		}
+		return &SetSecretResponse{Key: key, Scope: scope}, nil
 	case http.StatusConflict:
 		return nil, fmt.Errorf("secret %q already exists (use --force to overwrite)", key)
 	default:

--- a/pkg/sciontool/hub/client_test.go
+++ b/pkg/sciontool/hub/client_test.go
@@ -1420,7 +1420,7 @@ func TestClient_SetSecret_Created(t *testing.T) {
 	defer server.Close()
 
 	client := NewClientWithConfig(server.URL, "test-token", "agent-123")
-	resp, err := client.SetSecret(context.Background(), "MY_KEY", "c2VjcmV0", "file", "~/.config/auth.json", false)
+	resp, err := client.SetSecret(context.Background(), "MY_KEY", "c2VjcmV0", "file", "~/.config/auth.json", "", false)
 
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodPut, receivedMethod)
@@ -1444,7 +1444,7 @@ func TestClient_SetSecret_NoContent(t *testing.T) {
 	defer server.Close()
 
 	client := NewClientWithConfig(server.URL, "test-token", "agent-123")
-	resp, err := client.SetSecret(context.Background(), "MY_KEY", "dmFsdWU=", "", "", true)
+	resp, err := client.SetSecret(context.Background(), "MY_KEY", "dmFsdWU=", "", "", "", true)
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -1460,7 +1460,7 @@ func TestClient_SetSecret_Conflict(t *testing.T) {
 	defer server.Close()
 
 	client := NewClientWithConfig(server.URL, "test-token", "agent-123")
-	_, err := client.SetSecret(context.Background(), "MY_KEY", "dmFsdWU=", "", "", false)
+	_, err := client.SetSecret(context.Background(), "MY_KEY", "dmFsdWU=", "", "", "", false)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
@@ -1468,7 +1468,7 @@ func TestClient_SetSecret_Conflict(t *testing.T) {
 
 func TestClient_SetSecret_NotConfigured(t *testing.T) {
 	client := &Client{}
-	_, err := client.SetSecret(context.Background(), "KEY", "VAL", "", "", false)
+	_, err := client.SetSecret(context.Background(), "KEY", "VAL", "", "", "", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not configured")
 }
@@ -1549,7 +1549,7 @@ func TestClient_SetSecret_ServerError(t *testing.T) {
 	defer server.Close()
 
 	client := NewClientWithConfig(server.URL, "test-token", "agent-123")
-	_, err := client.SetSecret(context.Background(), "KEY", "dmFsdWU=", "", "", false)
+	_, err := client.SetSecret(context.Background(), "KEY", "dmFsdWU=", "", "", "", false)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "500")

--- a/web/src/components/pages/terminal.ts
+++ b/web/src/components/pages/terminal.ts
@@ -110,6 +110,12 @@ export class ScionPageTerminal extends LitElement {
   @state()
   private captureAuthConflicts: string[] | null = null;
 
+  @state()
+  private captureAuthScopeDialogOpen = false;
+
+  /** Remembers the scope chosen in the scope dialog so force-update reuses it. */
+  private captureAuthSelectedScope: 'project' | 'user' = 'project';
+
   // --- Drag-and-drop file upload state ---
   @state() private uploadEnabled = false;
   @state() private uploadDisabledReason = '';
@@ -242,6 +248,10 @@ export class ScionPageTerminal extends LitElement {
     .capture-auth-btn:disabled {
       opacity: 0.5;
       cursor: default;
+    }
+
+    #capture-scope-group {
+      margin-top: 0.75rem;
     }
 
     /* Window switcher toggle group: two rectangular icon buttons */
@@ -1201,12 +1211,12 @@ export class ScionPageTerminal extends LitElement {
 
   private static readonly SECRET_CONFLICT_RE = /secret "([^"]+)" already exists/g;
 
-  private async handleCaptureAuth(force = false): Promise<void> {
+  private async handleCaptureAuth(force = false, scope: 'project' | 'user' = 'project'): Promise<void> {
     if (!this.agent) return;
     this.captureAuthLoading = true;
     this.captureAuthConflicts = null;
     try {
-      const command = ['python3', '/home/scion/.scion/harness/capture_auth.py'];
+      const command = ['python3', '/home/scion/.scion/harness/capture_auth.py', '--scope', scope];
       if (force) command.push('--force');
 
       const response = await apiFetch(`/api/v1/agents/${this.agent.id}/exec`, {
@@ -1286,7 +1296,7 @@ export class ScionPageTerminal extends LitElement {
           slot="footer"
           variant="warning"
           ?loading=${this.captureAuthLoading}
-          @click=${() => void this.handleCaptureAuth(true)}
+          @click=${() => void this.handleCaptureAuth(true, this.captureAuthSelectedScope)}
           >Force Update</sl-button
         >
       </sl-dialog>
@@ -1426,7 +1436,7 @@ export class ScionPageTerminal extends LitElement {
               <button
                 class="capture-auth-btn"
                 ?disabled=${this.captureAuthLoading}
-                @click=${() => this.handleCaptureAuth()}
+                @click=${() => { this.captureAuthScopeDialogOpen = true; }}
                 title="Capture credentials from inside the container"
               >
                 ${this.captureAuthLoading ? 'Capturing...' : 'Capture Auth'}
@@ -1488,6 +1498,52 @@ export class ScionPageTerminal extends LitElement {
         </div>
       </div>
       ${this.renderCaptureAuthConflictDialog()}
+      ${this.renderCaptureAuthScopeDialog()}
+    `;
+  }
+
+  private renderCaptureAuthScopeDialog() {
+    if (!this.captureAuthScopeDialogOpen) return nothing;
+    return html`
+      <sl-dialog
+        label="Capture Auth — Choose Scope"
+        open
+        @sl-request-close=${() => {
+          this.captureAuthScopeDialogOpen = false;
+        }}
+      >
+        <p>Where should the captured credentials be stored?</p>
+        <sl-radio-group id="capture-scope-group" value="project">
+          <sl-radio-button value="project"
+            >Project secret (all project agents)</sl-radio-button
+          >
+          <sl-radio-button value="user"
+            >Profile secret (your personal credential)</sl-radio-button
+          >
+        </sl-radio-group>
+        <sl-button
+          slot="footer"
+          variant="default"
+          @click=${() => {
+            this.captureAuthScopeDialogOpen = false;
+          }}
+          >Cancel</sl-button
+        >
+        <sl-button
+          slot="footer"
+          variant="primary"
+          @click=${() => {
+            const group = this.shadowRoot?.querySelector<HTMLElement & { value: string }>(
+              '#capture-scope-group',
+            );
+            const scope = (group?.value ?? 'project') as 'project' | 'user';
+            this.captureAuthSelectedScope = scope;
+            this.captureAuthScopeDialogOpen = false;
+            void this.handleCaptureAuth(false, scope);
+          }}
+          >Capture</sl-button
+        >
+      </sl-dialog>
     `;
   }
 }

--- a/web/src/components/pages/terminal.ts
+++ b/web/src/components/pages/terminal.ts
@@ -114,6 +114,7 @@ export class ScionPageTerminal extends LitElement {
   private captureAuthScopeDialogOpen = false;
 
   /** Remembers the scope chosen in the scope dialog so force-update reuses it. */
+  @state()
   private captureAuthSelectedScope: 'project' | 'user' = 'project';
 
   // --- Drag-and-drop file upload state ---
@@ -1513,7 +1514,13 @@ export class ScionPageTerminal extends LitElement {
         }}
       >
         <p>Where should the captured credentials be stored?</p>
-        <sl-radio-group id="capture-scope-group" value="project">
+        <sl-radio-group
+          id="capture-scope-group"
+          .value=${this.captureAuthSelectedScope}
+          @sl-change=${(e: any) => {
+            this.captureAuthSelectedScope = e.target.value;
+          }}
+        >
           <sl-radio-button value="project"
             >Project secret (all project agents)</sl-radio-button
           >
@@ -1533,13 +1540,8 @@ export class ScionPageTerminal extends LitElement {
           slot="footer"
           variant="primary"
           @click=${() => {
-            const group = this.shadowRoot?.querySelector<HTMLElement & { value: string }>(
-              '#capture-scope-group',
-            );
-            const scope = (group?.value ?? 'project') as 'project' | 'user';
-            this.captureAuthSelectedScope = scope;
             this.captureAuthScopeDialogOpen = false;
-            void this.handleCaptureAuth(false, scope);
+            void this.handleCaptureAuth(false, this.captureAuthSelectedScope);
           }}
           >Capture</sl-button
         >


### PR DESCRIPTION
## Summary

Adds a scope selection dialog to the Capture Auth button on the agent terminal page. Users choose between project scope (all project agents) and profile/user scope (personal credential).

- Web UI: Shoelace dialog with radio buttons before capture auth exec
- capture_auth.py: accepts --scope arg, forwards to sciontool
- sciontool secret set: new --scope flag (project|user)
- Hub API: scope routing via agent JWT OriginUserID for user scope

Backward compatible — scope defaults to project when omitted.

Relates to ptone/scion#1166
