### PR TITLE
feat(chat): preserve project context when toggling between dashboard and chat

### DIFF
--- a/web/src/components/shared/header.test.ts
+++ b/web/src/components/shared/header.test.ts
@@ -60,6 +60,11 @@ describe('projectIdFromDashboardPath', () => {
     expect(projectIdFromDashboardPath('/agents/foo')).toBeNull();
     expect(projectIdFromDashboardPath('/chat')).toBeNull();
   });
+
+  it('ignores query parameters and hash fragments', () => {
+    expect(projectIdFromDashboardPath('/projects/abc-123?foo=bar')).toBe('abc-123');
+    expect(projectIdFromDashboardPath('/projects/abc-123#hash')).toBe('abc-123');
+  });
 });
 
 describe('projectIdFromChatSpacePath', () => {
@@ -81,6 +86,11 @@ describe('projectIdFromChatSpacePath', () => {
 
   it('returns null for bare /chat', () => {
     expect(projectIdFromChatSpacePath('/chat')).toBeNull();
+  });
+
+  it('ignores query parameters and hash fragments', () => {
+    expect(projectIdFromChatSpacePath('/chat/space/proj-42?thread=topic-7')).toBe('proj-42');
+    expect(projectIdFromChatSpacePath('/chat/space/proj-42#hash')).toBe('proj-42');
   });
 });
 
@@ -108,5 +118,10 @@ describe('slugFromChatPath', () => {
   it('returns null for non-chat paths', () => {
     expect(slugFromChatPath('/')).toBeNull();
     expect(slugFromChatPath('/projects/abc')).toBeNull();
+  });
+
+  it('ignores query parameters and hash fragments', () => {
+    expect(slugFromChatPath('/chat/my-project?foo=bar')).toBe('my-project');
+    expect(slugFromChatPath('/chat/my-project#hash')).toBe('my-project');
   });
 });

--- a/web/src/components/shared/header.test.ts
+++ b/web/src/components/shared/header.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the project-context helpers used by the dashboard ↔ chat mode
+ * switch in scion-header. These are pure functions — no DOM needed.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  projectIdFromDashboardPath,
+  projectIdFromChatSpacePath,
+  slugFromChatPath,
+} from './header.js';
+
+describe('projectIdFromDashboardPath', () => {
+  it('extracts the project ID from /projects/:id', () => {
+    expect(projectIdFromDashboardPath('/projects/abc-123')).toBe('abc-123');
+  });
+
+  it('extracts the project ID from /projects/:id/settings', () => {
+    expect(projectIdFromDashboardPath('/projects/abc-123/settings')).toBe('abc-123');
+  });
+
+  it('extracts the project ID from /projects/:id/schedules', () => {
+    expect(projectIdFromDashboardPath('/projects/abc-123/schedules')).toBe('abc-123');
+  });
+
+  it('extracts the project ID from /projects/:id/metrics', () => {
+    expect(projectIdFromDashboardPath('/projects/abc-123/metrics')).toBe('abc-123');
+  });
+
+  it('returns null for /projects/new (creation form)', () => {
+    expect(projectIdFromDashboardPath('/projects/new')).toBeNull();
+  });
+
+  it('returns null for /projects (list page)', () => {
+    expect(projectIdFromDashboardPath('/projects')).toBeNull();
+  });
+
+  it('returns null for the root path', () => {
+    expect(projectIdFromDashboardPath('/')).toBeNull();
+  });
+
+  it('returns null for unrelated paths', () => {
+    expect(projectIdFromDashboardPath('/agents/foo')).toBeNull();
+    expect(projectIdFromDashboardPath('/chat')).toBeNull();
+  });
+});
+
+describe('projectIdFromChatSpacePath', () => {
+  it('extracts project ID from /chat/space/:id', () => {
+    expect(projectIdFromChatSpacePath('/chat/space/proj-42')).toBe('proj-42');
+  });
+
+  it('extracts project ID from /chat/space/:id/thread/:tid', () => {
+    expect(projectIdFromChatSpacePath('/chat/space/proj-42/thread/topic-7')).toBe('proj-42');
+  });
+
+  it('returns null for /chat/:slug paths', () => {
+    expect(projectIdFromChatSpacePath('/chat/my-project')).toBeNull();
+  });
+
+  it('returns null for /chat/dm paths', () => {
+    expect(projectIdFromChatSpacePath('/chat/dm/abc')).toBeNull();
+  });
+
+  it('returns null for bare /chat', () => {
+    expect(projectIdFromChatSpacePath('/chat')).toBeNull();
+  });
+});
+
+describe('slugFromChatPath', () => {
+  it('extracts the slug from /chat/:slug', () => {
+    expect(slugFromChatPath('/chat/my-project')).toBe('my-project');
+  });
+
+  it('extracts the slug from /chat/:slug/:threadId', () => {
+    expect(slugFromChatPath('/chat/my-project/thread-1')).toBe('my-project');
+  });
+
+  it('returns null for /chat/space/:id (handled by projectIdFromChatSpacePath)', () => {
+    expect(slugFromChatPath('/chat/space/proj-42')).toBeNull();
+  });
+
+  it('returns null for /chat/dm/:key (DMs have no project context)', () => {
+    expect(slugFromChatPath('/chat/dm/abc')).toBeNull();
+  });
+
+  it('returns null for bare /chat', () => {
+    expect(slugFromChatPath('/chat')).toBeNull();
+  });
+
+  it('returns null for non-chat paths', () => {
+    expect(slugFromChatPath('/')).toBeNull();
+    expect(slugFromChatPath('/projects/abc')).toBeNull();
+  });
+});

--- a/web/src/components/shared/header.ts
+++ b/web/src/components/shared/header.ts
@@ -25,8 +25,41 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 import type { User } from '../../shared/types.js';
 import { isFeatureEnabled } from '../../utils/feature-flags.js';
+import { apiFetch } from '../../client/api.js';
 import './notification-tray.js';
 import './inbox-tray.js';
+
+// ---------------------------------------------------------------------------
+// Project-context helpers for the dashboard ↔ chat mode switch.
+//
+// These are pure functions exported for testing — they map URL paths to
+// the project identifier that should carry across the view toggle.
+// ---------------------------------------------------------------------------
+
+/** Extract a project ID from a dashboard-style path (`/projects/:id/…`). */
+export function projectIdFromDashboardPath(path: string): string | null {
+  const m = path.match(/^\/projects\/([^/]+)/);
+  // `/projects/new` is the creation form, not a project-scoped page.
+  return m && m[1] !== 'new' ? m[1] : null;
+}
+
+/** Extract a project ID from a legacy chat space path (`/chat/space/:id/…`). */
+export function projectIdFromChatSpacePath(path: string): string | null {
+  const m = path.match(/^\/chat\/space\/([^/]+)/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Extract a project slug from a readable chat path (`/chat/:slug` or
+ * `/chat/:slug/:threadId`). Returns null for space, dm, and bare `/chat`
+ * paths — those are handled by dedicated helpers or have no project context.
+ */
+export function slugFromChatPath(path: string): string | null {
+  if (/^\/chat\/space\//.test(path)) return null;
+  if (/^\/chat\/dm\//.test(path)) return null;
+  const m = path.match(/^\/chat\/([^/]+)/);
+  return m ? m[1] : null;
+}
 
 /** URL for the Scion documentation site, opened by the Help button. */
 const DOCS_URL = 'https://googlecloudplatform.github.io/scion/overview/';
@@ -382,7 +415,7 @@ export class ScionHeader extends LitElement {
             name="house"
             label="Dashboard"
             class=${isChat ? '' : 'active'}
-            @click=${(): void => this.handleModeSwitch('/')}
+            @click=${() => { this.handleModeSwitch('/'); }}
           ></sl-icon-button>
         </sl-tooltip>
         <sl-tooltip content="Chat">
@@ -390,7 +423,7 @@ export class ScionHeader extends LitElement {
             name="chat-dots"
             label="Chat"
             class=${isChat ? 'active' : ''}
-            @click=${(): void => this.handleModeSwitch('/chat')}
+            @click=${() => { this.handleModeSwitch('/chat'); }}
           ></sl-icon-button>
         </sl-tooltip>
       </div>
@@ -398,17 +431,74 @@ export class ScionHeader extends LitElement {
   }
 
   /**
-   * Navigate to the given mode. Uses the same nav-click event as the sidebar
-   * so the router handles it identically in both the app and chat shells.
+   * Navigate to the given mode, preserving project context when possible.
+   *
+   * Dashboard → Chat:  /projects/:id/… → /chat/space/:id
+   * Chat → Dashboard:  /chat/space/:id/… → /projects/:id
+   *                     /chat/:slug/…     → (resolve slug) → /projects/:id
+   *                     /chat/dm/…        → / (no project context)
+   *
+   * Uses the same nav-click event as the sidebar so the router handles it
+   * identically in both the app and chat shells.
    */
-  private handleModeSwitch(path: string): void {
+  private async handleModeSwitch(targetBase: string): Promise<void> {
+    const currentPath = this.currentPath || window.location.pathname;
+    let target: string;
+
+    if (targetBase === '/chat') {
+      // Dashboard → Chat: carry the project ID into a space URL.
+      const projectId = projectIdFromDashboardPath(currentPath);
+      target = projectId
+        ? `/chat/space/${encodeURIComponent(projectId)}`
+        : '/chat';
+    } else {
+      // Chat → Dashboard: resolve project ID from the chat URL.
+      const projectId = projectIdFromChatSpacePath(currentPath);
+      if (projectId) {
+        target = `/projects/${encodeURIComponent(projectId)}`;
+      } else {
+        const slug = slugFromChatPath(currentPath);
+        if (slug) {
+          const resolvedId = await this.resolveProjectIdBySlug(slug);
+          target = resolvedId
+            ? `/projects/${encodeURIComponent(resolvedId)}`
+            : '/';
+        } else {
+          target = '/';
+        }
+      }
+    }
+
     this.dispatchEvent(
       new CustomEvent('nav-click', {
-        detail: { path },
+        detail: { path: target },
         bubbles: true,
         composed: true,
       })
     );
+  }
+
+  /**
+   * Look up a project by slug via the projects API, returning the project ID
+   * or an empty string when the slug cannot be resolved.
+   */
+  private async resolveProjectIdBySlug(slug: string): Promise<string> {
+    try {
+      const res = await apiFetch(
+        `/api/v1/projects?slug=${encodeURIComponent(slug)}&limit=1`
+      );
+      if (res.ok) {
+        const data = (await res.json()) as {
+          items?: Array<{ id: string; slug: string }>;
+        };
+        if (data.items && data.items.length > 0) {
+          return data.items[0].id;
+        }
+      }
+    } catch {
+      // Slug resolution is best-effort; fall back to the top-level view.
+    }
+    return '';
   }
 
   private renderUserSection() {

--- a/web/src/components/shared/header.ts
+++ b/web/src/components/shared/header.ts
@@ -38,14 +38,14 @@ import './inbox-tray.js';
 
 /** Extract a project ID from a dashboard-style path (`/projects/:id/…`). */
 export function projectIdFromDashboardPath(path: string): string | null {
-  const m = path.match(/^\/projects\/([^/]+)/);
+  const m = path.match(/^\/projects\/([^/?#]+)/);
   // `/projects/new` is the creation form, not a project-scoped page.
   return m && m[1] !== 'new' ? m[1] : null;
 }
 
 /** Extract a project ID from a legacy chat space path (`/chat/space/:id/…`). */
 export function projectIdFromChatSpacePath(path: string): string | null {
-  const m = path.match(/^\/chat\/space\/([^/]+)/);
+  const m = path.match(/^\/chat\/space\/([^/?#]+)/);
   return m ? m[1] : null;
 }
 
@@ -57,7 +57,7 @@ export function projectIdFromChatSpacePath(path: string): string | null {
 export function slugFromChatPath(path: string): string | null {
   if (/^\/chat\/space\//.test(path)) return null;
   if (/^\/chat\/dm\//.test(path)) return null;
-  const m = path.match(/^\/chat\/([^/]+)/);
+  const m = path.match(/^\/chat\/([^/?#]+)/);
   return m ? m[1] : null;
 }
 
@@ -468,6 +468,9 @@ export class ScionHeader extends LitElement {
         }
       }
     }
+
+    // Guard: component may have disconnected during async slug resolution.
+    if (!this.isConnected) return;
 
     this.dispatchEvent(
       new CustomEvent('nav-click', {


### PR DESCRIPTION
When switching between dashboard and chat views, the current project context is now preserved. If viewing Project A's dashboard and clicking Chat, you land on Project A's chat (and vice versa). Top-level (no project) stays at top-level.

Includes 19 new unit tests for URL-parsing helpers.

Fixes ptone/scion#1172