### PR TITLE
fix(secret): correct inverted scope precedence in Resolve() and dedup

### DIFF
--- a/pkg/hub/resolve_secrets_test.go
+++ b/pkg/hub/resolve_secrets_test.go
@@ -112,16 +112,17 @@ func TestResolveSecrets(t *testing.T) {
 		byName[rs.Name] = rs
 	}
 
-	// API_KEY should be overridden by project scope
+	// API_KEY: user is the strongest scope (runtime_broker < hub < project
+	// < user), so the user-scoped value wins over the project-scoped one.
 	apiKey, ok := byName["API_KEY"]
 	if !ok {
 		t.Fatal("expected API_KEY in resolved secrets")
 	}
-	if apiKey.Value != "project-api-key" {
-		t.Errorf("expected API_KEY value from project scope %q, got %q", "project-api-key", apiKey.Value)
+	if apiKey.Value != "user-api-key" {
+		t.Errorf("expected API_KEY value from user scope %q, got %q", "user-api-key", apiKey.Value)
 	}
-	if apiKey.Source != store.ScopeProject {
-		t.Errorf("expected API_KEY source %q, got %q", store.ScopeProject, apiKey.Source)
+	if apiKey.Source != store.ScopeUser {
+		t.Errorf("expected API_KEY source %q, got %q", store.ScopeUser, apiKey.Source)
 	}
 
 	// DB_PASS should come from project scope
@@ -228,16 +229,16 @@ func TestResolveSecrets_WithBackend(t *testing.T) {
 		byName[rs.Name] = rs
 	}
 
-	// API_KEY should be overridden by project scope
+	// API_KEY: user is the strongest scope, so it wins over project.
 	apiKey, ok := byName["API_KEY"]
 	if !ok {
 		t.Fatal("expected API_KEY in resolved secrets")
 	}
-	if apiKey.Value != "project-api-key" {
-		t.Errorf("expected API_KEY value %q, got %q", "project-api-key", apiKey.Value)
+	if apiKey.Value != "user-api-key" {
+		t.Errorf("expected API_KEY value %q, got %q", "user-api-key", apiKey.Value)
 	}
-	if apiKey.Source != store.ScopeProject {
-		t.Errorf("expected API_KEY source %q, got %q", store.ScopeProject, apiKey.Source)
+	if apiKey.Source != store.ScopeUser {
+		t.Errorf("expected API_KEY source %q, got %q", store.ScopeUser, apiKey.Source)
 	}
 
 	// DB_PASS target should be preserved

--- a/pkg/secret/gcpbackend.go
+++ b/pkg/secret/gcpbackend.go
@@ -276,17 +276,27 @@ func (b *GCPBackend) Resolve(ctx context.Context, userID, projectID, brokerID st
 		scopeID string
 	}
 
+	// Scope precedence, lowest first: runtime_broker < hub < project < user.
+	// Later entries in this slice overwrite earlier ones in the merge loop
+	// below, so this order must match envScopePrecedence in
+	// pkg/hub/httpdispatcher.go — broker is the most infrastructural and
+	// least specific of the four scopes, so it is intentionally the
+	// weakest, not an override nobody can escape. (Previously this listed
+	// hub, user, project, broker, which put broker last and therefore
+	// strongest — the opposite of every other precedence-ordered resolver
+	// in this codebase, and the reason a stale broker-scoped secret could
+	// silently shadow a project-scoped one regardless of which was meant
+	// to win.)
 	var scopes []scopeEntry
-	// Hub scope is always included as lowest precedence
-	scopes = append(scopes, scopeEntry{scope: store.ScopeHub, scopeID: b.hubID})
-	if userID != "" {
-		scopes = append(scopes, scopeEntry{scope: store.ScopeUser, scopeID: userID})
+	if brokerID != "" {
+		scopes = append(scopes, scopeEntry{scope: store.ScopeRuntimeBroker, scopeID: brokerID})
 	}
+	scopes = append(scopes, scopeEntry{scope: store.ScopeHub, scopeID: b.hubID})
 	if projectID != "" {
 		scopes = append(scopes, scopeEntry{scope: store.ScopeProject, scopeID: projectID})
 	}
-	if brokerID != "" {
-		scopes = append(scopes, scopeEntry{scope: store.ScopeRuntimeBroker, scopeID: brokerID})
+	if userID != "" {
+		scopes = append(scopes, scopeEntry{scope: store.ScopeUser, scopeID: userID})
 	}
 
 	for _, sc := range scopes {

--- a/pkg/secret/gcpbackend.go
+++ b/pkg/secret/gcpbackend.go
@@ -287,7 +287,7 @@ func (b *GCPBackend) Resolve(ctx context.Context, userID, projectID, brokerID st
 	// in this codebase, and the reason a stale broker-scoped secret could
 	// silently shadow a project-scoped one regardless of which was meant
 	// to win.)
-	var scopes []scopeEntry
+	scopes := make([]scopeEntry, 0, 4)
 	if brokerID != "" {
 		scopes = append(scopes, scopeEntry{scope: store.ScopeRuntimeBroker, scopeID: brokerID})
 	}

--- a/pkg/secret/gcpbackend_test.go
+++ b/pkg/secret/gcpbackend_test.go
@@ -434,13 +434,14 @@ func TestGCPBackend_Resolve(t *testing.T) {
 		byName[sv.Name] = sv
 	}
 
-	// API_KEY overridden by project
+	// API_KEY: user scope wins over project (runtime_broker < hub < project
+	// < user, lowest first — user is the strongest scope).
 	apiKey, ok := byName["API_KEY"]
 	if !ok {
 		t.Fatal("expected API_KEY in resolved secrets")
 	}
-	if apiKey.Value != "grove-api-key" {
-		t.Errorf("expected project API_KEY value %q, got %q", "grove-api-key", apiKey.Value)
+	if apiKey.Value != "user-api-key" {
+		t.Errorf("expected user API_KEY value %q, got %q", "user-api-key", apiKey.Value)
 	}
 
 	// DB_PASS from project

--- a/pkg/secret/localbackend.go
+++ b/pkg/secret/localbackend.go
@@ -92,17 +92,27 @@ func (b *LocalBackend) Resolve(ctx context.Context, userID, projectID, brokerID 
 		scopeID string
 	}
 
+	// Scope precedence, lowest first: runtime_broker < hub < project < user.
+	// Later entries in this slice overwrite earlier ones in the merge loop
+	// below, so this order must match envScopePrecedence in
+	// pkg/hub/httpdispatcher.go — broker is the most infrastructural and
+	// least specific of the four scopes, so it is intentionally the
+	// weakest, not an override nobody can escape. (Previously this listed
+	// hub, user, project, broker, which put broker last and therefore
+	// strongest — the opposite of every other precedence-ordered resolver
+	// in this codebase, and the reason a stale broker-scoped secret could
+	// silently shadow a project-scoped one regardless of which was meant
+	// to win.)
 	var scopes []scopeEntry
-	// Hub scope is always included as lowest precedence
-	scopes = append(scopes, scopeEntry{scope: store.ScopeHub, scopeID: b.hubID})
-	if userID != "" {
-		scopes = append(scopes, scopeEntry{scope: store.ScopeUser, scopeID: userID})
+	if brokerID != "" {
+		scopes = append(scopes, scopeEntry{scope: store.ScopeRuntimeBroker, scopeID: brokerID})
 	}
+	scopes = append(scopes, scopeEntry{scope: store.ScopeHub, scopeID: b.hubID})
 	if projectID != "" {
 		scopes = append(scopes, scopeEntry{scope: store.ScopeProject, scopeID: projectID})
 	}
-	if brokerID != "" {
-		scopes = append(scopes, scopeEntry{scope: store.ScopeRuntimeBroker, scopeID: brokerID})
+	if userID != "" {
+		scopes = append(scopes, scopeEntry{scope: store.ScopeUser, scopeID: userID})
 	}
 
 	for _, sc := range scopes {

--- a/pkg/secret/localbackend.go
+++ b/pkg/secret/localbackend.go
@@ -103,7 +103,7 @@ func (b *LocalBackend) Resolve(ctx context.Context, userID, projectID, brokerID 
 	// in this codebase, and the reason a stale broker-scoped secret could
 	// silently shadow a project-scoped one regardless of which was meant
 	// to win.)
-	var scopes []scopeEntry
+	scopes := make([]scopeEntry, 0, 4)
 	if brokerID != "" {
 		scopes = append(scopes, scopeEntry{scope: store.ScopeRuntimeBroker, scopeID: brokerID})
 	}

--- a/pkg/secret/localbackend_test.go
+++ b/pkg/secret/localbackend_test.go
@@ -338,7 +338,8 @@ func TestLocalBackend_Resolve(t *testing.T) {
 		ScopeID:        "user-1",
 	})
 
-	// Project-level override
+	// Project-level value for the same key, but user is the strongest scope
+	// (runtime_broker < hub < project < user), so user's value must win.
 	seedSecret(t, s, &store.Secret{
 		ID:             tid("s3"),
 		Key:            "API_KEY",
@@ -368,16 +369,16 @@ func TestLocalBackend_Resolve(t *testing.T) {
 		byName[sv.Name] = sv
 	}
 
-	// API_KEY overridden by project
+	// API_KEY: user scope wins over project (user is stronger)
 	apiKey, ok := byName["API_KEY"]
 	if !ok {
 		t.Fatal("expected API_KEY in resolved secrets")
 	}
-	if apiKey.Value != "grove-api-key" {
-		t.Errorf("expected project API_KEY value %q, got %q", "grove-api-key", apiKey.Value)
+	if apiKey.Value != "user-api-key" {
+		t.Errorf("expected user API_KEY value %q, got %q", "user-api-key", apiKey.Value)
 	}
-	if apiKey.Scope != ScopeProject {
-		t.Errorf("expected API_KEY scope %q, got %q", ScopeProject, apiKey.Scope)
+	if apiKey.Scope != ScopeUser {
+		t.Errorf("expected API_KEY scope %q, got %q", ScopeUser, apiKey.Scope)
 	}
 
 	// TLS_CERT from user (no override)
@@ -419,7 +420,15 @@ func TestLocalBackend_ResolveNoScopes(t *testing.T) {
 	}
 }
 
-func TestLocalBackend_ResolveBrokerOverride(t *testing.T) {
+// TestLocalBackend_ResolveUserOverridesBroker asserts the documented scope
+// precedence (runtime_broker < hub < project < user, lowest first — see
+// envScopePrecedence in pkg/hub/httpdispatcher.go): runtime_broker is the
+// most infrastructural and least specific scope, so it must be the weakest,
+// not an override nobody can escape. This test used to be named
+// TestLocalBackend_ResolveBrokerOverride and asserted the opposite (broker
+// beating user) — that was the bug, not the spec; see the scope-ordering
+// comment in Resolve() for the incident this came from.
+func TestLocalBackend_ResolveUserOverridesBroker(t *testing.T) {
 	backend, s := createTestBackend(t)
 	ctx := context.Background()
 
@@ -450,11 +459,11 @@ func TestLocalBackend_ResolveBrokerOverride(t *testing.T) {
 	if len(resolved) != 1 {
 		t.Fatalf("expected 1 resolved secret, got %d", len(resolved))
 	}
-	if resolved[0].Value != "broker-key" {
-		t.Errorf("expected broker override %q, got %q", "broker-key", resolved[0].Value)
+	if resolved[0].Value != "user-key" {
+		t.Errorf("expected user scope to win over broker, got %q", resolved[0].Value)
 	}
-	if resolved[0].Scope != ScopeRuntimeBroker {
-		t.Errorf("expected scope %q, got %q", ScopeRuntimeBroker, resolved[0].Scope)
+	if resolved[0].Scope != ScopeUser {
+		t.Errorf("expected scope %q, got %q", ScopeUser, resolved[0].Scope)
 	}
 }
 
@@ -569,12 +578,13 @@ func TestLocalBackend_ResolveDuplicateTargetAcrossScopes(t *testing.T) {
 		t.Fatalf("expected 1 file secret for /tmp/my-secret.json, got %d", len(fileSecrets))
 	}
 
-	// Project-level (higher scope) should win
-	if fileSecrets[0].Name != "my-key" {
-		t.Errorf("expected project-level secret 'my-key' to win, got %q", fileSecrets[0].Name)
+	// User is the strongest scope (runtime_broker < hub < project < user),
+	// so the user-level secret should win.
+	if fileSecrets[0].Name != "my-svc-account" {
+		t.Errorf("expected user-level secret 'my-svc-account' to win, got %q", fileSecrets[0].Name)
 	}
-	if fileSecrets[0].Value != "grove-cert-data" {
-		t.Errorf("expected project-level value, got %q", fileSecrets[0].Value)
+	if fileSecrets[0].Value != "user-cert-data" {
+		t.Errorf("expected user-level value, got %q", fileSecrets[0].Value)
 	}
 }
 
@@ -618,8 +628,9 @@ func TestLocalBackend_ResolveDuplicateEnvTargetAcrossScopes(t *testing.T) {
 	if len(envSecrets) != 1 {
 		t.Fatalf("expected 1 env secret for FOO_VAR, got %d", len(envSecrets))
 	}
-	if envSecrets[0].Name != "grove-foo" {
-		t.Errorf("expected project-level secret to win, got %q", envSecrets[0].Name)
+	// User is the strongest scope (runtime_broker < hub < project < user).
+	if envSecrets[0].Name != "user-foo" {
+		t.Errorf("expected user-level secret to win, got %q", envSecrets[0].Name)
 	}
 }
 

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -154,15 +154,24 @@ type SecretBackend interface {
 
 // scopePrecedence returns a numeric rank for the given scope string.
 // Higher values indicate higher precedence. Unknown scopes get 0.
+//
+// Order must match envScopePrecedence in pkg/hub/httpdispatcher.go and the
+// scope ordering in LocalBackend.Resolve / GCPBackend.Resolve: runtime_broker
+// is the most infrastructural and least specific scope, so it is the
+// weakest, not an override nobody can escape. (This function previously
+// ranked runtime_broker highest — the opposite of every other
+// precedence-ordered resolver in this codebase — which let a stale
+// broker-scoped secret silently shadow a project- or user-scoped one for
+// any target two differently-named secrets happened to share.)
 func scopePrecedence(scope string) int {
 	switch scope {
-	case ScopeHub:
+	case ScopeRuntimeBroker:
 		return 1
-	case ScopeUser:
+	case ScopeHub:
 		return 2
 	case ScopeProject:
 		return 3
-	case ScopeRuntimeBroker:
+	case ScopeUser:
 		return 4
 	default:
 		return 0


### PR DESCRIPTION
## Summary

Fixes #1226 — secret scope precedence was inverted in three independent places, all putting `runtime_broker` (meant to be the weakest scope) ahead of `project` and `user`, and `project` ahead of `user`. The documented/intended order (see `envScopePrecedence` in `pkg/hub/httpdispatcher.go`) is:

```
runtime_broker < hub < project < user   (lowest precedence first)
```

## What was wrong

- `LocalBackend.Resolve()` (`pkg/secret/localbackend.go`) built its scope list as `[hub, user, project, broker]` and merged last-write-wins, making broker strongest.
- `GCPBackend.Resolve()` (`pkg/secret/gcpbackend.go`) — identical bug.
- `scopePrecedence()` (`pkg/secret/secret.go`, used by `DeduplicateByTarget` to resolve collisions between differently-named secrets sharing an injection target) ranked `hub=1, user=2, project=3, runtime_broker=4` (higher wins) — same inversion.

In practice this means a secret set at a weaker scope (e.g. `runtime_broker`, left over from a debugging session) can silently shadow the same key at a stronger scope (e.g. `project`), with no error — whichever scope happened to be enumerated last in the old order wins, regardless of which one the caller actually intended to take effect. Full repro and impact in #1226.

## Fix

- Reordered the scope list in both `Resolve()` implementations to `[runtime_broker, hub, project, user]`, matching `envScopePrecedence`.
- Corrected `scopePrecedence()`'s numeric ranks to `runtime_broker=1, hub=2, project=3, user=4`.
- Added a comment on each cross-referencing the other two implementations, since this is the second time the same ordering has needed fixing in three places independently (see the existing precedence-history comment above `envScopePrecedence` in `httpdispatcher.go`) — the comments try to make it easy to find all three the next time this needs to change.

## Tests

Five existing tests asserted the *inverted* precedence as expected behavior — they were passing because they were testing the bug, not despite it:

- `TestLocalBackend_ResolveBrokerOverride` → renamed `TestLocalBackend_ResolveUserOverridesBroker`, assertion flipped
- `TestLocalBackend_Resolve`, `TestLocalBackend_ResolveDuplicateTargetAcrossScopes`, `TestLocalBackend_ResolveDuplicateEnvTargetAcrossScopes` (`pkg/secret/localbackend_test.go`) — assertions flipped from "project wins" to "user wins"
- `TestGCPBackend_Resolve` (`pkg/secret/gcpbackend_test.go`) — same
- `TestResolveSecrets`, `TestResolveSecrets_WithBackend` (`pkg/hub/resolve_secrets_test.go`) — same, at the `dispatcher.resolveSecrets()` level

All updated to assert the documented precedence instead. `go test ./pkg/secret/... ./pkg/hub/... ./pkg/store/...` passes (five pre-existing, unrelated failures on this machine — `TestClassifyPath_*`/`TestFS*` — fail identically on an unpatched checkout at the same commit; looks like a macOS path-assumption issue in those tests, not something this PR touches).

## How this was found

Root-caused live while debugging why a project-scoped `GITHUB_TOKEN` (set with `--always` injection mode) wasn't reaching an agent container for Hub-mode's git-clone-at-start step, despite being stored correctly — a stale `runtime_broker`-scoped copy from an earlier debugging attempt was silently winning instead. Confirmed by patching temporary logging into a local build and tracing the resolved value hop by hop through the dispatch pipeline. Full writeup in #1226.
