### PR TITLE
fix(telegram): resolve registered sender's Hub user ID for outbound SenderID

### DIFF
--- a/extras/scion-telegram/internal/telegram/broker_v2.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2.go
@@ -1956,11 +1956,23 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 	}
 
 	// Check for scion identity mapping — unregistered users cannot route messages.
+	// hubSenderID carries the resolved Hub user UUID (when registered) for the
+	// outbound StructuredMessage.SenderID; senderID itself must stay the raw
+	// Telegram numeric ID since it also keys ConversationContext.TelegramUserID
+	// below. Without this split, the Hub's reply-affinity lookup
+	// (webchat_conversation_context, keyed by Hub user ID) never matches what
+	// gets recorded here, so an agent's reply falls back to whatever channel
+	// that Hub user last used elsewhere (e.g. the web dashboard) instead of
+	// routing back to Telegram.
+	hubSenderID := senderID
 	if senderID != "" {
 		mapping, err := b.store.GetUserMapping(ctx, senderID)
 		if err == nil && mapping != nil {
 			if mapping.ScionEmail != "" {
 				sender = "user:" + mapping.ScionEmail
+			}
+			if mapping.ScionUserID != "" {
+				hubSenderID = mapping.ScionUserID
 			}
 		} else if mapping == nil {
 			b.log.Debug("Unregistered user tried to mention agent", "sender_id", senderID)
@@ -2112,7 +2124,7 @@ func (b *TelegramBrokerV2) handleGroupMessage(tgMsg *TGMessage) {
 			Version:    messages.Version,
 			Timestamp:  time.Unix(tgMsg.Date, 0).UTC().Format(time.RFC3339),
 			Sender:     sender,
-			SenderID:   senderID,
+			SenderID:   hubSenderID,
 			Recipient:  recipient,
 			Recipients: recipientsSet,
 			Msg:        msgText,
@@ -2538,8 +2550,13 @@ func (b *TelegramBrokerV2) handleCallbackQuery(ctx context.Context, cb *Callback
 		}
 
 		mapping, mErr := b.store.GetUserMapping(ctx, senderID)
-		if mErr == nil && mapping != nil && mapping.ScionEmail != "" {
-			sender = "user:" + mapping.ScionEmail
+		if mErr == nil && mapping != nil {
+			if mapping.ScionEmail != "" {
+				sender = "user:" + mapping.ScionEmail
+			}
+			if mapping.ScionUserID != "" {
+				senderID = mapping.ScionUserID
+			}
 		}
 	}
 

--- a/extras/scion-telegram/internal/telegram/broker_v2_test.go
+++ b/extras/scion-telegram/internal/telegram/broker_v2_test.go
@@ -745,6 +745,71 @@ func TestV2_HandleGroupMessage_UserMappingResolution(t *testing.T) {
 	assert.Equal(t, "456", deliveredMsg.SenderID)
 }
 
+// TestV2_HandleGroupMessage_SenderIDUsesHubUserID verifies that once a
+// Telegram user is registered (mapping.ScionUserID populated), the outbound
+// StructuredMessage.SenderID carries the Hub user UUID rather than the raw
+// Telegram numeric ID. The Hub's outbound-message reply-affinity lookup
+// (webchat_conversation_context) is keyed by Hub user ID; sending the raw
+// Telegram ID there means a registered user's reply-affinity never matches,
+// and the agent's next reply falls back to whatever channel that Hub user
+// last used elsewhere (e.g. the web dashboard) instead of Telegram.
+func TestV2_HandleGroupMessage_SenderIDUsesHubUserID(t *testing.T) {
+	tgSrv := newFakeTGServerV2(t)
+	hub := newFakeHubClient()
+	hub.agents["proj-1"] = []AgentInfo{{Slug: "coder"}}
+	b := newTestBrokerV2WithHub(t, tgSrv, hub)
+
+	ctx := context.Background()
+	require.NoError(t, b.store.SaveGroupLink(ctx, &GroupLink{
+		ChatID:       -200,
+		ProjectID:    "proj-1",
+		DefaultAgent: "coder",
+		LinkedAt:     time.Now().UTC(),
+		Active:       true,
+	}))
+	require.NoError(t, b.store.SaveProjectAgents(ctx, &ProjectAgents{
+		ProjectID:   "proj-1",
+		Agents:      []AgentInfo{{Slug: "coder"}},
+		RefreshedAt: time.Now(),
+	}))
+	require.NoError(t, b.store.SaveUserMapping(ctx, &TelegramUserMapping{
+		TelegramUserID: "456",
+		ScionEmail:     "alice@example.com",
+		ScionUserID:    "hub-user-uuid-alice",
+		LinkedAt:       time.Now().UTC(),
+	}))
+
+	var deliveredMsg *messages.StructuredMessage
+	done := make(chan struct{}, 1)
+	b.InboundHandler = func(_ string, msg *messages.StructuredMessage) {
+		deliveredMsg = msg
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}
+
+	b.handleGroupMessage(&TGMessage{
+		MessageID: 42,
+		From:      &TGUser{ID: 456, Username: "alice"},
+		Chat:      TGChat{ID: -200, Type: "group"},
+		Date:      time.Now().Unix(),
+		Text:      "@test_bot hi",
+		Entities: []MessageEntity{
+			{Type: "mention", Offset: 0, Length: 9},
+		},
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out")
+	}
+
+	assert.Equal(t, "user:alice@example.com", deliveredMsg.Sender)
+	assert.Equal(t, "hub-user-uuid-alice", deliveredMsg.SenderID)
+}
+
 func TestV2_HandleGroupMessage_ConversationContextSaved(t *testing.T) {
 	tgSrv := newFakeTGServerV2(t)
 	hub := newFakeHubClient()


### PR DESCRIPTION
Fixes #1231

## Summary

`handleGroupMessage` and `handleCallbackQuery` in
`extras/scion-telegram/internal/telegram/broker_v2.go` resolve a registered
Telegram user's Hub email for the outbound message's `Sender` display
string, but never resolve their Hub user ID for `SenderID` — it stays the
raw Telegram numeric ID even after a successful `/register` lookup, despite
`TelegramUserMapping` already storing `ScionUserID` for exactly this
purpose.

This breaks the Hub's reply-affinity routing
(`webchat_conversation_context`, keyed by Hub user UUID): an inbound
message records "last channel" under the raw Telegram numeric ID, while an
agent's outbound reply (resolved to a recipient by Hub UUID, e.g. via
#1229's agent-creator fallback) looks up affinity under a different key
entirely. The two never match, so a registered user's Telegram conversation
silently loses its "reply here" routing and falls back to whichever channel
that Hub user last used elsewhere — with zero errors surfaced anywhere in
the chain, making this very hard to spot without directly comparing the
`channel` field on inbound vs. outbound log lines.

## Fix

In `handleGroupMessage`, split the raw Telegram ID (`senderID`, still
needed for `ConversationContext.TelegramUserID`) from the resolved Hub ID
(`hubSenderID`, used for the outbound message's `SenderID`). In
`handleCallbackQuery`, `senderID` has no other use in that function, so it's
overwritten directly once resolved.

## Testing

- Added `TestV2_HandleGroupMessage_SenderIDUsesHubUserID` — registers a
  mapping with `ScionUserID` set, asserts the delivered
  `StructuredMessage.SenderID` is the Hub UUID rather than the raw Telegram
  ID.
- Existing `TestV2_HandleGroupMessage_UserMappingResolution` (mapping
  without `ScionUserID` set) still passes unchanged — confirms no
  regression when a mapping predates this field or doesn't have it
  populated.
- `TestV2_HandleGroupMessage_ConversationContextSaved` still passes —
  confirms `ConversationContext.TelegramUserID` correctly keeps using the
  raw Telegram ID, not the Hub UUID.
- `go build ./...` — clean.
- Full `go test ./...` for this module: only pre-existing, unrelated
  failures (`TestV2_DownloadTelegramFile_*`, `mkdir /home/scion: permission
  denied` — an environment path issue in the file-download tests, unrelated
  to sender/messaging logic touched here).

Found and fixed while root-causing why an agent's Telegram replies weren't
reaching the user even after #1230 fixed the Hub-side recipient-resolution
bug — see that PR's issue (#1229) for the first layer of this chain.