### PR TITLE
docs: nightly doc update Aug 20 (secret scope, project context)

### DIFF
--- a/docs-site/src/content/docs/hosted/user/messaging.md
+++ b/docs-site/src/content/docs/hosted/user/messaging.md
@@ -19,6 +19,10 @@ Scion features an interactive, top-level **Native Web Chat** interface in the We
 ### Core Layout & Navigation
 
 - **Project-Scoped Spaces & Shared Threads**: Chat is organized into distinct spaces scoped to specific Projects. Within a project-scoped space, users and agents participate in shared discussion threads, creating focused hubs of collaboration.
+- **Project Context Preservation (Dashboard ↔ Chat Toggle)**: When you switch between dashboard and chat modes using the navigation icons in the header, Scion automatically maintains your active project context to avoid losing your work state:
+  - **Dashboard → Chat**: Clicking the **Chat** icon while on a project-scoped dashboard page (e.g., `/projects/:id/...` or inside an agent view) takes you straight to that project's chat space (`/chat/space/:id`).
+  - **Chat → Dashboard**: Clicking the **Dashboard** icon while in a project chat space (`/chat/space/:id/...` or `/chat/:slug/...`) takes you directly back to that project's detail page (`/projects/:id`).
+  - **DMs / General Chat**: If there is no active project context (such as when in Direct Messages or bare `/chat`), the toggle falls back to the top-level dashboard `/`.
 - **Direct Messaging (DMs)**: In addition to collaborative project spaces, the chat interface supports robust 1-on-1 Direct Messages (DMs). This includes both **human-to-human (H2H)** communication between team members and **human-to-agent (H2A)** chats. DMs are structured as a "global pair"—a single, consolidated thread per participant pair.
 - **Members Sidebar, Presence & Typing**: A right-hand members sidebar lists all participants in the active project space or DM. This includes real-time online **presence indicators** (active, away, offline) and live **typing indicators** to show when a team member or agent is actively composing a message.
 - **The Thread Rail & Mobile Swipe Navigation**: A left-hand navigation sidebar lists all active chat spaces, threads, and DMs. On mobile viewports, the rail supports native **swipe gestures** for fluid, app-like drawer navigation.

--- a/docs-site/src/content/docs/hosted/user/secrets.md
+++ b/docs-site/src/content/docs/hosted/user/secrets.md
@@ -171,10 +171,15 @@ From inside an agent container, use the `sciontool secret` command suite:
     export API_KEY=$(sciontool secret get MY_API_KEY)
     ```
 
-*   **Set a Project Secret**: You can also write/update secrets from inside the container to persist credentials discovered or generated at runtime:
+*   **Set a Secret**: You can write/update secrets from inside the container to persist credentials discovered or generated at runtime. Secrets can be scoped to either the **project** (visible to all agents in the project) or the **user** (personal secrets visible only to your own agents):
     ```bash
+    # Set a project-scoped secret (default)
     sciontool secret set NEW_TOKEN "secret-value"
+
+    # Set a user-scoped (personal) secret
+    sciontool secret set MY_PERSONAL_TOKEN "token-xyz" --scope user
     ```
+    *Note: `--scope` accepts `project` (default) or `user`.*
 
 #### Using the Hub API Directly
 Under the hood, `sciontool` interacts with the Hub's agent-specific secrets API:
@@ -185,7 +190,7 @@ Under the hood, `sciontool` interacts with the Hub's agent-specific secrets API:
 
 #### Security & Audit Logging
 *   **Authentication**: API access is restricted to the running agent container. The agent must include its unique Hub-issued JWT (loaded from `SCION_HUB_TOKEN`) in the `Authorization: Bearer <token>` header of every request.
-*   **Authorization**: Agents are strictly bounded to their own project's secrets. They cannot access secrets in other projects, user-scoped secrets, or global Hub secrets unless explicitly shared via progeny policies (descendant access).
+*   **Authorization**: Agents are strictly bounded to their own project's secrets. They can also access user-scoped (personal) secrets belonging to their originating user (the user who kicked off the agent chain), which are resolved on the Hub via the agent JWT's `OriginUserID` (representing the root user of the ancestry chain, i.e., `Ancestry[0]`). Agents cannot access secrets in other projects, other users' secrets, or global Hub secrets unless explicitly shared via progeny policies (descendant access).
 *   **Audit Trail**: To ensure accountability, every runtime read and write operation is fully audited on the Hub. Successful and failed retrieval attempts log an audit event (`agent_secret_read`) identifying the calling agent, requested key, and status.
 
 ---

--- a/docs-site/src/content/docs/hosted/user/secrets.md
+++ b/docs-site/src/content/docs/hosted/user/secrets.md
@@ -190,7 +190,7 @@ Under the hood, `sciontool` interacts with the Hub's agent-specific secrets API:
 
 #### Security & Audit Logging
 *   **Authentication**: API access is restricted to the running agent container. The agent must include its unique Hub-issued JWT (loaded from `SCION_HUB_TOKEN`) in the `Authorization: Bearer <token>` header of every request.
-*   **Authorization**: Agents are strictly bounded to their own project's secrets. They can also access user-scoped (personal) secrets belonging to their originating user (the user who kicked off the agent chain), which are resolved on the Hub via the agent JWT's `OriginUserID` (representing the root user of the ancestry chain, i.e., `Ancestry[0]`). Agents cannot access secrets in other projects, other users' secrets, or global Hub secrets unless explicitly shared via progeny policies (descendant access).
+*   **Authorization**: Agents are strictly bounded to their own project's secrets. They can also access user-scoped (personal) secrets belonging to their originating user (the user who kicked off the agent chain), which are resolved on the Hub via the agent JWT's `OriginUserID` (the user who originally started the agent chain). Agents cannot access secrets in other projects, other users' secrets, or global Hub secrets unless explicitly shared via progeny policies (descendant access).
 *   **Audit Trail**: To ensure accountability, every runtime read and write operation is fully audited on the Hub. Successful and failed retrieval attempts log an audit event (`agent_secret_read`) identifying the calling agent, requested key, and status.
 
 ---

--- a/docs-site/src/content/docs/local/agent-credentials.md
+++ b/docs-site/src/content/docs/local/agent-credentials.md
@@ -286,31 +286,38 @@ present or the agent fails to start with an actionable error.
 ## Capturing Credentials from a Running Agent
 
 For harnesses that authenticate through an interactive login (rather than a plain API key), you
-can capture the credentials an agent produced and store them as a project secret, so future
+can capture the credentials an agent produced and store them as a secret, so future
 agents start pre-authenticated instead of dropping to no-auth.
 
-After logging in interactively inside the agent (via `scion attach` or the terminal page), run the
-harness bundle's capture script from inside the container:
+After logging in interactively inside the agent (via `scion attach` or the terminal page), you can run the credential capture process.
 
-```bash
-python3 ~/.scion/harness/capture_auth.py
-```
+### Secret Scope Selection
+
+Credential capture supports scoping captured credentials to either the **project** (visible to all agents in the project) or the **user** (personal secrets visible only to your own agents).
+
+*   **In the Web UI**: Clicking the **Capture Auth** button triggers an interactive dialog allowing you to choose between **Project** scope and **User** scope before executing the capture script.
+*   **Via CLI/Script**: The `capture_auth.py` script accepts a `--scope` argument (`project` or `user`). If omitted, it defaults to `project` for backward compatibility:
+    ```bash
+    # Capture credentials to the project scope (default)
+    python3 ~/.scion/harness/capture_auth.py
+
+    # Capture credentials to the user scope (personal secret)
+    python3 ~/.scion/harness/capture_auth.py --scope user
+    ```
 
 ### How capture works
 
 The host generates a capture manifest (`inputs/capture-auth-config.json`) from the harness's
 `auth.types.*.required_files` declarations — every credential file the harness can authenticate
 with that has a well-known path. `capture_auth.py` reads that manifest, locates each file the
-harness just wrote, and stores it as a project secret by shelling out to
-`sciontool secret set <key> @<file> --type <type> --target <path>`.
+harness just wrote, and stores it as a secret by shelling out to
+`sciontool secret set <key> @<file> --type <type> --target <path> --scope <project|user>`.
 
 - **What is captured** — the harness's credential file(s). For example, Codex captures
   `~/.codex/auth.json` as the `CODEX_AUTH` file secret; Gemini captures
   `~/.gemini/oauth_creds.json` as `GEMINI_OAUTH_CREDS`. See the table in
   [The Three-Stage Auth Workflow](#the-three-stage-auth-workflow).
-- **Where it goes** — into the project **secret store** (the Hub's secret store in Hub mode). This
-  is why captured credentials survive container restarts: the file lives in the store, not in the
-  ephemeral container, and the host re-stages it on every subsequent start.
+- **Where it goes** — into the **secret store** (the Hub's secret store in Hub mode), scoped either to the project or the originating user. This is why captured credentials survive container restarts: the file lives in the store, not in the ephemeral container, and the host re-stages it on every subsequent start.
 - **Harness-specific extras** — some bundles override the generic flow:
   - **Claude** additionally scans the terminal scrollback for the `sk-ant-oat…` token printed by
     `claude setup-token` and stores it as the `CLAUDE_CODE_OAUTH_TOKEN` environment secret.
@@ -337,7 +344,7 @@ python3 ~/.scion/harness/capture_auth.py --force
 
 :::note
 There is currently no `scion auth capture` CLI wrapper; capture is performed by running
-`capture_auth.py` inside the agent, which delegates to `sciontool secret set`.
+`capture_auth.py` inside the agent (or clicking the button in the Web UI), which delegates to `sciontool secret set`.
 :::
 
 ## Persistence Across Restarts

--- a/docs-site/src/content/docs/workstation/dashboard.md
+++ b/docs-site/src/content/docs/workstation/dashboard.md
@@ -21,6 +21,10 @@ The dashboard features an integrated notification framework with real-time SSE d
 ### Native Web Chat
 When enabled via the `web.native_chat` feature flag, the dashboard includes a top-level **Native Web Chat** workspace (a fourth ShellType in the SPA). It offers a rich interface for direct communication and coordination with your running agents and team.
 - **Project-Scoped Spaces & Shared Threads**: Conversations are organized into distinct spaces scoped to specific Projects. Within these spaces, users and agents can collaborate on shared discussion threads.
+- **Project Context Preservation (Dashboard ↔ Chat Toggle)**: When you switch between dashboard and chat modes using the header buttons, the system maintains your active project context so you do not lose your place:
+  - **Dashboard → Chat**: Clicking the **Chat** icon while on a project-scoped dashboard page (e.g., `/projects/:id/...`) takes you straight to that project's chat space (`/chat/space/:id`).
+  - **Chat → Dashboard**: Clicking the **Dashboard** icon while in a project chat space (`/chat/space/:id/...` or `/chat/:slug/...`) takes you directly back to that project's detail page (`/projects/:id`).
+  - **DMs / General Chat**: If there is no active project context (such as when in Direct Messages or bare `/chat`), the view defaults back to the top-level dashboard `/`.
 - **Direct Messages (DMs)**: Start 1-on-1 direct messages covering both human-to-human (H2H) and human-to-agent (H2A) communication, consolidated as a single "global pair" thread per pair.
 - **Members Sidebar, Presence & Typing**: A right-hand sidebar displays active project members, showcasing real-time online presence status and typing indicators.
 - **Composer Default-Agent Disambiguation**: When sending messages in spaces with multiple active agents, the composer helps resolve which agent is targeted if no explicit mention is used.


### PR DESCRIPTION
Nightly documentation update for Aug 19 changelog.

- secrets.md: project vs user secret scope selection in capture auth
- agent-credentials.md: capture auth --scope flag and scope dialog
- dashboard.md: project context preservation in chat toggle
- messaging.md: project context retention in chat navigation

Cherry-picked from doc-writer agent du-0819.