### PR TITLE
fix: update stale scope-precedence comments after #1227

### DIFF
--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -1640,7 +1640,7 @@ func (d *HTTPAgentDispatcher) resolveAsNeededForKeys(
 			}
 		} else {
 			// Iterate in reverse: resolved is ordered lowest-precedence first
-			// (hub < user < project < runtime_broker), so walking backwards
+			// (runtime_broker < hub < project < user), so walking backwards
 			// lets higher-precedence secrets win.
 			for i := len(resolved) - 1; i >= 0; i-- {
 				sv := resolved[i]

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -2535,27 +2535,10 @@ func (d *HTTPAgentDispatcher) deferredLifecycle(
 // resolveSecrets queries secrets from all applicable scopes and merges them
 // into a flat list. Higher scopes override lower:
 //
-//	hub  <  user  <  project  <  runtime_broker
+//	runtime_broker  <  hub  <  project  <  user
 //
-// 🔴 SECRETS AND ENV VARS DO NOT USE THE SAME ORDER. Compare
-// envScopePrecedence above: env vars rank runtime_broker LOWEST and user
-// HIGHEST; secrets rank them the other way round, on both axes.
-//
-// DO NOT READ THIS COMMENT AS DOCUMENTING A DESIGNED DIFFERENCE. NOBODY HAS
-// ESTABLISHED THAT THE DIVERGENCE IS INTENTIONAL. It is FILED, as issue #624,
-// and open. What this comment records is only what the code does today: the
-// secret order is implemented independently in pkg/secret (both backends build
-// the scope list in this order and merge last-wins, and scopePrecedence ranks
-// it numerically). So editing this comment to match the env one would make it
-// describe code that does not exist — the divergence has to be closed in
-// pkg/secret, under #624, or not at all.
-//
-// Phase 10 widened the gap rather than creating it: demoting runtime_broker for
-// env vars added the second axis. That makes the pull toward "harmonising" the
-// two stronger, and it is exactly the change that must not be made here.
-//
-// The hub rung was missing from this comment before Phase 10; both backends
-// have always queried it as the lowest scope.
+// This matches envScopePrecedence (see above). The divergence previously
+// tracked in issue #624 was corrected in PR #1227.
 func (d *HTTPAgentDispatcher) resolveSecrets(ctx context.Context, agent *store.Agent) ([]ResolvedSecret, error) {
 	if d.secretBackend == nil {
 		if d.debug {

--- a/pkg/hub/resolve_secrets_test.go
+++ b/pkg/hub/resolve_secrets_test.go
@@ -50,7 +50,7 @@ func TestResolveSecrets(t *testing.T) {
 		ScopeID:        tid("project-1"),
 		InjectionMode:  store.InjectionModeAlways,
 	}
-	// Project-level override of user API_KEY
+	// Project-level API_KEY (same key as user; user scope wins)
 	projectOverride := &store.Secret{
 		ID:             tid("s3"),
 		Key:            "API_KEY",

--- a/pkg/secret/gcpbackend_test.go
+++ b/pkg/secret/gcpbackend_test.go
@@ -405,7 +405,7 @@ func TestGCPBackend_Resolve(t *testing.T) {
 		ScopeID:    "user-1",
 	})
 
-	// Project-level override
+	// Project-level value for the same key (user scope wins)
 	_, _, _ = backend.Set(ctx, &SetSecretInput{
 		Name:       "API_KEY",
 		Value:      "grove-api-key",

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -142,7 +142,7 @@ type SecretBackend interface {
 	GetMeta(ctx context.Context, name, scope, scopeID string) (*SecretMeta, error)
 
 	// Resolve collects and merges secrets from all applicable scopes for an agent.
-	// Scopes are resolved in order: user < project < runtime_broker (later overrides earlier).
+	// Scopes are resolved in order, lowest first: runtime_broker < hub < project < user.
 	// The opts parameter is optional; pass nil for the current behavior.
 	// When opts.AgentAncestry is present, user-scoped secrets marked allowProgeny
 	// whose creator appears in the ancestry chain are included in the result.


### PR DESCRIPTION
Updates five stale scope-precedence comments across pkg/hub and pkg/secret that still documented the old inverted order after PR #1227 corrected secret scope precedence. All comment-only, no behavioral changes. Ref: ptone/scion#1180