### PR TITLE
fix: exempt git credentials from NoAuth secret suppression

### DIFF
--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -1259,6 +1259,10 @@ func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Ag
 // runtime by the broker's resolveAuthEnvOverlay from settings.yaml or GCP
 // metadata — credentials the Hub cannot see at preflight time (#1165).
 func (s *Server) isAuthTypeSatisfied(ctx context.Context, agent *store.Agent, authMeta *config.HarnessAuthMetadata, authType string, gcpSAAssigned bool) (bool, error) {
+	if authMeta == nil {
+		return false, nil
+	}
+
 	// Determine whether this is a GCP-backed auth type whose runtime
 	// environment will be provided by the broker/GCP metadata server.
 	gcpRuntime := false

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -1251,15 +1251,42 @@ func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Ag
 // for a single auth type (as declared in authMeta) are met. Unlike the broker
 // preflight (which only enforces required: true files), this checks ALL listed
 // files so the hub can determine whether the auth type is viable.
+//
+// When gcpSAAssigned is true and the auth type is GCP-backed (has files with
+// SkippedWhenGCPServiceAccountAssigned), env-var requirements are also treated
+// as satisfied. This is because GCP-backed auth types (e.g. vertex-ai) get
+// their env vars (GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_REGION) injected at
+// runtime by the broker's resolveAuthEnvOverlay from settings.yaml or GCP
+// metadata — credentials the Hub cannot see at preflight time (#1165).
 func (s *Server) isAuthTypeSatisfied(ctx context.Context, agent *store.Agent, authMeta *config.HarnessAuthMetadata, authType string, gcpSAAssigned bool) (bool, error) {
-	keyGroups := harness.RequiredAuthEnvKeysFromConfig(authMeta, authType)
-	for _, group := range keyGroups {
-		found, err := s.hasAnyKey(ctx, agent, group)
-		if err != nil {
-			return false, err
+	// Determine whether this is a GCP-backed auth type whose runtime
+	// environment will be provided by the broker/GCP metadata server.
+	gcpRuntime := false
+	if gcpSAAssigned {
+		if t, ok := authMeta.Types[authType]; ok {
+			for _, f := range t.RequiredFiles {
+				if f.SkippedWhenGCPServiceAccountAssigned {
+					gcpRuntime = true
+					break
+				}
+			}
 		}
-		if !found {
-			return false, nil
+	}
+
+	// When gcpRuntime is true, skip the env-var check: the broker's
+	// resolveAuthEnvOverlay and GCP metadata will provide the required
+	// env vars at runtime, but they are invisible to the Hub's storage-only
+	// hasAnyKey check, causing a false NoAuth trigger.
+	if !gcpRuntime {
+		keyGroups := harness.RequiredAuthEnvKeysFromConfig(authMeta, authType)
+		for _, group := range keyGroups {
+			found, err := s.hasAnyKey(ctx, agent, group)
+			if err != nil {
+				return false, err
+			}
+			if !found {
+				return false, nil
+			}
 		}
 	}
 

--- a/pkg/hub/handlers_agent_create_helpers_noauth_test.go
+++ b/pkg/hub/handlers_agent_create_helpers_noauth_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// TestIsAuthTypeSatisfied_GCPServiceAccountSkipsEnvCheck verifies that when a
+// verified GCP service account is assigned, vertex-ai env requirements
+// (GOOGLE_CLOUD_PROJECT, GOOGLE_CLOUD_REGION) are treated as satisfied because
+// the broker's resolveAuthEnvOverlay and GCP metadata will provide them at
+// runtime. This prevents false NoAuth triggers for vertex-ai deployments (#1165).
+func TestIsAuthTypeSatisfied_GCPServiceAccountSkipsEnvCheck(t *testing.T) {
+	srv, memStore := testServer(t)
+	ctx := context.Background()
+
+	projectID := tid("gcp-proj-1")
+	project := &store.Project{
+		ID:   projectID,
+		Name: "vertex-test-project",
+		Slug: "vertex-test-project",
+	}
+	if err := memStore.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject failed: %v", err)
+	}
+
+	// Register a verified GCP service account for the project
+	sa := &store.GCPServiceAccount{
+		ID:                 tid("sa-1"),
+		Scope:              "project",
+		ScopeID:            projectID,
+		Email:              "agent@gcp-project.iam.gserviceaccount.com",
+		ProjectID:          "gcp-project",
+		Verified:           true,
+		VerifiedAt:         time.Now(),
+		VerificationStatus: "verified",
+		CreatedBy:          tid("user-1"),
+		CreatedAt:          time.Now(),
+	}
+	if err := memStore.CreateGCPServiceAccount(ctx, sa); err != nil {
+		t.Fatalf("CreateGCPServiceAccount failed: %v", err)
+	}
+
+	// Simulate the Claude harness config for vertex-ai
+	authMeta := &config.HarnessAuthMetadata{
+		Types: map[string]api.HarnessAuthTypeMetadata{
+			"vertex-ai": {
+				RequiredEnv: []api.HarnessAuthEnvRequirement{
+					{AnyOf: []string{"GOOGLE_CLOUD_PROJECT"}},
+					{AnyOf: []string{"GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"}},
+				},
+				RequiredFiles: []api.HarnessAuthFileRequirement{
+					{
+						Name:                                 "gcloud-adc",
+						Type:                                 "file",
+						Field:                                "GoogleAppCredentials",
+						AlternativeEnvKeys:                   []string{"GOOGLE_APPLICATION_CREDENTIALS"},
+						SkippedWhenGCPServiceAccountAssigned: true,
+						Required:                             true,
+					},
+				},
+			},
+			"api-key": {
+				RequiredEnv: []api.HarnessAuthEnvRequirement{
+					{AnyOf: []string{"ANTHROPIC_API_KEY"}},
+				},
+			},
+		},
+	}
+
+	t.Run("vertex-ai satisfied when GCP SA assigned even without Hub-stored env vars", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:            tid("agent-vertex"),
+			Name:          "vertex-agent",
+			Slug:          "vertex-agent",
+			OwnerID:       tid("user-1"),
+			ProjectID:     projectID,
+			AppliedConfig: &store.AgentAppliedConfig{},
+		}
+
+		// With GCP SA assigned, vertex-ai should be satisfied even though
+		// GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_REGION are not in Hub storage.
+		// They will be provided at runtime by broker env overlay / GCP metadata.
+		satisfied, err := srv.isAuthTypeSatisfied(ctx, agent, authMeta, "vertex-ai", true)
+		if err != nil {
+			t.Fatalf("isAuthTypeSatisfied failed: %v", err)
+		}
+		if !satisfied {
+			t.Error("expected vertex-ai to be satisfied when GCP SA is assigned (env vars come from runtime)")
+		}
+	})
+
+	t.Run("vertex-ai not satisfied without GCP SA and without Hub-stored env vars", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:            tid("agent-vertex-nosa"),
+			Name:          "vertex-no-sa",
+			Slug:          "vertex-no-sa",
+			OwnerID:       tid("user-1"),
+			ProjectID:     projectID,
+			AppliedConfig: &store.AgentAppliedConfig{},
+		}
+
+		// Without GCP SA, vertex-ai should not be satisfied because
+		// GOOGLE_CLOUD_PROJECT is not in Hub storage.
+		satisfied, err := srv.isAuthTypeSatisfied(ctx, agent, authMeta, "vertex-ai", false)
+		if err != nil {
+			t.Fatalf("isAuthTypeSatisfied failed: %v", err)
+		}
+		if satisfied {
+			t.Error("expected vertex-ai to NOT be satisfied without GCP SA and without Hub-stored env vars")
+		}
+	})
+
+	t.Run("api-key not affected by GCP SA (non-GCP auth type)", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:            tid("agent-apikey-gcp"),
+			Name:          "apikey-gcp",
+			Slug:          "apikey-gcp",
+			OwnerID:       tid("user-1"),
+			ProjectID:     projectID,
+			AppliedConfig: &store.AgentAppliedConfig{},
+		}
+
+		// api-key has no files with SkippedWhenGCPServiceAccountAssigned,
+		// so GCP SA should not affect its env-var check.
+		satisfied, err := srv.isAuthTypeSatisfied(ctx, agent, authMeta, "api-key", true)
+		if err != nil {
+			t.Fatalf("isAuthTypeSatisfied failed: %v", err)
+		}
+		if satisfied {
+			t.Error("expected api-key to NOT be satisfied without ANTHROPIC_API_KEY, even with GCP SA")
+		}
+	})
+
+	t.Run("hasRequiredAuthCredentials returns true for vertex-ai with GCP SA", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:            tid("agent-hasreq"),
+			Name:          "hasreq-vertex",
+			Slug:          "hasreq-vertex",
+			OwnerID:       tid("user-1"),
+			ProjectID:     projectID,
+			AppliedConfig: &store.AgentAppliedConfig{},
+		}
+
+		// When iterating all auth types, vertex-ai should be satisfied
+		// because of the GCP SA, preventing false NoAuth fallback.
+		hasCreds, err := srv.hasRequiredAuthCredentials(ctx, agent, "claude", authMeta)
+		if err != nil {
+			t.Fatalf("hasRequiredAuthCredentials failed: %v", err)
+		}
+		if !hasCreds {
+			t.Error("expected hasRequiredAuthCredentials to return true — vertex-ai should be satisfied with GCP SA")
+		}
+	})
+}

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -625,6 +625,29 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 						"agent_id", agent.ID, "project_id", agent.ProjectID)
 				}
 			}
+
+			// Fall back to the creating user's profile-level GITHUB_TOKEN,
+			// mirroring the cascade in resolveCloneToken. Users who store
+			// GITHUB_TOKEN at user/profile scope only (no project-scoped token)
+			// would otherwise still hit the NoAuth suppression bug (#1165).
+			if (ghSecret == nil || ghSecret.Value == "") && agent.OwnerID != "" {
+				ghSecret, err = d.secretBackend.Get(ctx, "GITHUB_TOKEN", secret.ScopeUser, agent.OwnerID)
+				if err != nil {
+					if d.debug {
+						d.log.Debug("NoAuth: failed to resolve GITHUB_TOKEN from user secrets",
+							"agent_id", agent.ID, "owner_id", agent.OwnerID, "error", err)
+					}
+				} else if ghSecret != nil && ghSecret.Value != "" {
+					if req.ResolvedEnv == nil {
+						req.ResolvedEnv = make(map[string]string)
+					}
+					req.ResolvedEnv["GITHUB_TOKEN"] = ghSecret.Value
+					if d.debug {
+						d.log.Debug("NoAuth: resolved GITHUB_TOKEN from user secrets for git operations",
+							"agent_id", agent.ID, "owner_id", agent.OwnerID)
+					}
+				}
+			}
 		}
 	}
 

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -616,9 +616,6 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 						"agent_id", agent.ID, "project_id", agent.ProjectID, "error", err)
 				}
 			} else if ghSecret != nil && ghSecret.Value != "" {
-				if req.ResolvedEnv == nil {
-					req.ResolvedEnv = make(map[string]string)
-				}
 				req.ResolvedEnv["GITHUB_TOKEN"] = ghSecret.Value
 				if d.debug {
 					d.log.Debug("NoAuth: resolved GITHUB_TOKEN from project secrets for git operations",
@@ -638,9 +635,6 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 							"agent_id", agent.ID, "owner_id", agent.OwnerID, "error", err)
 					}
 				} else if ghSecret != nil && ghSecret.Value != "" {
-					if req.ResolvedEnv == nil {
-						req.ResolvedEnv = make(map[string]string)
-					}
 					req.ResolvedEnv["GITHUB_TOKEN"] = ghSecret.Value
 					if d.debug {
 						d.log.Debug("NoAuth: resolved GITHUB_TOKEN from user secrets for git operations",

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -592,12 +592,39 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 	}
 
 	// Propagate no-auth intent from the agent's applied config.
+	// NoAuth suppresses LLM-auth secrets (API keys, credential files) but must
+	// NOT suppress git-related credentials (GITHUB_TOKEN) which are needed for
+	// repository clone/pull operations regardless of LLM auth status.
 	noAuth := agent.AppliedConfig != nil && agent.AppliedConfig.NoAuth
 	if noAuth {
 		req.NoAuth = true
 		req.ResolvedSecrets = nil
 		if d.debug {
 			d.log.Debug("NoAuth enabled: skipping secret resolution", "agent_id", agent.ID)
+		}
+
+		// Exempt git credentials from NoAuth suppression. GITHUB_TOKEN is
+		// stored in the project secrets table but is unrelated to LLM auth —
+		// it enables repository clone/pull in clone-per-agent workspaces.
+		// Without this, NoAuth blanket-suppresses all secrets including
+		// GITHUB_TOKEN, causing git clone failures (#1165).
+		if agent.ProjectID != "" && d.secretBackend != nil {
+			ghSecret, err := d.secretBackend.Get(ctx, "GITHUB_TOKEN", secret.ScopeProject, agent.ProjectID)
+			if err != nil {
+				if d.debug {
+					d.log.Debug("NoAuth: failed to resolve GITHUB_TOKEN from project secrets",
+						"agent_id", agent.ID, "project_id", agent.ProjectID, "error", err)
+				}
+			} else if ghSecret != nil && ghSecret.Value != "" {
+				if req.ResolvedEnv == nil {
+					req.ResolvedEnv = make(map[string]string)
+				}
+				req.ResolvedEnv["GITHUB_TOKEN"] = ghSecret.Value
+				if d.debug {
+					d.log.Debug("NoAuth: resolved GITHUB_TOKEN from project secrets for git operations",
+						"agent_id", agent.ID, "project_id", agent.ProjectID)
+				}
+			}
 		}
 	}
 

--- a/pkg/hub/httpdispatcher_noauth_github_token_test.go
+++ b/pkg/hub/httpdispatcher_noauth_github_token_test.go
@@ -31,11 +31,27 @@ import (
 type mockGitTokenSecretBackend struct {
 	secrets      []secret.SecretWithValue
 	getResponses map[string]*secret.SecretWithValue
-	getCalls     []string // track which secrets were fetched via Get
+	// getScopedResponses maps "name:scope" to a response, allowing
+	// scope-aware lookups (e.g. project vs user scope for GITHUB_TOKEN).
+	// When set for a key, it takes precedence over getResponses.
+	getScopedResponses map[string]*secret.SecretWithValue
+	getCalls           []getCall // track which secrets were fetched via Get
+}
+
+type getCall struct {
+	Name    string
+	Scope   string
+	ScopeID string
 }
 
 func (m *mockGitTokenSecretBackend) Get(_ context.Context, name, scope, scopeID string) (*secret.SecretWithValue, error) {
-	m.getCalls = append(m.getCalls, name)
+	m.getCalls = append(m.getCalls, getCall{Name: name, Scope: scope, ScopeID: scopeID})
+	// Check scope-specific responses first
+	if m.getScopedResponses != nil {
+		if sv, ok := m.getScopedResponses[name+":"+scope]; ok {
+			return sv, nil
+		}
+	}
 	if sv, ok := m.getResponses[name]; ok {
 		return sv, nil
 	}
@@ -165,10 +181,81 @@ func TestBuildCreateRequest_NoAuth_GitHubTokenSurvives(t *testing.T) {
 
 		// Without a project, Get should not have been called for GITHUB_TOKEN
 		for _, call := range backend.getCalls {
-			if call == "GITHUB_TOKEN" {
+			if call.Name == "GITHUB_TOKEN" {
 				t.Error("expected no GITHUB_TOKEN Get call when agent has no project")
 			}
 		}
+	})
+
+	t.Run("NoAuth=true falls back to user-scope GITHUB_TOKEN when project scope is empty", func(t *testing.T) {
+		userGHTokenValue := "ghp_user_profile_token_67890"
+
+		// Backend with no project-scope GITHUB_TOKEN but a user-scope one
+		userScopeBackend := &mockGitTokenSecretBackend{
+			secrets: []secret.SecretWithValue{
+				{SecretMeta: secret.SecretMeta{Name: "API_KEY", SecretType: "environment", Target: "API_KEY"}, Value: apiKeyValue},
+			},
+			getScopedResponses: map[string]*secret.SecretWithValue{
+				"GITHUB_TOKEN:" + secret.ScopeUser: {
+					SecretMeta: secret.SecretMeta{
+						Name:       "GITHUB_TOKEN",
+						SecretType: "environment",
+						Target:     "GITHUB_TOKEN",
+						Scope:      secret.ScopeUser,
+					},
+					Value: userGHTokenValue,
+				},
+			},
+		}
+		dispatcher.SetSecretBackend(userScopeBackend)
+
+		agent := &store.Agent{
+			ID:              tid("agent-noauth-user-gh"),
+			Name:            "noauth-user-gh-agent",
+			Slug:            "noauth-user-gh-agent",
+			OwnerID:         tid("user-1"),
+			ProjectID:       tid("project-1"),
+			RuntimeBrokerID: tid("host-1"),
+			AppliedConfig:   &store.AgentAppliedConfig{NoAuth: true},
+		}
+
+		req, err := dispatcher.buildCreateRequest(ctx, agent, "TestNoAuthUserScopeGitToken")
+		if err != nil {
+			t.Fatalf("buildCreateRequest failed: %v", err)
+		}
+
+		if !req.NoAuth {
+			t.Error("expected req.NoAuth to be true")
+		}
+
+		// ResolvedSecrets must still be nil (NoAuth suppresses LLM secrets)
+		if len(req.ResolvedSecrets) != 0 {
+			t.Errorf("expected no resolved secrets with NoAuth, got %d", len(req.ResolvedSecrets))
+		}
+
+		// GITHUB_TOKEN must be resolved from user scope
+		if got := req.ResolvedEnv["GITHUB_TOKEN"]; got != userGHTokenValue {
+			t.Errorf("expected GITHUB_TOKEN=%q in ResolvedEnv (user-scope fallback), got %q", userGHTokenValue, got)
+		}
+
+		// Verify both scopes were tried: project first, then user
+		if len(userScopeBackend.getCalls) < 2 {
+			t.Fatalf("expected at least 2 Get calls, got %d", len(userScopeBackend.getCalls))
+		}
+		if userScopeBackend.getCalls[0].Scope != secret.ScopeProject {
+			t.Errorf("expected first Get call to be project scope, got %q", userScopeBackend.getCalls[0].Scope)
+		}
+		if userScopeBackend.getCalls[1].Scope != secret.ScopeUser {
+			t.Errorf("expected second Get call to be user scope, got %q", userScopeBackend.getCalls[1].Scope)
+		}
+
+		// LLM API keys must NOT be in ResolvedEnv
+		if v, ok := req.ResolvedEnv["API_KEY"]; ok && v != "" {
+			t.Errorf("expected API_KEY to not be injected into ResolvedEnv with NoAuth, got %q", v)
+		}
+
+		// Restore original backend for remaining tests
+		dispatcher.SetSecretBackend(backend)
 	})
 
 	t.Run("NoAuth=false resolves secrets normally including GITHUB_TOKEN", func(t *testing.T) {

--- a/pkg/hub/httpdispatcher_noauth_github_token_test.go
+++ b/pkg/hub/httpdispatcher_noauth_github_token_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// mockGitTokenSecretBackend supports both Resolve (for normal secret resolution)
+// and Get (for the GITHUB_TOKEN exemption under NoAuth). It simulates a project
+// with GITHUB_TOKEN stored as a project-scoped secret alongside LLM auth secrets.
+type mockGitTokenSecretBackend struct {
+	secrets      []secret.SecretWithValue
+	getResponses map[string]*secret.SecretWithValue
+	getCalls     []string // track which secrets were fetched via Get
+}
+
+func (m *mockGitTokenSecretBackend) Get(_ context.Context, name, scope, scopeID string) (*secret.SecretWithValue, error) {
+	m.getCalls = append(m.getCalls, name)
+	if sv, ok := m.getResponses[name]; ok {
+		return sv, nil
+	}
+	return nil, nil
+}
+
+func (m *mockGitTokenSecretBackend) Set(_ context.Context, _ *secret.SetSecretInput) (bool, *secret.SecretMeta, error) {
+	return false, nil, nil
+}
+
+func (m *mockGitTokenSecretBackend) Delete(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func (m *mockGitTokenSecretBackend) List(_ context.Context, _ secret.Filter) ([]secret.SecretMeta, error) {
+	return nil, nil
+}
+
+func (m *mockGitTokenSecretBackend) GetMeta(_ context.Context, _, _, _ string) (*secret.SecretMeta, error) {
+	return nil, nil
+}
+
+func (m *mockGitTokenSecretBackend) Resolve(_ context.Context, _, _, _ string, _ *secret.ResolveOpts) ([]secret.SecretWithValue, error) {
+	return m.secrets, nil
+}
+
+func (m *mockGitTokenSecretBackend) HubID() string { return "test-hub" }
+
+func TestBuildCreateRequest_NoAuth_GitHubTokenSurvives(t *testing.T) {
+	ctx := context.Background()
+	memStore := createTestStore(t)
+
+	broker := &store.RuntimeBroker{
+		ID:       tid("host-1"),
+		Name:     "test-host",
+		Slug:     "test-host",
+		Endpoint: "http://localhost:9800",
+		Status:   store.BrokerStatusOnline,
+	}
+	if err := memStore.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create runtime broker: %v", err)
+	}
+
+	mockClient := &mockRuntimeBrokerClient{}
+	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
+
+	ghTokenValue := "ghp_test_pat_token_12345"
+	apiKeyValue := "sk-ant-api-key-secret"
+
+	backend := &mockGitTokenSecretBackend{
+		secrets: []secret.SecretWithValue{
+			{SecretMeta: secret.SecretMeta{Name: "CLAUDE_AUTH", SecretType: "file", Target: "~/.claude/.credentials.json"}, Value: "secret-data"},
+			{SecretMeta: secret.SecretMeta{Name: "API_KEY", SecretType: "environment", Target: "API_KEY"}, Value: apiKeyValue},
+		},
+		getResponses: map[string]*secret.SecretWithValue{
+			"GITHUB_TOKEN": {
+				SecretMeta: secret.SecretMeta{
+					Name:       "GITHUB_TOKEN",
+					SecretType: "environment",
+					Target:     "GITHUB_TOKEN",
+					Scope:      secret.ScopeProject,
+				},
+				Value: ghTokenValue,
+			},
+		},
+	}
+	dispatcher.SetSecretBackend(backend)
+
+	t.Run("NoAuth=true preserves GITHUB_TOKEN in ResolvedEnv", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:              tid("agent-noauth-git"),
+			Name:            "noauth-git-agent",
+			Slug:            "noauth-git-agent",
+			OwnerID:         tid("user-1"),
+			ProjectID:       tid("project-1"),
+			RuntimeBrokerID: tid("host-1"),
+			AppliedConfig:   &store.AgentAppliedConfig{NoAuth: true},
+		}
+
+		req, err := dispatcher.buildCreateRequest(ctx, agent, "TestNoAuthGitToken")
+		if err != nil {
+			t.Fatalf("buildCreateRequest failed: %v", err)
+		}
+
+		// NoAuth must be set
+		if !req.NoAuth {
+			t.Error("expected req.NoAuth to be true")
+		}
+
+		// ResolvedSecrets must still be nil (NoAuth suppresses LLM secrets)
+		if len(req.ResolvedSecrets) != 0 {
+			t.Errorf("expected no resolved secrets with NoAuth, got %d", len(req.ResolvedSecrets))
+		}
+
+		// GITHUB_TOKEN must survive in ResolvedEnv for git operations
+		if got := req.ResolvedEnv["GITHUB_TOKEN"]; got != ghTokenValue {
+			t.Errorf("expected GITHUB_TOKEN=%q in ResolvedEnv, got %q", ghTokenValue, got)
+		}
+
+		// LLM API keys must NOT be injected into ResolvedEnv (NoAuth suppression)
+		if v, ok := req.ResolvedEnv["API_KEY"]; ok && v != "" {
+			t.Errorf("expected API_KEY to not be injected into ResolvedEnv with NoAuth, got %q", v)
+		}
+	})
+
+	t.Run("NoAuth=true without project does not attempt GITHUB_TOKEN resolution", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:              tid("agent-noauth-noproj"),
+			Name:            "noauth-no-project",
+			Slug:            "noauth-no-project",
+			OwnerID:         tid("user-1"),
+			ProjectID:       "", // No project
+			RuntimeBrokerID: tid("host-1"),
+			AppliedConfig:   &store.AgentAppliedConfig{NoAuth: true},
+		}
+
+		backend.getCalls = nil // reset
+
+		req, err := dispatcher.buildCreateRequest(ctx, agent, "TestNoAuthNoProject")
+		if err != nil {
+			t.Fatalf("buildCreateRequest failed: %v", err)
+		}
+
+		if !req.NoAuth {
+			t.Error("expected req.NoAuth to be true")
+		}
+
+		// Without a project, Get should not have been called for GITHUB_TOKEN
+		for _, call := range backend.getCalls {
+			if call == "GITHUB_TOKEN" {
+				t.Error("expected no GITHUB_TOKEN Get call when agent has no project")
+			}
+		}
+	})
+
+	t.Run("NoAuth=false resolves secrets normally including GITHUB_TOKEN", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:              tid("agent-auth-git"),
+			Name:            "auth-git-agent",
+			Slug:            "auth-git-agent",
+			OwnerID:         tid("user-1"),
+			ProjectID:       tid("project-1"),
+			RuntimeBrokerID: tid("host-1"),
+			AppliedConfig:   &store.AgentAppliedConfig{},
+		}
+
+		req, err := dispatcher.buildCreateRequest(ctx, agent, "TestAuthGitToken")
+		if err != nil {
+			t.Fatalf("buildCreateRequest failed: %v", err)
+		}
+
+		if req.NoAuth {
+			t.Error("expected req.NoAuth to be false")
+		}
+
+		// Secrets should be resolved normally
+		if len(req.ResolvedSecrets) != 2 {
+			t.Errorf("expected 2 resolved secrets, got %d", len(req.ResolvedSecrets))
+		}
+
+		// API_KEY env-type secret should be in ResolvedEnv
+		if got := req.ResolvedEnv["API_KEY"]; got != apiKeyValue {
+			t.Errorf("expected API_KEY=%q in ResolvedEnv, got %q", apiKeyValue, got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

When NoAuth=true (auto-fallback for missing LLM credentials), buildCreateRequest blanket-suppressed ALL secrets including GITHUB_TOKEN, causing git clone failures in clone-per-agent workspaces.

- Primary fix: After NoAuth sets ResolvedSecrets=nil, resolve GITHUB_TOKEN from project secrets (with user-scope fallback) and inject into ResolvedEnv
- Secondary fix: isAuthTypeSatisfied skips env-var checks for GCP-backed auth types when verified GCP SA is assigned, preventing false NoAuth triggers
- 8 new test cases covering all paths

Ref: ptone/scion#1165

## Key files

- pkg/hub/httpdispatcher.go - NoAuth GITHUB_TOKEN exemption with scope cascade
- pkg/hub/handlers_agent_create_helpers.go - GCP SA auth type satisfaction fix
- pkg/hub/httpdispatcher_noauth_github_token_test.go - Primary fix tests
- pkg/hub/handlers_agent_create_helpers_noauth_test.go - Secondary fix tests