### PR TITLE
fix(web): use radio buttons instead of radio-button pills for scope dialog

### DIFF
--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -97,6 +97,7 @@ import '@shoelace-style/shoelace/dist/components/menu-item/menu-item.js';
 import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/radio-group/radio-group.js';
 import '@shoelace-style/shoelace/dist/components/radio-button/radio-button.js';
+import '@shoelace-style/shoelace/dist/components/radio/radio.js';
 import '@shoelace-style/shoelace/dist/components/range/range.js';
 import '@shoelace-style/shoelace/dist/components/switch/switch.js';
 import '@shoelace-style/shoelace/dist/components/details/details.js';

--- a/web/src/components/pages/terminal.ts
+++ b/web/src/components/pages/terminal.ts
@@ -253,9 +253,14 @@ export class ScionPageTerminal extends LitElement {
 
     #capture-scope-group {
       margin-top: 0.75rem;
-      display: flex;
-      flex-direction: column;
-      gap: 0.5rem;
+    }
+
+    #capture-scope-group sl-radio {
+      display: block;
+    }
+
+    #capture-scope-group sl-radio:not(:last-of-type) {
+      margin-bottom: 0.5rem;
     }
 
     /* Window switcher toggle group: two rectangular icon buttons */

--- a/web/src/components/pages/terminal.ts
+++ b/web/src/components/pages/terminal.ts
@@ -253,6 +253,9 @@ export class ScionPageTerminal extends LitElement {
 
     #capture-scope-group {
       margin-top: 0.75rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
     }
 
     /* Window switcher toggle group: two rectangular icon buttons */
@@ -1521,11 +1524,11 @@ export class ScionPageTerminal extends LitElement {
             this.captureAuthSelectedScope = e.target.value;
           }}
         >
-          <sl-radio-button value="project"
-            >Project secret (all project agents)</sl-radio-button
+          <sl-radio value="project"
+            >Project secret (all project agents)</sl-radio
           >
-          <sl-radio-button value="user"
-            >Profile secret (your personal credential)</sl-radio-button
+          <sl-radio value="user"
+            >Profile secret (your personal credential)</sl-radio
           >
         </sl-radio-group>
         <sl-button


### PR DESCRIPTION
## Summary

Follow-up to upstream PR #1222. Changes the Capture Auth scope dialog from sl-radio-button (pill/box style) to sl-radio (simple radio list) per reviewer feedback. Default remains project scope.

- Replaced sl-radio-button with sl-radio in renderCaptureAuthScopeDialog
- Added sl-radio import in main.ts
- Added flex layout CSS for vertical radio stacking

Ref: ptone/scion#1166