### PR TITLE
Don't override a hub-managed agent's real token with dev auth on localhost

### DIFF
--- a/cmd/hub.go
+++ b/cmd/hub.go
@@ -452,6 +452,11 @@ func getAuthInfo(settings *config.Settings, endpoint string) authInfo {
 	// When the endpoint is localhost and dev auth is available, prefer dev auth
 	// over a non-dev agent token — the scion-token may be stale from a previous
 	// remote hub connection while the dev-token was written by the running local server.
+	// Not for hub-managed agents (config.IsHubManagedAgent()): inside a
+	// broker-started container the scion-token is freshly minted for this Hub,
+	// not stale, and dev auth doesn't carry the per-agent identity some
+	// endpoints require — see the comment on createHubClient in
+	// pkg/hubsync/sync.go.
 	if token := readAgentTokenFile(); token != "" {
 		if apiclient.IsDevToken(token) {
 			info.Method = "Agent token (dev)"
@@ -461,7 +466,7 @@ func getAuthInfo(settings *config.Settings, endpoint string) authInfo {
 			info.TokenExpiry = parseJWTExpiry(token)
 			return info
 		}
-		if isLocalhostEndpoint(endpoint) {
+		if isLocalhostEndpoint(endpoint) && !config.IsHubManagedAgent() {
 			if devToken, devSource := apiclient.ResolveDevTokenWithSource(); devToken != "" {
 				util.Debugf("Skipping non-dev agent token from scion-token file; using dev auth (%s) for localhost endpoint", devSource)
 				info.Method = "Dev auth"
@@ -540,7 +545,9 @@ func getHubClient(settings *config.Settings) (hubclient.Client, error) {
 	// Note: hub.token and hub.apiKey are deprecated and no longer used for auth.
 	// Auth priority: OAuth credentials > scion-token file > SCION_AUTH_TOKEN env > SCION_HUB_TOKEN env > auto dev auth.
 	// Exception: for localhost endpoints, dev auth takes priority over non-dev agent tokens
-	// to avoid stale scion-token files from previous remote hub connections.
+	// to avoid stale scion-token files from previous remote hub connections. This exception
+	// is suppressed for hub-managed agents (config.IsHubManagedAgent()) — see the matching
+	// comment on createHubClient in pkg/hubsync/sync.go for why.
 	authConfigured := false
 
 	// Check for OAuth credentials from scion hub auth login
@@ -552,7 +559,7 @@ func getHubClient(settings *config.Settings) (hubclient.Client, error) {
 	// Check for agent auth token from canonical token file, then bootstrap env var
 	if !authConfigured {
 		if token := readAgentTokenFile(); token != "" {
-			if !apiclient.IsDevToken(token) && isLocalhostEndpoint(endpoint) {
+			if !apiclient.IsDevToken(token) && isLocalhostEndpoint(endpoint) && !config.IsHubManagedAgent() {
 				if devToken := apiclient.ResolveDevToken(); devToken != "" {
 					opts = append(opts, hubclient.WithBearerToken(devToken))
 					authConfigured = true

--- a/cmd/hub_test.go
+++ b/cmd/hub_test.go
@@ -112,6 +112,7 @@ func TestGetAuthInfo_DevAuthPreferredOverStaleAgentTokenOnLocalhost(t *testing.T
 	t.Setenv("SCION_DEV_TOKEN", "")
 	t.Setenv("SCION_DEV_TOKEN_FILE", "")
 	t.Setenv("SCION_HUB_TOKEN", "")
+	t.Setenv("SCION_AGENT_ID", "") // Not a hub-managed agent — the exception under test applies.
 
 	scionDir := filepath.Join(tmpDir, ".scion")
 	if err := os.MkdirAll(scionDir, 0755); err != nil {
@@ -133,6 +134,49 @@ func TestGetAuthInfo_DevAuthPreferredOverStaleAgentTokenOnLocalhost(t *testing.T
 	assert.Equal(t, "devauth", info.MethodType)
 	assert.Equal(t, "Dev auth", info.Method)
 	assert.True(t, info.IsDevAuth)
+}
+
+// TestGetAuthInfo_HubManagedAgentUsesRealTokenOnLocalhost is the counterpart
+// to TestGetAuthInfo_DevAuthPreferredOverStaleAgentTokenOnLocalhost: inside a
+// container the Runtime Broker started (SCION_AGENT_ID set), the scion-token
+// file is freshly minted for *this* Hub, not stale — so it must NOT be
+// overridden by dev auth even when the endpoint is localhost, since some Hub
+// endpoints (e.g. an agent's own outbound message to a user) require the
+// caller's authenticated identity to be that specific agent, which dev auth
+// does not provide. Regression test for the bug where every hub-managed
+// agent on a workstation-mode (loopback) Hub got 401'd trying to message a
+// user, because this same localhost exception silently swapped in dev auth.
+func TestGetAuthInfo_HubManagedAgentUsesRealTokenOnLocalhost(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("SCION_AUTH_TOKEN", "")
+	t.Setenv("SCION_DEV_TOKEN", "")
+	t.Setenv("SCION_DEV_TOKEN_FILE", "")
+	t.Setenv("SCION_HUB_TOKEN", "")
+	t.Setenv("SCION_AGENT_ID", "agent-uuid-123") // Hub-managed agent context.
+
+	scionDir := filepath.Join(tmpDir, ".scion")
+	if err := os.MkdirAll(scionDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Real per-agent token, freshly issued by the broker for this Hub.
+	if err := os.WriteFile(filepath.Join(scionDir, "scion-token"), []byte("eyJhbGciOiJIUzI1NiJ9.fresh-agent-jwt"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A dev token also happens to be present (this IS a dev-mode Hub) — must
+	// not be preferred over the agent's own token in this context.
+	if err := os.WriteFile(filepath.Join(scionDir, "dev-token"), []byte("scion_dev_abc123"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	settings := &config.Settings{}
+	info := getAuthInfo(settings, "http://localhost:8080")
+	assert.Equal(t, "agent_token", info.MethodType)
+	assert.Equal(t, "Agent token", info.Method)
+	assert.Equal(t, "scion-token file", info.Source)
+	assert.False(t, info.IsDevAuth)
 }
 
 func TestGetAuthInfo_AgentTokenUsedOnRemoteEndpoint(t *testing.T) {

--- a/pkg/hubsync/sync.go
+++ b/pkg/hubsync/sync.go
@@ -1337,7 +1337,13 @@ func readAgentTokenFile() string {
 // Note: hub.token and hub.apiKey are deprecated and no longer used for auth.
 // Auth priority: OAuth credentials > scion-token file > SCION_AUTH_TOKEN env > auto dev auth.
 // Exception: for localhost endpoints, dev auth takes priority over non-dev agent tokens
-// to avoid stale scion-token files from previous remote hub connections.
+// to avoid stale scion-token files from previous remote hub connections. This exception
+// is suppressed for hub-managed agents (config.IsHubManagedAgent(), i.e. SCION_AGENT_ID
+// is set): inside a container the Runtime Broker started, the scion-token file is freshly
+// minted for *this* Hub, not stale, and some Hub endpoints (e.g. an agent's own outbound
+// message to a user) require the real per-agent identity that only that token carries —
+// dev auth resolves to a superuser/dev identity, not any specific agent, so it 401s on
+// self-only endpoints. See https://github.com/GoogleCloudPlatform/scion/issues/<TBD>.
 func createHubClient(settings *config.Settings, endpoint string) (hubclient.Client, error) {
 	var opts []hubclient.Option
 
@@ -1353,7 +1359,7 @@ func createHubClient(settings *config.Settings, endpoint string) (hubclient.Clie
 	// 2. Check for agent token from canonical token file, then bootstrap env var
 	if !authConfigured {
 		if token := readAgentTokenFile(); token != "" {
-			if !apiclient.IsDevToken(token) && isLocalhostEndpoint(endpoint) {
+			if !apiclient.IsDevToken(token) && isLocalhostEndpoint(endpoint) && !config.IsHubManagedAgent() {
 				if devToken := apiclient.ResolveDevToken(); devToken != "" {
 					opts = append(opts, hubclient.WithBearerToken(devToken))
 					authConfigured = true

--- a/pkg/hubsync/sync_test.go
+++ b/pkg/hubsync/sync_test.go
@@ -1374,6 +1374,56 @@ func TestCreateHubClient_PrefersTokenFileOverEnv(t *testing.T) {
 	}
 }
 
+// TestCreateHubClient_HubManagedAgentUsesRealTokenOnLocalhost is the
+// createHubClient counterpart to
+// cmd.TestGetAuthInfo_HubManagedAgentUsesRealTokenOnLocalhost: a hub-managed
+// agent (SCION_AGENT_ID set) talking to a localhost Hub must authenticate
+// with its own scion-token, not get silently swapped onto dev auth, even
+// when a dev-token file is also present. Regression test for the bug where
+// every agent on a workstation-mode Hub 401'd sending an outbound message to
+// a user, because dev auth doesn't carry a specific agent identity and the
+// outbound-message endpoint requires the caller to be the agent itself.
+func TestCreateHubClient_HubManagedAgentUsesRealTokenOnLocalhost(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		agentToken := r.Header.Get("X-Scion-Agent-Token")
+		if agentToken != "fresh-agent-jwt" {
+			t.Errorf("expected X-Scion-Agent-Token 'fresh-agent-jwt', got %q", agentToken)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("expected no Authorization bearer header when the real agent token is used, got %q", auth)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	}))
+	defer server.Close()
+	// server.URL is http://127.0.0.1:<port> — exercises the localhost branch.
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("SCION_AGENT_ID", "agent-uuid-123") // Hub-managed agent context.
+	t.Setenv("SCION_AUTH_TOKEN", "")
+
+	scionDir := filepath.Join(tmpHome, ".scion")
+	_ = os.MkdirAll(scionDir, 0700)
+	// Real per-agent token, freshly issued by the broker for this Hub.
+	_ = os.WriteFile(filepath.Join(scionDir, "scion-token"), []byte("fresh-agent-jwt"), 0600)
+	// A dev token also present — must not be preferred in this context.
+	t.Setenv("SCION_DEV_TOKEN", "scion_dev_abc123")
+
+	settings := &config.Settings{}
+	client, err := createHubClient(settings, server.URL)
+	if err != nil {
+		t.Fatalf("createHubClient failed: %v", err)
+	}
+
+	_, err = client.Health(context.Background())
+	if err != nil {
+		t.Fatalf("Health check failed: %v", err)
+	}
+}
+
 func TestCreateHubClient_PrefersOAuthOverAgentToken(t *testing.T) {
 	// When OAuth credentials exist, they should take precedence over SCION_AUTH_TOKEN.
 	// We can't easily test this because credentials.GetAccessToken uses a global store,


### PR DESCRIPTION
## Summary

`createHubClient()` in `pkg/hubsync/sync.go` (and a duplicated copy,
`getHubClient()`, in `cmd/hub.go`, plus the display-only `getAuthInfo()`)
prefers dev auth over a non-dev `scion-token` whenever the Hub endpoint is
localhost, specifically to avoid a stale agent token left over on a
developer's machine from a previous *remote* hub connection.

That exception fires unconditionally — including inside a container the
Runtime Broker itself started. Workstation mode (Hub + Broker + Dashboard on
one machine, per the docs) always runs the Hub on `localhost`, so *every*
hub-managed agent in workstation mode hits this branch. Inside that
container the `scion-token` is freshly minted for this exact Hub, not stale
at all — but it gets silently swapped for dev auth anyway.

Dev auth resolves to a generic/dev identity, not a specific agent. Any Hub
endpoint that requires the caller to *be* a particular agent breaks under
it — concretely, `POST /api/v1/agents/{id}/outbound-message` (used by
`scion message user:<x>`, an agent's only way to reach a human's inbox
directly) 401s with "Agents can only send outbound messages as themselves",
surfaced to the CLI user as the generic `authentication failed, login to
hub with 'scion hub auth login'`.

Net effect: no hub-managed agent running against a workstation-mode Hub
could ever message a user directly via `scion message` — a full feature
gap for any agent/harness that doesn't have its own out-of-band relay to
the message broker (discovered running an OpenCode-harnessed agent, which
has no such native relay, alongside a Claude Code agent that does).

## Fix

Gate the localhost dev-auth-preference exception behind
`!config.IsHubManagedAgent()` — an existing helper keyed off
`SCION_AGENT_ID`, which the Runtime Broker sets when it starts an agent
container — in both `createHubClient` and `getHubClient`, and apply the
same condition in `getAuthInfo` so `scion hub auth status` reports
accurately from inside an agent container too.

The original developer-workstation scenario this exception was written for
is untouched: it only ever applied when `SCION_AGENT_ID` isn't set, which
is true for any normal CLI invocation outside an agent container.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./cmd/... ./pkg/hubsync/... ./pkg/config/...` — clean
- [x] `go test ./cmd/... ./pkg/hubsync/...` — all passing
- [x] Added `TestGetAuthInfo_HubManagedAgentUsesRealTokenOnLocalhost` and
      `TestCreateHubClient_HubManagedAgentUsesRealTokenOnLocalhost` —
      regression coverage for the fixed case (agent token used, not dev
      auth, when `SCION_AGENT_ID` is set on a localhost endpoint)
- [x] Fixed `TestGetAuthInfo_DevAuthPreferredOverStaleAgentTokenOnLocalhost`
      to explicitly clear `SCION_AGENT_ID` — a latent test-hermeticity gap
      the fix exposed (the existing suite happened to always run outside
      any agent context, so nothing had previously needed this cleared)
- [x] Verified live against a real workstation-mode deployment: an agent
      container that previously 401'd running `scion message
      user:<name> --channel telegram "..."` from inside itself