### PR TITLE
feat: bump antigravity medium model to Gemini 3.7 Flash

### DIFF
--- a/harnesses/antigravity/config.yaml
+++ b/harnesses/antigravity/config.yaml
@@ -32,7 +32,7 @@ env_template:
 
 model_aliases:
   small: "Gemini 3.1 Flash Lite"
-  medium: "Gemini 3.6 Flash (Medium)"
+  medium: "Gemini 3.7 Flash (Medium)"
   large: "Gemini 3.1 Pro (Low)"
   extra-large: "Gemini 3.1 Pro (Low)"
 

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -31,7 +31,7 @@ assert scion_harness.INTERFACE_VERSION >= 2, (
 
 PROVISION_VERSION = "2026-07-09T01:00:00Z"
 
-FLASH_MODEL = "Gemini 3.6 Flash (Medium)"
+FLASH_MODEL = "Gemini 3.7 Flash (Medium)"
 PRO_MODEL = "Gemini 3.1 Pro (Low)"
 
 


### PR DESCRIPTION
Bumps the antigravity harness default/medium model from Gemini 3.6 Flash (Medium) to Gemini 3.7 Flash (Medium).

Changes:
- config.yaml: medium model alias updated
- provision.py: FLASH_MODEL constant updated (controls default in settings.json)
