### PR TITLE
docs: nightly doc update Aug 21 (secret scope, user templates, git creds)

### DIFF
--- a/docs-site/src/content/docs/hosted/user/messaging.md
+++ b/docs-site/src/content/docs/hosted/user/messaging.md
@@ -200,6 +200,10 @@ When an agent signals `WAITING_FOR_INPUT` (by calling `sciontool status ask_user
 * **Parent Agent Role**: If you are the parent agent that created the waiting agent, you may be the intended respondent. Use `scion message agent:<name>` to reply with the answer.
 * **Peer Agent Rule**: Unrelated peer agents should **NOT** reply to `input-needed` notifications. Answering a peer's input prompt wastes context tokens, causes false loop signals, and violates project-scoped boundaries. To request a peer's input, always send an explicit `instruction` instead.
 
+:::tip[Project-Scoped Message Isolation]
+When using slug-based query paths or addressing agents via `agent:<name>` (e.g., `scion message agent:<name>`), Scion strictly scopes all message queries and deliveries by the active `ProjectID`. This ensures that even if different projects contain agents with identical names or slugs, messages are completely isolated within each project and never leak across project boundaries.
+:::
+
 ### 3. Subscription Management and Agent Self-Service
 
 * **Automatic Subscription**: The `--notify` flag on `scion start` is **deprecated**. When you start a sub-agent, Scion automatically registers your subscription via creation ancestry.

--- a/docs-site/src/content/docs/hosted/user/secrets.md
+++ b/docs-site/src/content/docs/hosted/user/secrets.md
@@ -22,11 +22,16 @@ Scion distinguishes between regular environment variables and secure secrets:
 
 Both variables and secrets can be scoped to different levels. Scion resolves these hierarchically when an agent starts:
 
-1.  **User Scope**: Personal secrets for a specific user. Applied to all agents owned by that user.
-2.  **Project Scope**: Project-level secrets. Available to all agents running in a specific Project.
-3.  **Broker Scope**: Infrastructure-level secrets. Available only to agents running on a specific Runtime Broker (e.g., for hardware-specific config).
+1.  **User Scope** (Highest Priority): Personal secrets or variables for a specific user. Applied to all agents owned by that user.
+2.  **Project Scope**: Project-level secrets or variables. Available to all agents running in a specific Project.
+3.  **Hub Scope**: Platform-wide settings or secrets configured by Hub administrators.
+4.  **Broker Scope** (Lowest Priority): Infrastructure-level secrets or variables. Available only to agents running on a specific Runtime Broker (e.g., for hardware-specific config).
 
-**Resolution Priority:** When multiple scopes define the same secret key, the more specific scope wins. Broker scope has the highest priority, followed by Project, then User, then Hub. Template `env` blocks and CLI `--env` flags are layered on top of resolved secrets.
+**Resolution Priority:** When multiple scopes define the same secret key, the more specific scope wins. The precedence order is:
+```text
+runtime_broker  <  hub  <  project  <  user
+```
+Therefore, user-scoped settings have the highest priority and will override project, hub, and broker-scoped variables or secrets of the same name. Template `env` blocks and CLI `--env` flags are layered on top of resolved secrets.
 
 ---
 ## Injection Modes
@@ -45,6 +50,24 @@ scion hub env set --project --always LOG_LEVEL=debug
 # Set a secret to be always injected for a user
 scion hub secret set --always MY_GLOBAL_TOKEN secret-value
 ```
+
+### Propagation to Descendant Agents (Progeny)
+
+When an agent creates child/sub-agents (referred to as **progeny**), they do not inherit the parent agent's user-scoped configuration or secrets by default. This preserves a strict security and least-privilege boundary across agent ancestry chains.
+
+However, you can explicitly configure user-scoped environment variables or secrets to propagate down the progeny tree by using the `--allow-progeny` flag.
+
+* **User-Scoped Secrets**: Can be marked for progeny propagation at any time.
+  ```bash
+  scion hub secret set --allow-progeny MY_PERSONAL_TOKEN token-value
+  ```
+* **User-Scoped Environment Variables**: Can only be marked for progeny propagation if their injection mode is set to `always`.
+  ```bash
+  scion hub env set --always --allow-progeny PERSONAL_ENV=value
+  ```
+
+#### How it Works Under the Hood
+Enabling progeny propagation dynamically registers implicit access policies (e.g. `progeny-secret-access:<id>` or `progeny-envvar-access:<id>`) on the Scion Hub. When a child agent resolves its configuration, Scion walks the ancestor chain of the calling agent container. If the configuration creator is part of that ancestry tree and has enabled progeny permission, the descendant agent safely inherits the setting or secret.
 
 ---
 

--- a/docs-site/src/content/docs/local/agent-credentials.md
+++ b/docs-site/src/content/docs/local/agent-credentials.md
@@ -283,6 +283,11 @@ The fallback applies only to **automatic** resolution. If you selected an auth t
 [Explicit Path](#the-explicit-path), the fallback is disabled — the required credentials must be
 present or the agent fails to start with an actionable error.
 
+:::note[Git Credentials and GCP Service Accounts in No-Auth Fallback]
+* **Git Credentials Exemption**: During a no-auth fallback (when LLM credentials are not yet found or captured), Scion previously suppressed all secrets. Now, Git credentials (specifically `GITHUB_TOKEN`) are **exempt from suppression**. Scion will resolve `GITHUB_TOKEN` from project secrets (with a fallback to user-scoped secrets) so that repository cloning in `clone-per-agent` workspaces succeeds even when running in no-auth fallback mode.
+* **GCP Service Account Check**: To prevent false no-auth fallback triggers, Scion skips explicit environment variable checks for GCP-backed auth types when a verified Google Cloud Service Account (SA) is assigned to the agent.
+:::
+
 ## Capturing Credentials from a Running Agent
 
 For harnesses that authenticate through an interactive login (rather than a plain API key), you
@@ -408,6 +413,16 @@ Two diagnostic commands help troubleshoot auth and connectivity:
 When an agent creates sub-agents (progeny), Scion enforces strict controls over which secrets those child agents can access.
 
 By default, child agents operate under a **granular secret access** model. They do not automatically inherit all secrets from the project or their parent. Instead, they only have access to the credentials necessary to perform their specific tasks, maintaining a least-privilege security boundary across the agent ancestry chain.
+
+### Propagation of User-Scoped Secrets (`--allow-progeny`)
+
+For user-scoped (personal) secrets, you can explicitly configure them to propagate down the agent ancestry chain (progeny) by setting the `--allow-progeny` flag upon creation:
+
+```bash
+scion hub secret set --allow-progeny MY_PERSONAL_TOKEN my-secret-value
+```
+
+When a child agent is created, Scion walks the ancestry chain of the agent (from child to ancestors) to resolve secrets. If the secret's creator is in the agent's ancestry chain AND `allow-progeny` is enabled, the secret is safely inherited and projected into the descendant agent. Under the hood, this dynamically manages implicit **progeny policies** (`progeny-secret-access:<id>`) on the Scion Hub.
 
 ---
 

--- a/docs-site/src/content/docs/local/skills.md
+++ b/docs-site/src/content/docs/local/skills.md
@@ -334,6 +334,12 @@ scion user skills remove <uuid>
 scion user skills remove skill://scion/global/personal-notes@latest
 ```
 
+#### Progeny Propagation for User Skills
+
+By default, child agents (progeny) do not inherit the user-scoped injected skills of the parent agent's owner. However, you can explicitly configure personal injected skills to propagate down the agent ancestry tree by enabling the **AllowProgeny** setting (available via the Scion Web Dashboard or Hub API).
+
+When enabled, Scion automatically manages an implicit **progeny policy** (`progeny-skill-access:<id>`) on the Hub. If a progeny agent is spawned, Scion walks its ancestor tree; if the personal skill's creator is in that tree and has granted progeny access, the descendant agent inherits the skill injection.
+
 ### Batch-Adding Injected Skills via the Web UI
 
 In addition to managing injected skills via the CLI, the Scion Web Dashboard allows configuring **Injected Skills** for a project, user profile, or globally on the Hub. To simplify adding multiple skills at once, Scion provides a **directory-discovery** workflow:

--- a/docs-site/src/content/docs/local/templates.md
+++ b/docs-site/src/content/docs/local/templates.md
@@ -222,7 +222,13 @@ When you reference a template by bare name, Scion searches in this order and use
 3. **Project** templates (`.scion/templates/`).
 4. **Global** templates (`~/.scion/templates/`).
 
-When connected to a Hub, templates can also resolve from the Hub (project scope, then global scope). If a name matches in several locations, the CLI prompts you to choose; the `--local`, `--hub`, and `--global` flags narrow the search.
+When connected to a Hub, templates can also resolve from the Hub across three scopes: **User** (personal templates), **Project** (project-level templates), and **Global** (hub-wide templates). If a name matches in several locations, the CLI prompts you to choose; the `--local`, `--hub`, and `--global` flags narrow the search.
+
+In the Web Dashboard's **New Agent** creation form, templates are automatically clustered and ordered by scope in the dropdown:
+```text
+User Templates  >  Project Templates  >  Global Templates
+```
+Visual separators clearly segment these categories, ensuring your personal, customized templates are always at the top of the dropdown for fast access.
 
 ## The `scion templates` CLI
 

--- a/docs-site/src/content/docs/supported-harnesses.md
+++ b/docs-site/src/content/docs/supported-harnesses.md
@@ -212,7 +212,7 @@ the Antigravity bundle's `capture_auth.py` (which can also extract the token fro
 - **MCP**: `~/.gemini/config/mcp_config.json`.
 - **Hooks**: Antigravity ships a hook dialect (`dialect.yaml`) mapping `agy` events to Scion lifecycle events. Hooks fire **project-locally** (wired via `/workspace/.agents/hooks.json`).
 - **Runtime**: requires gnome-keyring and D-Bus in the container (provided by the base image); a generated wrapper script bootstraps the keyring and injects the token before launching `agy`.
-- **Default model**: `Gemini 3.6 Flash (Medium)` (override via `AGY_MODEL`).
+- **Default model**: `Gemini 3.7 Flash (Medium)` (override via `AGY_MODEL`).
 
 ### Known Limitations
 - **System Prompt**: approximated via `GEMINI.md` (no native override).


### PR DESCRIPTION
Nightly documentation update for Aug 20 changelog.

- secrets.md: corrected scope precedence, git credential exemption from NoAuth
- agent-credentials.md: GITHUB_TOKEN resolution with user-scope fallback
- templates.md: user-scoped template ordering and visual separators
- skills.md: AllowProgeny flag for user-scoped injected skills
- messaging.md: project-scoped interagent message queries
- supported-harnesses.md: antigravity medium model Gemini 3.6 to 3.7

Cherry-picked from doc-writer agent du-0820.