### PR TITLE
fix: show register_url field on Discord and Telegram settings form

### DIFF
--- a/web/src/components/pages/admin-integrations.ts
+++ b/web/src/components/pages/admin-integrations.ts
@@ -223,6 +223,13 @@ const PLATFORM_FIELDS: Record<string, PlatformFieldDef[]> = {
       description: 'JSON map of Telegram usernames to scion user IDs (v1 migration seeding only)',
       defaultValue: '',
     },
+    {
+      key: 'register_url',
+      label: 'Register URL',
+      description: 'Public URL for user-facing registration links. Used instead of internal hub_url when behind auth proxies or custom domains.',
+      defaultValue: '',
+      placeholder: 'https://scion.example.com',
+    },
   ],
   discord: [
     {
@@ -238,6 +245,13 @@ const PLATFORM_FIELDS: Record<string, PlatformFieldDef[]> = {
         'Comma-separated Discord server IDs. Leave empty to register commands globally across all servers the bot joins.',
       defaultValue: '',
       placeholder: 'Global — all servers',
+    },
+    {
+      key: 'register_url',
+      label: 'Register URL',
+      description: 'Public URL for user-facing registration links. Used instead of internal hub_url when behind auth proxies or custom domains.',
+      defaultValue: '',
+      placeholder: 'https://scion.example.com',
     },
   ],
   slack: [


### PR DESCRIPTION
## Summary
- Add register_url to PLATFORM_FIELDS for both Discord and Telegram integrations
- Field now always renders on the admin settings form, allowing first-time value entry
- Previously the field only appeared when a value was already set (via config file or API), making it impossible to set through the UI