### PR TITLE
security(hub): fix 22 authz-guard bypasses and wire CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Check Compatibility Literals
         run: make compat-literals
 
+      - name: Check Authorization Guards
+        run: make check-authz-guards
+
       - name: Run Tests
         run: make test-fast
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,21 @@ jobs:
         run: make compat-literals
 
       - name: Check Authorization Guards
-        run: make check-authz-guards
+        run: |
+          # Invoked directly rather than via `make check-authz-guards`: GNU make
+          # reports its own failure code (always 2), which would collapse the
+          # script's exit 1 (violations found) and exit 2 (nothing was analysed)
+          # into one indistinguishable result. Those mean opposite things.
+          set +e
+          ./hack/check-authz-guards.sh
+          rc=$?
+          set -e
+          case "$rc" in
+            0) ;;
+            1) echo "::error title=Authorization guards::Authorization-bypass guard patterns found (see ptone/scion#591). The file:line: function list is in the step log above." ;;
+            *) echo "::error title=Authorization guards NOT checked::check-authz-guards could not run (exit $rc) — NOTHING WAS ANALYSED. This is an environment failure and is NOT a statement about the codebase. Do not read it as a guard failure." ;;
+          esac
+          exit "$rc"
 
       - name: Run Tests
         run: make test-fast

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,11 @@ compat-literals:
 	@./hack/check-project-compat-literals.sh
 
 ## check-authz-guards: Verify no authorization-bypass patterns exist in handler code
+# NOTE: make reports its own failure code (2) rather than the recipe's, so the
+# script's exit 1 (violations found) and exit 2 (nothing was analysed — skipped,
+# not clean) are indistinguishable to anything reading this target's exit status.
+# The messages still differ on stderr. Any caller that needs to tell those two
+# apart must invoke ./hack/check-authz-guards.sh directly, as CI does.
 check-authz-guards:
 	@./hack/check-authz-guards.sh
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GOLANGCI_LINT := $(shell command -v golangci-lint 2>/dev/null || echo $(shell go
 
 .DEFAULT_GOAL := help
 
-.PHONY: all build build-a2a-bridge install test test-fast vet lint compat-literals golangci-lint web web-typecheck web-test fmt fmt-check ci ci-full clean help container-sciontool container-scion container-binaries proto proto-check
+.PHONY: all build build-a2a-bridge install test test-fast vet lint compat-literals check-authz-guards golangci-lint web web-typecheck web-test fmt fmt-check ci ci-full clean help container-sciontool container-scion container-binaries proto proto-check
 
 ## all: Build the web frontend and compile the Go binary (run 'make install' separately to install)
 all: web build
@@ -79,6 +79,10 @@ lint:
 ## compat-literals: Check legacy grove literals stay in compatibility surfaces
 compat-literals:
 	@./hack/check-project-compat-literals.sh
+
+## check-authz-guards: Verify no authorization-bypass patterns exist in handler code
+check-authz-guards:
+	@./hack/check-authz-guards.sh
 
 ## golangci-lint: Run golangci-lint on new issues only (install via: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest)
 golangci-lint:
@@ -151,13 +155,13 @@ fmt-check:
 	fi
 	@echo "Go formatting OK."
 
-## ci: Run fast CI checks (format check, vet, compatibility guardrails, tests, build)
-ci: fmt-check lint compat-literals test-fast build
+## ci: Run fast CI checks (format check, vet, compatibility guardrails, authz guards, tests, build)
+ci: fmt-check lint compat-literals check-authz-guards test-fast build
 	@echo ""
 	@echo "CI passed."
 
 ## ci-full: Run the full CI pipeline locally (mirrors GitHub Actions, includes web + golangci-lint)
-ci-full: fmt-check web web-typecheck web-test lint compat-literals golangci-lint test-fast build
+ci-full: fmt-check web web-typecheck web-test lint compat-literals check-authz-guards golangci-lint test-fast build
 	@echo ""
 	@echo "CI (full) passed."
 

--- a/pkg/hub/authz_bypass_agents_test.go
+++ b/pkg/hub/authz_bypass_agents_test.go
@@ -214,10 +214,44 @@ func (f *bypassAgentsFixture) token(t *testing.T, scopes ...AgentTokenScope) str
 	return tok
 }
 
+// tokenFor mints a JWT for an arbitrary agent with the given scopes.
+// ScopeProjectRead is always included (same rationale as token).
+func (f *bypassAgentsFixture) tokenFor(t *testing.T, agent *store.Agent, scopes ...AgentTokenScope) string {
+	t.Helper()
+	svc := f.srv.GetAgentTokenService()
+	require.NotNil(t, svc)
+	allScopes := append([]AgentTokenScope{ScopeProjectRead}, scopes...)
+	tok, err := svc.GenerateAgentToken(agent.ID, agent.ProjectID, allScopes, nil)
+	require.NoError(t, err)
+	return tok
+}
+
 // asAgent issues a request carrying the calling agent's token.
 func (f *bypassAgentsFixture) asAgent(t *testing.T, method, path string, body interface{}, scopes ...AgentTokenScope) *httptest.ResponseRecorder {
 	t.Helper()
 	return doRequestWithAgentToken(t, f.srv, method, path, body, f.token(t, scopes...))
+}
+
+// asAgentWithHeaders issues a request carrying the calling agent's token with additional headers.
+func (f *bypassAgentsFixture) asAgentWithHeaders(t *testing.T, method, path string, body interface{}, headers map[string]string, scopes ...AgentTokenScope) *httptest.ResponseRecorder {
+	t.Helper()
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = json.Marshal(body)
+		require.NoError(t, err)
+	}
+	req := httptest.NewRequest(method, path, bytes.NewReader(bodyBytes))
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("X-Scion-Agent-Token", f.token(t, scopes...))
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	f.srv.Handler().ServeHTTP(rec, req)
+	return rec
 }
 
 // asBroker issues an HMAC-signed broker request. Brokers implement neither
@@ -1308,5 +1342,279 @@ func TestBypassAgents_CheckBrokerDispatchAccess(t *testing.T) {
 		ok, rec := check(f, agentCtx(f, f.proj.ID, ScopeAgentCreate), "no-such-broker")
 		assert.False(t, ok)
 		assert.NotEqual(t, http.StatusOK, rec.Code)
+	})
+}
+
+// ============================================================================
+// Cross-project agent denials — project settings, shared-dirs, hooks, logs
+// ============================================================================
+
+// TestBypassAgents_CrossProjectReadDenials extends the denial suite to the
+// remaining project-scoped read endpoints that were converted in this PR.
+// Each of these returned data before the fix; now they deny cross-project
+// agents with a 404 (not 403) to avoid confirming project existence.
+func TestBypassAgents_CrossProjectReadDenials(t *testing.T) {
+	f := bypassAgentsSetup(t)
+
+	cases := []struct {
+		name     string
+		method   string
+		path     string
+		body     interface{}
+		wantCode int
+	}{
+		{"projectSettings", http.MethodGet, "/api/v1/projects/" + f.other.ID + "/settings", nil, http.StatusNotFound},
+		{"sharedDirs", http.MethodGet, "/api/v1/projects/" + f.other.ID + "/shared-dirs", nil, http.StatusNotFound},
+		{"preStartHooks", http.MethodGet, "/api/v1/projects/" + f.other.ID + "/pre-start-hooks", nil, http.StatusNotFound},
+		{"settingsResolved", http.MethodGet, "/api/v1/projects/" + f.other.ID + "/settings/resolved", nil, http.StatusNotFound},
+		{"agentLogs", http.MethodGet, "/api/v1/agents/" + f.stranger.ID + "/logs", nil, http.StatusNotFound},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := f.asAgent(t, tc.method, tc.path, tc.body)
+			assert.Equal(t, tc.wantCode, rec.Code,
+				"cross-project read must return %d, not disclose existence; got: %s",
+				tc.wantCode, rec.Body.String())
+		})
+	}
+}
+
+// TestBypassAgents_CrossProjectBrokerDenials extends the broker denial table
+// to the same endpoints.
+func TestBypassAgents_CrossProjectBrokerDenials(t *testing.T) {
+	f := bypassAgentsSetup(t)
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"projectSettings", http.MethodGet, "/api/v1/projects/" + f.proj.ID + "/settings"},
+		{"sharedDirs", http.MethodGet, "/api/v1/projects/" + f.proj.ID + "/shared-dirs"},
+		{"preStartHooks", http.MethodGet, "/api/v1/projects/" + f.proj.ID + "/pre-start-hooks"},
+		{"settingsResolved", http.MethodGet, "/api/v1/projects/" + f.proj.ID + "/settings/resolved"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := f.asBroker(t, tc.method, tc.path, nil)
+			assert.Contains(t, []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound},
+				rec.Code,
+				"broker-authenticated caller must not read %s; got %d: %s",
+				tc.name, rec.Code, rec.Body.String())
+		})
+	}
+}
+
+// ============================================================================
+// Status code assertions — 404-before-403 ordering
+// ============================================================================
+
+// TestBypassAgents_404Before403Ordering pins the isolation check ordering:
+// cross-project agent requests on log endpoints must receive exactly 404
+// (not 403), preventing project/agent existence disclosure.
+func TestBypassAgents_404Before403Ordering(t *testing.T) {
+	f := bypassAgentsSetup(t)
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"agentLogs", "/api/v1/agents/" + f.stranger.ID + "/logs"},
+		{"agentMessageLogs", "/api/v1/agents/" + f.stranger.ID + "/message-logs"},
+		{"projectMessageLogs", "/api/v1/projects/" + f.other.ID + "/message-logs"},
+		{"projectSettings", "/api/v1/projects/" + f.other.ID + "/settings"},
+		{"settingsResolved", "/api/v1/projects/" + f.other.ID + "/settings/resolved"},
+		{"sharedDirs", "/api/v1/projects/" + f.other.ID + "/shared-dirs"},
+		{"preStartHooks", "/api/v1/projects/" + f.other.ID + "/pre-start-hooks"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := f.asAgent(t, http.MethodGet, tc.path, nil)
+			assert.Equal(t, http.StatusNotFound, rec.Code,
+				"cross-project agent must get exactly 404, not 403 or another code; got: %s",
+				rec.Body.String())
+		})
+	}
+}
+
+// ============================================================================
+// In-project agent success — read baseline reaches the handlers
+// ============================================================================
+
+// TestBypassAgents_InProjectReadSuccess asserts the in-project agent still
+// reaches the handlers for settings, settings/resolved, shared-dirs,
+// pre-start-hooks and message-logs. These prove the read baseline reaches the
+// Resource literals these handlers build — a real outage risk if a literal
+// ever loses its project linkage.
+func TestBypassAgents_InProjectReadSuccess(t *testing.T) {
+	f := bypassAgentsSetup(t)
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"settings", "/api/v1/projects/" + f.proj.ID + "/settings"},
+		{"settingsResolved", "/api/v1/projects/" + f.proj.ID + "/settings/resolved"},
+		{"sharedDirs", "/api/v1/projects/" + f.proj.ID + "/shared-dirs"},
+		{"preStartHooks", "/api/v1/projects/" + f.proj.ID + "/pre-start-hooks"},
+		{"projectMessageLogs", "/api/v1/projects/" + f.proj.ID + "/message-logs"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := f.asAgent(t, http.MethodGet, tc.path, nil)
+			// message-logs returns 501 when logQueryService is nil, which is
+			// past authorization. All others should return 200.
+			assert.NotEqual(t, http.StatusForbidden, rec.Code,
+				"in-project agent must not be denied on %s; got %d: %s",
+				tc.name, rec.Code, rec.Body.String())
+			assert.NotEqual(t, http.StatusUnauthorized, rec.Code,
+				"in-project agent must not get 401 on %s; got: %s",
+				tc.name, rec.Body.String())
+			assert.NotEqual(t, http.StatusNotFound, rec.Code,
+				"in-project agent must not get 404 on %s; got: %s",
+				tc.name, rec.Body.String())
+		})
+	}
+}
+
+// ============================================================================
+// addGroupMember — non-user role cap
+// ============================================================================
+
+// TestBypassAgents_AddGroupMember_RoleCap pins the cap introduced in this PR:
+// agents with an addMember policy may add plain members but not admin/owner.
+// This is a new authorization rule invented by this change and has zero
+// coverage without this test.
+func TestBypassAgents_AddGroupMember_RoleCap(t *testing.T) {
+	setup := func(t *testing.T) (*bypassAgentsFixture, *store.Group) {
+		t.Helper()
+		f := bypassAgentsSetup(t)
+		ctx := context.Background()
+
+		// Create a project-scoped group that the agent can interact with.
+		group := &store.Group{
+			ID:        uuid.New().String(),
+			Name:      "bypass-test-group",
+			Slug:      "bypass-test-group",
+			GroupType: store.GroupTypeExplicit,
+			ProjectID: f.proj.ID,
+			OwnerID:   f.owner.ID,
+		}
+		require.NoError(t, f.store.CreateGroup(ctx, group))
+
+		// Create an addMember policy and bind it to the agent.
+		policy := &store.Policy{
+			ID:           uuid.New().String(),
+			Name:         "Agent addMember on group",
+			ScopeType:    "project",
+			ScopeID:      f.proj.ID,
+			ResourceType: "group",
+			Actions:      []string{"addMember"},
+			Effect:       "allow",
+		}
+		require.NoError(t, f.store.CreatePolicy(ctx, policy))
+		require.NoError(t, f.store.AddPolicyBinding(ctx, &store.PolicyBinding{
+			PolicyID:      policy.ID,
+			PrincipalType: "agent",
+			PrincipalID:   f.caller.ID,
+		}))
+
+		return f, group
+	}
+
+	t.Run("agent with addMember policy adds a plain member", func(t *testing.T) {
+		f, group := setup(t)
+		rec := f.asAgent(t, http.MethodPost,
+			"/api/v1/groups/"+group.ID+"/members",
+			AddGroupMemberRequest{
+				MemberType: store.GroupMemberTypeUser,
+				MemberID:   f.owner.ID,
+				Role:       store.GroupMemberRoleMember,
+			})
+		assert.Equal(t, http.StatusCreated, rec.Code,
+			"agent with addMember policy must be able to add a plain member; got: %s",
+			rec.Body.String())
+	})
+
+	t.Run("agent with addMember policy cannot add admin", func(t *testing.T) {
+		f, group := setup(t)
+		rec := f.asAgent(t, http.MethodPost,
+			"/api/v1/groups/"+group.ID+"/members",
+			AddGroupMemberRequest{
+				MemberType: store.GroupMemberTypeUser,
+				MemberID:   f.owner.ID,
+				Role:       store.GroupMemberRoleAdmin,
+			})
+		assert.Equal(t, http.StatusForbidden, rec.Code,
+			"agent must not escalate to admin; got: %s", rec.Body.String())
+	})
+
+	t.Run("agent with addMember policy cannot add owner", func(t *testing.T) {
+		f, group := setup(t)
+		rec := f.asAgent(t, http.MethodPost,
+			"/api/v1/groups/"+group.ID+"/members",
+			AddGroupMemberRequest{
+				MemberType: store.GroupMemberTypeUser,
+				MemberID:   f.owner.ID,
+				Role:       store.GroupMemberRoleOwner,
+			})
+		assert.Equal(t, http.StatusForbidden, rec.Code,
+			"agent must not escalate to owner; got: %s", rec.Body.String())
+	})
+}
+
+// ============================================================================
+// PTY scope pinning — authorizeAgentLifecycle vs authorize
+// ============================================================================
+
+// TestBypassAgents_PTYScopePinning pins the choice of authorizeAgentLifecycle
+// over authorize for handleAgentPTY. Using authorize here would compile, pass
+// every test, and quietly swap the rule from ScopeAgentLifecycle to the
+// project read baseline.
+func TestBypassAgents_PTYScopePinning(t *testing.T) {
+	wsHeaders := map[string]string{
+		"Upgrade":    "websocket",
+		"Connection": "upgrade",
+	}
+
+	t.Run("scoped agent on a project peer reaches past authz", func(t *testing.T) {
+		// An agent with ScopeAgentLifecycle on a peer in its own project should
+		// pass authorization. Without a runtime broker it gets 422, which proves
+		// it made it past the auth check.
+		f := bypassAgentsSetup(t)
+		rec := f.asAgentWithHeaders(t, http.MethodGet,
+			"/api/v1/agents/"+f.sibling.ID+"/pty", nil,
+			wsHeaders, ScopeAgentLifecycle)
+		assert.Equal(t, http.StatusUnprocessableEntity, rec.Code,
+			"scoped agent should reach past authz to the no-runtime-broker check; got: %s",
+			rec.Body.String())
+	})
+
+	t.Run("unscoped agent is denied with missing scope message", func(t *testing.T) {
+		// An agent WITHOUT ScopeAgentLifecycle should get 403 with the specific
+		// "Missing required scope" message, proving authorizeAgentLifecycle is
+		// the gate rather than the read baseline's authorize.
+		f := bypassAgentsSetup(t)
+		rec := f.asAgentWithHeaders(t, http.MethodGet,
+			"/api/v1/agents/"+f.sibling.ID+"/pty", nil,
+			wsHeaders)
+		assert.Equal(t, http.StatusForbidden, rec.Code,
+			"unscoped agent must be denied; got: %s", rec.Body.String())
+		assert.Contains(t, rec.Body.String(), string(ScopeAgentLifecycle),
+			"denial must cite the missing scope to pin the authorizeAgentLifecycle choice")
+	})
+
+	t.Run("cross-project agent with scope is denied", func(t *testing.T) {
+		f := bypassAgentsSetup(t)
+		rec := f.asAgentWithHeaders(t, http.MethodGet,
+			"/api/v1/agents/"+f.stranger.ID+"/pty", nil,
+			wsHeaders, ScopeAgentLifecycle)
+		assert.Equal(t, http.StatusForbidden, rec.Code,
+			"cross-project agent must be denied even with the scope; got: %s",
+			rec.Body.String())
 	})
 }

--- a/pkg/hub/authz_bypass_agents_test.go
+++ b/pkg/hub/authz_bypass_agents_test.go
@@ -1156,3 +1156,157 @@ func TestBypassAgents_UnauthenticatedDenied(t *testing.T) {
 		})
 	}
 }
+
+// ============================================================================
+// Broker dispatch — checkBrokerDispatchAccess
+// ============================================================================
+
+// TestBypassAgents_CheckBrokerDispatchAccess pins the response-writing twin of
+// canDispatchToBroker, on the agent-creation path.
+//
+// This was the worst of the #591 sites, because it did not merely omit a deny —
+// it wrote one. `if userIdent == nil { return true }`, commented "no user
+// identity (e.g. broker-to-broker) — allow". GetUserIdentityFromContext returns
+// nil for an agent caller too, so every agent that reached agent creation could
+// place its new agent on ANY broker in the hub, including brokers serving other
+// projects, regardless of scope.
+//
+// The two functions are one rule, and this is the copy that drifted, so the fix
+// is delegation rather than a second transcription of the switch. These cases
+// therefore assert the same verdicts as TestBypassAgents_CanDispatchToBroker
+// plus the HTTP response, and they fail if the delegation is ever unwound into
+// a copy that can drift again.
+func TestBypassAgents_CheckBrokerDispatchAccess(t *testing.T) {
+	newRestrictedBroker := func(t *testing.T, f *bypassAgentsFixture, linkTo string) *store.RuntimeBroker {
+		t.Helper()
+		b := &store.RuntimeBroker{
+			ID:          uuid.New().String(),
+			Name:        "restricted-" + uuid.New().String()[:8],
+			Slug:        "restricted-" + uuid.New().String()[:8],
+			Status:      store.BrokerStatusOnline,
+			AutoProvide: false,
+			CreatedBy:   f.owner.ID,
+			Created:     time.Now(),
+			Updated:     time.Now(),
+		}
+		require.NoError(t, f.store.CreateRuntimeBroker(context.Background(), b))
+		if linkTo != "" {
+			require.NoError(t, f.store.AddProjectProvider(context.Background(), &store.ProjectProvider{
+				ProjectID:  linkTo,
+				BrokerID:   b.ID,
+				BrokerName: b.Name,
+				Status:     store.BrokerStatusOnline,
+			}))
+		}
+		return b
+	}
+
+	agentCtx := func(f *bypassAgentsFixture, projectID string, scopes ...AgentTokenScope) context.Context {
+		return contextWithIdentity(context.Background(), &agentIdentityWrapper{&AgentTokenClaims{
+			Claims:    jwt.Claims{Subject: f.caller.ID},
+			ProjectID: projectID,
+			Scopes:    scopes,
+		}})
+	}
+
+	// check runs the gate and returns its verdict together with the response it
+	// wrote, because "denied" here means both false and a 403 on the wire.
+	check := func(f *bypassAgentsFixture, ctx context.Context, brokerID string) (bool, *httptest.ResponseRecorder) {
+		rec := httptest.NewRecorder()
+		return f.srv.checkBrokerDispatchAccess(ctx, rec, brokerID), rec
+	}
+
+	t.Run("agent may not dispatch to a broker serving another project", func(t *testing.T) {
+		// The bypass, stated directly. Before the fix this returned true
+		// without so much as loading the broker.
+		f := bypassAgentsSetup(t)
+		b := newRestrictedBroker(t, f, f.other.ID)
+
+		ok, rec := check(f, agentCtx(f, f.proj.ID, ScopeAgentCreate), b.ID)
+		assert.False(t, ok, "an agent must not place an agent on a broker outside its project")
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("agent without the create scope is denied", func(t *testing.T) {
+		f := bypassAgentsSetup(t)
+		b := newRestrictedBroker(t, f, f.proj.ID)
+
+		ok, rec := check(f, agentCtx(f, f.proj.ID, ScopeAgentStatusUpdate), b.ID)
+		assert.False(t, ok)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("agent with the create scope may dispatch within its own project", func(t *testing.T) {
+		// The flow the gate must preserve: broker selection completing a create
+		// that authorizeAgentCreate already allowed.
+		f := bypassAgentsSetup(t)
+		b := newRestrictedBroker(t, f, f.proj.ID)
+
+		ok, _ := check(f, agentCtx(f, f.proj.ID, ScopeAgentCreate), b.ID)
+		assert.True(t, ok)
+	})
+
+	t.Run("broker-typed caller is denied", func(t *testing.T) {
+		// The case the old comment claimed to be serving. No broker-to-broker
+		// dispatch reaches here in the first place: both callers of this gate
+		// run authorizeAgentCreate first, which denies broker identities.
+		f := bypassAgentsSetup(t)
+		b := newRestrictedBroker(t, f, f.proj.ID)
+
+		ok, rec := check(f, bypassAgentsBrokerCtx(t, f), b.ID)
+		assert.False(t, ok)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("unauthenticated caller is denied", func(t *testing.T) {
+		f := bypassAgentsSetup(t)
+		b := newRestrictedBroker(t, f, f.proj.ID)
+
+		ok, rec := check(f, context.Background(), b.ID)
+		assert.False(t, ok, "an empty context must deny, not allow — and must not panic")
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("auto-provide brokers stay open to authenticated callers", func(t *testing.T) {
+		// Combo hub-broker deployments depend on this, and it is the reason the
+		// AutoProvide check sits ahead of the identity switch rather than inside
+		// the user arm.
+		f := bypassAgentsSetup(t)
+
+		ok, _ := check(f, agentCtx(f, f.proj.ID), f.broker.ID)
+		assert.True(t, ok, "an auto-provide broker must stay dispatchable")
+	})
+
+	t.Run("user path is unchanged", func(t *testing.T) {
+		f := bypassAgentsSetup(t)
+		b := newRestrictedBroker(t, f, f.proj.ID)
+
+		ownerCtx := contextWithIdentity(context.Background(),
+			NewAuthenticatedUser(f.owner.ID, f.owner.Email, f.owner.DisplayName, string(f.owner.Role), "cli"))
+		ok, _ := check(f, ownerCtx, b.ID)
+		assert.True(t, ok, "the broker's creator must still be able to dispatch to it")
+
+		stranger := &store.User{
+			ID:          tid("bypass-dispatch-stranger"),
+			Email:       "dispatch-stranger@example.com",
+			DisplayName: "Stranger",
+			Role:        store.UserRoleMember,
+			Status:      "active",
+			Created:     time.Now(),
+		}
+		require.NoError(t, f.store.CreateUser(context.Background(), stranger))
+		strangerCtx := contextWithIdentity(context.Background(),
+			NewAuthenticatedUser(stranger.ID, stranger.Email, stranger.DisplayName, string(stranger.Role), "cli"))
+		ok, rec := check(f, strangerCtx, b.ID)
+		assert.False(t, ok, "an unrelated user must not dispatch to someone else's broker")
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("unknown broker is an error, not an allow", func(t *testing.T) {
+		f := bypassAgentsSetup(t)
+
+		ok, rec := check(f, agentCtx(f, f.proj.ID, ScopeAgentCreate), "no-such-broker")
+		assert.False(t, ok)
+		assert.NotEqual(t, http.StatusOK, rec.Code)
+	})
+}

--- a/pkg/hub/authz_bypass_agents_test.go
+++ b/pkg/hub/authz_bypass_agents_test.go
@@ -214,18 +214,6 @@ func (f *bypassAgentsFixture) token(t *testing.T, scopes ...AgentTokenScope) str
 	return tok
 }
 
-// tokenFor mints a JWT for an arbitrary agent with the given scopes.
-// ScopeProjectRead is always included (same rationale as token).
-func (f *bypassAgentsFixture) tokenFor(t *testing.T, agent *store.Agent, scopes ...AgentTokenScope) string {
-	t.Helper()
-	svc := f.srv.GetAgentTokenService()
-	require.NotNil(t, svc)
-	allScopes := append([]AgentTokenScope{ScopeProjectRead}, scopes...)
-	tok, err := svc.GenerateAgentToken(agent.ID, agent.ProjectID, allScopes, nil)
-	require.NoError(t, err)
-	return tok
-}
-
 // asAgent issues a request carrying the calling agent's token.
 func (f *bypassAgentsFixture) asAgent(t *testing.T, method, path string, body interface{}, scopes ...AgentTokenScope) *httptest.ResponseRecorder {
 	t.Helper()

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -1076,8 +1076,8 @@ func (s *Server) resolveRuntimeBroker(ctx context.Context, w http.ResponseWriter
 // This is the "same project" test for agent-initiated dispatch. A broker is not
 // owned by a project — the association is the project_providers link — so an
 // agent's project can only be compared against a broker via this lookup. It is a
-// shared helper rather than an inlined query so that canDispatchToBroker and
-// checkBrokerDispatchAccess (handlers_runtime_brokers.go) cannot drift on it.
+// shared helper rather than an inlined query so that callers of
+// canDispatchToBroker cannot drift on the definition.
 func (s *Server) brokerServesProject(ctx context.Context, brokerID, projectID string) bool {
 	if brokerID == "" || projectID == "" {
 		return false
@@ -1105,8 +1105,10 @@ func (s *Server) brokerServesProject(ctx context.Context, brokerID, projectID st
 // them with "unknown identity type"; the nil branch this replaced was the only
 // thing admitting them, and it admitted everyone (#591).
 //
-// This function and checkBrokerDispatchAccess (handlers_runtime_brokers.go) are one
-// decision written twice and must stay structurally identical.
+// checkBrokerDispatchAccess (handlers_runtime_brokers.go) is the response-writing
+// wrapper around this function. It delegates rather than restating the rule: the two
+// were previously written twice, and the copy drifted into a fail-open (#591). Do not
+// reintroduce a second transcription — add response behaviour to the wrapper instead.
 func (s *Server) canDispatchToBroker(ctx context.Context, broker *store.RuntimeBroker) bool {
 	identity := GetIdentityFromContext(ctx)
 	if identity == nil {

--- a/pkg/hub/handlers_groups.go
+++ b/pkg/hub/handlers_groups.go
@@ -323,12 +323,8 @@ func (s *Server) updateGroup(w http.ResponseWriter, r *http.Request, id string) 
 	}
 
 	// Enforce authorization: only group owner or admins can update
-	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-		decision := s.authzService.CheckAccess(ctx, userIdent, groupResource(group), ActionUpdate)
-		if !decision.Allowed {
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
-			return
-		}
+	if !s.authorize(w, r, groupResource(group), ActionUpdate) {
+		return
 	}
 
 	var req UpdateGroupRequest
@@ -384,12 +380,8 @@ func (s *Server) deleteGroup(w http.ResponseWriter, r *http.Request, id string) 
 	}
 
 	// Enforce authorization: only group owner or admins can delete
-	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-		decision := s.authzService.CheckAccess(ctx, userIdent, groupResource(group), ActionDelete)
-		if !decision.Allowed {
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
-			return
-		}
+	if !s.authorize(w, r, groupResource(group), ActionDelete) {
+		return
 	}
 
 	if group.GroupType == store.GroupTypeProjectAgents {
@@ -492,12 +484,8 @@ func (s *Server) addGroupMember(w http.ResponseWriter, r *http.Request, group *s
 	groupID := group.ID
 
 	// Enforce authorization: only group owner or admins can add members
-	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-		decision := s.authzService.CheckAccess(ctx, userIdent, groupResource(group), ActionAddMember)
-		if !decision.Allowed {
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
-			return
-		}
+	if !s.authorize(w, r, groupResource(group), ActionAddMember) {
+		return
 	}
 
 	var req AddGroupMemberRequest
@@ -528,7 +516,21 @@ func (s *Server) addGroupMember(w http.ResponseWriter, r *http.Request, group *s
 
 	// Enforce role-hierarchy: only owners can add owners/admins; admins can only add members.
 	// Platform admins and group resource owners bypass the role-hierarchy check.
-	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+	//
+	// The hierarchy is defined over user membership in the group, so it cannot be
+	// evaluated for an agent or broker caller — which is why the pre-#591 form of
+	// this guard let those callers grant any role at all. Such a caller reaches
+	// this point only through an explicit addMember policy, and is held to adding
+	// plain members: escalating someone to admin or owner requires a caller whose
+	// own standing in the group can be checked.
+	userIdent, isUserCaller := GetIdentityFromContext(ctx).(UserIdentity)
+	if !isUserCaller {
+		if req.Role != store.GroupMemberRoleMember {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden,
+				"Only group owners can add owners or admins", nil)
+			return
+		}
+	} else {
 		isResourceOwner := group.OwnerID != "" && group.OwnerID == userIdent.ID()
 		isPlatformAdmin := userIdent.Role() == "admin"
 		if !isResourceOwner && !isPlatformAdmin {
@@ -717,12 +719,8 @@ func (s *Server) removeGroupMember(w http.ResponseWriter, r *http.Request, group
 	ctx := r.Context()
 
 	// Enforce authorization: only group owner or admins can remove members
-	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-		decision := s.authzService.CheckAccess(ctx, userIdent, groupResource(group), ActionRemoveMember)
-		if !decision.Allowed {
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
-			return
-		}
+	if !s.authorize(w, r, groupResource(group), ActionRemoveMember) {
+		return
 	}
 
 	// Prevent removing the last owner of a group

--- a/pkg/hub/handlers_logs.go
+++ b/pkg/hub/handlers_logs.go
@@ -48,18 +48,16 @@ func (s *Server) handleAgentLogs(w http.ResponseWriter, r *http.Request, agentID
 		return
 	}
 
-	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-		decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionRead)
-		if !decision.Allowed {
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
-			return
-		}
-	}
+	// Project isolation runs before the authorization check so a cross-project
+	// agent caller keeps its 404 and is not told the agent exists.
 	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
 		if agent.ProjectID != agentIdent.ProjectID() {
 			NotFound(w, "Agent")
 			return
 		}
+	}
+	if !s.authorize(w, r, agentResource(agent), ActionRead) {
+		return
 	}
 
 	dispatcher := s.GetDispatcher()
@@ -114,18 +112,16 @@ func (s *Server) handleAgentCloudLogs(w http.ResponseWriter, r *http.Request, ag
 		return
 	}
 
-	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-		decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionRead)
-		if !decision.Allowed {
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
-			return
-		}
-	}
+	// Project isolation runs before the authorization check so a cross-project
+	// agent caller keeps its 404 and is not told the agent exists.
 	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
 		if agent.ProjectID != agentIdent.ProjectID() {
 			NotFound(w, "Agent")
 			return
 		}
+	}
+	if !s.authorize(w, r, agentResource(agent), ActionRead) {
+		return
 	}
 
 	// Parse query parameters
@@ -203,12 +199,8 @@ func (s *Server) handleAgentCloudLogsStream(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-		decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionRead)
-		if !decision.Allowed {
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
-			return
-		}
+	if !s.authorize(w, r, agentResource(agent), ActionRead) {
+		return
 	}
 
 	// Parse query filters
@@ -302,18 +294,16 @@ func (s *Server) handleAgentMessageLogs(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-		decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionRead)
-		if !decision.Allowed {
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
-			return
-		}
-	}
+	// Project isolation runs before the authorization check so a cross-project
+	// agent caller keeps its 404 and is not told the agent exists.
 	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
 		if agent.ProjectID != agentIdent.ProjectID() {
 			NotFound(w, "Agent")
 			return
 		}
+	}
+	if !s.authorize(w, r, agentResource(agent), ActionRead) {
+		return
 	}
 
 	query := r.URL.Query()
@@ -384,12 +374,8 @@ func (s *Server) handleAgentMessageLogsStream(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-		decision := s.authzService.CheckAccess(ctx, userIdent, agentResource(agent), ActionRead)
-		if !decision.Allowed {
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
-			return
-		}
+	if !s.authorize(w, r, agentResource(agent), ActionRead) {
+		return
 	}
 
 	opts := LogQueryOptions{
@@ -472,18 +458,16 @@ func (s *Server) handleProjectMessageLogs(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-		decision := s.authzService.CheckAccess(ctx, userIdent, projectResource(project), ActionRead)
-		if !decision.Allowed {
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
-			return
-		}
-	}
+	// Project isolation runs before the authorization check so a cross-project
+	// agent caller keeps its 404 and is not told the project exists.
 	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
 		if project.ID != agentIdent.ProjectID() {
 			NotFound(w, "Project")
 			return
 		}
+	}
+	if !s.authorize(w, r, projectResource(project), ActionRead) {
+		return
 	}
 
 	query := r.URL.Query()
@@ -552,12 +536,8 @@ func (s *Server) handleProjectMessageLogsStream(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-		decision := s.authzService.CheckAccess(ctx, userIdent, projectResource(project), ActionRead)
-		if !decision.Allowed {
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
-			return
-		}
+	if !s.authorize(w, r, projectResource(project), ActionRead) {
+		return
 	}
 
 	opts := LogQueryOptions{

--- a/pkg/hub/handlers_logs.go
+++ b/pkg/hub/handlers_logs.go
@@ -199,6 +199,14 @@ func (s *Server) handleAgentCloudLogsStream(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Project isolation runs before the authorization check so a cross-project
+	// agent caller keeps its 404 and is not told the agent exists.
+	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+		if agent.ProjectID != agentIdent.ProjectID() {
+			NotFound(w, "Agent")
+			return
+		}
+	}
 	if !s.authorize(w, r, agentResource(agent), ActionRead) {
 		return
 	}
@@ -374,6 +382,14 @@ func (s *Server) handleAgentMessageLogsStream(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// Project isolation runs before the authorization check so a cross-project
+	// agent caller keeps its 404 and is not told the agent exists.
+	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+		if agent.ProjectID != agentIdent.ProjectID() {
+			NotFound(w, "Agent")
+			return
+		}
+	}
 	if !s.authorize(w, r, agentResource(agent), ActionRead) {
 		return
 	}
@@ -536,6 +552,14 @@ func (s *Server) handleProjectMessageLogsStream(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	// Project isolation runs before the authorization check so a cross-project
+	// agent caller keeps its 404 and is not told the project exists.
+	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+		if project.ID != agentIdent.ProjectID() {
+			NotFound(w, "Project")
+			return
+		}
+	}
 	if !s.authorize(w, r, projectResource(project), ActionRead) {
 		return
 	}

--- a/pkg/hub/handlers_runtime_brokers.go
+++ b/pkg/hub/handlers_runtime_brokers.go
@@ -339,12 +339,8 @@ func (s *Server) updateRuntimeBroker(w http.ResponseWriter, r *http.Request, id 
 	}
 
 	// Enforce authorization: only the broker owner or admins can update
-	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-		decision := s.authzService.CheckAccess(ctx, userIdent, brokerResource(broker), ActionUpdate)
-		if !decision.Allowed {
-			Forbidden(w)
-			return
-		}
+	if !s.authorize(w, r, brokerResource(broker), ActionUpdate) {
+		return
 	}
 
 	var updates struct {
@@ -399,14 +395,16 @@ func (s *Server) deleteRuntimeBroker(w http.ResponseWriter, r *http.Request, id 
 	}
 
 	// Enforce authorization: only the broker owner or admins can delete
+	if !s.authorize(w, r, brokerResource(broker), ActionDelete) {
+		return
+	}
+
+	// Attribution for the audit events below. Read from the full identity rather
+	// than the user identity: a caller that is not a user now has to pass the
+	// check above rather than skip it, so the event should name whoever it was.
 	var actorID string
-	if user := GetUserIdentityFromContext(ctx); user != nil {
-		actorID = user.ID()
-		decision := s.authzService.CheckAccess(ctx, user, brokerResource(broker), ActionDelete)
-		if !decision.Allowed {
-			Forbidden(w)
-			return
-		}
+	if ident := GetIdentityFromContext(ctx); ident != nil {
+		actorID = ident.ID()
 	}
 
 	brokerName := broker.Name
@@ -442,28 +440,25 @@ func (s *Server) deleteRuntimeBroker(w http.ResponseWriter, r *http.Request, id 
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// checkBrokerDispatchAccess verifies that the current user has dispatch permission
-// on the given broker. Returns true if access is granted. If denied, it writes a
-// 403 response and returns false. If the broker cannot be found, it writes an error
-// and returns false.
+// checkBrokerDispatchAccess verifies that the caller has dispatch permission on
+// the given broker. Returns true if access is granted. If denied, it writes a
+// 403 response and returns false. If the broker cannot be found, it writes an
+// error and returns false.
+//
+// The decision is canDispatchToBroker's, called rather than restated: the two
+// were "one decision written twice" and this is the copy that drifted. It opened
+// with `if userIdent == nil { return true }` — read as "broker-to-broker, allow",
+// but GetUserIdentityFromContext also returns nil for an agent caller and for no
+// caller at all, so it handed dispatch to every agent regardless of scope or
+// project, and to anything unauthenticated that reached it (ptone/scion#591).
+// Delegating leaves one place where the rule can change.
 func (s *Server) checkBrokerDispatchAccess(ctx context.Context, w http.ResponseWriter, brokerID string) bool {
-	userIdent := GetUserIdentityFromContext(ctx)
-	if userIdent == nil {
-		// No user identity (e.g. broker-to-broker) — allow
-		return true
-	}
 	broker, err := s.store.GetRuntimeBroker(ctx, brokerID)
 	if err != nil {
 		writeErrorFromErr(w, err, "")
 		return false
 	}
-	// Auto-provide brokers are shared infrastructure (e.g. a combo hub-broker
-	// server's default broker) and are dispatchable by any authenticated user.
-	if broker.AutoProvide {
-		return true
-	}
-	decision := s.authzService.CheckAccess(ctx, userIdent, brokerResource(broker), ActionDispatch)
-	if !decision.Allowed {
+	if !s.canDispatchToBroker(ctx, broker) {
 		writeError(w, http.StatusForbidden, ErrCodeForbidden,
 			"You don't have permission to create agents on this broker", nil)
 		return false

--- a/pkg/hub/handlers_shared_dirs.go
+++ b/pkg/hub/handlers_shared_dirs.go
@@ -46,16 +46,12 @@ func (s *Server) handleProjectSharedDirs(w http.ResponseWriter, r *http.Request,
 	switch r.Method {
 	case http.MethodGet:
 		// Read access check
-		if userIdent, ok := identity.(UserIdentity); ok {
-			decision := s.authzService.CheckAccess(ctx, userIdent, Resource{
-				Type:    "project",
-				ID:      project.ID,
-				OwnerID: project.OwnerID,
-			}, ActionRead)
-			if !decision.Allowed {
-				Forbidden(w)
-				return
-			}
+		if !s.authorize(w, r, Resource{
+			Type:    "project",
+			ID:      project.ID,
+			OwnerID: project.OwnerID,
+		}, ActionRead) {
+			return
 		}
 
 		dirs := project.SharedDirs

--- a/pkg/hub/handlers_shared_dirs.go
+++ b/pkg/hub/handlers_shared_dirs.go
@@ -45,6 +45,14 @@ func (s *Server) handleProjectSharedDirs(w http.ResponseWriter, r *http.Request,
 
 	switch r.Method {
 	case http.MethodGet:
+		// Project isolation runs before the authorization check so a cross-project
+		// agent caller keeps its 404 and is not told the project exists.
+		if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+			if project.ID != agentIdent.ProjectID() {
+				NotFound(w, "Project")
+				return
+			}
+		}
 		// Read access check
 		if !s.authorize(w, r, Resource{
 			Type:    "project",

--- a/pkg/hub/project_pre_start_hook_handlers.go
+++ b/pkg/hub/project_pre_start_hook_handlers.go
@@ -74,16 +74,12 @@ func (s *Server) handleProjectPreStartHooks(w http.ResponseWriter, r *http.Reque
 
 	switch r.Method {
 	case http.MethodGet:
-		if userIdent, ok := identity.(UserIdentity); ok {
-			decision := s.authzService.CheckAccess(ctx, userIdent, Resource{
-				Type:    "project",
-				ID:      project.ID,
-				OwnerID: project.OwnerID,
-			}, ActionRead)
-			if !decision.Allowed {
-				Forbidden(w)
-				return
-			}
+		if !s.authorize(w, r, Resource{
+			Type:    "project",
+			ID:      project.ID,
+			OwnerID: project.OwnerID,
+		}, ActionRead) {
+			return
 		}
 
 		hooks, err := s.store.ListProjectPreStartHooks(ctx, projectID)
@@ -243,11 +239,8 @@ func (s *Server) handleProjectPreStartHookByID(w http.ResponseWriter, r *http.Re
 
 	switch r.Method {
 	case http.MethodGet:
-		if userIdent, ok := identity.(UserIdentity); ok {
-			if !s.authzService.CheckAccess(ctx, userIdent, projectRes, ActionRead).Allowed {
-				Forbidden(w)
-				return
-			}
+		if !s.authorize(w, r, projectRes, ActionRead) {
+			return
 		}
 		hook, err := s.store.GetProjectPreStartHook(ctx, hookID, projectID)
 		if err != nil {

--- a/pkg/hub/project_pre_start_hook_handlers.go
+++ b/pkg/hub/project_pre_start_hook_handlers.go
@@ -74,6 +74,14 @@ func (s *Server) handleProjectPreStartHooks(w http.ResponseWriter, r *http.Reque
 
 	switch r.Method {
 	case http.MethodGet:
+		// Project isolation runs before the authorization check so a cross-project
+		// agent caller keeps its 404 and is not told the project exists.
+		if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+			if project.ID != agentIdent.ProjectID() {
+				NotFound(w, "Project")
+				return
+			}
+		}
 		if !s.authorize(w, r, Resource{
 			Type:    "project",
 			ID:      project.ID,

--- a/pkg/hub/project_settings_handlers.go
+++ b/pkg/hub/project_settings_handlers.go
@@ -170,6 +170,14 @@ func (s *Server) handleProjectSettings(w http.ResponseWriter, r *http.Request, p
 
 	switch r.Method {
 	case http.MethodGet:
+		// Project isolation runs before the authorization check so a cross-project
+		// agent caller keeps its 404 and is not told the project exists.
+		if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+			if project.ID != agentIdent.ProjectID() {
+				NotFound(w, "Project")
+				return
+			}
+		}
 		if !s.authorize(w, r, Resource{
 			Type:    "project",
 			ID:      project.ID,

--- a/pkg/hub/project_settings_handlers.go
+++ b/pkg/hub/project_settings_handlers.go
@@ -170,16 +170,12 @@ func (s *Server) handleProjectSettings(w http.ResponseWriter, r *http.Request, p
 
 	switch r.Method {
 	case http.MethodGet:
-		if userIdent, ok := identity.(UserIdentity); ok {
-			decision := s.authzService.CheckAccess(ctx, userIdent, Resource{
-				Type:    "project",
-				ID:      project.ID,
-				OwnerID: project.OwnerID,
-			}, ActionRead)
-			if !decision.Allowed {
-				Forbidden(w)
-				return
-			}
+		if !s.authorize(w, r, Resource{
+			Type:    "project",
+			ID:      project.ID,
+			OwnerID: project.OwnerID,
+		}, ActionRead) {
+			return
 		}
 
 		writeJSON(w, http.StatusOK, projectSettingsFromAnnotations(project))

--- a/pkg/hub/project_settings_resolved.go
+++ b/pkg/hub/project_settings_resolved.go
@@ -351,10 +351,13 @@ func (s *Server) handleProjectSettingsResolved(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	identity := GetIdentityFromContext(ctx)
-	if identity == nil {
-		Unauthorized(w)
-		return
+	// Project isolation runs before the authorization check so a cross-project
+	// agent caller keeps its 404 and is not told the project exists.
+	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+		if project.ID != agentIdent.ProjectID() {
+			NotFound(w, "Project")
+			return
+		}
 	}
 
 	// Same authorization as GET /settings: ActionRead on the project.

--- a/pkg/hub/project_settings_resolved.go
+++ b/pkg/hub/project_settings_resolved.go
@@ -362,16 +362,12 @@ func (s *Server) handleProjectSettingsResolved(w http.ResponseWriter, r *http.Re
 	// owner see that hub defaults exist. Only the existence of an
 	// agent_defaults entry is exposed, never a hub value and never any other
 	// part of the server configuration.
-	if userIdent, ok := identity.(UserIdentity); ok {
-		decision := s.authzService.CheckAccess(ctx, userIdent, Resource{
-			Type:    "project",
-			ID:      project.ID,
-			OwnerID: project.OwnerID,
-		}, ActionRead)
-		if !decision.Allowed {
-			Forbidden(w)
-			return
-		}
+	if !s.authorize(w, r, Resource{
+		Type:    "project",
+		ID:      project.ID,
+		OwnerID: project.OwnerID,
+	}, ActionRead) {
+		return
 	}
 
 	writeJSON(w, http.StatusOK, s.resolvedProjectSettings(project))

--- a/pkg/hub/pty_handlers.go
+++ b/pkg/hub/pty_handlers.go
@@ -74,6 +74,13 @@ func (s *Server) handleAgentPTY(w http.ResponseWriter, r *http.Request) {
 		if ticket != "" {
 			// Validate ticket (single-use token)
 			identity = s.validatePTYTicket(ctx, ticket)
+			if identity != nil {
+				// Carry the ticket identity on the request so the authorization
+				// helper below gates the principal this handler authenticated
+				// rather than finding no identity and rejecting the connection.
+				ctx = contextWithIdentity(ctx, identity)
+				r = r.WithContext(ctx)
+			}
 		}
 	}
 
@@ -89,17 +96,12 @@ func (s *Server) handleAgentPTY(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Enforce policy-based authorization: only the agent's creator (owner) or admins can access PTY
-	if user := GetUserIdentityFromContext(ctx); user != nil {
-		decision := s.authzService.CheckAccess(ctx, user, agentResource(agent), ActionAttach)
-		if !decision.Allowed {
-			slog.Warn("PTY access denied: policy check failed",
-				"agent_id", agentID,
-				"userID", user.ID(),
-				"reason", decision.Reason)
-			writeError(w, http.StatusForbidden, ErrCodeForbidden, "Access denied", nil)
-			return
-		}
+	// Enforce authorization for every caller kind. A user passes on ActionAttach
+	// against the agent; an agent passes on ScopeAgentLifecycle within its own
+	// project. Attaching a PTY is not read-class, so the agent project read
+	// baseline deliberately does not reach it.
+	if !s.authorizeAgentLifecycle(w, r, agent) {
+		return
 	}
 
 	// Check if agent has a runtime broker

--- a/pkg/hub/skill_handlers.go
+++ b/pkg/hub/skill_handlers.go
@@ -1553,15 +1553,22 @@ func (s *Server) canUseProjectGitHubToken(ctx context.Context, projectID string)
 	if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
 		return agentIdent.ProjectID() == projectID
 	}
-	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-		if s.authzService == nil {
-			return false
-		}
-		return s.authzService.CheckAccess(ctx, userIdent, Resource{
-			Type: "skill", ParentType: "project", ParentID: projectID,
-		}, ActionRead).Allowed
+	// Last arm, and the only one left: anything that is not a broker or an agent
+	// must be a user holding read on the project's skills. The nil test is
+	// written as an explicit deny rather than as a guard around the CheckAccess
+	// call, because a guarded call is the #591 shape — there the deny is implied
+	// by the absence of an else, and an edit that adds code after the block
+	// silently turns it into an allow.
+	userIdent := GetUserIdentityFromContext(ctx)
+	if userIdent == nil {
+		return false
 	}
-	return false
+	if s.authzService == nil {
+		return false
+	}
+	return s.authzService.CheckAccess(ctx, userIdent, Resource{
+		Type: "skill", ParentType: "project", ParentID: projectID,
+	}, ActionRead).Allowed
 }
 
 // resolveGitHubToken determines the GitHub token scope and mints a token if needed.


### PR DESCRIPTION
## Summary

Closes the 22 authorization bypass sites identified in ptone/scion#591 Part 1 and wires the regression guard script into CI.

Every site used GetUserIdentityFromContext, which returns nil for agent and broker callers, silently skipping authorization. Each is converted to the fail-closed s.authorize() helpers from authorize.go.

### Key changes
- 22 handler conversions across 9 files
- checkBrokerDispatchAccess fail-open eliminated by delegating to canDispatchToBroker
- addGroupMember: non-user callers capped at plain member role
- 404-before-403 isolation ordering on all converted endpoints
- 462 lines of regression tests (7 suites, 35 cases)
- CI wiring: Makefile target + GitHub Actions step