### PR TITLE
fix: apply hub default model and thinking level to agents

### DIFF
--- a/pkg/config/opsettings/koanf.go
+++ b/pkg/config/opsettings/koanf.go
@@ -210,7 +210,8 @@ func extractSubtree(k *koanf.Koanf, prefix string) (json.RawMessage, error) {
 func extractAgentDefaults(k *koanf.Koanf) (json.RawMessage, error) {
 	doc := make(map[string]interface{})
 	fields := []string{"default_template", "default_harness_config", "default_max_turns",
-		"default_max_model_calls", "default_max_duration", "default_resources"}
+		"default_max_model_calls", "default_max_duration", "default_resources",
+		"default_model", "default_thinking_level"}
 	for _, f := range fields {
 		if k.Exists(f) {
 			doc[f] = k.Get(f)

--- a/pkg/config/opsettings/koanf.go
+++ b/pkg/config/opsettings/koanf.go
@@ -211,7 +211,8 @@ func extractAgentDefaults(k *koanf.Koanf) (json.RawMessage, error) {
 	doc := make(map[string]interface{})
 	fields := []string{"default_template", "default_harness_config", "default_max_turns",
 		"default_max_model_calls", "default_max_duration", "default_resources",
-		"default_model", "default_thinking_level"}
+		"default_model", "default_thinking_level",
+		"default_max_agent_role", "default_agent_role"}
 	for _, f := range fields {
 		if k.Exists(f) {
 			doc[f] = k.Get(f)

--- a/pkg/hub/hub_agent_defaults.go
+++ b/pkg/hub/hub_agent_defaults.go
@@ -105,15 +105,16 @@ func resourceSpecEqual(a, b *api.ResourceSpec) bool {
 // exactly two call sites — the agent-create path and the scheduler-dispatch
 // path — and each sits strictly between those two functions.
 //
-// Only default_harness_config is handled here. default_template joins the
-// template ladder further up each path, because it has to be in place before
-// the template is resolved. The other four agent_defaults fields
-// (default_max_turns, default_max_model_calls, default_max_duration,
-// default_resources) deliberately do NOT belong here: writing them into
-// AppliedConfig/InlineConfig would send them to the broker as top-of-chain and
-// let a hub-wide floor override a template's explicit value — the inversion
-// this workstream exists to remove (design §3.2.1, rejected alternative A5).
-// They travel by a separate low-rank channel and are applied broker-side.
+// Only default_harness_config and default_model are handled here.
+// default_template joins the template ladder further up each path, because it
+// has to be in place before the template is resolved. The other four
+// agent_defaults fields (default_max_turns, default_max_model_calls,
+// default_max_duration, default_resources) deliberately do NOT belong here:
+// writing them into AppliedConfig/InlineConfig would send them to the broker
+// as top-of-chain and let a hub-wide floor override a template's explicit
+// value — the inversion this workstream exists to remove (design §3.2.1,
+// rejected alternative A5). They travel by a separate low-rank channel and
+// are applied broker-side.
 //
 // ACCEPTED CONSEQUENCE, so the next reader does not file it as a bug: a
 // harness config resolved here reaches the broker as a CLIFlag-rank value and
@@ -125,11 +126,16 @@ func applyHubAgentDefaults(ac *store.AgentAppliedConfig, d opsettings.AgentDefau
 	if ac == nil {
 		return false
 	}
+	changed := false
 	if ac.HarnessConfig == "" && d.DefaultHarnessConfig != "" {
 		ac.HarnessConfig = d.DefaultHarnessConfig
-		return true
+		changed = true
 	}
-	return false
+	if ac.Model == "" && d.DefaultModel != "" {
+		ac.Model = d.DefaultModel
+		changed = true
+	}
+	return changed
 }
 
 // warnHubDefaultTemplateUnusable logs the degradation described in

--- a/pkg/hub/hub_agent_defaults.go
+++ b/pkg/hub/hub_agent_defaults.go
@@ -140,7 +140,8 @@ func applyHubAgentDefaults(ac *store.AgentAppliedConfig, d opsettings.AgentDefau
 		ac.Model = d.DefaultModel
 	}
 	if ac.ThinkingLevel == nil && d.DefaultThinkingLevel != nil {
-		ac.ThinkingLevel = d.DefaultThinkingLevel
+		v := *d.DefaultThinkingLevel
+		ac.ThinkingLevel = &v
 	}
 	return hcChanged
 }

--- a/pkg/hub/hub_agent_defaults.go
+++ b/pkg/hub/hub_agent_defaults.go
@@ -105,16 +105,21 @@ func resourceSpecEqual(a, b *api.ResourceSpec) bool {
 // exactly two call sites — the agent-create path and the scheduler-dispatch
 // path — and each sits strictly between those two functions.
 //
-// Only default_harness_config and default_model are handled here.
-// default_template joins the template ladder further up each path, because it
-// has to be in place before the template is resolved. The other four
-// agent_defaults fields (default_max_turns, default_max_model_calls,
+// Only default_harness_config, default_model and default_thinking_level are
+// handled here. default_template joins the template ladder further up each
+// path, because it has to be in place before the template is resolved. The
+// other four agent_defaults fields (default_max_turns, default_max_model_calls,
 // default_max_duration, default_resources) deliberately do NOT belong here:
 // writing them into AppliedConfig/InlineConfig would send them to the broker
 // as top-of-chain and let a hub-wide floor override a template's explicit
 // value — the inversion this workstream exists to remove (design §3.2.1,
 // rejected alternative A5). They travel by a separate low-rank channel and
 // are applied broker-side.
+//
+// The return value reports whether HarnessConfig was supplied — callers use it
+// to set withHubDefaultHarnessConfig context for provenance logging. Model and
+// ThinkingLevel are applied unconditionally (only-if-empty) and do not affect
+// the return.
 //
 // ACCEPTED CONSEQUENCE, so the next reader does not file it as a bug: a
 // harness config resolved here reaches the broker as a CLIFlag-rank value and
@@ -126,16 +131,18 @@ func applyHubAgentDefaults(ac *store.AgentAppliedConfig, d opsettings.AgentDefau
 	if ac == nil {
 		return false
 	}
-	changed := false
+	hcChanged := false
 	if ac.HarnessConfig == "" && d.DefaultHarnessConfig != "" {
 		ac.HarnessConfig = d.DefaultHarnessConfig
-		changed = true
+		hcChanged = true
 	}
 	if ac.Model == "" && d.DefaultModel != "" {
 		ac.Model = d.DefaultModel
-		changed = true
 	}
-	return changed
+	if ac.ThinkingLevel == nil && d.DefaultThinkingLevel != nil {
+		ac.ThinkingLevel = d.DefaultThinkingLevel
+	}
+	return hcChanged
 }
 
 // warnHubDefaultTemplateUnusable logs the degradation described in

--- a/pkg/hub/hub_agent_defaults_ladder_test.go
+++ b/pkg/hub/hub_agent_defaults_ladder_test.go
@@ -151,6 +151,105 @@ func TestApplyHubAgentDefaults_HarnessConfig(t *testing.T) {
 	}
 }
 
+// TestApplyHubAgentDefaults_Model is the table the design asks for.
+// Analogous to TestApplyHubAgentDefaults_HarnessConfig: the hub operational
+// DefaultModel fills ac.Model only when no higher tier has set it.
+func TestApplyHubAgentDefaults_Model(t *testing.T) {
+	const hubDefault = "medium"
+
+	tests := []struct {
+		name      string
+		incumbent string
+		want      string
+	}{
+		{
+			name:      "LosesToRequest",
+			incumbent: "large",
+			want:      "large",
+		},
+		{
+			name:      "LosesToProjectAnnotation",
+			incumbent: "small",
+			want:      "small",
+		},
+		{
+			name:      "LosesToTemplate",
+			incumbent: "opus",
+			want:      "opus",
+		},
+		{
+			name:      "AppliesWhenEmpty",
+			incumbent: "",
+			want:      hubDefault,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ac := &store.AgentAppliedConfig{Model: tt.incumbent}
+			applied := applyHubAgentDefaults(ac, opsettings.AgentDefaultsSettings{
+				DefaultModel: hubDefault,
+			})
+			assert.Equal(t, tt.want, ac.Model)
+			assert.False(t, applied,
+				"the return value tracks harness-config provenance only; model must not affect it")
+		})
+	}
+}
+
+// TestApplyHubAgentDefaults_ModelEmptyDefault verifies that an empty hub
+// DefaultModel leaves ac.Model untouched.
+func TestApplyHubAgentDefaults_ModelEmptyDefault(t *testing.T) {
+	ac := &store.AgentAppliedConfig{}
+	applied := applyHubAgentDefaults(ac, opsettings.AgentDefaultsSettings{})
+	assert.Empty(t, ac.Model)
+	assert.False(t, applied)
+}
+
+// TestApplyHubAgentDefaults_ThinkingLevel verifies the only-if-nil guard for
+// DefaultThinkingLevel.
+func TestApplyHubAgentDefaults_ThinkingLevel(t *testing.T) {
+	hubLevel := 3
+
+	t.Run("AppliesWhenNil", func(t *testing.T) {
+		ac := &store.AgentAppliedConfig{}
+		applyHubAgentDefaults(ac, opsettings.AgentDefaultsSettings{
+			DefaultThinkingLevel: &hubLevel,
+		})
+		require.NotNil(t, ac.ThinkingLevel)
+		assert.Equal(t, 3, *ac.ThinkingLevel)
+	})
+
+	t.Run("LosesToPreSet", func(t *testing.T) {
+		existing := 5
+		ac := &store.AgentAppliedConfig{ThinkingLevel: &existing}
+		applyHubAgentDefaults(ac, opsettings.AgentDefaultsSettings{
+			DefaultThinkingLevel: &hubLevel,
+		})
+		require.NotNil(t, ac.ThinkingLevel)
+		assert.Equal(t, 5, *ac.ThinkingLevel)
+	})
+
+	t.Run("NilDefaultDoesNothing", func(t *testing.T) {
+		ac := &store.AgentAppliedConfig{}
+		applyHubAgentDefaults(ac, opsettings.AgentDefaultsSettings{})
+		assert.Nil(t, ac.ThinkingLevel)
+	})
+}
+
+// TestApplyHubAgentDefaults_ModelDoesNotAffectHCProvenance verifies that
+// applying only DefaultModel (no DefaultHarnessConfig) returns false, so
+// callers do not set withHubDefaultHarnessConfig context spuriously.
+func TestApplyHubAgentDefaults_ModelDoesNotAffectHCProvenance(t *testing.T) {
+	ac := &store.AgentAppliedConfig{}
+	applied := applyHubAgentDefaults(ac, opsettings.AgentDefaultsSettings{
+		DefaultModel: "medium",
+	})
+	assert.Equal(t, "medium", ac.Model)
+	assert.False(t, applied,
+		"model-only application must not signal harness-config provenance")
+}
+
 // TestApplyHubAgentDefaults_IgnoresTheFourLimitFields is the A5 guard at unit
 // level. The four limit/resource fields must not be stamped hub-side: doing so
 // would send them to the broker as top-of-chain and let a hub-wide floor


### PR DESCRIPTION
Fixes two bugs in hub agent defaults:

1. applyHubAgentDefaults now applies DefaultModel and DefaultThinkingLevel to agents (only-if-empty guard). Previously these fields were stored in operational settings but never stamped onto agents. The return value tracks only HarnessConfig provenance (callers use it for from_hub_default logging context).

2. extractAgentDefaults now includes default_model, default_thinking_level, default_max_agent_role, and default_agent_role in its field list, fixing silent drops during file-to-DB seeding.

Includes unit tests for all new model/thinking-level defaulting behavior (rank pinning, empty-default, provenance isolation).
