### PR TITLE
feat(web): make the terminal usable on a touchscreen — scroll by drag, and auto-reconnect

### DIFF
--- a/pkg/agent/manager.go
+++ b/pkg/agent/manager.go
@@ -202,10 +202,41 @@ func (m *AgentManager) Message(ctx context.Context, agentID, projectID string, m
 	return nil
 }
 
+// exitCopyModeCmd returns the tmux command that leaves copy-mode. Real keys
+// (interrupts, raw sequences) are dispatched through the mode's key table
+// rather than to the harness, so those paths must cancel the mode first.
+// -q is a no-op when the pane is not in a mode.
+func exitCopyModeCmd() []string {
+	return []string{"tmux", "copy-mode", "-q", "-t", "scion:0"}
+}
+
+// isExitCopyModeCmd reports whether cmd is the copy-mode exit, whose failure
+// is tolerated.
+func isExitCopyModeCmd(cmd []string) bool {
+	return len(cmd) > 1 && cmd[1] == "copy-mode"
+}
+
+// submitCmds returns the commands that submit whatever is in the harness's
+// input, without disturbing copy-mode: paste-buffer writes to the pane's pty
+// and bypasses the mode key table, so the operator's scroll position survives.
+//
+// A literal CR rather than LF, so this does not depend on paste-buffer's
+// LF->CR default. -d consumes the buffer as it is pasted: a named buffer still
+// sits on top of the operator's buffer stack, so without it their paste key
+// would fetch this CR instead of the text they copied.
+func submitCmds() [][]string {
+	return [][]string{
+		{"tmux", "set-buffer", "-b", "scion-submit", "--", "\r"},
+		{"tmux", "paste-buffer", "-d", "-b", "scion-submit", "-t", "scion:0"},
+	}
+}
+
 // MessageRaw sends literal bytes to an agent's tmux session via send-keys
 // with no trailing Enter keypresses. This bypasses the paste buffer and
 // debounce buffer, sending directly via tmux send-keys so that control
 // sequences (arrow keys, Escape, etc.) are interpreted by the terminal.
+// Leaves copy-mode first, since send-keys is dispatched through the mode's
+// key table rather than to the harness.
 func (m *AgentManager) MessageRaw(ctx context.Context, agentID, projectID string, keys string) error {
 	filter := map[string]string{"scion.name": strings.ToLower(agentID)}
 	if projectID != "" {
@@ -228,9 +259,17 @@ func (m *AgentManager) MessageRaw(ctx context.Context, agentID, projectID string
 		return fmt.Errorf("agent '%s' not found or not running", agentID)
 	}
 
-	cmd := []string{"tmux", "send-keys", "-t", "scion:0", "--", keys}
-	if _, err := m.Runtime.Exec(ctx, agent.ContainerID, cmd); err != nil {
-		return fmt.Errorf("failed to send raw keys to agent '%s': %w", agent.Name, err)
+	cmds := [][]string{
+		exitCopyModeCmd(),
+		{"tmux", "send-keys", "-t", "scion:0", "--", keys},
+	}
+	for _, cmd := range cmds {
+		if _, err := m.Runtime.Exec(ctx, agent.ContainerID, cmd); err != nil {
+			if isExitCopyModeCmd(cmd) {
+				continue
+			}
+			return fmt.Errorf("failed to send raw keys to agent '%s': %w", agent.Name, err)
+		}
 	}
 
 	return nil
@@ -285,6 +324,12 @@ func (m *AgentManager) deliverImmediate(ctx context.Context, agentID, projectID 
 	// 3. Prepare commands
 	var cmds [][]string
 
+	// Only the paths that send real KEYS need the mode cancelled; the message
+	// path submits via paste instead and leaves a reading operator alone.
+	if interrupt || message == "" {
+		cmds = append(cmds, exitCopyModeCmd())
+	}
+
 	if interrupt {
 		if seq := h.GetInterruptSequence(); len(seq) > 0 {
 			for _, key := range seq {
@@ -306,15 +351,23 @@ func (m *AgentManager) deliverImmediate(ctx context.Context, agentID, projectID 
 		// CLI treats '!' as a shell-mode toggle). Bracketed paste wraps the
 		// content in escape sequences (\e[200~...\e[201~) that signal the
 		// application to treat all characters as literal pasted text.
-		cmds = append(cmds, []string{"tmux", "set-buffer", "--", message})
-		cmds = append(cmds, []string{"tmux", "paste-buffer", "-t", "scion:0", "-p"})
-		cmds = append(cmds, []string{"tmux", "send-keys", "-t", "scion:0", "Enter"})
+		// Named buffer: an unnamed set-buffer pushes onto the operator's
+		// buffer stack, so their paste key would fetch the agent's message.
+		cmds = append(cmds, []string{"tmux", "set-buffer", "-b", "scion-msg", "--", message})
+		cmds = append(cmds, []string{"tmux", "paste-buffer", "-d", "-b", "scion-msg", "-t", "scion:0", "-p"})
+		cmds = append(cmds, submitCmds()...)
 	}
 
 	// 4. Execute
 	for _, cmd := range cmds {
 		_, err := m.Runtime.Exec(ctx, agent.ContainerID, cmd)
 		if err != nil {
+			if isExitCopyModeCmd(cmd) {
+				// tmux before 3.1 has no -q. Leaving the mode is best-effort:
+				// failing the delivery over it would lose a message that older
+				// tmux would otherwise have taken.
+				continue
+			}
 			return fmt.Errorf("failed to send message to agent '%s': %w", agent.Name, err)
 		}
 	}
@@ -322,11 +375,12 @@ func (m *AgentManager) deliverImmediate(ctx context.Context, agentID, projectID 
 	// After sending a message, send two extra Enter keypresses with a brief delay
 	// to ensure the input is accepted by the agent.
 	if message != "" {
-		enterCmd := []string{"tmux", "send-keys", "-t", "scion:0", "Enter"}
 		for range 2 {
 			time.Sleep(300 * time.Millisecond)
-			if _, err := m.Runtime.Exec(ctx, agent.ContainerID, enterCmd); err != nil {
-				return fmt.Errorf("failed to send Enter to agent '%s': %w", agent.Name, err)
+			for _, cmd := range submitCmds() {
+				if _, err := m.Runtime.Exec(ctx, agent.ContainerID, cmd); err != nil {
+					return fmt.Errorf("failed to send Enter to agent '%s': %w", agent.Name, err)
+				}
 			}
 		}
 	}

--- a/pkg/agent/message_test.go
+++ b/pkg/agent/message_test.go
@@ -16,7 +16,9 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -63,12 +65,17 @@ func TestMessage(t *testing.T) {
 	}
 
 	expectedCmds := []string{
+		"tmux copy-mode -q -t scion:0",
 		"tmux send-keys -t scion:0 C-c",
-		"tmux set-buffer -- hello world",
-		"tmux paste-buffer -t scion:0 -p",
-		"tmux send-keys -t scion:0 Enter",
-		"tmux send-keys -t scion:0 Enter",
-		"tmux send-keys -t scion:0 Enter",
+		"tmux set-buffer -b scion-msg -- hello world",
+		"tmux paste-buffer -d -b scion-msg -t scion:0 -p",
+		// -d consumes the buffer, so each retry re-sets it.
+		"tmux set-buffer -b scion-submit -- \r",
+		"tmux paste-buffer -d -b scion-submit -t scion:0",
+		"tmux set-buffer -b scion-submit -- \r",
+		"tmux paste-buffer -d -b scion-submit -t scion:0",
+		"tmux set-buffer -b scion-submit -- \r",
+		"tmux paste-buffer -d -b scion-submit -t scion:0",
 	}
 
 	if len(capturedCmd) != len(expectedCmds) {
@@ -110,9 +117,9 @@ func TestBroadcast(t *testing.T) {
 	mockRT.ExecFunc = func(ctx context.Context, id string, cmd []string) (string, error) {
 		mu.Lock()
 		capturedCalls = append(capturedCalls, fmt.Sprintf("%s: %s", id, strings.Join(cmd, " ")))
-		// Signal done for each bare Enter keypress (two trailing Enters per agent delivery).
-		// Bare Enter: ["tmux", "send-keys", "-t", "scion:0", "Enter"] → len 5.
-		if len(cmd) == 5 && cmd[0] == "tmux" && cmd[1] == "send-keys" && cmd[4] == "Enter" {
+		// Signal done for each submit paste (one for the message, two for the
+		// trailing retries, per agent delivery).
+		if cmd[0] == "tmux" && cmd[1] == "paste-buffer" && slices.Contains(cmd, "scion-submit") {
 			done <- struct{}{}
 		}
 		mu.Unlock()
@@ -140,7 +147,7 @@ func TestBroadcast(t *testing.T) {
 		t.Fatalf("Message 2 failed: %v", err)
 	}
 
-	// Wait for both buffered deliveries to complete (3 Enters per agent × 2 agents).
+	// Wait for both buffered deliveries to complete (3 submits per agent × 2 agents).
 	for i := 0; i < 6; i++ {
 		select {
 		case <-done:
@@ -152,21 +159,24 @@ func TestBroadcast(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	expectedCalls := []string{
-		"agent-1: tmux set-buffer -- hello",
-		"agent-1: tmux paste-buffer -t scion:0 -p",
-		"agent-1: tmux send-keys -t scion:0 Enter",
-		"agent-1: tmux send-keys -t scion:0 Enter",
-		"agent-1: tmux send-keys -t scion:0 Enter",
-		"agent-2: tmux set-buffer -- hello",
-		"agent-2: tmux paste-buffer -t scion:0 -p",
-		"agent-2: tmux send-keys -t scion:0 Enter",
-		"agent-2: tmux send-keys -t scion:0 Enter",
-		"agent-2: tmux send-keys -t scion:0 Enter",
+	// Per agent: the message paste, its submit, then two retry submits.
+	perAgent := func(a string) []string {
+		out := []string{
+			a + ": tmux set-buffer -b scion-msg -- hello",
+			a + ": tmux paste-buffer -d -b scion-msg -t scion:0 -p",
+		}
+		// One submit for the message, then the two retries. -d consumes the
+		// buffer, so each pairs a set with its paste.
+		for range 3 {
+			out = append(out,
+				a+": tmux set-buffer -b scion-submit -- \r",
+				a+": tmux paste-buffer -d -b scion-submit -t scion:0")
+		}
+		return out
 	}
 
-	if len(capturedCalls) != len(expectedCalls) {
-		t.Fatalf("Expected %d calls, got %d: %v", len(expectedCalls), len(capturedCalls), capturedCalls)
+	if want := len(perAgent("agent-1")) * 2; len(capturedCalls) != want {
+		t.Fatalf("Expected %d calls, got %d: %v", want, len(capturedCalls), capturedCalls)
 	}
 
 	// Since buffer delivery is async, agents may flush in either order.
@@ -174,14 +184,14 @@ func TestBroadcast(t *testing.T) {
 	agent1Calls := filterByPrefix(capturedCalls, "agent-1:")
 	agent2Calls := filterByPrefix(capturedCalls, "agent-2:")
 
-	if len(agent1Calls) != 5 || len(agent2Calls) != 5 {
-		t.Fatalf("Expected 5 calls per agent, got agent-1=%d agent-2=%d", len(agent1Calls), len(agent2Calls))
-	}
-	if agent1Calls[0] != "agent-1: tmux set-buffer -- hello" {
-		t.Errorf("Unexpected agent-1 call[0]: %s", agent1Calls[0])
-	}
-	if agent2Calls[0] != "agent-2: tmux set-buffer -- hello" {
-		t.Errorf("Unexpected agent-2 call[0]: %s", agent2Calls[0])
+	for _, tc := range []struct {
+		name string
+		got  []string
+	}{{"agent-1", agent1Calls}, {"agent-2", agent2Calls}} {
+		want := perAgent(tc.name)
+		if !slices.Equal(tc.got, want) {
+			t.Errorf("%s commands = %v, want %v", tc.name, tc.got, want)
+		}
 	}
 }
 
@@ -219,8 +229,10 @@ func TestMessageRaw(t *testing.T) {
 		t.Fatalf("MessageRaw failed: %v", err)
 	}
 
-	// Raw should produce exactly one send-keys command with no trailing Enter
+	// Raw should leave copy-mode, then produce exactly one send-keys command
+	// with no trailing Enter.
 	expectedCmds := []string{
+		"tmux copy-mode -q -t scion:0",
 		"tmux send-keys -t scion:0 -- Escape",
 	}
 
@@ -235,6 +247,135 @@ func TestMessageRaw(t *testing.T) {
 	}
 }
 
+// TestDeliveryReachesTheHarnessInCopyMode pins how each delivery path survives
+// a pane left in copy-mode by a scroll. Real keys are dispatched through the
+// mode's key table, so those paths cancel the mode first; the message path
+// submits by paste, which bypasses the key table and therefore must NOT cancel
+// - that is what keeps a reading operator's scroll position.
+func TestDeliveryReachesTheHarnessInCopyMode(t *testing.T) {
+	const exitCopyMode = "tmux copy-mode -q -t scion:0"
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		// deliver invokes one delivery path.
+		deliver func(mgr *AgentManager) error
+		// wantExit is whether that path must cancel copy-mode.
+		wantExit bool
+		// firstInput is the first command of that path that reaches the pane.
+		firstInput string
+	}{
+		{
+			name:       "message submits by paste and leaves the mode alone",
+			deliver:    func(mgr *AgentManager) error { return mgr.deliverImmediate(ctx, "test-agent", "", "hello", false) },
+			wantExit:   false,
+			firstInput: "tmux paste-buffer -d -b scion-msg -t scion:0 -p",
+		},
+		{
+			name:       "interrupt sends real keys so it must cancel first",
+			deliver:    func(mgr *AgentManager) error { return mgr.deliverImmediate(ctx, "test-agent", "", "hello", true) },
+			wantExit:   true,
+			firstInput: "tmux send-keys -t scion:0 C-c",
+		},
+		{
+			name:       "empty message is a bare Enter key so it must cancel first",
+			deliver:    func(mgr *AgentManager) error { return mgr.deliverImmediate(ctx, "test-agent", "", "", false) },
+			wantExit:   true,
+			firstInput: "tmux send-keys -t scion:0 Enter",
+		},
+		{
+			name:       "raw keys must cancel first",
+			deliver:    func(mgr *AgentManager) error { return mgr.MessageRaw(ctx, "test-agent", "", "Escape") },
+			wantExit:   true,
+			firstInput: "tmux send-keys -t scion:0 -- Escape",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedCmds []string
+			mockRT := &runtime.MockRuntime{
+				ListFunc: func(ctx context.Context, filter map[string]string) ([]api.AgentInfo, error) {
+					return []api.AgentInfo{
+						{
+							ContainerID:     "agent-1",
+							Name:            "test-agent",
+							ContainerStatus: "Up 2 minutes",
+							Labels:          map[string]string{"scion.name": "test-agent"},
+						},
+					}, nil
+				},
+				ExecFunc: func(ctx context.Context, id string, cmd []string) (string, error) {
+					capturedCmds = append(capturedCmds, strings.Join(cmd, " "))
+					return "", nil
+				},
+			}
+
+			mgr := &AgentManager{Runtime: mockRT}
+			if err := tt.deliver(mgr); err != nil {
+				t.Fatalf("delivery failed: %v", err)
+			}
+			if len(capturedCmds) == 0 {
+				t.Fatal("no commands were sent")
+			}
+
+			exitIdx := slices.Index(capturedCmds, exitCopyMode)
+			if tt.wantExit && exitIdx != 0 {
+				t.Errorf("expected cmd 0 to be %q, got %v", exitCopyMode, capturedCmds)
+			}
+			if !tt.wantExit && exitIdx >= 0 {
+				t.Errorf("path must not cancel copy-mode, but did at %d: %v", exitIdx, capturedCmds)
+			}
+
+			inputIdx := slices.Index(capturedCmds, tt.firstInput)
+			if inputIdx < 0 {
+				t.Fatalf("expected %q among the sent commands, got %v", tt.firstInput, capturedCmds)
+			}
+			if tt.wantExit && inputIdx < exitIdx {
+				t.Errorf("%q was sent before copy-mode was left: %v", tt.firstInput, capturedCmds)
+			}
+		})
+	}
+}
+
+// TestMessageSubmitsWithoutSendKeys guards the property the paste submit exists
+// for: nothing on the plain-message path may go through the mode's key table.
+func TestMessageSubmitsWithoutSendKeys(t *testing.T) {
+	var capturedCmds [][]string
+	mockRT := &runtime.MockRuntime{
+		ListFunc: func(ctx context.Context, filter map[string]string) ([]api.AgentInfo, error) {
+			return []api.AgentInfo{
+				{
+					ContainerID:     "agent-1",
+					Name:            "test-agent",
+					ContainerStatus: "Up 2 minutes",
+					Labels:          map[string]string{"scion.name": "test-agent"},
+				},
+			}, nil
+		},
+		ExecFunc: func(ctx context.Context, id string, cmd []string) (string, error) {
+			capturedCmds = append(capturedCmds, cmd)
+			return "", nil
+		},
+	}
+
+	mgr := &AgentManager{Runtime: mockRT}
+	if err := mgr.deliverImmediate(context.Background(), "test-agent", "", "hello", false); err != nil {
+		t.Fatalf("delivery failed: %v", err)
+	}
+
+	for _, cmd := range capturedCmds {
+		if len(cmd) > 1 && cmd[1] == "send-keys" {
+			t.Errorf("plain message path used send-keys, which copy-mode swallows: %v", cmd)
+		}
+	}
+	if !slices.ContainsFunc(capturedCmds, func(c []string) bool {
+		return len(c) > 1 && c[1] == "paste-buffer" && slices.Contains(c, "scion-submit")
+	}) {
+		t.Error("no submit paste was sent; the message would never be submitted")
+	}
+}
+
 // filterByPrefix returns entries from calls that start with the given prefix.
 func filterByPrefix(calls []string, prefix string) []string {
 	var result []string
@@ -244,4 +385,58 @@ func filterByPrefix(calls []string, prefix string) []string {
 		}
 	}
 	return result
+}
+
+// TestDeliveryToleratesOldTmux pins the fallback for tmux before 3.1, where
+// copy-mode -q does not exist: the delivery must still go through rather than
+// aborting on a command that is only best-effort.
+func TestDeliveryToleratesOldTmux(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tt := range []struct {
+		name    string
+		deliver func(mgr *AgentManager) error
+		want    string
+	}{
+		{
+			name:    "raw keys",
+			deliver: func(m *AgentManager) error { return m.MessageRaw(ctx, "test-agent", "", "Escape") },
+			want:    "tmux send-keys -t scion:0 -- Escape",
+		},
+		{
+			name:    "interrupt",
+			deliver: func(m *AgentManager) error { return m.deliverImmediate(ctx, "test-agent", "", "hello", true) },
+			want:    "tmux send-keys -t scion:0 C-c",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured []string
+			mockRT := &runtime.MockRuntime{
+				ListFunc: func(ctx context.Context, filter map[string]string) ([]api.AgentInfo, error) {
+					return []api.AgentInfo{{
+						ContainerID:     "agent-1",
+						Name:            "test-agent",
+						ContainerStatus: "Up 2 minutes",
+						Labels:          map[string]string{"scion.name": "test-agent"},
+					}}, nil
+				},
+				ExecFunc: func(ctx context.Context, id string, cmd []string) (string, error) {
+					joined := strings.Join(cmd, " ")
+					captured = append(captured, joined)
+					if strings.Contains(joined, "copy-mode") {
+						return "", errors.New("unknown flag: -q")
+					}
+					return "", nil
+				},
+			}
+
+			mgr := &AgentManager{Runtime: mockRT}
+			if err := tt.deliver(mgr); err != nil {
+				t.Fatalf("delivery aborted on an old-tmux copy-mode failure: %v", err)
+			}
+			if !slices.Contains(captured, tt.want) {
+				t.Errorf("expected %q to still be sent, got %v", tt.want, captured)
+			}
+		})
+	}
 }

--- a/web/src/components/pages/terminal.ts
+++ b/web/src/components/pages/terminal.ts
@@ -33,6 +33,7 @@ import type {
 } from '../../shared/types.js';
 import { isTerminalAvailable } from '../../shared/types.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
+import { clampCell, sgrWheel, wheelNotches } from '../../shared/terminal-wheel.js';
 import { dispatchPageTitle } from '../../client/page-title.js';
 import { SSEClient } from '../../client/sse-client.js';
 import type { SSEUpdateEvent } from '../../client/sse-client.js';
@@ -76,6 +77,17 @@ export class ScionPageTerminal extends LitElement {
 
   @state()
   private wasConnected = false;
+  /** Pending auto-reconnect timer, and how many attempts have been made. */
+  private _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private _reconnectAttempt = 0;
+  /** Set while cleanup/navigation is deliberate, to suppress auto-reconnect. */
+  private _closingDeliberately = false;
+  private _onVisibilityChange: (() => void) | null = null;
+  /** Whether THIS instance holds a claim on the document overscroll lock. */
+  private _hasLockedOverscroll = false;
+  /** Claims outstanding across instances, and the styles the first one displaced. */
+  private static _overscrollClaims = 0;
+  private static _priorOverscroll: { html: string; body: string } | null = null;
 
   @state()
   private error: string | null = null;
@@ -319,6 +331,9 @@ export class ScionPageTerminal extends LitElement {
       left: 0;
       right: 0;
       bottom: 0;
+      /* Stop a scroll that reaches the terminal's edge from chaining out to
+         the page, which on iOS is what produces the rubber-band bounce. */
+      overscroll-behavior: contain;
     }
 
     .disconnected-overlay {
@@ -539,6 +554,7 @@ export class ScionPageTerminal extends LitElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
+    this.lockDocumentOverscroll();
     // SSR property bindings (.agentId=) aren't restored during client-side
     // hydration for top-level page components. Fall back to URL parsing.
     if (!this.agentId && typeof window !== 'undefined') {
@@ -564,8 +580,55 @@ export class ScionPageTerminal extends LitElement {
   }
 
   override disconnectedCallback(): void {
-    super.disconnectedCallback();
+    try {
+      super.disconnectedCallback();
+    } finally {
+      // finally: a throwing reactive controller would otherwise strand the
+      // claim counter and leave the document locked for the whole session.
+      this.releaseDocumentOverscroll();
+    }
     this.cleanup();
+  }
+
+  /**
+   * Stops the PAGE bouncing while the terminal is on screen. The component's
+   * styles live in its shadow root and cannot reach the document, but the iOS
+   * rubber-band is the document's — so it has to be set here. Reversed on the
+   * way out, since every other page in the SPA does need to scroll.
+   *
+   * Claim-counted across instances rather than saved per instance: if two
+   * ever overlap, the second would capture 'none' as the prior value and the
+   * last to unmount would restore it, leaving the SPA unable to scroll. This
+   * router unmounts before it mounts, so the counter is a guard, not a fix.
+   */
+  private lockDocumentOverscroll(): void {
+    if (typeof document === 'undefined' || this._hasLockedOverscroll) return;
+    this._hasLockedOverscroll = true;
+    if (++ScionPageTerminal._overscrollClaims > 1) return;
+
+    const html = document.documentElement;
+    const body = document.body;
+    ScionPageTerminal._priorOverscroll = {
+      html: html.style.overscrollBehaviorY,
+      body: body.style.overscrollBehaviorY,
+    };
+    // Y only: the rubber-band is vertical, and suppressing the x-axis would
+    // also disable two-finger swipe-back navigation on desktop.
+    html.style.overscrollBehaviorY = 'none';
+    body.style.overscrollBehaviorY = 'none';
+  }
+
+  private releaseDocumentOverscroll(): void {
+    if (typeof document === 'undefined' || !this._hasLockedOverscroll) return;
+    this._hasLockedOverscroll = false;
+    ScionPageTerminal._overscrollClaims = Math.max(0, ScionPageTerminal._overscrollClaims - 1);
+    if (ScionPageTerminal._overscrollClaims > 0) return;
+
+    const prior = ScionPageTerminal._priorOverscroll;
+    if (!prior) return;
+    document.documentElement.style.overscrollBehaviorY = prior.html;
+    document.body.style.overscrollBehaviorY = prior.body;
+    ScionPageTerminal._priorOverscroll = null;
   }
 
   private async loadAgentInfo(): Promise<void> {
@@ -612,6 +675,11 @@ export class ScionPageTerminal extends LitElement {
       // Wait for render, then initialize terminal
       await this.updateComplete;
       await this.initTerminal();
+      // The dynamic imports in initTerminal can resolve after the router has
+      // already removed this page; connecting then would hold a PTY open and
+      // re-arm the reconnect loop on a component that will never disconnect
+      // again.
+      if (!this.isConnected) return;
       this.connectWebSocket();
     } catch (err) {
       console.error('Failed to load agent:', err);
@@ -730,6 +798,7 @@ export class ScionPageTerminal extends LitElement {
 
     this.terminal.open(container);
     this.enableShiftSelectionOnMac();
+    this.enableTouchWheelScroll();
 
     // Detect active tmux window from OSC 7337 sequence sent by the broker
     // on connect. Format: \033]7337;tmuxwindow=<name>\007
@@ -859,8 +928,119 @@ export class ScionPageTerminal extends LitElement {
     };
   }
 
+  /**
+   * Translates a vertical touch drag into wheel events, so an application
+   * holding the wheel (tmux with `mouse on`) has reachable scrollback on a
+   * device that has no wheel to turn and no Ctrl key for copy-mode.
+   *
+   * Only while mouse reporting is ACTIVE: with it off xterm.js already scrolls
+   * its own viewport on touch, and synthesising here would both duplicate that
+   * and inject escape sequences into an application that never asked for them.
+   */
+  private enableTouchWheelScroll(): void {
+    const el = this.terminal?.element;
+    if (!el) return;
+
+    // One notch per row of travel keeps the content under the finger.
+    const rowHeight = (): number => {
+      const rows = this.terminal?.rows ?? 24;
+      return Math.max(8, el.clientHeight / rows);
+    };
+
+    let lastY: number | null = null;
+    let carry = 0;
+    // Decided at touchstart, not on the first move that crosses a row: the
+    // browser begins its own scroll from the very first touchmove.
+    let consuming = false;
+
+    // areMouseEventsActive is true for ANY active protocol and says nothing
+    // about encoding, but sgrWheel only speaks SGR — an app that enabled
+    // mouse reporting without it would be handed a CSI it never negotiated.
+    const mouseActive = (): boolean => {
+      const svc = (this.terminal as (Terminal & {
+        _core?: {
+          coreMouseService?: {
+            areMouseEventsActive?: boolean;
+            activeEncoding?: string;
+          };
+        };
+      }) | undefined)?._core?.coreMouseService;
+      return Boolean(svc?.areMouseEventsActive) && svc?.activeEncoding === 'SGR';
+    };
+
+    const wheel = (up: boolean, touch: Touch): void => {
+      const rect = el.getBoundingClientRect();
+      const cols = this.terminal?.cols ?? 80;
+      const rows = this.terminal?.rows ?? 24;
+      const col = clampCell((touch.clientX - rect.left) / (rect.width / cols), cols);
+      const row = clampCell((touch.clientY - rect.top) / rowHeight(), rows);
+      this.sendData(sgrWheel(up, col, row));
+    };
+
+    el.addEventListener(
+      'touchstart',
+      (ev: TouchEvent) => {
+        consuming = ev.touches.length === 1 && mouseActive();
+        // touch-action is read when a gesture BEGINS, so this governs the
+        // NEXT one; preventDefault below handles the current one.
+        el.style.touchAction = consuming ? 'none' : '';
+        if (!consuming) return;
+        lastY = ev.touches[0].clientY;
+        carry = 0;
+      },
+      { passive: true }
+    );
+
+    el.addEventListener(
+      'touchmove',
+      (ev: TouchEvent) => {
+        // A second finger means pinch-zoom, which belongs to the browser.
+        if (ev.touches.length !== 1) {
+          consuming = false;
+          el.style.touchAction = '';
+          return;
+        }
+        if (!consuming || lastY === null) return;
+        // Re-checked per move: an app can drop mouse reporting mid-drag, and
+        // the reports would then land on whatever owns the tty (a shell).
+        if (!mouseActive()) {
+          consuming = false;
+          el.style.touchAction = '';
+          return;
+        }
+
+        // The whole gesture, not just the part that crosses a row — this is
+        // what stops the page moving underneath. Guarded: the first gesture
+        // after mouse reporting turns on can arrive with the browser scroll
+        // already committed, and cancelling that one only logs a warning.
+        if (ev.cancelable) ev.preventDefault();
+
+        const touch = ev.touches[0];
+        carry += lastY - touch.clientY;
+        lastY = touch.clientY;
+
+        const { notches, up, remainder } = wheelNotches(carry, rowHeight());
+        carry = remainder;
+        for (let i = 0; i < notches; i++) wheel(up, touch);
+      },
+      { passive: false }
+    );
+
+    const end = (): void => {
+      lastY = null;
+      carry = 0;
+      consuming = false;
+      // Left set while reporting is on, so it governs the NEXT gesture too.
+      el.style.touchAction = mouseActive() ? 'none' : '';
+    };
+    el.addEventListener('touchend', end, { passive: true });
+    el.addEventListener('touchcancel', end, { passive: true });
+  }
+
   private connectWebSocket(): void {
     if (!this.terminal) return;
+
+    this.watchVisibility();
 
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     const url = `${protocol}//${window.location.host}/api/v1/agents/${this.agentId}/pty?cols=${this.terminal.cols}&rows=${this.terminal.rows}`;
@@ -873,6 +1053,7 @@ export class ScionPageTerminal extends LitElement {
       this.connected = true;
       this.wasConnected = true;
       this.error = null;
+      this._reconnectAttempt = 0;
       // Re-fit now that the connection is live so tmux gets accurate dimensions
       if (this.fitAddon) {
         this.fitAddon.fit();
@@ -903,17 +1084,27 @@ export class ScionPageTerminal extends LitElement {
     };
 
     this.socket.onclose = (event: CloseEvent) => {
+      // Ignore a socket we have already replaced: its close must not tear down
+      // its healthy successor.
+      if (event.target !== this.socket) return;
       console.debug('[Terminal] WebSocket closed, code:', event.code, 'reason:', event.reason);
       this.connected = false;
-      if (event.code !== 1000) {
-        this.error = `Connection closed (code: ${event.code})`;
-      }
+      if (this._closingDeliberately) return;
+      // Not keyed on code 1000: the hub sends CloseNormalClosure on every exit
+      // path, including the read-deadline reap a backgrounded tab always hits,
+      // so a code check would decline to reconnect in exactly the case this
+      // exists for. _closingDeliberately is what actually distinguishes a
+      // teardown we asked for.
+      this.error = `Connection closed (code: ${event.code})`;
+      this.scheduleReconnect();
     };
 
     this.socket.onerror = (event) => {
       console.error('[Terminal] WebSocket error:', event);
       this.connected = false;
       this.error = 'WebSocket connection error';
+      // onerror is followed by onclose, which schedules the retry; scheduling
+      // here too would double the attempt count and halve the backoff.
     };
   }
 
@@ -1097,6 +1288,18 @@ export class ScionPageTerminal extends LitElement {
   }
 
   private cleanup(): void {
+    // Suppress auto-reconnect BEFORE the socket closes, or onclose schedules
+    // a retry for a terminal that is going away.
+    this._closingDeliberately = true;
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+    this._reconnectAttempt = 0;
+    if (this._onVisibilityChange) {
+      document.removeEventListener('visibilitychange', this._onVisibilityChange);
+      this._onVisibilityChange = null;
+    }
     this.sendTmuxDetach();
     this.disconnectSSE();
     if (this._windowDragOver) {
@@ -1326,8 +1529,78 @@ export class ScionPageTerminal extends LitElement {
     }
   }
 
+  /**
+   * Reconnects after an unexpected close, with backoff.
+   *
+   * Safe to do without asking because the PTY is a tmux client, not the
+   * session: reconnecting re-attaches to the same window and loses nothing.
+   * Deliberate closes are excluded — navigating away or detaching closes with
+   * 1000, and retrying there would resurrect a terminal just left.
+   */
+  private scheduleReconnect(): void {
+    if (this._closingDeliberately || this._reconnectTimer) return;
+
+    // 1s, 2s, 4s … capped at 30s; jitter so open tabs do not retry in lockstep.
+    const base = Math.min(30_000, 1000 * 2 ** this._reconnectAttempt);
+    const delay = base + Math.random() * 500;
+    this._reconnectAttempt++;
+
+    console.debug(`[Terminal] Reconnecting in ${Math.round(delay)}ms (attempt ${this._reconnectAttempt})`);
+    this._reconnectTimer = setTimeout(() => {
+      this._reconnectTimer = null;
+      if (this._closingDeliberately || this.connected) return;
+      this.reconnectNow();
+    }, delay);
+  }
+
+  /**
+   * Drops any pending backoff and reconnects immediately — used when the tab
+   * becomes visible, where waiting out an invisible backoff looks broken.
+   */
+  private reconnectNow(): void {
+    if (this._closingDeliberately || this.connected) return;
+    // A handshake already in flight will resolve on its own.
+    if (this.socket?.readyState === WebSocket.CONNECTING) return;
+    if (this._reconnectTimer) {
+      clearTimeout(this._reconnectTimer);
+      this._reconnectTimer = null;
+    }
+    // Close a socket stuck in CONNECTING/CLOSING first, so a half-open one
+    // cannot deliver into the terminal after its replacement.
+    if (this.socket && this.socket.readyState !== WebSocket.CLOSED) {
+      this.socket.onclose = null;
+      this.socket.onerror = null;
+      this.socket.onmessage = null;
+      try {
+        this.socket.close();
+      } catch {
+        /* already closing */
+      }
+    }
+    this.connectWebSocket();
+  }
+
+  /**
+   * Reconnect as soon as the tab is shown, not after whatever backoff was
+   * pending when it was hidden. iOS Safari closes sockets in background tabs,
+   * so this is the case that actually bites.
+   */
+  private watchVisibility(): void {
+    if (this._onVisibilityChange) return;
+    this._onVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') return;
+      if (this.connected || this._closingDeliberately) return;
+      this._reconnectAttempt = 0;
+      this.reconnectNow();
+    };
+    document.addEventListener('visibilitychange', this._onVisibilityChange);
+  }
+
   private handleReconnect(): void {
     this.cleanup();
+    // cleanup() suppresses auto-reconnect; a manual Retry is the one caller
+    // that means the opposite, so it lifts the flag itself.
+    this._closingDeliberately = false;
     void this.loadAgentInfo();
   }
 

--- a/web/src/shared/terminal-wheel.test.ts
+++ b/web/src/shared/terminal-wheel.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { WHEEL_DOWN, WHEEL_UP, clampCell, sgrWheel, wheelNotches } from './terminal-wheel';
+
+describe('sgrWheel', () => {
+  // The button numbers are the whole contract with tmux. Getting them the wrong
+  // way round scrolls backwards, which is the kind of bug that survives review
+  // because both directions "work".
+  it('encodes wheel-up as button 64 and wheel-down as 65', () => {
+    expect(sgrWheel(true, 1, 1)).toBe('\x1b[<64;1;1M');
+    expect(sgrWheel(false, 1, 1)).toBe('\x1b[<65;1;1M');
+    expect(WHEEL_UP).toBe(64);
+    expect(WHEEL_DOWN).toBe(65);
+  });
+
+  it('carries the cell the wheel is over, so the right tmux pane scrolls', () => {
+    expect(sgrWheel(true, 42, 7)).toBe('\x1b[<64;42;7M');
+  });
+});
+
+describe('wheelNotches', () => {
+  it('emits nothing until a full row has been travelled', () => {
+    const r = wheelNotches(9, 20);
+    expect(r.notches).toBe(0);
+  });
+
+  // Without this a slow drag never scrolls: each move is under one row, and
+  // discarding the remainder each time means the total is never reached.
+  it('keeps the remainder so a slow drag accumulates', () => {
+    let carry = 0;
+    let emitted = 0;
+    for (let i = 0; i < 4; i++) {
+      carry += 9;
+      const r = wheelNotches(carry, 20);
+      emitted += r.notches;
+      carry = r.remainder;
+    }
+    expect(emitted).toBe(1); // 36 travelled, one row of 20 crossed
+    expect(carry).toBeCloseTo(16);
+  });
+
+  it('maps a finger moving up to wheel-down, and vice versa', () => {
+    // Positive carry = the finger moved up the screen = content moves up =
+    // later output = wheel-down.
+    expect(wheelNotches(40, 20).up).toBe(false);
+    expect(wheelNotches(-40, 20).up).toBe(true);
+  });
+
+  it('bounds a flung gesture', () => {
+    expect(wheelNotches(10_000, 20).notches).toBe(20);
+    expect(wheelNotches(10_000, 20, 5).notches).toBe(5);
+  });
+
+  it('refuses nonsense rather than emitting NaN notches', () => {
+    for (const [carry, step] of [
+      [Number.NaN, 20],
+      [40, 0],
+      [40, -1],
+      [40, Number.NaN],
+    ] as const) {
+      expect(wheelNotches(carry, step).notches).toBe(0);
+    }
+  });
+});
+
+describe('clampCell', () => {
+  it('keeps coordinates inside the terminal, 1-based', () => {
+    expect(clampCell(0.2, 80)).toBe(1);
+    expect(clampCell(-5, 80)).toBe(1);
+    expect(clampCell(1000, 80)).toBe(80);
+    expect(clampCell(40.1, 80)).toBe(41);
+  });
+
+  it('survives a terminal that has not been sized yet', () => {
+    expect(clampCell(Number.NaN, 80)).toBe(1);
+    expect(clampCell(5, 0)).toBe(1);
+  });
+});

--- a/web/src/shared/terminal-wheel.ts
+++ b/web/src/shared/terminal-wheel.ts
@@ -1,0 +1,45 @@
+/** Wheel-event helpers for the web terminal's touch scrolling. */
+
+/** Wheel-up button code in SGR mouse encoding. */
+export const WHEEL_UP = 64;
+/** Wheel-down button code in SGR mouse encoding. */
+export const WHEEL_DOWN = 65;
+
+/**
+ * Encodes one wheel notch as an SGR mouse report.
+ *
+ * col and row are 1-based cell coordinates naming the pane the wheel is over,
+ * so a split tmux window scrolls the pane under the finger, not the active one.
+ */
+export function sgrWheel(up: boolean, col: number, row: number): string {
+  return `\x1b[<${up ? WHEEL_UP : WHEEL_DOWN};${col};${row}M`;
+}
+
+/**
+ * Splits accumulated drag distance into whole wheel notches plus the remainder
+ * to carry into the next move. Carrying it is what lets a drag of less than one
+ * row per event still scroll. `max` bounds a fling.
+ */
+export function wheelNotches(
+  carry: number,
+  step: number,
+  max = 20
+): { notches: number; up: boolean; remainder: number } {
+  if (!Number.isFinite(carry) || !Number.isFinite(step) || step <= 0) {
+    return { notches: 0, up: false, remainder: 0 };
+  }
+  const whole = Math.trunc(carry / step);
+  if (whole === 0) return { notches: 0, up: false, remainder: carry };
+  return {
+    notches: Math.min(Math.abs(whole), max),
+    // Negative carry = finger moved down = earlier output = wheel-up.
+    up: whole < 0,
+    remainder: carry - whole * step,
+  };
+}
+
+/** Clamps a 1-based cell coordinate into a terminal of the given size. */
+export function clampCell(value: number, size: number): number {
+  if (!Number.isFinite(value) || size < 1) return 1;
+  return Math.min(size, Math.max(1, Math.ceil(value)));
+}


### PR DESCRIPTION
Makes the web terminal usable on a touchscreen, and fixes a message-delivery bug that touch scrolling makes reachable from phones.

## Changes

**Touch scrolling.** A single-finger vertical drag is translated into SGR wheel reports when the application has mouse tracking active with SGR encoding (tmux with `mouse on`), so scrollback is reachable on a device with no wheel and no Ctrl key. Translation stops if the app drops mouse mode mid-drag; multi-touch is left to the browser so pinch-zoom still works. The arithmetic and encoding live in `web/src/shared/terminal-wheel.ts` with unit tests.

**No page bounce.** The gesture is claimed at `touchstart`, and `overscroll-behavior-y: none` is set on the document while the terminal page is mounted — claim-counted across instances and released in a `finally`. Y-axis only, so desktop two-finger swipe-back keeps working.

**Auto-reconnect.** The PTY WebSocket reconnects with jittered backoff, and immediately when the tab becomes visible. It retries on any close the client did not initiate — the hub sends code 1000 on every exit path, including the 60s idle reap that a backgrounded phone always hits, so a code check is the wrong signal. Deliberate teardown is excluded, and a page removed mid-init no longer resurrects itself.

**Copy-mode-safe delivery (Go, `pkg/agent/manager.go`).** A tmux pane in copy-mode accepts `paste-buffer` but swallows `send-keys`, so a delivered message landed in the harness composer and was never submitted — silently, with only a hub "stuck pending messages" sweep as a trace. Scrolling is what puts a pane in copy-mode, and this PR gives phones their first way to scroll. Messages now submit via a pasted CR (byte-identical `0x0D` at the pty), which preserves the operator's scroll position, selection, and paste buffer (`-d` consumes the named buffers). Paths that send real keys — interrupts, raw sequences, the bare-Enter nudge — exit copy-mode first; that exit is best-effort so tmux < 3.1, which lacks `copy-mode -q`, still delivers.

## Testing

- `go test ./pkg/agent/` — command-sequence tests for all four delivery paths, copy-mode ordering, buffer hygiene, and old-tmux tolerance; mutation-checked (wrong target, reintroduced cancel, reverted submit are all caught).
- `npx vitest run src/shared/terminal-wheel.test.ts` — encoding, remainder carry, direction, fling bound.
- Verified on iOS Safari against a live containerised agent: drag scrolls tmux scrollback, the page stays put, a backgrounded tab reconnects on return, and messages submit while an operator sits in copy-mode.
- Pre-existing failures on `main`, unrelated and verified on a clean checkout: `TestProvisionAgentNonGitWorkspace` (`pkg/agent`), and 43 web tests in the `chat-*`/`notification-tray-chat` suites.

## Notes for review

- Reads `_core.coreMouseService.{areMouseEventsActive,activeEncoding}` — private xterm API, but this component already reaches into `_core`, and the access is guarded so a rename degrades to no translation rather than misbehaviour.
- The `DISCONNECTED` overlay still has no tap target; that is a UI change and belongs in its own PR.
