### PR TITLE
feat: clickable file-path links in chat messages (#1148)

### DIFF
--- a/pkg/hub/project_workspace_handlers.go
+++ b/pkg/hub/project_workspace_handlers.go
@@ -489,6 +489,7 @@ func (s *Server) handleProjectWorkspaceDownload(w http.ResponseWriter, r *http.R
 	}
 
 	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	disposition := "attachment"
 	if r.URL.Query().Get("view") == "true" {
 		disposition = "inline"

--- a/web/src/components/shared/chat/chat-message.test.ts
+++ b/web/src/components/shared/chat/chat-message.test.ts
@@ -356,3 +356,110 @@ describe('scion-chat-message attachment previews', () => {
     expect(preview?.querySelector('.preview-placeholder.error')?.textContent).toContain('404');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Path-link entity patterns (#1148)
+// ---------------------------------------------------------------------------
+
+describe('scion-chat-message path links', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  function pathLinks(el: ScionChatMessage): HTMLElement[] {
+    return Array.from(el.shadowRoot?.querySelectorAll('.md-content .path-link') ?? []);
+  }
+
+  it('renders /workspace/... paths as clickable path links', async () => {
+    const el = await mount('check /workspace/src/main.go for details');
+    const links = pathLinks(el);
+
+    expect(links).toHaveLength(1);
+    expect(links[0].dataset.filePath).toBe('/workspace/src/main.go');
+    expect(links[0].textContent).toBe('/workspace/src/main.go');
+    expect(links[0].classList.contains('entity-link')).toBe(true);
+    expect(links[0].classList.contains('path-link')).toBe(true);
+  });
+
+  it('renders /scion-volumes/... paths as clickable path links', async () => {
+    const el = await mount('see /scion-volumes/scratchpad/reports/summary.md');
+    const links = pathLinks(el);
+
+    expect(links).toHaveLength(1);
+    expect(links[0].dataset.filePath).toBe('/scion-volumes/scratchpad/reports/summary.md');
+  });
+
+  it('renders /workspace/.scion-volumes/... paths as clickable path links', async () => {
+    const el = await mount('read /workspace/.scion-volumes/data/output.json');
+    const links = pathLinks(el);
+
+    expect(links).toHaveLength(1);
+    expect(links[0].dataset.filePath).toBe('/workspace/.scion-volumes/data/output.json');
+  });
+
+  it('matches paths without file extensions (directories)', async () => {
+    const el = await mount('look in /workspace/src/components for the code');
+    const links = pathLinks(el);
+
+    expect(links).toHaveLength(1);
+    expect(links[0].dataset.filePath).toBe('/workspace/src/components');
+  });
+
+  it('stops at spaces (paths with spaces are not linkable)', async () => {
+    // Spaces are ambiguous in prose — the regex stops at whitespace.
+    const el = await mount('see /workspace/my-file.txt here');
+    const links = pathLinks(el);
+
+    expect(links).toHaveLength(1);
+    expect(links[0].dataset.filePath).toBe('/workspace/my-file.txt');
+  });
+
+  it('does not match arbitrary absolute paths like /etc/passwd', async () => {
+    const el = await mount('file at /etc/passwd is dangerous');
+    const links = pathLinks(el);
+
+    expect(links).toHaveLength(0);
+  });
+
+  it('does not match relative paths', async () => {
+    const el = await mount('look at src/main.go for the code');
+    const links = pathLinks(el);
+
+    expect(links).toHaveLength(0);
+  });
+
+  it('leaves path links inside fenced code blocks as literal text', async () => {
+    const el = await mount('run:\n```\ncat /workspace/src/main.go\n```\nthen check /workspace/README.md');
+    const links = pathLinks(el);
+
+    // Only the one outside the fence should be linked.
+    expect(links).toHaveLength(1);
+    expect(links[0].dataset.filePath).toBe('/workspace/README.md');
+  });
+
+  it('emits a composed path-link-click event when a path link is clicked', async () => {
+    const el = await mount('see /workspace/src/main.go');
+    const seen: string[] = [];
+    document.addEventListener('path-link-click', (e) => {
+      seen.push((e as CustomEvent<{ path: string }>).detail.path);
+    });
+
+    const link = pathLinks(el)[0];
+    link.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+
+    expect(seen).toEqual(['/workspace/src/main.go']);
+  });
+
+  it('renders multiple path links in the same message', async () => {
+    const el = await mount('compare /workspace/a.ts and /scion-volumes/data/b.ts');
+    const links = pathLinks(el);
+
+    expect(links).toHaveLength(2);
+    expect(links[0].dataset.filePath).toBe('/workspace/a.ts');
+    expect(links[1].dataset.filePath).toBe('/scion-volumes/data/b.ts');
+  });
+});

--- a/web/src/components/shared/chat/chat-message.ts
+++ b/web/src/components/shared/chat/chat-message.ts
@@ -168,13 +168,12 @@ const ENTITY_PATTERNS: EntityPattern[] = [
       return `commit <a class="entity-link" href="/commits/${encodeURIComponent(sha)}" title="View commit ${sha}">${sha}</a>`;
     },
   },
-  // File paths: workspace-absolute or relative paths with extensions
+  // File paths: /workspace/... and /scion-volumes/... container paths
   {
-    regex: /(?:\/workspace\/|(?:^|(?<=\s)))([a-zA-Z0-9_.-]+(?:\/[a-zA-Z0-9_.-]+)+\.[a-zA-Z]{1,10})\b/g,
+    regex: /(?:\/scion-volumes\/[a-zA-Z0-9_.-]+(?:\/[a-zA-Z0-9_.-]+)*|\/workspace\/(?:\.scion-volumes\/[a-zA-Z0-9_.-]+(?:\/[a-zA-Z0-9_.-]+)*|[a-zA-Z0-9_.-]+(?:\/[a-zA-Z0-9_.-]+)*))/g,
     linkBuilder: (m) => {
-      const full = m[0];
-      const path = full.startsWith('/workspace/') ? full.slice('/workspace/'.length) : full.trimStart();
-      return `<a class="entity-link" href="/files/${encodeURIComponent(path)}" title="Open ${full.trim()}">${full}</a>`;
+      const path = m[0];
+      return `<a class="entity-link path-link" data-file-path="${path.replace(/"/g, '&quot;')}" href="javascript:void(0)" title="Open ${path.replace(/"/g, '&quot;')}">${path}</a>`;
     },
   },
 ];
@@ -197,8 +196,8 @@ function styleEntityLinksInText(text: string): string {
     const flags = pattern.regex.flags.includes('g') ? pattern.regex.flags : pattern.regex.flags + 'g';
     const re = new RegExp(pattern.regex.source, flags);
     let m: RegExpExecArray | null;
+    let prevIndex = 0;
     while ((m = re.exec(text)) !== null) {
-      const prevIndex = re.lastIndex;
       replacements.push({
         start: m.index,
         end: m.index + m[0].length,
@@ -207,6 +206,7 @@ function styleEntityLinksInText(text: string): string {
       // Safety: if lastIndex did not advance (e.g. zero-length match or
       // missing global flag), break to avoid an infinite loop.
       if (re.lastIndex === prevIndex) break;
+      prevIndex = re.lastIndex;
     }
   }
 
@@ -1299,6 +1299,18 @@ export class ScionChatMessage extends LitElement {
       color: var(--sl-color-primary-700, #1d4ed8);
     }
 
+    /* ---- Clickable file-path links (#1148) ---- */
+    .md-content .path-link {
+      color: var(--sl-color-primary-600, #2563eb);
+      cursor: pointer;
+      text-decoration: underline;
+      text-decoration-style: dotted;
+    }
+
+    .md-content .path-link:hover {
+      text-decoration-style: solid;
+    }
+
     /* ---- Rich output: diff blocks (#1060) ---- */
     .diff-block {
       font-family: var(--scion-font-mono, 'SF Mono', 'Fira Code', monospace);
@@ -1746,6 +1758,42 @@ export class ScionChatMessage extends LitElement {
     );
   }
 
+  /**
+   * Unified click handler for .md-content: delegates to mention or path-link
+   * handlers based on the click target.
+   */
+  private handleContentClick(e: MouseEvent): void {
+    // Check for path-link click first (more specific selector).
+    const pathTarget = (e.target as HTMLElement | null)?.closest('.path-link[data-file-path]');
+    if (pathTarget) {
+      this.handlePathLinkClick(e, pathTarget as HTMLElement);
+      return;
+    }
+    // Fall through to mention click handling.
+    this.handleMentionClick(e);
+  }
+
+  /**
+   * Clicking a file-path link dispatches a composed `path-link-click` event
+   * carrying the container path. The chat thread catches it, resolves the
+   * project context, and opens a file viewer.
+   */
+  private handlePathLinkClick(e: MouseEvent, target: HTMLElement): void {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const filePath = target.dataset.filePath;
+    if (!filePath) return;
+
+    this.dispatchEvent(
+      new CustomEvent('path-link-click', {
+        bubbles: true,
+        composed: true,
+        detail: { path: filePath },
+      })
+    );
+  }
+
   // ---- Phase-3: Action bar and event helpers ----
 
   /** Render the hover action bar with contextual actions. */
@@ -2018,7 +2066,7 @@ export class ScionChatMessage extends LitElement {
     }
     return html`<div
       class="md-content"
-      @click=${this.handleMentionClick}
+      @click=${this.handleContentClick}
       .innerHTML=${this.renderedHtml}
     ></div>`;
   }

--- a/web/src/components/shared/chat/chat-pathlink.test.ts
+++ b/web/src/components/shared/chat/chat-pathlink.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for path-link utilities (#1148): parseContainerPath and buildFileApiUrl.
+ */
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect } from 'vitest';
+import { parseContainerPath, buildFileApiUrl, type PathLinkTarget } from './chat-thread.js';
+
+describe('parseContainerPath', () => {
+  it('parses /scion-volumes/{dirName}/{filePath}', () => {
+    const result = parseContainerPath('/scion-volumes/scratchpad/reports/summary.md');
+    expect(result).toEqual({
+      kind: 'shared-dir',
+      dirName: 'scratchpad',
+      filePath: 'reports/summary.md',
+    });
+  });
+
+  it('parses /scion-volumes/{dirName} with no nested path', () => {
+    const result = parseContainerPath('/scion-volumes/scratchpad');
+    expect(result).toEqual({
+      kind: 'shared-dir',
+      dirName: 'scratchpad',
+      filePath: '',
+    });
+  });
+
+  it('parses /workspace/.scion-volumes/{dirName}/{filePath}', () => {
+    const result = parseContainerPath('/workspace/.scion-volumes/data/output.json');
+    expect(result).toEqual({
+      kind: 'shared-dir',
+      dirName: 'data',
+      filePath: 'output.json',
+    });
+  });
+
+  it('parses /workspace/{filePath}', () => {
+    const result = parseContainerPath('/workspace/src/main.go');
+    expect(result).toEqual({
+      kind: 'workspace',
+      filePath: 'src/main.go',
+    });
+  });
+
+  it('parses deeply nested workspace path', () => {
+    const result = parseContainerPath('/workspace/src/components/shared/chat/chat-message.ts');
+    expect(result).toEqual({
+      kind: 'workspace',
+      filePath: 'src/components/shared/chat/chat-message.ts',
+    });
+  });
+
+  it('returns null for unrecognized paths', () => {
+    expect(parseContainerPath('/etc/passwd')).toBeNull();
+    expect(parseContainerPath('/root/.ssh/id_rsa')).toBeNull();
+    expect(parseContainerPath('/tmp/something')).toBeNull();
+  });
+
+  it('returns null for bare /workspace with no sub-path', () => {
+    expect(parseContainerPath('/workspace')).toBeNull();
+    expect(parseContainerPath('/workspace/')).toBeNull();
+  });
+
+  it('handles paths with dots in directory names', () => {
+    const result = parseContainerPath('/scion-volumes/my.data/file.txt');
+    expect(result).toEqual({
+      kind: 'shared-dir',
+      dirName: 'my.data',
+      filePath: 'file.txt',
+    });
+  });
+
+  it('handles workspace path with .scion-volumes deeper than root', () => {
+    const result = parseContainerPath('/workspace/.scion-volumes/shared-stuff/deeply/nested/file.md');
+    expect(result).toEqual({
+      kind: 'shared-dir',
+      dirName: 'shared-stuff',
+      filePath: 'deeply/nested/file.md',
+    });
+  });
+});
+
+describe('buildFileApiUrl', () => {
+  it('builds workspace file URL', () => {
+    const target: PathLinkTarget = { kind: 'workspace', filePath: 'src/main.go' };
+    const url = buildFileApiUrl('proj-123', target);
+    expect(url).toBe('/api/v1/projects/proj-123/workspace/files/src/main.go');
+  });
+
+  it('builds shared-dir file URL', () => {
+    const target: PathLinkTarget = {
+      kind: 'shared-dir',
+      dirName: 'scratchpad',
+      filePath: 'reports/summary.md',
+    };
+    const url = buildFileApiUrl('proj-123', target);
+    expect(url).toBe('/api/v1/projects/proj-123/shared-dirs/scratchpad/files/reports/summary.md');
+  });
+
+  it('encodes special characters in path segments', () => {
+    const target: PathLinkTarget = { kind: 'workspace', filePath: 'src/my file.ts' };
+    const url = buildFileApiUrl('proj-123', target);
+    expect(url).toBe('/api/v1/projects/proj-123/workspace/files/src/my%20file.ts');
+  });
+
+  it('encodes special characters in project ID', () => {
+    const target: PathLinkTarget = { kind: 'workspace', filePath: 'main.go' };
+    const url = buildFileApiUrl('proj with space', target);
+    expect(url).toBe('/api/v1/projects/proj%20with%20space/workspace/files/main.go');
+  });
+
+  it('encodes special characters in shared-dir name', () => {
+    const target: PathLinkTarget = {
+      kind: 'shared-dir',
+      dirName: 'my dir',
+      filePath: 'file.txt',
+    };
+    const url = buildFileApiUrl('proj-123', target);
+    expect(url).toBe('/api/v1/projects/proj-123/shared-dirs/my%20dir/files/file.txt');
+  });
+});

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -2377,12 +2377,16 @@ export class ScionChatThread extends LitElement {
 
     try {
       const res = await apiFetch(`${downloadUrl}?format=json`);
+      // Staleness guard: user closed dialog or clicked a different file link.
+      if (this.filePreview?.containerPath !== containerPath) return;
       if (!res.ok) {
         const errMsg = await extractApiError(res, `HTTP ${res.status}`);
         this.filePreview = { ...this.filePreview, status: 'error', error: errMsg };
         return;
       }
       const data = (await res.json()) as { content: string; size: number };
+      // Staleness guard: user navigated away while parsing response.
+      if (this.filePreview?.containerPath !== containerPath) return;
       if (data.size > PATH_PREVIEW_MAX) {
         // Too large for inline preview, show download-only.
         this.filePreview = {
@@ -2398,6 +2402,8 @@ export class ScionChatThread extends LitElement {
         content: data.content,
       };
     } catch (err) {
+      // Staleness guard: user navigated away while request was in-flight.
+      if (this.filePreview?.containerPath !== containerPath) return;
       this.filePreview = {
         ...this.filePreview,
         status: 'error',

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -50,6 +50,9 @@ import './chat-visibility-toggle.js';
 import './chat-interagent-marker.js';
 import './send-to-agent-picker.js';
 import type { AgentSelectedDetail } from './send-to-agent-picker.js';
+import { getLanguageFromPath } from '../code-editor.js';
+import '../code-editor.js';
+import '../markdown-preview.js';
 
 /** Result from server-side mention fan-out. */
 interface MentionResult {
@@ -90,6 +93,113 @@ const SEEN_VISIBLE_MS = 5 * 60 * 1000;
 
 /** Typing send throttle in ms. */
 const TYPING_SEND_THROTTLE_MS = 4000;
+
+// ---------------------------------------------------------------------------
+// Path-link utilities (#1148) — parse container paths into API parameters.
+// ---------------------------------------------------------------------------
+
+/** Encode each segment of a file path for use in API URLs. */
+function encodeFilePath(filePath: string): string {
+  return filePath
+    .split('/')
+    .map((seg) => encodeURIComponent(seg))
+    .join('/');
+}
+
+interface PathLinkTarget {
+  kind: 'workspace' | 'shared-dir';
+  /** Shared-directory name (only for kind === 'shared-dir'). */
+  dirName?: string;
+  /** File path within the workspace or shared directory. */
+  filePath: string;
+}
+
+/**
+ * Parse a container path into the API type and parameters.
+ *
+ * Supported patterns:
+ *   /scion-volumes/{dirName}/{filePath}       -> shared-dir
+ *   /workspace/.scion-volumes/{dirName}/{fp}   -> shared-dir (in-workspace mount)
+ *   /workspace/{filePath}                      -> workspace
+ */
+function parseContainerPath(containerPath: string): PathLinkTarget | null {
+  // /scion-volumes/{dirName}/...
+  const sharedDirMatch = containerPath.match(/^\/scion-volumes\/([^/]+)(?:\/(.+))?$/);
+  if (sharedDirMatch) {
+    return {
+      kind: 'shared-dir',
+      dirName: sharedDirMatch[1],
+      filePath: sharedDirMatch[2] || '',
+    };
+  }
+
+  // /workspace/.scion-volumes/{dirName}/...
+  const inWorkspaceMatch = containerPath.match(
+    /^\/workspace\/\.scion-volumes\/([^/]+)(?:\/(.+))?$/
+  );
+  if (inWorkspaceMatch) {
+    return {
+      kind: 'shared-dir',
+      dirName: inWorkspaceMatch[1],
+      filePath: inWorkspaceMatch[2] || '',
+    };
+  }
+
+  // /workspace/...
+  const workspaceMatch = containerPath.match(/^\/workspace\/(.+)$/);
+  if (workspaceMatch) {
+    return {
+      kind: 'workspace',
+      filePath: workspaceMatch[1],
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Build the API URL for a parsed path-link target.
+ */
+function buildFileApiUrl(projectId: string, target: PathLinkTarget): string {
+  if (target.kind === 'shared-dir') {
+    return `/api/v1/projects/${encodeURIComponent(projectId)}/shared-dirs/${encodeURIComponent(target.dirName!)}/files/${encodeFilePath(target.filePath)}`;
+  }
+  return `/api/v1/projects/${encodeURIComponent(projectId)}/workspace/files/${encodeFilePath(target.filePath)}`;
+}
+
+/** Known image extensions for path-link preview. */
+const PATH_IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.bmp', '.ico']);
+
+/** Known markdown extensions for path-link preview. */
+const PATH_MD_EXTS = new Set(['.md', '.markdown']);
+
+/** Maximum file size for inline text preview (512 KB). */
+const PATH_PREVIEW_MAX = 512 * 1024;
+
+/** State for the file-path viewer dialog. */
+interface FilePreviewState {
+  /** The raw container path from the link. */
+  containerPath: string;
+  /** Resolved filename for display. */
+  fileName: string;
+  /** Loading / ready / error state. */
+  status: 'loading' | 'ready' | 'error';
+  /** File content (text) when ready. */
+  content?: string;
+  /** Error message when status is 'error'. */
+  error?: string;
+  /** Whether this is an image file. */
+  isImage?: boolean;
+  /** Whether this is a markdown file. */
+  isMarkdown?: boolean;
+  /** Whether this is a binary/unknown file (download-only). */
+  isBinary?: boolean;
+  /** API URL for download. */
+  downloadUrl?: string;
+}
+
+// Export the parse function for testing.
+export { parseContainerPath, buildFileApiUrl, type PathLinkTarget };
 
 @customElement('scion-chat-thread')
 export class ScionChatThread extends LitElement {
@@ -224,6 +334,11 @@ export class ScionChatThread extends LitElement {
 
   /** Temporarily stored message for send-to-agent flow. */
   private _pendingSendToAgentMessage: Message | null = null;
+
+  // ---- Path-link file preview state (#1148) ----
+
+  /** Current file preview dialog state, or null when closed. */
+  @state() private filePreview: FilePreviewState | null = null;
 
   /** Message extensions keyed by message ID. */
   private v2MessageExtMap = new Map<
@@ -630,6 +745,42 @@ export class ScionChatThread extends LitElement {
     .context-menu-item sl-icon {
       font-size: 0.875rem;
       color: var(--scion-text-muted, #64748b);
+    }
+
+    /* Path-link file preview dialog (#1148) */
+    .file-preview-dialog::part(panel) {
+      width: min(90vw, 800px);
+      max-height: 85vh;
+    }
+
+    .file-preview-dialog::part(body) {
+      padding: 0;
+      overflow: auto;
+    }
+
+    .file-preview-placeholder {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      padding: 3rem 2rem;
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.875rem;
+    }
+
+    .file-preview-placeholder.error {
+      color: var(--scion-danger-600, #dc2626);
+    }
+
+    .file-preview-image {
+      max-width: 100%;
+      max-height: 70vh;
+      display: block;
+      margin: 0 auto;
+    }
+
+    .file-preview-dialog scion-code-editor {
+      --editor-max-height: 70vh;
     }
 
     /* Phase-5: Slash command system message */
@@ -2173,6 +2324,152 @@ export class ScionChatThread extends LitElement {
   }
 
   // ---------------------------------------------------------------------------
+  // Path-link file preview (#1148)
+  // ---------------------------------------------------------------------------
+
+  /** Handle path-link-click event from a chat message. */
+  private async handlePathLinkClick(
+    e: CustomEvent<{ path: string }>
+  ): Promise<void> {
+    const containerPath = e.detail.path;
+
+    if (!this.projectId) {
+      this.sendError = 'Cannot open file: no project context';
+      setTimeout(() => {
+        if (this.sendError === 'Cannot open file: no project context') {
+          this.sendError = null;
+        }
+      }, 4000);
+      return;
+    }
+
+    const target = parseContainerPath(containerPath);
+    if (!target) {
+      this.sendError = 'Cannot open file: unrecognized path format';
+      setTimeout(() => {
+        if (this.sendError === 'Cannot open file: unrecognized path format') {
+          this.sendError = null;
+        }
+      }, 4000);
+      return;
+    }
+
+    const fileName = containerPath.split('/').pop() || containerPath;
+    const ext = fileName.includes('.') ? '.' + fileName.split('.').pop()!.toLowerCase() : '';
+    const isImage = PATH_IMAGE_EXTS.has(ext);
+    const isMarkdown = PATH_MD_EXTS.has(ext);
+    const downloadUrl = buildFileApiUrl(this.projectId, target);
+
+    this.filePreview = {
+      containerPath,
+      fileName,
+      status: 'loading',
+      isImage,
+      isMarkdown,
+      downloadUrl,
+    };
+
+    if (isImage) {
+      // Images are loaded directly by the browser via URL.
+      this.filePreview = { ...this.filePreview, status: 'ready' };
+      return;
+    }
+
+    try {
+      const res = await apiFetch(`${downloadUrl}?format=json`);
+      if (!res.ok) {
+        const errMsg = await extractApiError(res, `HTTP ${res.status}`);
+        this.filePreview = { ...this.filePreview, status: 'error', error: errMsg };
+        return;
+      }
+      const data = (await res.json()) as { content: string; size: number };
+      if (data.size > PATH_PREVIEW_MAX) {
+        // Too large for inline preview, show download-only.
+        this.filePreview = {
+          ...this.filePreview,
+          status: 'ready',
+          isBinary: true,
+        };
+        return;
+      }
+      this.filePreview = {
+        ...this.filePreview,
+        status: 'ready',
+        content: data.content,
+      };
+    } catch (err) {
+      this.filePreview = {
+        ...this.filePreview,
+        status: 'error',
+        error: err instanceof Error ? err.message : 'Failed to load file',
+      };
+    }
+  }
+
+  /** Close the file preview dialog. */
+  private closeFilePreview(): void {
+    this.filePreview = null;
+  }
+
+  /** Render the file preview overlay dialog. */
+  private renderFilePreview() {
+    const fp = this.filePreview;
+    if (!fp) return nothing;
+
+    let body;
+    if (fp.status === 'loading') {
+      body = html`
+        <div class="file-preview-placeholder">
+          <sl-spinner></sl-spinner>
+          Loading file…
+        </div>
+      `;
+    } else if (fp.status === 'error') {
+      body = html`<div class="file-preview-placeholder error">${fp.error}</div>`;
+    } else if (fp.isImage) {
+      body = html`<img class="file-preview-image" src="${fp.downloadUrl}?view=true" alt=${fp.fileName} />`;
+    } else if (fp.isBinary) {
+      body = html`
+        <div class="file-preview-placeholder">
+          This file is too large to preview inline. Use the Download button.
+        </div>
+      `;
+    } else if (fp.isMarkdown) {
+      body = html`<scion-markdown-preview .content=${fp.content ?? ''}></scion-markdown-preview>`;
+    } else {
+      body = html`
+        <scion-code-editor
+          .content=${fp.content ?? ''}
+          language=${getLanguageFromPath(fp.fileName)}
+          readonly
+        ></scion-code-editor>
+      `;
+    }
+
+    return html`
+      <sl-dialog
+        class="file-preview-dialog"
+        open
+        label=${fp.fileName}
+        @sl-after-hide=${(e: Event) => {
+          if (e.target === e.currentTarget) this.closeFilePreview();
+        }}
+      >
+        ${body}
+        <div slot="footer" style="display:flex;gap:0.5rem;align-items:center">
+          <span style="flex:1;font-size:0.75rem;color:var(--scion-text-muted,#64748b);overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title=${fp.containerPath}>
+            ${fp.containerPath}
+          </span>
+          <sl-button href="${fp.downloadUrl}" download=${fp.fileName} size="small">
+            <sl-icon slot="prefix" name="download"></sl-icon>
+            Download
+          </sl-button>
+        </div>
+      </sl-dialog>
+    `;
+  }
+
+  // ---------------------------------------------------------------------------
   // Phase-5: Slash command handling
   // ---------------------------------------------------------------------------
 
@@ -2444,6 +2741,7 @@ export class ScionChatThread extends LitElement {
               ></scion-chat-composer>
             `
           : nothing}
+        ${this.renderFilePreview()}
       </div>
     `;
   }
@@ -2473,6 +2771,7 @@ export class ScionChatThread extends LitElement {
           @chat-slash-command=${this.handleSlashCommand}
         ></scion-chat-composer>
         ${this.renderContextMenu()}
+        ${this.renderFilePreview()}
         <scion-send-to-agent-picker
           .agents=${this.agents}
           ?open=${this.showAgentPicker}
@@ -2798,6 +3097,7 @@ export class ScionChatThread extends LitElement {
           @message-delete=${this.handleMessageDeleteRequest}
           @message-copy-link=${this.handleCopyLink}
           @scroll-to-message=${this.handleScrollToMessage}
+          @path-link-click=${this.handlePathLinkClick}
         ></scion-chat-message>
       `);
 


### PR DESCRIPTION
Render /workspace/... and /scion-volumes/... paths in chat messages as clickable links that open an on-demand file viewer dialog. Files fetched from existing workspace/shared-dir APIs.

Closes ptone/scion#1148