### PR TITLE
feat: switch default harness config from claude to antigravity

### DIFF
--- a/pkg/agent/provision_compose_test.go
+++ b/pkg/agent/provision_compose_test.go
@@ -515,14 +515,14 @@ func TestComposition_FullInitProjectFlow(t *testing.T) {
 		t.Fatalf("ProvisionAgent failed: %v", err)
 	}
 
-	// Verify harness was resolved from claude harness-config
-	if cfg.Harness != "claude" {
-		t.Errorf("expected harness 'claude', got %q", cfg.Harness)
+	// Verify harness was resolved from antigravity harness-config
+	if cfg.Harness != "antigravity" {
+		t.Errorf("expected harness 'antigravity', got %q", cfg.Harness)
 	}
 
 	// Verify harness-config name is set
-	if cfg.HarnessConfig != "claude" {
-		t.Errorf("expected HarnessConfig 'claude', got %q", cfg.HarnessConfig)
+	if cfg.HarnessConfig != "antigravity" {
+		t.Errorf("expected HarnessConfig 'antigravity', got %q", cfg.HarnessConfig)
 	}
 
 	// Verify agent home exists

--- a/pkg/config/embeds/default_project_settings.yaml
+++ b/pkg/config/embeds/default_project_settings.yaml
@@ -27,6 +27,10 @@ schema_version: "1"
 # Env: SCION_ACTIVE_PROFILE
 active_profile: local
 
+# Default harness-config for new agents
+# Env: SCION_DEFAULT_HARNESS_CONFIG
+default_harness_config: antigravity
+
 # CLI behavior settings
 cli:
   autohelp: true

--- a/pkg/config/embeds/default_project_settings.yaml
+++ b/pkg/config/embeds/default_project_settings.yaml
@@ -27,10 +27,6 @@ schema_version: "1"
 # Env: SCION_ACTIVE_PROFILE
 active_profile: local
 
-# Default harness-config for new agents
-# Env: SCION_DEFAULT_HARNESS_CONFIG
-default_harness_config: antigravity
-
 # CLI behavior settings
 cli:
   autohelp: true

--- a/pkg/config/embeds/default_settings.yaml
+++ b/pkg/config/embeds/default_settings.yaml
@@ -29,7 +29,7 @@ default_template: default
 
 # Default harness-config for new agents
 # Env: SCION_DEFAULT_HARNESS_CONFIG
-default_harness_config: claude
+default_harness_config: antigravity
 
 # Container image registry path (REQUIRED)
 # Set this to the registry where your scion images are hosted.

--- a/pkg/config/settings_v1_test.go
+++ b/pkg/config/settings_v1_test.go
@@ -116,7 +116,7 @@ func TestLoadVersionedSettings_DefaultsOnly(t *testing.T) {
 	assert.Equal(t, "1", vs.SchemaVersion)
 	assert.Equal(t, "local", vs.ActiveProfile)
 	assert.Equal(t, "default", vs.DefaultTemplate)
-	assert.Equal(t, "claude", vs.DefaultHarnessConfig)
+	assert.Equal(t, "antigravity", vs.DefaultHarnessConfig)
 	// harness_configs block is no longer in default settings (lives on disk as harness-config dirs)
 	assert.Contains(t, vs.Runtimes, "docker")
 	assert.Equal(t, "docker", vs.Runtimes["docker"].Type)


### PR DESCRIPTION
Switch the default harness config for new setups from claude to antigravity.

Changes:
- pkg/config/embeds/default_settings.yaml: default_harness_config claude -> antigravity
- Updated tests in settings_v1_test.go and provision_compose_test.go to match new default

Related: ptone/scion#1213