### PR TITLE
security: encrypt local secret backend at rest

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -236,7 +236,7 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 		secretBackend, sbErr = secret.NewBackend(ctx, cfg.Secrets.Backend, s, secret.GCPBackendConfig{
 			ProjectID:       cfg.Secrets.GCPProjectID,
 			CredentialsJSON: cfg.Secrets.GCPCredentials,
-		}, hubID)
+		}, hubID, resolveSessionSecret())
 		if sbErr != nil {
 			log.Printf("Warning: failed to initialize secret backend: %v", sbErr)
 		}

--- a/pkg/ent/schema/secret.go
+++ b/pkg/ent/schema/secret.go
@@ -25,12 +25,14 @@ import (
 	"github.com/google/uuid"
 )
 
-// Secret holds the schema definition for the Secret entity, mapping the legacy
+// Secret holds the schema definition for the Secret entity, mapping the
 // SQLite `secrets` table. Secrets are polymorphically scoped (hub/user/project/
 // runtime_broker) via (scope, scope_id), so no FK edges are declared.
 //
-// encrypted_value stores the encrypted secret payload as TEXT (base64), not a
-// BLOB, and is marked Sensitive so it is never logged or serialized.
+// encrypted_value stores the AES-256-GCM encrypted secret payload (prefixed
+// with "enc:v1:" and base64-encoded). The local backend encrypts on write and
+// decrypts on read; the GCP Secret Manager backend stores only a reference
+// here. The field is marked Sensitive so it is never logged or serialized.
 type Secret struct {
 	ent.Schema
 }

--- a/pkg/hub/envgather_hubscope_regression_test.go
+++ b/pkg/hub/envgather_hubscope_regression_test.go
@@ -54,7 +54,7 @@ func TestBuildEnvGatherResponse_HubScopeSecretWarning(t *testing.T) {
 	}
 
 	// Set up the local secret backend so the cross-check can query it
-	backend := secret.NewLocalBackend(st, "test-hub-id")
+	backend := secret.NewLocalBackend(st, "test-hub-id", "test-secret")
 	srv.SetSecretBackend(backend)
 
 	agent := &store.Agent{

--- a/pkg/hub/envgather_resolution_test.go
+++ b/pkg/hub/envgather_resolution_test.go
@@ -113,7 +113,7 @@ func TestResolution_SecretUserScope(t *testing.T) {
 	}
 
 	// Store a secret via the local backend
-	backend := secret.NewLocalBackend(memStore, "test-hub-id")
+	backend := secret.NewLocalBackend(memStore, "test-hub-id", "test-secret")
 	_, _, err := backend.Set(ctx, &secret.SetSecretInput{
 		Name:          "SECRET_KEY",
 		Value:         "secret-key-value",
@@ -253,7 +253,7 @@ func TestResolution_SecretPromotedEnvVar(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	backend := secret.NewLocalBackend(memStore, "test-hub-id")
+	backend := secret.NewLocalBackend(memStore, "test-hub-id", "test-secret")
 
 	// Simulate the --secret flow: first store as plain env var, then promote
 	// to secret (which deletes the plain env var).

--- a/pkg/hub/envgather_test.go
+++ b/pkg/hub/envgather_test.go
@@ -946,7 +946,7 @@ func TestEnvGather_BuildResponse_SecretScope(t *testing.T) {
 	}
 
 	// Set up the secret backend on the server
-	backend := secret.NewLocalBackend(st, "test-hub-id")
+	backend := secret.NewLocalBackend(st, "test-hub-id", "test-secret")
 	srv.SetSecretBackend(backend)
 
 	agent := &store.Agent{
@@ -1599,7 +1599,7 @@ func TestProjectRoute_ResolvesUserScopedSecrets(t *testing.T) {
 	}
 
 	// Store a user-scoped secret for the dev-user
-	backend := secret.NewLocalBackend(st, "test-hub-id")
+	backend := secret.NewLocalBackend(st, "test-hub-id", "test-secret")
 	_, _, err := backend.Set(ctx, &secret.SetSecretInput{
 		Name:          "GEMINI_API_KEY",
 		Value:         "secret-gemini-key",

--- a/pkg/hub/handlers_agent_secret_getlist_test.go
+++ b/pkg/hub/handlers_agent_secret_getlist_test.go
@@ -39,7 +39,7 @@ import (
 func setupAgentSecretGetTest(t *testing.T) (*Server, store.Store, string, string, string) {
 	t.Helper()
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	projectID := tid("project-agent-get-secret")
@@ -157,7 +157,7 @@ func TestAgentGetSecret_AgentIDMismatch(t *testing.T) {
 
 func TestAgentGetSecret_NoAuth(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, "test-hub-id", "test-secret"))
 
 	rec := doRequestNoAuth(t, srv, http.MethodGet,
 		"/api/v1/agents/some-agent/secrets/MY_KEY", nil)
@@ -168,7 +168,7 @@ func TestAgentGetSecret_NoAuth(t *testing.T) {
 
 func TestAgentGetSecret_UserTokenRejected(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, "test-hub-id", "test-secret"))
 
 	// Using dev token (user auth) should be rejected — agent-only endpoint.
 	rec := doRequest(t, srv, http.MethodGet,
@@ -325,7 +325,7 @@ func TestAgentListSecrets_Empty(t *testing.T) {
 
 func TestAgentListSecrets_NoAuth(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, "test-hub-id", "test-secret"))
 
 	rec := doRequestNoAuth(t, srv, http.MethodGet,
 		"/api/v1/agents/some-agent/secrets", nil)

--- a/pkg/hub/handlers_agent_secrets_test.go
+++ b/pkg/hub/handlers_agent_secrets_test.go
@@ -32,7 +32,7 @@ import (
 func setupAgentSecretTest(t *testing.T) (*Server, store.Store, string, string, string) {
 	t.Helper()
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	projectID := tid("project-agent-secret")
@@ -155,7 +155,7 @@ func TestAgentSecrets_ForceOverwrite(t *testing.T) {
 
 func TestAgentSecrets_NoAuth(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, "test-hub-id", "test-secret"))
 
 	body := AgentSetSecretRequest{
 		Value: base64.StdEncoding.EncodeToString([]byte("value")),
@@ -169,7 +169,7 @@ func TestAgentSecrets_NoAuth(t *testing.T) {
 
 func TestAgentSecrets_UserTokenRejected(t *testing.T) {
 	srv, _ := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, "test-hub-id", "test-secret"))
 
 	body := AgentSetSecretRequest{
 		Value: base64.StdEncoding.EncodeToString([]byte("value")),

--- a/pkg/hub/handlers_envsecret_authz_test.go
+++ b/pkg/hub/handlers_envsecret_authz_test.go
@@ -464,7 +464,7 @@ func TestEnvVar_BrokerScope_AdminAccess(t *testing.T) {
 
 func TestSecret_UserScope_AdminAccess(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 
 	rec := doRequest(t, srv, http.MethodGet, "/api/v1/secrets?scope=user", nil)
 	if rec.Code != http.StatusOK {
@@ -484,7 +484,7 @@ func TestSecret_UserScope_AdminAccess(t *testing.T) {
 
 func TestSecret_UserScope_AdminDoesNotSeeOtherUserSecrets(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	// Create a member user and store a secret scoped to them.
@@ -525,7 +525,7 @@ func TestSecret_UserScope_AdminDoesNotSeeOtherUserSecrets(t *testing.T) {
 
 func TestSecret_UserScope_MemberAccess(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	member := &store.User{
@@ -553,7 +553,7 @@ func TestSecret_UserScope_MemberAccess(t *testing.T) {
 
 func TestSecret_UserScope_Unauthenticated(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 
 	rec := doRequestNoAuth(t, srv, http.MethodGet, "/api/v1/secrets?scope=user", nil)
 	if rec.Code != http.StatusUnauthorized {
@@ -563,7 +563,7 @@ func TestSecret_UserScope_Unauthenticated(t *testing.T) {
 
 func TestSecret_UserScope_WriteAuthWorks(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 
 	// Verify that an authenticated user passes auth checks for secret writes.
 	// The LocalBackend supports Set (stores plaintext in SQLite), so expect 200.
@@ -589,7 +589,7 @@ func TestSecret_UserScope_WriteAuthWorks(t *testing.T) {
 
 func TestSecret_ProjectScope_OwnerAccess(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	owner := &store.User{
@@ -616,7 +616,7 @@ func TestSecret_ProjectScope_OwnerAccess(t *testing.T) {
 
 func TestSecret_ProjectScope_NonOwnerDenied(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	nonOwner := &store.User{
@@ -643,7 +643,7 @@ func TestSecret_ProjectScope_NonOwnerDenied(t *testing.T) {
 
 func TestSecret_ProjectScope_AgentReadOwnProject(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	project := &store.Project{
@@ -676,7 +676,7 @@ func TestSecret_ProjectScope_AgentReadOwnProject(t *testing.T) {
 
 func TestSecret_ProjectScope_AgentWriteDenied(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	project := &store.Project{
@@ -777,7 +777,7 @@ func TestEnvVar_SecretPromotion_NoBackend_Returns501(t *testing.T) {
 
 func TestEnvVar_SecretPromotion_LocalBackend_Succeeds(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 
 	// LocalBackend.Set() now works — promotion should succeed with 200
 	body := SetEnvVarRequest{
@@ -792,7 +792,7 @@ func TestEnvVar_SecretPromotion_LocalBackend_Succeeds(t *testing.T) {
 
 func TestEnvVar_UnifiedList_MergesSecrets(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	// Create a plain env var
@@ -855,7 +855,7 @@ func TestEnvVar_UnifiedList_MergesSecrets(t *testing.T) {
 
 func TestEnvVar_UnifiedList_Deduplication(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	// Create a plain env var with key "DUPED_KEY"
@@ -903,7 +903,7 @@ func TestEnvVar_UnifiedList_Deduplication(t *testing.T) {
 
 func TestEnvVar_FallbackGet_FromSecretBackend(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	// Create a secret (no plain env var)
@@ -944,7 +944,7 @@ func TestEnvVar_FallbackGet_FromSecretBackend(t *testing.T) {
 
 func TestEnvVar_FallbackDelete_FromSecretBackend(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	// Create a secret (no plain env var)
@@ -975,7 +975,7 @@ func TestEnvVar_FallbackDelete_FromSecretBackend(t *testing.T) {
 
 func TestEnvVar_StaleCleanup_PlainEnvVarRemovedOnPromotion(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	// Create a plain env var
@@ -1008,7 +1008,7 @@ func TestEnvVar_StaleCleanup_PlainEnvVarRemovedOnPromotion(t *testing.T) {
 
 func TestEnvVar_NonEnvironmentSecrets_NotMerged(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	// Create a secret with type "variable" (not "environment")
@@ -1042,7 +1042,7 @@ func TestEnvVar_NonEnvironmentSecrets_NotMerged(t *testing.T) {
 
 func TestEnvVar_ProjectScope_SecretPromotion_Succeeds(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	project := &store.Project{
@@ -1062,7 +1062,7 @@ func TestEnvVar_ProjectScope_SecretPromotion_Succeeds(t *testing.T) {
 
 func TestEnvVar_ProjectScope_UnifiedList(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	project := &store.Project{
@@ -1122,7 +1122,7 @@ func TestEnvVar_ProjectScope_UnifiedList(t *testing.T) {
 
 func TestEnvVar_ProjectScope_FallbackGet(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	project := &store.Project{
@@ -1159,7 +1159,7 @@ func TestEnvVar_ProjectScope_FallbackGet(t *testing.T) {
 
 func TestEnvVar_ProjectScope_FallbackDelete(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	project := &store.Project{
@@ -1386,7 +1386,7 @@ func TestEnvVar_HubScope_Unauthenticated(t *testing.T) {
 
 func TestSecret_HubScope_AdminCanSetAndGet(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 
 	// Admin should be able to set hub-scoped secrets
 	body := SetSecretRequest{Value: "aHViLXNlY3JldC12YWw=", Description: "Hub-wide secret", Scope: "hub"}
@@ -1404,7 +1404,7 @@ func TestSecret_HubScope_AdminCanSetAndGet(t *testing.T) {
 
 func TestSecret_HubScope_MemberReadForbidden(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	member := &store.User{
@@ -1431,7 +1431,7 @@ func TestSecret_HubScope_MemberReadForbidden(t *testing.T) {
 
 func TestSecret_HubScope_MemberWriteForbidden(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	member := &store.User{

--- a/pkg/hub/handlers_project_test.go
+++ b/pkg/hub/handlers_project_test.go
@@ -1840,7 +1840,7 @@ func TestResolveCloneToken_FallsBackToCreatorUserToken(t *testing.T) {
 		ScopeID:        "creator-user-1",
 	}))
 
-	backend := secret.NewLocalBackend(st, "test-hub-id")
+	backend := secret.NewLocalBackend(st, "test-hub-id", "test-secret")
 	srv.SetSecretBackend(backend)
 
 	project := &store.Project{
@@ -1876,7 +1876,7 @@ func TestResolveCloneToken_PrefersProjectTokenOverUserToken(t *testing.T) {
 		ScopeID:        "creator-user-2",
 	}))
 
-	backend := secret.NewLocalBackend(st, "test-hub-id")
+	backend := secret.NewLocalBackend(st, "test-hub-id", "test-secret")
 	srv.SetSecretBackend(backend)
 
 	project := &store.Project{

--- a/pkg/hub/handlers_secret_base64_test.go
+++ b/pkg/hub/handlers_secret_base64_test.go
@@ -68,7 +68,7 @@ func checkJSONError(t *testing.T, body string) {
 // TestSetSecret_ValidBase64_Works confirms backward-compatible base64 path works.
 func TestSetSecret_ValidBase64_Works(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 
 	body := SetSecretRequest{
 		Value: base64.StdEncoding.EncodeToString([]byte("my-plain-value")),
@@ -83,7 +83,7 @@ func TestSetSecret_ValidBase64_Works(t *testing.T) {
 // explicit encoding="raw", values that fail base64 decode are rejected.
 func TestSetSecret_InvalidBase64_DefaultEncoding_Returns400(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 
 	body := SetSecretRequest{
 		// Raw text with characters that make it invalid base64.
@@ -102,7 +102,7 @@ func TestSetSecret_InvalidBase64_DefaultEncoding_Returns400(t *testing.T) {
 // the caller wants literal storage they must set Encoding:"raw".
 func TestSetSecret_ValidBase64LookingValue_DefaultEncoding_Decoded(t *testing.T) {
 	srv, s := testServer(t)
-	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
 	srv.SetSecretBackend(localBackend)
 	ctx := context.Background()
 
@@ -127,7 +127,7 @@ func TestSetSecret_ValidBase64LookingValue_DefaultEncoding_Decoded(t *testing.T)
 // the value byte-for-byte, including text that happens to be valid base64.
 func TestSetSecret_RawEncoding_StoresLiteralValue(t *testing.T) {
 	srv, s := testServer(t)
-	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
 	srv.SetSecretBackend(localBackend)
 	ctx := context.Background()
 
@@ -155,7 +155,7 @@ func TestSetSecret_RawEncoding_StoresLiteralValue(t *testing.T) {
 // arbitrary special-character strings without any encoding/decoding.
 func TestSetSecret_RawEncoding_SpecialCharsLiteral(t *testing.T) {
 	srv, s := testServer(t)
-	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
 	srv.SetSecretBackend(localBackend)
 	ctx := context.Background()
 
@@ -181,7 +181,7 @@ func TestSetSecret_RawEncoding_SpecialCharsLiteral(t *testing.T) {
 // validation still produces structured JSON regardless of encoding.
 func TestSetSecret_PathTraversal_ReturnsJSONError(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 
 	body := SetSecretRequest{
 		Value:  base64.StdEncoding.EncodeToString([]byte("data")),
@@ -200,7 +200,7 @@ func TestSetSecret_PathTraversal_ReturnsJSONError(t *testing.T) {
 // an oversized value.
 func TestSetSecret_SizeLimit_ReturnsJSONError(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 
 	body := SetSecretRequest{
 		Value:    strings.Repeat("x", 64*1024+1),
@@ -248,7 +248,7 @@ func TestAgentSecrets_InvalidBase64_DefaultEncoding_Returns400(t *testing.T) {
 
 func TestAgentSecrets_RawEncoding_StoresLiteralValue(t *testing.T) {
 	srv, s, agentID, projectID, agentToken := setupAgentSecretTest(t)
-	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
 	srv.SetSecretBackend(localBackend)
 	ctx := context.Background()
 
@@ -274,7 +274,7 @@ func TestAgentSecrets_RawEncoding_StoresLiteralValue(t *testing.T) {
 
 func TestAgentSecrets_RawEncoding_SpecialCharsLiteral(t *testing.T) {
 	srv, s, agentID, projectID, agentToken := setupAgentSecretTest(t)
-	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
 	srv.SetSecretBackend(localBackend)
 	ctx := context.Background()
 
@@ -337,7 +337,7 @@ func TestAgentSecrets_SizeLimit_ReturnsJSONError(t *testing.T) {
 func setupProjectSecretTest(t *testing.T) (*Server, string) {
 	t.Helper()
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	projectID := tid("proj-secret-b64")
@@ -384,7 +384,7 @@ func TestProjectSecretByKey_InvalidBase64_DefaultEncoding_Returns400(t *testing.
 
 func TestProjectSecretByKey_RawEncoding_StoresLiteralValue(t *testing.T) {
 	srv, s := testServer(t)
-	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
 	srv.SetSecretBackend(localBackend)
 	ctx := context.Background()
 
@@ -458,7 +458,7 @@ func TestProjectSecretByKey_SizeLimit_ReturnsJSONError(t *testing.T) {
 func setupBrokerSecretTest(t *testing.T) (*Server, string) {
 	t.Helper()
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 	ctx := context.Background()
 
 	brokerID := tid("broker-secret-b64")
@@ -505,7 +505,7 @@ func TestBrokerSecretByKey_InvalidBase64_DefaultEncoding_Returns400(t *testing.T
 
 func TestBrokerSecretByKey_RawEncoding_StoresLiteralValue(t *testing.T) {
 	srv, s := testServer(t)
-	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
 	srv.SetSecretBackend(localBackend)
 	ctx := context.Background()
 
@@ -582,7 +582,7 @@ func TestBrokerSecretByKey_SizeLimit_ReturnsJSONError(t *testing.T) {
 // strict base64.
 func TestSetSecret_UnrecognizedEncoding_Returns400(t *testing.T) {
 	srv, s := testServer(t)
-	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id"))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
 
 	body := SetSecretRequest{
 		Value:    base64.StdEncoding.EncodeToString([]byte("value")),

--- a/pkg/hub/handlers_skills_discover_test.go
+++ b/pkg/hub/handlers_skills_discover_test.go
@@ -116,7 +116,7 @@ func skillDiscoverProject(t *testing.T, srv *Server, s store.Store, suffix, toke
 		t.Fatalf("failed to create project: %v", err)
 	}
 	if token != "" {
-		srv.SetSecretBackend(secret.NewLocalBackend(s, ""))
+		srv.SetSecretBackend(secret.NewLocalBackend(s, "", "test-secret"))
 		if _, _, err := srv.GetSecretBackend().Set(ctx, &secret.SetSecretInput{
 			Name: "GITHUB_TOKEN", Value: token, SecretType: secret.TypeEnvironment,
 			Scope: secret.ScopeProject, ScopeID: projectID,
@@ -985,7 +985,7 @@ func TestHandleSkillsDiscoverDirectory_AgentOmitsProjectID(t *testing.T) {
 	srv, projectID, token := setupSkillDiscoverAgent(t, "noprojid",
 		[]AgentTokenScope{ScopeAgentStatusUpdate, ScopeAgentCreate})
 
-	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, ""))
+	srv.SetSecretBackend(secret.NewLocalBackend(srv.store, "", "test-secret"))
 	if _, _, err := srv.GetSecretBackend().Set(context.Background(), &secret.SetSecretInput{
 		Name: "GITHUB_TOKEN", Value: "agent-project-token", SecretType: secret.TypeEnvironment,
 		Scope: secret.ScopeProject, ScopeID: projectID,

--- a/pkg/hub/maintenance_executors_test.go
+++ b/pkg/hub/maintenance_executors_test.go
@@ -40,7 +40,7 @@ func TestSecretMigrationExecutor_NoGCPBackend(t *testing.T) {
 	}
 
 	// Use a local backend (not GCP) — migration should fail.
-	localBackend := secret.NewLocalBackend(s, "test-hub-id")
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
 
 	executor := &SecretMigrationExecutor{
 		store:         s,

--- a/pkg/hub/resolve_secrets_test.go
+++ b/pkg/hub/resolve_secrets_test.go
@@ -89,7 +89,7 @@ func TestResolveSecrets(t *testing.T) {
 	}
 
 	// Create dispatcher with local backend (reads work, writes are blocked)
-	backend := secret.NewLocalBackend(memStore, "test-hub-id")
+	backend := secret.NewLocalBackend(memStore, "test-hub-id", "test-secret")
 	mockClient := &mockRuntimeBrokerClient{}
 	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
 	dispatcher.SetSecretBackend(backend)
@@ -207,7 +207,7 @@ func TestResolveSecrets_WithBackend(t *testing.T) {
 	}
 
 	// Create dispatcher with local backend
-	backend := secret.NewLocalBackend(memStore, "test-hub-id")
+	backend := secret.NewLocalBackend(memStore, "test-hub-id", "test-secret")
 	mockClient := &mockRuntimeBrokerClient{}
 	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
 	dispatcher.SetSecretBackend(backend)
@@ -259,7 +259,7 @@ func TestResolveSecrets_NoOwner(t *testing.T) {
 	memStore := createTestStore(t)
 	ctx := context.Background()
 
-	backend := secret.NewLocalBackend(memStore, "test-hub-id")
+	backend := secret.NewLocalBackend(memStore, "test-hub-id", "test-secret")
 	mockClient := &mockRuntimeBrokerClient{}
 	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
 	dispatcher.SetSecretBackend(backend)
@@ -344,7 +344,7 @@ func TestResolveSecrets_HubScope(t *testing.T) {
 		}
 	}
 
-	backend := secret.NewLocalBackend(memStore, "test-hub-id")
+	backend := secret.NewLocalBackend(memStore, "test-hub-id", "test-secret")
 	mockClient := &mockRuntimeBrokerClient{}
 	dispatcher := NewHTTPAgentDispatcherWithClient(memStore, mockClient, false, slog.Default())
 	dispatcher.SetSecretBackend(backend)

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1591,9 +1591,22 @@ func (s *Server) ensureSigningKey(ctx context.Context, keyName string, existingK
 			if legacyScopeID == hubID {
 				continue
 			}
-			val, legacyErr := s.store.GetSecretValue(ctx, keyName, store.ScopeHub, legacyScopeID)
-			if legacyErr != nil {
-				continue
+			// When a secret backend is configured, read through it so that
+			// encrypted-at-rest values are decrypted transparently. Fall
+			// back to the raw store for configurations without a backend.
+			var val string
+			if hasSecretBackend {
+				sv, getErr := s.secretBackend.Get(ctx, keyName, store.ScopeHub, legacyScopeID)
+				if getErr == nil {
+					val = sv.Value
+				}
+			}
+			if val == "" {
+				rawVal, legacyErr := s.store.GetSecretValue(ctx, keyName, store.ScopeHub, legacyScopeID)
+				if legacyErr != nil {
+					continue
+				}
+				val = rawVal
 			}
 			slog.Info("Loaded signing key from legacy scope ID, will migrate", "key", keyName, "legacyScopeID", legacyScopeID)
 			key, decErr := base64.StdEncoding.DecodeString(val)

--- a/pkg/hub/server_test.go
+++ b/pkg/hub/server_test.go
@@ -171,7 +171,7 @@ func TestServer_SigningKeysExcludedFromResolve(t *testing.T) {
 	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
 
 	// Resolve secrets as if dispatching an agent — signing keys must not appear.
-	backend := secret.NewLocalBackend(s, "test-hub-resolve")
+	backend := secret.NewLocalBackend(s, "test-hub-resolve", "test-secret")
 	resolved, err := backend.Resolve(context.Background(), "", "", "", nil)
 	if err != nil {
 		t.Fatalf("Resolve failed: %v", err)
@@ -358,7 +358,7 @@ func TestServer_SigningKeyMigration_DeletesLegacyFromBackend(t *testing.T) {
 	legacyScopeID := "hub"
 
 	// Set up a LocalBackend as the secret backend with the new hub ID.
-	backend := secret.NewLocalBackend(s, newHubID)
+	backend := secret.NewLocalBackend(s, newHubID, "test-secret")
 
 	// Seed a legacy key under the old scope ID in both the store and backend.
 	legacyKey := make([]byte, 32)
@@ -433,7 +433,7 @@ func TestServer_SigningKeyBootstrapWithSecretBackend(t *testing.T) {
 	}
 
 	hubID := "test-backend-hub"
-	backend := secret.NewLocalBackend(s, hubID)
+	backend := secret.NewLocalBackend(s, hubID, "test-secret")
 
 	cfg := DefaultServerConfig()
 	cfg.HubID = hubID
@@ -515,7 +515,7 @@ func TestServer_SigningKeySyncFromStoreToBackend(t *testing.T) {
 	key1 := srv1.userTokenService.config.SigningKey
 
 	// Run 2: Secret backend configured — keys should sync from SQLite to backend
-	backend := secret.NewLocalBackend(s, hubID)
+	backend := secret.NewLocalBackend(s, hubID, "test-secret")
 	cfg.SecretBackend = backend
 	srv2, err := New(cfg, s)
 	if err != nil {
@@ -622,7 +622,7 @@ func TestServer_SigningKeyBackupAfterBackendSet(t *testing.T) {
 	}
 
 	hubID := "test-backup-hub"
-	backend := secret.NewLocalBackend(s, hubID)
+	backend := secret.NewLocalBackend(s, hubID, "test-secret")
 
 	cfg := DefaultServerConfig()
 	cfg.HubID = hubID
@@ -1045,7 +1045,7 @@ func TestServer_SigningKeyBackupPreservesSecretRef(t *testing.T) {
 	}
 
 	hubID := "test-ref-hub"
-	backend := secret.NewLocalBackend(s, hubID)
+	backend := secret.NewLocalBackend(s, hubID, "test-secret")
 
 	cfg := DefaultServerConfig()
 	cfg.HubID = hubID

--- a/pkg/hub/template_bootstrap_test.go
+++ b/pkg/hub/template_bootstrap_test.go
@@ -1166,7 +1166,7 @@ func TestImportTemplatesFromRemote_WithProjectGithubToken(t *testing.T) {
 		Scope:      secret.ScopeProject,
 		ScopeID:    projectID,
 	}
-	srv.SetSecretBackend(secret.NewLocalBackend(s, ""))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "", "test-secret"))
 	sb := srv.GetSecretBackend()
 	if sb == nil {
 		t.Fatal("secret backend is nil")
@@ -1286,7 +1286,7 @@ func TestImportHarnessConfigsFromRemote_WithProjectGithubToken(t *testing.T) {
 	}
 
 	// Save GITHUB_TOKEN secret via local secret backend.
-	srv.SetSecretBackend(secret.NewLocalBackend(s, ""))
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "", "test-secret"))
 	if _, _, err := srv.GetSecretBackend().Set(ctx, &secret.SetSecretInput{
 		Name:       "GITHUB_TOKEN",
 		Value:      "my-secret-token-12345",

--- a/pkg/secret/backend.go
+++ b/pkg/secret/backend.go
@@ -34,13 +34,14 @@ type GCPBackendConfig struct {
 }
 
 // NewBackend creates a SecretBackend of the specified type.
-// The "local" backend wraps the given SecretStore directly.
+// The "local" backend wraps the given SecretStore directly and encrypts values
+// at rest using a key derived from sharedSecret.
 // The "gcpsm" backend uses a hybrid approach: metadata in the Hub DB, values in GCP SM.
 // The hubID parameter is the unique hub instance identifier used for secret namespacing.
-func NewBackend(ctx context.Context, backendType string, s store.SecretStore, gcpCfg GCPBackendConfig, hubID string) (SecretBackend, error) {
+func NewBackend(ctx context.Context, backendType string, s store.SecretStore, gcpCfg GCPBackendConfig, hubID, sharedSecret string) (SecretBackend, error) {
 	switch backendType {
 	case BackendLocal, "":
-		return NewLocalBackend(s, hubID), nil
+		return NewLocalBackend(s, hubID, sharedSecret), nil
 	case BackendGCPSM:
 		return NewGCPBackend(ctx, s, gcpCfg, hubID)
 	default:

--- a/pkg/secret/localbackend.go
+++ b/pkg/secret/localbackend.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -161,7 +162,12 @@ func (b *LocalBackend) Resolve(ctx context.Context, userID, projectID, brokerID 
 			if err != nil {
 				continue
 			}
-			value := b.decryptRawValue(rawValue)
+			value, err := b.decryptRawValue(rawValue)
+			if err != nil {
+				slog.Warn("skipping secret: decryption not possible",
+					"key", s.Key, "error", err)
+				continue
+			}
 
 			secretType := s.SecretType
 			if secretType == "" {
@@ -225,7 +231,12 @@ func (b *LocalBackend) Resolve(ctx context.Context, userID, projectID, brokerID 
 			if err != nil {
 				continue
 			}
-			value := b.decryptRawValue(rawValue)
+			value, err := b.decryptRawValue(rawValue)
+			if err != nil {
+				slog.Warn("skipping progeny secret: decryption not possible",
+					"key", s.Key, "error", err)
+				continue
+			}
 
 			secretType := s.SecretType
 			if secretType == "" {
@@ -340,6 +351,11 @@ func (b *LocalBackend) decryptStoreSecret(s *store.Secret) (*SecretWithValue, er
 			return nil, fmt.Errorf("decrypting secret %q: %w", s.Key, err)
 		}
 		value = plaintext
+	} else if strings.HasPrefix(s.EncryptedValue, encryptedPrefix) {
+		// The stored value is encrypted but no encryption key is configured.
+		// Returning the raw ciphertext would leak an indistinguishable blob
+		// that the caller would treat as a real secret value.
+		return nil, fmt.Errorf("secret %q is encrypted but no encryption key is configured", s.Key)
 	}
 	return &SecretWithValue{
 		SecretMeta: *fromStoreSecretMeta(s),
@@ -353,15 +369,20 @@ func (b *LocalBackend) decryptStoreSecret(s *store.Secret) (*SecretWithValue, er
 // receive an encrypted blob as a secret value; a missing value is safer than
 // indistinguishable garbage. This is used in Resolve where individual
 // decryption failures should not abort the entire resolution.
-func (b *LocalBackend) decryptRawValue(raw string) string {
+func (b *LocalBackend) decryptRawValue(raw string) (string, error) {
 	if b.encryptionKey == nil {
-		return raw
+		if strings.HasPrefix(raw, encryptedPrefix) {
+			// The stored value is encrypted but no encryption key is
+			// configured. Return an error instead of leaking ciphertext.
+			return "", fmt.Errorf("value is encrypted but no encryption key is configured")
+		}
+		return raw, nil // legacy plaintext
 	}
 	plaintext, _, err := decryptValue(raw, b.encryptionKey)
 	if err != nil {
 		slog.Warn("failed to decrypt secret value, returning empty",
 			"error", err)
-		return ""
+		return "", nil
 	}
-	return plaintext
+	return plaintext, nil
 }

--- a/pkg/secret/localbackend.go
+++ b/pkg/secret/localbackend.go
@@ -348,18 +348,20 @@ func (b *LocalBackend) decryptStoreSecret(s *store.Secret) (*SecretWithValue, er
 }
 
 // decryptRawValue decrypts a raw encrypted value string. If decryption fails
-// (e.g. legacy plaintext), the value is returned as-is with a warning logged.
-// This is used in Resolve where individual decryption failures should not
-// abort the entire resolution.
+// (e.g. corrupted ciphertext or key mismatch after rotation), an empty string
+// is returned and a warning is logged. Returning "" ensures agents never
+// receive an encrypted blob as a secret value; a missing value is safer than
+// indistinguishable garbage. This is used in Resolve where individual
+// decryption failures should not abort the entire resolution.
 func (b *LocalBackend) decryptRawValue(raw string) string {
 	if b.encryptionKey == nil {
 		return raw
 	}
 	plaintext, _, err := decryptValue(raw, b.encryptionKey)
 	if err != nil {
-		slog.Warn("failed to decrypt secret value, returning raw",
+		slog.Warn("failed to decrypt secret value, returning empty",
 			"error", err)
-		return raw
+		return ""
 	}
 	return plaintext
 }

--- a/pkg/secret/localbackend.go
+++ b/pkg/secret/localbackend.go
@@ -16,21 +16,36 @@ package secret
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
 // LocalBackend implements SecretBackend using the local store.SecretStore.
-// Values are stored directly in the Hub database.
+// Values are encrypted at rest using AES-256-GCM before being written to
+// the Hub database. The encryption key is derived from the deployment-wide
+// shared signing secret via deriveLocalEncryptionKey.
 type LocalBackend struct {
-	store store.SecretStore
-	hubID string
+	store         store.SecretStore
+	hubID         string
+	encryptionKey []byte // 32-byte AES-256 key; nil disables encryption (legacy/dev)
 }
 
 // NewLocalBackend creates a LocalBackend wrapping the given SecretStore.
-func NewLocalBackend(s store.SecretStore, hubID string) *LocalBackend {
-	return &LocalBackend{store: s, hubID: hubID}
+// The sharedSecret parameter is the deployment-wide signing secret used to
+// derive the AES-256 encryption key for at-rest encryption. When empty,
+// encryption is disabled and values are stored as plaintext (with a warning).
+func NewLocalBackend(s store.SecretStore, hubID, sharedSecret string) *LocalBackend {
+	var key []byte
+	if sharedSecret != "" {
+		key = deriveLocalEncryptionKey(sharedSecret)
+	} else {
+		slog.Warn("local secret backend: no shared signing secret configured; " +
+			"secret values will be stored WITHOUT encryption")
+	}
+	return &LocalBackend{store: s, hubID: hubID, encryptionKey: key}
 }
 
 // HubID returns the hub instance ID used for hub-scoped secret namespacing.
@@ -43,11 +58,22 @@ func (b *LocalBackend) Get(ctx context.Context, name, scope, scopeID string) (*S
 	if err != nil {
 		return nil, err
 	}
-	return fromStoreSecretWithValue(s), nil
+	return b.decryptStoreSecret(s)
 }
 
 func (b *LocalBackend) Set(ctx context.Context, input *SetSecretInput) (bool, *SecretMeta, error) {
 	s := toStoreSecret(input)
+
+	// Encrypt the value before persisting. When no encryption key is
+	// configured the plaintext is stored as-is (legacy/dev mode).
+	if b.encryptionKey != nil {
+		encrypted, err := encryptValue(s.EncryptedValue, b.encryptionKey)
+		if err != nil {
+			return false, nil, fmt.Errorf("encrypting secret value: %w", err)
+		}
+		s.EncryptedValue = encrypted
+	}
+
 	created, err := b.store.UpsertSecret(ctx, s)
 	if err != nil {
 		return false, nil, err
@@ -131,10 +157,11 @@ func (b *LocalBackend) Resolve(ctx context.Context, userID, projectID, brokerID 
 				continue
 			}
 
-			value, err := b.store.GetSecretValue(ctx, s.Key, sc.scope, sc.scopeID)
+			rawValue, err := b.store.GetSecretValue(ctx, s.Key, sc.scope, sc.scopeID)
 			if err != nil {
 				continue
 			}
+			value := b.decryptRawValue(rawValue)
 
 			secretType := s.SecretType
 			if secretType == "" {
@@ -194,10 +221,11 @@ func (b *LocalBackend) Resolve(ctx context.Context, userID, projectID, brokerID 
 				continue
 			}
 
-			value, err := b.store.GetSecretValue(ctx, s.Key, s.Scope, s.ScopeID)
+			rawValue, err := b.store.GetSecretValue(ctx, s.Key, s.Scope, s.ScopeID)
 			if err != nil {
 				continue
 			}
+			value := b.decryptRawValue(rawValue)
 
 			secretType := s.SecretType
 			if secretType == "" {
@@ -238,7 +266,9 @@ func (b *LocalBackend) Resolve(ctx context.Context, userID, projectID, brokerID 
 	return DeduplicateByTarget(result), nil
 }
 
-// toStoreSecret converts a SetSecretInput to a store.Secret.
+// toStoreSecret converts a SetSecretInput to a store.Secret. The returned
+// Secret's EncryptedValue initially holds the plaintext; the caller (Set)
+// is responsible for encrypting it before persisting.
 func toStoreSecret(input *SetSecretInput) *store.Secret {
 	secretType := input.SecretType
 	if secretType == "" {
@@ -299,10 +329,37 @@ func fromStoreSecretMeta(s *store.Secret) *SecretMeta {
 	}
 }
 
-// fromStoreSecretWithValue converts a store.Secret (with EncryptedValue) to SecretWithValue.
-func fromStoreSecretWithValue(s *store.Secret) *SecretWithValue {
+// decryptStoreSecret converts a store.Secret to SecretWithValue, decrypting
+// the EncryptedValue if an encryption key is configured. Legacy plaintext
+// values (those without the enc:v1: prefix) are returned as-is.
+func (b *LocalBackend) decryptStoreSecret(s *store.Secret) (*SecretWithValue, error) {
+	value := s.EncryptedValue
+	if b.encryptionKey != nil {
+		plaintext, _, err := decryptValue(s.EncryptedValue, b.encryptionKey)
+		if err != nil {
+			return nil, fmt.Errorf("decrypting secret %q: %w", s.Key, err)
+		}
+		value = plaintext
+	}
 	return &SecretWithValue{
 		SecretMeta: *fromStoreSecretMeta(s),
-		Value:      s.EncryptedValue,
+		Value:      value,
+	}, nil
+}
+
+// decryptRawValue decrypts a raw encrypted value string. If decryption fails
+// (e.g. legacy plaintext), the value is returned as-is with a warning logged.
+// This is used in Resolve where individual decryption failures should not
+// abort the entire resolution.
+func (b *LocalBackend) decryptRawValue(raw string) string {
+	if b.encryptionKey == nil {
+		return raw
 	}
+	plaintext, _, err := decryptValue(raw, b.encryptionKey)
+	if err != nil {
+		slog.Warn("failed to decrypt secret value, returning raw",
+			"error", err)
+		return raw
+	}
+	return plaintext
 }

--- a/pkg/secret/localbackend_test.go
+++ b/pkg/secret/localbackend_test.go
@@ -38,7 +38,7 @@ func createTestStore(t *testing.T) store.SecretStore {
 func createTestBackend(t *testing.T) (*LocalBackend, store.SecretStore) {
 	t.Helper()
 	s := createTestStore(t)
-	return NewLocalBackend(s, "test-hub-id"), s
+	return NewLocalBackend(s, "test-hub-id", "test-shared-secret"), s
 }
 
 // seedSecret inserts a secret directly into the store for testing read operations.
@@ -1043,5 +1043,128 @@ func TestLocalBackend_SetProgeny_AllowProgenyPersists(t *testing.T) {
 	}
 	if meta2.AllowProgeny {
 		t.Error("expected AllowProgeny=false after update")
+	}
+}
+
+// ============================================================================
+// Encryption Tests
+// ============================================================================
+
+// TestLocalBackend_EncryptionAtRest verifies that values stored via Set() are
+// actually encrypted in the database (not stored as plaintext).
+func TestLocalBackend_EncryptionAtRest(t *testing.T) {
+	backend, s := createTestBackend(t)
+	ctx := context.Background()
+
+	plaintext := "super-secret-api-key"
+	_, _, err := backend.Set(ctx, &SetSecretInput{
+		Name:       "ENCRYPTED_KEY",
+		Value:      plaintext,
+		SecretType: TypeEnvironment,
+		Scope:      ScopeUser,
+		ScopeID:    "user-1",
+	})
+	if err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	// Read the raw value from the store (bypassing decryption)
+	rawValue, err := s.GetSecretValue(ctx, "ENCRYPTED_KEY", ScopeUser, "user-1")
+	if err != nil {
+		t.Fatalf("GetSecretValue failed: %v", err)
+	}
+
+	// The raw stored value must NOT be the plaintext
+	if rawValue == plaintext {
+		t.Error("stored value must not be plaintext — encryption is not happening")
+	}
+
+	// It should have the encrypted prefix
+	if len(rawValue) < 7 || rawValue[:7] != "enc:v1:" {
+		t.Errorf("stored value should have enc:v1: prefix, got %q", rawValue[:min(20, len(rawValue))])
+	}
+
+	// Reading back through the backend should return the original plaintext
+	sv, err := backend.Get(ctx, "ENCRYPTED_KEY", ScopeUser, "user-1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if sv.Value != plaintext {
+		t.Errorf("expected decrypted value %q, got %q", plaintext, sv.Value)
+	}
+}
+
+// TestLocalBackend_LegacyPlaintextMigration verifies that secrets stored as
+// plaintext (without the enc:v1: prefix) are still readable. This ensures
+// backward compatibility during migration.
+func TestLocalBackend_LegacyPlaintextMigration(t *testing.T) {
+	backend, s := createTestBackend(t)
+	ctx := context.Background()
+
+	// Seed a legacy plaintext secret directly into the store
+	seedSecret(t, s, &store.Secret{
+		ID:             tid("legacy-1"),
+		Key:            "LEGACY_KEY",
+		EncryptedValue: "legacy-plaintext-value",
+		SecretType:     store.SecretTypeEnvironment,
+		Target:         "LEGACY_KEY",
+		Scope:          store.ScopeUser,
+		ScopeID:        "user-1",
+	})
+
+	// Get should return the plaintext value (legacy compatibility)
+	sv, err := backend.Get(ctx, "LEGACY_KEY", ScopeUser, "user-1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if sv.Value != "legacy-plaintext-value" {
+		t.Errorf("expected %q, got %q", "legacy-plaintext-value", sv.Value)
+	}
+
+	// Resolve should also return the plaintext value
+	resolved, err := backend.Resolve(ctx, "user-1", "", "", nil)
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	found := false
+	for _, r := range resolved {
+		if r.Name == "LEGACY_KEY" {
+			found = true
+			if r.Value != "legacy-plaintext-value" {
+				t.Errorf("Resolve: expected %q, got %q", "legacy-plaintext-value", r.Value)
+			}
+		}
+	}
+	if !found {
+		t.Error("LEGACY_KEY not found in resolved secrets")
+	}
+}
+
+// TestLocalBackend_NoEncryptionKeyFallback verifies that when no shared secret
+// is provided, the backend stores values as plaintext (dev/testing mode).
+func TestLocalBackend_NoEncryptionKeyFallback(t *testing.T) {
+	s := createTestStore(t)
+	backend := NewLocalBackend(s, "test-hub-id", "") // empty secret = no encryption
+	ctx := context.Background()
+
+	plaintext := "unencrypted-value"
+	_, _, err := backend.Set(ctx, &SetSecretInput{
+		Name:       "PLAIN_KEY",
+		Value:      plaintext,
+		SecretType: TypeEnvironment,
+		Scope:      ScopeUser,
+		ScopeID:    "user-1",
+	})
+	if err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	// Without an encryption key, the value should be stored as plaintext
+	rawValue, err := s.GetSecretValue(ctx, "PLAIN_KEY", ScopeUser, "user-1")
+	if err != nil {
+		t.Fatalf("GetSecretValue failed: %v", err)
+	}
+	if rawValue != plaintext {
+		t.Errorf("without encryption key, value should be stored as plaintext; got %q", rawValue)
 	}
 }

--- a/pkg/secret/localbackend_test.go
+++ b/pkg/secret/localbackend_test.go
@@ -18,6 +18,7 @@ package secret
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
@@ -1166,5 +1167,123 @@ func TestLocalBackend_NoEncryptionKeyFallback(t *testing.T) {
 	}
 	if rawValue != plaintext {
 		t.Errorf("without encryption key, value should be stored as plaintext; got %q", rawValue)
+	}
+}
+
+// ============================================================================
+// Ciphertext-Leak Prevention Tests
+// ============================================================================
+
+// TestLocalBackend_DecryptStoreSecret_NilKeyEncryptedValue verifies that
+// decryptStoreSecret returns an error (not raw ciphertext) when the encryption
+// key is nil but the stored value has the enc:v1: prefix.
+func TestLocalBackend_DecryptStoreSecret_NilKeyEncryptedValue(t *testing.T) {
+	s := createTestStore(t)
+	backend := NewLocalBackend(s, "test-hub-id", "") // nil encryption key
+	ctx := context.Background()
+
+	// Seed a secret with an enc:v1:-prefixed value directly into the store,
+	// simulating a value that was encrypted by a previous deployment that
+	// had an encryption key configured.
+	seedSecret(t, s, &store.Secret{
+		ID:             tid("enc-no-key-1"),
+		Key:            "ENCRYPTED_SECRET",
+		EncryptedValue: "enc:v1:AAAAAAAAAAAAAAAAAAAAAA==",
+		SecretType:     store.SecretTypeEnvironment,
+		Target:         "ENCRYPTED_SECRET",
+		Scope:          store.ScopeUser,
+		ScopeID:        "user-1",
+	})
+
+	_, err := backend.Get(ctx, "ENCRYPTED_SECRET", ScopeUser, "user-1")
+	if err == nil {
+		t.Fatal("expected error when encryption key is nil but value is encrypted; got nil")
+	}
+	if !strings.Contains(err.Error(), "no encryption key is configured") {
+		t.Errorf("expected error about missing encryption key, got: %v", err)
+	}
+}
+
+// TestLocalBackend_DecryptStoreSecret_NilKeyPlaintextValue verifies that
+// decryptStoreSecret still returns plaintext values when the encryption key
+// is nil (legacy/dev mode).
+func TestLocalBackend_DecryptStoreSecret_NilKeyPlaintextValue(t *testing.T) {
+	s := createTestStore(t)
+	backend := NewLocalBackend(s, "test-hub-id", "") // nil encryption key
+	ctx := context.Background()
+
+	seedSecret(t, s, &store.Secret{
+		ID:             tid("plain-no-key-1"),
+		Key:            "PLAIN_SECRET",
+		EncryptedValue: "my-plaintext-value",
+		SecretType:     store.SecretTypeEnvironment,
+		Target:         "PLAIN_SECRET",
+		Scope:          store.ScopeUser,
+		ScopeID:        "user-1",
+	})
+
+	sv, err := backend.Get(ctx, "PLAIN_SECRET", ScopeUser, "user-1")
+	if err != nil {
+		t.Fatalf("expected no error for plaintext value with nil key, got: %v", err)
+	}
+	if sv.Value != "my-plaintext-value" {
+		t.Errorf("expected %q, got %q", "my-plaintext-value", sv.Value)
+	}
+}
+
+// TestLocalBackend_DecryptRawValue_NilKeyEncryptedValue verifies that
+// decryptRawValue returns an error (not raw ciphertext) when the encryption
+// key is nil but the value has the enc:v1: prefix.
+func TestLocalBackend_DecryptRawValue_NilKeyEncryptedValue(t *testing.T) {
+	s := createTestStore(t)
+	backend := NewLocalBackend(s, "test-hub-id", "") // nil encryption key
+
+	encrypted := "enc:v1:AAAAAAAAAAAAAAAAAAAAAA=="
+	value, err := backend.decryptRawValue(encrypted)
+	if err == nil {
+		t.Fatal("expected error when encryption key is nil but value is encrypted; got nil")
+	}
+	if value != "" {
+		t.Errorf("expected empty string on error, got %q", value)
+	}
+	if !strings.Contains(err.Error(), "no encryption key is configured") {
+		t.Errorf("expected error about missing encryption key, got: %v", err)
+	}
+
+	// Also verify via Resolve: encrypted values should be skipped, not leaked.
+	seedSecret(t, s, &store.Secret{
+		ID:             tid("resolve-enc-no-key"),
+		Key:            "LEAKED_SECRET",
+		EncryptedValue: encrypted,
+		SecretType:     store.SecretTypeEnvironment,
+		Target:         "LEAKED_SECRET",
+		Scope:          store.ScopeUser,
+		ScopeID:        "user-1",
+	})
+
+	ctx := context.Background()
+	resolved, err := backend.Resolve(ctx, "user-1", "", "", nil)
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	for _, sv := range resolved {
+		if sv.Name == "LEAKED_SECRET" {
+			t.Error("encrypted secret should not appear in resolved secrets when encryption key is nil")
+		}
+	}
+}
+
+// TestLocalBackend_DecryptRawValue_NilKeyPlaintextValue verifies that
+// decryptRawValue still returns plaintext values when the encryption key
+// is nil (legacy path).
+func TestLocalBackend_DecryptRawValue_NilKeyPlaintextValue(t *testing.T) {
+	backend := &LocalBackend{encryptionKey: nil}
+
+	value, err := backend.decryptRawValue("plain-legacy-value")
+	if err != nil {
+		t.Fatalf("expected no error for plaintext value with nil key, got: %v", err)
+	}
+	if value != "plain-legacy-value" {
+		t.Errorf("expected %q, got %q", "plain-legacy-value", value)
 	}
 }

--- a/pkg/secret/localcrypto.go
+++ b/pkg/secret/localcrypto.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secret
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+)
+
+// encryptedPrefix is prepended to every AES-256-GCM ciphertext stored by the
+// local backend. Its presence distinguishes encrypted values from legacy
+// plaintext, enabling transparent migration: if a stored value does not start
+// with this prefix it is treated as unencrypted plaintext.
+const encryptedPrefix = "enc:v1:"
+
+// deriveLocalEncryptionKey deterministically derives a 32-byte AES-256 key
+// from the deployment-wide shared signing secret using SHA-256 with a
+// domain-specific prefix. This parallels the derivation used for JWT signing
+// keys in pkg/hub/server.go (deriveSharedSigningKey) but uses a distinct
+// domain separator to ensure cryptographic independence.
+func deriveLocalEncryptionKey(sharedSecret string) []byte {
+	sum := sha256.Sum256([]byte("scion-hub-local-secret-encryption:" + sharedSecret))
+	return sum[:]
+}
+
+// encryptValue encrypts plaintext using AES-256-GCM and returns a string
+// suitable for storage in the encrypted_value column. The format is:
+//
+//	enc:v1:<base64(nonce + ciphertext)>
+//
+// The nonce is a 12-byte random value prepended to the ciphertext.
+func encryptValue(plaintext string, key []byte) (string, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("aes.NewCipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("cipher.NewGCM: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("generating nonce: %w", err)
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+	return encryptedPrefix + base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+// decryptValue decrypts a value produced by encryptValue. If the value does
+// not carry the enc:v1: prefix it is assumed to be legacy plaintext and
+// returned as-is (with isLegacy = true) so that callers can re-encrypt on
+// the next write.
+func decryptValue(stored string, key []byte) (plaintext string, isLegacy bool, err error) {
+	if len(stored) <= len(encryptedPrefix) || stored[:len(encryptedPrefix)] != encryptedPrefix {
+		// Legacy plaintext — return as-is.
+		return stored, true, nil
+	}
+
+	data, err := base64.StdEncoding.DecodeString(stored[len(encryptedPrefix):])
+	if err != nil {
+		return "", false, fmt.Errorf("base64 decode: %w", err)
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", false, fmt.Errorf("aes.NewCipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", false, fmt.Errorf("cipher.NewGCM: %w", err)
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return "", false, fmt.Errorf("ciphertext too short")
+	}
+
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	plaintextBytes, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", false, fmt.Errorf("gcm.Open: %w", err)
+	}
+	return string(plaintextBytes), false, nil
+}

--- a/pkg/secret/localcrypto_test.go
+++ b/pkg/secret/localcrypto_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secret
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDeriveLocalEncryptionKey_Deterministic(t *testing.T) {
+	key1 := deriveLocalEncryptionKey("my-secret")
+	key2 := deriveLocalEncryptionKey("my-secret")
+	if len(key1) != 32 {
+		t.Fatalf("expected 32-byte key, got %d", len(key1))
+	}
+	for i := range key1 {
+		if key1[i] != key2[i] {
+			t.Fatal("same input must produce the same key")
+		}
+	}
+}
+
+func TestDeriveLocalEncryptionKey_DifferentInputs(t *testing.T) {
+	key1 := deriveLocalEncryptionKey("secret-a")
+	key2 := deriveLocalEncryptionKey("secret-b")
+	same := true
+	for i := range key1 {
+		if key1[i] != key2[i] {
+			same = false
+			break
+		}
+	}
+	if same {
+		t.Fatal("different inputs must produce different keys")
+	}
+}
+
+func TestEncryptDecrypt_RoundTrip(t *testing.T) {
+	key := deriveLocalEncryptionKey("test-secret")
+
+	tests := []string{
+		"hello world",
+		"",
+		"sk-test-1234567890",
+		strings.Repeat("x", 10000),
+	}
+	for _, plaintext := range tests {
+		encrypted, err := encryptValue(plaintext, key)
+		if err != nil {
+			t.Fatalf("encryptValue(%q) failed: %v", plaintext, err)
+		}
+		if !strings.HasPrefix(encrypted, encryptedPrefix) {
+			t.Errorf("expected prefix %q, got %q", encryptedPrefix, encrypted[:len(encryptedPrefix)])
+		}
+		if encrypted == plaintext {
+			t.Error("encrypted value should differ from plaintext")
+		}
+
+		decrypted, isLegacy, err := decryptValue(encrypted, key)
+		if err != nil {
+			t.Fatalf("decryptValue failed: %v", err)
+		}
+		if isLegacy {
+			t.Error("expected isLegacy=false for encrypted value")
+		}
+		if decrypted != plaintext {
+			t.Errorf("round-trip mismatch: got %q, want %q", decrypted, plaintext)
+		}
+	}
+}
+
+func TestDecryptValue_LegacyPlaintext(t *testing.T) {
+	key := deriveLocalEncryptionKey("test-secret")
+
+	// Values without the enc:v1: prefix are treated as legacy plaintext.
+	legacyValues := []string{
+		"sk-test-123",
+		"plain-text-secret",
+		"",
+		"some random value",
+	}
+	for _, val := range legacyValues {
+		decrypted, isLegacy, err := decryptValue(val, key)
+		if err != nil {
+			t.Fatalf("decryptValue(%q) failed: %v", val, err)
+		}
+		if !isLegacy {
+			t.Errorf("expected isLegacy=true for %q", val)
+		}
+		if decrypted != val {
+			t.Errorf("expected %q, got %q", val, decrypted)
+		}
+	}
+}
+
+func TestEncryptValue_UniqueNonces(t *testing.T) {
+	key := deriveLocalEncryptionKey("test-secret")
+
+	// Encrypting the same plaintext twice should produce different ciphertexts
+	// due to random nonces.
+	enc1, err := encryptValue("same-value", key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc2, err := encryptValue("same-value", key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if enc1 == enc2 {
+		t.Error("two encryptions of the same plaintext should differ (random nonce)")
+	}
+
+	// Both should decrypt to the same value.
+	dec1, _, _ := decryptValue(enc1, key)
+	dec2, _, _ := decryptValue(enc2, key)
+	if dec1 != "same-value" || dec2 != "same-value" {
+		t.Error("both ciphertexts should decrypt to the same plaintext")
+	}
+}
+
+func TestDecryptValue_WrongKey(t *testing.T) {
+	key1 := deriveLocalEncryptionKey("secret-1")
+	key2 := deriveLocalEncryptionKey("secret-2")
+
+	encrypted, err := encryptValue("my-secret-data", key1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = decryptValue(encrypted, key2)
+	if err == nil {
+		t.Error("decrypting with wrong key should fail")
+	}
+}
+
+func TestDecryptValue_CorruptedCiphertext(t *testing.T) {
+	key := deriveLocalEncryptionKey("test-secret")
+
+	// Valid prefix but invalid base64 data
+	_, _, err := decryptValue(encryptedPrefix+"!!!invalid-base64!!!", key)
+	if err == nil {
+		t.Error("corrupted base64 should fail")
+	}
+
+	// Valid prefix and base64, but too short
+	_, _, err = decryptValue(encryptedPrefix+"AAAA", key)
+	if err == nil {
+		t.Error("truncated ciphertext should fail")
+	}
+}

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -25,9 +25,9 @@ import (
 	"time"
 )
 
-// ErrNoSecretBackend is returned when a secret operation requires a production
-// secrets backend (e.g., GCP Secret Manager) but only the local backend is configured.
-// The local backend does not encrypt secret values, so write operations are rejected.
+// ErrNoSecretBackend is returned when a secret operation is attempted but no
+// secret backend has been initialized (e.g., the hub was started without a
+// database or secret storage). Handlers translate this to HTTP 501.
 var ErrNoSecretBackend = errors.New("secret storage requires a configured secrets backend; set SCION_SERVER_SECRETS_BACKEND=gcpsm")
 
 // PermissionError indicates that a secret backend operation failed due to

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -28,7 +28,7 @@ import (
 // ErrNoSecretBackend is returned when a secret operation is attempted but no
 // secret backend has been initialized (e.g., the hub was started without a
 // database or secret storage). Handlers translate this to HTTP 501.
-var ErrNoSecretBackend = errors.New("secret storage requires a configured secrets backend; set SCION_SERVER_SECRETS_BACKEND=gcpsm")
+var ErrNoSecretBackend = errors.New("no secret backend is configured; set SCION_SERVER_SECRETS_BACKEND to \"local\" or \"gcpsm\"")
 
 // PermissionError indicates that a secret backend operation failed due to
 // insufficient permissions (e.g., the Hub service account lacks a required


### PR DESCRIPTION
Local secret backend stores plaintext in encrypted_value column with zero encryption. This adds AES-256-GCM encryption-at-rest with domain-separated key derivation from the hub signing secret. Legacy plaintext values are transparently readable and re-encrypted on next write. Also fixes ErrNoSecretBackend error message to reference both local and gcpsm backends.

Key files: pkg/secret/localbackend.go, pkg/secret/localcrypto.go (new), pkg/secret/secret.go
22 files changed, +553/-92. Relates to ptone/scion#1197
