### PR TITLE
fix(hub): respect intentional deletion of seeded policies

### DIFF
--- a/pkg/ent/accesspolicy.go
+++ b/pkg/ent/accesspolicy.go
@@ -50,6 +50,8 @@ type AccessPolicy struct {
 	Updated time.Time `json:"updated,omitempty"`
 	// CreatedBy holds the value of the "created_by" field.
 	CreatedBy string `json:"created_by,omitempty"`
+	// Origin holds the value of the "origin" field.
+	Origin string `json:"origin,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the AccessPolicyQuery when eager-loading is set.
 	Edges        AccessPolicyEdges `json:"edges"`
@@ -83,7 +85,7 @@ func (*AccessPolicy) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case accesspolicy.FieldPriority:
 			values[i] = new(sql.NullInt64)
-		case accesspolicy.FieldName, accesspolicy.FieldDescription, accesspolicy.FieldScopeType, accesspolicy.FieldScopeID, accesspolicy.FieldResourceType, accesspolicy.FieldResourceID, accesspolicy.FieldEffect, accesspolicy.FieldCreatedBy:
+		case accesspolicy.FieldName, accesspolicy.FieldDescription, accesspolicy.FieldScopeType, accesspolicy.FieldScopeID, accesspolicy.FieldResourceType, accesspolicy.FieldResourceID, accesspolicy.FieldEffect, accesspolicy.FieldCreatedBy, accesspolicy.FieldOrigin:
 			values[i] = new(sql.NullString)
 		case accesspolicy.FieldCreated, accesspolicy.FieldUpdated:
 			values[i] = new(sql.NullTime)
@@ -208,6 +210,12 @@ func (_m *AccessPolicy) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.CreatedBy = value.String
 			}
+		case accesspolicy.FieldOrigin:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field origin", values[i])
+			} else if value.Valid {
+				_m.Origin = value.String
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -293,6 +301,9 @@ func (_m *AccessPolicy) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("created_by=")
 	builder.WriteString(_m.CreatedBy)
+	builder.WriteString(", ")
+	builder.WriteString("origin=")
+	builder.WriteString(_m.Origin)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/pkg/ent/accesspolicy/accesspolicy.go
+++ b/pkg/ent/accesspolicy/accesspolicy.go
@@ -46,6 +46,8 @@ const (
 	FieldUpdated = "updated"
 	// FieldCreatedBy holds the string denoting the created_by field in the database.
 	FieldCreatedBy = "created_by"
+	// FieldOrigin holds the string denoting the origin field in the database.
+	FieldOrigin = "origin"
 	// EdgeBindings holds the string denoting the bindings edge name in mutations.
 	EdgeBindings = "bindings"
 	// Table holds the table name of the accesspolicy in the database.
@@ -77,6 +79,7 @@ var Columns = []string{
 	FieldCreated,
 	FieldUpdated,
 	FieldCreatedBy,
+	FieldOrigin,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -104,6 +107,8 @@ var (
 	DefaultUpdated func() time.Time
 	// UpdateDefaultUpdated holds the default value on update for the "updated" field.
 	UpdateDefaultUpdated func() time.Time
+	// DefaultOrigin holds the default value on creation for the "origin" field.
+	DefaultOrigin string
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() uuid.UUID
 )
@@ -216,6 +221,11 @@ func ByUpdated(opts ...sql.OrderTermOption) OrderOption {
 // ByCreatedBy orders the results by the created_by field.
 func ByCreatedBy(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldCreatedBy, opts...).ToFunc()
+}
+
+// ByOrigin orders the results by the origin field.
+func ByOrigin(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldOrigin, opts...).ToFunc()
 }
 
 // ByBindingsCount orders the results by bindings count.

--- a/pkg/ent/accesspolicy/where.go
+++ b/pkg/ent/accesspolicy/where.go
@@ -101,6 +101,11 @@ func CreatedBy(v string) predicate.AccessPolicy {
 	return predicate.AccessPolicy(sql.FieldEQ(FieldCreatedBy, v))
 }
 
+// Origin applies equality check predicate on the "origin" field. It's identical to OriginEQ.
+func Origin(v string) predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldEQ(FieldOrigin, v))
+}
+
 // NameEQ applies the EQ predicate on the "name" field.
 func NameEQ(v string) predicate.AccessPolicy {
 	return predicate.AccessPolicy(sql.FieldEQ(FieldName, v))
@@ -719,6 +724,81 @@ func CreatedByEqualFold(v string) predicate.AccessPolicy {
 // CreatedByContainsFold applies the ContainsFold predicate on the "created_by" field.
 func CreatedByContainsFold(v string) predicate.AccessPolicy {
 	return predicate.AccessPolicy(sql.FieldContainsFold(FieldCreatedBy, v))
+}
+
+// OriginEQ applies the EQ predicate on the "origin" field.
+func OriginEQ(v string) predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldEQ(FieldOrigin, v))
+}
+
+// OriginNEQ applies the NEQ predicate on the "origin" field.
+func OriginNEQ(v string) predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldNEQ(FieldOrigin, v))
+}
+
+// OriginIn applies the In predicate on the "origin" field.
+func OriginIn(vs ...string) predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldIn(FieldOrigin, vs...))
+}
+
+// OriginNotIn applies the NotIn predicate on the "origin" field.
+func OriginNotIn(vs ...string) predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldNotIn(FieldOrigin, vs...))
+}
+
+// OriginGT applies the GT predicate on the "origin" field.
+func OriginGT(v string) predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldGT(FieldOrigin, v))
+}
+
+// OriginGTE applies the GTE predicate on the "origin" field.
+func OriginGTE(v string) predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldGTE(FieldOrigin, v))
+}
+
+// OriginLT applies the LT predicate on the "origin" field.
+func OriginLT(v string) predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldLT(FieldOrigin, v))
+}
+
+// OriginLTE applies the LTE predicate on the "origin" field.
+func OriginLTE(v string) predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldLTE(FieldOrigin, v))
+}
+
+// OriginContains applies the Contains predicate on the "origin" field.
+func OriginContains(v string) predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldContains(FieldOrigin, v))
+}
+
+// OriginHasPrefix applies the HasPrefix predicate on the "origin" field.
+func OriginHasPrefix(v string) predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldHasPrefix(FieldOrigin, v))
+}
+
+// OriginHasSuffix applies the HasSuffix predicate on the "origin" field.
+func OriginHasSuffix(v string) predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldHasSuffix(FieldOrigin, v))
+}
+
+// OriginIsNil applies the IsNil predicate on the "origin" field.
+func OriginIsNil() predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldIsNull(FieldOrigin))
+}
+
+// OriginNotNil applies the NotNil predicate on the "origin" field.
+func OriginNotNil() predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldNotNull(FieldOrigin))
+}
+
+// OriginEqualFold applies the EqualFold predicate on the "origin" field.
+func OriginEqualFold(v string) predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldEqualFold(FieldOrigin, v))
+}
+
+// OriginContainsFold applies the ContainsFold predicate on the "origin" field.
+func OriginContainsFold(v string) predicate.AccessPolicy {
+	return predicate.AccessPolicy(sql.FieldContainsFold(FieldOrigin, v))
 }
 
 // HasBindings applies the HasEdge predicate on the "bindings" edge.

--- a/pkg/ent/accesspolicy_create.go
+++ b/pkg/ent/accesspolicy_create.go
@@ -172,6 +172,20 @@ func (_c *AccessPolicyCreate) SetNillableCreatedBy(v *string) *AccessPolicyCreat
 	return _c
 }
 
+// SetOrigin sets the "origin" field.
+func (_c *AccessPolicyCreate) SetOrigin(v string) *AccessPolicyCreate {
+	_c.mutation.SetOrigin(v)
+	return _c
+}
+
+// SetNillableOrigin sets the "origin" field if the given value is not nil.
+func (_c *AccessPolicyCreate) SetNillableOrigin(v *string) *AccessPolicyCreate {
+	if v != nil {
+		_c.SetOrigin(*v)
+	}
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *AccessPolicyCreate) SetID(v uuid.UUID) *AccessPolicyCreate {
 	_c.mutation.SetID(v)
@@ -251,6 +265,10 @@ func (_c *AccessPolicyCreate) defaults() {
 	if _, ok := _c.mutation.Updated(); !ok {
 		v := accesspolicy.DefaultUpdated()
 		_c.mutation.SetUpdated(v)
+	}
+	if _, ok := _c.mutation.Origin(); !ok {
+		v := accesspolicy.DefaultOrigin
+		_c.mutation.SetOrigin(v)
 	}
 	if _, ok := _c.mutation.ID(); !ok {
 		v := accesspolicy.DefaultID()
@@ -399,6 +417,10 @@ func (_c *AccessPolicyCreate) createSpec() (*AccessPolicy, *sqlgraph.CreateSpec)
 	if value, ok := _c.mutation.CreatedBy(); ok {
 		_spec.SetField(accesspolicy.FieldCreatedBy, field.TypeString, value)
 		_node.CreatedBy = value
+	}
+	if value, ok := _c.mutation.Origin(); ok {
+		_spec.SetField(accesspolicy.FieldOrigin, field.TypeString, value)
+		_node.Origin = value
 	}
 	if nodes := _c.mutation.BindingsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -681,6 +703,24 @@ func (u *AccessPolicyUpsert) UpdateCreatedBy() *AccessPolicyUpsert {
 // ClearCreatedBy clears the value of the "created_by" field.
 func (u *AccessPolicyUpsert) ClearCreatedBy() *AccessPolicyUpsert {
 	u.SetNull(accesspolicy.FieldCreatedBy)
+	return u
+}
+
+// SetOrigin sets the "origin" field.
+func (u *AccessPolicyUpsert) SetOrigin(v string) *AccessPolicyUpsert {
+	u.Set(accesspolicy.FieldOrigin, v)
+	return u
+}
+
+// UpdateOrigin sets the "origin" field to the value that was provided on create.
+func (u *AccessPolicyUpsert) UpdateOrigin() *AccessPolicyUpsert {
+	u.SetExcluded(accesspolicy.FieldOrigin)
+	return u
+}
+
+// ClearOrigin clears the value of the "origin" field.
+func (u *AccessPolicyUpsert) ClearOrigin() *AccessPolicyUpsert {
+	u.SetNull(accesspolicy.FieldOrigin)
 	return u
 }
 
@@ -984,6 +1024,27 @@ func (u *AccessPolicyUpsertOne) UpdateCreatedBy() *AccessPolicyUpsertOne {
 func (u *AccessPolicyUpsertOne) ClearCreatedBy() *AccessPolicyUpsertOne {
 	return u.Update(func(s *AccessPolicyUpsert) {
 		s.ClearCreatedBy()
+	})
+}
+
+// SetOrigin sets the "origin" field.
+func (u *AccessPolicyUpsertOne) SetOrigin(v string) *AccessPolicyUpsertOne {
+	return u.Update(func(s *AccessPolicyUpsert) {
+		s.SetOrigin(v)
+	})
+}
+
+// UpdateOrigin sets the "origin" field to the value that was provided on create.
+func (u *AccessPolicyUpsertOne) UpdateOrigin() *AccessPolicyUpsertOne {
+	return u.Update(func(s *AccessPolicyUpsert) {
+		s.UpdateOrigin()
+	})
+}
+
+// ClearOrigin clears the value of the "origin" field.
+func (u *AccessPolicyUpsertOne) ClearOrigin() *AccessPolicyUpsertOne {
+	return u.Update(func(s *AccessPolicyUpsert) {
+		s.ClearOrigin()
 	})
 }
 
@@ -1454,6 +1515,27 @@ func (u *AccessPolicyUpsertBulk) UpdateCreatedBy() *AccessPolicyUpsertBulk {
 func (u *AccessPolicyUpsertBulk) ClearCreatedBy() *AccessPolicyUpsertBulk {
 	return u.Update(func(s *AccessPolicyUpsert) {
 		s.ClearCreatedBy()
+	})
+}
+
+// SetOrigin sets the "origin" field.
+func (u *AccessPolicyUpsertBulk) SetOrigin(v string) *AccessPolicyUpsertBulk {
+	return u.Update(func(s *AccessPolicyUpsert) {
+		s.SetOrigin(v)
+	})
+}
+
+// UpdateOrigin sets the "origin" field to the value that was provided on create.
+func (u *AccessPolicyUpsertBulk) UpdateOrigin() *AccessPolicyUpsertBulk {
+	return u.Update(func(s *AccessPolicyUpsert) {
+		s.UpdateOrigin()
+	})
+}
+
+// ClearOrigin clears the value of the "origin" field.
+func (u *AccessPolicyUpsertBulk) ClearOrigin() *AccessPolicyUpsertBulk {
+	return u.Update(func(s *AccessPolicyUpsert) {
+		s.ClearOrigin()
 	})
 }
 

--- a/pkg/ent/accesspolicy_update.go
+++ b/pkg/ent/accesspolicy_update.go
@@ -243,6 +243,26 @@ func (_u *AccessPolicyUpdate) ClearCreatedBy() *AccessPolicyUpdate {
 	return _u
 }
 
+// SetOrigin sets the "origin" field.
+func (_u *AccessPolicyUpdate) SetOrigin(v string) *AccessPolicyUpdate {
+	_u.mutation.SetOrigin(v)
+	return _u
+}
+
+// SetNillableOrigin sets the "origin" field if the given value is not nil.
+func (_u *AccessPolicyUpdate) SetNillableOrigin(v *string) *AccessPolicyUpdate {
+	if v != nil {
+		_u.SetOrigin(*v)
+	}
+	return _u
+}
+
+// ClearOrigin clears the value of the "origin" field.
+func (_u *AccessPolicyUpdate) ClearOrigin() *AccessPolicyUpdate {
+	_u.mutation.ClearOrigin()
+	return _u
+}
+
 // AddBindingIDs adds the "bindings" edge to the PolicyBinding entity by IDs.
 func (_u *AccessPolicyUpdate) AddBindingIDs(ids ...uuid.UUID) *AccessPolicyUpdate {
 	_u.mutation.AddBindingIDs(ids...)
@@ -427,6 +447,12 @@ func (_u *AccessPolicyUpdate) sqlSave(ctx context.Context) (_node int, err error
 	}
 	if _u.mutation.CreatedByCleared() {
 		_spec.ClearField(accesspolicy.FieldCreatedBy, field.TypeString)
+	}
+	if value, ok := _u.mutation.Origin(); ok {
+		_spec.SetField(accesspolicy.FieldOrigin, field.TypeString, value)
+	}
+	if _u.mutation.OriginCleared() {
+		_spec.ClearField(accesspolicy.FieldOrigin, field.TypeString)
 	}
 	if _u.mutation.BindingsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -704,6 +730,26 @@ func (_u *AccessPolicyUpdateOne) ClearCreatedBy() *AccessPolicyUpdateOne {
 	return _u
 }
 
+// SetOrigin sets the "origin" field.
+func (_u *AccessPolicyUpdateOne) SetOrigin(v string) *AccessPolicyUpdateOne {
+	_u.mutation.SetOrigin(v)
+	return _u
+}
+
+// SetNillableOrigin sets the "origin" field if the given value is not nil.
+func (_u *AccessPolicyUpdateOne) SetNillableOrigin(v *string) *AccessPolicyUpdateOne {
+	if v != nil {
+		_u.SetOrigin(*v)
+	}
+	return _u
+}
+
+// ClearOrigin clears the value of the "origin" field.
+func (_u *AccessPolicyUpdateOne) ClearOrigin() *AccessPolicyUpdateOne {
+	_u.mutation.ClearOrigin()
+	return _u
+}
+
 // AddBindingIDs adds the "bindings" edge to the PolicyBinding entity by IDs.
 func (_u *AccessPolicyUpdateOne) AddBindingIDs(ids ...uuid.UUID) *AccessPolicyUpdateOne {
 	_u.mutation.AddBindingIDs(ids...)
@@ -918,6 +964,12 @@ func (_u *AccessPolicyUpdateOne) sqlSave(ctx context.Context) (_node *AccessPoli
 	}
 	if _u.mutation.CreatedByCleared() {
 		_spec.ClearField(accesspolicy.FieldCreatedBy, field.TypeString)
+	}
+	if value, ok := _u.mutation.Origin(); ok {
+		_spec.SetField(accesspolicy.FieldOrigin, field.TypeString, value)
+	}
+	if _u.mutation.OriginCleared() {
+		_spec.ClearField(accesspolicy.FieldOrigin, field.TypeString)
 	}
 	if _u.mutation.BindingsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/pkg/ent/migrate/schema.go
+++ b/pkg/ent/migrate/schema.go
@@ -27,6 +27,7 @@ var (
 		{Name: "created", Type: field.TypeTime},
 		{Name: "updated", Type: field.TypeTime},
 		{Name: "created_by", Type: field.TypeString, Nullable: true},
+		{Name: "origin", Type: field.TypeString, Nullable: true, Default: ""},
 	}
 	// AccessPoliciesTable holds the schema information for the "access_policies" table.
 	AccessPoliciesTable = &schema.Table{

--- a/pkg/ent/mutation.go
+++ b/pkg/ent/mutation.go
@@ -142,6 +142,7 @@ type AccessPolicyMutation struct {
 	created         *time.Time
 	updated         *time.Time
 	created_by      *string
+	origin          *string
 	clearedFields   map[string]struct{}
 	bindings        map[uuid.UUID]struct{}
 	removedbindings map[uuid.UUID]struct{}
@@ -922,6 +923,55 @@ func (m *AccessPolicyMutation) ResetCreatedBy() {
 	delete(m.clearedFields, accesspolicy.FieldCreatedBy)
 }
 
+// SetOrigin sets the "origin" field.
+func (m *AccessPolicyMutation) SetOrigin(s string) {
+	m.origin = &s
+}
+
+// Origin returns the value of the "origin" field in the mutation.
+func (m *AccessPolicyMutation) Origin() (r string, exists bool) {
+	v := m.origin
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldOrigin returns the old "origin" field's value of the AccessPolicy entity.
+// If the AccessPolicy object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AccessPolicyMutation) OldOrigin(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldOrigin is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldOrigin requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldOrigin: %w", err)
+	}
+	return oldValue.Origin, nil
+}
+
+// ClearOrigin clears the value of the "origin" field.
+func (m *AccessPolicyMutation) ClearOrigin() {
+	m.origin = nil
+	m.clearedFields[accesspolicy.FieldOrigin] = struct{}{}
+}
+
+// OriginCleared returns if the "origin" field was cleared in this mutation.
+func (m *AccessPolicyMutation) OriginCleared() bool {
+	_, ok := m.clearedFields[accesspolicy.FieldOrigin]
+	return ok
+}
+
+// ResetOrigin resets all changes to the "origin" field.
+func (m *AccessPolicyMutation) ResetOrigin() {
+	m.origin = nil
+	delete(m.clearedFields, accesspolicy.FieldOrigin)
+}
+
 // AddBindingIDs adds the "bindings" edge to the PolicyBinding entity by ids.
 func (m *AccessPolicyMutation) AddBindingIDs(ids ...uuid.UUID) {
 	if m.bindings == nil {
@@ -1010,7 +1060,7 @@ func (m *AccessPolicyMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *AccessPolicyMutation) Fields() []string {
-	fields := make([]string, 0, 15)
+	fields := make([]string, 0, 16)
 	if m.name != nil {
 		fields = append(fields, accesspolicy.FieldName)
 	}
@@ -1056,6 +1106,9 @@ func (m *AccessPolicyMutation) Fields() []string {
 	if m.created_by != nil {
 		fields = append(fields, accesspolicy.FieldCreatedBy)
 	}
+	if m.origin != nil {
+		fields = append(fields, accesspolicy.FieldOrigin)
+	}
 	return fields
 }
 
@@ -1094,6 +1147,8 @@ func (m *AccessPolicyMutation) Field(name string) (ent.Value, bool) {
 		return m.Updated()
 	case accesspolicy.FieldCreatedBy:
 		return m.CreatedBy()
+	case accesspolicy.FieldOrigin:
+		return m.Origin()
 	}
 	return nil, false
 }
@@ -1133,6 +1188,8 @@ func (m *AccessPolicyMutation) OldField(ctx context.Context, name string) (ent.V
 		return m.OldUpdated(ctx)
 	case accesspolicy.FieldCreatedBy:
 		return m.OldCreatedBy(ctx)
+	case accesspolicy.FieldOrigin:
+		return m.OldOrigin(ctx)
 	}
 	return nil, fmt.Errorf("unknown AccessPolicy field %s", name)
 }
@@ -1247,6 +1304,13 @@ func (m *AccessPolicyMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetCreatedBy(v)
 		return nil
+	case accesspolicy.FieldOrigin:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetOrigin(v)
+		return nil
 	}
 	return fmt.Errorf("unknown AccessPolicy field %s", name)
 }
@@ -1313,6 +1377,9 @@ func (m *AccessPolicyMutation) ClearedFields() []string {
 	if m.FieldCleared(accesspolicy.FieldCreatedBy) {
 		fields = append(fields, accesspolicy.FieldCreatedBy)
 	}
+	if m.FieldCleared(accesspolicy.FieldOrigin) {
+		fields = append(fields, accesspolicy.FieldOrigin)
+	}
 	return fields
 }
 
@@ -1347,6 +1414,9 @@ func (m *AccessPolicyMutation) ClearField(name string) error {
 		return nil
 	case accesspolicy.FieldCreatedBy:
 		m.ClearCreatedBy()
+		return nil
+	case accesspolicy.FieldOrigin:
+		m.ClearOrigin()
 		return nil
 	}
 	return fmt.Errorf("unknown AccessPolicy nullable field %s", name)
@@ -1400,6 +1470,9 @@ func (m *AccessPolicyMutation) ResetField(name string) error {
 		return nil
 	case accesspolicy.FieldCreatedBy:
 		m.ResetCreatedBy()
+		return nil
+	case accesspolicy.FieldOrigin:
+		m.ResetOrigin()
 		return nil
 	}
 	return fmt.Errorf("unknown AccessPolicy field %s", name)

--- a/pkg/ent/runtime.go
+++ b/pkg/ent/runtime.go
@@ -86,6 +86,10 @@ func init() {
 	accesspolicy.DefaultUpdated = accesspolicyDescUpdated.Default.(func() time.Time)
 	// accesspolicy.UpdateDefaultUpdated holds the default value on update for the updated field.
 	accesspolicy.UpdateDefaultUpdated = accesspolicyDescUpdated.UpdateDefault.(func() time.Time)
+	// accesspolicyDescOrigin is the schema descriptor for origin field.
+	accesspolicyDescOrigin := accesspolicyFields[16].Descriptor()
+	// accesspolicy.DefaultOrigin holds the default value on creation for the origin field.
+	accesspolicy.DefaultOrigin = accesspolicyDescOrigin.Default.(string)
 	// accesspolicyDescID is the schema descriptor for id field.
 	accesspolicyDescID := accesspolicyFields[0].Descriptor()
 	// accesspolicy.DefaultID holds the default value on creation for the id field.

--- a/pkg/ent/schema/policy.go
+++ b/pkg/ent/schema/policy.go
@@ -69,6 +69,9 @@ func (AccessPolicy) Fields() []ent.Field {
 			UpdateDefault(time.Now),
 		field.String("created_by").
 			Optional(),
+		field.String("origin").
+			Optional().
+			Default(""),
 	}
 }
 

--- a/pkg/hub/handlers_policies.go
+++ b/pkg/hub/handlers_policies.go
@@ -16,7 +16,9 @@ package hub
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -403,9 +405,32 @@ func (s *Server) deletePolicy(w http.ResponseWriter, r *http.Request, id string)
 
 	ctx := r.Context()
 
+	// Look up the policy before deleting so we can record a tombstone for
+	// seeded policies.
+	policy, err := s.store.GetPolicy(ctx, id)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
 	if err := s.store.DeletePolicy(ctx, id); err != nil {
 		writeErrorFromErr(w, err, "")
 		return
+	}
+
+	// If this was a seeded policy, record a tombstone so the startup seeder
+	// does not silently recreate it on the next restart.
+	if policy.Origin == store.PolicyOriginSeeded {
+		key := seedPolicyTombstoneKey(policy.Name)
+		if _, upsertErr := s.store.UpsertHubSetting(
+			ctx, key, json.RawMessage(`"true"`), "system", -1, "managed",
+		); upsertErr != nil {
+			slog.Warn("failed to record seed-policy deletion tombstone",
+				"policy", policy.Name, "error", upsertErr)
+		} else {
+			slog.Warn("seeded policy deleted; it will not be recreated on restart",
+				"policy", policy.Name)
+		}
 	}
 
 	w.WriteHeader(http.StatusNoContent)

--- a/pkg/hub/handlers_policies.go
+++ b/pkg/hub/handlers_policies.go
@@ -428,7 +428,7 @@ func (s *Server) deletePolicy(w http.ResponseWriter, r *http.Request, id string)
 			slog.Warn("failed to record seed-policy deletion tombstone",
 				"policy", policy.Name, "error", upsertErr)
 		} else {
-			slog.Warn("seeded policy deleted; it will not be recreated on restart",
+			slog.Info("seeded policy deleted; it will not be recreated on restart",
 				"policy", policy.Name)
 		}
 	}

--- a/pkg/hub/handlers_policies.go
+++ b/pkg/hub/handlers_policies.go
@@ -413,24 +413,35 @@ func (s *Server) deletePolicy(w http.ResponseWriter, r *http.Request, id string)
 		return
 	}
 
-	if err := s.store.DeletePolicy(ctx, id); err != nil {
-		writeErrorFromErr(w, err, "")
-		return
-	}
-
-	// If this was a seeded policy, record a tombstone so the startup seeder
-	// does not silently recreate it on the next restart.
+	// Write tombstone BEFORE deleting the policy — fail-closed. If the
+	// tombstone write fails we abort so the policy is never silently
+	// recreated on restart due to a missing tombstone.
 	if policy.Origin == store.PolicyOriginSeeded {
 		key := seedPolicyTombstoneKey(policy.Name)
 		if _, upsertErr := s.store.UpsertHubSetting(
 			ctx, key, json.RawMessage(`"true"`), "system", -1, "managed",
 		); upsertErr != nil {
-			slog.Warn("failed to record seed-policy deletion tombstone",
+			slog.Error("cannot record seed-policy tombstone; aborting delete to prevent silent recreation",
 				"policy", policy.Name, "error", upsertErr)
-		} else {
-			slog.Info("seeded policy deleted; it will not be recreated on restart",
-				"policy", policy.Name)
+			writeError(w, http.StatusInternalServerError, "", "failed to record deletion tombstone", nil)
+			return
 		}
+	}
+
+	if err := s.store.DeletePolicy(ctx, id); err != nil {
+		// Best-effort: clean up the tombstone we just wrote so an
+		// un-deleted policy does not appear tombstoned.
+		if policy.Origin == store.PolicyOriginSeeded {
+			key := seedPolicyTombstoneKey(policy.Name)
+			_ = s.store.DeleteHubSetting(ctx, key)
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	if policy.Origin == store.PolicyOriginSeeded {
+		slog.Info("seeded policy deleted; it will not be recreated on restart",
+			"policy", policy.Name)
 	}
 
 	w.WriteHeader(http.StatusNoContent)

--- a/pkg/hub/seed.go
+++ b/pkg/hub/seed.go
@@ -286,9 +286,16 @@ func seedPolicyTombstoneKey(policyName string) string {
 
 // hasSeedPolicyTombstone returns true if a tombstone hub setting exists for the
 // given seeded policy name, indicating it was intentionally deleted.
-func hasSeedPolicyTombstone(ctx context.Context, s store.Store, policyName string) bool {
+// It returns an error for transient store failures so the caller can fail-closed.
+func hasSeedPolicyTombstone(ctx context.Context, s store.Store, policyName string) (bool, error) {
 	_, err := s.GetHubSetting(ctx, seedPolicyTombstoneKey(policyName))
-	return err == nil
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, store.ErrNotFound) {
+		return false, nil
+	}
+	return false, err
 }
 
 // seedPolicy creates a policy and binds it to the given group, skipping
@@ -307,7 +314,13 @@ func seedPolicy(ctx context.Context, s store.Store, groupID string, policy *stor
 
 	// Check for deletion tombstone — an operator intentionally deleted this
 	// seeded policy and it should not be recreated.
-	if hasSeedPolicyTombstone(ctx, s, policy.Name) {
+	hasTombstone, err := hasSeedPolicyTombstone(ctx, s, policy.Name)
+	if err != nil {
+		slog.Warn("failed to check tombstone; skipping recreation as precaution",
+			"name", policy.Name, "error", err)
+		return // fail-closed
+	}
+	if hasTombstone {
 		slog.Info("seeded policy was intentionally deleted; skipping recreation",
 			"name", policy.Name)
 		return

--- a/pkg/hub/seed.go
+++ b/pkg/hub/seed.go
@@ -17,6 +17,7 @@ package hub
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
@@ -69,6 +70,13 @@ func seedDefaultPoliciesAndGroups(ctx context.Context, s store.Store) {
 		ResourceType: "project",
 		Actions:      []string{"create"},
 		Effect:       "allow",
+	})
+
+	// Backfill Origin="seeded" on any existing seeded policies that predate
+	// the Origin field.
+	backfillSeededPolicyOrigin(ctx, s, []string{
+		"hub-member-read-all",
+		"hub-member-create-projects",
 	})
 
 	// The human half of the svc-accnt service-account assign baseline is
@@ -270,8 +278,22 @@ func backfillProjectAssignPolicies(ctx context.Context, s store.Store) {
 	}
 }
 
+// seedPolicyTombstoneKey returns the hub-setting key used to record that a
+// seeded policy was intentionally deleted by an operator.
+func seedPolicyTombstoneKey(policyName string) string {
+	return fmt.Sprintf("seed.policy.deleted.%s", policyName)
+}
+
+// hasSeedPolicyTombstone returns true if a tombstone hub setting exists for the
+// given seeded policy name, indicating it was intentionally deleted.
+func hasSeedPolicyTombstone(ctx context.Context, s store.Store, policyName string) bool {
+	_, err := s.GetHubSetting(ctx, seedPolicyTombstoneKey(policyName))
+	return err == nil
+}
+
 // seedPolicy creates a policy and binds it to the given group, skipping
-// if a policy with the same name already exists.
+// if a policy with the same name already exists or if a deletion tombstone
+// is present.
 func seedPolicy(ctx context.Context, s store.Store, groupID string, policy *store.Policy) {
 	// Check if policy already exists by name
 	existing, err := s.ListPolicies(ctx, store.PolicyFilter{Name: policy.Name}, store.ListOptions{Limit: 1})
@@ -282,6 +304,17 @@ func seedPolicy(ctx context.Context, s store.Store, groupID string, policy *stor
 	if existing.TotalCount > 0 {
 		return
 	}
+
+	// Check for deletion tombstone — an operator intentionally deleted this
+	// seeded policy and it should not be recreated.
+	if hasSeedPolicyTombstone(ctx, s, policy.Name) {
+		slog.Info("seeded policy was intentionally deleted; skipping recreation",
+			"name", policy.Name)
+		return
+	}
+
+	// Mark as seeded so the delete handler can record a tombstone.
+	policy.Origin = store.PolicyOriginSeeded
 
 	if err := s.CreatePolicy(ctx, policy); err != nil {
 		slog.Warn("failed to create seed policy", "name", policy.Name, "error", err)
@@ -298,6 +331,28 @@ func seedPolicy(ctx context.Context, s store.Store, groupID string, policy *stor
 	if err := s.AddPolicyBinding(ctx, binding); err != nil {
 		slog.Warn("failed to bind seed policy to hub-members group",
 			"policy", policy.Name, "error", err)
+	}
+}
+
+// backfillSeededPolicyOrigin marks existing seeded policies with
+// Origin="seeded" if they were created before the Origin field existed.
+// This ensures existing deployments get the marker on upgrade.
+func backfillSeededPolicyOrigin(ctx context.Context, s store.Store, seededNames []string) {
+	for _, name := range seededNames {
+		existing, err := s.ListPolicies(ctx, store.PolicyFilter{Name: name}, store.ListOptions{Limit: 1})
+		if err != nil || len(existing.Items) == 0 {
+			continue
+		}
+		p := &existing.Items[0]
+		if p.Origin == "" {
+			p.Origin = store.PolicyOriginSeeded
+			if err := s.UpdatePolicy(ctx, p); err != nil {
+				slog.Warn("failed to backfill seeded policy origin",
+					"name", name, "error", err)
+			} else {
+				slog.Info("backfilled seeded policy origin", "name", name, "id", p.ID)
+			}
+		}
 	}
 }
 

--- a/pkg/hub/seed.go
+++ b/pkg/hub/seed.go
@@ -302,8 +302,8 @@ func hasSeedPolicyTombstone(ctx context.Context, s store.Store, policyName strin
 // if a policy with the same name already exists or if a deletion tombstone
 // is present.
 func seedPolicy(ctx context.Context, s store.Store, groupID string, policy *store.Policy) {
-	// Check if policy already exists by name
-	existing, err := s.ListPolicies(ctx, store.PolicyFilter{Name: policy.Name}, store.ListOptions{Limit: 1})
+	// Check if policy already exists by name+scope.
+	existing, err := s.ListPolicies(ctx, store.PolicyFilter{Name: policy.Name, ScopeType: policy.ScopeType}, store.ListOptions{Limit: 1})
 	if err != nil {
 		slog.Warn("failed to check for existing policy", "name", policy.Name, "error", err)
 		return
@@ -352,7 +352,7 @@ func seedPolicy(ctx context.Context, s store.Store, groupID string, policy *stor
 // This ensures existing deployments get the marker on upgrade.
 func backfillSeededPolicyOrigin(ctx context.Context, s store.Store, seededNames []string) {
 	for _, name := range seededNames {
-		existing, err := s.ListPolicies(ctx, store.PolicyFilter{Name: name}, store.ListOptions{Limit: 1})
+		existing, err := s.ListPolicies(ctx, store.PolicyFilter{Name: name, ScopeType: "hub"}, store.ListOptions{Limit: 1})
 		if err != nil || len(existing.Items) == 0 {
 			continue
 		}

--- a/pkg/hub/seed_tombstone_test.go
+++ b/pkg/hub/seed_tombstone_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSeedPolicy_SeededPoliciesHaveOrigin verifies that the startup seeder sets
+// Origin="seeded" on the default policies.
+func TestSeedPolicy_SeededPoliciesHaveOrigin(t *testing.T) {
+	_, s := testServer(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"hub-member-read-all", "hub-member-create-projects"} {
+		res, err := s.ListPolicies(ctx, store.PolicyFilter{Name: name}, store.ListOptions{Limit: 1})
+		require.NoError(t, err)
+		require.Len(t, res.Items, 1, "expected seeded policy %q to exist", name)
+		assert.Equal(t, store.PolicyOriginSeeded, res.Items[0].Origin,
+			"seeded policy %q should have Origin=%q", name, store.PolicyOriginSeeded)
+	}
+}
+
+// TestSeedPolicy_SkipsRecreationWhenTombstoneExists verifies that seedPolicy
+// does not recreate a policy when a deletion tombstone hub setting exists.
+func TestSeedPolicy_SkipsRecreationWhenTombstoneExists(t *testing.T) {
+	_, s := testServer(t)
+	ctx := context.Background()
+
+	const policyName = "hub-member-read-all"
+
+	// Delete the seeded policy so we can test recreation.
+	res, err := s.ListPolicies(ctx, store.PolicyFilter{Name: policyName}, store.ListOptions{Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, res.Items, 1)
+	require.NoError(t, s.DeletePolicy(ctx, res.Items[0].ID))
+
+	// Plant a tombstone hub setting.
+	key := seedPolicyTombstoneKey(policyName)
+	_, err = s.UpsertHubSetting(ctx, key, json.RawMessage(`"true"`), "system", -1, "managed")
+	require.NoError(t, err)
+
+	// Get the hub-members group for the seedPolicy call.
+	group, err := s.GetGroupBySlug(ctx, "hub-members")
+	require.NoError(t, err)
+
+	// Re-run seedPolicy — it should NOT recreate.
+	seedPolicy(ctx, s, group.ID, &store.Policy{
+		ID:           api.NewUUID(),
+		Name:         policyName,
+		Description:  "Allow hub members to read all resources",
+		ScopeType:    "hub",
+		ResourceType: "*",
+		Actions:      []string{"read", "list"},
+		Effect:       "allow",
+	})
+
+	// Confirm it was not recreated.
+	res, err = s.ListPolicies(ctx, store.PolicyFilter{Name: policyName}, store.ListOptions{Limit: 1})
+	require.NoError(t, err)
+	assert.Equal(t, 0, res.TotalCount, "tombstoned policy should not be recreated")
+}
+
+// TestDeletePolicy_SeededPolicyCreatesTombstone verifies that deleting a seeded
+// policy via the HTTP handler records a tombstone hub setting.
+func TestDeletePolicy_SeededPolicyCreatesTombstone(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	const policyName = "hub-member-read-all"
+
+	// Find the seeded policy.
+	res, err := s.ListPolicies(ctx, store.PolicyFilter{Name: policyName}, store.ListOptions{Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, res.Items, 1)
+	policyID := res.Items[0].ID
+
+	// Confirm it has seeded origin.
+	assert.Equal(t, store.PolicyOriginSeeded, res.Items[0].Origin)
+
+	// Delete via HTTP handler (as admin).
+	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/policies/"+policyID, nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Verify tombstone was created.
+	key := seedPolicyTombstoneKey(policyName)
+	setting, err := s.GetHubSetting(ctx, key)
+	require.NoError(t, err, "tombstone hub setting should exist after deleting seeded policy")
+	assert.Equal(t, key, setting.Section)
+}
+
+// TestDeletePolicy_UserCreatedPolicyNoTombstone verifies that deleting a
+// user-created policy (non-seeded) does NOT create a tombstone hub setting.
+func TestDeletePolicy_UserCreatedPolicyNoTombstone(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// Create a user-created policy (no Origin set).
+	policy := &store.Policy{
+		ID:           api.NewUUID(),
+		Name:         "user-custom-policy",
+		Description:  "A user-created policy",
+		ScopeType:    "hub",
+		ResourceType: "*",
+		Actions:      []string{"read"},
+		Effect:       "allow",
+	}
+	require.NoError(t, s.CreatePolicy(ctx, policy))
+
+	// Delete via HTTP handler.
+	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/policies/"+policy.ID, nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Verify NO tombstone was created.
+	key := seedPolicyTombstoneKey(policy.Name)
+	_, err := s.GetHubSetting(ctx, key)
+	assert.ErrorIs(t, err, store.ErrNotFound,
+		"no tombstone should be created for user-created policy deletion")
+}
+
+// TestBackfillSeededPolicyOrigin verifies that backfillSeededPolicyOrigin marks
+// existing policies with Origin="seeded" when they have empty Origin.
+func TestBackfillSeededPolicyOrigin(t *testing.T) {
+	_, s := testServer(t)
+	ctx := context.Background()
+
+	const testPolicyName = "test-backfill-policy"
+
+	// Create a policy with empty Origin (simulating a pre-upgrade policy).
+	policy := &store.Policy{
+		ID:           api.NewUUID(),
+		Name:         testPolicyName,
+		Description:  "A policy needing backfill",
+		ScopeType:    "hub",
+		ResourceType: "*",
+		Actions:      []string{"read"},
+		Effect:       "allow",
+		// Origin intentionally empty — simulates pre-upgrade state.
+	}
+	require.NoError(t, s.CreatePolicy(ctx, policy))
+
+	// Run backfill with this policy name.
+	backfillSeededPolicyOrigin(ctx, s, []string{testPolicyName})
+
+	// Verify Origin was set.
+	res, err := s.ListPolicies(ctx, store.PolicyFilter{Name: testPolicyName}, store.ListOptions{Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, res.Items, 1)
+	assert.Equal(t, store.PolicyOriginSeeded, res.Items[0].Origin,
+		"backfill should set Origin to %q", store.PolicyOriginSeeded)
+}
+
+// TestBackfillSeededPolicyOrigin_SkipsAlreadySet verifies that backfill does
+// not re-update a policy that already has Origin="seeded".
+func TestBackfillSeededPolicyOrigin_SkipsAlreadySet(t *testing.T) {
+	_, s := testServer(t)
+	ctx := context.Background()
+
+	// The seeded policies already have Origin set by the seeder.
+	// Record the Updated timestamp before backfill.
+	res, err := s.ListPolicies(ctx, store.PolicyFilter{Name: "hub-member-read-all"}, store.ListOptions{Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, res.Items, 1)
+	updatedBefore := res.Items[0].Updated
+
+	// Run backfill again.
+	backfillSeededPolicyOrigin(ctx, s, []string{"hub-member-read-all"})
+
+	// Verify it was not updated (timestamp should be unchanged).
+	res, err = s.ListPolicies(ctx, store.PolicyFilter{Name: "hub-member-read-all"}, store.ListOptions{Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, res.Items, 1)
+	assert.Equal(t, updatedBefore, res.Items[0].Updated,
+		"backfill should skip policies that already have Origin set")
+}

--- a/pkg/store/entadapter/policy_store.go
+++ b/pkg/store/entadapter/policy_store.go
@@ -54,6 +54,7 @@ func entPolicyToStore(p *ent.AccessPolicy) *store.Policy {
 		Created:      p.Created,
 		Updated:      p.Updated,
 		CreatedBy:    p.CreatedBy,
+		Origin:       p.Origin,
 	}
 	if p.Conditions != nil {
 		sp.Conditions = entConditionsToStore(p.Conditions)
@@ -142,6 +143,9 @@ func (s *PolicyStore) CreatePolicy(ctx context.Context, p *store.Policy) error {
 	if p.CreatedBy != "" {
 		create.SetCreatedBy(p.CreatedBy)
 	}
+	if p.Origin != "" {
+		create.SetOrigin(p.Origin)
+	}
 
 	created, err := create.Save(ctx)
 	if err != nil {
@@ -213,6 +217,9 @@ func (s *PolicyStore) UpdatePolicy(ctx context.Context, p *store.Policy) error {
 	}
 	if p.CreatedBy != "" {
 		update.SetCreatedBy(p.CreatedBy)
+	}
+	if p.Origin != "" {
+		update.SetOrigin(p.Origin)
 	}
 
 	updated, err := update.Save(ctx)

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -1283,7 +1283,16 @@ type Policy struct {
 
 	// Ownership
 	CreatedBy string `json:"createdBy,omitempty"`
+
+	// Origin tracks how the policy was created.
+	// "" (empty) = user-created (default), "seeded" = created by startup seeder.
+	Origin string `json:"origin,omitempty"`
 }
+
+// PolicyOrigin constants
+const (
+	PolicyOriginSeeded = "seeded"
+)
 
 // DelegatedFromCondition specifies a delegation source for policy matching.
 // When set on a policy, the policy applies to agents whose creator matches.


### PR DESCRIPTION
## Summary

Seeded policies (hub-member-read-all, hub-member-create-projects) are silently recreated on every server restart after intentional deletion via the admin API. This undoes operator security fixes with no warning.

Closes ptone/scion#1199