### PR TITLE
feat: complete user-scoped template support

### DIFF
--- a/cmd/template_resolution.go
+++ b/cmd/template_resolution.go
@@ -183,6 +183,25 @@ func findTemplateOnHub(ctx context.Context, hubCtx *HubContext, name, scope, pro
 		}
 	}
 
+	// Check user scope
+	userOpts := &hubclient.ListTemplatesOptions{
+		Name:   name,
+		Scope:  "user",
+		Status: "active",
+	}
+
+	userResp, err := hubCtx.Client.Templates().List(listCtx, userOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range userResp.Templates {
+		t := &userResp.Templates[i]
+		if t.Name == name || t.Slug == name {
+			return t, nil
+		}
+	}
+
 	// Check global scope
 	globalOpts := &hubclient.ListTemplatesOptions{
 		Name:   name,
@@ -580,6 +599,7 @@ func formatTemplateNotFoundError(name, projectPath string) error {
 	if projectPath != "" {
 		locations = append(locations, "  - Hub (project scope) - not found")
 	}
+	locations = append(locations, "  - Hub (user scope) - not found")
 	locations = append(locations, "  - Hub (global) - not found")
 
 	// Check local locations

--- a/cmd/templates.go
+++ b/cmd/templates.go
@@ -56,7 +56,7 @@ func runTemplateList(cmd *cobra.Command, args []string) error {
 
 	// Check if Hub is available (suppress errors, just skip Hub if not available)
 	var hubCtx *HubContext
-	var hubGlobal, hubProject []hubclient.Template
+	var hubGlobal, hubProject, hubUser []hubclient.Template
 	hubAvailable := false
 
 	if !noHub {
@@ -90,12 +90,24 @@ func runTemplateList(cmd *cobra.Command, args []string) error {
 				}
 			}
 
+			// Fetch user-scoped templates from Hub
+			userResp, err := hubCtx.Client.Templates().List(ctx, &hubclient.ListTemplatesOptions{
+				Scope:  "user",
+				Status: "active",
+			})
+			if err == nil {
+				hubUser = userResp.Templates
+			}
+
 			// Sort hub templates by name for consistent output
 			sort.Slice(hubGlobal, func(i, j int) bool {
 				return hubGlobal[i].Name < hubGlobal[j].Name
 			})
 			sort.Slice(hubProject, func(i, j int) bool {
 				return hubProject[i].Name < hubProject[j].Name
+			})
+			sort.Slice(hubUser, func(i, j int) bool {
+				return hubUser[i].Name < hubUser[j].Name
 			})
 		}
 	}
@@ -144,6 +156,13 @@ func runTemplateList(cmd *cobra.Command, args []string) error {
 				}
 				hubSection["project"] = entries
 			}
+			if len(hubUser) > 0 {
+				entries := make([]templateEntry, len(hubUser))
+				for i, t := range hubUser {
+					entries[i] = templateEntry{Name: t.Name, ID: t.ID, ContentHash: t.ContentHash}
+				}
+				hubSection["user"] = entries
+			}
 			if len(hubSection) > 0 {
 				output["hub"] = hubSection
 			}
@@ -155,8 +174,8 @@ func runTemplateList(cmd *cobra.Command, args []string) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
 	if hubAvailable {
-		// Hub mode: group by local/hub, then by global/project
-		printTemplateListHubMode(w, localGlobal, localProject, hubGlobal, hubProject)
+		// Hub mode: group by local/hub, then by global/project/user
+		printTemplateListHubMode(w, localGlobal, localProject, hubGlobal, hubProject, hubUser)
 	} else {
 		// Local mode: group by global/project
 		printTemplateListLocalMode(w, localGlobal, localProject)
@@ -195,14 +214,15 @@ func printTemplateListLocalMode(w *tabwriter.Writer, global, project []*config.T
 	}
 }
 
-func printTemplateListHubMode(w *tabwriter.Writer, localGlobal, localProject []*config.Template, hubGlobal, hubProject []hubclient.Template) {
+func printTemplateListHubMode(w *tabwriter.Writer, localGlobal, localProject []*config.Template, hubGlobal, hubProject, hubUser []hubclient.Template) {
 	hasLocalGlobal := len(localGlobal) > 0
 	hasLocalProject := len(localProject) > 0
 	hasHubGlobal := len(hubGlobal) > 0
 	hasHubProject := len(hubProject) > 0
+	hasHubUser := len(hubUser) > 0
 
 	hasLocal := hasLocalGlobal || hasLocalProject
-	hasHub := hasHubGlobal || hasHubProject
+	hasHub := hasHubGlobal || hasHubProject || hasHubUser
 
 	if !hasLocal && !hasHub {
 		_, _ = fmt.Fprintln(w, "No templates found.")
@@ -251,6 +271,16 @@ func printTemplateListHubMode(w *tabwriter.Writer, localGlobal, localProject []*
 			_, _ = fmt.Fprintln(w, "  Project:")
 			_, _ = fmt.Fprintln(w, "    NAME\tID\tHASH")
 			for _, t := range hubProject {
+				_, _ = fmt.Fprintf(w, "    %s\t%s\t%s\n", t.Name, t.ID, truncateHash(t.ContentHash))
+			}
+		}
+		if hasHubUser {
+			if hasHubGlobal || hasHubProject {
+				_, _ = fmt.Fprintln(w)
+			}
+			_, _ = fmt.Fprintln(w, "  User:")
+			_, _ = fmt.Fprintln(w, "    NAME\tID\tHASH")
+			for _, t := range hubUser {
 				_, _ = fmt.Fprintf(w, "    %s\t%s\t%s\n", t.Name, t.ID, truncateHash(t.ContentHash))
 			}
 		}

--- a/pkg/hub/handlers_user_templates.go
+++ b/pkg/hub/handlers_user_templates.go
@@ -1,0 +1,440 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/storage"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// =============================================================================
+// User-scoped templates (/api/v1/users/me/templates)
+// =============================================================================
+
+// isUserTemplateOwner returns true if the template is user-scoped and owned by
+// the given user ID (matching either OwnerID or ScopeID).
+func isUserTemplateOwner(t *store.Template, uid string) bool {
+	return t.Scope == store.TemplateScopeUser &&
+		(t.OwnerID == uid || t.ScopeID == uid)
+}
+
+// handleUserMeTemplates routes GET/POST on /api/v1/users/me/templates.
+func (s *Server) handleUserMeTemplates(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listUserTemplates(w, r)
+	case http.MethodPost:
+		s.createUserTemplate(w, r)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// handleUserMeTemplateByID routes GET/PUT/DELETE on
+// /api/v1/users/me/templates/{id} and sub-actions.
+func (s *Server) handleUserMeTemplateByID(w http.ResponseWriter, r *http.Request, templateID string) {
+	// Check for sub-actions (upload, finalize, download, clone)
+	parts := strings.SplitN(templateID, "/", 2)
+	id := parts[0]
+	action := ""
+	if len(parts) > 1 {
+		action = parts[1]
+	}
+
+	switch action {
+	case "":
+		s.handleUserTemplateCRUD(w, r, id)
+	case "upload":
+		s.handleUserTemplateUpload(w, r, id)
+	case "finalize":
+		s.handleUserTemplateFinalize(w, r, id)
+	case "download":
+		s.handleUserTemplateDownload(w, r, id)
+	default:
+		NotFound(w, "Template action")
+	}
+}
+
+// handleUserTemplateCRUD routes CRUD for a single user template.
+func (s *Server) handleUserTemplateCRUD(w http.ResponseWriter, r *http.Request, id string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.getUserTemplate(w, r, id)
+	case http.MethodPut:
+		s.updateUserTemplate(w, r, id)
+	case http.MethodDelete:
+		s.deleteUserTemplate(w, r, id)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// listUserTemplates handles GET /api/v1/users/me/templates.
+func (s *Server) listUserTemplates(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	userIdent := GetUserIdentityFromContext(ctx)
+	if userIdent == nil {
+		Unauthorized(w)
+		return
+	}
+
+	filter := store.TemplateFilter{
+		Scope:   store.TemplateScopeUser,
+		ScopeID: userIdent.ID(),
+		Status:  store.TemplateStatusActive,
+	}
+
+	// Allow filtering by query params
+	query := r.URL.Query()
+	if name := query.Get("name"); name != "" {
+		filter.Name = name
+	}
+	if harness := query.Get("harness"); harness != "" {
+		filter.Harness = harness
+	}
+	if status := query.Get("status"); status != "" {
+		filter.Status = status
+	}
+
+	result, err := s.store.ListTemplates(ctx, filter, store.ListOptions{
+		Limit: 100,
+	})
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	templates := make([]TemplateWithCapabilities, len(result.Items))
+	for i := range result.Items {
+		templates[i] = TemplateWithCapabilities{Template: result.Items[i]}
+	}
+
+	writeJSON(w, http.StatusOK, ListTemplatesResponse{
+		Templates:  templates,
+		TotalCount: result.TotalCount,
+	})
+}
+
+// createUserTemplate handles POST /api/v1/users/me/templates.
+func (s *Server) createUserTemplate(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	userIdent := GetUserIdentityFromContext(ctx)
+	if userIdent == nil {
+		Unauthorized(w)
+		return
+	}
+
+	var req CreateTemplateRequest
+	if err := readJSON(r, &req); err != nil {
+		BadRequest(w, "Invalid request body: "+err.Error())
+		return
+	}
+
+	if req.Name == "" {
+		ValidationError(w, "name is required", nil)
+		return
+	}
+
+	slug := req.Slug
+	if slug != "" {
+		slug = api.Slugify(slug)
+	}
+	if slug == "" {
+		slug = api.Slugify(req.Name)
+	}
+	if slug == "" {
+		BadRequest(w, "invalid slug: name cannot be slugified")
+		return
+	}
+
+	template := &store.Template{
+		ID:           api.NewUUID(),
+		Name:         req.Name,
+		Slug:         slug,
+		DisplayName:  req.DisplayName,
+		Description:  req.Description,
+		Harness:      req.Harness,
+		Config:       req.Config,
+		Scope:        store.TemplateScopeUser,
+		ScopeID:      userIdent.ID(),
+		OwnerID:      userIdent.ID(),
+		CreatedBy:    userIdent.ID(),
+		BaseTemplate: req.BaseTemplate,
+		Visibility:   req.Visibility,
+		Status:       store.TemplateStatusPending,
+	}
+
+	if template.Visibility == "" {
+		template.Visibility = store.VisibilityPrivate
+	}
+
+	// Generate storage path and URI
+	storagePath := storage.TemplateStoragePath(s.HubID(), template.Scope, template.ScopeID, template.Slug)
+	template.StoragePath = storagePath
+
+	stor := s.GetStorage()
+	if stor != nil {
+		template.StorageBucket = stor.Bucket()
+		template.StorageURI = storage.TemplateStorageURI(s.HubID(), stor.Bucket(), template.Scope, template.ScopeID, template.Slug)
+	}
+
+	if err := s.store.CreateTemplate(ctx, template); err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			writeError(w, http.StatusConflict, "conflict", "A template with this name already exists in your user scope. Choose a different name.", nil)
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	response := CreateTemplateResponse{
+		Template: template,
+	}
+
+	// Generate upload URLs if files were specified
+	if len(req.Files) > 0 && stor != nil {
+		uploadURLs, manifestURL, err := generateUploadURLs(ctx, stor, storagePath, req.Files)
+		if err == nil || len(uploadURLs) > 0 {
+			if stor.Provider() == storage.ProviderLocal {
+				hubURL := requestBaseURL(r)
+				uploadURLs = rewriteLocalUploadURLs(uploadURLs, hubURL, "templates", template.ID)
+			}
+			response.UploadURLs = uploadURLs
+			response.ManifestURL = manifestURL
+		}
+	}
+
+	writeJSON(w, http.StatusCreated, response)
+}
+
+// getUserTemplate handles GET /api/v1/users/me/templates/{id}.
+func (s *Server) getUserTemplate(w http.ResponseWriter, r *http.Request, id string) {
+	ctx := r.Context()
+
+	userIdent := GetUserIdentityFromContext(ctx)
+	if userIdent == nil {
+		Unauthorized(w)
+		return
+	}
+
+	template, err := s.store.GetTemplate(ctx, id)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Verify ownership
+	if !isUserTemplateOwner(template, userIdent.ID()) {
+		NotFound(w, "Template")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, TemplateWithCapabilities{Template: *template})
+}
+
+// updateUserTemplate handles PUT /api/v1/users/me/templates/{id}.
+func (s *Server) updateUserTemplate(w http.ResponseWriter, r *http.Request, id string) {
+	ctx := r.Context()
+
+	userIdent := GetUserIdentityFromContext(ctx)
+	if userIdent == nil {
+		Unauthorized(w)
+		return
+	}
+
+	existing, err := s.store.GetTemplate(ctx, id)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Verify ownership
+	if !isUserTemplateOwner(existing, userIdent.ID()) {
+		NotFound(w, "Template")
+		return
+	}
+
+	var template store.Template
+	if err := readJSON(r, &template); err != nil {
+		BadRequest(w, "Invalid request body: "+err.Error())
+		return
+	}
+
+	// Preserve immutable fields
+	template.ID = existing.ID
+	template.Scope = store.TemplateScopeUser
+	template.ScopeID = userIdent.ID()
+	template.OwnerID = userIdent.ID()
+	template.Created = existing.Created
+	template.CreatedBy = existing.CreatedBy
+	template.UpdatedBy = userIdent.ID()
+	// Preserve system-managed fields that must not be zeroed by client input
+	template.StoragePath = existing.StoragePath
+	template.StorageBucket = existing.StorageBucket
+	template.StorageURI = existing.StorageURI
+	template.Files = existing.Files
+	template.ContentHash = existing.ContentHash
+	template.Status = existing.Status
+	if template.Slug != "" {
+		template.Slug = api.Slugify(template.Slug)
+	}
+	if template.Slug == "" {
+		template.Slug = api.Slugify(template.Name)
+	}
+
+	if err := s.store.UpdateTemplate(ctx, &template); err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, template)
+}
+
+// deleteUserTemplate handles DELETE /api/v1/users/me/templates/{id}.
+func (s *Server) deleteUserTemplate(w http.ResponseWriter, r *http.Request, id string) {
+	ctx := r.Context()
+
+	userIdent := GetUserIdentityFromContext(ctx)
+	if userIdent == nil {
+		Unauthorized(w)
+		return
+	}
+
+	existing, err := s.store.GetTemplate(ctx, id)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Verify ownership
+	if !isUserTemplateOwner(existing, userIdent.ID()) {
+		NotFound(w, "Template")
+		return
+	}
+
+	// Delete files from storage if requested
+	deleteFiles := r.URL.Query().Get("deleteFiles") == "true"
+	if deleteFiles && existing.StoragePath != "" {
+		if stor := s.GetStorage(); stor != nil {
+			_ = stor.DeletePrefix(ctx, existing.StoragePath)
+		}
+	}
+
+	if err := s.store.DeleteTemplate(ctx, id); err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleUserTemplateUpload handles POST /api/v1/users/me/templates/{id}/upload.
+func (s *Server) handleUserTemplateUpload(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	userIdent := GetUserIdentityFromContext(ctx)
+	if userIdent == nil {
+		Unauthorized(w)
+		return
+	}
+
+	template, err := s.store.GetTemplate(ctx, id)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Verify ownership
+	if !isUserTemplateOwner(template, userIdent.ID()) {
+		NotFound(w, "Template")
+		return
+	}
+
+	// Delegate to the shared upload handler
+	s.handleTemplateUpload(w, r, id)
+}
+
+// handleUserTemplateFinalize handles POST /api/v1/users/me/templates/{id}/finalize.
+func (s *Server) handleUserTemplateFinalize(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		MethodNotAllowed(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	userIdent := GetUserIdentityFromContext(ctx)
+	if userIdent == nil {
+		Unauthorized(w)
+		return
+	}
+
+	template, err := s.store.GetTemplate(ctx, id)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Verify ownership
+	if !isUserTemplateOwner(template, userIdent.ID()) {
+		NotFound(w, "Template")
+		return
+	}
+
+	// Delegate to the shared finalize handler
+	s.handleTemplateFinalize(w, r, id)
+}
+
+// handleUserTemplateDownload handles GET /api/v1/users/me/templates/{id}/download.
+func (s *Server) handleUserTemplateDownload(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	ctx := r.Context()
+
+	userIdent := GetUserIdentityFromContext(ctx)
+	if userIdent == nil {
+		Unauthorized(w)
+		return
+	}
+
+	template, err := s.store.GetTemplate(ctx, id)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Verify ownership
+	if !isUserTemplateOwner(template, userIdent.ID()) {
+		NotFound(w, "Template")
+		return
+	}
+
+	// Delegate to the shared download handler
+	s.handleTemplateDownload(w, r, id)
+}

--- a/pkg/hub/handlers_user_templates_test.go
+++ b/pkg/hub/handlers_user_templates_test.go
@@ -1,0 +1,288 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// setupUserTemplateTest creates a test server with two users (alice and bob)
+// and returns the server, store, and both users. Both users have hub membership.
+func setupUserTemplateTest(t *testing.T) (*Server, store.Store, *store.User, *store.User) {
+	t.Helper()
+
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	alice := &store.User{
+		ID:          tid("ut-alice"),
+		Email:       "alice@test.com",
+		DisplayName: "Alice",
+		Role:        store.UserRoleMember,
+		Status:      "active",
+		Created:     time.Now(),
+	}
+	require.NoError(t, s.CreateUser(ctx, alice))
+
+	bob := &store.User{
+		ID:          tid("ut-bob"),
+		Email:       "bob@test.com",
+		DisplayName: "Bob",
+		Role:        store.UserRoleMember,
+		Status:      "active",
+		Created:     time.Now(),
+	}
+	require.NoError(t, s.CreateUser(ctx, bob))
+
+	ensureHubMembership(ctx, s, alice.ID)
+	ensureHubMembership(ctx, s, bob.ID)
+
+	return srv, s, alice, bob
+}
+
+// createUserTemplate creates a user-scoped template directly in the store.
+func createUserTemplate(t *testing.T, s store.Store, ownerID, name string) *store.Template {
+	t.Helper()
+	tmpl := &store.Template{
+		ID:         api.NewUUID(),
+		Name:       name,
+		Slug:       api.Slugify(name),
+		Harness:    "antigravity",
+		Scope:      store.TemplateScopeUser,
+		ScopeID:    ownerID,
+		OwnerID:    ownerID,
+		CreatedBy:  ownerID,
+		Status:     store.TemplateStatusActive,
+		Visibility: store.VisibilityPrivate,
+	}
+	require.NoError(t, s.CreateTemplate(context.Background(), tmpl))
+	return tmpl
+}
+
+// TestListUserTemplates_IsolationBetweenUsers verifies that listing
+// /api/v1/users/me/templates returns only the caller's user-scoped templates.
+func TestListUserTemplates_IsolationBetweenUsers(t *testing.T) {
+	srv, s, alice, bob := setupUserTemplateTest(t)
+
+	// Create templates owned by each user.
+	aliceTmpl := createUserTemplate(t, s, alice.ID, "alice-template")
+	_ = createUserTemplate(t, s, bob.ID, "bob-template")
+
+	// Alice lists her templates — should see only hers.
+	rec := doRequestAsUser(t, srv, alice, http.MethodGet, "/api/v1/users/me/templates", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ListTemplatesResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	assert.Equal(t, 1, resp.TotalCount, "alice should see exactly 1 template")
+	require.Len(t, resp.Templates, 1)
+	assert.Equal(t, aliceTmpl.ID, resp.Templates[0].ID)
+	assert.Equal(t, "alice-template", resp.Templates[0].Name)
+
+	// Bob lists his templates — should see only his.
+	rec = doRequestAsUser(t, srv, bob, http.MethodGet, "/api/v1/users/me/templates", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.TotalCount, "bob should see exactly 1 template")
+	require.Len(t, resp.Templates, 1)
+	assert.Equal(t, "bob-template", resp.Templates[0].Name)
+}
+
+// TestCreateUserTemplate_SetsScopeIDAndOwnerID verifies that creating a template
+// via /api/v1/users/me/templates forces ScopeID and OwnerID from the authenticated user.
+func TestCreateUserTemplate_SetsScopeIDAndOwnerID(t *testing.T) {
+	srv, _, alice, _ := setupUserTemplateTest(t)
+
+	body := CreateTemplateRequest{
+		Name:    "my-template",
+		Harness: "antigravity",
+	}
+
+	rec := doRequestAsUser(t, srv, alice, http.MethodPost, "/api/v1/users/me/templates", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp CreateTemplateResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	assert.Equal(t, store.TemplateScopeUser, resp.Template.Scope)
+	assert.Equal(t, alice.ID, resp.Template.ScopeID, "ScopeID should be set to the authenticated user")
+	assert.Equal(t, alice.ID, resp.Template.OwnerID, "OwnerID should be set to the authenticated user")
+	assert.Equal(t, alice.ID, resp.Template.CreatedBy, "CreatedBy should be set to the authenticated user")
+}
+
+// TestGetUserTemplate_NotFoundForOtherUser verifies that GET returns 404
+// when a user tries to access another user's template.
+func TestGetUserTemplate_NotFoundForOtherUser(t *testing.T) {
+	srv, s, alice, bob := setupUserTemplateTest(t)
+
+	// Create a template owned by alice.
+	aliceTmpl := createUserTemplate(t, s, alice.ID, "alice-private")
+
+	// Alice can access her own template.
+	rec := doRequestAsUser(t, srv, alice, http.MethodGet, "/api/v1/users/me/templates/"+aliceTmpl.ID, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Bob cannot access Alice's template — should get 404.
+	rec = doRequestAsUser(t, srv, bob, http.MethodGet, "/api/v1/users/me/templates/"+aliceTmpl.ID, nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestUpdateUserTemplate_NotFoundForOtherUser verifies that PUT returns 404
+// when a user tries to update another user's template.
+func TestUpdateUserTemplate_NotFoundForOtherUser(t *testing.T) {
+	srv, s, alice, bob := setupUserTemplateTest(t)
+
+	aliceTmpl := createUserTemplate(t, s, alice.ID, "alice-update-test")
+
+	updateBody := store.Template{
+		Name:        "updated-name",
+		Description: "updated description",
+		Status:      store.TemplateStatusActive,
+		Visibility:  store.VisibilityPrivate,
+	}
+
+	// Alice can update her own template.
+	rec := doRequestAsUser(t, srv, alice, http.MethodPut, "/api/v1/users/me/templates/"+aliceTmpl.ID, updateBody)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Bob cannot update Alice's template — should get 404.
+	rec = doRequestAsUser(t, srv, bob, http.MethodPut, "/api/v1/users/me/templates/"+aliceTmpl.ID, updateBody)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestDeleteUserTemplate_NotFoundForOtherUser verifies that DELETE returns 404
+// when a user tries to delete another user's template.
+func TestDeleteUserTemplate_NotFoundForOtherUser(t *testing.T) {
+	srv, s, alice, bob := setupUserTemplateTest(t)
+
+	aliceTmpl := createUserTemplate(t, s, alice.ID, "alice-delete-test")
+
+	// Bob cannot delete Alice's template — should get 404.
+	rec := doRequestAsUser(t, srv, bob, http.MethodDelete, "/api/v1/users/me/templates/"+aliceTmpl.ID, nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+
+	// Alice can delete her own template.
+	rec = doRequestAsUser(t, srv, alice, http.MethodDelete, "/api/v1/users/me/templates/"+aliceTmpl.ID, nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+// TestListTemplatesV2_UserScopeIsolation verifies the R1 fix: listing templates
+// via the generic /api/v1/templates?scope=user endpoint restricts results to
+// the authenticated user's templates.
+func TestListTemplatesV2_UserScopeIsolation(t *testing.T) {
+	srv, s, alice, bob := setupUserTemplateTest(t)
+
+	_ = createUserTemplate(t, s, alice.ID, "alice-v2-template")
+	_ = createUserTemplate(t, s, bob.ID, "bob-v2-template")
+
+	// Alice lists with scope=user via the generic endpoint.
+	rec := doRequestAsUser(t, srv, alice, http.MethodGet, "/api/v1/templates?scope=user", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ListTemplatesResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	// Alice should only see her own template, not Bob's.
+	require.Len(t, resp.Templates, 1, "generic scope=user should return only caller's templates")
+	assert.Equal(t, "alice-v2-template", resp.Templates[0].Name)
+}
+
+// TestCreateTemplateV2_ScopeIDInjectionBlocked verifies the R2 fix: creating
+// a user-scoped template via the generic /api/v1/templates endpoint always
+// forces ScopeID from the authenticated user, ignoring any caller-supplied value.
+func TestCreateTemplateV2_ScopeIDInjectionBlocked(t *testing.T) {
+	srv, _, alice, bob := setupUserTemplateTest(t)
+
+	// Alice tries to create a template with Bob's ID as ScopeID.
+	body := CreateTemplateRequest{
+		Name:    "injected-template",
+		Harness: "antigravity",
+		Scope:   store.TemplateScopeUser,
+		ScopeID: bob.ID, // Attempt to inject Bob's ID
+	}
+
+	rec := doRequestAsUser(t, srv, alice, http.MethodPost, "/api/v1/templates", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp CreateTemplateResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	// ScopeID must be Alice's, not Bob's.
+	assert.Equal(t, alice.ID, resp.Template.ScopeID, "ScopeID should be forced to the caller's ID")
+	assert.Equal(t, alice.ID, resp.Template.OwnerID, "OwnerID should be forced to the caller's ID")
+}
+
+// TestIsUserTemplateOwner tests the ownership helper function.
+func TestIsUserTemplateOwner(t *testing.T) {
+	uid := "user-123"
+
+	tests := []struct {
+		name     string
+		template *store.Template
+		want     bool
+	}{
+		{
+			name:     "owner by OwnerID",
+			template: &store.Template{Scope: store.TemplateScopeUser, OwnerID: uid, ScopeID: "other"},
+			want:     true,
+		},
+		{
+			name:     "owner by ScopeID",
+			template: &store.Template{Scope: store.TemplateScopeUser, OwnerID: "other", ScopeID: uid},
+			want:     true,
+		},
+		{
+			name:     "owner by both",
+			template: &store.Template{Scope: store.TemplateScopeUser, OwnerID: uid, ScopeID: uid},
+			want:     true,
+		},
+		{
+			name:     "not owner",
+			template: &store.Template{Scope: store.TemplateScopeUser, OwnerID: "other", ScopeID: "other"},
+			want:     false,
+		},
+		{
+			name:     "wrong scope global",
+			template: &store.Template{Scope: store.TemplateScopeGlobal, OwnerID: uid},
+			want:     false,
+		},
+		{
+			name:     "wrong scope project",
+			template: &store.Template{Scope: store.TemplateScopeProject, OwnerID: uid},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isUserTemplateOwner(tt.template, uid)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/hub/route_classification_test.go
+++ b/pkg/hub/route_classification_test.go
@@ -82,6 +82,8 @@ var routePermissionClassifications = map[string]string{
 	"/api/v1/principals/":                       "authenticated:principal",
 	"/api/v1/users/me/injected-skills":          "authenticated:injected-skills",
 	"/api/v1/users/me/injected-skills/":         "authenticated:injected-skills",
+	"/api/v1/users/me/templates":                "authenticated:user-templates",
+	"/api/v1/users/me/templates/":               "authenticated:user-templates",
 	"/api/v1/hub/settings/injected-skills":      "hub-admin:injected-skills",
 	"/api/v1/brokers":                           "broker-hmac:registration",
 	"/api/v1/brokers/join":                      "broker-hmac:registration",

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3561,6 +3561,14 @@ func (s *Server) registerRoutes() {
 		s.handleUserMeInjectedSkillByID(w, r, entryID)
 	})
 
+	// User-scoped template endpoints (/users/me/templates)
+	s.mux.HandleFunc("/api/v1/users/me/templates", s.handleUserMeTemplates)
+	s.mux.HandleFunc("/api/v1/users/me/templates/", func(w http.ResponseWriter, r *http.Request) {
+		templateID := strings.TrimPrefix(r.URL.Path, "/api/v1/users/me/templates/")
+		templateID = strings.TrimSuffix(templateID, "/")
+		s.handleUserMeTemplateByID(w, r, templateID)
+	})
+
 	// Hub-scope injected-skills endpoint
 	s.mux.HandleFunc("/api/v1/hub/settings/injected-skills", s.handleHubInjectedSkills)
 

--- a/pkg/hub/template_handlers.go
+++ b/pkg/hub/template_handlers.go
@@ -187,6 +187,24 @@ func (s *Server) listTemplatesV2(w http.ResponseWriter, r *http.Request) {
 		filter.Status = store.TemplateStatusActive
 	}
 
+	// When listing without explicit scope, include user-scoped templates
+	// for the authenticated user in the resolution results.
+	switch filter.Scope {
+	case "":
+		if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+			filter.UserID = userIdent.ID()
+		}
+	case store.TemplateScopeUser:
+		// When listing user-scoped templates, always force ScopeID to the
+		// authenticated user's ID to prevent cross-user template enumeration.
+		userIdent := GetUserIdentityFromContext(ctx)
+		if userIdent == nil {
+			Unauthorized(w)
+			return
+		}
+		filter.ScopeID = userIdent.ID()
+	}
+
 	limit := 50
 	if l := query.Get("limit"); l != "" {
 		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
@@ -255,10 +273,18 @@ func (s *Server) createTemplateV2(w http.ResponseWriter, r *http.Request) {
 		scopeID = req.ProjectID
 	}
 
-	// Generate slug from request or name
+	// Generate slug from request or name — always sanitize caller-supplied
+	// slugs through Slugify to prevent path-traversal via crafted values.
 	slug := req.Slug
+	if slug != "" {
+		slug = api.Slugify(slug)
+	}
 	if slug == "" {
 		slug = api.Slugify(req.Name)
+	}
+	if slug == "" {
+		BadRequest(w, "invalid slug: name cannot be slugified")
+		return
 	}
 
 	// Create template record
@@ -283,6 +309,20 @@ func (s *Server) createTemplateV2(w http.ResponseWriter, r *http.Request) {
 	}
 	if template.Visibility == "" {
 		template.Visibility = store.VisibilityPrivate
+	}
+
+	// For user-scoped templates, always set the owner and scope ID from the
+	// authenticated user. ScopeID is forced unconditionally to prevent callers
+	// from injecting another user's ID.
+	if template.Scope == store.TemplateScopeUser {
+		userIdent := GetUserIdentityFromContext(ctx)
+		if userIdent == nil {
+			Unauthorized(w)
+			return
+		}
+		template.OwnerID = userIdent.ID()
+		template.CreatedBy = userIdent.ID()
+		template.ScopeID = userIdent.ID()
 	}
 
 	// If no files provided, keep the template in 'pending' status so it
@@ -538,6 +578,16 @@ func (s *Server) deleteTemplateV2(w http.ResponseWriter, r *http.Request, id str
 			}
 		} else {
 			writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required", nil)
+			return
+		}
+	case store.TemplateScopeUser:
+		userIdent := GetUserIdentityFromContext(ctx)
+		if userIdent == nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required", nil)
+			return
+		}
+		if existing.OwnerID != userIdent.ID() && existing.ScopeID != userIdent.ID() {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden, "You can only delete your own user-scoped templates", nil)
 			return
 		}
 	}
@@ -823,6 +873,19 @@ func (s *Server) handleTemplateClone(w http.ResponseWriter, r *http.Request, id 
 			writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required", nil)
 			return
 		}
+	case store.TemplateScopeUser:
+		userIdent := GetUserIdentityFromContext(ctx)
+		if userIdent == nil {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required", nil)
+			return
+		}
+		// User scope: scopeID must match the authenticated user
+		if scopeID == "" {
+			scopeID = userIdent.ID()
+		} else if scopeID != userIdent.ID() {
+			writeError(w, http.StatusForbidden, ErrCodeForbidden, "You can only clone templates into your own user scope", nil)
+			return
+		}
 	}
 
 	// Create new template based on source
@@ -848,6 +911,14 @@ func (s *Server) handleTemplateClone(w http.ResponseWriter, r *http.Request, id 
 	}
 	if clone.Visibility == "" {
 		clone.Visibility = source.Visibility
+	}
+
+	// For user-scoped clones, set the owner from the authenticated user
+	if clone.Scope == store.TemplateScopeUser {
+		if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+			clone.OwnerID = userIdent.ID()
+			clone.CreatedBy = userIdent.ID()
+		}
 	}
 
 	// Generate storage path for the clone

--- a/pkg/store/entadapter/template_store.go
+++ b/pkg/store/entadapter/template_store.go
@@ -22,6 +22,7 @@ import (
 	entsql "entgo.io/ent/dialect/sql"
 	"github.com/GoogleCloudPlatform/scion/pkg/ent"
 	entharnessconfig "github.com/GoogleCloudPlatform/scion/pkg/ent/harnessconfig"
+	"github.com/GoogleCloudPlatform/scion/pkg/ent/predicate"
 	enttemplate "github.com/GoogleCloudPlatform/scion/pkg/ent/template"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
@@ -278,8 +279,8 @@ func (s *TemplateStore) ListTemplates(ctx context.Context, filter store.Template
 			enttemplate.ProjectIDEQ(filter.ScopeID),
 		))
 	case filter.ProjectID != "" && filter.Scope == "":
-		// Project-without-scope: return global plus this project's templates.
-		query.Where(enttemplate.Or(
+		// Project-without-scope: return global + project + user-scoped templates.
+		scopePredicates := []predicate.Template{
 			enttemplate.ScopeEQ(store.TemplateScopeGlobal),
 			enttemplate.And(
 				enttemplate.ScopeEQ(store.TemplateScopeProject),
@@ -288,7 +289,17 @@ func (s *TemplateStore) ListTemplates(ctx context.Context, filter store.Template
 					enttemplate.ProjectIDEQ(filter.ProjectID),
 				),
 			),
-		))
+		}
+		// Include user-scoped templates when UserID is provided.
+		if filter.UserID != "" {
+			scopePredicates = append(scopePredicates,
+				enttemplate.And(
+					enttemplate.ScopeEQ(store.TemplateScopeUser),
+					enttemplate.ScopeIDEQ(filter.UserID),
+				),
+			)
+		}
+		query.Where(enttemplate.Or(scopePredicates...))
 	case filter.ProjectID != "":
 		query.Where(enttemplate.Or(
 			enttemplate.ScopeIDEQ(filter.ProjectID),

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -526,7 +526,8 @@ type TemplateFilter struct {
 	Name      string // Exact match on template name
 	Scope     string
 	ScopeID   string
-	ProjectID string // When set without Scope, returns global + project-scoped templates for this project
+	ProjectID string // When set without Scope, returns global + project-scoped + user-scoped templates for this project
+	UserID    string // When set with ProjectID (no Scope), also includes user-scoped templates for this user
 	Harness   string
 	OwnerID   string
 	Status    string

--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -388,6 +388,11 @@ const ROUTES: RouteConfig[] = [
     load: () => import('../components/pages/profile-skills.js'),
   },
   {
+    pattern: /^\/profile\/templates$/,
+    tag: 'scion-page-profile-templates',
+    load: () => import('../components/pages/profile-templates.js'),
+  },
+  {
     pattern: /^\/profile$/,
     tag: 'scion-page-profile-env-vars',
     load: () => import('../components/pages/profile-env-vars.js'),
@@ -514,6 +519,7 @@ const PROFILE_ROUTES = new Set([
   'scion-page-profile-teams',
   'scion-page-profile-discord',
   'scion-page-profile-skills',
+  'scion-page-profile-templates',
 ]);
 
 /**

--- a/web/src/components/pages/profile-templates.ts
+++ b/web/src/components/pages/profile-templates.ts
@@ -1,0 +1,359 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Profile Templates page
+ *
+ * Manages user-scoped templates via /api/v1/users/me/templates.
+ * Follows the same structure as profile-skills.ts and profile-secrets.ts.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+
+import { apiFetch, extractApiError } from '../../client/api.js';
+import { showToast } from '../../utils/toast.js';
+
+interface UserTemplate {
+  id: string;
+  name: string;
+  slug: string;
+  displayName?: string;
+  description?: string;
+  harness?: string;
+  status: string;
+  contentHash?: string;
+  created: string;
+  updated: string;
+}
+
+interface ListResponse {
+  templates: UserTemplate[];
+  totalCount: number;
+}
+
+@customElement('scion-page-profile-templates')
+export class ScionPageProfileTemplates extends LitElement {
+  @state() private templates: UserTemplate[] = [];
+  @state() private loading = true;
+  @state() private error: string | null = null;
+
+  // Delete dialog state
+  @state() private deleteTarget: UserTemplate | null = null;
+  @state() private deleteLoading = false;
+
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    .page-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      margin-bottom: 1.5rem;
+      gap: 1rem;
+    }
+
+    .page-header-info h1 {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--scion-text, #1e293b);
+      margin: 0 0 0.25rem 0;
+    }
+
+    .page-header-info p {
+      color: var(--scion-text-muted, #64748b);
+      font-size: 0.875rem;
+      margin: 0;
+    }
+
+    .template-list {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .template-card {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 1rem;
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: 0.5rem;
+      transition: border-color 0.15s ease;
+    }
+
+    .template-card:hover {
+      border-color: var(--scion-primary, #3b82f6);
+    }
+
+    .template-info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .template-name {
+      font-size: 0.9375rem;
+      font-weight: 600;
+      color: var(--scion-text, #1e293b);
+      margin: 0 0 0.25rem 0;
+    }
+
+    .template-meta {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      font-size: 0.8125rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .template-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 500;
+      background: var(--scion-bg-subtle, #f1f5f9);
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .template-badge.active {
+      background: var(--sl-color-success-100, #dcfce7);
+      color: var(--sl-color-success-700, #15803d);
+    }
+
+    .template-badge.pending {
+      background: var(--sl-color-warning-100, #fef3c7);
+      color: var(--sl-color-warning-700, #a16207);
+    }
+
+    .template-actions {
+      display: flex;
+      gap: 0.5rem;
+      flex-shrink: 0;
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 3rem 2rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .empty-state sl-icon {
+      font-size: 2.5rem;
+      margin-bottom: 1rem;
+      opacity: 0.5;
+    }
+
+    .empty-state h3 {
+      margin: 0 0 0.5rem 0;
+      color: var(--scion-text, #1e293b);
+      font-size: 1.125rem;
+    }
+
+    .empty-state p {
+      margin: 0;
+      font-size: 0.875rem;
+    }
+
+    .error-box {
+      padding: 1rem;
+      border-radius: 0.5rem;
+      background: var(--sl-color-danger-50, #fef2f2);
+      border: 1px solid var(--sl-color-danger-200, #fecaca);
+      color: var(--sl-color-danger-700, #b91c1c);
+      font-size: 0.875rem;
+    }
+
+    .loading-spinner {
+      display: flex;
+      justify-content: center;
+      padding: 3rem;
+    }
+  `;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.loadTemplates();
+  }
+
+  private async loadTemplates(): Promise<void> {
+    this.loading = true;
+    this.error = null;
+
+    try {
+      const resp = await apiFetch('/api/v1/users/me/templates');
+      if (!resp.ok) {
+        throw new Error(await extractApiError(resp, 'Request failed'));
+      }
+      const data = (await resp.json()) as ListResponse;
+      this.templates = data.templates || [];
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to load templates';
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private async handleDelete(): Promise<void> {
+    if (!this.deleteTarget) return;
+
+    this.deleteLoading = true;
+    try {
+      const resp = await apiFetch(
+        `/api/v1/users/me/templates/${this.deleteTarget.id}?deleteFiles=true`,
+        { method: 'DELETE' }
+      );
+      if (!resp.ok) {
+        throw new Error(await extractApiError(resp, 'Request failed'));
+      }
+      showToast(`Template "${this.deleteTarget.name}" deleted`, 'success');
+      this.deleteTarget = null;
+      await this.loadTemplates();
+    } catch (err) {
+      showToast(err instanceof Error ? err.message : 'Failed to delete template', 'danger');
+    } finally {
+      this.deleteLoading = false;
+    }
+  }
+
+  private formatDate(dateStr: string): string {
+    try {
+      return new Date(dateStr).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
+    } catch {
+      return dateStr;
+    }
+  }
+
+  override render() {
+    return html`
+      <div class="page-header">
+        <div class="page-header-info">
+          <h1>Templates</h1>
+          <p>
+            Manage your personal agent templates. Use
+            <code>scion template sync --template-scope user</code> to upload templates from the CLI.
+          </p>
+        </div>
+      </div>
+
+      ${this.loading
+        ? html`<div class="loading-spinner"><sl-spinner style="font-size: 2rem;"></sl-spinner></div>`
+        : this.error
+          ? html`<div class="error-box">${this.error}</div>`
+          : this.templates.length === 0
+            ? this.renderEmptyState()
+            : this.renderTemplateList()}
+      ${this.renderDeleteDialog()}
+    `;
+  }
+
+  private renderEmptyState() {
+    return html`
+      <div class="empty-state">
+        <sl-icon name="file-earmark-code"></sl-icon>
+        <h3>No user templates</h3>
+        <p>
+          Upload personal templates using the CLI:<br />
+          <code>scion template sync my-template --template-scope user</code>
+        </p>
+      </div>
+    `;
+  }
+
+  private renderTemplateList() {
+    return html`
+      <div class="template-list">
+        ${this.templates.map(
+          (t) => html`
+            <div class="template-card">
+              <div class="template-info">
+                <div class="template-name">${t.displayName || t.name}</div>
+                <div class="template-meta">
+                  ${t.harness
+                    ? html`<span class="template-badge">${t.harness}</span>`
+                    : nothing}
+                  <span class="template-badge ${t.status}">${t.status}</span>
+                  ${t.description
+                    ? html`<span>${t.description}</span>`
+                    : nothing}
+                  <span>Updated ${this.formatDate(t.updated)}</span>
+                </div>
+              </div>
+              <div class="template-actions">
+                <sl-icon-button
+                  name="trash"
+                  label="Delete"
+                  @click=${() => {
+                    this.deleteTarget = t;
+                  }}
+                ></sl-icon-button>
+              </div>
+            </div>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  private renderDeleteDialog() {
+    if (!this.deleteTarget) return nothing;
+
+    return html`
+      <sl-dialog
+        label="Delete Template"
+        open
+        @sl-after-hide=${() => {
+          this.deleteTarget = null;
+        }}
+      >
+        <p>
+          Are you sure you want to delete the template
+          <strong>${this.deleteTarget.name}</strong>? This will also remove the template files from
+          storage. This action cannot be undone.
+        </p>
+        <div slot="footer">
+          <sl-button
+            variant="default"
+            @click=${() => {
+              this.deleteTarget = null;
+            }}
+            >Cancel</sl-button
+          >
+          <sl-button
+            variant="danger"
+            ?loading=${this.deleteLoading}
+            @click=${() => this.handleDelete()}
+            >Delete</sl-button
+          >
+        </div>
+      </sl-dialog>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-page-profile-templates': ScionPageProfileTemplates;
+  }
+}

--- a/web/src/components/profile/profile-nav.ts
+++ b/web/src/components/profile/profile-nav.ts
@@ -46,6 +46,7 @@ const PROFILE_SECTIONS: NavSection[] = [
       { path: '/profile/secrets', label: 'Secrets', icon: 'shield-lock' },
       { path: '/profile/tokens', label: 'Access Tokens', icon: 'key' },
       { path: '/profile/skills', label: 'Skills', icon: 'puzzle' },
+      { path: '/profile/templates', label: 'Templates', icon: 'file-earmark-code' },
     ],
   },
   {


### PR DESCRIPTION
Wires user-scoped templates end-to-end. The data model (schema, constants, slug lookup) existed but was never connected to API handlers, CLI resolution, store listing, or web UI.

Changes: user-scoped CRUD at /api/v1/users/me/templates, CLI resolution user step, web UI profile page, store listing inclusion, authorization hardening (ScopeID forced from auth context on both list and create to prevent cross-user poisoning/injection). 8 functional tests for ownership enforcement and scope isolation.

Key files: pkg/hub/template_handlers.go, pkg/hub/handlers_user_templates.go (new), cmd/template_resolution.go, web/src/pages/profile-templates.ts (new), pkg/store/entadapter/template_store.go

Relates to ptone/scion#1217
