### PR TITLE
fix(sciontool): cap assistant replies in the hub's unit, not bytes

### DIFF
--- a/pkg/sciontool/hooks/handlers/hub.go
+++ b/pkg/sciontool/hooks/handlers/hub.go
@@ -7,11 +7,14 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
+	"unicode/utf8"
 
 	state "github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hub"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/log"
@@ -136,13 +139,7 @@ func (h *HubHandler) Handle(event *hooks.Event) error {
 		// can distinguish automatic assistant replies from explicit
 		// agent→user messages.
 		if event.Name == hooks.EventAgentEnd && event.Data.AssistantText != "" {
-			text := event.Data.AssistantText
-			// Guard against very large assistant responses (e.g. full file
-			// dumps) bloating the message store and slowing the Messages tab.
-			const maxAssistantTextBytes = 64 * 1024
-			if len(text) > maxAssistantTextBytes {
-				text = text[:maxAssistantTextBytes] + "\n[truncated]"
-			}
+			text := truncateAssistantText(event.Data.AssistantText)
 
 			// Build metadata tags for content classification.
 			metadata := map[string]string{
@@ -329,6 +326,28 @@ func (h *HubHandler) ReportCounts(turnCount, modelCallCount int) error {
 		CurrentTurns:      &turnCount,
 		CurrentModelCalls: &modelCallCount,
 	})
+}
+
+// truncateAssistantText caps an assistant reply at the hub's message-length
+// limit, measured in runes as the hub measures it, keeping the start of the
+// reply and reserving room for a marker reporting how many were dropped.
+func truncateAssistantText(text string) string {
+	total := utf8.RuneCountInString(text)
+	if total <= messages.MaxMessageLength {
+		return text
+	}
+
+	marker := func(dropped int) string {
+		return fmt.Sprintf("\n[truncated, %d characters omitted]", dropped)
+	}
+	// Sized against the worst case: the dropped count can only shrink the marker.
+	keep := messages.MaxMessageLength - utf8.RuneCountInString(marker(total))
+	if keep <= 0 {
+		// Defensive: unreachable at the current limit, but a negative slice
+		// would panic and no caller up to dispatchEvent recovers.
+		return string([]rune(text)[:messages.MaxMessageLength])
+	}
+	return string([]rune(text)[:keep]) + marker(total-keep)
 }
 
 // truncateMessage truncates a message to the specified length.

--- a/pkg/sciontool/hooks/handlers/hub_test.go
+++ b/pkg/sciontool/hooks/handlers/hub_test.go
@@ -6,13 +6,16 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"sync"
 	"testing"
+	"unicode/utf8"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/sciontool/hooks"
 )
 
@@ -632,7 +635,7 @@ func TestHubHandler_AssistantTextForwarding(t *testing.T) {
 		}
 	})
 
-	t.Run("truncates assistant text exceeding 64KB", func(t *testing.T) {
+	t.Run("truncates assistant text to the hub message limit", func(t *testing.T) {
 		tmpHome := t.TempDir()
 		t.Setenv("HOME", tmpHome)
 
@@ -666,12 +669,7 @@ func TestHubHandler_AssistantTextForwarding(t *testing.T) {
 			t.Fatal("Expected handler to be created")
 		}
 
-		// Create a 100KB string (well over the 64KB limit).
-		bigText := string(make([]byte, 100*1024))
-		for i := range []byte(bigText) {
-			_ = i // filled with zeros, but the length is what matters
-		}
-		bigText = strings.Repeat("A", 100*1024)
+		bigText := strings.Repeat("A", messages.MaxMessageLength*4)
 
 		err := handler.Handle(&hooks.Event{
 			Name: hooks.EventAgentEnd,
@@ -684,12 +682,73 @@ func TestHubHandler_AssistantTextForwarding(t *testing.T) {
 		mu.Lock()
 		defer mu.Unlock()
 
-		maxLen := 64*1024 + len("\n[truncated]")
-		if len(outboundMsg) > maxLen {
-			t.Errorf("Expected outbound msg to be at most %d bytes, got %d", maxLen, len(outboundMsg))
+		// Runes, not bytes: this is the unit the hub rejects on.
+		if got := utf8.RuneCountInString(outboundMsg); got > messages.MaxMessageLength {
+			t.Errorf("Expected outbound msg to be at most %d runes, got %d", messages.MaxMessageLength, got)
 		}
-		if !strings.HasSuffix(outboundMsg, "\n[truncated]") {
-			t.Error("Expected truncated message to end with '\\n[truncated]'")
+		if !strings.Contains(outboundMsg, "[truncated,") {
+			t.Error("Expected the truncated message to carry a marker saying how much went")
+		}
+	})
+}
+
+func TestTruncateAssistantText(t *testing.T) {
+	const marker = "[truncated,"
+
+	t.Run("text at or under the limit is untouched", func(t *testing.T) {
+		for _, n := range []int{0, 1, messages.MaxMessageLength - 1, messages.MaxMessageLength} {
+			// Multi-byte: with ASCII, bytes and runes agree and a byte-counting
+			// implementation passes unnoticed.
+			in := strings.Repeat("\u3042", n)
+			if got := truncateAssistantText(in); got != in {
+				t.Errorf("%d runes was modified", n)
+			}
+		}
+	})
+
+	// Non-uniform input: a homogeneous repeat cannot tell head-truncation from
+	// tail-truncation.
+	t.Run("keeps the START of the reply", func(t *testing.T) {
+		in := "OPENING-SENTINEL" + strings.Repeat("x", messages.MaxMessageLength*2) + "CLOSING-SENTINEL"
+		got := truncateAssistantText(in)
+
+		if !strings.HasPrefix(got, "OPENING-SENTINEL") {
+			t.Error("the opening of the reply was discarded")
+		}
+		if strings.Contains(got, "CLOSING-SENTINEL") {
+			t.Error("kept the end of the reply instead of the start")
+		}
+		if body := got[:strings.LastIndex(got, "\n"+marker)]; !strings.HasPrefix(in, body) {
+			t.Error("the kept text is not a prefix of the input")
+		}
+	})
+
+	t.Run("result always fits the hub limit", func(t *testing.T) {
+		for _, in := range []string{
+			strings.Repeat("a", messages.MaxMessageLength+1),
+			strings.Repeat("\u3042", messages.MaxMessageLength+1),
+			strings.Repeat("a", messages.MaxMessageLength*10),
+			"\xff\xfe" + strings.Repeat("b", messages.MaxMessageLength+1),
+		} {
+			got := truncateAssistantText(in)
+			if n := utf8.RuneCountInString(got); n > messages.MaxMessageLength {
+				t.Errorf("%d runes exceeds the hub limit of %d", n, messages.MaxMessageLength)
+			}
+			if !strings.Contains(got, marker) {
+				t.Error("a truncated reply carries no marker")
+			}
+		}
+	})
+
+	t.Run("the marker reports how much went", func(t *testing.T) {
+		over := 500
+		got := truncateAssistantText(strings.Repeat("a", messages.MaxMessageLength+over))
+		var dropped int
+		if _, err := fmt.Sscanf(got[strings.LastIndex(got, marker):], "[truncated, %d characters omitted]", &dropped); err != nil {
+			t.Fatalf("marker is not parseable: %v", err)
+		}
+		if dropped < over {
+			t.Errorf("marker says %d dropped, but at least %d were", dropped, over)
 		}
 	})
 }


### PR DESCRIPTION
The assistant-reply hook truncates at `64 * 1024` measured in **bytes**. The hub rejects above `messages.MaxMessageLength` measured in **runes** (`utf8.RuneCountInString`). Every reply in the gap is posted whole and refused with a 400 — dropped rather than truncated, which is the opposite of what the cap exists to do.

The hook logs the failure and moves on, so the only symptom is a reply that never arrives.

```go
// pkg/sciontool/hooks/handlers/hub.go
const maxAssistantTextBytes = 64 * 1024
if len(text) > maxAssistantTextBytes {
    text = text[:maxAssistantTextBytes] + "\n[truncated]"
}

// pkg/hub/handlers_agent_messaging.go
if msgLen := utf8.RuneCountInString(req.Msg); msgLen > messages.MaxMessageLength {
```

Note the marker is appended *after* truncating, so even a same-unit cap of `MaxMessageLength` would post `limit + 12` and still be refused. The fix reserves room for it.

## What changed

The cap now derives from the hub's own constant and counts in runes. Deriving it removes the second hard-coded number so the two cannot drift again — they already had, by 4× and in different units.

The marker reports the magnitude: `[truncated, N characters omitted]`. A bare `[truncated]` cannot distinguish ten lost characters from a hundred thousand, in text a human is meant to read.

Two smaller things:

- **Guard the slice.** If the limit were ever below the marker length the index would go negative and panic, and nothing above `dispatchEvent` recovers — the hook process would die on every turn end. Unreachable today; one line.
- **Assert which end survives.** The previous test used only homogeneous repeats (`"A"×N`), so an implementation keeping the *tail* instead of the head produced byte-identical output and passed. That mutant now fails on two assertions.

## Scope

Deliberately only the unit mismatch. This does not touch the recipient question being discussed on #1230 — the two are independent, and this one is a defect whichever way that goes.

Not addressed here, and worth knowing: the hook still swallows every rejection. The live one that survives is the rate limiter — agent mirror sends are capped at 30/minute, charged before payload validation, so a fast-turning agent still loses replies to a 429 with the same invisible symptom. The hub returns a retryable 429 with `Retry-After` specifically so a caller can back off and resend, and this is the only caller on that path.

## Testing

- `go test ./pkg/sciontool/hooks/handlers/` — passes, including four new subtests: untouched at/under the limit; keeps the start; result always fits the limit (ASCII, CJK, invalid UTF-8, 10× over); marker reports the magnitude.
- Mutation-tested. Killed: keeping the tail instead of the head; dropping the marker; not reserving room for it; an off-by-one on the kept length; `<` instead of `<=` at the boundary. The under-limit cases use multi-byte input deliberately — with ASCII, bytes and runes agree and a byte-counting implementation passes unnoticed, which is the regression this exists to catch.
- `go build ./...` clean, `gofmt` clean.
- **Note:** four tests fail in `pkg/sciontool/hooks` (`TestRunPreStart_*`) on this tree, unrelated and pre-existing — the fixtures use `echo -n`, and macOS `/bin/sh` prints `-n` literally.

## Layering

`pkg/sciontool/hub` already imports `pkg/messages` for the wire types, and `pkg/messages` has no internal dependencies (`go list -deps` shows stdlib only), so this adds no cycle and no weight to the agent binary.

One caveat worth stating: the constant is compiled into `sciontool`, which ships in the agent image. A hub that later *lowers* its limit would start rejecting again until images are rebuilt. `SendOutboundMessage` already returns the hub's 400 body verbatim, and that text carries the live limit, so a single re-truncate-and-resend would make the constant a hint rather than a contract — happy to add that here if you'd prefer it in one go.
