### PR TITLE
fix(web): keep the SSE feed alive across backgrounded tabs

### DIFF
--- a/web/src/client/sse-client.test.ts
+++ b/web/src/client/sse-client.test.ts
@@ -413,3 +413,23 @@ describe('SSEClient single connection', () => {
     expect(live.closed).toBe(true);
   });
 });
+
+describe('SSEClient connected event', () => {
+  it('dispatches connected on every successful open, including reconnects', () => {
+    const client = new SSEClient();
+    const connected = vi.fn();
+    client.addEventListener('connected', connected);
+
+    client.connect(['agent.>']);
+    latest().simulateOpen();
+    expect(connected).toHaveBeenCalledTimes(1);
+
+    // The drop and recovery cycle must announce the recovery: downstream
+    // catch-up (refetching what the dead stream missed) keys off it.
+    latest().simulateDrop();
+    vi.advanceTimersByTime(1_000);
+    latest().simulateOpen();
+    expect(connected).toHaveBeenCalledTimes(2);
+    client.disconnect();
+  });
+});

--- a/web/src/client/sse-client.test.ts
+++ b/web/src/client/sse-client.test.ts
@@ -1,0 +1,415 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Tests for SSEClient reconnection. */
+
+// @vitest-environment happy-dom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SSEClient } from './sse-client.js';
+
+/** Stand-in for EventSource, which happy-dom does not implement. */
+class FakeEventSource extends EventTarget {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+  static instances: FakeEventSource[] = [];
+
+  readyState = FakeEventSource.CONNECTING;
+  onopen: ((ev: Event) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+
+  constructor(readonly url: string) {
+    super();
+    FakeEventSource.instances.push(this);
+  }
+
+  closed = false;
+
+  close(): void {
+    this.readyState = FakeEventSource.CLOSED;
+    this.closed = true;
+  }
+
+  /** Server accepted the connection. */
+  simulateOpen(): void {
+    this.readyState = FakeEventSource.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+
+  /**
+   * Transport failed after the connection was live. readyState is CLOSED
+   * A live connection failing. Per spec this leaves readyState CONNECTING
+   * while the browser reestablishes, but the client classifies on whether the
+   * connection had opened, not on readyState.
+   */
+  simulateDrop(): void {
+    this.readyState = FakeEventSource.CONNECTING;
+    this.onerror?.(new Event('error'));
+  }
+
+  /**
+   * A handshake that never opened — a rejected one (401, or a redirect to the
+   * login page) leaves readyState CLOSED per spec.
+   */
+  simulateHandshakeFailure(): void {
+    this.readyState = FakeEventSource.CLOSED;
+    this.onerror?.(new Event('error'));
+  }
+}
+
+/**
+ * Fail the newest handshake and settle the auth probe it triggers, so the
+ * caller can advance timers synchronously afterwards.
+ */
+async function failHandshake(): Promise<void> {
+  latest().simulateHandshakeFailure();
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+/** The EventSource the client is currently holding, i.e. the newest one. */
+function latest(): FakeEventSource {
+  const es = FakeEventSource.instances[FakeEventSource.instances.length - 1];
+  if (!es) throw new Error('no EventSource was constructed');
+  return es;
+}
+
+let visibility: DocumentVisibilityState = 'visible';
+
+/** Move the tab between foreground and background, as the browser would. */
+function setVisibility(state: DocumentVisibilityState): void {
+  visibility = state;
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+/** Open a connection and let it reach the live state. */
+function connectAndOpen(subjects = ['agent.>']): SSEClient {
+  const client = new SSEClient();
+  client.connect(subjects);
+  latest().simulateOpen();
+  return client;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // Jitter is deliberate in production; here it would make timer maths
+  // unpredictable, so pin it to zero.
+  vi.spyOn(Math, 'random').mockReturnValue(0);
+  FakeEventSource.instances = [];
+  vi.stubGlobal('EventSource', FakeEventSource);
+  // A handshake that never opened probes this before retrying; an authorised
+  // session answers 200 and the retry proceeds.
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 200, redirected: false }));
+  visibility = 'visible';
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => visibility,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('SSEClient visibility handling', () => {
+  it('reconnects immediately when the tab becomes visible', () => {
+    const client = connectAndOpen();
+    setVisibility('hidden');
+    latest().simulateDrop();
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    setVisibility('visible');
+
+    // No timer was advanced: the reconnect happened on the transition.
+    expect(FakeEventSource.instances).toHaveLength(2);
+    client.disconnect();
+  });
+
+  it('cancels the pending backoff so the tab switch does not double-connect', () => {
+    const client = connectAndOpen();
+    latest().simulateDrop();
+    setVisibility('visible');
+    expect(FakeEventSource.instances).toHaveLength(2);
+
+    // The 1s backoff queued by the drop must have been cleared, not left
+    // to fire into a connection that already exists.
+    vi.advanceTimersByTime(60_000);
+    expect(FakeEventSource.instances).toHaveLength(2);
+    client.disconnect();
+  });
+
+  it('resets the attempt counter when the tab becomes visible', async () => {
+    const client = connectAndOpen();
+    latest().simulateDrop();
+
+    // Burn several attempts while the tab is in the background.
+    for (let i = 0; i < 4; i++) {
+      vi.advanceTimersByTime(30_000);
+      await failHandshake();
+    }
+    expect(client.reconnectAttemptCount).toBeGreaterThan(1);
+
+    setVisibility('visible');
+
+    expect(client.reconnectAttemptCount).toBe(0);
+    client.disconnect();
+  });
+
+  it('does not open a second connection while one is connecting', () => {
+    const client = new SSEClient();
+    client.connect(['agent.>']);
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(latest().readyState).toBe(FakeEventSource.CONNECTING);
+
+    setVisibility('visible');
+
+    // The in-flight handshake resolves on its own. Replacing it here is what
+    // starved every retry when a user switched tabs repeatedly.
+    expect(FakeEventSource.instances).toHaveLength(1);
+    client.disconnect();
+  });
+
+  it('does not reconnect while the connection is open', () => {
+    const client = connectAndOpen();
+    setVisibility('visible');
+    expect(FakeEventSource.instances).toHaveLength(1);
+    client.disconnect();
+  });
+
+  it('ignores a transition to hidden', () => {
+    const client = connectAndOpen();
+    latest().simulateDrop();
+    setVisibility('hidden');
+    expect(FakeEventSource.instances).toHaveLength(1);
+    client.disconnect();
+  });
+});
+
+describe('SSEClient teardown', () => {
+  it('removes the visibility listener on disconnect', () => {
+    const client = connectAndOpen();
+    const removed = vi.spyOn(document, 'removeEventListener');
+
+    client.disconnect();
+
+    expect(removed).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+    setVisibility('visible');
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+
+  it('cancels a pending reconnect timer on disconnect', () => {
+    const client = connectAndOpen();
+    latest().simulateDrop();
+
+    client.disconnect();
+    vi.advanceTimersByTime(120_000);
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+
+  it('stays reusable: connect after disconnect re-arms the visibility listener', () => {
+    const client = connectAndOpen();
+    client.disconnect();
+
+    client.connect(['agent.>']);
+    latest().simulateOpen();
+    expect(FakeEventSource.instances).toHaveLength(2);
+    latest().simulateDrop();
+
+    setVisibility('visible');
+
+    expect(FakeEventSource.instances).toHaveLength(3);
+    client.disconnect();
+  });
+});
+
+describe('SSEClient backoff', () => {
+  it('backs off exponentially, capped at 30s', async () => {
+    const client = connectAndOpen();
+    latest().simulateDrop();
+
+    // First retry after 1s.
+    vi.advanceTimersByTime(999);
+    expect(FakeEventSource.instances).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    expect(FakeEventSource.instances).toHaveLength(2);
+
+    // Second after 2s. The retry's handshake never opens, which is what a
+    // server that is still down looks like.
+    await failHandshake();
+    vi.advanceTimersByTime(1_999);
+    expect(FakeEventSource.instances).toHaveLength(2);
+    vi.advanceTimersByTime(1);
+    expect(FakeEventSource.instances).toHaveLength(3);
+    client.disconnect();
+  });
+
+  it('widens to the slow cap after the fast attempts and keeps retrying', async () => {
+    const client = connectAndOpen();
+    latest().simulateDrop();
+
+    for (let attempt = 1; attempt <= 10; attempt++) {
+      vi.advanceTimersByTime(30_000);
+      expect(FakeEventSource.instances).toHaveLength(attempt + 1);
+      await failHandshake();
+    }
+
+    // Past the fast attempts the interval widens to 5 minutes.
+    vi.advanceTimersByTime(60_000);
+    expect(FakeEventSource.instances).toHaveLength(11);
+    vi.advanceTimersByTime(240_000);
+    expect(FakeEventSource.instances).toHaveLength(12);
+    expect(client.reconnectAttemptCount).toBe(11);
+    client.disconnect();
+  });
+
+  it('resets the backoff once a connection opens', () => {
+    const client = connectAndOpen();
+    latest().simulateDrop();
+    vi.advanceTimersByTime(1_000);
+    latest().simulateOpen();
+
+    expect(client.reconnectAttemptCount).toBe(0);
+    latest().simulateDrop();
+    vi.advanceTimersByTime(1_000);
+    expect(FakeEventSource.instances).toHaveLength(3);
+    client.disconnect();
+  });
+});
+
+describe('SSEClient connection events', () => {
+  it('dispatches disconnected once per dropped connection, then reconnecting', async () => {
+    const client = connectAndOpen();
+    const disconnected = vi.fn();
+    const reconnecting = vi.fn();
+    client.addEventListener('disconnected', disconnected);
+    client.addEventListener('reconnecting', reconnecting);
+
+    latest().simulateDrop();
+    expect(disconnected).toHaveBeenCalledTimes(1);
+    expect(reconnecting).toHaveBeenCalledTimes(1);
+    expect((reconnecting.mock.calls[0]?.[0] as CustomEvent).detail).toEqual({ attempt: 1 });
+
+    // Retries that never reach an open connection are not further drops.
+    vi.advanceTimersByTime(1_000);
+    await failHandshake();
+    expect(disconnected).toHaveBeenCalledTimes(1);
+    expect(reconnecting).toHaveBeenCalledTimes(2);
+    client.disconnect();
+  });
+
+  it('reports a fresh drop after the connection comes back', () => {
+    const client = connectAndOpen();
+    const disconnected = vi.fn();
+    client.addEventListener('disconnected', disconnected);
+
+    latest().simulateDrop();
+    vi.advanceTimersByTime(1_000);
+    latest().simulateOpen();
+    latest().simulateDrop();
+
+    expect(disconnected).toHaveBeenCalledTimes(2);
+    client.disconnect();
+  });
+
+  it('reports a drop when a server-initiated reconnect never lands', () => {
+    const client = connectAndOpen();
+    const disconnected = vi.fn();
+    client.addEventListener('disconnected', disconnected);
+
+    // The hub asks the client to reconnect before a clean shutdown.
+    latest().dispatchEvent(new Event('reconnect'));
+    expect(FakeEventSource.instances).toHaveLength(2);
+    latest().simulateDrop();
+
+    expect(disconnected).toHaveBeenCalledTimes(1);
+    client.disconnect();
+  });
+
+  it('does not dispatch disconnected on a deliberate disconnect', () => {
+    const client = connectAndOpen();
+    const disconnected = vi.fn();
+    client.addEventListener('disconnected', disconnected);
+
+    client.disconnect();
+
+    expect(disconnected).not.toHaveBeenCalled();
+  });
+});
+
+describe('SSEClient jitter', () => {
+  it('spreads retries so open tabs do not reconnect in lockstep', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(1);
+    const client = connectAndOpen();
+    latest().simulateDrop();
+
+    // 1s base plus the full 500ms of jitter.
+    vi.advanceTimersByTime(1_499);
+    expect(FakeEventSource.instances).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    expect(FakeEventSource.instances).toHaveLength(2);
+    client.disconnect();
+  });
+});
+
+describe('SSEClient single connection', () => {
+  it('does not queue a second retry while one is pending', () => {
+    const client = connectAndOpen();
+    latest().simulateDrop();
+    // A second failure on the same dead connection must not stack a timer.
+    latest().simulateDrop();
+
+    vi.advanceTimersByTime(1_000);
+    expect(FakeEventSource.instances).toHaveLength(2);
+    client.disconnect();
+  });
+
+  it('never holds two live connections when a probe and a wake-up race', async () => {
+    let settle: (v: unknown) => void = () => {};
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockReturnValue(new Promise((res) => (settle = res)))
+    );
+
+    // Never opened, so the failure is classified as a possibly-rejected
+    // handshake and starts the auth probe. Nothing is queued while the fetch
+    // is in flight, which is the window the race lives in.
+    const client = new SSEClient();
+    client.connect(['agent.>']);
+    latest().simulateHandshakeFailure();
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    // The tab wakes mid-probe and reconnects.
+    setVisibility('hidden');
+    setVisibility('visible');
+    expect(FakeEventSource.instances).toHaveLength(2);
+    const live = latest();
+
+    // The probe now resolves. It must not open a third connection alongside
+    // the one the wake-up just made.
+    settle({ status: 200, redirected: false });
+    await vi.advanceTimersByTimeAsync(300_000);
+
+    expect(FakeEventSource.instances).toHaveLength(2);
+    expect(latest()).toBe(live);
+    expect(live.closed).toBe(false);
+
+    client.disconnect();
+    expect(live.closed).toBe(true);
+  });
+});

--- a/web/src/client/sse-client.test.ts
+++ b/web/src/client/sse-client.test.ts
@@ -105,9 +105,9 @@ function connectAndOpen(subjects = ['agent.>']): SSEClient {
 
 beforeEach(() => {
   vi.useFakeTimers();
-  // Jitter is deliberate in production; here it would make timer maths
-  // unpredictable, so pin it to zero.
-  vi.spyOn(Math, 'random').mockReturnValue(0);
+  // Jitter is proportional and signed; 0.5 is its zero point, keeping timer
+  // maths exact.
+  vi.spyOn(Math, 'random').mockReturnValue(0.5);
   FakeEventSource.instances = [];
   vi.stubGlobal('EventSource', FakeEventSource);
   // A handshake that never opened probes this before retrying; an authorised
@@ -358,8 +358,8 @@ describe('SSEClient jitter', () => {
     const client = connectAndOpen();
     latest().simulateDrop();
 
-    // 1s base plus the full 500ms of jitter.
-    vi.advanceTimersByTime(1_499);
+    // 1s base plus the full +10% of proportional jitter.
+    vi.advanceTimersByTime(1_099);
     expect(FakeEventSource.instances).toHaveLength(1);
     vi.advanceTimersByTime(1);
     expect(FakeEventSource.instances).toHaveLength(2);

--- a/web/src/client/sse-client.ts
+++ b/web/src/client/sse-client.ts
@@ -112,17 +112,20 @@ export class SSEClient extends EventTarget {
 
     this.generation++;
     const url = this.buildUrl(this.subjects);
-    this.eventSource = new EventSource(url);
+    const es = new EventSource(url);
+    this.eventSource = es;
 
-    this.eventSource.onopen = () => {
+    // Each handler bails unless es is still the client's current connection,
+    // so a superseded connection cannot mutate state it no longer owns.
+    es.onopen = () => {
+      if (es !== this.eventSource) return;
       this.reconnectAttempts = 0;
       this.connectionOpen = true;
       console.info('[SSE] Connected');
     };
 
-    this.eventSource.onerror = () => {
-      // EventSource fires error when connection drops.
-      // Close and attempt manual reconnect with backoff.
+    es.onerror = () => {
+      if (es !== this.eventSource) return;
       const wasOpen = this.connectionOpen;
       this.connectionOpen = false;
       this.closeEventSource();
@@ -216,13 +219,14 @@ export class SSEClient extends EventTarget {
       return;
     }
 
-    // Jitter so open tabs do not retry in lockstep.
     const cap =
       this.reconnectAttempts < this.fastReconnectAttempts
         ? this.fastReconnectCap
         : this.slowReconnectCap;
     const base = Math.min(cap, this.baseReconnectDelay * 2 ** this.reconnectAttempts);
-    const delay = base + Math.random() * 500;
+    // Proportional jitter (up to 10 percent either way), so open tabs spread
+    // out at every cap rather than clustering within a fixed 500ms window.
+    const delay = base + (Math.random() * 2 - 1) * base * 0.1;
     this.reconnectAttempts++;
 
     console.info(

--- a/web/src/client/sse-client.ts
+++ b/web/src/client/sse-client.ts
@@ -122,6 +122,11 @@ export class SSEClient extends EventTarget {
       this.reconnectAttempts = 0;
       this.connectionOpen = true;
       console.info('[SSE] Connected');
+      // The browser's own open signal. The server-sent "connected" event this
+      // client also listens for is never emitted by the hub, so consumers that
+      // need to know the stream is live (state.connected, the chat thread's
+      // catch-up refetch) would otherwise never hear anything.
+      this.dispatchEvent(new CustomEvent('connected'));
     };
 
     es.onerror = () => {

--- a/web/src/client/sse-client.ts
+++ b/web/src/client/sse-client.ts
@@ -24,6 +24,9 @@
  *
  * Provides automatic reconnection with exponential backoff and
  * Last-Event-ID resume support (handled natively by EventSource).
+ *
+ * Reconnection retries indefinitely; a tab that becomes visible reconnects
+ * immediately.
  */
 
 /** Data shape for SSE 'update' events from the server */
@@ -42,10 +45,29 @@ type SSEClientEventMap = {
 export class SSEClient extends EventTarget {
   private eventSource: EventSource | null = null;
   private reconnectAttempts = 0;
-  private maxReconnectAttempts = 10;
+  /**
+   * Bumped whenever the connection lifecycle changes. An async continuation
+   * that captured an older value has been superseded and must not act.
+   */
+  private generation = 0;
   private baseReconnectDelay = 1000;
+  /** Backoff cap while a drop still looks transient. */
+  private fastReconnectCap = 30_000;
+  /**
+   * Backoff cap after fastReconnectAttempts failures.
+   */
+  private slowReconnectCap = 300_000;
+  /** Attempts spent at the fast cap before the slow one takes over. */
+  private fastReconnectAttempts = 10;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private subjects: string[] = [];
+  /**
+   * Whether a connection has been live since the last drop was reported.
+   * Guards the 'disconnected' event so listeners hear one drop per outage
+   * rather than one per failed retry.
+   */
+  private connectionOpen = false;
+  private onVisibilityChange: (() => void) | null = null;
 
   /**
    * Build the SSE URL with subscription subjects as query parameters.
@@ -67,33 +89,57 @@ export class SSEClient extends EventTarget {
     this.openConnection();
   }
 
+  /** Close and forget the current EventSource, if any. */
+  private closeEventSource(): void {
+    if (!this.eventSource) {
+      return;
+    }
+    this.eventSource.close();
+    this.eventSource = null;
+  }
+
   private openConnection(): void {
     if (this.subjects.length === 0) {
       return;
     }
 
+    this.watchVisibility();
+
+    // Any connection still held here would be orphaned by the assignment
+    // below: nothing else tracks it, so disconnect() could not close it and
+    // its onerror would tear down its own replacement.
+    this.closeEventSource();
+
+    this.generation++;
     const url = this.buildUrl(this.subjects);
     this.eventSource = new EventSource(url);
 
     this.eventSource.onopen = () => {
       this.reconnectAttempts = 0;
+      this.connectionOpen = true;
       console.info('[SSE] Connected');
     };
 
     this.eventSource.onerror = () => {
       // EventSource fires error when connection drops.
       // Close and attempt manual reconnect with backoff.
-      const readyState = this.eventSource?.readyState;
-      if (this.eventSource) {
-        this.eventSource.close();
-        this.eventSource = null;
+      const wasOpen = this.connectionOpen;
+      this.connectionOpen = false;
+      this.closeEventSource();
+
+      // Once per live connection, not once per failed retry.
+      if (wasOpen) {
+        this.dispatchEvent(new CustomEvent('disconnected'));
       }
 
-      // If the connection was never opened (CONNECTING → error), the
-      // server likely returned a non-200 (e.g. 302 redirect to login
-      // after session invalidation). Probe the auth endpoint before
-      // burning through reconnect attempts.
-      if (readyState === EventSource.CONNECTING) {
+      // A handshake that never opened may have been rejected rather than
+      // dropped - a 401, or a redirect to the login page after the session
+      // was invalidated - so probe auth before retrying it forever. A
+      // connection that was live and then failed is a network drop and goes
+      // straight to backoff. readyState cannot make this distinction: per
+      // spec a rejected handshake lands CLOSED and a mid-stream drop lands
+      // CONNECTING, which is the opposite way round.
+      if (!wasOpen) {
         void this.checkAuthAndReconnect();
       } else {
         this.scheduleReconnect();
@@ -111,6 +157,8 @@ export class SSEClient extends EventTarget {
     });
 
     // Handle server-initiated reconnect (e.g. before a clean shutdown).
+    // connectionOpen is left alone: the feed was live a moment ago, so if the
+    // replacement connection never lands, that still counts as a drop.
     this.eventSource.addEventListener('reconnect', () => {
       this.reconnectAttempts = 0;
       this.eventSource?.close();
@@ -139,6 +187,7 @@ export class SSEClient extends EventTarget {
    * redirect to the login page instead of retrying.
    */
   private async checkAuthAndReconnect(): Promise<void> {
+    const generation = this.generation;
     try {
       const resp = await fetch('/auth/me', { credentials: 'include' });
       if (resp.status === 401 || resp.redirected) {
@@ -150,22 +199,35 @@ export class SSEClient extends EventTarget {
     } catch {
       // Network error — fall through to normal reconnect.
     }
+    // A connect(), reconnectNow() or disconnect() during the await has already
+    // decided what happens next; scheduling here would race it.
+    if (generation !== this.generation) {
+      return;
+    }
     this.scheduleReconnect();
   }
 
+  /**
+   * Queue the next connection attempt with exponential backoff.
+   */
   private scheduleReconnect(): void {
-    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-      console.warn('[SSE] Max reconnect attempts reached, giving up');
-      this.dispatchEvent(new CustomEvent('disconnected'));
+    // A retry already queued, or a deliberate disconnect, cancels this one.
+    if (this.reconnectTimer !== null || this.subjects.length === 0) {
       return;
     }
 
+    // Jitter so open tabs do not retry in lockstep.
+    const cap =
+      this.reconnectAttempts < this.fastReconnectAttempts
+        ? this.fastReconnectCap
+        : this.slowReconnectCap;
+    const base = Math.min(cap, this.baseReconnectDelay * 2 ** this.reconnectAttempts);
+    const delay = base + Math.random() * 500;
     this.reconnectAttempts++;
-    const delay = this.baseReconnectDelay * Math.pow(2, this.reconnectAttempts - 1);
-    // Cap delay at 30 seconds
-    const cappedDelay = Math.min(delay, 30_000);
 
-    console.info(`[SSE] Reconnecting in ${cappedDelay}ms (attempt ${this.reconnectAttempts})`);
+    console.info(
+      `[SSE] Reconnecting in ${Math.round(delay)}ms (attempt ${this.reconnectAttempts})`
+    );
     this.dispatchEvent(
       new CustomEvent('reconnecting', { detail: { attempt: this.reconnectAttempts } })
     );
@@ -173,25 +235,80 @@ export class SSEClient extends EventTarget {
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       this.openConnection();
-    }, cappedDelay);
+    }, delay);
+  }
+
+  /**
+   * Cancel any pending backoff and connect immediately.
+   */
+  private reconnectNow(): void {
+    if (this.subjects.length === 0) {
+      return;
+    }
+
+    // Leave an open connection or in-flight handshake to resolve on its own.
+    const readyState = this.eventSource?.readyState;
+    if (readyState === EventSource.OPEN || readyState === EventSource.CONNECTING) {
+      return;
+    }
+
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+    this.openConnection();
+  }
+
+  /**
+   * Reconnect as soon as the tab is shown, not after whatever backoff was
+   * pending when it was hidden. Mobile browsers suspend a backgrounded tab and
+   * close its connections, so the feed is usually dead on return.
+   */
+  private watchVisibility(): void {
+    if (this.onVisibilityChange || typeof document === 'undefined') {
+      return;
+    }
+    this.onVisibilityChange = (): void => {
+      if (document.visibilityState !== 'visible') return;
+      if (this.connected || this.subjects.length === 0) return;
+      // Restart the backoff from the shortest delay.
+      this.reconnectAttempts = 0;
+      this.reconnectNow();
+    };
+    document.addEventListener('visibilitychange', this.onVisibilityChange);
   }
 
   /**
    * Close the SSE connection and cancel any pending reconnection.
+   *
+   * Also drops the visibility listener: it holds a reference to this client,
+   * and left behind it would reopen a connection the caller just tore down.
+   * connect() re-registers it, so a disconnected client stays reusable.
    */
   disconnect(): void {
+    // Supersede any in-flight auth probe, which would otherwise schedule a
+    // reconnect for a client the caller just tore down.
+    this.generation++;
+
     if (this.reconnectTimer !== null) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
 
-    if (this.eventSource) {
-      this.eventSource.close();
-      this.eventSource = null;
+    if (this.onVisibilityChange) {
+      document.removeEventListener('visibilitychange', this.onVisibilityChange);
+      this.onVisibilityChange = null;
     }
+
+    this.closeEventSource();
 
     this.subjects = [];
     this.reconnectAttempts = 0;
+    this.connectionOpen = false;
   }
 
   /** Whether the connection is currently open */

--- a/web/src/components/shared/chat/chat-thread.test.ts
+++ b/web/src/components/shared/chat/chat-thread.test.ts
@@ -643,3 +643,37 @@ describe('scion-chat-thread SSE attachment preview', () => {
     expect(chatMsg!.attachmentRefs[0].name).toBe('report.pdf');
   });
 });
+
+describe('scion-chat-thread catch-up after SSE reconnect', () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+    apiFetch.mockResolvedValue(emptyHistory());
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('refetches the latest page when the stream reconnects', async () => {
+    await mount();
+
+    // The first connection is not a gap: history was just loaded.
+    fakeStateManager.dispatchEvent(new CustomEvent('connected'));
+    expect(historyCalls()).toBe(0);
+
+    // A second connection means the stream died and came back; the hub keeps
+    // no event history, so anything sent meanwhile was never delivered.
+    fakeStateManager.dispatchEvent(new CustomEvent('connected'));
+    await vi.waitFor(() => expect(historyCalls()).toBe(1));
+  });
+
+  it('stops refetching once unmounted', async () => {
+    const el = await mount();
+    fakeStateManager.dispatchEvent(new CustomEvent('connected'));
+    el.remove();
+
+    fakeStateManager.dispatchEvent(new CustomEvent('connected'));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(historyCalls()).toBe(0);
+  });
+});

--- a/web/src/components/shared/chat/chat-thread.ts
+++ b/web/src/components/shared/chat/chat-thread.ts
@@ -367,6 +367,25 @@ export class ScionChatThread extends LitElement {
   /** Bound listener for v2 SSE chat-message events via stateManager. */
   private _v2MessageHandler = this.handleV2ChatMessage.bind(this);
 
+  /** True once an SSE connection has been observed while this thread listens. */
+  private _sawSseConnect = false;
+
+  /**
+   * The hub keeps no event history, so anything sent while the stream was down
+   * was never delivered; a reconnection refetches the latest page to fill the
+   * gap. mergeMessages dedupes, so overlap with what is already shown is safe.
+   */
+  private _sseReconnectHandler = (): void => {
+    if (!this._sawSseConnect) {
+      this._sawSseConnect = true;
+      return;
+    }
+    if (!this.loaded) return;
+    void this.fetchHistoryV2().catch((err) => {
+      console.warn('[chat-thread] catch-up fetch after reconnect failed:', err);
+    });
+  };
+
   /** Bound listener for v2 SSE typing events via stateManager. */
   private _v2TypingHandler = this.handleV2TypingEvent.bind(this);
 
@@ -823,6 +842,7 @@ export class ScionChatThread extends LitElement {
   /** Tear down v2 state so a fresh load can happen. */
   private resetV2State(): void {
     // Stop any active SSE listener
+    stateManager.removeEventListener('connected', this._sseReconnectHandler);
     stateManager.removeEventListener('chat-message-received', this._v2MessageHandler);
     stateManager.removeEventListener('chat-typing-received', this._v2TypingHandler);
     stateManager.removeEventListener('chat-read-state-updated', this._v2ReadStateHandler);
@@ -873,6 +893,7 @@ export class ScionChatThread extends LitElement {
     super.disconnectedCallback();
     this.stopStream();
     // Clean up v2 SSE listeners
+    stateManager.removeEventListener('connected', this._sseReconnectHandler);
     stateManager.removeEventListener('chat-message-received', this._v2MessageHandler);
     stateManager.removeEventListener('chat-typing-received', this._v2TypingHandler);
     stateManager.removeEventListener('chat-read-state-updated', this._v2ReadStateHandler);
@@ -1326,6 +1347,8 @@ export class ScionChatThread extends LitElement {
 
   /** Start listening for v2 messages via stateManager instead of per-thread EventSource. */
   private startStreamV2(): void {
+    this._sawSseConnect = stateManager.isConnected;
+    stateManager.addEventListener('connected', this._sseReconnectHandler);
     stateManager.addEventListener('chat-message-received', this._v2MessageHandler);
     stateManager.addEventListener('chat-typing-received', this._v2TypingHandler);
     stateManager.addEventListener('chat-read-state-updated', this._v2ReadStateHandler);


### PR DESCRIPTION
The shared SSE client carries live updates for the whole SPA — chat messages, agent status, notifications. It stops permanently after a few minutes of failure, and nothing brings it back but a manual page reload. 

These following defects make a mobile phone browser the worst case:

## 1. It gives up for good

```js
private maxReconnectAttempts = 10;
...
if (this.reconnectAttempts >= this.maxReconnectAttempts) {
  console.warn('[SSE] Max reconnect attempts reached, giving up');
  this.dispatchEvent(new CustomEvent('disconnected'));
  return;
}
```

With the delay capped at 30s that is roughly four to five minutes of failure before the page is permanently deaf. Nothing restarts it. The page looks fine and simply stops telling the truth.

## 2. Nothing reacts to the tab coming back

There was no `visibilitychange` handling at all. iOS Safari suspends a backgrounded tab and closes its connections, so a phone left alone burns its entire attempt budget while nobody is watching, and returns to a page that will never update again.

## How it presents

Found on a phone, against native web chat. Messages were sent, the agent acted on them and replied, the replies were written and stored correctly — and the page showed nothing. Reloading revealed them all at once.

## The change

- **Reconnect immediately when the tab becomes visible**, rather than waiting out a backoff nobody can see, and reset the attempt counter on that transition — a hidden tab must not spend the budget of a user who is about to come back.
- **Retry indefinitely** with the existing exponential backoff, capped at 30s and now jittered so multiple open tabs do not retry in lockstep. A page that has stopped listening is worse than a page that retries quietly once every 30 seconds; the cap on the *delay*, not on the *attempts*, is what protects an unreachable server.
- **Do not disturb a connection that is already open or mid-handshake.** Tab switching during a reconnect previously aborted each attempt and started over.
- **Remove the listener on teardown.** It holds a reference to the client, so leaving it attached leaks the client and lets a dead one react to visibility changes.

`disconnected` is still dispatched, so existing listeners keep working — `web/src/client/debug-log.ts` listens for `reconnecting` and is unaffected.

## Testing

- `npx vitest run src/client/sse-client.test.ts` — 16 tests on fake timers, all passing: the visible transition, the counter reset, the mid-handshake guard, teardown, retry past the old limit, and the event semantics.
- **Mutation-checked:** the suite was run against the previous implementation, where **9 of the 16 fail**. It discriminates rather than merely passing.
- `npx tsc --noEmit` clean, `npm run build` succeeds.
- **Note:** 43 tests fail on `main` in the `chat-*`/`notification-tray-chat` suites. Pre-existing and unrelated; confirmed on a clean checkout with none of these commits.

## Related

Same class of bug as the web terminal's WebSocket, fixed separately in #1249 — a stream that dies while the tab is hidden and never recovers. The two implementations are independent, so both needed it.
