### PR TITLE
fix(web): supply detail in SSE connected event and guard handlers by connection identity

### DIFF
--- a/web/src/client/sse-client.test.ts
+++ b/web/src/client/sse-client.test.ts
@@ -445,7 +445,7 @@ describe('SSEClient connected event', () => {
     const event = connected.mock.calls[0]?.[0] as CustomEvent;
     expect(event.detail).not.toBeNull();
     expect(event.detail).toEqual({
-      connectionId: expect.any(String),
+      connectionId: '',
       subjects: ['agent.>', 'project.123'],
     });
     client.disconnect();

--- a/web/src/client/sse-client.test.ts
+++ b/web/src/client/sse-client.test.ts
@@ -432,4 +432,22 @@ describe('SSEClient connected event', () => {
     expect(connected).toHaveBeenCalledTimes(2);
     client.disconnect();
   });
+
+  it('supplies a non-null detail matching SSEClientEventMap on the connected event', () => {
+    const client = new SSEClient();
+    const connected = vi.fn();
+    client.addEventListener('connected', connected);
+
+    client.connect(['agent.>', 'project.123']);
+    latest().simulateOpen();
+
+    expect(connected).toHaveBeenCalledTimes(1);
+    const event = connected.mock.calls[0]?.[0] as CustomEvent;
+    expect(event.detail).not.toBeNull();
+    expect(event.detail).toEqual({
+      connectionId: expect.any(String),
+      subjects: ['agent.>', 'project.123'],
+    });
+    client.disconnect();
+  });
 });

--- a/web/src/client/sse-client.ts
+++ b/web/src/client/sse-client.ts
@@ -128,7 +128,7 @@ export class SSEClient extends EventTarget {
       // catch-up refetch) would otherwise never hear anything.
       this.dispatchEvent(
         new CustomEvent('connected', {
-          detail: { connectionId: '', subjects: this.subjects },
+          detail: { connectionId: '', subjects: [...this.subjects] },
         })
       );
     };

--- a/web/src/client/sse-client.ts
+++ b/web/src/client/sse-client.ts
@@ -126,7 +126,11 @@ export class SSEClient extends EventTarget {
       // client also listens for is never emitted by the hub, so consumers that
       // need to know the stream is live (state.connected, the chat thread's
       // catch-up refetch) would otherwise never hear anything.
-      this.dispatchEvent(new CustomEvent('connected'));
+      this.dispatchEvent(
+        new CustomEvent('connected', {
+          detail: { connectionId: '', subjects: this.subjects },
+        })
+      );
     };
 
     es.onerror = () => {
@@ -156,6 +160,7 @@ export class SSEClient extends EventTarget {
 
     // Handle state update events from the server
     this.eventSource.addEventListener('update', (event) => {
+      if (es !== this.eventSource) return;
       try {
         const data = JSON.parse((event as MessageEvent).data) as SSEUpdateEvent;
         this.dispatchEvent(new CustomEvent('update', { detail: data }));
@@ -168,14 +173,16 @@ export class SSEClient extends EventTarget {
     // connectionOpen is left alone: the feed was live a moment ago, so if the
     // replacement connection never lands, that still counts as a drop.
     this.eventSource.addEventListener('reconnect', () => {
+      if (es !== this.eventSource) return;
       this.reconnectAttempts = 0;
-      this.eventSource?.close();
+      es.close();
       this.eventSource = null;
       this.openConnection();
     });
 
     // Handle initial connection acknowledgement
     this.eventSource.addEventListener('connected', (event) => {
+      if (es !== this.eventSource) return;
       try {
         const data = JSON.parse((event as MessageEvent).data) as {
           connectionId: string;


### PR DESCRIPTION
Follow-up to #1258. The onopen handler dispatched a connected CustomEvent with null detail, which threw a TypeError in debug-log.ts on every SSE connection (the listener accesses event.detail.connectionId without null-guard). Also adds identity guards to the three addEventListener-registered handlers (update, reconnect, server-sent connected) for consistency with onopen/onerror, and fixes the reconnect handler to close via the captured local es instead of this.eventSource.

Ref: ptone/scion#1258