### PR TITLE
fix(hub): serialize message timestamps as UTC

### DIFF
--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -228,7 +228,7 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		Channel:     req.Channel,
 		ThreadID:    req.ThreadID,
 		Visibility:  req.Visibility,
-		CreatedAt:   time.Now(),
+		CreatedAt:   time.Now().UTC(),
 	}
 
 	// Build a structured message for external dispatch paths.
@@ -709,7 +709,7 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 			Channel:       structuredMsg.Channel,
 			ThreadID:      structuredMsg.ThreadID,
 			DispatchState: store.MessageDispatchDispatched,
-			CreatedAt:     time.Now(),
+			CreatedAt:     time.Now().UTC(),
 		}
 		// Propagate GroupID from metadata so CLI-originated group[] messages
 		// preserve correlation in the store.
@@ -933,7 +933,7 @@ func (s *Server) handleGroupMessage(w http.ResponseWriter, r *http.Request, anch
 				AgentID:       agent.ID,
 				GroupID:       groupID,
 				DispatchState: store.MessageDispatchDispatched,
-				CreatedAt:     time.Now(),
+				CreatedAt:     time.Now().UTC(),
 			}
 			if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 				s.messageLog.Error("Failed to persist set message", "recipient", recipStr, "error", err)
@@ -1027,7 +1027,7 @@ func (s *Server) handleGroupMessage(w http.ResponseWriter, r *http.Request, anch
 				Urgent:      userMsg.Urgent,
 				AgentID:     anchorAgent.ID,
 				GroupID:     groupID,
-				CreatedAt:   time.Now(),
+				CreatedAt:   time.Now().UTC(),
 			}
 			if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 				s.messageLog.Error("Failed to persist set message", "recipient", recipStr, "error", err)
@@ -1233,7 +1233,7 @@ func (s *Server) broadcastDirect(w http.ResponseWriter, r *http.Request, project
 			Broadcasted:   true,
 			AgentID:       agent.ID,
 			DispatchState: store.MessageDispatchDispatched,
-			CreatedAt:     time.Now(),
+			CreatedAt:     time.Now().UTC(),
 		}
 		if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 			s.messageLog.Error("Failed to persist broadcast message", "agent_id", agent.ID, "error", err)
@@ -1360,7 +1360,7 @@ func (s *Server) processMentions(ctx context.Context, mentionSlugs []string, pri
 			Channel:       mentionMsg.Channel,
 			ThreadID:      mentionMsg.ThreadID,
 			DispatchState: store.MessageDispatchDispatched,
-			CreatedAt:     time.Now(),
+			CreatedAt:     time.Now().UTC(),
 		}
 		if mentionMsg.Metadata != nil {
 			storeMsg.GroupID = mentionMsg.Metadata["group_id"]

--- a/pkg/hub/handlers_agent_messaging_test.go
+++ b/pkg/hub/handlers_agent_messaging_test.go
@@ -264,3 +264,41 @@ func TestOutboundMessage_TranscriptMirrorDoesNotStarveAgentMessages(t *testing.T
 			rr.Code, rr.Body.String())
 	}
 }
+
+// TestOutboundMessageTimestampIsUTC pins stored message CreatedAt to UTC so
+// serialized timestamps carry a Z suffix rather than a server-local offset.
+func TestOutboundMessageTimestampIsUTC(t *testing.T) {
+	// On a UTC host local time IS UTC and the assertion below cannot fire, so
+	// the test would guard nothing on CI. Pin a non-UTC zone for its duration.
+	origLocal := time.Local
+	time.Local = time.FixedZone("TST", 2*60*60)
+	t.Cleanup(func() { time.Local = origLocal })
+
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{ID: api.NewUUID(), Name: "tz", Slug: "tz", Visibility: store.VisibilityPrivate}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	human := &store.User{ID: api.NewUUID(), Email: "human@example.com", DisplayName: "Human", Status: store.UserStatusActive}
+	if err := s.CreateUser(ctx, human); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	agent := &store.Agent{ID: api.NewUUID(), Name: "a", Slug: "a", ProjectID: project.ID, Phase: "running", Visibility: store.VisibilityPrivate}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	if rr := postOutbound(t, srv, project.ID, agent.ID, "hello"); rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	res, err := s.ListMessages(ctx, store.MessageFilter{}, store.ListOptions{Limit: 1})
+	if err != nil || len(res.Items) == 0 {
+		t.Fatalf("ListMessages: %v (%d items)", err, len(res.Items))
+	}
+	if _, off := res.Items[0].CreatedAt.Zone(); off != 0 {
+		t.Errorf("stored CreatedAt has offset %ds, want UTC", off)
+	}
+}

--- a/pkg/hub/handlers_agent_messaging_test.go
+++ b/pkg/hub/handlers_agent_messaging_test.go
@@ -270,6 +270,9 @@ func TestOutboundMessage_TranscriptMirrorDoesNotStarveAgentMessages(t *testing.T
 func TestOutboundMessageTimestampIsUTC(t *testing.T) {
 	// On a UTC host local time IS UTC and the assertion below cannot fire, so
 	// the test would guard nothing on CI. Pin a non-UTC zone for its duration.
+	// time.Local is process-global, so this test must stay non-parallel (no
+	// t.Parallel): go test runs a package's tests sequentially by default, and
+	// t.Cleanup restores the zone before any later test observes it.
 	origLocal := time.Local
 	time.Local = time.FixedZone("TST", 2*60*60)
 	t.Cleanup(func() { time.Local = origLocal })

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -452,7 +452,7 @@ func (p *MessageBrokerProxy) deliverToUser(ctx context.Context, projectID, topic
 		Channel:     msg.Channel,
 		ThreadID:    msg.ThreadID,
 		Visibility:  msg.Visibility,
-		CreatedAt:   time.Now(),
+		CreatedAt:   time.Now().UTC(),
 	}
 	if err := p.store.CreateMessage(ctx, storeMsg); err != nil {
 		p.log.Error("Failed to persist user message from broker", "topic", topic, "error", err)
@@ -591,7 +591,7 @@ func (p *MessageBrokerProxy) deliverToAgent(ctx context.Context, projectID, agen
 		Broadcasted:   msg.Broadcasted,
 		AgentID:       agent.ID,
 		DispatchState: store.MessageDispatchDispatched,
-		CreatedAt:     time.Now(),
+		CreatedAt:     time.Now().UTC(),
 	}
 	if err := p.store.CreateMessage(ctx, storeMsg); err != nil {
 		p.log.Error("Failed to persist broker message to store", "agentSlug", agentSlug, "error", err)

--- a/pkg/hub/notifications.go
+++ b/pkg/hub/notifications.go
@@ -489,7 +489,7 @@ func (nd *NotificationDispatcher) createInboxMessage(ctx context.Context, sub *s
 		Msg:         msgBody,
 		Type:        msgType,
 		AgentID:     agent.ID,
-		CreatedAt:   time.Now(),
+		CreatedAt:   time.Now().UTC(),
 	}
 
 	if err := nd.store.CreateMessage(ctx, storeMsg); err != nil {

--- a/pkg/store/entadapter/message_store.go
+++ b/pkg/store/entadapter/message_store.go
@@ -164,7 +164,9 @@ func (s *MessageStore) CreateMessage(ctx context.Context, msg *store.Message) er
 	if err != nil {
 		return mapError(err)
 	}
-	msg.CreatedAt = created.Created
+	// Zero input takes the ent default, which is local; normalise the value we
+	// hand back so the announced/serialised message is UTC like every other path.
+	msg.CreatedAt = created.Created.UTC()
 	msg.Type = created.Type
 	msg.DispatchState = created.DispatchState
 

--- a/pkg/store/entadapter/message_store.go
+++ b/pkg/store/entadapter/message_store.go
@@ -96,7 +96,7 @@ func entMessageToStore(e *ent.Message) *store.Message {
 		Channel:               e.Channel,
 		ThreadID:              e.ThreadID,
 		Visibility:            vis,
-		CreatedAt:             e.Created,
+		CreatedAt:             e.Created.UTC(),
 		DispatchState:         e.DispatchState,
 		DispatchedAt:          e.DispatchedAt,
 		DispatchFailureReason: e.DispatchFailureReason,
@@ -107,6 +107,11 @@ func entMessageToStore(e *ent.Message) *store.Message {
 func (s *MessageStore) CreateMessage(ctx context.Context, msg *store.Message) error {
 	if msg.ID == "" || msg.ProjectID == "" || msg.Msg == "" {
 		return store.ErrInvalidInput
+	}
+	// Canonical wire format is UTC. Normalising at the single point every
+	// message passes through covers all callers, present and future.
+	if !msg.CreatedAt.IsZero() {
+		msg.CreatedAt = msg.CreatedAt.UTC()
 	}
 	uid, err := parseUUID(msg.ID)
 	if err != nil {

--- a/pkg/store/entadapter/message_store_test.go
+++ b/pkg/store/entadapter/message_store_test.go
@@ -200,3 +200,49 @@ func TestCreateMessagePublishesEvent(t *testing.T) {
 	require.Len(t, pub.published, 1)
 	assert.Equal(t, msg.ID, pub.published[0].ID)
 }
+
+// TestCreateMessageReturnsUTCWhenCreatedAtZero covers the return path when the
+// caller supplies no timestamp and the ent schema default (local time) fills
+// it in. CreateMessage announces and hands back this same object, so a local
+// zone here would serialize a stale offset. See the gemini review on #1263.
+func TestCreateMessageReturnsUTCWhenCreatedAtZero(t *testing.T) {
+	// Pin a non-UTC zone so a missed .UTC() shows a non-zero offset; on a UTC
+	// host the two coincide and the assertion could not fire. time.Local is
+	// process-global — keep this test non-parallel; t.Cleanup restores it.
+	origLocal := time.Local
+	time.Local = time.FixedZone("TST", 2*60*60)
+	t.Cleanup(func() { time.Local = origLocal })
+
+	s := newTestMessageStore(t)
+	ctx := context.Background()
+
+	msg := newTestMessage(uuid.NewString(), "agent-1")
+	msg.CreatedAt = time.Time{} // caller supplies no timestamp
+	require.NoError(t, s.CreateMessage(ctx, msg))
+
+	require.False(t, msg.CreatedAt.IsZero())
+	_, offset := msg.CreatedAt.Zone()
+	assert.Equal(t, 0, offset, "returned CreatedAt must be UTC (zero offset), got %s", msg.CreatedAt)
+}
+
+// TestCreateMessageNormalizesNonUTCInputToUTC checks the input path with an
+// explicit non-UTC zone instead of mutating time.Local, so it is parallel-safe
+// and host-independent. It asserts the UTC shape of the result and that the
+// instant is preserved (noon at +02:00 is 10:00 UTC). It cannot isolate the
+// post-Save return normalization — the top-of-function input normalization masks
+// it; TestCreateMessageReturnsUTCWhenCreatedAtZero covers that path.
+func TestCreateMessageNormalizesNonUTCInputToUTC(t *testing.T) {
+	t.Parallel()
+
+	s := newTestMessageStore(t)
+	ctx := context.Background()
+
+	msg := newTestMessage(uuid.NewString(), "agent-1")
+	msg.CreatedAt = time.Date(2026, 1, 2, 12, 0, 0, 0, time.FixedZone("TST", 2*60*60))
+	require.NoError(t, s.CreateMessage(ctx, msg))
+
+	require.False(t, msg.CreatedAt.IsZero())
+	_, offset := msg.CreatedAt.Zone()
+	assert.Equal(t, 0, offset, "returned CreatedAt must be UTC, got %s", msg.CreatedAt)
+	assert.Equal(t, 10, msg.CreatedAt.UTC().Hour(), "instant must be preserved: 12:00+02:00 == 10:00Z")
+}


### PR DESCRIPTION
One conversation mixes Z-suffixed and offset-suffixed RFC3339Nano timestamps: the chat send path stamps `CreatedAt` in UTC (`handlers_chat_v2.go`), while nine other message-writing sites — agent messaging, broker delivery, the notification inbox mirror — stamp server-local time.

Mixed formats are the defect regardless of any particular parser. Observed in the field on iOS Safari: agent replies displayed skewed by exactly the server's UTC offset while the viewer's own Z-stamped messages in the same thread displayed correctly — consistent with the offset being ignored on parse. Current JavaScriptCore parses these forms correctly, so the affected engine version wasn't pinned down; historical WebKit rejected long-fraction-plus-offset timestamps outright (moment#1200, date-fns#1924). Serializing UTC everywhere removes the class rather than arguing with parsers.

## The change — three layers, so the property holds structurally

- The nine local stamps now match the chat path's `.UTC()`.
- `CreateMessage` normalizes `CreatedAt` at the single point every message passes through, covering current and future callers (including the ent schema default, which is local).
- The read side (`entMessageToStore`) normalizes too. This is what fixes **Postgres** — pgx re-localizes `timestamptz` to process-local on scan regardless of what was stamped — and makes **historical rows** serialize as UTC instead of waiting for time to heal them.

## One-time boundary worth knowing

Rows written before the fix keep local-zone storage; in SQLite's TEXT ordering they interleave with new rows inside a stratum as wide as the server's offset. The chat client re-sorts fetched pages by epoch, and the same misordering already existed continuously between chat sends and agent stamps — so this converts a permanent skew into a one-time artifact.

## Testing

- `go test ./pkg/hub/ -run TestOutboundMessageTimestampIsUTC` — posts an outbound message and asserts the stored row reads back with zero offset, through the real store.
- The test **pins a non-UTC local zone for its duration**: on a UTC host local time *is* UTC and the assertion could never fire — which is exactly what CI runners are. Verified under `TZ=UTC`: the test fails against the reverted implementation (offset 7200s detected) and passes against the fix.
- `go build ./...` clean.
- **Note:** six tests fail on `main` in `pkg/hub` (`TestBypassAgents_404Before403Ordering`, `TestClassifyPath_*`, `TestFSValidatePath_ManagedOverlap`, `TestFSList_*`) — pre-existing, environment-dependent, identical on a clean checkout.

## Verified live

Deployed against a real hub with a UTC+3 viewer talking to a UTC+2 server: new agent replies carry `Z` and display at the correct local time; the viewer's exact symptom (replies two hours late beside correctly-timed own messages) is gone.
