### PR TITLE
docs: rename gemini.md to GEMINI.md and fix casing

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/gemini.md
+++ b/gemini.md
@@ -1,1 +1,0 @@
-agents.md


### PR DESCRIPTION
Fixes the broken gemini.md symlink by renaming it to GEMINI.md (uppercase) and pointing it to AGENTS.md, resolving case-sensitivity issues on Linux.