### PR TITLE
fix(grok-build): remove GROK_HOME from env_template to fix auth path in container

### DIFF
--- a/harnesses/grok-build/capture_auth.py
+++ b/harnesses/grok-build/capture_auth.py
@@ -12,82 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Capture-auth for grok-build — delegates to the standard capture flow,
-then captures ~/.grok/auth.json as a GROK_AUTH file secret."""
+"""Capture-auth shim for grok-build — delegates to the standard capture flow.
+
+The standard capture_auth_main() handles GROK_AUTH capture via the
+auto-generated capture-auth-config.json (derived from config.yaml's
+auth.types.auth-file.required_files). No custom capture logic is needed.
+"""
 
 import os
-import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import scion_harness
 
-_GROK_AUTH = os.path.join(
-    os.environ.get("HOME") or os.path.expanduser("~"),
-    ".grok", "auth.json",
-)
-
-
-def _capture_auth_json(force: bool = False, scope: str = "project") -> bool:
-    """Capture ~/.grok/auth.json as a GROK_AUTH file secret."""
-    if not os.path.isfile(_GROK_AUTH):
-        print(
-            f"capture-auth: {_GROK_AUTH} not found — "
-            "run 'grok login --device-auth' first, then re-run this script",
-            file=sys.stderr,
-        )
-        return False
-
-    cmd = [
-        "sciontool", "secret", "set", "GROK_AUTH",
-        f"@{_GROK_AUTH}",
-        "--type", "file",
-        "--target", _GROK_AUTH,
-        "--scope", scope,
-    ]
-    if force:
-        cmd.append("--force")
-
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    except FileNotFoundError:
-        print("capture-auth: sciontool not found in PATH", file=sys.stderr)
-        return False
-    except subprocess.TimeoutExpired:
-        print("capture-auth: sciontool timed out setting GROK_AUTH", file=sys.stderr)
-        return False
-
-    if result.returncode != 0:
-        stderr = result.stderr.strip()
-        if "already exists" in stderr.lower():
-            print(
-                'capture-auth: GROK_AUTH already exists (use --force to overwrite)',
-            )
-            return False
-        print(f"capture-auth: failed to set GROK_AUTH: {stderr}", file=sys.stderr)
-        return False
-
-    print(f"capture-auth: GROK_AUTH: captured from {_GROK_AUTH}")
-    return True
-
-
 if __name__ == "__main__":
-    import argparse
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--scope", choices=["project", "user"], default="project")
-    known, _ = parser.parse_known_args()
-
-    rc = scion_harness.capture_auth_main()
-
-    force = "--force" in sys.argv
-    config_ok = _capture_auth_json(force, known.scope)
-
-    if rc == 0 and not config_ok:
-        # capture_auth_main succeeded (e.g. env-key) but grok auth.json
-        # capture failed — report partial success with non-zero exit.
-        print("capture-auth: warning: env-key captured but ~/.grok/auth.json not found",
-              file=sys.stderr)
-        sys.exit(1)
-    if rc != 0 and config_ok:
-        sys.exit(0)
-    sys.exit(rc)
+    sys.exit(scion_harness.capture_auth_main())

--- a/harnesses/grok-build/config.yaml
+++ b/harnesses/grok-build/config.yaml
@@ -46,7 +46,6 @@ command:
 
 env_template:
   SCION_AGENT_NAME: "{{ .AgentName }}"
-  GROK_HOME: "{{ .AgentHome }}/.grok"
   NO_COLOR: "1"
 
 capabilities:

--- a/harnesses/grok-build/provision.py
+++ b/harnesses/grok-build/provision.py
@@ -106,7 +106,7 @@ def _write_auth_file(ctx: scion_harness.ProvisionContext) -> None:
         raise scion_harness.ProvisionError(
             f"GROK_AUTH secret is not valid JSON: {exc}"
         ) from exc
-    config_dir = scion_harness.expand_path("~/.grok")
+    config_dir = os.environ.get("GROK_HOME") or scion_harness.expand_path("~/.grok")
     os.makedirs(config_dir, exist_ok=True)
     target = os.path.join(config_dir, "auth.json")
     tmp = target + ".tmp"


### PR DESCRIPTION
## Summary

- Remove `GROK_HOME` from `env_template` in config.yaml — `{{ .AgentHome }}` resolves to the host-side path, not the container-side path, causing grok to write auth.json to the wrong location inside the container
- Simplify `capture_auth.py` to standard two-line shim — the custom `_capture_auth_json()` was redundant with the standard `capture_auth_main()` flow and caused a duplicate capture conflict
- Make `provision.py` `_write_auth_file()` GROK_HOME-aware as fallback

## Files changed
- `harnesses/grok-build/config.yaml` (1 line removed)
- `harnesses/grok-build/capture_auth.py` (simplified to standard shim)
- `harnesses/grok-build/provision.py` (1 line changed)
