### PR TITLE
fix(grok-build): check disk for broker-staged auth.json before read_file_secret

### DIFF
--- a/harnesses/grok-build/provision.py
+++ b/harnesses/grok-build/provision.py
@@ -91,7 +91,27 @@ def _read_token(ctx: scion_harness.ProvisionContext, env_key: str) -> str:
 
 
 def _write_auth_file(ctx: scion_harness.ProvisionContext) -> None:
-    """Write ~/.grok/auth.json from a staged GROK_AUTH file secret."""
+    """Write ~/.grok/auth.json from a staged GROK_AUTH file secret.
+
+    The broker may stage the file directly to the target path via secret
+    injection, bypassing the auth-candidates file_secret_files metadata.
+    Check the target path first before trying read_file_secret().
+    """
+    config_dir = os.environ.get("GROK_HOME") or scion_harness.expand_path("~/.grok")
+    target = os.path.join(config_dir, "auth.json")
+
+    # Check if broker already staged the file directly
+    if os.path.isfile(target):
+        try:
+            with open(target, "r", encoding="utf-8") as f:
+                content = f.read()
+            json.loads(content)  # Validate JSON
+            ctx.info("auth.json already present on disk (broker-staged)")
+            return
+        except (OSError, json.JSONDecodeError):
+            pass  # Fall through to secret-based write
+
+    # Fall back to reading from file_secret_files metadata
     content = ctx.read_file_secret("GROK_AUTH")
     if not content:
         raise scion_harness.ProvisionError(
@@ -106,9 +126,7 @@ def _write_auth_file(ctx: scion_harness.ProvisionContext) -> None:
         raise scion_harness.ProvisionError(
             f"GROK_AUTH secret is not valid JSON: {exc}"
         ) from exc
-    config_dir = os.environ.get("GROK_HOME") or scion_harness.expand_path("~/.grok")
     os.makedirs(config_dir, exist_ok=True)
-    target = os.path.join(config_dir, "auth.json")
     tmp = target + ".tmp"
     with open(tmp, "w", encoding="utf-8") as f:
         f.write(content)

--- a/harnesses/grok-build/provision_test.py
+++ b/harnesses/grok-build/provision_test.py
@@ -325,6 +325,26 @@ class WriteAuthFileTest(unittest.TestCase):
                     provision._write_auth_file(ctx)
                 self.assertIn("not valid JSON", str(cm.exception))
 
+    def test_auth_file_already_on_disk(self) -> None:
+        """Broker-staged auth.json is accepted without read_file_secret."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs_dir = os.path.join(tmp, "inputs")
+            os.makedirs(inputs_dir)
+            scion_harness.atomic_write_json(
+                os.path.join(inputs_dir, "auth-candidates.json"),
+                {"file_secret_files": {}},
+            )
+            ctx = _make_ctx({"harness_bundle_dir": tmp})
+            grok_dir = os.path.join(tmp, ".grok")
+            os.makedirs(grok_dir)
+            auth_path = os.path.join(grok_dir, "auth.json")
+            with open(auth_path, "w") as f:
+                json.dump({"token": "test123"}, f)
+            with temporary_home(tmp):
+                provision._write_auth_file(ctx)
+            # Should succeed without raising ProvisionError
+            self.assertTrue(os.path.isfile(auth_path))
+
     def test_output_file_has_0600_permissions(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             inputs_dir = os.path.join(tmp, "inputs")


### PR DESCRIPTION
## Summary

- Check if `~/.grok/auth.json` already exists on disk before calling `read_file_secret("GROK_AUTH")`
- When the broker stages file-type secrets via direct injection, the file arrives at its target path but `auth-candidates.json` `file_secret_files` is empty. The provisioner now detects the existing valid file and returns early.
- Adds test for the broker-staged auth path

Structural fix for the Go-side metadata gap tracked separately.

## Files changed
- `harnesses/grok-build/provision.py` — disk check before read_file_secret
- `harnesses/grok-build/provision_test.py` — new test_auth_file_already_on_disk
