### PR TITLE
fix(harness): populate file_secret_files from broker-staged file secrets

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -503,9 +503,15 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		// Keep a copy of the full resolved auth material for secret filtering.
 		resolvedForSecretFilter := *resolved
 		if opts.BrokerMode {
-			// File projection is handled by writeFileSecrets() from ResolvedSecrets
-			// at container launch, not by applyResolvedAuth from local paths.
-			resolved.Files = nil
+			// File content projection is handled by writeFileSecrets() from
+			// ResolvedSecrets at container launch (via SCION_STAGED_SECRETS),
+			// not by applyResolvedAuth from local paths. Clear SourcePath so
+			// stageFileSecretFiles won't try to read host files, but preserve
+			// ContainerPath so it can populate file_secret_files in
+			// auth-candidates.json.
+			for i := range resolved.Files {
+				resolved.Files[i].SourcePath = ""
+			}
 		}
 		util.Debugf("auth: resolved — method=%q, envVars=%v, files=%d", resolved.Method, resolved.EnvVars, len(resolved.Files))
 		if err := harness.ValidateAuth(resolved); err != nil {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -501,7 +501,20 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 			return nil, fmt.Errorf("auth resolution failed: %w", err)
 		}
 		// Keep a copy of the full resolved auth material for secret filtering.
+		// Deep-copy the Files slice so in-place SourcePath clearing below
+		// does not leak into resolvedForSecretFilter.
 		resolvedForSecretFilter := *resolved
+		resolvedForSecretFilter.Files = append([]api.FileMapping(nil), resolved.Files...)
+		util.Debugf("auth: resolved — method=%q, envVars=%v, files=%d", resolved.Method, resolved.EnvVars, len(resolved.Files))
+		if err := harness.ValidateAuth(resolved); err != nil {
+			if canFallbackToNoAuth() {
+				util.Debugf("auth: validation failed, falling back to no-auth mode: %v", err)
+				opts.NoAuth = true
+				warnings = append(warnings, "Auth: credential validation failed, starting in no-auth mode")
+				goto authDone
+			}
+			return nil, fmt.Errorf("auth validation failed: %w", err)
+		}
 		if opts.BrokerMode {
 			// File content projection is handled by writeFileSecrets() from
 			// ResolvedSecrets at container launch (via SCION_STAGED_SECRETS),
@@ -512,16 +525,6 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 			for i := range resolved.Files {
 				resolved.Files[i].SourcePath = ""
 			}
-		}
-		util.Debugf("auth: resolved — method=%q, envVars=%v, files=%d", resolved.Method, resolved.EnvVars, len(resolved.Files))
-		if err := harness.ValidateAuth(resolved); err != nil {
-			if canFallbackToNoAuth() {
-				util.Debugf("auth: validation failed, falling back to no-auth mode: %v", err)
-				opts.NoAuth = true
-				warnings = append(warnings, "Auth: credential validation failed, starting in no-auth mode")
-				goto authDone
-			}
-			return nil, fmt.Errorf("auth validation failed: %w", err)
 		}
 		// Allow harnesses to update their native settings files (e.g. Gemini settings.json)
 		if applier, ok := h.(api.AuthSettingsApplier); ok {

--- a/pkg/harness/container_script_harness.go
+++ b/pkg/harness/container_script_harness.go
@@ -678,8 +678,11 @@ func (c *ContainerScriptHarness) stageFileSecretFiles(agentHome string, files []
 		}
 
 		if f.SourcePath == "" {
-			// No host path to read; keep as bind-mount fallback.
-			remaining = append(remaining, f)
+			// Broker mode: file content is staged via SCION_STAGED_SECRETS
+			// (stagedsecrets.Write), so there is no host-side source path.
+			// Record the container target path in file_secret_files so the
+			// container-side provisioner script can locate the file.
+			fileSecretFiles[matchedName] = normCP
 			continue
 		}
 

--- a/pkg/harness/container_script_harness_test.go
+++ b/pkg/harness/container_script_harness_test.go
@@ -781,6 +781,102 @@ func TestContainerScriptHarness_ApplyAuthSettings_StagesFileSecrets_AbsolutePath
 	}
 }
 
+func TestContainerScriptHarness_ApplyAuthSettings_BrokerModePopulatesFileSecretFiles(t *testing.T) {
+	// In broker mode, file content is staged via SCION_STAGED_SECRETS by
+	// stagedsecrets.Write(), so FileMappings arrive with SourcePath=""
+	// (cleared by run.go). stageFileSecretFiles must still populate the
+	// file_secret_files map entry pointing to the ContainerPath so the
+	// container-side provisioner can find the file. No secret file should
+	// be written to the secrets dir (the broker already handled that).
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "config.yaml"), "harness: codex\nimage: scion-codex:latest\n")
+	writeFile(t, filepath.Join(dir, "provision.py"), "#!/usr/bin/env python3\nimport sys\nsys.exit(0)\n")
+
+	entry := config.HarnessConfigEntry{
+		Harness: "codex",
+		Image:   "scion-codex:latest",
+		Provisioner: &config.HarnessProvisionerConfig{
+			Type:             "container-script",
+			InterfaceVersion: 1,
+			Command:          []string{"python3", "$HOME/.scion/harness/provision.py"},
+		},
+		Auth: &config.HarnessAuthMetadata{
+			Types: map[string]config.HarnessAuthTypeMetadata{
+				"auth-file": {
+					RequiredFiles: []config.HarnessAuthFileRequirement{
+						{
+							Name:         "CODEX_AUTH",
+							Type:         "file",
+							TargetSuffix: "/.codex/auth.json",
+							Field:        "CodexAuthFile",
+						},
+					},
+				},
+			},
+		},
+	}
+	h, err := NewContainerScriptHarness(dir, entry)
+	if err != nil {
+		t.Fatalf("NewContainerScriptHarness: %v", err)
+	}
+
+	agentHome := t.TempDir()
+
+	// Broker mode: SourcePath is empty (cleared by run.go), ContainerPath
+	// is preserved so the map entry can be populated.
+	resolved := &api.ResolvedAuth{
+		Method:  "container-script",
+		EnvVars: map[string]string{},
+		Files: []api.FileMapping{
+			{SourcePath: "", ContainerPath: "~/.codex/auth.json"},
+		},
+	}
+
+	if err := h.ApplyAuthSettings(agentHome, resolved); err != nil {
+		t.Fatalf("ApplyAuthSettings: %v", err)
+	}
+
+	// The FileMapping should have been consumed — NOT kept as a bind-mount.
+	if len(resolved.Files) != 0 {
+		t.Errorf("expected resolved.Files to be empty after staging; got %+v", resolved.Files)
+	}
+
+	// No secret file should be staged (broker handles content staging).
+	secretPath := filepath.Join(agentHome, ".scion", "harness", "secrets", "CODEX_AUTH")
+	if _, err := os.Stat(secretPath); err == nil {
+		t.Errorf("secret file should NOT be staged in broker mode; found at %s", secretPath)
+	}
+
+	// auth-candidates.json must have file_secret_files.CODEX_AUTH pointing
+	// to the container path where the broker stages the file.
+	data, err := os.ReadFile(filepath.Join(agentHome, ".scion", "harness", "inputs", "auth-candidates.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]interface{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	fsf, ok := payload["file_secret_files"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("file_secret_files missing or wrong type: %T", payload["file_secret_files"])
+	}
+	codexAuthPath, ok := fsf["CODEX_AUTH"].(string)
+	if !ok || codexAuthPath == "" {
+		t.Errorf("file_secret_files.CODEX_AUTH missing or empty: %v", fsf)
+	}
+	// The path should be the normalized ContainerPath ($HOME/... form).
+	if codexAuthPath != "$HOME/.codex/auth.json" {
+		t.Errorf("file_secret_files.CODEX_AUTH=%q, want $HOME/.codex/auth.json", codexAuthPath)
+	}
+
+	// The files array should be empty (no bind-mounts).
+	filesRaw, _ := payload["files"].([]interface{})
+	if len(filesRaw) != 0 {
+		t.Errorf("files array should be empty; got %v", filesRaw)
+	}
+}
+
 func TestContainerScriptHarness_ApplyAuthSettings_NonFileCredentialKeptAsBindMount(t *testing.T) {
 	// FileMappings for credentials without a required_files declaration should
 	// remain as bind-mounts (not staged as secrets).


### PR DESCRIPTION
In broker mode, file-type secrets (GROK_AUTH, COPILOT_CONFIG, etc) are staged
to disk by the broker via SCION_STAGED_SECRETS, but auth-candidates.json file_secret_files
was empty. The Python provisioner read_file_secret() returned empty, causing ProvisionError.

Root cause: run.go set resolved.Files = nil in broker mode before ApplyAuthSettings could
populate the file_secret_files map in auth-candidates.json.

Fix:
- Clear SourcePath (not the slice) after ValidateAuth, preserving ContainerPath metadata
- Deep-copy Files slice for resolvedForSecretFilter to prevent mutation leak
- stageFileSecretFiles records container target path for broker-mode entries without
  staging content (broker already did that)

Affects all container-script harnesses using auth-file type with required_files.

Closes ptone/scion#1229