### PR TITLE
fix(hub): accept text files with unusual control chars in attachment upload

### DIFF
--- a/pkg/hub/attachment_classify.go
+++ b/pkg/hub/attachment_classify.go
@@ -111,7 +111,7 @@ func ClassifyAttachment(filename string, head []byte) (string, error) {
 	// binary payload wearing a .json name should not become an attachment the
 	// UI offers to preview as source.
 	if textLikeExtensions[ext] {
-		if !isTextContentType(detected) {
+		if !isTextContentType(detected, head) {
 			return "", fmt.Errorf("%s content does not look like text", ext)
 		}
 		if ext == ".md" {
@@ -136,11 +136,23 @@ func ClassifyAttachment(filename string, head []byte) (string, error) {
 // text/html or text/xml when the content opens with markup — a Markdown file
 // starting with a tag, say. All of them are text; which of them a text-like
 // extension is stored as is decided by the extension, not by this.
-func isTextContentType(detected string) bool {
-	// text/* types are obviously text. application/octet-stream is Go's
-	// http.DetectContentType fallback for "I don't know" — it fires for
-	// valid UTF-8 containing control characters the sniffer doesn't expect
-	// (e.g. vertical tab 0x0B). Since the caller already confirmed a
-	// text-like extension, treating "I don't know" as text is safe.
-	return strings.HasPrefix(detected, "text/") || detected == "application/octet-stream"
+func isTextContentType(detected string, head []byte) bool {
+	if strings.HasPrefix(detected, "text/") {
+		return true
+	}
+	// application/octet-stream is Go's http.DetectContentType fallback
+	// for "I don't know" — it fires for valid UTF-8 containing control
+	// characters the sniffer doesn't expect (e.g. vertical tab 0x0B).
+	// Since the caller already confirmed a text-like extension, treat
+	// "I don't know" as text unless the content contains null bytes,
+	// which are characteristic of genuinely binary files.
+	if detected == "application/octet-stream" {
+		for _, b := range head {
+			if b == 0 {
+				return false
+			}
+		}
+		return true
+	}
+	return false
 }

--- a/pkg/hub/attachment_classify.go
+++ b/pkg/hub/attachment_classify.go
@@ -137,5 +137,10 @@ func ClassifyAttachment(filename string, head []byte) (string, error) {
 // starting with a tag, say. All of them are text; which of them a text-like
 // extension is stored as is decided by the extension, not by this.
 func isTextContentType(detected string) bool {
-	return strings.HasPrefix(detected, "text/")
+	// text/* types are obviously text. application/octet-stream is Go's
+	// http.DetectContentType fallback for "I don't know" — it fires for
+	// valid UTF-8 containing control characters the sniffer doesn't expect
+	// (e.g. vertical tab 0x0B). Since the caller already confirmed a
+	// text-like extension, treating "I don't know" as text is safe.
+	return strings.HasPrefix(detected, "text/") || detected == "application/octet-stream"
 }

--- a/pkg/hub/attachment_classify_test.go
+++ b/pkg/hub/attachment_classify_test.go
@@ -332,6 +332,28 @@ func TestClassifyAttachment_TextWithUnusualControlChars(t *testing.T) {
 			}
 		})
 	}
+
+	// Null bytes in content with a text-like extension should be rejected —
+	// they indicate genuinely binary data wearing a text-like name.
+	nullTests := []struct {
+		name     string
+		filename string
+		head     []byte
+	}{
+		{
+			name:     "text with null byte",
+			filename: "doc.md",
+			head:     []byte("# Title\x00binary"),
+		},
+	}
+	for _, tt := range nullTests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ClassifyAttachment(tt.filename, tt.head)
+			if err == nil {
+				t.Errorf("ClassifyAttachment(%q) accepted content with null bytes; want rejection", tt.filename)
+			}
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/hub/attachment_classify_test.go
+++ b/pkg/hub/attachment_classify_test.go
@@ -279,6 +279,61 @@ func TestClassifyAttachment_EmptyFileIsText(t *testing.T) {
 	}
 }
 
+// Text files with unusual control characters (e.g. vertical tab 0x0B) cause
+// Go's http.DetectContentType to return application/octet-stream, which used
+// to be rejected. Since the extension is a known text-like extension, the
+// content sniffer's "I don't know" should be treated as text.
+func TestClassifyAttachment_TextWithUnusualControlChars(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		head     []byte
+		wantMIME string
+	}{
+		{
+			name:     "markdown with vertical tab",
+			filename: "doc.md",
+			head:     []byte("# Title\n\nSome text\x0bMore text\n"),
+			wantMIME: "text/markdown",
+		},
+		{
+			name:     "json with vertical tab",
+			filename: "config.json",
+			head:     []byte("{\"key\": \"value\x0b\"}\n"),
+			wantMIME: "text/plain",
+		},
+		{
+			name:     "yaml with vertical tab",
+			filename: "deploy.yaml",
+			head:     []byte("services:\n  hub:\x0b {}\n"),
+			wantMIME: "text/plain",
+		},
+		{
+			name:     "go source with vertical tab",
+			filename: "main.go",
+			head:     []byte("package main\n\nfunc main() {\x0b}\n"),
+			wantMIME: "text/plain",
+		},
+		{
+			name:     "log with vertical tab",
+			filename: "app.log",
+			head:     []byte("2026-01-01 INFO started\x0bmore output\n"),
+			wantMIME: "text/plain",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ClassifyAttachment(tt.filename, tt.head)
+			if err != nil {
+				t.Fatalf("ClassifyAttachment(%q) error: %v", tt.filename, err)
+			}
+			if got != tt.wantMIME {
+				t.Errorf("ClassifyAttachment(%q) = %q, want %q", tt.filename, got, tt.wantMIME)
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Upload handler: classification and per-file results
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes attachment upload rejecting valid text files (e.g. markdown from Google Docs) that contain unusual control characters like vertical tab (0x0B)
- Go's `http.DetectContentType` treats vertical tab as binary, returning `application/octet-stream` — our `isTextContentType` now also accepts that fallback since the caller already confirmed a text-like extension
- Adds 5 test cases covering .md, .json, .yaml, .go, and .log files with vertical tab

Fork staging: ptone/scion#1232

## Test plan
- [x] `go test ./pkg/hub/... -run Classify -v` — all pass including new cases
- [x] `go build` / `go vet` / `gofmt` — clean
- [x] CI green on fork staging PR ptone/scion#1232