### PR TITLE
feat(grok-build): add Vertex AI support via auth_provider and custom model config

### DIFF
--- a/docs-site/src/content/docs/supported-harnesses.md
+++ b/docs-site/src/content/docs/supported-harnesses.md
@@ -233,6 +233,12 @@ from the `XAI_API_KEY` environment variable.
 Alternatively, a file-based auth method (`auth-file`) is supported using `~/.grok/auth.json`,
 produced by `grok login --device-auth`. Capture the credential with `capture_auth.py` after login.
 
+A **Vertex AI** auth method (`vertex-ai`) routes inference through Google Cloud's Vertex AI
+Model Garden. Set `GOOGLE_CLOUD_PROJECT` and optionally `GOOGLE_CLOUD_REGION` (defaults to the
+global endpoint). The provisioner writes `[auth_provider]` and `[model]` entries to
+`~/.grok/config.toml` using `gcloud auth print-access-token` for on-demand token refresh.
+Application Default Credentials (ADC) are placed automatically when staged.
+
 If no credentials are found, the agent drops to a shell — run `grok login --device-auth`
 interactively, then capture the credential with the container's `capture_auth.py`
 (see [Harness Authentication](/scion/local/agent-credentials/#capturing-credentials-from-a-running-agent)).
@@ -241,6 +247,7 @@ interactively, then capture the credential with the container's `capture_auth.py
 |---|---|---|
 | API Key | `XAI_API_KEY` | Set env var with xAI API key |
 | Auth File | `~/.grok/auth.json` | `grok login --device-auth` + capture |
+| Vertex AI | `GOOGLE_CLOUD_PROJECT` | Set env var with GCP project ID |
 
 ### Configuration
 - **Config directory**: `~/.grok/` (settings in `config.toml`).
@@ -277,7 +284,7 @@ The following table summarizes the capabilities supported by each agent harness 
 | **Auth: API Key** | ✅ | ✅ | ✅ | ✅ | ✅¹ | ✅ | ❌ | ✅ |
 | **Auth: OAuth Token** | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | **Auth: Auth File** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅² | ✅ |
-| **Auth: Vertex AI** | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| **Auth: Vertex AI** | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
 
 * **Resume with Prompt**: Ability to provide a new task/prompt when resuming an existing session.
 * **Interject** (pending feature): Key used to interrupt the agent (e.g., stop generation).

--- a/harnesses/grok-build/config.yaml
+++ b/harnesses/grok-build/config.yaml
@@ -63,7 +63,7 @@ capabilities:
     api_key: { support: "yes" }
     auth_file: { support: "yes" }
     oauth_token: { support: "no" }
-    vertex_ai: { support: "no", reason: "Grok CLI only supports xAI API authentication" }
+    vertex_ai: { support: "yes" }
   mcp:
     stdio: { support: "yes" }
     sse: { support: "yes" }
@@ -90,8 +90,18 @@ auth:
           type: file
           target_suffix: "/.grok/auth.json"
           field: GrokAuthFile
+    vertex-ai:
+      required_env:
+        - any_of: ["GOOGLE_CLOUD_PROJECT"]
+      required_files:
+        - name: gcloud-adc
+          type: file
+          field: GoogleAppCredentials
+          target_suffix: "/.config/gcloud/application_default_credentials.json"
   autodetect:
     env:
       XAI_API_KEY: api-key
+      GOOGLE_CLOUD_PROJECT: vertex-ai
     files:
       GROK_AUTH: auth-file
+      gcloud-adc: vertex-ai

--- a/harnesses/grok-build/provision.py
+++ b/harnesses/grok-build/provision.py
@@ -169,15 +169,18 @@ def _configure_vertex_ai(
         adc_dir = os.path.join(ctx.home, ".config", "gcloud")
         os.makedirs(adc_dir, exist_ok=True)
         adc_target = os.path.join(adc_dir, "application_default_credentials.json")
-        scion_harness.atomic_write_text(adc_target, adc_content)
-        os.chmod(adc_target, 0o600)
+        scion_harness.atomic_write_text(adc_target, adc_content, mode=0o600)
         env["GOOGLE_APPLICATION_CREDENTIALS"] = adc_target
         ctx.info(f"placed ADC credentials at {adc_target}")
 
-    # Write Vertex AI model config to config.toml.
-    _write_vertex_config(ctx, base_url)
+    # Resolve model ID — allow SCION_MODEL to override the default.
+    raw_model = os.environ.get("SCION_MODEL", "").strip()
+    model_id = raw_model if raw_model else _VERTEX_MODEL_ID
 
-    ctx.info(f"vertex-ai: project={project} base_url={base_url}")
+    # Write Vertex AI model config to config.toml.
+    _write_vertex_config(ctx, base_url, model_id)
+
+    ctx.info(f"vertex-ai: project={project} model={model_id} base_url={base_url}")
 
     return {"vertex_ai": True, "vertex_base_url": base_url}
 
@@ -185,6 +188,7 @@ def _configure_vertex_ai(
 def _write_vertex_config(
     ctx: scion_harness.ProvisionContext,
     base_url: str,
+    model_id: str,
 ) -> None:
     """Append Vertex AI auth_provider and model config to config.toml."""
     config_path = os.path.join(ctx.home, ".grok", "config.toml")
@@ -213,7 +217,7 @@ def _write_vertex_config(
 command = "gcloud auth print-access-token"
 
 [model.{_VERTEX_MODEL_CONFIG_NAME}]
-model = "{_VERTEX_MODEL_ID}"
+model = "{scion_harness.toml_escape(model_id)}"
 base_url = "{scion_harness.toml_escape(base_url)}"
 auth_provider = "{_VERTEX_AUTH_PROVIDER_NAME}"
 
@@ -572,9 +576,7 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
         resolved_model = aliases.get(raw_model.lower(), raw_model) if raw_model else ""
         if resolved_model:
             env["GROK_DEFAULT_MODEL"] = resolved_model
-    else:
-        if os.environ.get("SCION_MODEL", "").strip():
-            ctx.info("vertex-ai: SCION_MODEL ignored; model routing via config.toml [models]")
+    # vertex-ai model resolution handled in _configure_vertex_ai
 
     # --- Telemetry: inject native OTel env vars when enabled ----------------
     telemetry_payload = ctx.telemetry

--- a/harnesses/grok-build/provision.py
+++ b/harnesses/grok-build/provision.py
@@ -62,6 +62,11 @@ AUTH = scion_harness.AuthSpec(
             hint="provide grok auth at ~/.grok/auth.json",
             secret_key="GROK_AUTH",
         ),
+        scion_harness.env_method(
+            "vertex-ai",
+            all_of=["GOOGLE_CLOUD_PROJECT"],
+            hint="set GOOGLE_CLOUD_PROJECT for Vertex AI model routing",
+        ),
     ],
     fallback_to_none_on_error=True,
 )
@@ -108,6 +113,121 @@ def _write_auth_file(ctx: scion_harness.ProvisionContext) -> None:
         f.write(content)
     os.chmod(tmp, 0o600)
     os.replace(tmp, target)
+
+
+# ---------------------------------------------------------------------------
+# Vertex AI configuration
+# ---------------------------------------------------------------------------
+
+_VERTEX_MODEL_ID = "xai/grok-4.6"
+_VERTEX_AUTH_PROVIDER_NAME = "vertex-grok"
+_VERTEX_MODEL_CONFIG_NAME = "vertex-grok"
+
+
+def _configure_vertex_ai(
+    ctx: scion_harness.ProvisionContext,
+    env: dict[str, str],
+) -> dict[str, Any]:
+    """Configure grok to route inference through Vertex AI Model Garden.
+
+    Writes:
+      - [auth_provider.vertex-grok] with gcloud token command
+      - [model.vertex-grok] with Vertex AI base_url and auth_provider ref
+      - [models] default = "vertex-grok"
+    """
+    project = _read_token(ctx, "GOOGLE_CLOUD_PROJECT")
+    if not project:
+        raise scion_harness.ProvisionError(
+            "vertex-ai auth selected but GOOGLE_CLOUD_PROJECT is empty"
+        )
+    env["GOOGLE_CLOUD_PROJECT"] = project
+
+    # Region is optional — when empty, use the global multi-region endpoint.
+    region = ""
+    for key in ("GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"):
+        val = _read_token(ctx, key)
+        if val:
+            region = val
+            env[key] = val
+            break
+
+    # Construct Vertex AI base URL.
+    if region:
+        base_url = (
+            f"https://{region}-aiplatform.googleapis.com"
+            f"/v1beta1/projects/{project}/locations/{region}/endpoints/openapi"
+        )
+    else:
+        base_url = (
+            f"https://aiplatform.googleapis.com"
+            f"/v1beta1/projects/{project}/locations/global/endpoints/openapi"
+        )
+
+    # Place ADC credentials file if staged.
+    adc_path = ""
+    adc_content = ctx.read_file_secret("gcloud-adc")
+    if adc_content:
+        adc_dir = os.path.join(ctx.home, ".config", "gcloud")
+        os.makedirs(adc_dir, exist_ok=True)
+        adc_target = os.path.join(adc_dir, "application_default_credentials.json")
+        scion_harness.atomic_write_text(adc_target, adc_content)
+        os.chmod(adc_target, 0o600)
+        adc_path = adc_target
+        env["GOOGLE_APPLICATION_CREDENTIALS"] = adc_path
+        ctx.info(f"placed ADC credentials at {adc_target}")
+
+    # Write Vertex AI model config to config.toml.
+    _write_vertex_config(ctx, base_url)
+
+    ctx.info(f"vertex-ai: project={project} base_url={base_url}")
+
+    return {"vertex_ai": True, "vertex_base_url": base_url}
+
+
+def _write_vertex_config(
+    ctx: scion_harness.ProvisionContext,
+    base_url: str,
+) -> None:
+    """Append Vertex AI auth_provider and model config to config.toml."""
+    config_path = os.path.join(ctx.home, ".grok", "config.toml")
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+
+    existing = ""
+    if os.path.isfile(config_path):
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                existing = f.read()
+        except OSError:
+            pass
+
+    # Strip any existing vertex config sections to avoid duplicates.
+    cleaned = scion_harness.strip_toml_sections(
+        existing,
+        lambda line: (
+            line == f"[auth_provider.{_VERTEX_AUTH_PROVIDER_NAME}]"
+            or line == f"[model.{_VERTEX_MODEL_CONFIG_NAME}]"
+            or line == "[models]"
+        ),
+    )
+
+    # Build the vertex config block.
+    vertex_toml = f'''[auth_provider.{_VERTEX_AUTH_PROVIDER_NAME}]
+command = "gcloud auth print-access-token"
+
+[model.{_VERTEX_MODEL_CONFIG_NAME}]
+model = "{_VERTEX_MODEL_ID}"
+base_url = "{base_url}"
+auth_provider = "{_VERTEX_AUTH_PROVIDER_NAME}"
+
+[models]
+default = "{_VERTEX_MODEL_CONFIG_NAME}"'''
+
+    content = cleaned.rstrip("\n")
+    if content:
+        content += "\n\n"
+    content += vertex_toml + "\n"
+
+    scion_harness.atomic_write_text(config_path, content)
 
 
 # ---------------------------------------------------------------------------
@@ -440,14 +560,20 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
         _write_auth_file(ctx)
         extra = {"auth_file_written": True}
 
+    if resolved.method == "vertex-ai":
+        extra = _configure_vertex_ai(ctx, env)
+
     # --- Model resolution ---------------------------------------------------
     # The Go side does not populate ctx.model_resolution for out-of-tree
     # harnesses. Use the SCION_MODEL env var and resolve via model_aliases.
-    raw_model = os.environ.get("SCION_MODEL", "").strip()
-    aliases = ctx.harness_config.get("model_aliases") or {}
-    resolved_model = aliases.get(raw_model.lower(), raw_model) if raw_model else ""
-    if resolved_model:
-        env["GROK_DEFAULT_MODEL"] = resolved_model
+    # When vertex-ai is selected, model routing is handled by the config.toml
+    # [models] block, so skip GROK_DEFAULT_MODEL to avoid conflicts.
+    if resolved.method != "vertex-ai":
+        raw_model = os.environ.get("SCION_MODEL", "").strip()
+        aliases = ctx.harness_config.get("model_aliases") or {}
+        resolved_model = aliases.get(raw_model.lower(), raw_model) if raw_model else ""
+        if resolved_model:
+            env["GROK_DEFAULT_MODEL"] = resolved_model
 
     # --- Telemetry: inject native OTel env vars when enabled ----------------
     telemetry_payload = ctx.telemetry

--- a/harnesses/grok-build/provision.py
+++ b/harnesses/grok-build/provision.py
@@ -164,7 +164,6 @@ def _configure_vertex_ai(
         )
 
     # Place ADC credentials file if staged.
-    adc_path = ""
     adc_content = ctx.read_file_secret("gcloud-adc")
     if adc_content:
         adc_dir = os.path.join(ctx.home, ".config", "gcloud")
@@ -172,8 +171,7 @@ def _configure_vertex_ai(
         adc_target = os.path.join(adc_dir, "application_default_credentials.json")
         scion_harness.atomic_write_text(adc_target, adc_content)
         os.chmod(adc_target, 0o600)
-        adc_path = adc_target
-        env["GOOGLE_APPLICATION_CREDENTIALS"] = adc_path
+        env["GOOGLE_APPLICATION_CREDENTIALS"] = adc_target
         ctx.info(f"placed ADC credentials at {adc_target}")
 
     # Write Vertex AI model config to config.toml.
@@ -216,7 +214,7 @@ command = "gcloud auth print-access-token"
 
 [model.{_VERTEX_MODEL_CONFIG_NAME}]
 model = "{_VERTEX_MODEL_ID}"
-base_url = "{base_url}"
+base_url = "{scion_harness.toml_escape(base_url)}"
 auth_provider = "{_VERTEX_AUTH_PROVIDER_NAME}"
 
 [models]
@@ -574,6 +572,9 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
         resolved_model = aliases.get(raw_model.lower(), raw_model) if raw_model else ""
         if resolved_model:
             env["GROK_DEFAULT_MODEL"] = resolved_model
+    else:
+        if os.environ.get("SCION_MODEL", "").strip():
+            ctx.info("vertex-ai: SCION_MODEL ignored; model routing via config.toml [models]")
 
     # --- Telemetry: inject native OTel env vars when enabled ----------------
     telemetry_payload = ctx.telemetry

--- a/harnesses/grok-build/provision_test.py
+++ b/harnesses/grok-build/provision_test.py
@@ -833,5 +833,278 @@ class CaFileEnvTest(BaseTelemetryTest):
         self.assertNotIn("OTEL_EXPORTER_OTLP_CERTIFICATE", env)
 
 
+# ---------------------------------------------------------------------------
+# Vertex AI Auth Tests
+# ---------------------------------------------------------------------------
+
+
+class VertexAIAuthTest(unittest.TestCase):
+    """Test Vertex AI auth selection and provisioning."""
+
+    _saved_env: dict[str, str]
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._saved_env = {}
+        for key in list(os.environ):
+            if key.startswith(("GOOGLE_", "CLOUD_ML_", "SCION_MODEL")):
+                self._saved_env[key] = os.environ.pop(key)
+
+    def tearDown(self) -> None:
+        for key in list(os.environ):
+            if key.startswith(("GOOGLE_", "CLOUD_ML_", "SCION_MODEL")):
+                os.environ.pop(key, None)
+        os.environ.update(self._saved_env)
+        super().tearDown()
+
+    def test_vertex_ai_selected_when_project_present(self) -> None:
+        """vertex-ai auth is selected when GOOGLE_CLOUD_PROJECT is in env_vars
+        and neither XAI_API_KEY nor GROK_AUTH are present."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs_dir = os.path.join(tmp, "inputs")
+            os.makedirs(inputs_dir)
+            secret_path = os.path.join(tmp, "project-id")
+            with open(secret_path, "w") as f:
+                f.write("my-gcp-project")
+            scion_harness.atomic_write_json(
+                os.path.join(inputs_dir, "auth-candidates.json"),
+                {
+                    "env_vars": ["GOOGLE_CLOUD_PROJECT"],
+                    "env_secret_files": {
+                        "GOOGLE_CLOUD_PROJECT": secret_path,
+                    },
+                    "file_secret_files": {},
+                },
+            )
+            ctx = _make_ctx({"harness_bundle_dir": tmp})
+            with temporary_home(tmp):
+                resolved = ctx.select_auth(provision.AUTH)
+            self.assertEqual(resolved.method, "vertex-ai")
+
+    def test_vertex_config_written_to_config_toml(self) -> None:
+        """When vertex-ai method is used, config.toml contains correct entries."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs_dir = os.path.join(tmp, "inputs")
+            os.makedirs(inputs_dir)
+            secret_path = os.path.join(tmp, "project-id")
+            with open(secret_path, "w") as f:
+                f.write("my-gcp-project")
+            scion_harness.atomic_write_json(
+                os.path.join(inputs_dir, "auth-candidates.json"),
+                {
+                    "env_vars": ["GOOGLE_CLOUD_PROJECT"],
+                    "env_secret_files": {
+                        "GOOGLE_CLOUD_PROJECT": secret_path,
+                    },
+                    "file_secret_files": {},
+                },
+            )
+            ctx = _make_ctx({"harness_bundle_dir": tmp})
+            env: dict[str, str] = {}
+            with temporary_home(tmp):
+                provision._configure_vertex_ai(ctx, env)
+                config_path = os.path.join(tmp, ".grok", "config.toml")
+                self.assertTrue(os.path.isfile(config_path))
+                with open(config_path) as f:
+                    content = f.read()
+            self.assertIn("[auth_provider.vertex-grok]", content)
+            self.assertIn("[model.vertex-grok]", content)
+            self.assertIn("[models]", content)
+            self.assertIn('default = "vertex-grok"', content)
+            self.assertIn("my-gcp-project", content)
+
+    def test_vertex_global_endpoint_when_no_region(self) -> None:
+        """When GOOGLE_CLOUD_REGION is not set, the base_url uses the global
+        endpoint."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs_dir = os.path.join(tmp, "inputs")
+            os.makedirs(inputs_dir)
+            secret_path = os.path.join(tmp, "project-id")
+            with open(secret_path, "w") as f:
+                f.write("my-gcp-project")
+            scion_harness.atomic_write_json(
+                os.path.join(inputs_dir, "auth-candidates.json"),
+                {
+                    "env_vars": ["GOOGLE_CLOUD_PROJECT"],
+                    "env_secret_files": {
+                        "GOOGLE_CLOUD_PROJECT": secret_path,
+                    },
+                    "file_secret_files": {},
+                },
+            )
+            ctx = _make_ctx({"harness_bundle_dir": tmp})
+            env: dict[str, str] = {}
+            with temporary_home(tmp):
+                provision._configure_vertex_ai(ctx, env)
+                config_path = os.path.join(tmp, ".grok", "config.toml")
+                with open(config_path) as f:
+                    content = f.read()
+            self.assertIn(
+                "https://aiplatform.googleapis.com"
+                "/v1beta1/projects/my-gcp-project/locations/global/endpoints/openapi",
+                content,
+            )
+
+    def test_vertex_regional_endpoint_when_region_set(self) -> None:
+        """When GOOGLE_CLOUD_REGION is set, the base_url uses the regional
+        endpoint."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs_dir = os.path.join(tmp, "inputs")
+            os.makedirs(inputs_dir)
+            project_path = os.path.join(tmp, "project-id")
+            with open(project_path, "w") as f:
+                f.write("my-gcp-project")
+            region_path = os.path.join(tmp, "region")
+            with open(region_path, "w") as f:
+                f.write("us-central1")
+            scion_harness.atomic_write_json(
+                os.path.join(inputs_dir, "auth-candidates.json"),
+                {
+                    "env_vars": ["GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_REGION"],
+                    "env_secret_files": {
+                        "GOOGLE_CLOUD_PROJECT": project_path,
+                        "GOOGLE_CLOUD_REGION": region_path,
+                    },
+                    "file_secret_files": {},
+                },
+            )
+            ctx = _make_ctx({"harness_bundle_dir": tmp})
+            env: dict[str, str] = {}
+            with temporary_home(tmp):
+                provision._configure_vertex_ai(ctx, env)
+                config_path = os.path.join(tmp, ".grok", "config.toml")
+                with open(config_path) as f:
+                    content = f.read()
+            self.assertIn(
+                "https://us-central1-aiplatform.googleapis.com"
+                "/v1beta1/projects/my-gcp-project/locations/us-central1/endpoints/openapi",
+                content,
+            )
+
+    def test_vertex_adc_placed_when_staged(self) -> None:
+        """When gcloud-adc file secret is staged, it is written to
+        ~/.config/gcloud/application_default_credentials.json and
+        GOOGLE_APPLICATION_CREDENTIALS is set."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs_dir = os.path.join(tmp, "inputs")
+            os.makedirs(inputs_dir)
+            project_path = os.path.join(tmp, "project-id")
+            with open(project_path, "w") as f:
+                f.write("my-gcp-project")
+            adc_path = os.path.join(tmp, "adc-creds")
+            with open(adc_path, "w") as f:
+                f.write('{"type": "authorized_user", "client_id": "test"}')
+            scion_harness.atomic_write_json(
+                os.path.join(inputs_dir, "auth-candidates.json"),
+                {
+                    "env_vars": ["GOOGLE_CLOUD_PROJECT"],
+                    "env_secret_files": {
+                        "GOOGLE_CLOUD_PROJECT": project_path,
+                    },
+                    "file_secret_files": {
+                        "gcloud-adc": adc_path,
+                    },
+                },
+            )
+            ctx = _make_ctx({"harness_bundle_dir": tmp})
+            env: dict[str, str] = {}
+            with temporary_home(tmp):
+                provision._configure_vertex_ai(ctx, env)
+                target = os.path.join(
+                    tmp, ".config", "gcloud",
+                    "application_default_credentials.json",
+                )
+                self.assertTrue(os.path.isfile(target))
+                with open(target) as f:
+                    content = f.read()
+                self.assertIn("authorized_user", content)
+                mode = os.stat(target).st_mode & 0o777
+                self.assertEqual(mode, 0o600)
+            self.assertIn("GOOGLE_APPLICATION_CREDENTIALS", env)
+            self.assertEqual(env["GOOGLE_APPLICATION_CREDENTIALS"], target)
+
+    def test_vertex_no_adc_still_works(self) -> None:
+        """vertex-ai works without ADC credentials (workload identity
+        environments)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs_dir = os.path.join(tmp, "inputs")
+            os.makedirs(inputs_dir)
+            project_path = os.path.join(tmp, "project-id")
+            with open(project_path, "w") as f:
+                f.write("my-gcp-project")
+            scion_harness.atomic_write_json(
+                os.path.join(inputs_dir, "auth-candidates.json"),
+                {
+                    "env_vars": ["GOOGLE_CLOUD_PROJECT"],
+                    "env_secret_files": {
+                        "GOOGLE_CLOUD_PROJECT": project_path,
+                    },
+                    "file_secret_files": {},
+                },
+            )
+            ctx = _make_ctx({"harness_bundle_dir": tmp})
+            env: dict[str, str] = {}
+            with temporary_home(tmp):
+                extra = provision._configure_vertex_ai(ctx, env)
+            self.assertTrue(extra.get("vertex_ai"))
+            self.assertNotIn("GOOGLE_APPLICATION_CREDENTIALS", env)
+
+    def test_vertex_auth_provider_command(self) -> None:
+        """Verify the auth_provider block uses 'gcloud auth print-access-token'
+        as the command."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs_dir = os.path.join(tmp, "inputs")
+            os.makedirs(inputs_dir)
+            project_path = os.path.join(tmp, "project-id")
+            with open(project_path, "w") as f:
+                f.write("my-gcp-project")
+            scion_harness.atomic_write_json(
+                os.path.join(inputs_dir, "auth-candidates.json"),
+                {
+                    "env_vars": ["GOOGLE_CLOUD_PROJECT"],
+                    "env_secret_files": {
+                        "GOOGLE_CLOUD_PROJECT": project_path,
+                    },
+                    "file_secret_files": {},
+                },
+            )
+            ctx = _make_ctx({"harness_bundle_dir": tmp})
+            env: dict[str, str] = {}
+            with temporary_home(tmp):
+                provision._configure_vertex_ai(ctx, env)
+                config_path = os.path.join(tmp, ".grok", "config.toml")
+                with open(config_path) as f:
+                    content = f.read()
+            self.assertIn(
+                'command = "gcloud auth print-access-token"', content
+            )
+
+    def test_vertex_empty_project_raises(self) -> None:
+        """When GOOGLE_CLOUD_PROJECT is empty, ProvisionError is raised."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs_dir = os.path.join(tmp, "inputs")
+            os.makedirs(inputs_dir)
+            # Create an empty project file.
+            project_path = os.path.join(tmp, "project-id")
+            with open(project_path, "w") as f:
+                f.write("")
+            scion_harness.atomic_write_json(
+                os.path.join(inputs_dir, "auth-candidates.json"),
+                {
+                    "env_vars": ["GOOGLE_CLOUD_PROJECT"],
+                    "env_secret_files": {
+                        "GOOGLE_CLOUD_PROJECT": project_path,
+                    },
+                    "file_secret_files": {},
+                },
+            )
+            ctx = _make_ctx({"harness_bundle_dir": tmp})
+            env: dict[str, str] = {}
+            with temporary_home(tmp):
+                with self.assertRaises(scion_harness.ProvisionError) as cm:
+                    provision._configure_vertex_ai(ctx, env)
+                self.assertIn("GOOGLE_CLOUD_PROJECT", str(cm.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/harnesses/grok-build/provision_test.py
+++ b/harnesses/grok-build/provision_test.py
@@ -1079,6 +1079,25 @@ class VertexAIAuthTest(unittest.TestCase):
                 'command = "gcloud auth print-access-token"', content
             )
 
+    def test_api_key_preferred_over_vertex_ai(self) -> None:
+        """When both XAI_API_KEY and GOOGLE_CLOUD_PROJECT are present,
+        api-key is selected (listed first in AUTH)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs_dir = os.path.join(tmp, "inputs")
+            os.makedirs(inputs_dir)
+            scion_harness.atomic_write_json(
+                os.path.join(inputs_dir, "auth-candidates.json"),
+                {
+                    "env_vars": ["XAI_API_KEY", "GOOGLE_CLOUD_PROJECT"],
+                    "env_secret_files": {},
+                    "file_secret_files": {},
+                },
+            )
+            ctx = _make_ctx({"harness_bundle_dir": tmp})
+            with temporary_home(tmp):
+                resolved = ctx.select_auth(provision.AUTH)
+            self.assertEqual(resolved.method, "api-key")
+
     def test_vertex_empty_project_raises(self) -> None:
         """When GOOGLE_CLOUD_PROJECT is empty, ProvisionError is raised."""
         with tempfile.TemporaryDirectory() as tmp:

--- a/harnesses/grok-build/provision_test.py
+++ b/harnesses/grok-build/provision_test.py
@@ -1098,6 +1098,38 @@ class VertexAIAuthTest(unittest.TestCase):
                 resolved = ctx.select_auth(provision.AUTH)
             self.assertEqual(resolved.method, "api-key")
 
+    def test_vertex_custom_model_from_scion_model(self) -> None:
+        """SCION_MODEL overrides the default vertex model ID."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs_dir = os.path.join(tmp, "inputs")
+            os.makedirs(inputs_dir)
+            secret_path = os.path.join(tmp, "project-id")
+            with open(secret_path, "w") as f:
+                f.write("my-gcp-project")
+            scion_harness.atomic_write_json(
+                os.path.join(inputs_dir, "auth-candidates.json"),
+                {
+                    "env_vars": ["GOOGLE_CLOUD_PROJECT"],
+                    "env_secret_files": {
+                        "GOOGLE_CLOUD_PROJECT": secret_path,
+                    },
+                    "file_secret_files": {},
+                },
+            )
+            ctx = _make_ctx({"harness_bundle_dir": tmp})
+            env: dict[str, str] = {}
+            os.environ["SCION_MODEL"] = "xai/grok-4.2"
+            try:
+                with temporary_home(tmp):
+                    provision._configure_vertex_ai(ctx, env)
+                    config_path = os.path.join(tmp, ".grok", "config.toml")
+                    with open(config_path) as f:
+                        content = f.read()
+            finally:
+                os.environ.pop("SCION_MODEL", None)
+            self.assertIn("xai/grok-4.2", content)
+            self.assertNotIn("xai/grok-4.6", content)
+
     def test_vertex_empty_project_raises(self) -> None:
         """When GOOGLE_CLOUD_PROJECT is empty, ProvisionError is raised."""
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- Adds complete Vertex AI support to grok-build harness via grok native auth_provider mechanism
- Uses gcloud auth print-access-token for auto-refreshing GCP tokens
- Writes config.toml with custom model entries pointing at Vertex AI Model Garden
- Global endpoint default, regional when GOOGLE_CLOUD_REGION set
- ADC credentials placement optional (workload identity works without)

## Key Files
- harnesses/grok-build/config.yaml — vertex-ai auth type, autodetect, capabilities
- harnesses/grok-build/provision.py — _configure_vertex_ai, _write_vertex_config
- harnesses/grok-build/provision_test.py — 9 new tests (71 total)
- docs-site/src/content/docs/supported-harnesses.md — Vertex AI docs

## Test Plan
- All 71 tests pass
- Integration test with live Vertex AI endpoint pending

ptone/scion#1237
