### PR TITLE
fix(harness): move SourcePath clearing before ValidateAuth and guard empty paths

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -505,16 +505,6 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		// does not leak into resolvedForSecretFilter.
 		resolvedForSecretFilter := *resolved
 		resolvedForSecretFilter.Files = append([]api.FileMapping(nil), resolved.Files...)
-		util.Debugf("auth: resolved — method=%q, envVars=%v, files=%d", resolved.Method, resolved.EnvVars, len(resolved.Files))
-		if err := harness.ValidateAuth(resolved); err != nil {
-			if canFallbackToNoAuth() {
-				util.Debugf("auth: validation failed, falling back to no-auth mode: %v", err)
-				opts.NoAuth = true
-				warnings = append(warnings, "Auth: credential validation failed, starting in no-auth mode")
-				goto authDone
-			}
-			return nil, fmt.Errorf("auth validation failed: %w", err)
-		}
 		if opts.BrokerMode {
 			// File content projection is handled by writeFileSecrets() from
 			// ResolvedSecrets at container launch (via SCION_STAGED_SECRETS),
@@ -525,6 +515,16 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 			for i := range resolved.Files {
 				resolved.Files[i].SourcePath = ""
 			}
+		}
+		util.Debugf("auth: resolved — method=%q, envVars=%v, files=%d", resolved.Method, resolved.EnvVars, len(resolved.Files))
+		if err := harness.ValidateAuth(resolved); err != nil {
+			if canFallbackToNoAuth() {
+				util.Debugf("auth: validation failed, falling back to no-auth mode: %v", err)
+				opts.NoAuth = true
+				warnings = append(warnings, "Auth: credential validation failed, starting in no-auth mode")
+				goto authDone
+			}
+			return nil, fmt.Errorf("auth validation failed: %w", err)
 		}
 		// Allow harnesses to update their native settings files (e.g. Gemini settings.json)
 		if applier, ok := h.(api.AuthSettingsApplier); ok {

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -500,6 +500,16 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 			}
 			return nil, fmt.Errorf("auth resolution failed: %w", err)
 		}
+		if resolved == nil {
+			// ResolveAuth returned nil without error — treat as no auth available.
+			if canFallbackToNoAuth() {
+				util.Debugf("auth: resolution returned nil, falling back to no-auth mode")
+				opts.NoAuth = true
+				warnings = append(warnings, "Auth: no credentials found, starting in no-auth mode")
+				goto authDone
+			}
+			return nil, fmt.Errorf("auth resolution returned nil for method %q", auth.SelectedType)
+		}
 		// Keep a copy of the full resolved auth material for secret filtering.
 		// Deep-copy the Files slice so in-place SourcePath clearing below
 		// does not leak into resolvedForSecretFilter.
@@ -517,7 +527,7 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 			}
 		}
 		util.Debugf("auth: resolved — method=%q, envVars=%v, files=%d", resolved.Method, resolved.EnvVars, len(resolved.Files))
-		if err := harness.ValidateAuth(resolved); err != nil {
+		if err := harness.ValidateAuth(resolved, opts.BrokerMode); err != nil {
 			if canFallbackToNoAuth() {
 				util.Debugf("auth: validation failed, falling back to no-auth mode: %v", err)
 				opts.NoAuth = true

--- a/pkg/harness/auth.go
+++ b/pkg/harness/auth.go
@@ -271,7 +271,7 @@ func OverlaySettings(auth *api.AuthConfig, h api.Harness, agentDir string) {
 // It acts as a post-resolution safety net: ResolveAuth should produce correct
 // results, but ValidateAuth catches any bugs or race conditions (e.g., a
 // credential file deleted between GatherAuth and container launch).
-func ValidateAuth(resolved *api.ResolvedAuth) error {
+func ValidateAuth(resolved *api.ResolvedAuth, brokerMode bool) error {
 	if resolved == nil {
 		return fmt.Errorf("auth validation failed: resolved auth is nil")
 	}
@@ -297,10 +297,16 @@ func ValidateAuth(resolved *api.ResolvedAuth) error {
 		if f.ContainerPath == "" {
 			return fmt.Errorf("auth validation failed: file mapping for %q has no container path", f.SourcePath)
 		}
-		if f.SourcePath != "" {
-			if _, err := os.Stat(f.SourcePath); err != nil {
-				return fmt.Errorf("auth validation failed: credential file %q does not exist: %w", f.SourcePath, err)
+		if f.SourcePath == "" {
+			if brokerMode {
+				// Broker mode: SourcePath intentionally cleared — file content
+				// is staged via SCION_STAGED_SECRETS, not local paths.
+				continue
 			}
+			return fmt.Errorf("auth validation failed: file mapping for container path %q has no source path", f.ContainerPath)
+		}
+		if _, err := os.Stat(f.SourcePath); err != nil {
+			return fmt.Errorf("auth validation failed: credential file %q does not exist: %w", f.SourcePath, err)
 		}
 	}
 

--- a/pkg/harness/auth.go
+++ b/pkg/harness/auth.go
@@ -297,8 +297,10 @@ func ValidateAuth(resolved *api.ResolvedAuth) error {
 		if f.ContainerPath == "" {
 			return fmt.Errorf("auth validation failed: file mapping for %q has no container path", f.SourcePath)
 		}
-		if _, err := os.Stat(f.SourcePath); err != nil {
-			return fmt.Errorf("auth validation failed: credential file %q does not exist: %w", f.SourcePath, err)
+		if f.SourcePath != "" {
+			if _, err := os.Stat(f.SourcePath); err != nil {
+				return fmt.Errorf("auth validation failed: credential file %q does not exist: %w", f.SourcePath, err)
+			}
 		}
 	}
 

--- a/pkg/harness/auth_test.go
+++ b/pkg/harness/auth_test.go
@@ -303,7 +303,7 @@ func TestValidateAuth_Valid(t *testing.T) {
 			"ANTHROPIC_API_KEY": "sk-ant-test",
 		},
 	}
-	if err := ValidateAuth(resolved); err != nil {
+	if err := ValidateAuth(resolved, false); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -322,13 +322,13 @@ func TestValidateAuth_ValidWithFiles(t *testing.T) {
 			{SourcePath: tmpFile, ContainerPath: "~/.config/gcp/adc.json"},
 		},
 	}
-	if err := ValidateAuth(resolved); err != nil {
+	if err := ValidateAuth(resolved, false); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
 func TestValidateAuth_Nil(t *testing.T) {
-	err := ValidateAuth(nil)
+	err := ValidateAuth(nil, false)
 	if err == nil {
 		t.Fatal("expected error for nil resolved auth")
 	}
@@ -342,7 +342,7 @@ func TestValidateAuth_EmptyMethod(t *testing.T) {
 		Method:  "",
 		EnvVars: map[string]string{"KEY": "value"},
 	}
-	err := ValidateAuth(resolved)
+	err := ValidateAuth(resolved, false)
 	if err == nil {
 		t.Fatal("expected error for empty method")
 	}
@@ -359,7 +359,7 @@ func TestValidateAuth_EmptyEnvValue(t *testing.T) {
 			"EMPTY_KEY": "",
 		},
 	}
-	err := ValidateAuth(resolved)
+	err := ValidateAuth(resolved, false)
 	if err == nil {
 		t.Fatal("expected error for empty env var value")
 	}
@@ -375,7 +375,7 @@ func TestValidateAuth_MissingSourceFile(t *testing.T) {
 			{SourcePath: "/nonexistent/path/creds.json", ContainerPath: "~/.config/gcp/adc.json"},
 		},
 	}
-	err := ValidateAuth(resolved)
+	err := ValidateAuth(resolved, false)
 	if err == nil {
 		t.Fatal("expected error for missing source file")
 	}
@@ -394,7 +394,7 @@ func TestValidateAuth_EmptyContainerPath(t *testing.T) {
 			{SourcePath: tmpFile, ContainerPath: ""},
 		},
 	}
-	err := ValidateAuth(resolved)
+	err := ValidateAuth(resolved, false)
 	if err == nil {
 		t.Fatal("expected error for empty container path")
 	}
@@ -408,8 +408,25 @@ func TestValidateAuth_EmptyEnvVarsAndFiles(t *testing.T) {
 	resolved := &api.ResolvedAuth{
 		Method: "passthrough",
 	}
-	if err := ValidateAuth(resolved); err != nil {
+	if err := ValidateAuth(resolved, false); err != nil {
 		t.Errorf("unexpected error for passthrough with no env/files: %v", err)
+	}
+}
+
+func TestValidateAuth_BrokerModeEmptySourcePath(t *testing.T) {
+	resolved := &api.ResolvedAuth{
+		Method: "auth-file",
+		Files: []api.FileMapping{
+			{SourcePath: "", ContainerPath: "~/.codex/auth.json"},
+		},
+	}
+	// In broker mode, empty SourcePath is valid.
+	if err := ValidateAuth(resolved, true); err != nil {
+		t.Errorf("ValidateAuth(brokerMode=true) should accept empty SourcePath: %v", err)
+	}
+	// In non-broker mode, empty SourcePath is an error.
+	if err := ValidateAuth(resolved, false); err == nil {
+		t.Error("ValidateAuth(brokerMode=false) should reject empty SourcePath")
 	}
 }
 


### PR DESCRIPTION
In broker mode, ValidateAuth was seeing container-side SourcePaths (e.g. ~/.grok/auth.json) that don't exist on the broker host. os.Stat failed, causing silent fallback to no-auth and skipping ApplyAuthSettings.

Fix: move broker-mode SourcePath clearing to before ValidateAuth (after the deep-copy for resolvedForSecretFilter), and guard os.Stat in ValidateAuth to skip when SourcePath is empty.

Follow-up to ptone/scion#1229 (merged upstream as #1273).

Key changes:
- pkg/agent/run.go: reorder broker-mode SourcePath clearing to before ValidateAuth
- pkg/harness/auth.go: guard os.Stat to skip when SourcePath is empty (defense-in-depth)

Ref: https://github.com/ptone/scion/issues/1236