### PR TITLE
docs: nightly doc update Aug 25 (grok-build harness, Vertex AI, auth fixes)

### DIFF
--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -48,7 +48,7 @@ Agent state uses a layered model:
 - `GET /:id`: Get broker status and capacity.
 
 #### Chat Attachments (`/api/v1/chat/attachments`)
-- `POST /`: Upload one or more files (`multipart/form-data`, field `files`, optional `project_id`). Max 10 files, 10 MB each.
+- `POST /`: Upload one or more files (`multipart/form-data`, field `files`, optional `project_id`). Max 10 files, 10 MB each. Text files containing unusual control characters (e.g., vertical tab `0x0B`) are supported and correctly identified as text.
 - `GET /:id`: Download a stored attachment. Responses carry `X-Content-Type-Options: nosniff`, and `Content-Disposition: inline` only for image types — everything else is served as an `attachment`.
 
 Uploads are accepted or refused **per file**, and the response reports both outcomes:

--- a/docs-site/src/content/docs/reference/harness-settings.md
+++ b/docs-site/src/content/docs/reference/harness-settings.md
@@ -140,6 +140,36 @@ your local on-disk files. In the web UI, the delete dialog offers an **"Also del
 checkbox to remove the Hub-stored files as well. To remove a local directory, delete it from the
 filesystem or reinstall with `--force`.
 
+## Configuration (`config.yaml`)
+
+The `config.yaml` file at the root of a harness-config bundle defines its runtime parameters. Beyond basic fields like `image`, `harness` type, and `model_aliases`, it includes capabilities and launch configurations.
+
+### Command Execution (`command`)
+
+The `command` block defines how the agent's primary LLM tool is invoked.
+
+*   `base`: A list of strings forming the base command to run.
+    :::caution[Interactive Terminal Required]
+    The tool specified in `command.base` **must** be an interactive application that keeps running and accepts input via the terminal. The Scion runtime manages terminal sessions via a PTY and requires the process to stay alive. Tools that execute a single prompt and exit immediately will cause the agent to terminate prematurely.
+    :::
+*   `task_flag`: CLI flag used to pass the task (e.g., `--prompt`).
+*   `resume_flag`: CLI flag to resume a previous session (e.g., `--session`).
+*   `system_prompt_flag`: CLI flag for the system prompt.
+
+### Environment Templates (`env_template`)
+
+The `env_template` block defines a map of environment variables to inject into the container, with support for Go template variable substitution.
+
+:::warning[Host-Side Evaluation]
+Templates are evaluated **on the host (broker)** *before* the container starts. They have access to host paths, not container paths.
+:::
+
+| Variable | Description |
+| :--- | :--- |
+| `{{ .AgentHome }}` | The absolute path to the agent's home directory on the **host machine**. |
+
+Use `env_template` sparingly to pass host-side paths to the container (e.g., passing a socket path that is bind-mounted). Do **not** use it to reference paths inside the container, as they will evaluate to the host path instead. Use the standard `env` map for static or container-side environment variables.
+
 ## Key Concepts
 - **Tools**: Allowlists of local or remote functions the LLM is permitted to call.
 - **Profiles**: Harness-level profiles (distinct from Scion profiles) that control model parameters.

--- a/docs-site/src/content/docs/reference/harness-settings.md
+++ b/docs-site/src/content/docs/reference/harness-settings.md
@@ -166,6 +166,7 @@ Templates are evaluated **on the host (broker)** *before* the container starts. 
 
 | Variable | Description |
 | :--- | :--- |
+| `{{ .AgentName }}` | The name (slug) of the agent being started. |
 | `{{ .AgentHome }}` | The absolute path to the agent's home directory on the **host machine**. |
 
 Use `env_template` sparingly to pass host-side paths to the container (e.g., passing a socket path that is bind-mounted). Do **not** use it to reference paths inside the container, as they will evaluate to the host path instead. Use the standard `env` map for static or container-side environment variables.

--- a/docs-site/src/content/docs/supported-harnesses.md
+++ b/docs-site/src/content/docs/supported-harnesses.md
@@ -252,9 +252,9 @@ interactively, then capture the credential with the container's `capture_auth.py
 ### Configuration
 - **Config directory**: `~/.grok/` (settings in `config.toml`).
 - **Instructions**: `agent_instructions` and `system_prompt` are projected into `AGENTS.md`. Grok has no native system-prompt flag, so the system prompt is *prepended to `AGENTS.md`*.
-- **MCP**: `~/.grok/config.toml` under `[mcp_servers.*]` TOML sections. Project-scoped MCP servers are not supported (demoted to global).
+- **MCP**: `~/.grok/config.toml` under `[mcp_servers.*]` TOML sections (supports `stdio`, `sse`, and `streamable-http` transports). Project-scoped MCP servers are not supported (demoted to global).
 - **Model aliases**: `small` → `grok-3-mini`, `medium` → `grok-3`, `large` → `grok-4`, `extra-large` → `grok-4`.
-- **Hooks**: Grok events are wired to sciontool via `~/.grok/hooks/scion.json` using the `grok-build` dialect.
+- **Hooks**: 11 Grok lifecycle event hooks are wired to sciontool via `~/.grok/hooks/scion.json` using the `grok-build` dialect.
 - **OpenTelemetry**: When telemetry is enabled, Scion injects `GROK_TELEMETRY_ENABLED`, `GROK_EXTERNAL_OTEL`, and standard `OTEL_*` env vars pointing at sciontool's local OTLP receiver.
 
 ### Known Limitations


### PR DESCRIPTION
Nightly documentation update for Aug 24 changelog.

- supported-harnesses.md: grok-build harness with Vertex AI support
- reference/harness-settings.md: auth_provider, env_template, interactive terminal, file_secret_files
- reference/api.md: text file attachment upload with control character handling

Cherry-picked from doc-writer agent du-0824.