### PR TITLE
fix(web): reflow hard-wrapped agent text in chat messages

### DIFF
--- a/web/src/utils/markdown.ts
+++ b/web/src/utils/markdown.ts
@@ -54,7 +54,7 @@ export async function getMarkdownRenderer(): Promise<MarkdownRenderer> {
 
       return {
         render(markdown: string): string {
-          const rawHtml = marked.parse(markdown, { async: false, breaks: true }) as string;
+          const rawHtml = marked.parse(markdown, { async: false }) as string;
           return purify.sanitize(rawHtml);
         },
       };

--- a/web/src/utils/markdown.ts
+++ b/web/src/utils/markdown.ts
@@ -54,7 +54,7 @@ export async function getMarkdownRenderer(): Promise<MarkdownRenderer> {
 
       return {
         render(markdown: string): string {
-          const rawHtml = marked.parse(markdown, { async: false }) as string;
+          const rawHtml = marked.parseSync(markdown);
           return purify.sanitize(rawHtml);
         },
       };


### PR DESCRIPTION
## Summary
- Removes `breaks: true` from the `marked.parse()` call in the markdown renderer
- Standard markdown behavior: single newlines become spaces (text reflows naturally), double newlines create paragraph breaks
- Fixes agents' hard-wrapped ~80-char lines rendering as jagged text instead of reflowed paragraphs

Fork staging: ptone/scion#1246

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — all tests pass
- [x] CI green on fork staging PR ptone/scion#1246