### PR TITLE
fix(web): revert parseSync to marked.parse — fix broken build

### DIFF
--- a/web/src/utils/markdown.ts
+++ b/web/src/utils/markdown.ts
@@ -54,7 +54,7 @@ export async function getMarkdownRenderer(): Promise<MarkdownRenderer> {
 
       return {
         render(markdown: string): string {
-          const rawHtml = marked.parseSync(markdown);
+          const rawHtml = marked.parse(markdown, { async: false }) as string;
           return purify.sanitize(rawHtml);
         },
       };


### PR DESCRIPTION
## Summary
- Fixes broken main caused by PR #1284 which introduced `marked.parseSync()` — a method that does not exist on the version of `marked` in use
- Reverts to the correct call: `marked.parse(markdown, { async: false }) as string`
- `breaks: true` remains removed per the original intent of #1284

Fork staging: ptone/scion#1248

## Test plan
- [x] `npx tsc --noEmit` — clean (this was the failing check)
- [x] `npx vitest run` — 467 tests pass
- [x] `go build ./...` — clean
- [x] CI green on fork staging PR ptone/scion#1248