### PR TITLE
feat: add grok-build harness to aggregate Cloud Build configs

### DIFF
--- a/image-build/cloudbuild-common.yaml
+++ b/image-build/cloudbuild-common.yaml
@@ -74,6 +74,13 @@ steps:
       - 'DOCKER_CLI_EXPERIMENTAL=enabled'
 
   - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-scion-grok-build'
+    dir: 'harnesses/grok-build'
+    args: ['buildx', 'build', '--platform', 'linux/amd64,linux/arm64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_SHORT_SHA', '-t', '$_REGISTRY/scion-grok-build:$_SHORT_SHA', '-t', '$_REGISTRY/scion-grok-build:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  - name: 'gcr.io/cloud-builders/docker'
     id: 'build-scion-hermes'
     dir: 'harnesses/hermes'
     args: ['buildx', 'build', '--platform', 'linux/amd64,linux/arm64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_SHORT_SHA', '-t', '$_REGISTRY/scion-hermes:$_SHORT_SHA', '-t', '$_REGISTRY/scion-hermes:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']

--- a/image-build/cloudbuild-harnesses.yaml
+++ b/image-build/cloudbuild-harnesses.yaml
@@ -68,6 +68,13 @@ steps:
       - 'DOCKER_CLI_EXPERIMENTAL=enabled'
 
   - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-scion-grok-build'
+    dir: 'harnesses/grok-build'
+    args: ['buildx', 'build', '--platform', 'linux/amd64,linux/arm64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_TAG', '-t', '$_REGISTRY/scion-grok-build:$_SHORT_SHA', '-t', '$_REGISTRY/scion-grok-build:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  - name: 'gcr.io/cloud-builders/docker'
     id: 'build-scion-hermes'
     dir: 'harnesses/hermes'
     args: ['buildx', 'build', '--platform', 'linux/amd64,linux/arm64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_TAG', '-t', '$_REGISTRY/scion-hermes:$_SHORT_SHA', '-t', '$_REGISTRY/scion-hermes:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']

--- a/image-build/cloudbuild-thick.yaml
+++ b/image-build/cloudbuild-thick.yaml
@@ -85,6 +85,13 @@ steps:
       - 'DOCKER_CLI_EXPERIMENTAL=enabled'
 
   - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-scion-grok-build'
+    dir: 'harnesses/grok-build'
+    args: ['buildx', 'build', '--platform', 'linux/amd64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_SHORT_SHA', '-t', '$_REGISTRY/scion-grok-build:$_SHORT_SHA', '-t', '$_REGISTRY/scion-grok-build:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  - name: 'gcr.io/cloud-builders/docker'
     id: 'build-scion-hermes'
     dir: 'harnesses/hermes'
     args: ['buildx', 'build', '--platform', 'linux/amd64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_SHORT_SHA', '-t', '$_REGISTRY/scion-hermes:$_SHORT_SHA', '-t', '$_REGISTRY/scion-hermes:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']

--- a/image-build/cloudbuild.yaml
+++ b/image-build/cloudbuild.yaml
@@ -87,6 +87,13 @@ steps:
       - 'DOCKER_CLI_EXPERIMENTAL=enabled'
 
   - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-scion-grok-build'
+    dir: 'harnesses/grok-build'
+    args: ['buildx', 'build', '--platform', 'linux/amd64,linux/arm64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_SHORT_SHA', '-t', '$_REGISTRY/scion-grok-build:$_SHORT_SHA', '-t', '$_REGISTRY/scion-grok-build:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']
+    env:
+      - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+
+  - name: 'gcr.io/cloud-builders/docker'
     id: 'build-scion-hermes'
     dir: 'harnesses/hermes'
     args: ['buildx', 'build', '--platform', 'linux/amd64,linux/arm64', '--build-arg', 'BASE_IMAGE=$_REGISTRY/scion-base:$_SHORT_SHA', '-t', '$_REGISTRY/scion-hermes:$_SHORT_SHA', '-t', '$_REGISTRY/scion-hermes:$_TAG', '-f', 'Dockerfile', '--pull', '--push', '.']


### PR DESCRIPTION
Adds the grok-build harness build step to the four static aggregate Cloud Build YAML files under image-build/.

The grok-build harness already had a working Dockerfile and per-harness cloudbuild.yaml, and the dynamic discovery builders (local-docker, local-podman) already included it automatically. This PR closes the gap by adding it to the static aggregate configs used by the cloud-build builder.

## Changes

Each file gets one new build-scion-grok-build step inserted alphabetically between gemini-cli and hermes, following the exact pattern of adjacent harness steps:

- cloudbuild-harnesses.yaml — BASE_IMAGE uses $_TAG, dual platform (amd64+arm64)
- cloudbuild-common.yaml — BASE_IMAGE uses $_SHORT_SHA, dual platform
- cloudbuild.yaml — BASE_IMAGE uses $_SHORT_SHA, dual platform
- cloudbuild-thick.yaml — BASE_IMAGE uses $_SHORT_SHA, amd64 only

Related: ptone/scion#1251
