### PR TITLE
fix(grok-build): fix instructions path and add native system prompt routing

### DIFF
--- a/harnesses/grok-build/config.yaml
+++ b/harnesses/grok-build/config.yaml
@@ -30,7 +30,7 @@ provisioner:
 config_dir: .grok
 skills_dir: .grok/skills
 interrupt_key: C-c
-instructions_file: AGENTS.md
+instructions_file: .grok/AGENTS.md
 system_prompt_mode: prepend_to_instructions
 
 model_aliases:
@@ -57,7 +57,7 @@ capabilities:
     enabled: { support: "yes" }
     native_emitter: { support: "yes" }
   prompts:
-    system_prompt: { support: "partial", reason: "System prompt is prepended to AGENTS.md" }
+    system_prompt: { support: "partial", reason: "System prompt is prepended to .grok/AGENTS.md" }
     agent_instructions: { support: "yes" }
   auth:
     api_key: { support: "yes" }

--- a/harnesses/grok-build/config.yaml
+++ b/harnesses/grok-build/config.yaml
@@ -31,7 +31,8 @@ config_dir: .grok
 skills_dir: .grok/skills
 interrupt_key: C-c
 instructions_file: .grok/AGENTS.md
-system_prompt_mode: prepend_to_instructions
+system_prompt_file: .grok/system-prompt.md
+system_prompt_mode: native
 
 model_aliases:
   small: grok-3-mini
@@ -43,6 +44,7 @@ command:
   base: ["grok", "--yolo", "--sandbox", "off"]
   resume_flag: "-c"
   task_position: after_base_args
+  system_prompt_flag: "--system-prompt-override"
 
 env_template:
   SCION_AGENT_NAME: "{{ .AgentName }}"
@@ -57,7 +59,7 @@ capabilities:
     enabled: { support: "yes" }
     native_emitter: { support: "yes" }
   prompts:
-    system_prompt: { support: "partial", reason: "System prompt is prepended to .grok/AGENTS.md" }
+    system_prompt: { support: "yes" }
     agent_instructions: { support: "yes" }
   auth:
     api_key: { support: "yes" }

--- a/harnesses/grok-build/provision.py
+++ b/harnesses/grok-build/provision.py
@@ -23,7 +23,9 @@ Grok-build-native concerns handled here:
     written to ~/.grok/auth.json from a staged file secret.
   - MCP servers translate to TOML [mcp_servers.*] entries in
     ~/.grok/config.toml (stdio→command/args/env, sse/http→url/headers).
-  - Instructions project to AGENTS.md (configurable via instructions_file).
+  - Instructions project to .grok/AGENTS.md (configurable via instructions_file).
+  - System prompt is written to .grok/system-prompt.md and passed via
+    --system-prompt-override (native routing).
   - ~/.grok/config.toml gets hardened defaults (auto-update off, telemetry
     off, memory off, subagents off).
   - Hook wiring to sciontool via ~/.grok/hooks/scion.json.
@@ -113,6 +115,33 @@ def _write_auth_file(ctx: scion_harness.ProvisionContext) -> None:
         f.write(content)
     os.chmod(tmp, 0o600)
     os.replace(tmp, target)
+
+
+def _apply_native_system_prompt(ctx: scion_harness.ProvisionContext) -> None:
+    """Write the staged system prompt to the native grok CLI location.
+
+    config.yaml declares system_prompt_file (.grok/system-prompt.md) and
+    system_prompt_mode (native), so the prompt goes into its own file rather
+    than being prepended to the instructions file. The Go-side harness reads
+    this file and passes it via --system-prompt-override.
+    """
+    system_prompt = ctx.read_input_text("system-prompt.md")
+    if not system_prompt.strip():
+        return
+
+    target = str(ctx.harness_config.get("system_prompt_file") or "")
+    if not target:
+        return
+
+    full = os.path.join(ctx.home, target)
+    parent = os.path.dirname(full)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    tmp = full + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(system_prompt)
+    os.replace(tmp, full)
+    ctx.info(f"wrote system prompt to {full}")
 
 
 # ---------------------------------------------------------------------------
@@ -613,15 +642,18 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
 
     ctx.write_outputs(resolved, env=env, extra=extra)
 
+    # --- System prompt (native routing) -------------------------------------
+    _apply_native_system_prompt(ctx)
+
     # --- Instructions projection --------------------------------------------
     harness_cfg = ctx.harness_config
-    instructions_file = harness_cfg.get("instructions_file") or "AGENTS.md"
+    instructions_file = harness_cfg.get("instructions_file") or ".grok/AGENTS.md"
     target = os.path.join(ctx.home, instructions_file)
     os.makedirs(os.path.dirname(target), exist_ok=True)
     # include_skills left at default False: config.yaml declares skills_dir,
     # so the host-side provisioner installs skills as individual files.
     try:
-        scion_harness.project_instructions(ctx, target)
+        scion_harness.project_instructions(ctx, target, system_prompt_mode="none")
     except OSError as exc:
         ctx.warn(f"failed to project instructions: {exc}")
 

--- a/harnesses/grok-build/provision_test.py
+++ b/harnesses/grok-build/provision_test.py
@@ -1275,5 +1275,93 @@ class VertexAIAuthTest(unittest.TestCase):
                 self.assertIn("GOOGLE_CLOUD_PROJECT", str(cm.exception))
 
 
+# ---------------------------------------------------------------------------
+# Native System Prompt Tests
+# ---------------------------------------------------------------------------
+
+
+class NativeSystemPromptTest(unittest.TestCase):
+    """Test native system prompt routing via _apply_native_system_prompt."""
+
+    def test_system_prompt_written_to_native_file(self) -> None:
+        """System prompt is written to .grok/system-prompt.md when staged."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs_dir = os.path.join(tmp, "inputs")
+            os.makedirs(inputs_dir)
+            with open(os.path.join(inputs_dir, "system-prompt.md"), "w") as f:
+                f.write("You are a helpful assistant.\n")
+            ctx = _make_ctx({
+                "harness_bundle_dir": tmp,
+                "harness_config": {
+                    "no_auth": {"behavior": "drop-to-shell"},
+                    "instructions_file": ".grok/AGENTS.md",
+                    "system_prompt_file": ".grok/system-prompt.md",
+                    "system_prompt_mode": "native",
+                    "skills_dir": ".grok/skills",
+                },
+            })
+            with temporary_home(tmp):
+                provision._apply_native_system_prompt(ctx)
+                target = os.path.join(tmp, ".grok", "system-prompt.md")
+                self.assertTrue(os.path.isfile(target))
+                with open(target) as f:
+                    content = f.read()
+                self.assertEqual(content, "You are a helpful assistant.\n")
+
+    def test_system_prompt_not_in_agents_md(self) -> None:
+        """When native routing is used, system prompt is NOT in AGENTS.md."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs_dir = os.path.join(tmp, "inputs")
+            os.makedirs(inputs_dir)
+            with open(os.path.join(inputs_dir, "system-prompt.md"), "w") as f:
+                f.write("You are a system prompt.\n")
+            with open(os.path.join(inputs_dir, "instructions.md"), "w") as f:
+                f.write("Do the thing.\n")
+            ctx = _make_ctx({
+                "harness_bundle_dir": tmp,
+                "harness_config": {
+                    "no_auth": {"behavior": "drop-to-shell"},
+                    "instructions_file": ".grok/AGENTS.md",
+                    "system_prompt_file": ".grok/system-prompt.md",
+                    "system_prompt_mode": "native",
+                    "skills_dir": ".grok/skills",
+                },
+            })
+            with temporary_home(tmp):
+                provision._apply_native_system_prompt(ctx)
+                target = os.path.join(tmp, ".grok", "AGENTS.md")
+                os.makedirs(os.path.dirname(target), exist_ok=True)
+                scion_harness.project_instructions(
+                    ctx, target, system_prompt_mode="none",
+                )
+                with open(target) as f:
+                    content = f.read()
+                self.assertIn("Do the thing.", content)
+                self.assertNotIn("You are a system prompt.", content)
+
+    def test_no_system_prompt_file_when_empty(self) -> None:
+        """When no system prompt is staged, .grok/system-prompt.md is not created."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inputs_dir = os.path.join(tmp, "inputs")
+            os.makedirs(inputs_dir)
+            # Stage an empty system prompt.
+            with open(os.path.join(inputs_dir, "system-prompt.md"), "w") as f:
+                f.write("   \n")
+            ctx = _make_ctx({
+                "harness_bundle_dir": tmp,
+                "harness_config": {
+                    "no_auth": {"behavior": "drop-to-shell"},
+                    "instructions_file": ".grok/AGENTS.md",
+                    "system_prompt_file": ".grok/system-prompt.md",
+                    "system_prompt_mode": "native",
+                    "skills_dir": ".grok/skills",
+                },
+            })
+            with temporary_home(tmp):
+                provision._apply_native_system_prompt(ctx)
+                target = os.path.join(tmp, ".grok", "system-prompt.md")
+                self.assertFalse(os.path.isfile(target))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Instructions path: AGENTS.md -> .grok/AGENTS.md
- Native system prompt via --system-prompt-override

## Test plan

- [x] 79 Python tests pass
- [x] Go bundle contract tests pass
- [x] Code review approved
