### PR TITLE
fix(hub): make hasAnyKey progeny-aware for auth credential detection

### DIFF
--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -1364,7 +1364,9 @@ func (s *Server) projectHasVerifiedGCPSA(ctx context.Context, projectID string) 
 }
 
 // hasAnyKey returns true if at least one of the keys is present in the
-// agent's env, or in the hub's env/secret stores at user or project scope.
+// agent's env, or in the hub's env/secret stores at user, project, or hub scope.
+// For progeny agents (those with ancestry len > 1), it also checks for
+// allowProgeny secrets and env vars inherited through the ancestry chain.
 func (s *Server) hasAnyKey(ctx context.Context, agent *store.Agent, keys []string) (bool, error) {
 	for _, key := range keys {
 		if agent.AppliedConfig != nil && agent.AppliedConfig.Env != nil {
@@ -1421,5 +1423,37 @@ func (s *Server) hasAnyKey(ctx context.Context, agent *store.Agent, keys []strin
 			}
 		}
 	}
+
+	// Progeny resolution: when the agent has ancestry (len > 1 means it is a
+	// progeny agent, not a direct user agent), check for allowProgeny secrets
+	// and env vars inherited through the ancestry chain. This parallels the
+	// resolution in pkg/secret/localbackend.go.
+	if len(agent.Ancestry) > 1 {
+		keySet := make(map[string]struct{}, len(keys))
+		for _, k := range keys {
+			keySet[k] = struct{}{}
+		}
+
+		progenySecrets, err := s.store.ListProgenySecrets(ctx, agent.Ancestry)
+		if err != nil {
+			return false, err
+		}
+		for _, ps := range progenySecrets {
+			if _, ok := keySet[ps.Key]; ok {
+				return true, nil
+			}
+		}
+
+		progenyEnvVars, err := s.store.ListProgenyEnvVars(ctx, agent.Ancestry)
+		if err != nil {
+			return false, err
+		}
+		for _, pev := range progenyEnvVars {
+			if _, ok := keySet[pev.Key]; ok {
+				return true, nil
+			}
+		}
+	}
+
 	return false, nil
 }

--- a/pkg/hub/handlers_agent_create_helpers_test.go
+++ b/pkg/hub/handlers_agent_create_helpers_test.go
@@ -829,3 +829,143 @@ func TestResumeInPlaceDecision(t *testing.T) {
 		})
 	}
 }
+
+// TestHasAnyKey_ProgenySecretResolution verifies that hasAnyKey correctly finds
+// allowProgeny secrets inherited through a progeny agent's ancestry chain.
+func TestHasAnyKey_ProgenySecretResolution(t *testing.T) {
+	srv, st := testServer(t)
+	ctx := context.Background()
+
+	userID := tid("hak-user-1")
+	parentAgentID := tid("hak-parent-agent")
+	childAgentID := tid("hak-child-agent")
+
+	// Create a user-scoped secret with AllowProgeny=true, created by the user.
+	require.NoError(t, st.CreateSecret(ctx, &store.Secret{
+		ID:             tid("sec-progeny-apikey"),
+		Key:            "ANTHROPIC_API_KEY",
+		EncryptedValue: "encrypted-value",
+		SecretType:     store.SecretTypeEnvironment,
+		Scope:          store.ScopeUser,
+		ScopeID:        userID,
+		AllowProgeny:   true,
+		CreatedBy:      userID,
+		InjectionMode:  store.InjectionModeAsNeeded,
+	}))
+
+	t.Run("progeny agent finds inherited secret", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:       childAgentID,
+			OwnerID:  parentAgentID, // Not the user — this is the bug scenario
+			Ancestry: []string{childAgentID, parentAgentID, userID},
+			AppliedConfig: &store.AgentAppliedConfig{},
+		}
+
+		found, err := srv.hasAnyKey(ctx, agent, []string{"ANTHROPIC_API_KEY"})
+		require.NoError(t, err)
+		assert.True(t, found,
+			"progeny agent should find allowProgeny secret via ancestry")
+	})
+
+	t.Run("direct agent finds own secret", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:       tid("hak-direct-agent"),
+			OwnerID:  userID, // Direct user ownership
+			Ancestry: []string{tid("hak-direct-agent")},
+			AppliedConfig: &store.AgentAppliedConfig{},
+		}
+
+		found, err := srv.hasAnyKey(ctx, agent, []string{"ANTHROPIC_API_KEY"})
+		require.NoError(t, err)
+		assert.True(t, found,
+			"direct agent should find secret via OwnerID lookup")
+	})
+
+	t.Run("progeny agent without matching secret returns false", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:       childAgentID,
+			OwnerID:  parentAgentID,
+			Ancestry: []string{childAgentID, parentAgentID, userID},
+			AppliedConfig: &store.AgentAppliedConfig{},
+		}
+
+		found, err := srv.hasAnyKey(ctx, agent, []string{"NONEXISTENT_KEY"})
+		require.NoError(t, err)
+		assert.False(t, found,
+			"progeny agent should not find nonexistent key")
+	})
+}
+
+// TestHasAnyKey_ProgenyEnvVarResolution verifies that hasAnyKey correctly finds
+// allowProgeny env vars inherited through a progeny agent's ancestry chain.
+func TestHasAnyKey_ProgenyEnvVarResolution(t *testing.T) {
+	srv, st := testServer(t)
+	ctx := context.Background()
+
+	userID := tid("hak-ev-user-1")
+	parentAgentID := tid("hak-ev-parent-agent")
+	childAgentID := tid("hak-ev-child-agent")
+
+	// Create a user-scoped env var with AllowProgeny=true.
+	require.NoError(t, st.CreateEnvVar(ctx, &store.EnvVar{
+		ID:            tid("ev-progeny-key"),
+		Key:           "GEMINI_API_KEY",
+		Value:         "gemini-value",
+		Scope:         store.ScopeUser,
+		ScopeID:       userID,
+		AllowProgeny:  true,
+		CreatedBy:     userID,
+		InjectionMode: store.InjectionModeAlways,
+	}))
+
+	t.Run("progeny agent finds inherited env var", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:       childAgentID,
+			OwnerID:  parentAgentID,
+			Ancestry: []string{childAgentID, parentAgentID, userID},
+			AppliedConfig: &store.AgentAppliedConfig{},
+		}
+
+		found, err := srv.hasAnyKey(ctx, agent, []string{"GEMINI_API_KEY"})
+		require.NoError(t, err)
+		assert.True(t, found,
+			"progeny agent should find allowProgeny env var via ancestry")
+	})
+}
+
+// TestHasAnyKey_NoProgenyForDirectAgent verifies that the progeny code path
+// does not fire for direct agents (ancestry length <= 1).
+func TestHasAnyKey_NoProgenyForDirectAgent(t *testing.T) {
+	srv, st := testServer(t)
+	ctx := context.Background()
+
+	userID := tid("hak-noprog-user")
+	otherUserID := tid("hak-noprog-other")
+
+	// Create a secret owned by otherUser with AllowProgeny=true.
+	require.NoError(t, st.CreateSecret(ctx, &store.Secret{
+		ID:             tid("sec-noprog"),
+		Key:            "SECRET_KEY",
+		EncryptedValue: "encrypted",
+		SecretType:     store.SecretTypeEnvironment,
+		Scope:          store.ScopeUser,
+		ScopeID:        otherUserID,
+		AllowProgeny:   true,
+		CreatedBy:      otherUserID,
+		InjectionMode:  store.InjectionModeAsNeeded,
+	}))
+
+	t.Run("direct agent does not use progeny path", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:       tid("hak-noprog-agent"),
+			OwnerID:  userID, // Different from otherUser
+			Ancestry: nil,    // No ancestry — direct agent
+			AppliedConfig: &store.AgentAppliedConfig{},
+		}
+
+		found, err := srv.hasAnyKey(ctx, agent, []string{"SECRET_KEY"})
+		require.NoError(t, err)
+		assert.False(t, found,
+			"direct agent should not find secrets via progeny resolution")
+	})
+}

--- a/pkg/hub/handlers_agent_create_helpers_test.go
+++ b/pkg/hub/handlers_agent_create_helpers_test.go
@@ -855,9 +855,9 @@ func TestHasAnyKey_ProgenySecretResolution(t *testing.T) {
 
 	t.Run("progeny agent finds inherited secret", func(t *testing.T) {
 		agent := &store.Agent{
-			ID:       childAgentID,
-			OwnerID:  parentAgentID, // Not the user — this is the bug scenario
-			Ancestry: []string{childAgentID, parentAgentID, userID},
+			ID:            childAgentID,
+			OwnerID:       parentAgentID, // Not the user — this is the bug scenario
+			Ancestry:      []string{childAgentID, parentAgentID, userID},
 			AppliedConfig: &store.AgentAppliedConfig{},
 		}
 
@@ -869,9 +869,9 @@ func TestHasAnyKey_ProgenySecretResolution(t *testing.T) {
 
 	t.Run("direct agent finds own secret", func(t *testing.T) {
 		agent := &store.Agent{
-			ID:       tid("hak-direct-agent"),
-			OwnerID:  userID, // Direct user ownership
-			Ancestry: []string{tid("hak-direct-agent")},
+			ID:            tid("hak-direct-agent"),
+			OwnerID:       userID, // Direct user ownership
+			Ancestry:      []string{tid("hak-direct-agent")},
 			AppliedConfig: &store.AgentAppliedConfig{},
 		}
 
@@ -883,9 +883,9 @@ func TestHasAnyKey_ProgenySecretResolution(t *testing.T) {
 
 	t.Run("progeny agent without matching secret returns false", func(t *testing.T) {
 		agent := &store.Agent{
-			ID:       childAgentID,
-			OwnerID:  parentAgentID,
-			Ancestry: []string{childAgentID, parentAgentID, userID},
+			ID:            childAgentID,
+			OwnerID:       parentAgentID,
+			Ancestry:      []string{childAgentID, parentAgentID, userID},
 			AppliedConfig: &store.AgentAppliedConfig{},
 		}
 
@@ -920,9 +920,9 @@ func TestHasAnyKey_ProgenyEnvVarResolution(t *testing.T) {
 
 	t.Run("progeny agent finds inherited env var", func(t *testing.T) {
 		agent := &store.Agent{
-			ID:       childAgentID,
-			OwnerID:  parentAgentID,
-			Ancestry: []string{childAgentID, parentAgentID, userID},
+			ID:            childAgentID,
+			OwnerID:       parentAgentID,
+			Ancestry:      []string{childAgentID, parentAgentID, userID},
 			AppliedConfig: &store.AgentAppliedConfig{},
 		}
 
@@ -957,9 +957,9 @@ func TestHasAnyKey_NoProgenyForDirectAgent(t *testing.T) {
 
 	t.Run("direct agent does not use progeny path", func(t *testing.T) {
 		agent := &store.Agent{
-			ID:       tid("hak-noprog-agent"),
-			OwnerID:  userID, // Different from otherUser
-			Ancestry: nil,    // No ancestry — direct agent
+			ID:            tid("hak-noprog-agent"),
+			OwnerID:       userID, // Different from otherUser
+			Ancestry:      nil,    // No ancestry — direct agent
 			AppliedConfig: &store.AgentAppliedConfig{},
 		}
 


### PR DESCRIPTION
Fixes a bug where progeny agents fall into no-auth mode even when they should inherit user-scoped secrets (file or env) with allowProgeny=true.

Root cause: The hub auto no-auth fallback in populateAgentConfig calls hasAnyKey() which uses agent.OwnerID to look up user-scoped secrets. For progeny agents, OwnerID is the creating agent s ID -- not the user s ID -- so user-scoped secrets are never found. The hub preemptively sets NoAuth=true, which gates off resolveSecrets() entirely. The correctly-working progeny-aware ListProgenySecrets() path never runs.

Fix: After existing per-key scope checks fail, hasAnyKey now falls back to ListProgenySecrets() and ListProgenyEnvVars() for progeny agents (len(ancestry) > 1), paralleling the established pattern in pkg/secret/localbackend.go.

Why explicit --harness-auth worked: It bypasses the auto no-auth fallback entirely (HarnessAuth is non-empty), so resolveSecrets runs and ListProgenySecrets correctly finds the inherited secret.

## Key files
- pkg/hub/handlers_agent_create_helpers.go -- progeny-aware hasAnyKey
- pkg/hub/handlers_agent_create_helpers_test.go -- 5 new test cases

Related: ptone/scion#1252
