### PR TITLE
feat(hub): add DefaultHarnessAuth setting at hub and project level

### DIFF
--- a/pkg/config/opsettings/sections.go
+++ b/pkg/config/opsettings/sections.go
@@ -59,6 +59,7 @@ type AutoExposePortsSettings struct {
 type AgentDefaultsSettings struct {
 	DefaultTemplate      string            `json:"default_template,omitempty"`
 	DefaultHarnessConfig string            `json:"default_harness_config,omitempty"`
+	DefaultHarnessAuth   string            `json:"default_harness_auth,omitempty"`
 	DefaultMaxTurns      int               `json:"default_max_turns,omitempty"`
 	DefaultMaxModelCalls int               `json:"default_max_model_calls,omitempty"`
 	DefaultMaxDuration   string            `json:"default_max_duration,omitempty"`

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -37,6 +37,13 @@
       "x-scope": "any",
       "x-since": "1"
     },
+    "default_harness_auth": {
+      "type": "string",
+      "enum": ["api-key", "oauth-token", "auth-file", "vertex-ai", "none"],
+      "description": "Default authentication type for new agents. Applied when no explicit auth type is set at the agent, harness-config, or profile level.",
+      "x-scope": "any",
+      "x-since": "1"
+    },
     "image_registry": {
       "type": "string",
       "description": "Container image registry prefix. When set, replaces the registry portion of any scion-* harness-config image at resolution time.",

--- a/pkg/config/schemas/settings-v1.schema.json
+++ b/pkg/config/schemas/settings-v1.schema.json
@@ -39,8 +39,9 @@
     },
     "default_harness_auth": {
       "type": "string",
-      "enum": ["api-key", "oauth-token", "auth-file", "vertex-ai", "none"],
+      "enum": ["", "api-key", "oauth-token", "auth-file", "vertex-ai", "none"],
       "description": "Default authentication type for new agents. Applied when no explicit auth type is set at the agent, harness-config, or profile level.",
+      "x-env-var": "SCION_DEFAULT_HARNESS_AUTH",
       "x-scope": "any",
       "x-since": "1"
     },

--- a/pkg/hub/hub_agent_defaults.go
+++ b/pkg/hub/hub_agent_defaults.go
@@ -60,6 +60,7 @@ func (s *Server) hubAgentDefaults() opsettings.AgentDefaultsSettings {
 func agentDefaultsEqual(a, b opsettings.AgentDefaultsSettings) bool {
 	if a.DefaultTemplate != b.DefaultTemplate ||
 		a.DefaultHarnessConfig != b.DefaultHarnessConfig ||
+		a.DefaultHarnessAuth != b.DefaultHarnessAuth ||
 		a.DefaultMaxTurns != b.DefaultMaxTurns ||
 		a.DefaultMaxModelCalls != b.DefaultMaxModelCalls ||
 		a.DefaultMaxDuration != b.DefaultMaxDuration ||
@@ -135,6 +136,9 @@ func applyHubAgentDefaults(ac *store.AgentAppliedConfig, d opsettings.AgentDefau
 	if ac.HarnessConfig == "" && d.DefaultHarnessConfig != "" {
 		ac.HarnessConfig = d.DefaultHarnessConfig
 		hcChanged = true
+	}
+	if ac.HarnessAuth == "" && d.DefaultHarnessAuth != "" {
+		ac.HarnessAuth = d.DefaultHarnessAuth
 	}
 	if ac.Model == "" && d.DefaultModel != "" {
 		ac.Model = d.DefaultModel

--- a/pkg/hub/hub_agent_defaults_ladder_test.go
+++ b/pkg/hub/hub_agent_defaults_ladder_test.go
@@ -278,6 +278,66 @@ func TestApplyHubAgentDefaults_NilAppliedConfig(t *testing.T) {
 	}))
 }
 
+// TestApplyHubAgentDefaults_HarnessAuth verifies the only-if-empty guard for
+// DefaultHarnessAuth. Same pattern as DefaultHarnessConfig: the hub operational
+// default fills ac.HarnessAuth only when no higher tier has set it.
+func TestApplyHubAgentDefaults_HarnessAuth(t *testing.T) {
+	const hubDefault = "vertex-ai"
+
+	tests := []struct {
+		name      string
+		incumbent string
+		want      string
+	}{
+		{
+			name:      "LosesToRequest",
+			incumbent: "api-key",
+			want:      "api-key",
+		},
+		{
+			name:      "LosesToProjectAnnotation",
+			incumbent: "oauth-token",
+			want:      "oauth-token",
+		},
+		{
+			name:      "AppliesWhenEmpty",
+			incumbent: "",
+			want:      hubDefault,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ac := &store.AgentAppliedConfig{HarnessAuth: tt.incumbent}
+			applyHubAgentDefaults(ac, opsettings.AgentDefaultsSettings{
+				DefaultHarnessAuth: hubDefault,
+			})
+			assert.Equal(t, tt.want, ac.HarnessAuth)
+		})
+	}
+}
+
+// TestApplyHubAgentDefaults_HarnessAuthEmptyDefault verifies that an empty hub
+// DefaultHarnessAuth leaves ac.HarnessAuth untouched.
+func TestApplyHubAgentDefaults_HarnessAuthEmptyDefault(t *testing.T) {
+	ac := &store.AgentAppliedConfig{}
+	applyHubAgentDefaults(ac, opsettings.AgentDefaultsSettings{})
+	assert.Empty(t, ac.HarnessAuth)
+}
+
+// TestApplyHubAgentDefaults_HarnessAuthDoesNotAffectHCProvenance verifies that
+// applying only DefaultHarnessAuth (no DefaultHarnessConfig) returns false, so
+// callers do not set withHubDefaultHarnessConfig context spuriously.
+func TestApplyHubAgentDefaults_HarnessAuthDoesNotAffectHCProvenance(t *testing.T) {
+	ac := &store.AgentAppliedConfig{}
+	applied := applyHubAgentDefaults(ac, opsettings.AgentDefaultsSettings{
+		DefaultHarnessAuth: "vertex-ai",
+	})
+	assert.Equal(t, "vertex-ai", ac.HarnessAuth)
+	assert.False(t, applied,
+		"auth-only application must not signal harness-config provenance")
+}
+
 // ---------------------------------------------------------------------------
 // default_template — create path, and the degradation rule
 // ---------------------------------------------------------------------------

--- a/pkg/hub/project_settings_handlers.go
+++ b/pkg/hub/project_settings_handlers.go
@@ -32,6 +32,7 @@ import (
 const (
 	projectSettingDefaultTemplate        = "scion.io/default-template"
 	projectSettingDefaultHarnessConfig   = "scion.io/default-harness-config"
+	projectSettingDefaultHarnessAuth     = "scion.io/default-harness-auth"
 	projectSettingDefaultModel           = "scion.io/default-model"
 	projectSettingDefaultThinkingLevel   = "scion.io/default-thinking-level"
 	projectSettingTelemetryEnabled       = "scion.io/telemetry-enabled"
@@ -121,6 +122,7 @@ const (
 var projectSettingKeys = []string{
 	projectSettingDefaultTemplate,
 	projectSettingDefaultHarnessConfig,
+	projectSettingDefaultHarnessAuth,
 	projectSettingDefaultModel,
 	projectSettingDefaultThinkingLevel,
 	projectSettingTelemetryEnabled,
@@ -320,6 +322,7 @@ func projectSettingsFromAnnotations(project *store.Project) *hubclient.ProjectSe
 
 	settings.DefaultTemplate = project.Annotations[projectSettingDefaultTemplate]
 	settings.DefaultHarnessConfig = project.Annotations[projectSettingDefaultHarnessConfig]
+	settings.DefaultHarnessAuth = project.Annotations[projectSettingDefaultHarnessAuth]
 	settings.DefaultModel = project.Annotations[projectSettingDefaultModel]
 	if val, ok := project.Annotations[projectSettingDefaultThinkingLevel]; ok {
 		if n, err := strconv.Atoi(val); err == nil {
@@ -401,6 +404,7 @@ func applyProjectSettingsToAnnotations(project *store.Project, settings *hubclie
 
 	setOrDelete(project.Annotations, projectSettingDefaultTemplate, settings.DefaultTemplate)
 	setOrDelete(project.Annotations, projectSettingDefaultHarnessConfig, settings.DefaultHarnessConfig)
+	setOrDelete(project.Annotations, projectSettingDefaultHarnessAuth, settings.DefaultHarnessAuth)
 	setOrDelete(project.Annotations, projectSettingDefaultModel, settings.DefaultModel)
 	if settings.DefaultThinkingLevel != nil {
 		project.Annotations[projectSettingDefaultThinkingLevel] = strconv.Itoa(*settings.DefaultThinkingLevel)
@@ -492,6 +496,11 @@ func applyProjectDefaults(ac *store.AgentAppliedConfig, project *store.Project) 
 	// Apply default harness config (only if not already set)
 	if ac.HarnessConfig == "" && settings.DefaultHarnessConfig != "" {
 		ac.HarnessConfig = settings.DefaultHarnessConfig
+	}
+
+	// Apply default harness auth (only if not already set)
+	if ac.HarnessAuth == "" && settings.DefaultHarnessAuth != "" {
+		ac.HarnessAuth = settings.DefaultHarnessAuth
 	}
 
 	// Apply default model (only if not already set by agent/template/CLI)

--- a/pkg/hub/project_settings_handlers_test.go
+++ b/pkg/hub/project_settings_handlers_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/config/opsettings"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/stretchr/testify/assert"
@@ -210,6 +211,169 @@ func TestApplyProjectDefaults_HarnessConfig(t *testing.T) {
 		applyProjectDefaults(ac, project)
 		assert.Empty(t, ac.HarnessConfig)
 	})
+}
+
+func TestApplyProjectDefaults_HarnessAuth(t *testing.T) {
+	t.Run("applies default harness auth when empty", func(t *testing.T) {
+		project := &store.Project{
+			Annotations: map[string]string{
+				"scion.io/default-harness-auth": "vertex-ai",
+			},
+		}
+		ac := &store.AgentAppliedConfig{}
+		applyProjectDefaults(ac, project)
+		assert.Equal(t, "vertex-ai", ac.HarnessAuth)
+	})
+
+	t.Run("does not override explicit harness auth", func(t *testing.T) {
+		project := &store.Project{
+			Annotations: map[string]string{
+				"scion.io/default-harness-auth": "vertex-ai",
+			},
+		}
+		ac := &store.AgentAppliedConfig{HarnessAuth: "api-key"}
+		applyProjectDefaults(ac, project)
+		assert.Equal(t, "api-key", ac.HarnessAuth)
+	})
+
+	t.Run("nil project is safe", func(t *testing.T) {
+		ac := &store.AgentAppliedConfig{}
+		applyProjectDefaults(ac, nil)
+		assert.Empty(t, ac.HarnessAuth)
+	})
+
+	t.Run("nil annotations is safe", func(t *testing.T) {
+		project := &store.Project{}
+		ac := &store.AgentAppliedConfig{}
+		applyProjectDefaults(ac, project)
+		assert.Empty(t, ac.HarnessAuth)
+	})
+
+	t.Run("no default set leaves auth empty", func(t *testing.T) {
+		project := &store.Project{
+			Annotations: map[string]string{},
+		}
+		ac := &store.AgentAppliedConfig{}
+		applyProjectDefaults(ac, project)
+		assert.Empty(t, ac.HarnessAuth)
+	})
+}
+
+// TestProjectSettings_DefaultHarnessAuth_RoundTrip verifies the annotation
+// round-trip: PUT stores the value, GET returns it, empty PUT clears it.
+func TestProjectSettings_DefaultHarnessAuth_RoundTrip(t *testing.T) {
+	srv, s := testServer(t)
+	project := createTestProjectForSettings(t, s)
+
+	putBody := hubclient.ProjectSettings{
+		DefaultHarnessAuth: "vertex-ai",
+	}
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/projects/"+project.ID+"/settings", putBody)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var putResp hubclient.ProjectSettings
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&putResp))
+	assert.Equal(t, "vertex-ai", putResp.DefaultHarnessAuth)
+
+	// GET should return persisted value
+	rec = doRequest(t, srv, http.MethodGet, "/api/v1/projects/"+project.ID+"/settings", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var getResp hubclient.ProjectSettings
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&getResp))
+	assert.Equal(t, "vertex-ai", getResp.DefaultHarnessAuth)
+
+	// Clear by sending empty value
+	clearBody := hubclient.ProjectSettings{}
+	rec = doRequest(t, srv, http.MethodPut, "/api/v1/projects/"+project.ID+"/settings", clearBody)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var clearResp hubclient.ProjectSettings
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&clearResp))
+	assert.Empty(t, clearResp.DefaultHarnessAuth)
+}
+
+// TestHarnessAuth_Precedence_ProjectBeatsHub verifies the full precedence chain:
+// project default beats hub default when per-agent is empty.
+func TestHarnessAuth_Precedence_ProjectBeatsHub(t *testing.T) {
+	project := &store.Project{
+		Annotations: map[string]string{
+			"scion.io/default-harness-auth": "oauth-token",
+		},
+	}
+
+	ac := &store.AgentAppliedConfig{}
+
+	// Step 1: project defaults fill first
+	applyProjectDefaults(ac, project)
+	assert.Equal(t, "oauth-token", ac.HarnessAuth,
+		"project default should fill empty HarnessAuth")
+
+	// Step 2: hub defaults run after — should NOT override the project value
+	applyHubAgentDefaults(ac, opsettings.AgentDefaultsSettings{
+		DefaultHarnessAuth: "vertex-ai",
+	})
+	assert.Equal(t, "oauth-token", ac.HarnessAuth,
+		"hub default must not override project default")
+}
+
+// TestHarnessAuth_Precedence_ExplicitBeatsAll verifies that an explicit per-agent
+// harnessAuth beats both project and hub defaults.
+func TestHarnessAuth_Precedence_ExplicitBeatsAll(t *testing.T) {
+	project := &store.Project{
+		Annotations: map[string]string{
+			"scion.io/default-harness-auth": "oauth-token",
+		},
+	}
+
+	ac := &store.AgentAppliedConfig{HarnessAuth: "api-key"}
+
+	applyProjectDefaults(ac, project)
+	assert.Equal(t, "api-key", ac.HarnessAuth,
+		"explicit per-agent should beat project default")
+
+	applyHubAgentDefaults(ac, opsettings.AgentDefaultsSettings{
+		DefaultHarnessAuth: "vertex-ai",
+	})
+	assert.Equal(t, "api-key", ac.HarnessAuth,
+		"explicit per-agent should beat hub default")
+}
+
+// TestHarnessAuth_Precedence_HubFillsWhenBothEmpty verifies that the hub default
+// fills when both per-agent and project defaults are empty.
+func TestHarnessAuth_Precedence_HubFillsWhenBothEmpty(t *testing.T) {
+	project := &store.Project{
+		Annotations: map[string]string{},
+	}
+
+	ac := &store.AgentAppliedConfig{}
+
+	applyProjectDefaults(ac, project)
+	assert.Empty(t, ac.HarnessAuth,
+		"no project default → HarnessAuth stays empty")
+
+	applyHubAgentDefaults(ac, opsettings.AgentDefaultsSettings{
+		DefaultHarnessAuth: "vertex-ai",
+	})
+	assert.Equal(t, "vertex-ai", ac.HarnessAuth,
+		"hub default should fill when both per-agent and project are empty")
+}
+
+// TestHarnessAuth_Precedence_NoDefaultUnchanged verifies that when no default
+// is set at any level, behavior is unchanged (harnessAuth stays empty).
+func TestHarnessAuth_Precedence_NoDefaultUnchanged(t *testing.T) {
+	project := &store.Project{
+		Annotations: map[string]string{},
+	}
+
+	ac := &store.AgentAppliedConfig{}
+
+	applyProjectDefaults(ac, project)
+	applyHubAgentDefaults(ac, opsettings.AgentDefaultsSettings{})
+
+	assert.Empty(t, ac.HarnessAuth,
+		"no defaults at any level → HarnessAuth stays empty")
 }
 
 func TestProjectSettings_DefaultModel(t *testing.T) {

--- a/pkg/hub/project_settings_registry_test.go
+++ b/pkg/hub/project_settings_registry_test.go
@@ -38,7 +38,7 @@ const projectSettingsSourceFile = "project_settings_handlers.go"
 // .design/project-templates.md §3.1. It is asserted separately from the drift
 // guard so that adding or removing a setting shows up as a deliberate edit in
 // the diff rather than passing silently.
-const expectedProjectSettingCount = 19
+const expectedProjectSettingCount = 20
 
 // isProjectSettingConstName reports whether an identifier names a project
 // settings annotation key constant.

--- a/pkg/hub/project_settings_resolved.go
+++ b/pkg/hub/project_settings_resolved.go
@@ -236,6 +236,11 @@ var resolvedSettingDescriptors = map[string]resolvedSettingDescriptor{
 		path:              []string{"default_harness_config"},
 		absentWhenMissing: false, // string, "" dropped by omitempty
 	},
+	projectSettingDefaultHarnessAuth: {
+		source:            hubSourceAgentDefaults,
+		path:              []string{"default_harness_auth"},
+		absentWhenMissing: false, // string, "" dropped by omitempty
+	},
 	projectSettingDefaultModel: {
 		source:            hubSourceAgentDefaults,
 		path:              []string{"default_model"},

--- a/pkg/hubclient/types.go
+++ b/pkg/hubclient/types.go
@@ -203,6 +203,7 @@ type ProjectSettings struct {
 	ActiveProfile          string                 `json:"activeProfile,omitempty"`
 	DefaultTemplate        string                 `json:"defaultTemplate,omitempty"`
 	DefaultHarnessConfig   string                 `json:"defaultHarnessConfig,omitempty"`
+	DefaultHarnessAuth     string                 `json:"defaultHarnessAuth,omitempty"`
 	DefaultModel           string                 `json:"defaultModel,omitempty"`
 	DefaultThinkingLevel   *int                   `json:"defaultThinkingLevel,omitempty"`
 	TelemetryEnabled       *bool                  `json:"telemetryEnabled,omitempty"`

--- a/web/src/components/pages/admin-server-config.ts
+++ b/web/src/components/pages/admin-server-config.ts
@@ -222,6 +222,7 @@ interface ServerConfigResponse {
   active_profile?: string;
   default_template?: string;
   default_harness_config?: string;
+  default_harness_auth?: string;
   image_registry?: string;
   workspace_path?: string;
   server?: V1ServerConfig;
@@ -375,6 +376,7 @@ const KOANF_KEY_LABELS: Record<string, string> = {
   // agent_defaults section
   default_template: 'Default Template',
   default_harness_config: 'Default Harness Config',
+  default_harness_auth: 'Default Harness Auth',
   default_max_turns: 'Default Max Turns',
   default_max_model_calls: 'Default Max Model Calls',
   default_max_duration: 'Default Max Duration',
@@ -436,6 +438,7 @@ export class ScionPageAdminServerConfig extends LitElement {
   @state() private defaultHarnessConfig = '';
   @state() private harnessConfigSelection = '';
   @state() private customHarnessConfig = '';
+  @state() private defaultHarnessAuth = '';
   @state() private harnessConfigs: HarnessConfigEntry[] = [];
   @state() private imageRegistry = '';
   @state() private workspacePath = '';
@@ -1419,6 +1422,7 @@ export class ScionPageAdminServerConfig extends LitElement {
     this.defaultTemplate = data.default_template || '';
     this.defaultHarnessConfig = data.default_harness_config || '';
     this.syncHarnessConfigSelection();
+    this.defaultHarnessAuth = data.default_harness_auth || '';
     this.imageRegistry = data.image_registry || '';
     this.workspacePath = data.workspace_path || '';
 
@@ -1662,6 +1666,7 @@ export class ScionPageAdminServerConfig extends LitElement {
     // General — only Layer-1 top-level keys
     if (ok('default_template')) payload.default_template = this.defaultTemplate;
     if (ok('default_harness_config')) payload.default_harness_config = this.resolvedHarnessConfig;
+    if (ok('default_harness_auth')) payload.default_harness_auth = this.defaultHarnessAuth || '';
     if (ok('image_registry')) payload.image_registry = this.imageRegistry;
 
     // Default agent limits
@@ -1822,6 +1827,8 @@ export class ScionPageAdminServerConfig extends LitElement {
     if (ok('default_template')) payload.default_template = this.defaultTemplate || undefined;
     if (ok('default_harness_config'))
       payload.default_harness_config = this.defaultHarnessConfig || undefined;
+    if (ok('default_harness_auth'))
+      payload.default_harness_auth = this.defaultHarnessAuth || undefined;
     if (ok('image_registry')) payload.image_registry = this.imageRegistry || undefined;
     if (ok('workspace_path')) payload.workspace_path = this.workspacePath || undefined;
 
@@ -2872,6 +2879,35 @@ export class ScionPageAdminServerConfig extends LitElement {
                       </div>
                     `
                   : nothing}
+                <div class="form-field">
+                  <label>Default Harness Auth</label>
+                  ${this.renderFieldValue(
+                    'default_harness_auth',
+                    this.defaultHarnessAuth
+                      ? {
+                          'api-key': 'Provider API Key',
+                          'oauth-token': 'OAuth Token',
+                          'auth-file': 'Harness credential file',
+                          'vertex-ai': 'Vertex Model Garden',
+                          none: 'No Authentication',
+                        }[this.defaultHarnessAuth] || this.defaultHarnessAuth
+                      : 'None',
+                    html`${this.renderEnvBadge('default_harness_auth')}
+                      <sl-select
+                        .value=${this.defaultHarnessAuth}
+                        @sl-change=${(e: Event) => {
+                          this.defaultHarnessAuth = (e.target as HTMLSelectElement).value;
+                        }}
+                      >
+                        <sl-option value="">None</sl-option>
+                        <sl-option value="api-key">Provider API Key</sl-option>
+                        <sl-option value="oauth-token">OAuth Token</sl-option>
+                        <sl-option value="auth-file">Harness credential file</sl-option>
+                        <sl-option value="vertex-ai">Vertex Model Garden</sl-option>
+                        <sl-option value="none">No Authentication</sl-option>
+                      </sl-select>`
+                  )}
+                </div>
                 <div class="form-field full-width">
                   <label>Workspace Path</label>
                   <span class="hint">Override default workspace path for agent worktrees</span>

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -66,6 +66,7 @@ interface ProjectResourceSpec {
 interface ProjectSettings {
   defaultTemplate?: string | undefined;
   defaultHarnessConfig?: string | undefined;
+  defaultHarnessAuth?: string | undefined;
   telemetryEnabled?: boolean | null | undefined;
   autoExposePortsEnabled?: boolean | null | undefined;
   activeProfile?: string | undefined;
@@ -168,6 +169,9 @@ export class ScionPageProjectSettings extends LitElement {
 
   @state()
   private configDefaultHarnessConfig = '';
+
+  @state()
+  private configDefaultHarnessAuth = '';
 
   @state()
   private configTelemetryEnabled: boolean | null = null;
@@ -1037,6 +1041,7 @@ export class ScionPageProjectSettings extends LitElement {
       // Populate form state from settings (same as before)
       this.configDefaultTemplate = this.settings.defaultTemplate || '';
       this.configDefaultHarnessConfig = this.settings.defaultHarnessConfig || '';
+      this.configDefaultHarnessAuth = this.settings.defaultHarnessAuth || '';
       this.configTelemetryEnabled = this.settings.telemetryEnabled ?? null;
       this.configAutoExposePortsEnabled = this.settings.autoExposePortsEnabled ?? null;
       this.configDefaultMaxTurns = this.settings.defaultMaxTurns || 0;
@@ -1244,6 +1249,7 @@ export class ScionPageProjectSettings extends LitElement {
       const body: ProjectSettings = {
         defaultTemplate: this.configDefaultTemplate || undefined,
         defaultHarnessConfig: this.configDefaultHarnessConfig || undefined,
+        defaultHarnessAuth: this.configDefaultHarnessAuth || undefined,
         defaultModel: defaultModel || undefined,
         telemetryEnabled: this.configTelemetryEnabled,
         autoExposePortsEnabled: this.configAutoExposePortsEnabled,
@@ -1827,6 +1833,38 @@ export class ScionPageProjectSettings extends LitElement {
                 </sl-select>
                 <span class="field-help"
                   >Harness configuration used by default for new agents.</span
+                >
+              </div>
+
+              <div
+                class="config-field ${this.isHubDefault('scion.io/default-harness-auth')
+                  ? 'hub-inherited'
+                  : ''}"
+              >
+                <label
+                  >Default Harness Auth
+                  ${this.renderHubIndicator('scion.io/default-harness-auth')}</label
+                >
+                <sl-select
+                  placeholder=${this.hubSelectLabel(
+                    'scion.io/default-harness-auth',
+                    'None (use server default)'
+                  )}
+                  clearable
+                  value=${this.configDefaultHarnessAuth}
+                  ?disabled=${!canEdit}
+                  @sl-change=${(e: Event) => {
+                    this.configDefaultHarnessAuth = (e.target as HTMLSelectElement).value;
+                  }}
+                >
+                  <sl-option value="api-key">Provider API Key</sl-option>
+                  <sl-option value="oauth-token">OAuth Token</sl-option>
+                  <sl-option value="auth-file">Harness credential file</sl-option>
+                  <sl-option value="vertex-ai">Vertex Model Garden</sl-option>
+                  <sl-option value="none">No Authentication</sl-option>
+                </sl-select>
+                <span class="field-help"
+                  >Default authentication type for new agents in this project.</span
                 >
               </div>
 


### PR DESCRIPTION
Adds DefaultHarnessAuth as a soft-default setting at hub and project level, following the established DefaultHarnessConfig pattern.

When set, provides the default auth type for new agents. Per-agent override at creation time still wins. Precedence: per-agent > project > hub.

11 files, +326/-1. Backend (opsettings, project annotations, apply-defaults), frontend (admin + project settings dropdowns), comprehensive precedence tests.

Ref: ptone/scion#1253