### PR TITLE
feat: add ExitCode and ExitReason structured fields

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -503,8 +503,7 @@ func RunAgent(cmd *cobra.Command, args []string, resume bool) error {
 		if err == nil {
 			for _, a := range agents {
 				if strings.EqualFold(a.Name, agentName) || a.ID == agentName || strings.EqualFold(strings.TrimPrefix(a.Name, "/"), agentName) {
-					status := strings.ToLower(a.ContainerStatus)
-					isRunning := strings.HasPrefix(status, "up") || status == "running"
+					isRunning := a.Phase == string(state.PhaseRunning)
 					if isRunning {
 						fmt.Printf("Agent '%s' is already running. Attaching...\n", agentName)
 						return rt.Attach(context.Background(), agentName)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent"
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
@@ -111,12 +112,8 @@ var deleteCmd = &cobra.Command{
 					continue // Not a scion-managed container
 				}
 
-				status := strings.ToLower(a.ContainerStatus)
-				// Check if running
-				if strings.HasPrefix(status, "up") ||
-					strings.HasPrefix(status, "running") ||
-					strings.HasPrefix(status, "pending") ||
-					strings.HasPrefix(status, "restarting") {
+				// Skip running/provisioning agents
+				if a.Phase == string(state.PhaseRunning) || a.Phase == string(state.PhaseProvisioning) {
 					continue
 				}
 

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent"
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
@@ -347,8 +348,7 @@ Examples:
 				return err
 			}
 			for _, a := range agents {
-				status := strings.ToLower(a.ContainerStatus)
-				if strings.HasPrefix(status, "up") || status == "running" {
+				if a.Phase == string(state.PhaseRunning) {
 					targets = append(targets, a.Name)
 				}
 			}

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent"
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
@@ -157,9 +158,7 @@ func stopAllAgents() error {
 			continue
 		}
 
-		status := strings.ToLower(a.ContainerStatus)
-		if strings.HasPrefix(status, "up") ||
-			strings.HasPrefix(status, "running") {
+		if a.Phase == string(state.PhaseRunning) {
 			running = append(running, runningAgent{Name: agentName})
 		}
 	}
@@ -309,9 +308,7 @@ func stopAllAgentsViaHub(hubCtx *HubContext) error {
 	// Filter for running agents
 	var running []hubclient.Agent
 	for _, a := range resp.Agents {
-		status := strings.ToLower(a.ContainerStatus)
-		if strings.HasPrefix(status, "up") ||
-			strings.HasPrefix(status, "running") {
+		if a.Phase == string(state.PhaseRunning) {
 			running = append(running, a)
 		}
 	}

--- a/cmd/suspend.go
+++ b/cmd/suspend.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent"
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/harness"
@@ -165,9 +166,7 @@ func suspendAllAgents() error {
 		if agentName == "" {
 			continue
 		}
-		status := strings.ToLower(a.ContainerStatus)
-		if strings.HasPrefix(status, "up") ||
-			strings.HasPrefix(status, "running") {
+		if a.Phase == string(state.PhaseRunning) {
 			running = append(running, runningAgent{Name: agentName})
 		}
 	}
@@ -298,9 +297,7 @@ func suspendAllAgentsViaHub(hubCtx *HubContext) error {
 
 	var running []hubclient.Agent
 	for _, a := range resp.Agents {
-		status := strings.ToLower(a.ContainerStatus)
-		if strings.HasPrefix(status, "up") ||
-			strings.HasPrefix(status, "running") {
+		if a.Phase == string(state.PhaseRunning) {
 			running = append(running, a)
 		}
 	}

--- a/pkg/agent/list.go
+++ b/pkg/agent/list.go
@@ -21,15 +21,12 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	scionruntime "github.com/GoogleCloudPlatform/scion/pkg/runtime"
 )
-
-const legacyFailedContainerStatusPrefix = "failed"
 
 func (m *AgentManager) List(ctx context.Context, filter map[string]string) ([]api.AgentInfo, error) {
 	agents, err := m.Runtime.List(ctx, filter)
@@ -78,7 +75,12 @@ func (m *AgentManager) List(ctx context.Context, filter map[string]string) ([]ap
 	}
 
 	runningNames := make(map[string]bool)
+	runtimePhases := make(map[int]string, len(agents))
 	for i := range agents {
+		// Capture the runtime's Phase before agent-info.json overwrites it.
+		// The runtime Phase (derived from container state) is authoritative
+		// for running/stopped reconciliation below.
+		runtimePhases[i] = agents[i].Phase
 		runningNames[agents[i].Name] = true
 		if agents[i].ProjectPath != "" {
 			// ResolveAgentDir probes both worktree and shared-workspace
@@ -157,19 +159,24 @@ func (m *AgentManager) List(ctx context.Context, filter map[string]string) ([]ap
 		}
 
 		// Reconcile phase with actual container status.
-		// Container runtime status is authoritative for running/stopped.
-		containerStatusLower := strings.ToLower(agents[i].ContainerStatus)
-		isContainerRunning := strings.HasPrefix(containerStatusLower, "up") || containerStatusLower == "running"
-		isContainerStopped := strings.HasPrefix(containerStatusLower, "exited") || containerStatusLower == "stopped"
+		// The runtime Phase (captured before agent-info.json merge) is
+		// authoritative for whether the container is running or stopped.
+		runtimePhase := runtimePhases[i]
+		isContainerRunning := runtimePhase == string(state.PhaseRunning)
+		isContainerStopped := runtimePhase == string(state.PhaseStopped) || runtimePhase == string(state.PhaseError)
 
 		if isContainerRunning && agents[i].Phase == string(state.PhaseStopped) {
 			agents[i].Phase = string(state.PhaseRunning)
 		}
 		if isContainerStopped {
 			// A non-zero exit code means the agent crashed; map to error
-			// (restartable) rather than a clean stop. A zero exit (or a plain
-			// "stopped" with no embedded code) is a clean stop.
-			exitCode, hasCode := scionruntime.ExitCodeFromContainerStatus(agents[i].ContainerStatus)
+			// (restartable) rather than a clean stop. A zero exit (or no
+			// exit code) is a clean stop.
+			exitCode := 0
+			hasCode := agents[i].ExitCode != nil
+			if hasCode {
+				exitCode = *agents[i].ExitCode
+			}
 			crashed := hasCode && exitCode != 0
 			p := state.Phase(agents[i].Phase)
 			switch p {
@@ -315,8 +322,7 @@ func terminalRuntimePhase(agent api.AgentInfo) string {
 	if agent.Phase != scionruntime.LegacyAgentPhaseEnded {
 		return ""
 	}
-	containerStatus := strings.ToLower(agent.ContainerStatus)
-	if strings.Contains(containerStatus, legacyFailedContainerStatusPrefix) {
+	if agent.ExitCode != nil && *agent.ExitCode != 0 {
 		return string(state.PhaseError)
 	}
 	return string(state.PhaseStopped)

--- a/pkg/agent/list.go
+++ b/pkg/agent/list.go
@@ -75,12 +75,12 @@ func (m *AgentManager) List(ctx context.Context, filter map[string]string) ([]ap
 	}
 
 	runningNames := make(map[string]bool)
-	runtimePhases := make(map[int]string, len(agents))
+	runtimePhases := make(map[string]string, len(agents))
 	for i := range agents {
 		// Capture the runtime's Phase before agent-info.json overwrites it.
 		// The runtime Phase (derived from container state) is authoritative
 		// for running/stopped reconciliation below.
-		runtimePhases[i] = agents[i].Phase
+		runtimePhases[agents[i].Name] = agents[i].Phase
 		runningNames[agents[i].Name] = true
 		if agents[i].ProjectPath != "" {
 			// ResolveAgentDir probes both worktree and shared-workspace
@@ -161,7 +161,7 @@ func (m *AgentManager) List(ctx context.Context, filter map[string]string) ([]ap
 		// Reconcile phase with actual container status.
 		// The runtime Phase (captured before agent-info.json merge) is
 		// authoritative for whether the container is running or stopped.
-		runtimePhase := runtimePhases[i]
+		runtimePhase := runtimePhases[agents[i].Name]
 		isContainerRunning := runtimePhase == string(state.PhaseRunning)
 		isContainerStopped := runtimePhase == string(state.PhaseStopped) || runtimePhase == string(state.PhaseError)
 
@@ -177,7 +177,7 @@ func (m *AgentManager) List(ctx context.Context, filter map[string]string) ([]ap
 			if hasCode {
 				exitCode = *agents[i].ExitCode
 			}
-			crashed := hasCode && exitCode != 0
+			crashed := (hasCode && exitCode != 0) || runtimePhase == string(state.PhaseError)
 			p := state.Phase(agents[i].Phase)
 			switch p {
 			case state.PhaseRunning:

--- a/pkg/agent/list_test.go
+++ b/pkg/agent/list_test.go
@@ -513,6 +513,225 @@ func TestListPreservesRuntimeTerminalStateForKubernetes(t *testing.T) {
 	}
 }
 
+func TestListTerminalPhaseOverridesAgentInfoPhase(t *testing.T) {
+	// When the runtime reports a terminal phase (stopped/error), it takes
+	// precedence over whatever agent-info.json says. The runtimePhases map
+	// captures the runtime's Phase before agent-info.json merge to make the
+	// reconciliation authoritative.
+	nonZero := 137
+	zero := 0
+	tests := []struct {
+		name         string
+		runtimePhase string
+		exitCode     *int
+		infoPhase    string
+		infoActivity string
+		wantPhase    string
+		wantActivity string
+	}{
+		{
+			name:         "runtime stopped overrides info running",
+			runtimePhase: string(state.PhaseStopped),
+			exitCode:     &zero,
+			infoPhase:    string(state.PhaseRunning),
+			infoActivity: string(state.ActivityThinking),
+			wantPhase:    string(state.PhaseStopped),
+			wantActivity: "",
+		},
+		{
+			name:         "runtime error overrides info running",
+			runtimePhase: string(state.PhaseError),
+			exitCode:     &nonZero,
+			infoPhase:    string(state.PhaseRunning),
+			infoActivity: string(state.ActivityExecuting),
+			wantPhase:    string(state.PhaseError),
+			wantActivity: "",
+		},
+		{
+			name:         "runtime stopped with non-zero exit stays stopped locally",
+			runtimePhase: string(state.PhaseStopped),
+			exitCode:     &nonZero,
+			infoPhase:    string(state.PhaseRunning),
+			infoActivity: string(state.ActivityThinking),
+			wantPhase:    string(state.PhaseStopped),
+			wantActivity: "",
+		},
+		{
+			name:         "runtime stopped with nil exit code stays stopped",
+			runtimePhase: string(state.PhaseStopped),
+			exitCode:     nil,
+			infoPhase:    string(state.PhaseRunning),
+			infoActivity: string(state.ActivityThinking),
+			wantPhase:    string(state.PhaseStopped),
+			wantActivity: "",
+		},
+		{
+			name:         "runtime running allows info phase through",
+			runtimePhase: string(state.PhaseRunning),
+			infoPhase:    string(state.PhaseRunning),
+			infoActivity: string(state.ActivityThinking),
+			wantPhase:    string(state.PhaseRunning),
+			wantActivity: string(state.ActivityThinking),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			projectPath := filepath.Join(tmpDir, ".scion")
+			agentName := "terminal-phase-agent"
+			agentHome := filepath.Join(projectPath, "agents", agentName, "home")
+			if err := os.MkdirAll(agentHome, 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			info := api.AgentInfo{
+				Name:     agentName,
+				Phase:    tc.infoPhase,
+				Activity: tc.infoActivity,
+			}
+			infoData, _ := json.MarshalIndent(info, "", "  ")
+			if err := os.WriteFile(filepath.Join(agentHome, "agent-info.json"), infoData, 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(projectPath, "agents", agentName, "scion-agent.json"), []byte("{}"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			mock := &runtime.MockRuntime{
+				ListFunc: func(_ context.Context, _ map[string]string) ([]api.AgentInfo, error) {
+					return []api.AgentInfo{
+						{
+							Name:            agentName,
+							ProjectPath:     projectPath,
+							Phase:           tc.runtimePhase,
+							ContainerStatus: "Exited (137) 2 minutes ago",
+							ExitCode:        tc.exitCode,
+						},
+					}, nil
+				},
+			}
+
+			mgr := NewManager(mock)
+			agents, err := mgr.List(context.Background(), nil)
+			if err != nil {
+				t.Fatalf("List() error: %v", err)
+			}
+
+			var found *api.AgentInfo
+			for i := range agents {
+				if agents[i].Name == agentName {
+					found = &agents[i]
+					break
+				}
+			}
+			if found == nil {
+				t.Fatal("agent not found in list results")
+			}
+
+			if found.Phase != tc.wantPhase {
+				t.Errorf("Phase = %q, want %q", found.Phase, tc.wantPhase)
+			}
+			if found.Activity != tc.wantActivity {
+				t.Errorf("Activity = %q, want %q", found.Activity, tc.wantActivity)
+			}
+		})
+	}
+}
+
+func TestListLegacyEndedWithExitCode(t *testing.T) {
+	// Verify that the legacy "ended" Phase uses the structured ExitCode
+	// field (not ContainerStatus string parsing) to decide stopped vs error.
+	t.Setenv("HOME", t.TempDir())
+	zero := 0
+	nonZero := 1
+	tests := []struct {
+		name            string
+		exitCode        *int
+		containerStatus string
+		wantPhase       string
+	}{
+		{
+			name:            "ended with zero exit code maps to stopped",
+			exitCode:        &zero,
+			containerStatus: "Succeeded (Completed)",
+			wantPhase:       string(state.PhaseStopped),
+		},
+		{
+			name:            "ended with non-zero exit code maps to error",
+			exitCode:        &nonZero,
+			containerStatus: "Failed (Error)",
+			wantPhase:       string(state.PhaseError),
+		},
+		{
+			name:            "ended with nil exit code maps to stopped",
+			exitCode:        nil,
+			containerStatus: "Succeeded (Completed)",
+			wantPhase:       string(state.PhaseStopped),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			projectPath := filepath.Join(tmpDir, ".scion")
+			agentName := "legacy-ended-agent"
+			agentHome := filepath.Join(projectPath, "agents", agentName, "home")
+			if err := os.MkdirAll(agentHome, 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			info := api.AgentInfo{
+				Name:     agentName,
+				Phase:    string(state.PhaseRunning),
+				Activity: string(state.ActivityThinking),
+				Runtime:  "kubernetes",
+			}
+			infoData, _ := json.MarshalIndent(info, "", "  ")
+			infoPath := filepath.Join(agentHome, "agent-info.json")
+			if err := os.WriteFile(infoPath, infoData, 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(projectPath, "agents", agentName, "scion-agent.json"), []byte("{}"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			mock := &runtime.MockRuntime{
+				ListFunc: func(_ context.Context, _ map[string]string) ([]api.AgentInfo, error) {
+					return []api.AgentInfo{
+						{
+							Name:            agentName,
+							ProjectPath:     projectPath,
+							Runtime:         "kubernetes",
+							Phase:           runtime.LegacyAgentPhaseEnded,
+							ContainerStatus: tc.containerStatus,
+							ExitCode:        tc.exitCode,
+						},
+					}, nil
+				},
+			}
+
+			mgr := NewManager(mock)
+			agents, err := mgr.List(context.Background(), map[string]string{
+				"scion.grove_path": projectPath,
+			})
+			if err != nil {
+				t.Fatalf("List() error: %v", err)
+			}
+
+			if len(agents) != 1 {
+				t.Fatalf("expected 1 agent, got %d", len(agents))
+			}
+			if agents[0].Phase != tc.wantPhase {
+				t.Errorf("Phase = %q, want %q", agents[0].Phase, tc.wantPhase)
+			}
+			if agents[0].Activity != "" {
+				t.Errorf("Activity = %q, want empty", agents[0].Activity)
+			}
+		})
+	}
+}
+
 func TestPersistAgentInfoState_AtomicallyRewritesAndPreservesMode(t *testing.T) {
 	tmpDir := t.TempDir()
 	infoPath := filepath.Join(tmpDir, "agent-info.json")

--- a/pkg/agent/list_test.go
+++ b/pkg/agent/list_test.go
@@ -513,6 +513,97 @@ func TestListPreservesRuntimeTerminalStateForKubernetes(t *testing.T) {
 	}
 }
 
+func TestListPhaseErrorPreservedWithNilExitCode(t *testing.T) {
+	// Verify that when the runtime reports PhaseError but ExitCode is nil
+	// (unknown), the phase is NOT downgraded to PhaseStopped. This covers
+	// the case where a K8s pod fails without a captured exit code.
+	nonZero := 137
+	tests := []struct {
+		name         string
+		runtimePhase string
+		exitCode     *int
+		infoPhase    string
+		wantPhase    string
+	}{
+		{
+			name:         "PhaseError with nil exit code stays PhaseError",
+			runtimePhase: string(state.PhaseError),
+			exitCode:     nil,
+			infoPhase:    string(state.PhaseRunning),
+			wantPhase:    string(state.PhaseError),
+		},
+		{
+			name:         "PhaseError with non-zero exit code stays PhaseError",
+			runtimePhase: string(state.PhaseError),
+			exitCode:     &nonZero,
+			infoPhase:    string(state.PhaseRunning),
+			wantPhase:    string(state.PhaseError),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			projectPath := filepath.Join(tmpDir, ".scion")
+			agentName := "phase-error-agent"
+			agentHome := filepath.Join(projectPath, "agents", agentName, "home")
+			if err := os.MkdirAll(agentHome, 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			info := api.AgentInfo{
+				Name:     agentName,
+				Phase:    tc.infoPhase,
+				Activity: string(state.ActivityThinking),
+			}
+			infoData, _ := json.MarshalIndent(info, "", "  ")
+			if err := os.WriteFile(filepath.Join(agentHome, "agent-info.json"), infoData, 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(projectPath, "agents", agentName, "scion-agent.json"), []byte("{}"), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			mock := &runtime.MockRuntime{
+				ListFunc: func(_ context.Context, _ map[string]string) ([]api.AgentInfo, error) {
+					return []api.AgentInfo{
+						{
+							Name:        agentName,
+							ProjectPath: projectPath,
+							Phase:       tc.runtimePhase,
+							ExitCode:    tc.exitCode,
+						},
+					}, nil
+				},
+			}
+
+			mgr := NewManager(mock)
+			agents, err := mgr.List(context.Background(), nil)
+			if err != nil {
+				t.Fatalf("List() error: %v", err)
+			}
+
+			var found *api.AgentInfo
+			for i := range agents {
+				if agents[i].Name == agentName {
+					found = &agents[i]
+					break
+				}
+			}
+			if found == nil {
+				t.Fatal("agent not found in list results")
+			}
+
+			if found.Phase != tc.wantPhase {
+				t.Errorf("Phase = %q, want %q", found.Phase, tc.wantPhase)
+			}
+			if found.Activity != "" {
+				t.Errorf("Activity = %q, want empty (should be cleared for terminal phase)", found.Activity)
+			}
+		})
+	}
+}
+
 func TestListTerminalPhaseOverridesAgentInfoPhase(t *testing.T) {
 	// When the runtime reports a terminal phase (stopped/error), it takes
 	// precedence over whatever agent-info.json says. The runtimePhases map

--- a/pkg/agent/list_test.go
+++ b/pkg/agent/list_test.go
@@ -278,9 +278,12 @@ func TestListNonRunningAgentIncludesHarnessConfig(t *testing.T) {
 }
 
 func TestListReconcilesPhaseWithContainerStatus(t *testing.T) {
+	zero := 0
 	tests := []struct {
 		name            string
+		runtimePhase    string
 		containerStatus string
+		exitCode        *int
 		infoPhase       string
 		infoActivity    string
 		wantPhase       string
@@ -288,19 +291,23 @@ func TestListReconcilesPhaseWithContainerStatus(t *testing.T) {
 	}{
 		{
 			name:            "running container overrides stopped phase",
+			runtimePhase:    string(state.PhaseRunning),
 			containerStatus: "Up 2 hours",
 			infoPhase:       string(state.PhaseStopped),
 			wantPhase:       string(state.PhaseRunning),
 		},
 		{
 			name:            "running status overrides stopped phase",
+			runtimePhase:    string(state.PhaseRunning),
 			containerStatus: "running",
 			infoPhase:       string(state.PhaseStopped),
 			wantPhase:       string(state.PhaseRunning),
 		},
 		{
 			name:            "exited container overrides running phase",
+			runtimePhase:    string(state.PhaseStopped),
 			containerStatus: "Exited (0) 5 minutes ago",
+			exitCode:        &zero,
 			infoPhase:       string(state.PhaseRunning),
 			infoActivity:    string(state.ActivityThinking),
 			wantPhase:       string(state.PhaseStopped),
@@ -308,7 +315,9 @@ func TestListReconcilesPhaseWithContainerStatus(t *testing.T) {
 		},
 		{
 			name:            "stopped container overrides running phase",
+			runtimePhase:    string(state.PhaseStopped),
 			containerStatus: "stopped",
+			exitCode:        &zero,
 			infoPhase:       string(state.PhaseRunning),
 			infoActivity:    string(state.ActivityExecuting),
 			wantPhase:       string(state.PhaseStopped),
@@ -316,6 +325,7 @@ func TestListReconcilesPhaseWithContainerStatus(t *testing.T) {
 		},
 		{
 			name:            "consistent running state unchanged",
+			runtimePhase:    string(state.PhaseRunning),
 			containerStatus: "Up 10 minutes",
 			infoPhase:       string(state.PhaseRunning),
 			infoActivity:    string(state.ActivityThinking),
@@ -324,7 +334,9 @@ func TestListReconcilesPhaseWithContainerStatus(t *testing.T) {
 		},
 		{
 			name:            "consistent stopped state unchanged",
+			runtimePhase:    string(state.PhaseStopped),
 			containerStatus: "Exited (0) 1 hour ago",
+			exitCode:        &zero,
 			infoPhase:       string(state.PhaseStopped),
 			wantPhase:       string(state.PhaseStopped),
 		},
@@ -359,7 +371,9 @@ func TestListReconcilesPhaseWithContainerStatus(t *testing.T) {
 						{
 							Name:            agentName,
 							ProjectPath:     projectPath,
+							Phase:           tc.runtimePhase,
 							ContainerStatus: tc.containerStatus,
+							ExitCode:        tc.exitCode,
 						},
 					}, nil
 				},
@@ -394,10 +408,12 @@ func TestListReconcilesPhaseWithContainerStatus(t *testing.T) {
 
 func TestListPreservesRuntimeTerminalStateForKubernetes(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	nonZero := 1
 	tests := []struct {
 		name            string
 		runtimePhase    string
 		containerStatus string
+		exitCode        *int
 		wantPhase       string
 	}{
 		{
@@ -410,6 +426,7 @@ func TestListPreservesRuntimeTerminalStateForKubernetes(t *testing.T) {
 			name:            "legacy ended maps failed pod to error",
 			runtimePhase:    runtime.LegacyAgentPhaseEnded,
 			containerStatus: "Failed (Error)",
+			exitCode:        &nonZero,
 			wantPhase:       string(state.PhaseError),
 		},
 		{
@@ -454,6 +471,7 @@ func TestListPreservesRuntimeTerminalStateForKubernetes(t *testing.T) {
 							Runtime:         "kubernetes",
 							Phase:           tc.runtimePhase,
 							ContainerStatus: tc.containerStatus,
+							ExitCode:        tc.exitCode,
 						},
 					}, nil
 				},

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
@@ -98,8 +99,7 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 			if !matchAgentProject(a, projectName, projectID) {
 				continue
 			}
-			status := strings.ToLower(a.ContainerStatus)
-			isRunning := strings.HasPrefix(status, "up") || status == "running"
+			isRunning := a.Phase == string(state.PhaseRunning)
 			if isRunning {
 				// If a new task is provided, we might want to recreate even if running
 				// but if no task provided, we just return the running one
@@ -1066,8 +1066,7 @@ authDone:
 		for _, a := range allAgents {
 			if a.ContainerID == id || strings.EqualFold(a.Name, opts.Name) {
 				// Check if the container has already exited
-				containerStatus := strings.ToLower(a.ContainerStatus)
-				if strings.Contains(containerStatus, "exited") || strings.Contains(containerStatus, "dead") {
+				if a.Phase == string(state.PhaseStopped) || a.Phase == string(state.PhaseError) {
 					// Try to get logs for diagnosis
 					logs, _ := m.Runtime.GetLogs(ctx, id)
 					_ = m.Runtime.Delete(ctx, id)

--- a/pkg/agent/run_test.go
+++ b/pkg/agent/run_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
@@ -907,9 +908,7 @@ profiles:
 
 func TestStartReturnsRunningStatus(t *testing.T) {
 	// This tests the early-return path when a container is already running.
-	// The runtime's List() may return a stale Status (e.g. "created") from the
-	// container runtime, but Start() should override it to "running" since
-	// isRunning is confirmed true via ContainerStatus.
+	// The runtime's Phase field is authoritative for running state detection.
 	mockRT := &runtime.MockRuntime{
 		ListFunc: func(ctx context.Context, labelFilter map[string]string) ([]api.AgentInfo, error) {
 			return []api.AgentInfo{
@@ -917,7 +916,7 @@ func TestStartReturnsRunningStatus(t *testing.T) {
 					ContainerID:     "abc123",
 					Name:            "test-agent",
 					ContainerStatus: "Up 2 hours",
-					Phase:           "created", // stale phase from runtime
+					Phase:           string(state.PhaseRunning),
 				},
 			}, nil
 		},

--- a/pkg/agent/state/state.go
+++ b/pkg/agent/state/state.go
@@ -131,6 +131,26 @@ const (
 	ActivityCrashed         Activity = "crashed"
 )
 
+// ExitReason describes why an agent process terminated. Unlike Activity
+// (self-reported by the agent), ExitReason is runtime-derived and set by
+// the platform when it observes a container/process exit.
+type ExitReason string
+
+const (
+	ExitReasonCrashed        ExitReason = "crashed"
+	ExitReasonLimitsExceeded ExitReason = "limits_exceeded"
+)
+
+// IsValid reports whether r is a recognised ExitReason value.
+// Empty string is valid (no reason given).
+func (r ExitReason) IsValid() bool {
+	switch r {
+	case "", ExitReasonCrashed, ExitReasonLimitsExceeded:
+		return true
+	}
+	return false
+}
+
 // allActivities is the internal list; Activities() returns a copy.
 var allActivities = []Activity{
 	ActivityWorking,

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -579,6 +579,8 @@ type AgentInfo struct {
 	ContainerStatus string       `json:"containerStatus,omitempty"` // Container status (e.g., Up 2 hours)
 	Phase           string       `json:"phase,omitempty"`           // Lifecycle phase (created, provisioning, running, stopped, error)
 	Activity        string       `json:"activity,omitempty"`        // Runtime activity (working, thinking, executing, waiting_for_input, completed)
+	ExitCode        *int         `json:"exitCode,omitempty"`        // Structured exit code from runtime (nil = unknown)
+	ExitReason      string       `json:"exitReason,omitempty"`      // Terminal reason: "crashed" or "limits_exceeded"
 	Detail          *AgentDetail `json:"detail,omitempty"`          // Freeform context about the current activity
 
 	// Runtime configuration

--- a/pkg/ent/agent.go
+++ b/pkg/ent/agent.go
@@ -53,6 +53,10 @@ type Agent struct {
 	ConnectionState string `json:"connection_state,omitempty"`
 	// ContainerStatus holds the value of the "container_status" field.
 	ContainerStatus string `json:"container_status,omitempty"`
+	// ExitCode holds the value of the "exit_code" field.
+	ExitCode *int `json:"exit_code,omitempty"`
+	// ExitReason holds the value of the "exit_reason" field.
+	ExitReason string `json:"exit_reason,omitempty"`
 	// RuntimeState holds the value of the "runtime_state" field.
 	RuntimeState string `json:"runtime_state,omitempty"`
 	// StalledFromActivity holds the value of the "stalled_from_activity" field.
@@ -154,9 +158,9 @@ func (*Agent) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case agent.FieldDelegationEnabled, agent.FieldDetached, agent.FieldWebPtyEnabled:
 			values[i] = new(sql.NullBool)
-		case agent.FieldCurrentTurns, agent.FieldCurrentModelCalls, agent.FieldStateVersion:
+		case agent.FieldExitCode, agent.FieldCurrentTurns, agent.FieldCurrentModelCalls, agent.FieldStateVersion:
 			values[i] = new(sql.NullInt64)
-		case agent.FieldSlug, agent.FieldName, agent.FieldTemplate, agent.FieldStatus, agent.FieldVisibility, agent.FieldPhase, agent.FieldActivity, agent.FieldToolName, agent.FieldConnectionState, agent.FieldContainerStatus, agent.FieldRuntimeState, agent.FieldStalledFromActivity, agent.FieldImage, agent.FieldRuntime, agent.FieldRuntimeBrokerID, agent.FieldTaskSummary, agent.FieldMessage, agent.FieldAppliedConfig:
+		case agent.FieldSlug, agent.FieldName, agent.FieldTemplate, agent.FieldStatus, agent.FieldVisibility, agent.FieldPhase, agent.FieldActivity, agent.FieldToolName, agent.FieldConnectionState, agent.FieldContainerStatus, agent.FieldExitReason, agent.FieldRuntimeState, agent.FieldStalledFromActivity, agent.FieldImage, agent.FieldRuntime, agent.FieldRuntimeBrokerID, agent.FieldTaskSummary, agent.FieldMessage, agent.FieldAppliedConfig:
 			values[i] = new(sql.NullString)
 		case agent.FieldCreated, agent.FieldUpdated, agent.FieldLastSeen, agent.FieldLastActivityEvent, agent.FieldStartedAt, agent.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -284,6 +288,19 @@ func (_m *Agent) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field container_status", values[i])
 			} else if value.Valid {
 				_m.ContainerStatus = value.String
+			}
+		case agent.FieldExitCode:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field exit_code", values[i])
+			} else if value.Valid {
+				_m.ExitCode = new(int)
+				*_m.ExitCode = int(value.Int64)
+			}
+		case agent.FieldExitReason:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field exit_reason", values[i])
+			} else if value.Valid {
+				_m.ExitReason = value.String
 			}
 		case agent.FieldRuntimeState:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -521,6 +538,14 @@ func (_m *Agent) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("container_status=")
 	builder.WriteString(_m.ContainerStatus)
+	builder.WriteString(", ")
+	if v := _m.ExitCode; v != nil {
+		builder.WriteString("exit_code=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
+	builder.WriteString(", ")
+	builder.WriteString("exit_reason=")
+	builder.WriteString(_m.ExitReason)
 	builder.WriteString(", ")
 	builder.WriteString("runtime_state=")
 	builder.WriteString(_m.RuntimeState)

--- a/pkg/ent/agent/agent.go
+++ b/pkg/ent/agent/agent.go
@@ -48,6 +48,10 @@ const (
 	FieldConnectionState = "connection_state"
 	// FieldContainerStatus holds the string denoting the container_status field in the database.
 	FieldContainerStatus = "container_status"
+	// FieldExitCode holds the string denoting the exit_code field in the database.
+	FieldExitCode = "exit_code"
+	// FieldExitReason holds the string denoting the exit_reason field in the database.
+	FieldExitReason = "exit_reason"
 	// FieldRuntimeState holds the string denoting the runtime_state field in the database.
 	FieldRuntimeState = "runtime_state"
 	// FieldStalledFromActivity holds the string denoting the stalled_from_activity field in the database.
@@ -140,6 +144,8 @@ var Columns = []string{
 	FieldToolName,
 	FieldConnectionState,
 	FieldContainerStatus,
+	FieldExitCode,
+	FieldExitReason,
 	FieldRuntimeState,
 	FieldStalledFromActivity,
 	FieldCurrentTurns,
@@ -311,6 +317,16 @@ func ByConnectionState(opts ...sql.OrderTermOption) OrderOption {
 // ByContainerStatus orders the results by the container_status field.
 func ByContainerStatus(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldContainerStatus, opts...).ToFunc()
+}
+
+// ByExitCode orders the results by the exit_code field.
+func ByExitCode(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldExitCode, opts...).ToFunc()
+}
+
+// ByExitReason orders the results by the exit_reason field.
+func ByExitReason(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldExitReason, opts...).ToFunc()
 }
 
 // ByRuntimeState orders the results by the runtime_state field.

--- a/pkg/ent/agent/where.go
+++ b/pkg/ent/agent/where.go
@@ -121,6 +121,16 @@ func ContainerStatus(v string) predicate.Agent {
 	return predicate.Agent(sql.FieldEQ(FieldContainerStatus, v))
 }
 
+// ExitCode applies equality check predicate on the "exit_code" field. It's identical to ExitCodeEQ.
+func ExitCode(v int) predicate.Agent {
+	return predicate.Agent(sql.FieldEQ(FieldExitCode, v))
+}
+
+// ExitReason applies equality check predicate on the "exit_reason" field. It's identical to ExitReasonEQ.
+func ExitReason(v string) predicate.Agent {
+	return predicate.Agent(sql.FieldEQ(FieldExitReason, v))
+}
+
 // RuntimeState applies equality check predicate on the "runtime_state" field. It's identical to RuntimeStateEQ.
 func RuntimeState(v string) predicate.Agent {
 	return predicate.Agent(sql.FieldEQ(FieldRuntimeState, v))
@@ -1029,6 +1039,131 @@ func ContainerStatusEqualFold(v string) predicate.Agent {
 // ContainerStatusContainsFold applies the ContainsFold predicate on the "container_status" field.
 func ContainerStatusContainsFold(v string) predicate.Agent {
 	return predicate.Agent(sql.FieldContainsFold(FieldContainerStatus, v))
+}
+
+// ExitCodeEQ applies the EQ predicate on the "exit_code" field.
+func ExitCodeEQ(v int) predicate.Agent {
+	return predicate.Agent(sql.FieldEQ(FieldExitCode, v))
+}
+
+// ExitCodeNEQ applies the NEQ predicate on the "exit_code" field.
+func ExitCodeNEQ(v int) predicate.Agent {
+	return predicate.Agent(sql.FieldNEQ(FieldExitCode, v))
+}
+
+// ExitCodeIn applies the In predicate on the "exit_code" field.
+func ExitCodeIn(vs ...int) predicate.Agent {
+	return predicate.Agent(sql.FieldIn(FieldExitCode, vs...))
+}
+
+// ExitCodeNotIn applies the NotIn predicate on the "exit_code" field.
+func ExitCodeNotIn(vs ...int) predicate.Agent {
+	return predicate.Agent(sql.FieldNotIn(FieldExitCode, vs...))
+}
+
+// ExitCodeGT applies the GT predicate on the "exit_code" field.
+func ExitCodeGT(v int) predicate.Agent {
+	return predicate.Agent(sql.FieldGT(FieldExitCode, v))
+}
+
+// ExitCodeGTE applies the GTE predicate on the "exit_code" field.
+func ExitCodeGTE(v int) predicate.Agent {
+	return predicate.Agent(sql.FieldGTE(FieldExitCode, v))
+}
+
+// ExitCodeLT applies the LT predicate on the "exit_code" field.
+func ExitCodeLT(v int) predicate.Agent {
+	return predicate.Agent(sql.FieldLT(FieldExitCode, v))
+}
+
+// ExitCodeLTE applies the LTE predicate on the "exit_code" field.
+func ExitCodeLTE(v int) predicate.Agent {
+	return predicate.Agent(sql.FieldLTE(FieldExitCode, v))
+}
+
+// ExitCodeIsNil applies the IsNil predicate on the "exit_code" field.
+func ExitCodeIsNil() predicate.Agent {
+	return predicate.Agent(sql.FieldIsNull(FieldExitCode))
+}
+
+// ExitCodeNotNil applies the NotNil predicate on the "exit_code" field.
+func ExitCodeNotNil() predicate.Agent {
+	return predicate.Agent(sql.FieldNotNull(FieldExitCode))
+}
+
+// ExitReasonEQ applies the EQ predicate on the "exit_reason" field.
+func ExitReasonEQ(v string) predicate.Agent {
+	return predicate.Agent(sql.FieldEQ(FieldExitReason, v))
+}
+
+// ExitReasonNEQ applies the NEQ predicate on the "exit_reason" field.
+func ExitReasonNEQ(v string) predicate.Agent {
+	return predicate.Agent(sql.FieldNEQ(FieldExitReason, v))
+}
+
+// ExitReasonIn applies the In predicate on the "exit_reason" field.
+func ExitReasonIn(vs ...string) predicate.Agent {
+	return predicate.Agent(sql.FieldIn(FieldExitReason, vs...))
+}
+
+// ExitReasonNotIn applies the NotIn predicate on the "exit_reason" field.
+func ExitReasonNotIn(vs ...string) predicate.Agent {
+	return predicate.Agent(sql.FieldNotIn(FieldExitReason, vs...))
+}
+
+// ExitReasonGT applies the GT predicate on the "exit_reason" field.
+func ExitReasonGT(v string) predicate.Agent {
+	return predicate.Agent(sql.FieldGT(FieldExitReason, v))
+}
+
+// ExitReasonGTE applies the GTE predicate on the "exit_reason" field.
+func ExitReasonGTE(v string) predicate.Agent {
+	return predicate.Agent(sql.FieldGTE(FieldExitReason, v))
+}
+
+// ExitReasonLT applies the LT predicate on the "exit_reason" field.
+func ExitReasonLT(v string) predicate.Agent {
+	return predicate.Agent(sql.FieldLT(FieldExitReason, v))
+}
+
+// ExitReasonLTE applies the LTE predicate on the "exit_reason" field.
+func ExitReasonLTE(v string) predicate.Agent {
+	return predicate.Agent(sql.FieldLTE(FieldExitReason, v))
+}
+
+// ExitReasonContains applies the Contains predicate on the "exit_reason" field.
+func ExitReasonContains(v string) predicate.Agent {
+	return predicate.Agent(sql.FieldContains(FieldExitReason, v))
+}
+
+// ExitReasonHasPrefix applies the HasPrefix predicate on the "exit_reason" field.
+func ExitReasonHasPrefix(v string) predicate.Agent {
+	return predicate.Agent(sql.FieldHasPrefix(FieldExitReason, v))
+}
+
+// ExitReasonHasSuffix applies the HasSuffix predicate on the "exit_reason" field.
+func ExitReasonHasSuffix(v string) predicate.Agent {
+	return predicate.Agent(sql.FieldHasSuffix(FieldExitReason, v))
+}
+
+// ExitReasonIsNil applies the IsNil predicate on the "exit_reason" field.
+func ExitReasonIsNil() predicate.Agent {
+	return predicate.Agent(sql.FieldIsNull(FieldExitReason))
+}
+
+// ExitReasonNotNil applies the NotNil predicate on the "exit_reason" field.
+func ExitReasonNotNil() predicate.Agent {
+	return predicate.Agent(sql.FieldNotNull(FieldExitReason))
+}
+
+// ExitReasonEqualFold applies the EqualFold predicate on the "exit_reason" field.
+func ExitReasonEqualFold(v string) predicate.Agent {
+	return predicate.Agent(sql.FieldEqualFold(FieldExitReason, v))
+}
+
+// ExitReasonContainsFold applies the ContainsFold predicate on the "exit_reason" field.
+func ExitReasonContainsFold(v string) predicate.Agent {
+	return predicate.Agent(sql.FieldContainsFold(FieldExitReason, v))
 }
 
 // RuntimeStateEQ applies the EQ predicate on the "runtime_state" field.

--- a/pkg/ent/agent_create.go
+++ b/pkg/ent/agent_create.go
@@ -212,6 +212,34 @@ func (_c *AgentCreate) SetNillableContainerStatus(v *string) *AgentCreate {
 	return _c
 }
 
+// SetExitCode sets the "exit_code" field.
+func (_c *AgentCreate) SetExitCode(v int) *AgentCreate {
+	_c.mutation.SetExitCode(v)
+	return _c
+}
+
+// SetNillableExitCode sets the "exit_code" field if the given value is not nil.
+func (_c *AgentCreate) SetNillableExitCode(v *int) *AgentCreate {
+	if v != nil {
+		_c.SetExitCode(*v)
+	}
+	return _c
+}
+
+// SetExitReason sets the "exit_reason" field.
+func (_c *AgentCreate) SetExitReason(v string) *AgentCreate {
+	_c.mutation.SetExitReason(v)
+	return _c
+}
+
+// SetNillableExitReason sets the "exit_reason" field if the given value is not nil.
+func (_c *AgentCreate) SetNillableExitReason(v *string) *AgentCreate {
+	if v != nil {
+		_c.SetExitReason(*v)
+	}
+	return _c
+}
+
 // SetRuntimeState sets the "runtime_state" field.
 func (_c *AgentCreate) SetRuntimeState(v string) *AgentCreate {
 	_c.mutation.SetRuntimeState(v)
@@ -775,6 +803,14 @@ func (_c *AgentCreate) createSpec() (*Agent, *sqlgraph.CreateSpec) {
 		_spec.SetField(agent.FieldContainerStatus, field.TypeString, value)
 		_node.ContainerStatus = value
 	}
+	if value, ok := _c.mutation.ExitCode(); ok {
+		_spec.SetField(agent.FieldExitCode, field.TypeInt, value)
+		_node.ExitCode = &value
+	}
+	if value, ok := _c.mutation.ExitReason(); ok {
+		_spec.SetField(agent.FieldExitReason, field.TypeString, value)
+		_node.ExitReason = value
+	}
 	if value, ok := _c.mutation.RuntimeState(); ok {
 		_spec.SetField(agent.FieldRuntimeState, field.TypeString, value)
 		_node.RuntimeState = value
@@ -1209,6 +1245,48 @@ func (u *AgentUpsert) UpdateContainerStatus() *AgentUpsert {
 // ClearContainerStatus clears the value of the "container_status" field.
 func (u *AgentUpsert) ClearContainerStatus() *AgentUpsert {
 	u.SetNull(agent.FieldContainerStatus)
+	return u
+}
+
+// SetExitCode sets the "exit_code" field.
+func (u *AgentUpsert) SetExitCode(v int) *AgentUpsert {
+	u.Set(agent.FieldExitCode, v)
+	return u
+}
+
+// UpdateExitCode sets the "exit_code" field to the value that was provided on create.
+func (u *AgentUpsert) UpdateExitCode() *AgentUpsert {
+	u.SetExcluded(agent.FieldExitCode)
+	return u
+}
+
+// AddExitCode adds v to the "exit_code" field.
+func (u *AgentUpsert) AddExitCode(v int) *AgentUpsert {
+	u.Add(agent.FieldExitCode, v)
+	return u
+}
+
+// ClearExitCode clears the value of the "exit_code" field.
+func (u *AgentUpsert) ClearExitCode() *AgentUpsert {
+	u.SetNull(agent.FieldExitCode)
+	return u
+}
+
+// SetExitReason sets the "exit_reason" field.
+func (u *AgentUpsert) SetExitReason(v string) *AgentUpsert {
+	u.Set(agent.FieldExitReason, v)
+	return u
+}
+
+// UpdateExitReason sets the "exit_reason" field to the value that was provided on create.
+func (u *AgentUpsert) UpdateExitReason() *AgentUpsert {
+	u.SetExcluded(agent.FieldExitReason)
+	return u
+}
+
+// ClearExitReason clears the value of the "exit_reason" field.
+func (u *AgentUpsert) ClearExitReason() *AgentUpsert {
+	u.SetNull(agent.FieldExitReason)
 	return u
 }
 
@@ -1896,6 +1974,55 @@ func (u *AgentUpsertOne) UpdateContainerStatus() *AgentUpsertOne {
 func (u *AgentUpsertOne) ClearContainerStatus() *AgentUpsertOne {
 	return u.Update(func(s *AgentUpsert) {
 		s.ClearContainerStatus()
+	})
+}
+
+// SetExitCode sets the "exit_code" field.
+func (u *AgentUpsertOne) SetExitCode(v int) *AgentUpsertOne {
+	return u.Update(func(s *AgentUpsert) {
+		s.SetExitCode(v)
+	})
+}
+
+// AddExitCode adds v to the "exit_code" field.
+func (u *AgentUpsertOne) AddExitCode(v int) *AgentUpsertOne {
+	return u.Update(func(s *AgentUpsert) {
+		s.AddExitCode(v)
+	})
+}
+
+// UpdateExitCode sets the "exit_code" field to the value that was provided on create.
+func (u *AgentUpsertOne) UpdateExitCode() *AgentUpsertOne {
+	return u.Update(func(s *AgentUpsert) {
+		s.UpdateExitCode()
+	})
+}
+
+// ClearExitCode clears the value of the "exit_code" field.
+func (u *AgentUpsertOne) ClearExitCode() *AgentUpsertOne {
+	return u.Update(func(s *AgentUpsert) {
+		s.ClearExitCode()
+	})
+}
+
+// SetExitReason sets the "exit_reason" field.
+func (u *AgentUpsertOne) SetExitReason(v string) *AgentUpsertOne {
+	return u.Update(func(s *AgentUpsert) {
+		s.SetExitReason(v)
+	})
+}
+
+// UpdateExitReason sets the "exit_reason" field to the value that was provided on create.
+func (u *AgentUpsertOne) UpdateExitReason() *AgentUpsertOne {
+	return u.Update(func(s *AgentUpsert) {
+		s.UpdateExitReason()
+	})
+}
+
+// ClearExitReason clears the value of the "exit_reason" field.
+func (u *AgentUpsertOne) ClearExitReason() *AgentUpsertOne {
+	return u.Update(func(s *AgentUpsert) {
+		s.ClearExitReason()
 	})
 }
 
@@ -2807,6 +2934,55 @@ func (u *AgentUpsertBulk) UpdateContainerStatus() *AgentUpsertBulk {
 func (u *AgentUpsertBulk) ClearContainerStatus() *AgentUpsertBulk {
 	return u.Update(func(s *AgentUpsert) {
 		s.ClearContainerStatus()
+	})
+}
+
+// SetExitCode sets the "exit_code" field.
+func (u *AgentUpsertBulk) SetExitCode(v int) *AgentUpsertBulk {
+	return u.Update(func(s *AgentUpsert) {
+		s.SetExitCode(v)
+	})
+}
+
+// AddExitCode adds v to the "exit_code" field.
+func (u *AgentUpsertBulk) AddExitCode(v int) *AgentUpsertBulk {
+	return u.Update(func(s *AgentUpsert) {
+		s.AddExitCode(v)
+	})
+}
+
+// UpdateExitCode sets the "exit_code" field to the value that was provided on create.
+func (u *AgentUpsertBulk) UpdateExitCode() *AgentUpsertBulk {
+	return u.Update(func(s *AgentUpsert) {
+		s.UpdateExitCode()
+	})
+}
+
+// ClearExitCode clears the value of the "exit_code" field.
+func (u *AgentUpsertBulk) ClearExitCode() *AgentUpsertBulk {
+	return u.Update(func(s *AgentUpsert) {
+		s.ClearExitCode()
+	})
+}
+
+// SetExitReason sets the "exit_reason" field.
+func (u *AgentUpsertBulk) SetExitReason(v string) *AgentUpsertBulk {
+	return u.Update(func(s *AgentUpsert) {
+		s.SetExitReason(v)
+	})
+}
+
+// UpdateExitReason sets the "exit_reason" field to the value that was provided on create.
+func (u *AgentUpsertBulk) UpdateExitReason() *AgentUpsertBulk {
+	return u.Update(func(s *AgentUpsert) {
+		s.UpdateExitReason()
+	})
+}
+
+// ClearExitReason clears the value of the "exit_reason" field.
+func (u *AgentUpsertBulk) ClearExitReason() *AgentUpsertBulk {
+	return u.Update(func(s *AgentUpsert) {
+		s.ClearExitReason()
 	})
 }
 

--- a/pkg/ent/agent_update.go
+++ b/pkg/ent/agent_update.go
@@ -302,6 +302,53 @@ func (_u *AgentUpdate) ClearContainerStatus() *AgentUpdate {
 	return _u
 }
 
+// SetExitCode sets the "exit_code" field.
+func (_u *AgentUpdate) SetExitCode(v int) *AgentUpdate {
+	_u.mutation.ResetExitCode()
+	_u.mutation.SetExitCode(v)
+	return _u
+}
+
+// SetNillableExitCode sets the "exit_code" field if the given value is not nil.
+func (_u *AgentUpdate) SetNillableExitCode(v *int) *AgentUpdate {
+	if v != nil {
+		_u.SetExitCode(*v)
+	}
+	return _u
+}
+
+// AddExitCode adds value to the "exit_code" field.
+func (_u *AgentUpdate) AddExitCode(v int) *AgentUpdate {
+	_u.mutation.AddExitCode(v)
+	return _u
+}
+
+// ClearExitCode clears the value of the "exit_code" field.
+func (_u *AgentUpdate) ClearExitCode() *AgentUpdate {
+	_u.mutation.ClearExitCode()
+	return _u
+}
+
+// SetExitReason sets the "exit_reason" field.
+func (_u *AgentUpdate) SetExitReason(v string) *AgentUpdate {
+	_u.mutation.SetExitReason(v)
+	return _u
+}
+
+// SetNillableExitReason sets the "exit_reason" field if the given value is not nil.
+func (_u *AgentUpdate) SetNillableExitReason(v *string) *AgentUpdate {
+	if v != nil {
+		_u.SetExitReason(*v)
+	}
+	return _u
+}
+
+// ClearExitReason clears the value of the "exit_reason" field.
+func (_u *AgentUpdate) ClearExitReason() *AgentUpdate {
+	_u.mutation.ClearExitReason()
+	return _u
+}
+
 // SetRuntimeState sets the "runtime_state" field.
 func (_u *AgentUpdate) SetRuntimeState(v string) *AgentUpdate {
 	_u.mutation.SetRuntimeState(v)
@@ -909,6 +956,21 @@ func (_u *AgentUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if _u.mutation.ContainerStatusCleared() {
 		_spec.ClearField(agent.FieldContainerStatus, field.TypeString)
 	}
+	if value, ok := _u.mutation.ExitCode(); ok {
+		_spec.SetField(agent.FieldExitCode, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedExitCode(); ok {
+		_spec.AddField(agent.FieldExitCode, field.TypeInt, value)
+	}
+	if _u.mutation.ExitCodeCleared() {
+		_spec.ClearField(agent.FieldExitCode, field.TypeInt)
+	}
+	if value, ok := _u.mutation.ExitReason(); ok {
+		_spec.SetField(agent.FieldExitReason, field.TypeString, value)
+	}
+	if _u.mutation.ExitReasonCleared() {
+		_spec.ClearField(agent.FieldExitReason, field.TypeString)
+	}
 	if value, ok := _u.mutation.RuntimeState(); ok {
 		_spec.SetField(agent.FieldRuntimeState, field.TypeString, value)
 	}
@@ -1434,6 +1496,53 @@ func (_u *AgentUpdateOne) SetNillableContainerStatus(v *string) *AgentUpdateOne 
 // ClearContainerStatus clears the value of the "container_status" field.
 func (_u *AgentUpdateOne) ClearContainerStatus() *AgentUpdateOne {
 	_u.mutation.ClearContainerStatus()
+	return _u
+}
+
+// SetExitCode sets the "exit_code" field.
+func (_u *AgentUpdateOne) SetExitCode(v int) *AgentUpdateOne {
+	_u.mutation.ResetExitCode()
+	_u.mutation.SetExitCode(v)
+	return _u
+}
+
+// SetNillableExitCode sets the "exit_code" field if the given value is not nil.
+func (_u *AgentUpdateOne) SetNillableExitCode(v *int) *AgentUpdateOne {
+	if v != nil {
+		_u.SetExitCode(*v)
+	}
+	return _u
+}
+
+// AddExitCode adds value to the "exit_code" field.
+func (_u *AgentUpdateOne) AddExitCode(v int) *AgentUpdateOne {
+	_u.mutation.AddExitCode(v)
+	return _u
+}
+
+// ClearExitCode clears the value of the "exit_code" field.
+func (_u *AgentUpdateOne) ClearExitCode() *AgentUpdateOne {
+	_u.mutation.ClearExitCode()
+	return _u
+}
+
+// SetExitReason sets the "exit_reason" field.
+func (_u *AgentUpdateOne) SetExitReason(v string) *AgentUpdateOne {
+	_u.mutation.SetExitReason(v)
+	return _u
+}
+
+// SetNillableExitReason sets the "exit_reason" field if the given value is not nil.
+func (_u *AgentUpdateOne) SetNillableExitReason(v *string) *AgentUpdateOne {
+	if v != nil {
+		_u.SetExitReason(*v)
+	}
+	return _u
+}
+
+// ClearExitReason clears the value of the "exit_reason" field.
+func (_u *AgentUpdateOne) ClearExitReason() *AgentUpdateOne {
+	_u.mutation.ClearExitReason()
 	return _u
 }
 
@@ -2073,6 +2182,21 @@ func (_u *AgentUpdateOne) sqlSave(ctx context.Context) (_node *Agent, err error)
 	}
 	if _u.mutation.ContainerStatusCleared() {
 		_spec.ClearField(agent.FieldContainerStatus, field.TypeString)
+	}
+	if value, ok := _u.mutation.ExitCode(); ok {
+		_spec.SetField(agent.FieldExitCode, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedExitCode(); ok {
+		_spec.AddField(agent.FieldExitCode, field.TypeInt, value)
+	}
+	if _u.mutation.ExitCodeCleared() {
+		_spec.ClearField(agent.FieldExitCode, field.TypeInt)
+	}
+	if value, ok := _u.mutation.ExitReason(); ok {
+		_spec.SetField(agent.FieldExitReason, field.TypeString, value)
+	}
+	if _u.mutation.ExitReasonCleared() {
+		_spec.ClearField(agent.FieldExitReason, field.TypeString)
 	}
 	if value, ok := _u.mutation.RuntimeState(); ok {
 		_spec.SetField(agent.FieldRuntimeState, field.TypeString, value)

--- a/pkg/ent/migrate/schema.go
+++ b/pkg/ent/migrate/schema.go
@@ -60,6 +60,8 @@ var (
 		{Name: "tool_name", Type: field.TypeString, Nullable: true},
 		{Name: "connection_state", Type: field.TypeString, Nullable: true},
 		{Name: "container_status", Type: field.TypeString, Nullable: true},
+		{Name: "exit_code", Type: field.TypeInt, Nullable: true},
+		{Name: "exit_reason", Type: field.TypeString, Nullable: true},
 		{Name: "runtime_state", Type: field.TypeString, Nullable: true},
 		{Name: "stalled_from_activity", Type: field.TypeString, Nullable: true},
 		{Name: "current_turns", Type: field.TypeInt, Default: 0},
@@ -91,7 +93,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "agents_projects_agents",
-				Columns:    []*schema.Column{AgentsColumns[37]},
+				Columns:    []*schema.Column{AgentsColumns[39]},
 				RefColumns: []*schema.Column{ProjectsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -100,7 +102,7 @@ var (
 			{
 				Name:    "agent_slug_project_id",
 				Unique:  true,
-				Columns: []*schema.Column{AgentsColumns[1], AgentsColumns[37]},
+				Columns: []*schema.Column{AgentsColumns[1], AgentsColumns[39]},
 			},
 		},
 	}

--- a/pkg/ent/mutation.go
+++ b/pkg/ent/mutation.go
@@ -1583,6 +1583,9 @@ type AgentMutation struct {
 	tool_name              *string
 	connection_state       *string
 	container_status       *string
+	exit_code              *int
+	addexit_code           *int
+	exit_reason            *string
 	runtime_state          *string
 	stalled_from_activity  *string
 	current_turns          *int
@@ -2431,6 +2434,125 @@ func (m *AgentMutation) ContainerStatusCleared() bool {
 func (m *AgentMutation) ResetContainerStatus() {
 	m.container_status = nil
 	delete(m.clearedFields, agent.FieldContainerStatus)
+}
+
+// SetExitCode sets the "exit_code" field.
+func (m *AgentMutation) SetExitCode(i int) {
+	m.exit_code = &i
+	m.addexit_code = nil
+}
+
+// ExitCode returns the value of the "exit_code" field in the mutation.
+func (m *AgentMutation) ExitCode() (r int, exists bool) {
+	v := m.exit_code
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldExitCode returns the old "exit_code" field's value of the Agent entity.
+// If the Agent object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AgentMutation) OldExitCode(ctx context.Context) (v *int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldExitCode is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldExitCode requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldExitCode: %w", err)
+	}
+	return oldValue.ExitCode, nil
+}
+
+// AddExitCode adds i to the "exit_code" field.
+func (m *AgentMutation) AddExitCode(i int) {
+	if m.addexit_code != nil {
+		*m.addexit_code += i
+	} else {
+		m.addexit_code = &i
+	}
+}
+
+// AddedExitCode returns the value that was added to the "exit_code" field in this mutation.
+func (m *AgentMutation) AddedExitCode() (r int, exists bool) {
+	v := m.addexit_code
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearExitCode clears the value of the "exit_code" field.
+func (m *AgentMutation) ClearExitCode() {
+	m.exit_code = nil
+	m.addexit_code = nil
+	m.clearedFields[agent.FieldExitCode] = struct{}{}
+}
+
+// ExitCodeCleared returns if the "exit_code" field was cleared in this mutation.
+func (m *AgentMutation) ExitCodeCleared() bool {
+	_, ok := m.clearedFields[agent.FieldExitCode]
+	return ok
+}
+
+// ResetExitCode resets all changes to the "exit_code" field.
+func (m *AgentMutation) ResetExitCode() {
+	m.exit_code = nil
+	m.addexit_code = nil
+	delete(m.clearedFields, agent.FieldExitCode)
+}
+
+// SetExitReason sets the "exit_reason" field.
+func (m *AgentMutation) SetExitReason(s string) {
+	m.exit_reason = &s
+}
+
+// ExitReason returns the value of the "exit_reason" field in the mutation.
+func (m *AgentMutation) ExitReason() (r string, exists bool) {
+	v := m.exit_reason
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldExitReason returns the old "exit_reason" field's value of the Agent entity.
+// If the Agent object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AgentMutation) OldExitReason(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldExitReason is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldExitReason requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldExitReason: %w", err)
+	}
+	return oldValue.ExitReason, nil
+}
+
+// ClearExitReason clears the value of the "exit_reason" field.
+func (m *AgentMutation) ClearExitReason() {
+	m.exit_reason = nil
+	m.clearedFields[agent.FieldExitReason] = struct{}{}
+}
+
+// ExitReasonCleared returns if the "exit_reason" field was cleared in this mutation.
+func (m *AgentMutation) ExitReasonCleared() bool {
+	_, ok := m.clearedFields[agent.FieldExitReason]
+	return ok
+}
+
+// ResetExitReason resets all changes to the "exit_reason" field.
+func (m *AgentMutation) ResetExitReason() {
+	m.exit_reason = nil
+	delete(m.clearedFields, agent.FieldExitReason)
 }
 
 // SetRuntimeState sets the "runtime_state" field.
@@ -3632,7 +3754,7 @@ func (m *AgentMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *AgentMutation) Fields() []string {
-	fields := make([]string, 0, 37)
+	fields := make([]string, 0, 39)
 	if m.slug != nil {
 		fields = append(fields, agent.FieldSlug)
 	}
@@ -3680,6 +3802,12 @@ func (m *AgentMutation) Fields() []string {
 	}
 	if m.container_status != nil {
 		fields = append(fields, agent.FieldContainerStatus)
+	}
+	if m.exit_code != nil {
+		fields = append(fields, agent.FieldExitCode)
+	}
+	if m.exit_reason != nil {
+		fields = append(fields, agent.FieldExitReason)
 	}
 	if m.runtime_state != nil {
 		fields = append(fields, agent.FieldRuntimeState)
@@ -3784,6 +3912,10 @@ func (m *AgentMutation) Field(name string) (ent.Value, bool) {
 		return m.ConnectionState()
 	case agent.FieldContainerStatus:
 		return m.ContainerStatus()
+	case agent.FieldExitCode:
+		return m.ExitCode()
+	case agent.FieldExitReason:
+		return m.ExitReason()
 	case agent.FieldRuntimeState:
 		return m.RuntimeState()
 	case agent.FieldStalledFromActivity:
@@ -3867,6 +3999,10 @@ func (m *AgentMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldConnectionState(ctx)
 	case agent.FieldContainerStatus:
 		return m.OldContainerStatus(ctx)
+	case agent.FieldExitCode:
+		return m.OldExitCode(ctx)
+	case agent.FieldExitReason:
+		return m.OldExitReason(ctx)
 	case agent.FieldRuntimeState:
 		return m.OldRuntimeState(ctx)
 	case agent.FieldStalledFromActivity:
@@ -4030,6 +4166,20 @@ func (m *AgentMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetContainerStatus(v)
 		return nil
+	case agent.FieldExitCode:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetExitCode(v)
+		return nil
+	case agent.FieldExitReason:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetExitReason(v)
+		return nil
 	case agent.FieldRuntimeState:
 		v, ok := value.(string)
 		if !ok {
@@ -4185,6 +4335,9 @@ func (m *AgentMutation) SetField(name string, value ent.Value) error {
 // this mutation.
 func (m *AgentMutation) AddedFields() []string {
 	var fields []string
+	if m.addexit_code != nil {
+		fields = append(fields, agent.FieldExitCode)
+	}
 	if m.addcurrent_turns != nil {
 		fields = append(fields, agent.FieldCurrentTurns)
 	}
@@ -4202,6 +4355,8 @@ func (m *AgentMutation) AddedFields() []string {
 // was not set, or was not defined in the schema.
 func (m *AgentMutation) AddedField(name string) (ent.Value, bool) {
 	switch name {
+	case agent.FieldExitCode:
+		return m.AddedExitCode()
 	case agent.FieldCurrentTurns:
 		return m.AddedCurrentTurns()
 	case agent.FieldCurrentModelCalls:
@@ -4217,6 +4372,13 @@ func (m *AgentMutation) AddedField(name string) (ent.Value, bool) {
 // type.
 func (m *AgentMutation) AddField(name string, value ent.Value) error {
 	switch name {
+	case agent.FieldExitCode:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddExitCode(v)
+		return nil
 	case agent.FieldCurrentTurns:
 		v, ok := value.(int)
 		if !ok {
@@ -4275,6 +4437,12 @@ func (m *AgentMutation) ClearedFields() []string {
 	}
 	if m.FieldCleared(agent.FieldContainerStatus) {
 		fields = append(fields, agent.FieldContainerStatus)
+	}
+	if m.FieldCleared(agent.FieldExitCode) {
+		fields = append(fields, agent.FieldExitCode)
+	}
+	if m.FieldCleared(agent.FieldExitReason) {
+		fields = append(fields, agent.FieldExitReason)
 	}
 	if m.FieldCleared(agent.FieldRuntimeState) {
 		fields = append(fields, agent.FieldRuntimeState)
@@ -4361,6 +4529,12 @@ func (m *AgentMutation) ClearField(name string) error {
 		return nil
 	case agent.FieldContainerStatus:
 		m.ClearContainerStatus()
+		return nil
+	case agent.FieldExitCode:
+		m.ClearExitCode()
+		return nil
+	case agent.FieldExitReason:
+		m.ClearExitReason()
 		return nil
 	case agent.FieldRuntimeState:
 		m.ClearRuntimeState()
@@ -4459,6 +4633,12 @@ func (m *AgentMutation) ResetField(name string) error {
 		return nil
 	case agent.FieldContainerStatus:
 		m.ResetContainerStatus()
+		return nil
+	case agent.FieldExitCode:
+		m.ResetExitCode()
+		return nil
+	case agent.FieldExitReason:
+		m.ResetExitReason()
 		return nil
 	case agent.FieldRuntimeState:
 		m.ResetRuntimeState()

--- a/pkg/ent/runtime.go
+++ b/pkg/ent/runtime.go
@@ -113,33 +113,33 @@ func init() {
 	// agent.DefaultVisibility holds the default value on creation for the visibility field.
 	agent.DefaultVisibility = agentDescVisibility.Default.(string)
 	// agentDescCurrentTurns is the schema descriptor for current_turns field.
-	agentDescCurrentTurns := agentFields[19].Descriptor()
+	agentDescCurrentTurns := agentFields[21].Descriptor()
 	// agent.DefaultCurrentTurns holds the default value on creation for the current_turns field.
 	agent.DefaultCurrentTurns = agentDescCurrentTurns.Default.(int)
 	// agentDescCurrentModelCalls is the schema descriptor for current_model_calls field.
-	agentDescCurrentModelCalls := agentFields[20].Descriptor()
+	agentDescCurrentModelCalls := agentFields[22].Descriptor()
 	// agent.DefaultCurrentModelCalls holds the default value on creation for the current_model_calls field.
 	agent.DefaultCurrentModelCalls = agentDescCurrentModelCalls.Default.(int)
 	// agentDescDetached is the schema descriptor for detached field.
-	agentDescDetached := agentFields[22].Descriptor()
+	agentDescDetached := agentFields[24].Descriptor()
 	// agent.DefaultDetached holds the default value on creation for the detached field.
 	agent.DefaultDetached = agentDescDetached.Default.(bool)
 	// agentDescWebPtyEnabled is the schema descriptor for web_pty_enabled field.
-	agentDescWebPtyEnabled := agentFields[25].Descriptor()
+	agentDescWebPtyEnabled := agentFields[27].Descriptor()
 	// agent.DefaultWebPtyEnabled holds the default value on creation for the web_pty_enabled field.
 	agent.DefaultWebPtyEnabled = agentDescWebPtyEnabled.Default.(bool)
 	// agentDescCreated is the schema descriptor for created field.
-	agentDescCreated := agentFields[31].Descriptor()
+	agentDescCreated := agentFields[33].Descriptor()
 	// agent.DefaultCreated holds the default value on creation for the created field.
 	agent.DefaultCreated = agentDescCreated.Default.(func() time.Time)
 	// agentDescUpdated is the schema descriptor for updated field.
-	agentDescUpdated := agentFields[32].Descriptor()
+	agentDescUpdated := agentFields[34].Descriptor()
 	// agent.DefaultUpdated holds the default value on creation for the updated field.
 	agent.DefaultUpdated = agentDescUpdated.Default.(func() time.Time)
 	// agent.UpdateDefaultUpdated holds the default value on update for the updated field.
 	agent.UpdateDefaultUpdated = agentDescUpdated.UpdateDefault.(func() time.Time)
 	// agentDescStateVersion is the schema descriptor for state_version field.
-	agentDescStateVersion := agentFields[37].Descriptor()
+	agentDescStateVersion := agentFields[39].Descriptor()
 	// agent.DefaultStateVersion holds the default value on creation for the state_version field.
 	agent.DefaultStateVersion = agentDescStateVersion.Default.(int64)
 	// agentDescID is the schema descriptor for id field.

--- a/pkg/ent/schema/agent.go
+++ b/pkg/ent/schema/agent.go
@@ -87,6 +87,11 @@ func (Agent) Fields() []ent.Field {
 			Optional(),
 		field.String("container_status").
 			Optional(),
+		field.Int("exit_code").
+			Optional().
+			Nillable(),
+		field.String("exit_reason").
+			Optional(),
 		field.String("runtime_state").
 			Optional(),
 		field.String("stalled_from_activity").

--- a/pkg/hub/exit_reason_test.go
+++ b/pkg/hub/exit_reason_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import "testing"
+
+func TestIsValidExitReason(t *testing.T) {
+	tests := []struct {
+		reason string
+		want   bool
+	}{
+		// Valid: empty means "no reason given"
+		{"", true},
+		// Valid terminal activities
+		{"crashed", true},
+		{"limits_exceeded", true},
+		// Invalid: non-terminal activities
+		{"working", false},
+		{"thinking", false},
+		{"executing", false},
+		{"waiting_for_input", false},
+		{"completed", false},
+		{"blocked", false},
+		{"stalled", false},
+		{"offline", false},
+		// Invalid: arbitrary strings
+		{"random_string", false},
+		{"error", false},
+		{"stopped", false},
+	}
+
+	for _, tc := range tests {
+		t.Run("reason="+tc.reason, func(t *testing.T) {
+			got := isValidExitReason(tc.reason)
+			if got != tc.want {
+				t.Errorf("isValidExitReason(%q) = %v, want %v", tc.reason, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/hub/handlers_agent_lifecycle.go
+++ b/pkg/hub/handlers_agent_lifecycle.go
@@ -54,6 +54,13 @@ func (s *Server) updateAgentStatus(w http.ResponseWriter, r *http.Request, id st
 		return
 	}
 
+	// Validate ExitReason before passing to the store: only terminal
+	// activities are valid exit reasons. Silently drop invalid values
+	// rather than rejecting the entire status update.
+	if status.ExitReason != "" && !isValidExitReason(status.ExitReason) {
+		status.ExitReason = "" // silently drop invalid values
+	}
+
 	// Guard against phase regressions and auto-correct phase from activity.
 	if status.Phase != "" || status.Activity != "" {
 		agent, err := s.store.GetAgent(ctx, id)

--- a/pkg/hub/handlers_agent_lifecycle.go
+++ b/pkg/hub/handlers_agent_lifecycle.go
@@ -308,6 +308,8 @@ func (s *Server) handleAgentLifecycle(w http.ResponseWriter, r *http.Request, id
 	if action == api.AgentActionStop {
 		statusUpdate.ContainerStatus = "stopped"
 		statusUpdate.Activity = ""
+		zero := 0
+		statusUpdate.ExitCode = &zero
 	}
 	// When starting or restarting, propagate container status from broker response
 	if (action == api.AgentActionStart || action == api.AgentActionRestart) && agent.ContainerStatus != "" {
@@ -443,10 +445,12 @@ func (s *Server) handleStopAllAgents(w http.ResponseWriter, r *http.Request, pro
 					"agent_id", agent.ID, "error", dispatchErr)
 			} else {
 				// Update agent status in store
+				zero := 0
 				statusUpdate := store.AgentStatusUpdate{
 					Phase:           string(state.PhaseStopped),
 					ContainerStatus: "stopped",
 					Activity:        "",
+					ExitCode:        &zero,
 				}
 				if updateErr := s.store.UpdateAgentStatus(ctx, agent.ID, statusUpdate); updateErr != nil {
 					res.Status = "error"

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -5217,3 +5217,197 @@ func TestListAgents_ResponseMetadata(t *testing.T) {
 	assert.Greater(t, resp.TotalCount, 0, "totalCount should be present and non-zero")
 	assert.NotEmpty(t, resp.NextCursor, "nextCursor should be non-empty when more results exist")
 }
+
+// TestBrokerHeartbeat_BackfillsContainerStatusFromStructuredPhase verifies
+// that when a broker sends structured Phase/ExitCode but no ContainerStatus,
+// the hub renders a backward-compatible ContainerStatus display string.
+func TestBrokerHeartbeat_BackfillsContainerStatusFromStructuredPhase(t *testing.T) {
+	zero := 0
+	nonZero := 137
+	cases := []struct {
+		name                 string
+		initialPhase         string // agent's initial phase in store
+		hbPhase              string
+		hbExitCode           *int
+		wantContainerStatus  string
+		wantPhase            string
+	}{
+		{
+			name:                "running phase backfills running",
+			initialPhase:        string(state.PhaseRunning),
+			hbPhase:             string(state.PhaseRunning),
+			wantContainerStatus: "running",
+			wantPhase:           string(state.PhaseRunning),
+		},
+		{
+			name:                "stopped phase backfills stopped",
+			initialPhase:        string(state.PhaseRunning),
+			hbPhase:             string(state.PhaseStopped),
+			hbExitCode:          &zero,
+			wantContainerStatus: "stopped",
+			wantPhase:           string(state.PhaseStopped),
+		},
+		{
+			name:                "error phase with exit code backfills exited (N)",
+			initialPhase:        string(state.PhaseRunning),
+			hbPhase:             string(state.PhaseStopped),
+			hbExitCode:          &nonZero,
+			wantContainerStatus: "exited (137)",
+			wantPhase:           string(state.PhaseError),
+		},
+		{
+			name:                "provisioning phase backfills created",
+			initialPhase:        string(state.PhaseCreated),
+			hbPhase:             string(state.PhaseProvisioning),
+			wantContainerStatus: "created",
+			wantPhase:           string(state.PhaseProvisioning),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, s := testServer(t)
+			ctx := context.Background()
+
+			project := &store.Project{ID: tid("proj-backfill-" + tc.name), Name: "P", Slug: "backfill-proj-" + tc.name}
+			require.NoError(t, s.CreateProject(ctx, project))
+			broker := &store.RuntimeBroker{
+				ID: tid("broker-backfill-" + tc.name), Name: "B", Slug: "backfill-broker-" + tc.name,
+				Status: store.BrokerStatusOnline,
+			}
+			require.NoError(t, s.CreateRuntimeBroker(ctx, broker))
+			agent := &store.Agent{
+				ID: tid("agent-backfill-" + tc.name), Slug: "backfill-slug-" + tc.name, Name: "A",
+				ProjectID: project.ID, RuntimeBrokerID: broker.ID,
+				Phase: tc.initialPhase,
+			}
+			require.NoError(t, s.CreateAgent(ctx, agent))
+
+			hb := brokerHeartbeatRequest{
+				Status: "online",
+				Projects: []brokerProjectHeartbeat{{
+					ProjectID:  project.ID,
+					AgentCount: 1,
+					Agents: []brokerAgentHeartbeat{{
+						Slug:     agent.Slug,
+						Phase:    tc.hbPhase,
+						ExitCode: tc.hbExitCode,
+						// No ContainerStatus — should be backfilled
+					}},
+				}},
+			}
+
+			rec := doRequest(t, srv, http.MethodPost, "/api/v1/runtime-brokers/"+broker.ID+"/heartbeat", hb)
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			updated, err := s.GetAgent(ctx, agent.ID)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPhase, updated.Phase, "phase mismatch")
+			assert.Equal(t, tc.wantContainerStatus, updated.ContainerStatus, "ContainerStatus should be backfilled from structured Phase")
+		})
+	}
+}
+
+// TestBrokerHeartbeat_NoBackfillWhenContainerStatusPresent verifies that
+// the backfill logic does not overwrite a ContainerStatus that the broker
+// already sent.
+func TestBrokerHeartbeat_NoBackfillWhenContainerStatusPresent(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{ID: tid("proj-no-backfill"), Name: "P", Slug: "no-backfill-proj"}
+	require.NoError(t, s.CreateProject(ctx, project))
+	broker := &store.RuntimeBroker{
+		ID: tid("broker-no-backfill"), Name: "B", Slug: "no-backfill-broker",
+		Status: store.BrokerStatusOnline,
+	}
+	require.NoError(t, s.CreateRuntimeBroker(ctx, broker))
+	agent := &store.Agent{
+		ID: tid("agent-no-backfill"), Slug: "no-backfill-slug", Name: "A",
+		ProjectID: project.ID, RuntimeBrokerID: broker.ID,
+		Phase: string(state.PhaseRunning),
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	hb := brokerHeartbeatRequest{
+		Status: "online",
+		Projects: []brokerProjectHeartbeat{{
+			ProjectID:  project.ID,
+			AgentCount: 1,
+			Agents: []brokerAgentHeartbeat{{
+				Slug:            agent.Slug,
+				Phase:           string(state.PhaseRunning),
+				ContainerStatus: "Up 2 hours", // Explicit ContainerStatus from broker
+			}},
+		}},
+	}
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/runtime-brokers/"+broker.ID+"/heartbeat", hb)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	updated, err := s.GetAgent(ctx, agent.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Up 2 hours", updated.ContainerStatus, "broker-provided ContainerStatus should not be overwritten")
+}
+
+// TestStopAgent_SetsExitCodeZero verifies that when an agent is stopped via
+// the lifecycle handler, the ExitCode is set to 0 (clean exit).
+func TestStopAgent_SetsExitCodeZero(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{ID: tid("proj-stop-exitcode"), Name: "P", Slug: "stop-exitcode-proj"}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	agent := &store.Agent{
+		ID:        tid("agent-stop-exitcode"),
+		Slug:      "stop-exitcode-slug",
+		Name:      "Stop ExitCode Agent",
+		ProjectID: project.ID,
+		Phase:     string(state.PhaseRunning),
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/agents/"+agent.ID+"/stop", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	updated, err := s.GetAgent(ctx, agent.ID)
+	require.NoError(t, err)
+	assert.Equal(t, string(state.PhaseStopped), updated.Phase)
+	assert.Equal(t, "stopped", updated.ContainerStatus)
+	require.NotNil(t, updated.ExitCode, "ExitCode should be set on stop")
+	assert.Equal(t, 0, *updated.ExitCode, "ExitCode should be 0 for clean stop")
+}
+
+// TestStopAllAgents_SetsExitCodeZero verifies that the stop-all handler
+// records ExitCode=0 for each stopped agent.
+func TestStopAllAgents_SetsExitCodeZero(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{ID: tid("proj-stopall-exit"), Name: "P", Slug: "stopall-exit-proj"}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	agentIDs := []string{tid("agent-stopall-exit-1"), tid("agent-stopall-exit-2")}
+	for _, id := range agentIDs {
+		agent := &store.Agent{
+			ID:        id,
+			Slug:      id,
+			Name:      id,
+			ProjectID: project.ID,
+			Phase:     string(state.PhaseRunning),
+		}
+		require.NoError(t, s.CreateAgent(ctx, agent))
+	}
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects/"+project.ID+"/agents/stop-all", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	for _, id := range agentIDs {
+		updated, err := s.GetAgent(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, string(state.PhaseStopped), updated.Phase, "agent %s should be stopped", id)
+		require.NotNil(t, updated.ExitCode, "agent %s ExitCode should be set", id)
+		assert.Equal(t, 0, *updated.ExitCode, "agent %s ExitCode should be 0 for clean stop", id)
+	}
+}

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -5225,12 +5225,12 @@ func TestBrokerHeartbeat_BackfillsContainerStatusFromStructuredPhase(t *testing.
 	zero := 0
 	nonZero := 137
 	cases := []struct {
-		name                 string
-		initialPhase         string // agent's initial phase in store
-		hbPhase              string
-		hbExitCode           *int
-		wantContainerStatus  string
-		wantPhase            string
+		name                string
+		initialPhase        string // agent's initial phase in store
+		hbPhase             string
+		hbExitCode          *int
+		wantContainerStatus string
+		wantPhase           string
 	}{
 		{
 			name:                "running phase backfills running",

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -5218,6 +5218,106 @@ func TestListAgents_ResponseMetadata(t *testing.T) {
 	assert.NotEmpty(t, resp.NextCursor, "nextCursor should be non-empty when more results exist")
 }
 
+// TestBrokerHeartbeat_PhaseErrorPersistsExitCodeAndReason verifies that when
+// a broker directly reports PhaseError (e.g. a failed K8s pod), the hub
+// persists ExitCode and ExitReason. Previously the exit-code extraction block
+// was gated on PhaseStopped only, so PhaseError heartbeats lost this data.
+func TestBrokerHeartbeat_PhaseErrorPersistsExitCodeAndReason(t *testing.T) {
+	nonZero := 137
+	cases := []struct {
+		name           string
+		hbPhase        string
+		hbExitCode     *int
+		hbExitReason   string
+		wantPhase      string
+		wantExitCode   *int
+		wantExitReason string
+		wantMessage    string
+	}{
+		{
+			name:           "PhaseError with non-zero exit code persists ExitCode and ExitReason",
+			hbPhase:        string(state.PhaseError),
+			hbExitCode:     &nonZero,
+			hbExitReason:   "crashed",
+			wantPhase:      string(state.PhaseError),
+			wantExitCode:   &nonZero,
+			wantExitReason: "crashed",
+			wantMessage:    "Agent crashed with exit code 137",
+		},
+		{
+			name:           "PhaseError with nil exit code preserves PhaseError and ExitReason",
+			hbPhase:        string(state.PhaseError),
+			hbExitCode:     nil,
+			hbExitReason:   "crashed",
+			wantPhase:      string(state.PhaseError),
+			wantExitCode:   nil,
+			wantExitReason: "crashed",
+		},
+		{
+			name:           "PhaseStopped with non-zero exit code still promotes to PhaseError",
+			hbPhase:        string(state.PhaseStopped),
+			hbExitCode:     &nonZero,
+			hbExitReason:   "crashed",
+			wantPhase:      string(state.PhaseError),
+			wantExitCode:   &nonZero,
+			wantExitReason: "crashed",
+			wantMessage:    "Agent crashed with exit code 137",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, s := testServer(t)
+			ctx := context.Background()
+
+			project := &store.Project{ID: tid("proj-pe-exit-" + tc.name), Name: "P", Slug: "pe-exit-proj-" + tc.name}
+			require.NoError(t, s.CreateProject(ctx, project))
+			broker := &store.RuntimeBroker{
+				ID: tid("broker-pe-exit-" + tc.name), Name: "B", Slug: "pe-exit-broker-" + tc.name,
+				Status: store.BrokerStatusOnline,
+			}
+			require.NoError(t, s.CreateRuntimeBroker(ctx, broker))
+			agent := &store.Agent{
+				ID: tid("agent-pe-exit-" + tc.name), Slug: "pe-exit-slug-" + tc.name, Name: "A",
+				ProjectID: project.ID, RuntimeBrokerID: broker.ID,
+				Phase: string(state.PhaseRunning),
+			}
+			require.NoError(t, s.CreateAgent(ctx, agent))
+
+			heartbeat := brokerHeartbeatRequest{
+				Status: "online",
+				Projects: []brokerProjectHeartbeat{{
+					ProjectID:  project.ID,
+					AgentCount: 1,
+					Agents: []brokerAgentHeartbeat{{
+						Slug:       agent.Slug,
+						Phase:      tc.hbPhase,
+						ExitCode:   tc.hbExitCode,
+						ExitReason: tc.hbExitReason,
+					}},
+				}},
+			}
+
+			rec := doRequest(t, srv, http.MethodPost, "/api/v1/runtime-brokers/"+broker.ID+"/heartbeat", heartbeat)
+			assert.Equal(t, http.StatusOK, rec.Code)
+
+			updated, err := s.GetAgent(ctx, agent.ID)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantPhase, updated.Phase, "phase mismatch")
+			if tc.wantExitCode != nil {
+				require.NotNil(t, updated.ExitCode, "ExitCode should be persisted")
+				assert.Equal(t, *tc.wantExitCode, *updated.ExitCode, "ExitCode value mismatch")
+			}
+			if tc.wantExitReason != "" {
+				assert.Equal(t, tc.wantExitReason, updated.ExitReason, "ExitReason should be persisted")
+			}
+			if tc.wantMessage != "" {
+				assert.Equal(t, tc.wantMessage, updated.Message, "Message mismatch")
+			}
+		})
+	}
+}
+
 // TestBrokerHeartbeat_BackfillsContainerStatusFromStructuredPhase verifies
 // that when a broker sends structured Phase/ExitCode but no ContainerStatus,
 // the hub renders a backward-compatible ContainerStatus display string.

--- a/pkg/hub/handlers_runtime_brokers.go
+++ b/pkg/hub/handlers_runtime_brokers.go
@@ -731,7 +731,7 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 							}
 						} else if agentHB.ExitCode == nil {
 							// Legacy fallback: parse from ContainerStatus string (old broker)
-							if code, ok := scionruntime.ExitCodeFromContainerStatus(agentHB.ContainerStatus); ok && code != 0 {
+							if code, ok := scionruntime.ExitCodeFromContainerStatus(agentHB.ContainerStatus); ok && code != 0 { //nolint:staticcheck // legacy fallback for brokers without ExitCode
 								hbPhase = state.PhaseError
 								agentHB.Phase = string(state.PhaseError)
 								c := code
@@ -792,7 +792,7 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 					case strings.HasPrefix(containerStatusLower, "exited") || containerStatusLower == "stopped":
 						// A non-zero exit code means the agent crashed → error
 						// (restartable); a zero/absent code is a clean stop.
-						if code, ok := scionruntime.ExitCodeFromContainerStatus(agentHB.ContainerStatus); ok && code != 0 {
+						if code, ok := scionruntime.ExitCodeFromContainerStatus(agentHB.ContainerStatus); ok && code != 0 { //nolint:staticcheck // legacy fallback for brokers without ExitCode
 							statusUpdate.Phase = string(state.PhaseError)
 							c := code
 							statusUpdate.ExitCode = &c

--- a/pkg/hub/handlers_runtime_brokers.go
+++ b/pkg/hub/handlers_runtime_brokers.go
@@ -715,11 +715,14 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 					// Derive a crash from the exit code even when the broker
 					// reports a plain "stopped". Prefer the structured ExitCode
 					// field; fall back to parsing ContainerStatus for old brokers.
-					if hbPhase == state.PhaseStopped {
+					if hbPhase == state.PhaseStopped || hbPhase == state.PhaseError {
 						if agentHB.ExitCode != nil && *agentHB.ExitCode != 0 {
 							// crash path
-							hbPhase = state.PhaseError
-							agentHB.Phase = string(state.PhaseError)
+							if hbPhase == state.PhaseStopped {
+								// Promote PhaseStopped→PhaseError when exit code is non-zero.
+								hbPhase = state.PhaseError
+								agentHB.Phase = string(state.PhaseError)
+							}
 							statusUpdate.ExitCode = agentHB.ExitCode
 							if isValidExitReason(agentHB.ExitReason) {
 								statusUpdate.ExitReason = agentHB.ExitReason
@@ -729,8 +732,9 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 							if statusUpdate.Message == "" {
 								statusUpdate.Message = fmt.Sprintf("Agent crashed with exit code %d", *agentHB.ExitCode)
 							}
-						} else if agentHB.ExitCode == nil {
-							// Legacy fallback: parse from ContainerStatus string (old broker)
+						} else if hbPhase == state.PhaseStopped && agentHB.ExitCode == nil {
+							// Legacy fallback: parse from ContainerStatus string (old broker).
+							// Only applies to PhaseStopped — PhaseError already has the correct phase.
 							if code, ok := scionruntime.ExitCodeFromContainerStatus(agentHB.ContainerStatus); ok && code != 0 { //nolint:staticcheck // legacy fallback for brokers without ExitCode
 								hbPhase = state.PhaseError
 								agentHB.Phase = string(state.PhaseError)
@@ -741,7 +745,8 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 								}
 							}
 						} else {
-							// ExitCode == 0: clean exit, keep PhaseStopped
+							// PhaseStopped with ExitCode == 0 (clean exit) or
+							// PhaseError with nil/zero ExitCode: persist what we have.
 							statusUpdate.ExitCode = agentHB.ExitCode
 							if isValidExitReason(agentHB.ExitReason) {
 								statusUpdate.ExitReason = agentHB.ExitReason

--- a/pkg/hub/handlers_runtime_brokers.go
+++ b/pkg/hub/handlers_runtime_brokers.go
@@ -717,7 +717,7 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 					// field; fall back to parsing ContainerStatus for old brokers.
 					if hbPhase == state.PhaseStopped {
 						if agentHB.ExitCode != nil && *agentHB.ExitCode != 0 {
-							// Structured path: use ExitCode directly
+							// crash path
 							hbPhase = state.PhaseError
 							agentHB.Phase = string(state.PhaseError)
 							statusUpdate.ExitCode = agentHB.ExitCode
@@ -738,9 +738,8 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 									statusUpdate.Message = fmt.Sprintf("Agent crashed with exit code %d", code)
 								}
 							}
-						}
-						// If ExitCode is non-nil and == 0: clean exit, keep PhaseStopped
-						if agentHB.ExitCode != nil && *agentHB.ExitCode == 0 {
+						} else {
+							// ExitCode == 0: clean exit, keep PhaseStopped
 							statusUpdate.ExitCode = agentHB.ExitCode
 							if isValidExitReason(agentHB.ExitReason) {
 								statusUpdate.ExitReason = agentHB.ExitReason

--- a/pkg/hub/handlers_runtime_brokers.go
+++ b/pkg/hub/handlers_runtime_brokers.go
@@ -723,6 +723,8 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 							statusUpdate.ExitCode = agentHB.ExitCode
 							if isValidExitReason(agentHB.ExitReason) {
 								statusUpdate.ExitReason = agentHB.ExitReason
+							} else if agentHB.ExitReason != "" {
+								slog.Debug("dropping invalid ExitReason from heartbeat", "exitReason", agentHB.ExitReason, "agent", agentHB.Slug)
 							}
 							if statusUpdate.Message == "" {
 								statusUpdate.Message = fmt.Sprintf("Agent crashed with exit code %d", *agentHB.ExitCode)
@@ -743,6 +745,8 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 							statusUpdate.ExitCode = agentHB.ExitCode
 							if isValidExitReason(agentHB.ExitReason) {
 								statusUpdate.ExitReason = agentHB.ExitReason
+							} else if agentHB.ExitReason != "" {
+								slog.Debug("dropping invalid ExitReason from heartbeat", "exitReason", agentHB.ExitReason, "agent", agentHB.Slug)
 							}
 						}
 					}
@@ -917,8 +921,6 @@ func (s *Server) getBrokerProjects(w http.ResponseWriter, r *http.Request, broke
 }
 
 // isValidExitReason reports whether reason is a valid ExitReason value.
-// Only terminal activities ("crashed", "limits_exceeded") are valid exit reasons.
-// An empty string is also valid (no reason given).
 func isValidExitReason(reason string) bool {
-	return reason == "" || state.Activity(reason).IsTerminal()
+	return state.ExitReason(reason).IsValid()
 }

--- a/pkg/hub/handlers_runtime_brokers.go
+++ b/pkg/hub/handlers_runtime_brokers.go
@@ -618,6 +618,8 @@ type brokerAgentHeartbeat struct {
 	Message         string `json:"message,omitempty"`     // Error or status message from agent
 	HarnessAuth     string `json:"harnessAuth,omitempty"` // Resolved auth method from container labels
 	Profile         string `json:"profile,omitempty"`     // Settings profile used
+	ExitCode        *int   `json:"exitCode,omitempty"`    // Structured exit code from runtime (nil = unknown)
+	ExitReason      string `json:"exitReason,omitempty"`  // Terminal reason: "crashed" or "limits_exceeded"
 }
 
 func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, id string) {
@@ -710,20 +712,38 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 					hbPhase := state.Phase(agentHB.Phase)
 					curPhase := state.Phase(agent.Phase)
 
-					// Derive a crash from the container exit code even when the
-					// broker reports a plain "stopped" (its phase derivation is
-					// based on the container being exited, not on the exit code).
-					// A non-zero exit means the agent crashed → error, with the
-					// exit code recorded so the UI can show it. This works even
-					// if sciontool's own crash report never reached the hub.
+					// Derive a crash from the exit code even when the broker
+					// reports a plain "stopped". Prefer the structured ExitCode
+					// field; fall back to parsing ContainerStatus for old brokers.
 					if hbPhase == state.PhaseStopped {
-						if code, ok := scionruntime.ExitCodeFromContainerStatus(agentHB.ContainerStatus); ok && code != 0 {
+						if agentHB.ExitCode != nil && *agentHB.ExitCode != 0 {
+							// Structured path: use ExitCode directly
 							hbPhase = state.PhaseError
 							agentHB.Phase = string(state.PhaseError)
-							c := code
-							statusUpdate.ExitCode = &c
+							statusUpdate.ExitCode = agentHB.ExitCode
+							if isValidExitReason(agentHB.ExitReason) {
+								statusUpdate.ExitReason = agentHB.ExitReason
+							}
 							if statusUpdate.Message == "" {
-								statusUpdate.Message = fmt.Sprintf("Agent crashed with exit code %d", code)
+								statusUpdate.Message = fmt.Sprintf("Agent crashed with exit code %d", *agentHB.ExitCode)
+							}
+						} else if agentHB.ExitCode == nil {
+							// Legacy fallback: parse from ContainerStatus string (old broker)
+							if code, ok := scionruntime.ExitCodeFromContainerStatus(agentHB.ContainerStatus); ok && code != 0 {
+								hbPhase = state.PhaseError
+								agentHB.Phase = string(state.PhaseError)
+								c := code
+								statusUpdate.ExitCode = &c
+								if statusUpdate.Message == "" {
+									statusUpdate.Message = fmt.Sprintf("Agent crashed with exit code %d", code)
+								}
+							}
+						}
+						// If ExitCode is non-nil and == 0: clean exit, keep PhaseStopped
+						if agentHB.ExitCode != nil && *agentHB.ExitCode == 0 {
+							statusUpdate.ExitCode = agentHB.ExitCode
+							if isValidExitReason(agentHB.ExitReason) {
+								statusUpdate.ExitReason = agentHB.ExitReason
 							}
 						}
 					}
@@ -895,4 +915,11 @@ func (s *Server) getBrokerProjects(w http.ResponseWriter, r *http.Request, broke
 	writeJSON(w, http.StatusOK, ListBrokerProjectsResponse{
 		Projects: projects,
 	})
+}
+
+// isValidExitReason reports whether reason is a valid ExitReason value.
+// Only terminal activities ("crashed", "limits_exceeded") are valid exit reasons.
+// An empty string is also valid (no reason given).
+func isValidExitReason(reason string) bool {
+	return reason == "" || state.Activity(reason).IsTerminal()
 }

--- a/pkg/hub/handlers_runtime_brokers.go
+++ b/pkg/hub/handlers_runtime_brokers.go
@@ -814,6 +814,27 @@ func (s *Server) handleBrokerHeartbeat(w http.ResponseWriter, r *http.Request, i
 				}
 			}
 
+			// If the broker didn't send a ContainerStatus but we have structured
+			// fields, render a display string for backward-compatible clients.
+			if statusUpdate.ContainerStatus == "" && agentHB.ContainerStatus == "" {
+				if statusUpdate.Phase != "" {
+					switch state.Phase(statusUpdate.Phase) {
+					case state.PhaseRunning:
+						statusUpdate.ContainerStatus = "running"
+					case state.PhaseStopped:
+						statusUpdate.ContainerStatus = "stopped"
+					case state.PhaseError:
+						if statusUpdate.ExitCode != nil {
+							statusUpdate.ContainerStatus = fmt.Sprintf("exited (%d)", *statusUpdate.ExitCode)
+						} else {
+							statusUpdate.ContainerStatus = "exited"
+						}
+					case state.PhaseProvisioning:
+						statusUpdate.ContainerStatus = "created"
+					}
+				}
+			}
+
 			// Backfill HarnessAuth and Profile from heartbeat if the agent record is missing them.
 			// This covers agents created before tracking was added, or
 			// agents where values were auto-detected rather than explicitly set.

--- a/pkg/hub/heartbeat_exit_code_test.go
+++ b/pkg/hub/heartbeat_exit_code_test.go
@@ -1,0 +1,335 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupHeartbeatExitCodeTest creates a server with a broker, project, and
+// running agent so that heartbeat processing can be tested end-to-end.
+func setupHeartbeatExitCodeTest(t *testing.T) (srv *Server, s store.Store, brokerID, projectID, agentSlug string) {
+	t.Helper()
+
+	srv, s = testServer(t)
+	ctx := context.Background()
+
+	broker := &store.RuntimeBroker{
+		ID:      tid("hb-broker"),
+		Name:    "HB Broker",
+		Slug:    "hb-broker",
+		Status:  store.BrokerStatusOnline,
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	require.NoError(t, s.CreateRuntimeBroker(ctx, broker))
+
+	project := &store.Project{
+		ID:      tid("hb-project"),
+		Slug:    "hb-project",
+		Name:    "HB Project",
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	require.NoError(t, s.AddProjectProvider(ctx, &store.ProjectProvider{
+		ProjectID:  project.ID,
+		BrokerID:   broker.ID,
+		BrokerName: broker.Name,
+		Status:     broker.Status,
+	}))
+
+	agent := &store.Agent{
+		ID:              tid("hb-agent"),
+		Slug:            "hb-agent",
+		Name:            "HB Agent",
+		Template:        "default",
+		ProjectID:       project.ID,
+		RuntimeBrokerID: broker.ID,
+		Phase:           "running",
+		Activity:        "working",
+		Labels:          map[string]string{},
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	return srv, s, broker.ID, project.ID, agent.Slug
+}
+
+// sendHeartbeat sends a broker heartbeat with the given agent heartbeat data
+// and returns the HTTP status code.
+func sendHeartbeat(t *testing.T, srv *Server, brokerID, projectID string, agentHB brokerAgentHeartbeat) int {
+	t.Helper()
+	hb := brokerHeartbeatRequest{
+		Status: "online",
+		Projects: []brokerProjectHeartbeat{
+			{
+				ProjectID: projectID,
+				Agents:    []brokerAgentHeartbeat{agentHB},
+			},
+		},
+	}
+	rec := doRequest(t, srv, http.MethodPost,
+		"/api/v1/runtime-brokers/"+brokerID+"/heartbeat", hb)
+	return rec.Code
+}
+
+// getAgentState retrieves the current agent state from the store.
+func getAgentState(t *testing.T, s store.Store, slug, projectID string) *store.Agent {
+	t.Helper()
+	agent, err := s.GetAgentBySlug(context.Background(), projectID, slug)
+	require.NoError(t, err)
+	return agent
+}
+
+// TestHeartbeatExitCode_StructuredCrash verifies that a heartbeat with a
+// non-zero ExitCode (structured path) promotes stopped → error and records
+// the exit code and reason.
+func TestHeartbeatExitCode_StructuredCrash(t *testing.T) {
+	srv, s, brokerID, projectID, agentSlug := setupHeartbeatExitCodeTest(t)
+
+	ec := 137
+	code := sendHeartbeat(t, srv, brokerID, projectID, brokerAgentHeartbeat{
+		Slug:       agentSlug,
+		Phase:      "stopped",
+		Activity:   "crashed",
+		ExitCode:   &ec,
+		ExitReason: "crashed",
+	})
+	assert.Equal(t, http.StatusOK, code)
+
+	got := getAgentState(t, s, agentSlug, projectID)
+	assert.Equal(t, "error", got.Phase, "non-zero ExitCode should promote stopped to error")
+	assert.Equal(t, "crashed", got.Activity)
+	require.NotNil(t, got.ExitCode, "ExitCode should be persisted")
+	assert.Equal(t, 137, *got.ExitCode)
+	assert.Equal(t, "crashed", got.ExitReason)
+	assert.Contains(t, got.Message, "exit code 137")
+}
+
+// TestHeartbeatExitCode_StructuredCleanExit verifies that ExitCode==0 keeps
+// PhaseStopped (clean exit) and still records the exit code.
+func TestHeartbeatExitCode_StructuredCleanExit(t *testing.T) {
+	srv, s, brokerID, projectID, agentSlug := setupHeartbeatExitCodeTest(t)
+
+	ec := 0
+	code := sendHeartbeat(t, srv, brokerID, projectID, brokerAgentHeartbeat{
+		Slug:     agentSlug,
+		Phase:    "stopped",
+		Activity: "completed",
+		ExitCode: &ec,
+	})
+	assert.Equal(t, http.StatusOK, code)
+
+	got := getAgentState(t, s, agentSlug, projectID)
+	assert.Equal(t, "stopped", got.Phase, "ExitCode 0 should keep stopped phase")
+	require.NotNil(t, got.ExitCode, "ExitCode 0 should be persisted")
+	assert.Equal(t, 0, *got.ExitCode)
+}
+
+// TestHeartbeatExitCode_LegacyFallback verifies that when ExitCode is nil
+// (old broker), the hub falls back to parsing the ContainerStatus string.
+func TestHeartbeatExitCode_LegacyFallback(t *testing.T) {
+	srv, s, brokerID, projectID, agentSlug := setupHeartbeatExitCodeTest(t)
+
+	code := sendHeartbeat(t, srv, brokerID, projectID, brokerAgentHeartbeat{
+		Slug:            agentSlug,
+		Phase:           "stopped",
+		ContainerStatus: "Exited (1) 5 minutes ago",
+		// No ExitCode field — simulating an old broker
+	})
+	assert.Equal(t, http.StatusOK, code)
+
+	got := getAgentState(t, s, agentSlug, projectID)
+	assert.Equal(t, "error", got.Phase, "legacy fallback should promote stopped to error")
+	require.NotNil(t, got.ExitCode, "ExitCode should be derived from ContainerStatus")
+	assert.Equal(t, 1, *got.ExitCode)
+	assert.Contains(t, got.Message, "exit code 1")
+}
+
+// TestHeartbeatExitCode_LegacyCleanExit verifies that when ExitCode is nil
+// and ContainerStatus shows exit code 0, the phase stays stopped.
+func TestHeartbeatExitCode_LegacyCleanExit(t *testing.T) {
+	srv, s, brokerID, projectID, agentSlug := setupHeartbeatExitCodeTest(t)
+
+	code := sendHeartbeat(t, srv, brokerID, projectID, brokerAgentHeartbeat{
+		Slug:            agentSlug,
+		Phase:           "stopped",
+		ContainerStatus: "Exited (0) 5 minutes ago",
+	})
+	assert.Equal(t, http.StatusOK, code)
+
+	got := getAgentState(t, s, agentSlug, projectID)
+	assert.Equal(t, "stopped", got.Phase, "legacy clean exit should keep stopped phase")
+}
+
+// TestHeartbeatExitCode_InvalidReasonDropped verifies that an invalid
+// ExitReason (non-terminal activity) is silently dropped.
+func TestHeartbeatExitCode_InvalidReasonDropped(t *testing.T) {
+	srv, s, brokerID, projectID, agentSlug := setupHeartbeatExitCodeTest(t)
+
+	ec := 1
+	code := sendHeartbeat(t, srv, brokerID, projectID, brokerAgentHeartbeat{
+		Slug:       agentSlug,
+		Phase:      "stopped",
+		ExitCode:   &ec,
+		ExitReason: "working", // invalid — not a terminal activity
+	})
+	assert.Equal(t, http.StatusOK, code)
+
+	got := getAgentState(t, s, agentSlug, projectID)
+	assert.Equal(t, "error", got.Phase, "non-zero ExitCode should still promote to error")
+	require.NotNil(t, got.ExitCode)
+	assert.Equal(t, 1, *got.ExitCode)
+	assert.Equal(t, "", got.ExitReason, "invalid exit reason must be dropped")
+}
+
+// TestHeartbeatExitCode_LimitsExceeded verifies that "limits_exceeded" is
+// accepted as a valid ExitReason.
+func TestHeartbeatExitCode_LimitsExceeded(t *testing.T) {
+	srv, s, brokerID, projectID, agentSlug := setupHeartbeatExitCodeTest(t)
+
+	ec := 1
+	code := sendHeartbeat(t, srv, brokerID, projectID, brokerAgentHeartbeat{
+		Slug:       agentSlug,
+		Phase:      "stopped",
+		ExitCode:   &ec,
+		ExitReason: "limits_exceeded",
+	})
+	assert.Equal(t, http.StatusOK, code)
+
+	got := getAgentState(t, s, agentSlug, projectID)
+	assert.Equal(t, "error", got.Phase)
+	assert.Equal(t, "limits_exceeded", got.ExitReason)
+}
+
+// TestHeartbeatExitCode_CleanExitWithReason verifies that a clean exit
+// (ExitCode 0) with a valid reason records the reason.
+func TestHeartbeatExitCode_CleanExitWithReason(t *testing.T) {
+	srv, s, brokerID, projectID, agentSlug := setupHeartbeatExitCodeTest(t)
+
+	ec := 0
+	code := sendHeartbeat(t, srv, brokerID, projectID, brokerAgentHeartbeat{
+		Slug:       agentSlug,
+		Phase:      "stopped",
+		ExitCode:   &ec,
+		ExitReason: "limits_exceeded",
+	})
+	assert.Equal(t, http.StatusOK, code)
+
+	got := getAgentState(t, s, agentSlug, projectID)
+	assert.Equal(t, "stopped", got.Phase, "ExitCode 0 keeps stopped")
+	assert.Equal(t, "limits_exceeded", got.ExitReason, "valid reason on clean exit should be recorded")
+}
+
+// TestHeartbeatExitCode_WireCompat_OldBrokerNoExitCode verifies backward
+// compatibility: a heartbeat with no ExitCode field (old broker) that has
+// a running container status doesn't erroneously set exit info.
+func TestHeartbeatExitCode_WireCompat_OldBrokerNoExitCode(t *testing.T) {
+	srv, s, brokerID, projectID, agentSlug := setupHeartbeatExitCodeTest(t)
+
+	// Old broker sending running status — no ExitCode
+	code := sendHeartbeat(t, srv, brokerID, projectID, brokerAgentHeartbeat{
+		Slug:            agentSlug,
+		Phase:           "running",
+		Activity:        "thinking",
+		ContainerStatus: "Up 5 minutes",
+	})
+	assert.Equal(t, http.StatusOK, code)
+
+	got := getAgentState(t, s, agentSlug, projectID)
+	assert.Equal(t, "running", got.Phase)
+	assert.Nil(t, got.ExitCode, "running agent should not have ExitCode set")
+	assert.Equal(t, "", got.ExitReason)
+}
+
+// TestHeartbeatExitCode_JSONWireFormat verifies that the ExitCode and
+// ExitReason fields serialize/deserialize correctly in the heartbeat JSON,
+// including the omitempty behavior for nil ExitCode.
+func TestHeartbeatExitCode_JSONWireFormat(t *testing.T) {
+	t.Run("nil ExitCode omitted from JSON", func(t *testing.T) {
+		hb := brokerAgentHeartbeat{
+			Slug:  "test-agent",
+			Phase: "running",
+		}
+		data, err := json.Marshal(hb)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+		_, hasExitCode := m["exitCode"]
+		assert.False(t, hasExitCode, "nil ExitCode should be omitted from JSON")
+	})
+
+	t.Run("non-nil ExitCode present in JSON", func(t *testing.T) {
+		ec := 42
+		hb := brokerAgentHeartbeat{
+			Slug:       "test-agent",
+			Phase:      "stopped",
+			ExitCode:   &ec,
+			ExitReason: "crashed",
+		}
+		data, err := json.Marshal(hb)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+		exitCode, ok := m["exitCode"]
+		assert.True(t, ok, "non-nil ExitCode should be present in JSON")
+		assert.Equal(t, float64(42), exitCode)
+		assert.Equal(t, "crashed", m["exitReason"])
+	})
+
+	t.Run("ExitCode zero present in JSON", func(t *testing.T) {
+		ec := 0
+		hb := brokerAgentHeartbeat{
+			Slug:     "test-agent",
+			Phase:    "stopped",
+			ExitCode: &ec,
+		}
+		data, err := json.Marshal(hb)
+		require.NoError(t, err)
+
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &m))
+		exitCode, ok := m["exitCode"]
+		assert.True(t, ok, "ExitCode 0 should be present in JSON (not omitted)")
+		assert.Equal(t, float64(0), exitCode)
+	})
+
+	t.Run("round-trip through JSON preserves nil", func(t *testing.T) {
+		original := brokerAgentHeartbeat{
+			Slug:  "test-agent",
+			Phase: "running",
+		}
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded brokerAgentHeartbeat
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Nil(t, decoded.ExitCode, "nil ExitCode should round-trip as nil")
+		assert.Equal(t, "", decoded.ExitReason)
+	})
+}

--- a/pkg/hubclient/runtime_brokers.go
+++ b/pkg/hubclient/runtime_brokers.go
@@ -195,6 +195,8 @@ type AgentHeartbeat struct {
 	Message         string `json:"message,omitempty"`     // Error or status message from agent-info.json
 	HarnessAuth     string `json:"harnessAuth,omitempty"` // Resolved auth method from container labels
 	Profile         string `json:"profile,omitempty"`     // Settings profile used
+	ExitCode        *int   `json:"exitCode,omitempty"`    // Structured exit code from runtime (nil = unknown)
+	ExitReason      string `json:"exitReason,omitempty"`  // Terminal reason: "crashed" or "limits_exceeded"
 }
 
 // CreateBrokerRequest is the request to create a new broker registration.

--- a/pkg/hubclient/types.go
+++ b/pkg/hubclient/types.go
@@ -58,6 +58,8 @@ type Agent struct {
 	OwnerID           string            `json:"ownerId,omitempty"`
 	Visibility        string            `json:"visibility,omitempty"`
 	StateVersion      int64             `json:"stateVersion,omitempty"`
+	ExitCode          *int              `json:"exitCode,omitempty"`
+	ExitReason        string            `json:"exitReason,omitempty"`
 }
 
 // UnmarshalJSON implements custom unmarshaling to support legacy grove fields.

--- a/pkg/runtime/apple_container.go
+++ b/pkg/runtime/apple_container.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
@@ -225,7 +226,7 @@ func (r *AppleContainerRuntime) List(ctx context.Context, labelFilter map[string
 			}
 		}
 
-		agents = append(agents, api.AgentInfo{
+		info := api.AgentInfo{
 			ContainerID:     c.Configuration.ID,
 			Name:            c.Configuration.Labels["scion.name"],
 			Template:        c.Configuration.Labels["scion.template"],
@@ -240,7 +241,15 @@ func (r *AppleContainerRuntime) List(ctx context.Context, labelFilter map[string
 			Phase:           phaseFromContainerStatus(c.Status.State),
 			Image:           c.Configuration.Image.Reference,
 			Runtime:         r.Name(),
-		})
+		}
+		if code, ok := ExitCodeFromContainerStatus(c.Status.State); ok {
+			ec := code
+			info.ExitCode = &ec
+			if code != 0 {
+				info.ExitReason = string(state.ActivityCrashed)
+			}
+		}
+		agents = append(agents, info)
 	}
 
 	return agents, nil

--- a/pkg/runtime/apple_container.go
+++ b/pkg/runtime/apple_container.go
@@ -246,7 +246,7 @@ func (r *AppleContainerRuntime) List(ctx context.Context, labelFilter map[string
 			ec := code
 			info.ExitCode = &ec
 			if code != 0 {
-				info.ExitReason = string(state.ActivityCrashed)
+				info.ExitReason = string(state.ExitReasonCrashed)
 			}
 		}
 		agents = append(agents, info)

--- a/pkg/runtime/apple_container.go
+++ b/pkg/runtime/apple_container.go
@@ -280,8 +280,7 @@ func (r *AppleContainerRuntime) Attach(ctx context.Context, id string) error {
 	}
 
 	// Check if running
-	status := strings.ToLower(a.ContainerStatus)
-	if !strings.HasPrefix(status, "up") && status != "running" {
+	if a.Phase != string(state.PhaseRunning) {
 		return fmt.Errorf("agent '%s' is not running (status: %s), use 'scion start %s' to resume it", id, a.ContainerStatus, id)
 	}
 

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -961,10 +961,10 @@ func phaseFromContainerStatus(status string) string {
 // as "Exited (137) 2 minutes ago" (Docker/Podman) or "exited (0)".
 var exitedStatusRe = regexp.MustCompile(`(?i)exited\s*\((\d+)\)`)
 
-// ExitCodeFromContainerStatus extracts the exit code from a container status
-// string like "Exited (137) 2 minutes ago". It returns (code, true) when an
-// exited status with a parseable code is present, otherwise (0, false). A plain
-// "stopped" (no embedded code) yields (0, false).
+// Deprecated: ExitCodeFromContainerStatus parses exit codes from container
+// status strings like "Exited (137)". New code should use the structured
+// ExitCode field on AgentInfo/AgentHeartbeat instead. This function remains
+// for the hub's legacy heartbeat fallback path (old brokers without ExitCode).
 func ExitCodeFromContainerStatus(status string) (int, bool) {
 	m := exitedStatusRe.FindStringSubmatch(status)
 	if m == nil {

--- a/pkg/runtime/docker.go
+++ b/pkg/runtime/docker.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/gcp"
 	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
@@ -205,7 +206,7 @@ func (r *DockerRuntime) List(ctx context.Context, labelFilter map[string]string)
 			if agentName == "" {
 				agentName = d.Names
 			}
-			agents = append(agents, api.AgentInfo{
+			info := api.AgentInfo{
 				ContainerID:     d.ID,
 				Name:            agentName,
 				ContainerStatus: d.Status,
@@ -220,7 +221,15 @@ func (r *DockerRuntime) List(ctx context.Context, labelFilter map[string]string)
 				ProjectID:       projectcompat.ProjectIDFromLabels(labels),
 				ProjectPath:     projectcompat.ProjectPathFromLabels(labels),
 				Runtime:         r.Name(),
-			})
+			}
+			if code, ok := ExitCodeFromContainerStatus(d.Status); ok {
+				c := code
+				info.ExitCode = &c
+				if code != 0 {
+					info.ExitReason = string(state.ActivityCrashed)
+				}
+			}
+			agents = append(agents, info)
 		}
 	}
 

--- a/pkg/runtime/docker.go
+++ b/pkg/runtime/docker.go
@@ -262,8 +262,7 @@ func (r *DockerRuntime) Attach(ctx context.Context, id string) error {
 	}
 
 	// Check if running
-	status := strings.ToLower(agent.ContainerStatus)
-	if !strings.HasPrefix(status, "up") && status != "running" {
+	if agent.Phase != string(state.PhaseRunning) {
 		return fmt.Errorf("agent '%s' is not running (status: %s), use 'scion start %s' to resume it", id, agent.ContainerStatus, id)
 	}
 

--- a/pkg/runtime/docker.go
+++ b/pkg/runtime/docker.go
@@ -226,7 +226,7 @@ func (r *DockerRuntime) List(ctx context.Context, labelFilter map[string]string)
 				c := code
 				info.ExitCode = &c
 				if code != 0 {
-					info.ExitReason = string(state.ActivityCrashed)
+					info.ExitReason = string(state.ExitReasonCrashed)
 				}
 			}
 			agents = append(agents, info)

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -1934,7 +1934,7 @@ func (r *KubernetesRuntime) List(ctx context.Context, labelFilter map[string]str
 					ec := int(cs.State.Terminated.ExitCode)
 					exitCode = &ec
 					if ec != 0 {
-						exitReason = string(state.ActivityCrashed)
+						exitReason = string(state.ExitReasonCrashed)
 					}
 					if agentStatus == "" {
 						if cs.State.Terminated.ExitCode == 0 {

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -2046,7 +2046,7 @@ func (r *KubernetesRuntime) Attach(ctx context.Context, id string) error {
 	podName = agent.ContainerID
 
 	// For Kubernetes, we want to ensure it is in Running phase
-	if !strings.EqualFold(agent.ContainerStatus, string(corev1.PodRunning)) {
+	if agent.Phase != string(state.PhaseRunning) {
 		return fmt.Errorf("agent '%s' is not running (status: %s), use 'scion start %s' to resume it", id, agent.ContainerStatus, id)
 	}
 

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -1912,6 +1912,8 @@ func (r *KubernetesRuntime) List(ctx context.Context, labelFilter map[string]str
 
 		status := string(p.Status.Phase)
 		agentStatus := ""
+		var exitCode *int
+		var exitReason string
 		switch p.Status.Phase {
 		case corev1.PodSucceeded:
 			agentStatus = string(state.PhaseStopped)
@@ -1929,6 +1931,11 @@ func (r *KubernetesRuntime) List(ctx context.Context, labelFilter map[string]str
 					status = fmt.Sprintf("%s (%s)", p.Status.Phase, cs.State.Waiting.Reason)
 				} else if cs.State.Terminated != nil {
 					status = fmt.Sprintf("%s (%s)", p.Status.Phase, cs.State.Terminated.Reason)
+					ec := int(cs.State.Terminated.ExitCode)
+					exitCode = &ec
+					if ec != 0 {
+						exitReason = string(state.ActivityCrashed)
+					}
 					if agentStatus == "" {
 						if cs.State.Terminated.ExitCode == 0 {
 							agentStatus = string(state.PhaseStopped)
@@ -1965,6 +1972,8 @@ func (r *KubernetesRuntime) List(ctx context.Context, labelFilter map[string]str
 			Annotations:     p.Annotations,
 			ContainerStatus: status,
 			Phase:           agentStatus,
+			ExitCode:        exitCode,
+			ExitReason:      exitReason,
 			Image:           agentImage,
 			Runtime:         r.Name(),
 			Kubernetes: &api.AgentK8sMetadata{

--- a/pkg/runtime/k8s_runtime_test.go
+++ b/pkg/runtime/k8s_runtime_test.go
@@ -182,6 +182,25 @@ func TestKubernetesRuntime_List_TerminalPhases(t *testing.T) {
 	if got["failed-agent"].ContainerStatus != "Failed (Error)" {
 		t.Errorf("failed-agent container status = %q, want %q", got["failed-agent"].ContainerStatus, "Failed (Error)")
 	}
+
+	// Verify structured ExitCode and ExitReason fields (Phase 1 of #1257).
+	if got["completed-agent"].ExitCode == nil {
+		t.Error("completed-agent ExitCode should be set for terminated pod")
+	} else if *got["completed-agent"].ExitCode != 0 {
+		t.Errorf("completed-agent ExitCode = %d, want 0", *got["completed-agent"].ExitCode)
+	}
+	if got["completed-agent"].ExitReason != "" {
+		t.Errorf("completed-agent ExitReason = %q, want empty (clean exit)", got["completed-agent"].ExitReason)
+	}
+
+	if got["failed-agent"].ExitCode == nil {
+		t.Error("failed-agent ExitCode should be set for terminated pod")
+	} else if *got["failed-agent"].ExitCode != 1 {
+		t.Errorf("failed-agent ExitCode = %d, want 1", *got["failed-agent"].ExitCode)
+	}
+	if got["failed-agent"].ExitReason != "crashed" {
+		t.Errorf("failed-agent ExitReason = %q, want %q", got["failed-agent"].ExitReason, "crashed")
+	}
 }
 
 func TestKubernetesRuntime_BuildPod_Env(t *testing.T) {

--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/gcp"
 	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
@@ -317,7 +318,7 @@ func (r *PodmanRuntime) List(ctx context.Context, labelFilter map[string]string)
 				name = c.Names[0]
 			}
 
-			agents = append(agents, api.AgentInfo{
+			info := api.AgentInfo{
 				ContainerID:     c.Id,
 				Name:            name,
 				ContainerStatus: c.Status,
@@ -332,7 +333,15 @@ func (r *PodmanRuntime) List(ctx context.Context, labelFilter map[string]string)
 				ProjectID:       projectcompat.ProjectIDFromLabels(labels),
 				ProjectPath:     projectcompat.ProjectPathFromLabels(labels),
 				Runtime:         r.Name(),
-			})
+			}
+			if code, ok := ExitCodeFromContainerStatus(c.Status); ok {
+				ec := code
+				info.ExitCode = &ec
+				if code != 0 {
+					info.ExitReason = string(state.ActivityCrashed)
+				}
+			}
+			agents = append(agents, info)
 		}
 	}
 

--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -338,7 +338,7 @@ func (r *PodmanRuntime) List(ctx context.Context, labelFilter map[string]string)
 				ec := code
 				info.ExitCode = &ec
 				if code != 0 {
-					info.ExitReason = string(state.ActivityCrashed)
+					info.ExitReason = string(state.ExitReasonCrashed)
 				}
 			}
 			agents = append(agents, info)

--- a/pkg/runtime/podman.go
+++ b/pkg/runtime/podman.go
@@ -374,8 +374,7 @@ func (r *PodmanRuntime) Attach(ctx context.Context, id string) error {
 	}
 
 	// Check if running
-	status := strings.ToLower(agent.ContainerStatus)
-	if !strings.HasPrefix(status, "up") && status != "running" {
+	if agent.Phase != string(state.PhaseRunning) {
 		return fmt.Errorf("agent '%s' is not running (status: %s), use 'scion start %s' to resume it", id, agent.ContainerStatus, id)
 	}
 

--- a/pkg/runtimebroker/heartbeat.go
+++ b/pkg/runtimebroker/heartbeat.go
@@ -283,6 +283,8 @@ func (s *HeartbeatService) gatherProjectAgents(ctx context.Context) []hubclient.
 			ContainerStatus: ag.ContainerStatus,
 			HarnessAuth:     ag.HarnessAuth,
 			Profile:         ag.Profile,
+			ExitCode:        ag.ExitCode,
+			ExitReason:      ag.ExitReason,
 		}
 		if ag.Detail != nil && ag.Detail.Message != "" {
 			agentHB.Message = ag.Detail.Message

--- a/pkg/runtimebroker/types.go
+++ b/pkg/runtimebroker/types.go
@@ -582,7 +582,9 @@ func AgentInfoToResponse(info api.AgentInfo) AgentResponse {
 		phase = info.Phase
 		status = info.Phase
 	} else {
-		// Legacy fallback: derive phase and status from container status
+		// Legacy fallback: derive phase from ContainerStatus for runtimes
+		// that don't populate Phase directly. All current runtimes populate
+		// Phase as of #1257, but this remains for backward compatibility.
 		switch {
 		case info.ContainerStatus == "":
 			phase = string(state.PhaseCreated)
@@ -639,7 +641,8 @@ func AgentInfoToResponse(info api.AgentInfo) AgentResponse {
 	return resp
 }
 
-// containsAny checks if s contains any of the substrings (case-insensitive).
+// containsAny is used by the legacy ContainerStatus-to-Phase fallback.
+// It checks if s contains any of the substrings (case-insensitive).
 func containsAny(s string, substrs ...string) bool {
 	s = strings.ToLower(s)
 	for _, sub := range substrs {

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -99,6 +99,8 @@ func entAgentToStore(a *ent.Agent) *store.Agent {
 		ToolName:            a.ToolName,
 		ConnectionState:     a.ConnectionState,
 		ContainerStatus:     a.ContainerStatus,
+		ExitCode:            a.ExitCode,
+		ExitReason:          a.ExitReason,
 		RuntimeState:        a.RuntimeState,
 		StalledFromActivity: a.StalledFromActivity,
 		CurrentTurns:        a.CurrentTurns,
@@ -381,6 +383,8 @@ func (s *AgentStore) UpdateAgent(ctx context.Context, a *store.Agent) error {
 		SetContainerStatus(a.ContainerStatus).
 		SetRuntimeState(a.RuntimeState).
 		SetStalledFromActivity(a.StalledFromActivity).
+		SetNillableExitCode(a.ExitCode).
+		SetExitReason(a.ExitReason).
 		SetImage(a.Image).
 		SetDetached(a.Detached).
 		SetRuntime(a.Runtime).
@@ -702,6 +706,12 @@ func (s *AgentStore) UpdateAgentStatus(ctx context.Context, id string, su store.
 	}
 	if su.ContainerStatus != "" {
 		upd.SetContainerStatus(su.ContainerStatus)
+	}
+	if su.ExitCode != nil {
+		upd.SetExitCode(*su.ExitCode)
+	}
+	if su.ExitReason != "" {
+		upd.SetExitReason(su.ExitReason)
 	}
 	if su.RuntimeState != "" {
 		upd.SetRuntimeState(su.RuntimeState)

--- a/pkg/store/entadapter/agent_store.go
+++ b/pkg/store/entadapter/agent_store.go
@@ -383,8 +383,6 @@ func (s *AgentStore) UpdateAgent(ctx context.Context, a *store.Agent) error {
 		SetContainerStatus(a.ContainerStatus).
 		SetRuntimeState(a.RuntimeState).
 		SetStalledFromActivity(a.StalledFromActivity).
-		SetNillableExitCode(a.ExitCode).
-		SetExitReason(a.ExitReason).
 		SetImage(a.Image).
 		SetDetached(a.Detached).
 		SetRuntime(a.Runtime).
@@ -395,6 +393,13 @@ func (s *AgentStore) UpdateAgent(ctx context.Context, a *store.Agent) error {
 		SetVisibility(a.Visibility).
 		SetUpdated(now).
 		SetStateVersion(newVersion)
+
+	if a.ExitCode != nil {
+		update.SetExitCode(*a.ExitCode)
+	} else {
+		update.ClearExitCode()
+	}
+	update.SetExitReason(a.ExitReason)
 
 	if a.Labels != nil {
 		update.SetLabels(a.Labels)
@@ -696,6 +701,8 @@ func (s *AgentStore) UpdateAgentStatus(ctx context.Context, id string, su store.
 			upd.SetMessage("")
 		}
 		upd.SetStalledFromActivity("")
+		upd.ClearExitCode()
+		upd.SetExitReason("")
 	}
 
 	if su.Message != "" {

--- a/pkg/store/entadapter/agent_store_test.go
+++ b/pkg/store/entadapter/agent_store_test.go
@@ -940,4 +940,66 @@ func TestAgentStore_ExitCodeExitReason_Persistence(t *testing.T) {
 		assert.Equal(t, 42, *got.ExitCode)
 		assert.Equal(t, "limits_exceeded", got.ExitReason)
 	})
+
+	t.Run("restart clears ExitCode and ExitReason", func(t *testing.T) {
+		s, projectID := newTestAgentStore(t)
+		a := makeAgent(projectID, "exit-restart")
+		a.Phase = "running"
+		require.NoError(t, s.CreateAgent(ctx, a))
+
+		// Set ExitCode=137 and ExitReason="crashed" via UpdateAgentStatus
+		ec := 137
+		require.NoError(t, s.UpdateAgentStatus(ctx, a.ID, store.AgentStatusUpdate{
+			Phase:      "error",
+			Activity:   "crashed",
+			ExitCode:   &ec,
+			ExitReason: "crashed",
+		}))
+
+		// Verify they were set
+		got, err := s.GetAgent(ctx, a.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.ExitCode)
+		assert.Equal(t, 137, *got.ExitCode)
+		assert.Equal(t, "crashed", got.ExitReason)
+
+		// Simulate restart: transition from error to running
+		require.NoError(t, s.UpdateAgentStatus(ctx, a.ID, store.AgentStatusUpdate{
+			Phase:    "running",
+			Activity: "working",
+		}))
+
+		// Verify ExitCode is nil and ExitReason is "" after restart
+		got, err = s.GetAgent(ctx, a.ID)
+		require.NoError(t, err)
+		assert.Nil(t, got.ExitCode, "ExitCode must be cleared on restart")
+		assert.Equal(t, "", got.ExitReason, "ExitReason must be cleared on restart")
+	})
+
+	t.Run("UpdateAgent clears nil ExitCode", func(t *testing.T) {
+		s, projectID := newTestAgentStore(t)
+		a := makeAgent(projectID, "exit-clear")
+		require.NoError(t, s.CreateAgent(ctx, a))
+
+		// Set an exit code via UpdateAgent
+		ec := 42
+		a.ExitCode = &ec
+		a.ExitReason = "crashed"
+		require.NoError(t, s.UpdateAgent(ctx, a))
+
+		got, err := s.GetAgent(ctx, a.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.ExitCode)
+		assert.Equal(t, 42, *got.ExitCode)
+
+		// Clear ExitCode by setting it to nil via UpdateAgent
+		got.ExitCode = nil
+		got.ExitReason = ""
+		require.NoError(t, s.UpdateAgent(ctx, got))
+
+		got2, err := s.GetAgent(ctx, a.ID)
+		require.NoError(t, err)
+		assert.Nil(t, got2.ExitCode, "nil ExitCode via UpdateAgent must clear the field")
+		assert.Equal(t, "", got2.ExitReason, "empty ExitReason via UpdateAgent must clear the field")
+	})
 }

--- a/pkg/store/entadapter/agent_store_test.go
+++ b/pkg/store/entadapter/agent_store_test.go
@@ -837,3 +837,107 @@ func TestAgentStore_AppliedConfigValidatedOnRead(t *testing.T) {
 		}
 	})
 }
+
+// TestAgentStore_ExitCodeExitReason_Persistence verifies that ExitCode and
+// ExitReason survive a round-trip through UpdateAgentStatus and are readable
+// via GetAgent.
+func TestAgentStore_ExitCodeExitReason_Persistence(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("UpdateAgentStatus sets ExitCode and ExitReason", func(t *testing.T) {
+		s, projectID := newTestAgentStore(t)
+		a := makeAgent(projectID, "exit-fields")
+		require.NoError(t, s.CreateAgent(ctx, a))
+
+		ec := 137
+		require.NoError(t, s.UpdateAgentStatus(ctx, a.ID, store.AgentStatusUpdate{
+			Phase:      "error",
+			Activity:   "crashed",
+			ExitCode:   &ec,
+			ExitReason: "crashed",
+		}))
+
+		got, err := s.GetAgent(ctx, a.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.ExitCode, "ExitCode should be set")
+		assert.Equal(t, 137, *got.ExitCode)
+		assert.Equal(t, "crashed", got.ExitReason)
+	})
+
+	t.Run("ExitCode zero is persisted (clean exit)", func(t *testing.T) {
+		s, projectID := newTestAgentStore(t)
+		a := makeAgent(projectID, "exit-zero")
+		require.NoError(t, s.CreateAgent(ctx, a))
+
+		ec := 0
+		require.NoError(t, s.UpdateAgentStatus(ctx, a.ID, store.AgentStatusUpdate{
+			Phase:    "stopped",
+			ExitCode: &ec,
+		}))
+
+		got, err := s.GetAgent(ctx, a.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.ExitCode, "ExitCode 0 should be persisted, not dropped")
+		assert.Equal(t, 0, *got.ExitCode)
+	})
+
+	t.Run("ExitCode nil leaves field unchanged", func(t *testing.T) {
+		s, projectID := newTestAgentStore(t)
+		a := makeAgent(projectID, "exit-nil")
+		require.NoError(t, s.CreateAgent(ctx, a))
+
+		// First set an exit code
+		ec := 1
+		require.NoError(t, s.UpdateAgentStatus(ctx, a.ID, store.AgentStatusUpdate{
+			ExitCode: &ec,
+		}))
+
+		// Then update without ExitCode — should not clear
+		require.NoError(t, s.UpdateAgentStatus(ctx, a.ID, store.AgentStatusUpdate{
+			Activity: "working",
+		}))
+
+		got, err := s.GetAgent(ctx, a.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.ExitCode, "nil ExitCode in status update must not clear existing value")
+		assert.Equal(t, 1, *got.ExitCode)
+	})
+
+	t.Run("ExitReason empty leaves field unchanged", func(t *testing.T) {
+		s, projectID := newTestAgentStore(t)
+		a := makeAgent(projectID, "reason-empty")
+		require.NoError(t, s.CreateAgent(ctx, a))
+
+		ec := 1
+		require.NoError(t, s.UpdateAgentStatus(ctx, a.ID, store.AgentStatusUpdate{
+			ExitCode:   &ec,
+			ExitReason: "crashed",
+		}))
+
+		// Update with empty ExitReason — should not clear
+		require.NoError(t, s.UpdateAgentStatus(ctx, a.ID, store.AgentStatusUpdate{
+			Activity: "working",
+		}))
+
+		got, err := s.GetAgent(ctx, a.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "crashed", got.ExitReason, "empty ExitReason in status update must not clear existing value")
+	})
+
+	t.Run("UpdateAgent round-trips ExitCode and ExitReason", func(t *testing.T) {
+		s, projectID := newTestAgentStore(t)
+		a := makeAgent(projectID, "exit-update")
+		require.NoError(t, s.CreateAgent(ctx, a))
+
+		ec := 42
+		a.ExitCode = &ec
+		a.ExitReason = "limits_exceeded"
+		require.NoError(t, s.UpdateAgent(ctx, a))
+
+		got, err := s.GetAgent(ctx, a.ID)
+		require.NoError(t, err)
+		require.NotNil(t, got.ExitCode)
+		assert.Equal(t, 42, *got.ExitCode)
+		assert.Equal(t, "limits_exceeded", got.ExitReason)
+	})
+}

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -46,6 +46,8 @@ type Agent struct {
 	ConnectionState string `json:"connectionState,omitempty"` // connected, disconnected, unknown
 	ContainerStatus string `json:"containerStatus,omitempty"` // Container-level status
 	RuntimeState    string `json:"runtimeState,omitempty"`    // Low-level runtime state
+	ExitCode        *int   `json:"exitCode,omitempty"`        // Structured exit code from runtime (nil = unknown)
+	ExitReason      string `json:"exitReason,omitempty"`      // Terminal reason: "crashed" or "limits_exceeded"
 
 	// Limits tracking (updated by sciontool status reports)
 	CurrentTurns      int       `json:"currentTurns,omitempty"`

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -1916,6 +1916,8 @@ func (a *Agent) ToAPI() *api.AgentInfo {
 		Activity:        a.Activity,
 		ContainerStatus: a.ContainerStatus,
 		RuntimeState:    a.RuntimeState,
+		ExitCode:        a.ExitCode,
+		ExitReason:      a.ExitReason,
 
 		// Runtime configuration
 		Image:           a.Image,

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -288,7 +288,8 @@ type AgentStatusUpdate struct {
 	StartedAt         string `json:"startedAt,omitempty"`
 
 	// Exit tracking
-	ExitCode *int `json:"exitCode,omitempty"`
+	ExitCode   *int   `json:"exitCode,omitempty"`
+	ExitReason string `json:"exitReason,omitempty"`
 }
 
 // ProjectStore defines project-related persistence operations.


### PR DESCRIPTION
Replace regex-parsed ContainerStatus prose with structured ExitCode/ExitReason fields for agent crash detection. Persists exit_code and exit_reason in DB. All runtimes populate natively. Hub uses structured path with legacy fallback for old brokers. Migrates 22+ ContainerStatus string-matching call sites to use structured fields. Ref: ptone/scion#1257