### PR TITLE
feat: complete auth capture journey with user-scope and progeny support

### DIFF
--- a/cmd/sciontool/commands/secret.go
+++ b/cmd/sciontool/commands/secret.go
@@ -21,10 +21,11 @@ import (
 )
 
 var (
-	secretType   string
-	secretTarget string
-	secretForce  bool
-	secretScope  string
+	secretType         string
+	secretTarget       string
+	secretForce        bool
+	secretScope        string
+	secretAllowProgeny bool
 )
 
 var secretCmd = &cobra.Command{
@@ -138,7 +139,7 @@ Examples:
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		resp, err := hubClient.SetSecret(ctx, key, value, localType, localTarget, secretScope, secretForce)
+		resp, err := hubClient.SetSecret(ctx, key, value, localType, localTarget, secretScope, secretForce, secretAllowProgeny)
 		if err != nil {
 			log.Error("%v", err)
 			os.Exit(1)
@@ -249,4 +250,5 @@ func init() {
 	secretSetCmd.Flags().StringVar(&secretTarget, "target", "", "Injection target path (defaults to key for env, required for file)")
 	secretSetCmd.Flags().BoolVar(&secretForce, "force", false, "Overwrite existing secret")
 	secretSetCmd.Flags().StringVar(&secretScope, "scope", "", "Secret scope: project (default) or user")
+	secretSetCmd.Flags().BoolVar(&secretAllowProgeny, "allow-progeny", false, "Allow progeny agents to inherit this secret (user scope only)")
 }

--- a/harnesses/antigravity/scion_harness.py
+++ b/harnesses/antigravity/scion_harness.py
@@ -1047,8 +1047,8 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--scope",
         choices=["project", "user"],
-        default="project",
-        help="Secret scope: project (default) or user",
+        default="user",
+        help="Secret scope: project or user (default)",
     )
     parser.add_argument(
         "--bundle",
@@ -1130,7 +1130,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "user") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1145,6 +1145,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project"
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
            "--type", secret_type, "--target", target,
            "--scope", scope]
+    if scope == "user":
+        cmd.append("--allow-progeny")
     if force:
         cmd.append("--force")
 

--- a/harnesses/claude/scion_harness.py
+++ b/harnesses/claude/scion_harness.py
@@ -1047,8 +1047,8 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--scope",
         choices=["project", "user"],
-        default="project",
-        help="Secret scope: project (default) or user",
+        default="user",
+        help="Secret scope: project or user (default)",
     )
     parser.add_argument(
         "--bundle",
@@ -1130,7 +1130,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "user") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1145,6 +1145,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project"
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
            "--type", secret_type, "--target", target,
            "--scope", scope]
+    if scope == "user":
+        cmd.append("--allow-progeny")
     if force:
         cmd.append("--force")
 

--- a/harnesses/codex/scion_harness.py
+++ b/harnesses/codex/scion_harness.py
@@ -1047,8 +1047,8 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--scope",
         choices=["project", "user"],
-        default="project",
-        help="Secret scope: project (default) or user",
+        default="user",
+        help="Secret scope: project or user (default)",
     )
     parser.add_argument(
         "--bundle",
@@ -1130,7 +1130,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "user") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1145,6 +1145,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project"
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
            "--type", secret_type, "--target", target,
            "--scope", scope]
+    if scope == "user":
+        cmd.append("--allow-progeny")
     if force:
         cmd.append("--force")
 

--- a/harnesses/copilot/capture_auth.py
+++ b/harnesses/copilot/capture_auth.py
@@ -28,7 +28,7 @@ _COPILOT_CONFIG = os.path.join(
 )
 
 
-def _capture_config_json(force: bool = False, scope: str = "project") -> bool:
+def _capture_config_json(force: bool = False, scope: str = "user") -> bool:
     """Capture ~/.copilot/config.json as a COPILOT_CONFIG file secret."""
     if not os.path.isfile(_COPILOT_CONFIG):
         print(
@@ -45,6 +45,8 @@ def _capture_config_json(force: bool = False, scope: str = "project") -> bool:
         "--target", _COPILOT_CONFIG,
         "--scope", scope,
     ]
+    if scope == "user":
+        cmd.append("--allow-progeny")
     if force:
         cmd.append("--force")
 
@@ -74,7 +76,7 @@ def _capture_config_json(force: bool = False, scope: str = "project") -> bool:
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--scope", choices=["project", "user"], default="project")
+    parser.add_argument("--scope", choices=["project", "user"], default="user")
     known, _ = parser.parse_known_args()
 
     rc = scion_harness.capture_auth_main()

--- a/harnesses/copilot/scion_harness.py
+++ b/harnesses/copilot/scion_harness.py
@@ -1047,8 +1047,8 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--scope",
         choices=["project", "user"],
-        default="project",
-        help="Secret scope: project (default) or user",
+        default="user",
+        help="Secret scope: project or user (default)",
     )
     parser.add_argument(
         "--bundle",
@@ -1130,7 +1130,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "user") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1145,6 +1145,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project"
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
            "--type", secret_type, "--target", target,
            "--scope", scope]
+    if scope == "user":
+        cmd.append("--allow-progeny")
     if force:
         cmd.append("--force")
 

--- a/harnesses/gemini-cli/scion_harness.py
+++ b/harnesses/gemini-cli/scion_harness.py
@@ -1047,8 +1047,8 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--scope",
         choices=["project", "user"],
-        default="project",
-        help="Secret scope: project (default) or user",
+        default="user",
+        help="Secret scope: project or user (default)",
     )
     parser.add_argument(
         "--bundle",
@@ -1130,7 +1130,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "user") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1145,6 +1145,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project"
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
            "--type", secret_type, "--target", target,
            "--scope", scope]
+    if scope == "user":
+        cmd.append("--allow-progeny")
     if force:
         cmd.append("--force")
 

--- a/harnesses/grok-build/scion_harness.py
+++ b/harnesses/grok-build/scion_harness.py
@@ -1047,8 +1047,8 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--scope",
         choices=["project", "user"],
-        default="project",
-        help="Secret scope: project (default) or user",
+        default="user",
+        help="Secret scope: project or user (default)",
     )
     parser.add_argument(
         "--bundle",
@@ -1130,7 +1130,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "user") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1145,6 +1145,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project"
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
            "--type", secret_type, "--target", target,
            "--scope", scope]
+    if scope == "user":
+        cmd.append("--allow-progeny")
     if force:
         cmd.append("--force")
 

--- a/harnesses/hermes/scion_harness.py
+++ b/harnesses/hermes/scion_harness.py
@@ -1047,8 +1047,8 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--scope",
         choices=["project", "user"],
-        default="project",
-        help="Secret scope: project (default) or user",
+        default="user",
+        help="Secret scope: project or user (default)",
     )
     parser.add_argument(
         "--bundle",
@@ -1130,7 +1130,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "user") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1145,6 +1145,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project"
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
            "--type", secret_type, "--target", target,
            "--scope", scope]
+    if scope == "user":
+        cmd.append("--allow-progeny")
     if force:
         cmd.append("--force")
 

--- a/harnesses/opencode/scion_harness.py
+++ b/harnesses/opencode/scion_harness.py
@@ -1047,8 +1047,8 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--scope",
         choices=["project", "user"],
-        default="project",
-        help="Secret scope: project (default) or user",
+        default="user",
+        help="Secret scope: project or user (default)",
     )
     parser.add_argument(
         "--bundle",
@@ -1130,7 +1130,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "user") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1145,6 +1145,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project"
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
            "--type", secret_type, "--target", target,
            "--scope", scope]
+    if scope == "user":
+        cmd.append("--allow-progeny")
     if force:
         cmd.append("--force")
 

--- a/harnesses/scion_harness.py
+++ b/harnesses/scion_harness.py
@@ -1046,8 +1046,8 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--scope",
         choices=["project", "user"],
-        default="project",
-        help="Secret scope: project (default) or user",
+        default="user",
+        help="Secret scope: project or user (default)",
     )
     parser.add_argument(
         "--bundle",
@@ -1129,7 +1129,7 @@ def capture_auth_main(argv: list[str] | None = None) -> int:
     return _CA_EXIT_OK
 
 
-def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project") -> tuple[bool, str | None]:
+def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "user") -> tuple[bool, str | None]:
     key = entry.get("key", "")
     source = expand_path(entry.get("source", ""))
     secret_type = entry.get("type", "file")
@@ -1144,6 +1144,8 @@ def _capture_one_cred(entry: dict[str, Any], force: bool, scope: str = "project"
     cmd = ["sciontool", "secret", "set", key, f"@{source}",
            "--type", secret_type, "--target", target,
            "--scope", scope]
+    if scope == "user":
+        cmd.append("--allow-progeny")
     if force:
         cmd.append("--force")
 

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -991,12 +991,13 @@ func (s *Server) deleteSecret(w http.ResponseWriter, r *http.Request, key string
 
 // AgentSetSecretRequest is the request body for agent-initiated secret creation.
 type AgentSetSecretRequest struct {
-	Value    string `json:"value"`              // Secret value (base64-encoded by default; use Encoding:"raw" for literal text)
-	Encoding string `json:"encoding,omitempty"` // "base64" (default) or "raw" (value is literal text, no decoding)
-	Type     string `json:"type,omitempty"`     // environment (default), variable, file
-	Target   string `json:"target,omitempty"`   // Injection target path
-	Force    bool   `json:"force,omitempty"`    // Overwrite existing secret
-	Scope    string `json:"scope,omitempty"`    // "project" (default) or "user"
+	Value        string `json:"value"`                  // Secret value (base64-encoded by default; use Encoding:"raw" for literal text)
+	Encoding     string `json:"encoding,omitempty"`     // "base64" (default) or "raw" (value is literal text, no decoding)
+	Type         string `json:"type,omitempty"`         // environment (default), variable, file
+	Target       string `json:"target,omitempty"`       // Injection target path
+	Force        bool   `json:"force,omitempty"`        // Overwrite existing secret
+	Scope        string `json:"scope,omitempty"`        // "project" (default) or "user"
+	AllowProgeny bool   `json:"allowProgeny,omitempty"` // Allow creator's progeny agents to access (user scope only)
 }
 
 // AgentSetSecretResponse is returned on successful agent secret creation.
@@ -1131,6 +1132,15 @@ func (s *Server) handleAgentSecrets(w http.ResponseWriter, r *http.Request, agen
 		return
 	}
 
+	// allowProgeny is only valid on user-scoped secrets
+	if req.AllowProgeny && scope != store.ScopeUser {
+		ValidationError(w, "allowProgeny is only supported on user-scoped secrets", map[string]interface{}{
+			"field": "allowProgeny",
+			"scope": scope,
+		})
+		return
+	}
+
 	var decoded []byte
 	if req.Encoding == "raw" {
 		// Caller explicitly opted in to raw text — store the value as-is.
@@ -1202,14 +1212,15 @@ func (s *Server) handleAgentSecrets(w http.ResponseWriter, r *http.Request, agen
 	}
 
 	input := &secret.SetSecretInput{
-		Name:       key,
-		Value:      string(decoded),
-		SecretType: secretType,
-		Target:     target,
-		Scope:      scope,
-		ScopeID:    scopeID,
-		CreatedBy:  fmt.Sprintf("agent:%s", agentID),
-		UpdatedBy:  fmt.Sprintf("agent:%s", agentID),
+		Name:         key,
+		Value:        string(decoded),
+		SecretType:   secretType,
+		Target:       target,
+		Scope:        scope,
+		ScopeID:      scopeID,
+		AllowProgeny: req.AllowProgeny,
+		CreatedBy:    fmt.Sprintf("agent:%s", agentID),
+		UpdatedBy:    fmt.Sprintf("agent:%s", agentID),
 	}
 
 	created, _, err := s.secretBackend.Set(ctx, input)

--- a/pkg/sciontool/hub/client.go
+++ b/pkg/sciontool/hub/client.go
@@ -381,11 +381,12 @@ func (c *Client) ReportState(ctx context.Context, phase state.Phase, activity st
 
 // SetSecretRequest is the request body for agent-initiated secret creation.
 type SetSecretRequest struct {
-	Value  string `json:"value"`
-	Type   string `json:"type,omitempty"`
-	Target string `json:"target,omitempty"`
-	Force  bool   `json:"force,omitempty"`
-	Scope  string `json:"scope,omitempty"`
+	Value        string `json:"value"`
+	Type         string `json:"type,omitempty"`
+	Target       string `json:"target,omitempty"`
+	Force        bool   `json:"force,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+	AllowProgeny bool   `json:"allowProgeny,omitempty"`
 }
 
 // SetSecretResponse is the response from the agent secret creation endpoint.
@@ -509,7 +510,7 @@ func (c *Client) absoluteURL(path string) string {
 // SetSecret stores a secret via the Hub API.
 // The value should already be base64-encoded. Scope selects project (default)
 // or user; an empty scope is treated as "project".
-func (c *Client) SetSecret(ctx context.Context, key, value, secretType, target, scope string, force bool) (*SetSecretResponse, error) {
+func (c *Client) SetSecret(ctx context.Context, key, value, secretType, target, scope string, force, allowProgeny bool) (*SetSecretResponse, error) {
 	if !c.IsConfigured() {
 		return nil, fmt.Errorf("hub client not configured (is SCION_HUB_ENDPOINT set?)")
 	}
@@ -518,11 +519,12 @@ func (c *Client) SetSecret(ctx context.Context, key, value, secretType, target, 
 		strings.TrimSuffix(c.hubURL, "/"), c.agentID, key)
 
 	reqBody := SetSecretRequest{
-		Value:  value,
-		Type:   secretType,
-		Target: target,
-		Force:  force,
-		Scope:  scope,
+		Value:        value,
+		Type:         secretType,
+		Target:       target,
+		Force:        force,
+		Scope:        scope,
+		AllowProgeny: allowProgeny,
 	}
 
 	body, err := json.Marshal(reqBody)

--- a/pkg/sciontool/hub/client_test.go
+++ b/pkg/sciontool/hub/client_test.go
@@ -1420,7 +1420,7 @@ func TestClient_SetSecret_Created(t *testing.T) {
 	defer server.Close()
 
 	client := NewClientWithConfig(server.URL, "test-token", "agent-123")
-	resp, err := client.SetSecret(context.Background(), "MY_KEY", "c2VjcmV0", "file", "~/.config/auth.json", "", false)
+	resp, err := client.SetSecret(context.Background(), "MY_KEY", "c2VjcmV0", "file", "~/.config/auth.json", "", false, false)
 
 	require.NoError(t, err)
 	assert.Equal(t, http.MethodPut, receivedMethod)
@@ -1430,11 +1430,46 @@ func TestClient_SetSecret_Created(t *testing.T) {
 	assert.Equal(t, "file", receivedReq.Type)
 	assert.Equal(t, "~/.config/auth.json", receivedReq.Target)
 	assert.False(t, receivedReq.Force)
+	assert.False(t, receivedReq.AllowProgeny)
 
 	require.NotNil(t, resp)
 	assert.Equal(t, "MY_KEY", resp.Key)
 	assert.Equal(t, "project", resp.Scope)
 	assert.Equal(t, "project-123", resp.ScopeID)
+}
+
+func TestClient_SetSecret_AllowProgeny(t *testing.T) {
+	var receivedReq SetSecretRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&receivedReq); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(SetSecretResponse{
+			Key:     "MY_SECRET",
+			Scope:   "user",
+			ScopeID: "user-456",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClientWithConfig(server.URL, "test-token", "agent-123")
+	resp, err := client.SetSecret(context.Background(), "MY_SECRET", "c2VjcmV0", "environment", "", "user", false, true)
+
+	require.NoError(t, err)
+	assert.Equal(t, "c2VjcmV0", receivedReq.Value)
+	assert.Equal(t, "environment", receivedReq.Type)
+	assert.Equal(t, "user", receivedReq.Scope)
+	assert.True(t, receivedReq.AllowProgeny, "allowProgeny should be true in the serialized request")
+	assert.False(t, receivedReq.Force)
+
+	require.NotNil(t, resp)
+	assert.Equal(t, "MY_SECRET", resp.Key)
+	assert.Equal(t, "user", resp.Scope)
+	assert.Equal(t, "user-456", resp.ScopeID)
 }
 
 func TestClient_SetSecret_NoContent(t *testing.T) {
@@ -1444,7 +1479,7 @@ func TestClient_SetSecret_NoContent(t *testing.T) {
 	defer server.Close()
 
 	client := NewClientWithConfig(server.URL, "test-token", "agent-123")
-	resp, err := client.SetSecret(context.Background(), "MY_KEY", "dmFsdWU=", "", "", "", true)
+	resp, err := client.SetSecret(context.Background(), "MY_KEY", "dmFsdWU=", "", "", "", true, false)
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -1460,7 +1495,7 @@ func TestClient_SetSecret_Conflict(t *testing.T) {
 	defer server.Close()
 
 	client := NewClientWithConfig(server.URL, "test-token", "agent-123")
-	_, err := client.SetSecret(context.Background(), "MY_KEY", "dmFsdWU=", "", "", "", false)
+	_, err := client.SetSecret(context.Background(), "MY_KEY", "dmFsdWU=", "", "", "", false, false)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exists")
@@ -1468,7 +1503,7 @@ func TestClient_SetSecret_Conflict(t *testing.T) {
 
 func TestClient_SetSecret_NotConfigured(t *testing.T) {
 	client := &Client{}
-	_, err := client.SetSecret(context.Background(), "KEY", "VAL", "", "", "", false)
+	_, err := client.SetSecret(context.Background(), "KEY", "VAL", "", "", "", false, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not configured")
 }
@@ -1549,7 +1584,7 @@ func TestClient_SetSecret_ServerError(t *testing.T) {
 	defer server.Close()
 
 	client := NewClientWithConfig(server.URL, "test-token", "agent-123")
-	_, err := client.SetSecret(context.Background(), "KEY", "dmFsdWU=", "", "", "", false)
+	_, err := client.SetSecret(context.Background(), "KEY", "dmFsdWU=", "", "", "", false, false)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "500")


### PR DESCRIPTION
Add --allow-progeny flag to sciontool secret set so capture scripts can mark secrets as inheritable by progeny agents. Update all capture paths to default to user scope with progeny enabled, completing the no-auth capture journey.

Key changes:
- cmd/sciontool/commands/secret.go: add --allow-progeny flag
- pkg/sciontool/hub/client.go: wire AllowProgeny through SetSecretRequest
- pkg/hub/handlers_env_secrets.go: wire AllowProgeny in agent handler + scope validation
- harnesses/scion_harness.py + all generated copies: default scope=user, add --allow-progeny
- harnesses/copilot/capture_auth.py: default scope=user, add --allow-progeny
- pkg/sciontool/hub/client_test.go: add AllowProgeny=true positive test

ptone/scion#1261