### PR TITLE
fix: WebServer reads live operational settings via AccessSettingsProvider

### DIFF
--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -366,7 +366,7 @@ func runServerStart(cmd *cobra.Command, args []string) error {
 	// 12. Start Web
 	var webSrv *hub.WebServer
 	if enableWeb {
-		webSrv, err = initWebServer(ctx, cfg, hubSrv, devAuthToken, adminEmailList, adminMode, maintenanceMessage, requestLogger, hubDBRec)
+		webSrv, err = initWebServer(ctx, cfg, hubSrv, devAuthToken, adminMode, maintenanceMessage, requestLogger, hubDBRec)
 		if err != nil {
 			return err
 		}
@@ -2178,7 +2178,7 @@ func newCommandBus(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 // initWebServer creates and configures the Web server. The provided context is
 // threaded to the event publisher so that the Postgres LISTEN/NOTIFY goroutine
 // is cancelled cleanly on shutdown, preventing connection leaks.
-func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Server, devAuthToken string, adminEmailList []string, adminMode bool, maintenanceMessage string, requestLogger *slog.Logger, dbRec dbmetrics.Recorder) (*hub.WebServer, error) {
+func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Server, devAuthToken string, adminMode bool, maintenanceMessage string, requestLogger *slog.Logger, dbRec dbmetrics.Recorder) (*hub.WebServer, error) {
 	webHost := cfg.Hub.Host
 	if webHost == "" {
 		webHost = "0.0.0.0"
@@ -2192,16 +2192,6 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 	}
 	if baseURL == "" {
 		baseURL = fmt.Sprintf("http://localhost:%d", webPort)
-	}
-
-	// Resolve authorized domains and admin email list for the web server
-	var webAuthorizedDomains []string
-	if len(cfg.Auth.AuthorizedDomains) > 0 {
-		webAuthorizedDomains = cfg.Auth.AuthorizedDomains
-	}
-	webAdminEmails := splitCommaList(adminEmails)
-	if len(webAdminEmails) == 0 && len(cfg.Hub.AdminEmails) > 0 {
-		webAdminEmails = cfg.Hub.AdminEmails
 	}
 
 	// Construct proxy authenticator for the web server when auth mode is "proxy".
@@ -2235,9 +2225,6 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 		BaseURL:              baseURL,
 		DevAuthToken:         devAuthToken,
 		AuthMode:             cfg.Auth.Mode,
-		AuthorizedDomains:    webAuthorizedDomains,
-		AdminEmails:          webAdminEmails,
-		UserAccessMode:       cfg.Auth.UserAccessMode,
 		AdminMode:            adminMode,
 		MaintenanceMessage:   maintenanceMessage,
 		EnableTestLogin:      enableTestLogin,
@@ -2261,6 +2248,7 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 	if hubSrv != nil {
 		hubSrv.SetEventPublisher(eventPub)
 		startSettingsPropagation(ctx, hubSrv, eventPub)
+		webSrv.SetAccessSettingsProvider(hubSrv)
 		webSrv.SetOAuthService(hubSrv.GetOAuthService())
 		webSrv.SetStore(hubSrv.GetStore())
 		webSrv.SetUserTokenService(hubSrv.GetUserTokenService())

--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -1235,7 +1235,7 @@ func (s *Server) provisionUser(ctx context.Context, info *ExternalUserInfo) (*st
 	// Authorization check
 	if !s.isUserAuthorized(ctx, info.Email) {
 		reason := "not_on_allow_list"
-		if s.config.UserAccessMode != "invite_only" {
+		if s.UserAccessMode() != "invite_only" {
 			reason = "domain_not_authorized"
 		}
 		LogInviteAuditFailure(ctx, s.auditLogger, InviteAuditLoginDenied, info.Email, reason)
@@ -1314,7 +1314,7 @@ func generateID() string {
 // isUserAuthorized checks whether a user is permitted to log in based on
 // admin_emails, authorized_domains, and user_access_mode (allow list).
 func (s *Server) isUserAuthorized(ctx context.Context, email string) bool {
-	return checkUserAuthorized(ctx, email, s.config.AuthorizedDomains, s.config.AdminEmails, s.config.UserAccessMode, s.store)
+	return checkUserAuthorized(ctx, email, s.AuthorizedDomains(), s.AdminEmails(), s.UserAccessMode(), s.store)
 }
 
 // checkUserAuthorized is a package-level authorization check used by both
@@ -1454,7 +1454,7 @@ func determineUserRole(email string, adminEmails []string, currentRole string) s
 
 // (s *Server) getUserRole is a convenience method to determine role using server config.
 func (s *Server) getUserRole(email, currentRole string) string {
-	return determineUserRole(email, s.config.AdminEmails, currentRole)
+	return determineUserRole(email, s.AdminEmails(), currentRole)
 }
 
 // handleInviteRedeem handles POST /api/v1/auth/invite/redeem.
@@ -1489,8 +1489,9 @@ func (s *Server) handleInviteRedeem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check authorized domains before allowing redemption
-	if len(s.config.AuthorizedDomains) > 0 {
-		if !isEmailInDomains(strings.ToLower(user.Email()), s.config.AuthorizedDomains) {
+	authorizedDomains := s.AuthorizedDomains()
+	if len(authorizedDomains) > 0 {
+		if !isEmailInDomains(strings.ToLower(user.Email()), authorizedDomains) {
 			writeError(w, http.StatusForbidden, "unauthorized_domain",
 				"your email domain is not authorized to join this hub", nil)
 			return

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -2108,6 +2108,35 @@ func (s *Server) HubName() string {
 	return s.config.HubName
 }
 
+// AdminEmails returns the current admin email list. The returned slice is a
+// defensive copy — callers may iterate safely without holding s.mu.
+// Implements AccessSettingsProvider.
+func (s *Server) AdminEmails() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]string, len(s.config.AdminEmails))
+	copy(result, s.config.AdminEmails)
+	return result
+}
+
+// AuthorizedDomains returns the current authorized domain list. The returned
+// slice is a defensive copy. Implements AccessSettingsProvider.
+func (s *Server) AuthorizedDomains() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]string, len(s.config.AuthorizedDomains))
+	copy(result, s.config.AuthorizedDomains)
+	return result
+}
+
+// UserAccessMode returns the current user access mode. Thread-safe.
+// Implements AccessSettingsProvider.
+func (s *Server) UserAccessMode() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.config.UserAccessMode
+}
+
 // SetSecretBackend sets the secret backend for pluggable secret storage.
 func (s *Server) SetSecretBackend(b secret.SecretBackend) {
 	s.mu.Lock()

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -110,6 +110,20 @@ func getWebSessionUser(ctx context.Context) *webSessionUser {
 	return nil
 }
 
+// AccessSettingsProvider supplies the operational access settings that can
+// change at runtime (e.g. via the admin UI or ApplySnapshot). WebServer
+// reads these through the provider instead of holding its own snapshot.
+// Implementations must be safe for concurrent use.
+type AccessSettingsProvider interface {
+	// AdminEmails returns the current list of bootstrap/admin-UI admin emails.
+	AdminEmails() []string
+	// AuthorizedDomains returns the current list of allowed email domains.
+	AuthorizedDomains() []string
+	// UserAccessMode returns the current login-time access mode
+	// ("open", "domain_restricted", "invite_only").
+	UserAccessMode() string
+}
+
 // WebServerConfig holds configuration for the web frontend server.
 type WebServerConfig struct {
 	// Port is the HTTP port to listen on (default 8080).
@@ -130,12 +144,6 @@ type WebServerConfig struct {
 	// AuthMode is the exclusive human auth mode: "oauth" (default), "proxy", "dev".
 	// In proxy mode, OAuth providers are not shown and logout behavior changes.
 	AuthMode string
-	// AuthorizedDomains is the list of allowed email domains (empty = all allowed).
-	AuthorizedDomains []string
-	// AdminEmails is the list of bootstrap admin emails (bypass domain check).
-	AdminEmails []string
-	// UserAccessMode controls login-time access evaluation ("open", "domain_restricted", "invite_only").
-	UserAccessMode string
 	// AdminMode restricts access to admin users only (maintenance mode).
 	AdminMode bool
 	// MaintenanceMessage is the custom message shown during admin mode.
@@ -158,8 +166,9 @@ type WebServerConfig struct {
 
 // WebServer serves the web frontend SPA shell and static assets.
 type WebServer struct {
-	config       WebServerConfig
-	httpServer   *http.Server
+	config         WebServerConfig
+	accessSettings AccessSettingsProvider // live operational settings (nil-safe: falls back to zero values)
+	httpServer     *http.Server
 	mux          *http.ServeMux
 	assets       fs.FS  // embedded or nil
 	assetsDisk   string // filesystem override path, or ""
@@ -558,6 +567,40 @@ func (ws *WebServer) SetUserTokenService(svc *UserTokenService) {
 // SetEventPublisher sets the event publisher for real-time SSE streaming.
 func (ws *WebServer) SetEventPublisher(pub EventPublisher) {
 	ws.events = pub
+}
+
+// adminEmails returns the live admin email list from the access settings
+// provider. Returns nil when no provider is configured.
+func (ws *WebServer) adminEmails() []string {
+	if ws.accessSettings == nil {
+		return nil
+	}
+	return ws.accessSettings.AdminEmails()
+}
+
+// authorizedDomains returns the live authorized domains list from the access
+// settings provider. Returns nil when no provider is configured.
+func (ws *WebServer) authorizedDomains() []string {
+	if ws.accessSettings == nil {
+		return nil
+	}
+	return ws.accessSettings.AuthorizedDomains()
+}
+
+// userAccessMode returns the live user access mode from the access settings
+// provider. Returns "" when no provider is configured.
+func (ws *WebServer) userAccessMode() string {
+	if ws.accessSettings == nil {
+		return ""
+	}
+	return ws.accessSettings.UserAccessMode()
+}
+
+// SetAccessSettingsProvider sets the live operational access settings provider.
+// When set, WebServer reads AdminEmails, AuthorizedDomains, and UserAccessMode
+// through this provider rather than from its static config snapshot.
+func (ws *WebServer) SetAccessSettingsProvider(p AccessSettingsProvider) {
+	ws.accessSettings = p
 }
 
 // SetAuthzService sets the authorization service for SSE subject-level checks.
@@ -1533,7 +1576,7 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 							"email", email, "error", err)
 					}
 				}
-				expectedRole := determineUserRole(email, ws.config.AdminEmails, storedRole)
+				expectedRole := determineUserRole(email, ws.adminEmails(), storedRole)
 				if currentRole == expectedRole {
 					// Role unchanged — inject user into context and proceed
 					// without saving session (avoids redundant write).
@@ -1604,7 +1647,7 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		if !checkUserAuthorized(ctx, proxyUser.Email, ws.config.AuthorizedDomains, ws.config.AdminEmails, ws.config.UserAccessMode, ws.store) {
+		if !checkUserAuthorized(ctx, proxyUser.Email, ws.authorizedDomains(), ws.adminEmails(), ws.userAccessMode(), ws.store) {
 			ws.logger().Warn("Proxy auth: user not authorized", "email", proxyUser.Email)
 			http.Error(w, "access denied: email not authorized", http.StatusForbidden)
 			return
@@ -1620,7 +1663,7 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 		}
 		if err != nil {
 			// User not found — create new user
-			role := determineUserRole(proxyUser.Email, ws.config.AdminEmails, "")
+			role := determineUserRole(proxyUser.Email, ws.adminEmails(), "")
 			user = &store.User{
 				ID:          generateID(),
 				Email:       proxyUser.Email,
@@ -1650,7 +1693,7 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 				user.DisplayName = proxyUser.DisplayName
 			}
 			// Re-evaluate admin status on every login (matches handleOAuthCallback / provisionUser)
-			if newRole := determineUserRole(proxyUser.Email, ws.config.AdminEmails, user.Role); user.Role != newRole {
+			if newRole := determineUserRole(proxyUser.Email, ws.adminEmails(), user.Role); user.Role != newRole {
 				ws.logger().Info("User role changed on proxy login", "email", proxyUser.Email, "old_role", user.Role, "new_role", newRole)
 				user.Role = newRole
 			}
@@ -1893,7 +1936,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Check if user is authorized (admin bypass, domain check, access mode)
-	if !checkUserAuthorized(ctx, userInfo.Email, ws.config.AuthorizedDomains, ws.config.AdminEmails, ws.config.UserAccessMode, ws.store) {
+	if !checkUserAuthorized(ctx, userInfo.Email, ws.authorizedDomains(), ws.adminEmails(), ws.userAccessMode(), ws.store) {
 		ws.logger().Warn("Unauthorized user", "email", userInfo.Email)
 		http.Redirect(w, r, "/login?error=unauthorized_domain", http.StatusFound)
 		return
@@ -1904,7 +1947,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		// Create new user (only reachable in open/domain_restricted modes;
 		// in invite_only mode, checkUserAuthorized already confirmed a User record exists)
-		role := determineUserRole(userInfo.Email, ws.config.AdminEmails, "")
+		role := determineUserRole(userInfo.Email, ws.adminEmails(), "")
 		user = &store.User{
 			ID:          generateID(),
 			Email:       userInfo.Email,
@@ -1941,7 +1984,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 				user.AvatarURL = userInfo.AvatarURL
 			}
 			user.LastLogin = time.Now()
-			user.Role = determineUserRole(userInfo.Email, ws.config.AdminEmails, user.Role)
+			user.Role = determineUserRole(userInfo.Email, ws.adminEmails(), user.Role)
 			// Log the activation via slog (WebServer does not have a structured
 			// audit logger; the hub.Server audit path covers API/CLI auth).
 			ws.logger().Info("invite audit: user_activated", "email", userInfo.Email, "user_id", user.ID)
@@ -1955,7 +1998,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 				user.DisplayName = userInfo.DisplayName
 			}
 			// Re-evaluate admin status on every login
-			newRole := determineUserRole(userInfo.Email, ws.config.AdminEmails, user.Role)
+			newRole := determineUserRole(userInfo.Email, ws.adminEmails(), user.Role)
 			if user.Role != newRole {
 				ws.logger().Info("User role changed on login", "email", userInfo.Email, "old_role", user.Role, "new_role", newRole)
 				user.Role = newRole

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -169,21 +169,21 @@ type WebServer struct {
 	config         WebServerConfig
 	accessSettings AccessSettingsProvider // live operational settings (nil-safe: falls back to zero values)
 	httpServer     *http.Server
-	mux          *http.ServeMux
-	assets       fs.FS  // embedded or nil
-	assetsDisk   string // filesystem override path, or ""
-	shellTmpl    *template.Template
-	sessionStore *sessions.CookieStore
-	oauthService *OAuthService
-	store        store.Store
-	userTokenSvc *UserTokenService
-	events       EventPublisher              // nil when no publisher configured
-	hubHandler   http.Handler                // mounted Hub API handler, or nil
-	hubShutdown  func(context.Context) error // Hub resource cleanup, or nil
-	maintenance  *MaintenanceState           // runtime maintenance mode state (shared with Hub)
-	authzService *AuthzService               // authorization service for SSE subject checks
-	startTime    time.Time
-	log          *slog.Logger // subsystem logger for hub.web
+	mux            *http.ServeMux
+	assets         fs.FS  // embedded or nil
+	assetsDisk     string // filesystem override path, or ""
+	shellTmpl      *template.Template
+	sessionStore   *sessions.CookieStore
+	oauthService   *OAuthService
+	store          store.Store
+	userTokenSvc   *UserTokenService
+	events         EventPublisher              // nil when no publisher configured
+	hubHandler     http.Handler                // mounted Hub API handler, or nil
+	hubShutdown    func(context.Context) error // Hub resource cleanup, or nil
+	maintenance    *MaintenanceState           // runtime maintenance mode state (shared with Hub)
+	authzService   *AuthzService               // authorization service for SSE subject checks
+	startTime      time.Time
+	log            *slog.Logger // subsystem logger for hub.web
 
 	// Dedicated request logger (nil = disabled)
 	requestLogger *slog.Logger

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -94,6 +94,18 @@ func (s *proxyAuthStore) GetUser(_ context.Context, id string) (*store.User, err
 	return nil, store.ErrNotFound
 }
 
+// staticAccessSettings is a test implementation of AccessSettingsProvider
+// with mutable fields for simulating live config changes in tests.
+type staticAccessSettings struct {
+	adminEmails       []string
+	authorizedDomains []string
+	userAccessMode    string
+}
+
+func (s *staticAccessSettings) AdminEmails() []string       { return s.adminEmails }
+func (s *staticAccessSettings) AuthorizedDomains() []string { return s.authorizedDomains }
+func (s *staticAccessSettings) UserAccessMode() string      { return s.userAccessMode }
+
 func newTestWebServer(t *testing.T, cfg WebServerConfig) *WebServer {
 	t.Helper()
 	ws := NewWebServer(cfg)
@@ -2867,8 +2879,10 @@ func TestProxyAuthMiddleware_KeepsAdminWhenNotInList(t *testing.T) {
 	ws := newTestWebServer(t, WebServerConfig{
 		AuthMode:           "proxy",
 		ProxyAuthenticator: mockAuth,
-		// AdminEmails does NOT include ui-admin@example.com
-		AdminEmails: []string{"other-admin@example.com"},
+	})
+	// AdminEmails does NOT include ui-admin@example.com
+	ws.SetAccessSettingsProvider(&staticAccessSettings{
+		adminEmails: []string{"other-admin@example.com"},
 	})
 	ws.SetStore(st)
 
@@ -2910,7 +2924,9 @@ func TestProxyAuthMiddleware_PromotesToAdminWhenAddedToList(t *testing.T) {
 	ws := newTestWebServer(t, WebServerConfig{
 		AuthMode:           "proxy",
 		ProxyAuthenticator: mockAuth,
-		AdminEmails:        []string{"new-admin@example.com"},
+	})
+	ws.SetAccessSettingsProvider(&staticAccessSettings{
+		adminEmails: []string{"new-admin@example.com"},
 	})
 	ws.SetStore(st)
 
@@ -2940,12 +2956,13 @@ func TestProxyAuthMiddleware_ExistingSession_ReEvaluatesRoleOnPromotion(t *testi
 	}
 
 	st := newProxyAuthStore()
+	// Initially NOT an admin
+	accessCfg := &staticAccessSettings{adminEmails: []string{}}
 	ws := newTestWebServer(t, WebServerConfig{
 		AuthMode:           "proxy",
 		ProxyAuthenticator: mockAuth,
-		// Initially NOT an admin
-		AdminEmails: []string{},
 	})
+	ws.SetAccessSettingsProvider(accessCfg)
 	ws.SetStore(st)
 
 	handler := ws.Handler()
@@ -2966,7 +2983,7 @@ func TestProxyAuthMiddleware_ExistingSession_ReEvaluatesRoleOnPromotion(t *testi
 	assert.Equal(t, "member", created.Role)
 
 	// Now add user to admin list (simulates config change)
-	ws.config.AdminEmails = []string{"user@example.com"}
+	accessCfg.adminEmails = []string{"user@example.com"}
 
 	// Second request: re-uses the session cookie
 	req2 := httptest.NewRequest("GET", "/projects", nil)
@@ -3008,12 +3025,13 @@ func TestProxyAuthMiddleware_ExistingSession_ReEvaluatesRoleOnUIDemotion(t *test
 	}
 
 	st := newProxyAuthStore()
+	// Initially IS an admin
+	accessCfg := &staticAccessSettings{adminEmails: []string{"admin@example.com"}}
 	ws := newTestWebServer(t, WebServerConfig{
 		AuthMode:           "proxy",
 		ProxyAuthenticator: mockAuth,
-		// Initially IS an admin
-		AdminEmails: []string{"admin@example.com"},
 	})
+	ws.SetAccessSettingsProvider(accessCfg)
 	ws.SetStore(st)
 
 	handler := ws.Handler()
@@ -3034,7 +3052,7 @@ func TestProxyAuthMiddleware_ExistingSession_ReEvaluatesRoleOnUIDemotion(t *test
 	assert.Equal(t, "admin", created.Role)
 
 	// Remove from the config list AND demote through the UI (explicit action).
-	ws.config.AdminEmails = []string{}
+	accessCfg.adminEmails = []string{}
 	created.Role = "member"
 	require.NoError(t, st.UpdateUser(context.Background(), created))
 
@@ -3076,11 +3094,12 @@ func TestProxyAuthMiddleware_ExistingSession_KeepsRoleWhenRemovedFromList(t *tes
 	}
 
 	st := newProxyAuthStore()
+	accessCfg := &staticAccessSettings{adminEmails: []string{"admin@example.com"}}
 	ws := newTestWebServer(t, WebServerConfig{
 		AuthMode:           "proxy",
 		ProxyAuthenticator: mockAuth,
-		AdminEmails:        []string{"admin@example.com"},
 	})
+	ws.SetAccessSettingsProvider(accessCfg)
 	ws.SetStore(st)
 
 	handler := ws.Handler()
@@ -3099,7 +3118,7 @@ func TestProxyAuthMiddleware_ExistingSession_KeepsRoleWhenRemovedFromList(t *tes
 	require.Equal(t, "admin", created.Role)
 
 	// Config change only — no UI demotion.
-	ws.config.AdminEmails = []string{}
+	accessCfg.adminEmails = []string{}
 
 	req2 := httptest.NewRequest("GET", "/projects", nil)
 	req2.Header.Set("Accept", "text/html")
@@ -3135,8 +3154,8 @@ func TestProxyAuthMiddleware_ExistingSession_PicksUpUIPromotion(t *testing.T) {
 	ws := newTestWebServer(t, WebServerConfig{
 		AuthMode:           "proxy",
 		ProxyAuthenticator: mockAuth,
-		AdminEmails:        []string{},
 	})
+	ws.SetAccessSettingsProvider(&staticAccessSettings{adminEmails: []string{}})
 	ws.SetStore(st)
 
 	handler := ws.Handler()
@@ -3193,8 +3212,8 @@ func TestProxyAuthMiddleware_ExistingSession_SuspendedUserRejected(t *testing.T)
 	ws := newTestWebServer(t, WebServerConfig{
 		AuthMode:           "proxy",
 		ProxyAuthenticator: mockAuth,
-		AdminEmails:        []string{},
 	})
+	ws.SetAccessSettingsProvider(&staticAccessSettings{adminEmails: []string{}})
 	ws.SetStore(st)
 
 	handler := ws.Handler()
@@ -3246,8 +3265,8 @@ func TestProxyAuthMiddleware_ExistingSession_DeletedUserRejected(t *testing.T) {
 	ws := newTestWebServer(t, WebServerConfig{
 		AuthMode:           "proxy",
 		ProxyAuthenticator: mockAuth,
-		AdminEmails:        []string{}, // not an admin by config
 	})
+	ws.SetAccessSettingsProvider(&staticAccessSettings{adminEmails: []string{}}) // not an admin by config
 	ws.SetStore(st)
 
 	handler := ws.Handler()
@@ -3311,8 +3330,8 @@ func TestProxyAuthMiddleware_ExistingSession_NoUpdateWhenRoleUnchanged(t *testin
 	ws := newTestWebServer(t, WebServerConfig{
 		AuthMode:           "proxy",
 		ProxyAuthenticator: mockAuth,
-		AdminEmails:        []string{},
 	})
+	ws.SetAccessSettingsProvider(&staticAccessSettings{adminEmails: []string{}})
 	ws.SetStore(st)
 
 	handler := ws.Handler()
@@ -3346,4 +3365,79 @@ func TestProxyAuthMiddleware_ExistingSession_NoUpdateWhenRoleUnchanged(t *testin
 		}
 	}
 	assert.False(t, sessionReSet, "session cookie should NOT be re-set when role is unchanged")
+}
+
+// ---------------------------------------------------------------------------
+// Live operational settings propagation — regression tests for issue #1270
+// ---------------------------------------------------------------------------
+
+func TestWebServer_AccessSettings_LivePropagation(t *testing.T) {
+	// Verify that WebServer reads operational settings through the
+	// AccessSettingsProvider rather than holding its own snapshot.
+	// When the provider's values change (e.g. via ApplySnapshot on the
+	// Server), WebServer immediately sees the new values.
+
+	srv := &Server{
+		maintenance: NewMaintenanceState(false, ""),
+	}
+	srv.config.AdminEmails = []string{"initial-admin@example.com"}
+	srv.config.AuthorizedDomains = []string{"example.com"}
+	srv.config.UserAccessMode = "open"
+
+	ws := NewWebServer(WebServerConfig{})
+	ws.SetAccessSettingsProvider(srv)
+
+	// Verify initial values
+	assert.Equal(t, []string{"initial-admin@example.com"}, ws.adminEmails())
+	assert.Equal(t, []string{"example.com"}, ws.authorizedDomains())
+	assert.Equal(t, "open", ws.userAccessMode())
+
+	// Simulate runtime update via ApplySnapshot
+	ApplySnapshot(srv, Layer1Snapshot{
+		AdminEmails:    []string{"new-admin@example.com", "other@example.com"},
+		UserAccessMode: "domain_restricted",
+	})
+
+	// WebServer must see the UPDATED values immediately — no restart needed
+	assert.Equal(t, []string{"new-admin@example.com", "other@example.com"}, ws.adminEmails(),
+		"AdminEmails must reflect live update after ApplySnapshot")
+	assert.Equal(t, "domain_restricted", ws.userAccessMode(),
+		"UserAccessMode must reflect live update after ApplySnapshot")
+}
+
+func TestWebServer_AccessSettings_NilProviderSafe(t *testing.T) {
+	// When no AccessSettingsProvider is configured (e.g. web-only mode
+	// without a Hub), the accessors return zero values rather than panicking.
+	ws := NewWebServer(WebServerConfig{})
+
+	assert.Nil(t, ws.adminEmails(), "nil provider should return nil AdminEmails")
+	assert.Nil(t, ws.authorizedDomains(), "nil provider should return nil AuthorizedDomains")
+	assert.Equal(t, "", ws.userAccessMode(), "nil provider should return empty UserAccessMode")
+}
+
+func TestServer_ImplementsAccessSettingsProvider(t *testing.T) {
+	// Verify the Server type satisfies the AccessSettingsProvider interface
+	// at compile time and with correct locking behavior.
+	srv := &Server{
+		maintenance: NewMaintenanceState(false, ""),
+	}
+	srv.config.AdminEmails = []string{"a@b.com"}
+	srv.config.AuthorizedDomains = []string{"b.com"}
+	srv.config.UserAccessMode = "invite_only"
+
+	var provider AccessSettingsProvider = srv // compile-time check
+
+	// Accessors return defensive copies — mutating the result must not
+	// affect the server state.
+	emails := provider.AdminEmails()
+	emails[0] = "MUTATED"
+	assert.Equal(t, "a@b.com", provider.AdminEmails()[0],
+		"AdminEmails must return a defensive copy")
+
+	domains := provider.AuthorizedDomains()
+	domains[0] = "MUTATED"
+	assert.Equal(t, "b.com", provider.AuthorizedDomains()[0],
+		"AuthorizedDomains must return a defensive copy")
+
+	assert.Equal(t, "invite_only", provider.UserAccessMode())
 }


### PR DESCRIPTION
## Summary

WebServer held a by-value copy of operational settings. Fix adds AccessSettingsProvider interface so WebServer reads live values from Server. Also fixes data race in handlers_auth.go.

Closes ptone/scion#1270