### PR TITLE
feat: add PATCH endpoint for secret metadata-only updates

### DIFF
--- a/cmd/hub_secret.go
+++ b/cmd/hub_secret.go
@@ -148,6 +148,25 @@ Examples:
 	RunE: runSecretList,
 }
 
+// hubSecretUpdateCmd updates secret metadata without changing the value
+var hubSecretUpdateCmd = &cobra.Command{
+	Use:   "update KEY",
+	Short: "Update secret metadata",
+	Long: `Update secret metadata without re-entering the secret value.
+
+Only the specified flags are updated; all other fields remain unchanged.
+At least one metadata flag must be provided.
+
+Examples:
+  scion hub secret update API_KEY --description "Production API key"
+  scion hub secret update API_KEY --injection-mode always
+  scion hub secret update API_KEY --type variable
+  scion hub secret update API_KEY --allow-progeny
+  scion hub secret update --project API_KEY --description "Project key"`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSecretUpdate,
+}
+
 // hubSecretClearCmd clears a secret
 var hubSecretClearCmd = &cobra.Command{
 	Use:   "clear KEY",
@@ -168,12 +187,13 @@ func init() {
 	hubSecretCmd.AddCommand(hubSecretGetCmd)
 	hubSecretCmd.AddCommand(hubSecretListCmd)
 	hubSecretCmd.AddCommand(hubSecretClearCmd)
+	hubSecretCmd.AddCommand(hubSecretUpdateCmd)
 
 	// Add scope flags to all subcommands.
 	// --scope selects the scope level (hub, user). --project/--broker select their
 	// respective scopes and support both bare usage (infer from settings) and
 	// explicit name/ID via --project=<name|id>.
-	for _, cmd := range []*cobra.Command{hubSecretSetCmd, hubSecretGetCmd, hubSecretListCmd, hubSecretClearCmd} {
+	for _, cmd := range []*cobra.Command{hubSecretSetCmd, hubSecretGetCmd, hubSecretListCmd, hubSecretClearCmd, hubSecretUpdateCmd} {
 		cmd.Flags().StringVar(&secretScope, "scope", "", "Scope level: hub, user (default: user)")
 		cmd.Flags().StringVar(&secretProjectScope, "project", "", "Project scope (bare flag infers current project, or use --project=<name|id>)")
 		cmd.Flags().Lookup("project").NoOptDefVal = scopeInferSentinel
@@ -194,6 +214,13 @@ func init() {
 	hubSecretSetCmd.Flags().StringVar(&secretType, "type", "", "Secret type: environment (default), variable, file")
 	hubSecretSetCmd.Flags().StringVar(&secretTarget, "target", "", "Projection target (env var name, json key, or file path; defaults to KEY)")
 	hubSecretSetCmd.Flags().BoolVar(&secretAllowProgeny, "allow-progeny", false, "Allow creator's progeny agents to access this secret (user scope only)")
+
+	// Metadata flags for update command
+	hubSecretUpdateCmd.Flags().StringP("description", "d", "", "Description for the secret")
+	hubSecretUpdateCmd.Flags().String("injection-mode", "", "Injection mode: always or as_needed")
+	hubSecretUpdateCmd.Flags().String("type", "", "Secret type: environment, variable, file")
+	hubSecretUpdateCmd.Flags().String("target", "", "Projection target (env var name, json key, or file path)")
+	hubSecretUpdateCmd.Flags().Bool("allow-progeny", false, "Allow creator's progeny agents to access this secret (user scope only)")
 }
 
 // resolveSecretScope determines the scope and scopeID based on flags.
@@ -530,6 +557,108 @@ func runSecretList(cmd *cobra.Command, _ []string) error {
 		fmt.Printf("%-30s  %-12s  %-8s  v%-7d  %s\n", truncate(s.Key, 30), typeLabel, progenyLabel, s.Version, s.Updated.Format("2006-01-02 15:04:05"))
 	}
 
+	return nil
+}
+
+func runSecretUpdate(cmd *cobra.Command, args []string) error {
+	key := args[0]
+
+	// Validate key
+	if key == "" {
+		return fmt.Errorf("key cannot be empty")
+	}
+
+	// Check that at least one metadata flag is provided
+	descChanged := cmd.Flags().Changed("description")
+	injectionChanged := cmd.Flags().Changed("injection-mode")
+	typeChanged := cmd.Flags().Changed("type")
+	targetChanged := cmd.Flags().Changed("target")
+	progenyChanged := cmd.Flags().Changed("allow-progeny")
+
+	if !descChanged && !injectionChanged && !typeChanged && !targetChanged && !progenyChanged {
+		return fmt.Errorf("at least one metadata flag must be provided (--description, --injection-mode, --type, --target, --allow-progeny)")
+	}
+
+	// Validate injection-mode if provided
+	injectionMode, _ := cmd.Flags().GetString("injection-mode")
+	if injectionChanged && injectionMode != "always" && injectionMode != "as_needed" {
+		return fmt.Errorf("injection-mode must be \"always\" or \"as_needed\"")
+	}
+
+	// Validate type if provided
+	secretTypeVal, _ := cmd.Flags().GetString("type")
+	if typeChanged {
+		switch secretTypeVal {
+		case "environment", "variable", "file":
+			// valid
+		default:
+			return fmt.Errorf("type must be one of: environment, variable, file")
+		}
+	}
+
+	resolvedPath, _, err := config.ResolveProjectPath(projectPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve project path: %w", err)
+	}
+
+	settings, err := config.LoadSettings(resolvedPath)
+	if err != nil {
+		return fmt.Errorf("failed to load settings: %w", err)
+	}
+
+	client, err := getHubClient(settings)
+	if err != nil {
+		return err
+	}
+
+	scope, scopeID, err := resolveSecretScope(cmd, settings)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	scopeID, err = resolveScopeID(ctx, client, scope, scopeID)
+	if err != nil {
+		return err
+	}
+
+	req := &hubclient.UpdateSecretMetaRequest{
+		Scope:   scope,
+		ScopeID: scopeID,
+	}
+
+	if descChanged {
+		desc, _ := cmd.Flags().GetString("description")
+		req.Description = &desc
+	}
+	if injectionChanged {
+		req.InjectionMode = injectionMode
+	}
+	if typeChanged {
+		req.Type = secretTypeVal
+	}
+	if targetChanged {
+		target, _ := cmd.Flags().GetString("target")
+		req.Target = target
+	}
+	if progenyChanged {
+		progeny, _ := cmd.Flags().GetBool("allow-progeny")
+		req.AllowProgeny = &progeny
+	}
+
+	secret, err := client.Secrets().UpdateMeta(ctx, key, req)
+	if err != nil {
+		return fmt.Errorf("failed to update secret metadata: %w", err)
+	}
+
+	typeLabel := secret.SecretType
+	if typeLabel == "" {
+		typeLabel = "environment"
+	}
+
+	fmt.Printf("Updated secret metadata for %s (scope: %s, type: %s, version: %d)\n", key, scope, typeLabel, secret.Version)
 	return nil
 }
 

--- a/cmd/server_foreground_pluginsecrets_test.go
+++ b/cmd/server_foreground_pluginsecrets_test.go
@@ -64,6 +64,10 @@ func (f *fakeSecretBackend) GetMeta(context.Context, string, string, string) (*s
 	return nil, store.ErrNotFound
 }
 
+func (f *fakeSecretBackend) UpdateMeta(_ context.Context, _ *secret.UpdateMetaInput) (*secret.SecretMeta, error) {
+	return nil, nil
+}
+
 func (f *fakeSecretBackend) Resolve(context.Context, string, string, string, *secret.ResolveOpts) ([]secret.SecretWithValue, error) {
 	return nil, nil
 }

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -997,16 +997,16 @@ func (s *Server) patchSecret(w http.ResponseWriter, r *http.Request, key string)
 		}
 	}
 
-	// Validate target for file type constraints if both are provided
-	if req.Target != "" && req.Type == store.SecretTypeFile {
-		if strings.Contains(req.Target, "..") {
-			BadRequest(w, "target path must not contain '..'")
-			return
-		}
-		if !strings.HasPrefix(req.Target, "/") && !strings.HasPrefix(req.Target, "~/") {
-			ValidationError(w, "file secret target must be an absolute path (or start with ~/)", map[string]interface{}{
-				"field": "target",
-				"value": req.Target,
+	// Validate injectionMode if provided
+	if req.InjectionMode != "" {
+		switch req.InjectionMode {
+		case store.InjectionModeAlways, store.InjectionModeAsNeeded:
+			// valid
+		default:
+			ValidationError(w, "injectionMode must be \"always\" or \"as_needed\"", map[string]interface{}{
+				"field":   "injectionMode",
+				"value":   req.InjectionMode,
+				"allowed": []string{"always", "as_needed"},
 			})
 			return
 		}
@@ -1020,6 +1020,33 @@ func (s *Server) patchSecret(w http.ResponseWriter, r *http.Request, key string)
 	scopeID, ok := s.resolveEnvSecretAccess(w, r, scope, r.URL.Query().Get("scopeId"), true)
 	if !ok {
 		return
+	}
+
+	// Determine the effective secret type for target validation
+	effectiveType := req.Type
+	if effectiveType == "" && req.Target != "" {
+		// Fetch stored type to validate target against it
+		existing, err := s.secretBackend.GetMeta(ctx, key, scope, scopeID)
+		if err != nil {
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		effectiveType = existing.SecretType
+	}
+
+	// Validate file-specific target constraints
+	if req.Target != "" && effectiveType == store.SecretTypeFile {
+		if strings.Contains(req.Target, "..") {
+			BadRequest(w, "target path must not contain '..'")
+			return
+		}
+		if !strings.HasPrefix(req.Target, "/") && !strings.HasPrefix(req.Target, "~/") {
+			ValidationError(w, "file secret target must be an absolute path (or start with ~/)", map[string]interface{}{
+				"field": "target",
+				"value": req.Target,
+			})
+			return
+		}
 	}
 
 	// allowProgeny is only valid on user-scoped secrets
@@ -2015,7 +2042,33 @@ func (s *Server) handleProjectSecretByKey(w http.ResponseWriter, r *http.Request
 				return
 			}
 		}
-		if req.Target != "" && req.Type == store.SecretTypeFile {
+		// Validate injectionMode if provided
+		if req.InjectionMode != "" {
+			switch req.InjectionMode {
+			case store.InjectionModeAlways, store.InjectionModeAsNeeded:
+				// valid
+			default:
+				ValidationError(w, "injectionMode must be \"always\" or \"as_needed\"", map[string]interface{}{
+					"field":   "injectionMode",
+					"value":   req.InjectionMode,
+					"allowed": []string{"always", "as_needed"},
+				})
+				return
+			}
+		}
+		// Determine the effective secret type for target validation
+		effectiveType := req.Type
+		if effectiveType == "" && req.Target != "" {
+			// Fetch stored type to validate target against it
+			existing, err := s.secretBackend.GetMeta(ctx, key, store.ScopeProject, projectID)
+			if err != nil {
+				writeErrorFromErr(w, err, "")
+				return
+			}
+			effectiveType = existing.SecretType
+		}
+		// Validate file-specific target constraints
+		if req.Target != "" && effectiveType == store.SecretTypeFile {
 			if strings.Contains(req.Target, "..") {
 				BadRequest(w, "target path must not contain '..'")
 				return
@@ -2743,7 +2796,33 @@ func (s *Server) handleBrokerSecretByKey(w http.ResponseWriter, r *http.Request,
 				return
 			}
 		}
-		if req.Target != "" && req.Type == store.SecretTypeFile {
+		// Validate injectionMode if provided
+		if req.InjectionMode != "" {
+			switch req.InjectionMode {
+			case store.InjectionModeAlways, store.InjectionModeAsNeeded:
+				// valid
+			default:
+				ValidationError(w, "injectionMode must be \"always\" or \"as_needed\"", map[string]interface{}{
+					"field":   "injectionMode",
+					"value":   req.InjectionMode,
+					"allowed": []string{"always", "as_needed"},
+				})
+				return
+			}
+		}
+		// Determine the effective secret type for target validation
+		effectiveType := req.Type
+		if effectiveType == "" && req.Target != "" {
+			// Fetch stored type to validate target against it
+			existing, err := s.secretBackend.GetMeta(ctx, key, store.ScopeRuntimeBroker, brokerID)
+			if err != nil {
+				writeErrorFromErr(w, err, "")
+				return
+			}
+			effectiveType = existing.SecretType
+		}
+		// Validate file-specific target constraints
+		if req.Target != "" && effectiveType == store.SecretTypeFile {
 			if strings.Contains(req.Target, "..") {
 				BadRequest(w, "target path must not contain '..'")
 				return

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -553,9 +553,9 @@ type SetSecretResponse struct {
 type PatchSecretRequest struct {
 	Description   *string `json:"description"`             // null = no change, "" = clear
 	InjectionMode string  `json:"injectionMode,omitempty"` // "" = no change
-	Type          string  `json:"type,omitempty"`           // "" = no change
-	Target        string  `json:"target,omitempty"`         // "" = no change
-	AllowProgeny  *bool   `json:"allowProgeny,omitempty"`   // null = no change
+	Type          string  `json:"type,omitempty"`          // "" = no change
+	Target        string  `json:"target,omitempty"`        // "" = no change
+	AllowProgeny  *bool   `json:"allowProgeny,omitempty"`  // null = no change
 }
 
 // metaToStoreSecret converts a secret.SecretMeta to a store.Secret for API response compatibility.
@@ -2025,6 +2025,14 @@ func (s *Server) handleProjectSecretByKey(w http.ResponseWriter, r *http.Request
 				return
 			}
 		}
+		// allowProgeny is only valid on user-scoped secrets
+		if req.AllowProgeny != nil && *req.AllowProgeny {
+			ValidationError(w, "allowProgeny is only supported on user-scoped secrets", map[string]interface{}{
+				"field": "allowProgeny",
+				"scope": store.ScopeProject,
+			})
+			return
+		}
 		patchInput := &secret.UpdateMetaInput{
 			Name:          key,
 			Scope:         store.ScopeProject,
@@ -2744,6 +2752,14 @@ func (s *Server) handleBrokerSecretByKey(w http.ResponseWriter, r *http.Request,
 				ValidationError(w, "file secret target must be an absolute path (or start with ~/)", map[string]interface{}{"field": "target", "value": req.Target})
 				return
 			}
+		}
+		// allowProgeny is only valid on user-scoped secrets
+		if req.AllowProgeny != nil && *req.AllowProgeny {
+			ValidationError(w, "allowProgeny is only supported on user-scoped secrets", map[string]interface{}{
+				"field": "allowProgeny",
+				"scope": store.ScopeRuntimeBroker,
+			})
+			return
 		}
 		patchInput := &secret.UpdateMetaInput{
 			Name:          key,

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -1034,16 +1034,25 @@ func (s *Server) patchSecret(w http.ResponseWriter, r *http.Request, key string)
 		effectiveType = existing.SecretType
 	}
 
-	// Validate file-specific target constraints
-	if req.Target != "" && effectiveType == store.SecretTypeFile {
-		if strings.Contains(req.Target, "..") {
+	// Validate file-specific target constraints (including stored target when type changes to file)
+	effectiveTarget := req.Target
+	if effectiveType == store.SecretTypeFile && effectiveTarget == "" {
+		existing, err := s.secretBackend.GetMeta(ctx, key, scope, scopeID)
+		if err != nil {
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		effectiveTarget = existing.Target
+	}
+	if effectiveTarget != "" && effectiveType == store.SecretTypeFile {
+		if strings.Contains(effectiveTarget, "..") {
 			BadRequest(w, "target path must not contain '..'")
 			return
 		}
-		if !strings.HasPrefix(req.Target, "/") && !strings.HasPrefix(req.Target, "~/") {
+		if !strings.HasPrefix(effectiveTarget, "/") && !strings.HasPrefix(effectiveTarget, "~/") {
 			ValidationError(w, "file secret target must be an absolute path (or start with ~/)", map[string]interface{}{
 				"field": "target",
-				"value": req.Target,
+				"value": effectiveTarget,
 			})
 			return
 		}
@@ -2067,14 +2076,23 @@ func (s *Server) handleProjectSecretByKey(w http.ResponseWriter, r *http.Request
 			}
 			effectiveType = existing.SecretType
 		}
-		// Validate file-specific target constraints
-		if req.Target != "" && effectiveType == store.SecretTypeFile {
-			if strings.Contains(req.Target, "..") {
+		// Validate file-specific target constraints (including stored target when type changes to file)
+		effectiveTarget := req.Target
+		if effectiveType == store.SecretTypeFile && effectiveTarget == "" {
+			existing, err := s.secretBackend.GetMeta(ctx, key, store.ScopeProject, projectID)
+			if err != nil {
+				writeErrorFromErr(w, err, "")
+				return
+			}
+			effectiveTarget = existing.Target
+		}
+		if effectiveTarget != "" && effectiveType == store.SecretTypeFile {
+			if strings.Contains(effectiveTarget, "..") {
 				BadRequest(w, "target path must not contain '..'")
 				return
 			}
-			if !strings.HasPrefix(req.Target, "/") && !strings.HasPrefix(req.Target, "~/") {
-				ValidationError(w, "file secret target must be an absolute path (or start with ~/)", map[string]interface{}{"field": "target", "value": req.Target})
+			if !strings.HasPrefix(effectiveTarget, "/") && !strings.HasPrefix(effectiveTarget, "~/") {
+				ValidationError(w, "file secret target must be an absolute path (or start with ~/)", map[string]interface{}{"field": "target", "value": effectiveTarget})
 				return
 			}
 		}
@@ -2821,14 +2839,23 @@ func (s *Server) handleBrokerSecretByKey(w http.ResponseWriter, r *http.Request,
 			}
 			effectiveType = existing.SecretType
 		}
-		// Validate file-specific target constraints
-		if req.Target != "" && effectiveType == store.SecretTypeFile {
-			if strings.Contains(req.Target, "..") {
+		// Validate file-specific target constraints (including stored target when type changes to file)
+		effectiveTarget := req.Target
+		if effectiveType == store.SecretTypeFile && effectiveTarget == "" {
+			existing, err := s.secretBackend.GetMeta(ctx, key, store.ScopeRuntimeBroker, brokerID)
+			if err != nil {
+				writeErrorFromErr(w, err, "")
+				return
+			}
+			effectiveTarget = existing.Target
+		}
+		if effectiveTarget != "" && effectiveType == store.SecretTypeFile {
+			if strings.Contains(effectiveTarget, "..") {
 				BadRequest(w, "target path must not contain '..'")
 				return
 			}
-			if !strings.HasPrefix(req.Target, "/") && !strings.HasPrefix(req.Target, "~/") {
-				ValidationError(w, "file secret target must be an absolute path (or start with ~/)", map[string]interface{}{"field": "target", "value": req.Target})
+			if !strings.HasPrefix(effectiveTarget, "/") && !strings.HasPrefix(effectiveTarget, "~/") {
+				ValidationError(w, "file secret target must be an absolute path (or start with ~/)", map[string]interface{}{"field": "target", "value": effectiveTarget})
 				return
 			}
 		}

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -972,7 +972,10 @@ func (s *Server) setSecret(w http.ResponseWriter, r *http.Request, key string) {
 	})
 }
 
-func (s *Server) patchSecret(w http.ResponseWriter, r *http.Request, key string) {
+// patchSecretValidateAndUpdate is the shared helper for all PATCH secret
+// handlers. It decodes and validates the PatchSecretRequest, applies the
+// metadata update, manages progeny-policy lifecycle, and writes the response.
+func (s *Server) patchSecretValidateAndUpdate(w http.ResponseWriter, r *http.Request, key, scope, scopeID string) {
 	ctx := r.Context()
 
 	r.Body = http.MaxBytesReader(w, r.Body, 128*1024)
@@ -1010,16 +1013,6 @@ func (s *Server) patchSecret(w http.ResponseWriter, r *http.Request, key string)
 			})
 			return
 		}
-	}
-
-	scope := r.URL.Query().Get("scope")
-	if scope == "" {
-		scope = store.ScopeUser
-	}
-
-	scopeID, ok := s.resolveEnvSecretAccess(w, r, scope, r.URL.Query().Get("scopeId"), true)
-	if !ok {
-		return
 	}
 
 	// Determine the effective secret type for target validation
@@ -1095,6 +1088,20 @@ func (s *Server) patchSecret(w http.ResponseWriter, r *http.Request, key string)
 
 	result := metaToStoreSecret(*meta)
 	writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) patchSecret(w http.ResponseWriter, r *http.Request, key string) {
+	scope := r.URL.Query().Get("scope")
+	if scope == "" {
+		scope = store.ScopeUser
+	}
+
+	scopeID, ok := s.resolveEnvSecretAccess(w, r, scope, r.URL.Query().Get("scopeId"), true)
+	if !ok {
+		return
+	}
+
+	s.patchSecretValidateAndUpdate(w, r, key, scope, scopeID)
 }
 
 func (s *Server) deleteSecret(w http.ResponseWriter, r *http.Request, key string) {
@@ -2037,93 +2044,7 @@ func (s *Server) handleProjectSecretByKey(w http.ResponseWriter, r *http.Request
 		writeJSON(w, http.StatusOK, SetSecretResponse{Secret: &result, Created: created})
 
 	case http.MethodPatch:
-		r.Body = http.MaxBytesReader(w, r.Body, 128*1024)
-		var req PatchSecretRequest
-		if err := readJSON(r, &req); err != nil {
-			BadRequest(w, "Invalid request body: "+err.Error())
-			return
-		}
-		if req.Type != "" {
-			switch req.Type {
-			case store.SecretTypeEnvironment, store.SecretTypeVariable, store.SecretTypeFile:
-			default:
-				ValidationError(w, "type must be one of: environment, variable, file", map[string]interface{}{"field": "type", "value": req.Type})
-				return
-			}
-		}
-		// Validate injectionMode if provided
-		if req.InjectionMode != "" {
-			switch req.InjectionMode {
-			case store.InjectionModeAlways, store.InjectionModeAsNeeded:
-				// valid
-			default:
-				ValidationError(w, "injectionMode must be \"always\" or \"as_needed\"", map[string]interface{}{
-					"field":   "injectionMode",
-					"value":   req.InjectionMode,
-					"allowed": []string{"always", "as_needed"},
-				})
-				return
-			}
-		}
-		// Determine the effective secret type for target validation
-		effectiveType := req.Type
-		if effectiveType == "" && req.Target != "" {
-			// Fetch stored type to validate target against it
-			existing, err := s.secretBackend.GetMeta(ctx, key, store.ScopeProject, projectID)
-			if err != nil {
-				writeErrorFromErr(w, err, "")
-				return
-			}
-			effectiveType = existing.SecretType
-		}
-		// Validate file-specific target constraints (including stored target when type changes to file)
-		effectiveTarget := req.Target
-		if effectiveType == store.SecretTypeFile && effectiveTarget == "" {
-			existing, err := s.secretBackend.GetMeta(ctx, key, store.ScopeProject, projectID)
-			if err != nil {
-				writeErrorFromErr(w, err, "")
-				return
-			}
-			effectiveTarget = existing.Target
-		}
-		if effectiveTarget != "" && effectiveType == store.SecretTypeFile {
-			if strings.Contains(effectiveTarget, "..") {
-				BadRequest(w, "target path must not contain '..'")
-				return
-			}
-			if !strings.HasPrefix(effectiveTarget, "/") && !strings.HasPrefix(effectiveTarget, "~/") {
-				ValidationError(w, "file secret target must be an absolute path (or start with ~/)", map[string]interface{}{"field": "target", "value": effectiveTarget})
-				return
-			}
-		}
-		// allowProgeny is only valid on user-scoped secrets
-		if req.AllowProgeny != nil && *req.AllowProgeny {
-			ValidationError(w, "allowProgeny is only supported on user-scoped secrets", map[string]interface{}{
-				"field": "allowProgeny",
-				"scope": store.ScopeProject,
-			})
-			return
-		}
-		patchInput := &secret.UpdateMetaInput{
-			Name:          key,
-			Scope:         store.ScopeProject,
-			ScopeID:       projectID,
-			Description:   req.Description,
-			InjectionMode: req.InjectionMode,
-			SecretType:    req.Type,
-			Target:        req.Target,
-			AllowProgeny:  req.AllowProgeny,
-		}
-		if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-			patchInput.UpdatedBy = userIdent.ID()
-		}
-		patchMeta, err := s.secretBackend.UpdateMeta(ctx, patchInput)
-		if err != nil {
-			writeErrorFromErr(w, err, "")
-			return
-		}
-		patchResult := metaToStoreSecret(*patchMeta)
-		writeJSON(w, http.StatusOK, patchResult)
+		s.patchSecretValidateAndUpdate(w, r, key, store.ScopeProject, projectID)
 
 	case http.MethodDelete:
 		if err := s.secretBackend.Delete(ctx, key, store.ScopeProject, projectID); err != nil {
@@ -2800,93 +2721,7 @@ func (s *Server) handleBrokerSecretByKey(w http.ResponseWriter, r *http.Request,
 		writeJSON(w, http.StatusOK, SetSecretResponse{Secret: &result, Created: created})
 
 	case http.MethodPatch:
-		r.Body = http.MaxBytesReader(w, r.Body, 128*1024)
-		var req PatchSecretRequest
-		if err := readJSON(r, &req); err != nil {
-			BadRequest(w, "Invalid request body: "+err.Error())
-			return
-		}
-		if req.Type != "" {
-			switch req.Type {
-			case store.SecretTypeEnvironment, store.SecretTypeVariable, store.SecretTypeFile:
-			default:
-				ValidationError(w, "type must be one of: environment, variable, file", map[string]interface{}{"field": "type", "value": req.Type})
-				return
-			}
-		}
-		// Validate injectionMode if provided
-		if req.InjectionMode != "" {
-			switch req.InjectionMode {
-			case store.InjectionModeAlways, store.InjectionModeAsNeeded:
-				// valid
-			default:
-				ValidationError(w, "injectionMode must be \"always\" or \"as_needed\"", map[string]interface{}{
-					"field":   "injectionMode",
-					"value":   req.InjectionMode,
-					"allowed": []string{"always", "as_needed"},
-				})
-				return
-			}
-		}
-		// Determine the effective secret type for target validation
-		effectiveType := req.Type
-		if effectiveType == "" && req.Target != "" {
-			// Fetch stored type to validate target against it
-			existing, err := s.secretBackend.GetMeta(ctx, key, store.ScopeRuntimeBroker, brokerID)
-			if err != nil {
-				writeErrorFromErr(w, err, "")
-				return
-			}
-			effectiveType = existing.SecretType
-		}
-		// Validate file-specific target constraints (including stored target when type changes to file)
-		effectiveTarget := req.Target
-		if effectiveType == store.SecretTypeFile && effectiveTarget == "" {
-			existing, err := s.secretBackend.GetMeta(ctx, key, store.ScopeRuntimeBroker, brokerID)
-			if err != nil {
-				writeErrorFromErr(w, err, "")
-				return
-			}
-			effectiveTarget = existing.Target
-		}
-		if effectiveTarget != "" && effectiveType == store.SecretTypeFile {
-			if strings.Contains(effectiveTarget, "..") {
-				BadRequest(w, "target path must not contain '..'")
-				return
-			}
-			if !strings.HasPrefix(effectiveTarget, "/") && !strings.HasPrefix(effectiveTarget, "~/") {
-				ValidationError(w, "file secret target must be an absolute path (or start with ~/)", map[string]interface{}{"field": "target", "value": effectiveTarget})
-				return
-			}
-		}
-		// allowProgeny is only valid on user-scoped secrets
-		if req.AllowProgeny != nil && *req.AllowProgeny {
-			ValidationError(w, "allowProgeny is only supported on user-scoped secrets", map[string]interface{}{
-				"field": "allowProgeny",
-				"scope": store.ScopeRuntimeBroker,
-			})
-			return
-		}
-		patchInput := &secret.UpdateMetaInput{
-			Name:          key,
-			Scope:         store.ScopeRuntimeBroker,
-			ScopeID:       brokerID,
-			Description:   req.Description,
-			InjectionMode: req.InjectionMode,
-			SecretType:    req.Type,
-			Target:        req.Target,
-			AllowProgeny:  req.AllowProgeny,
-		}
-		if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
-			patchInput.UpdatedBy = userIdent.ID()
-		}
-		patchMeta, err := s.secretBackend.UpdateMeta(ctx, patchInput)
-		if err != nil {
-			writeErrorFromErr(w, err, "")
-			return
-		}
-		patchResult := metaToStoreSecret(*patchMeta)
-		writeJSON(w, http.StatusOK, patchResult)
+		s.patchSecretValidateAndUpdate(w, r, key, store.ScopeRuntimeBroker, brokerID)
 
 	case http.MethodDelete:
 		if err := s.secretBackend.Delete(ctx, key, store.ScopeRuntimeBroker, brokerID); err != nil {

--- a/pkg/hub/handlers_env_secrets.go
+++ b/pkg/hub/handlers_env_secrets.go
@@ -548,6 +548,16 @@ type SetSecretResponse struct {
 	Created bool          `json:"created"`
 }
 
+// PatchSecretRequest is the request body for metadata-only secret updates (PATCH).
+// Only non-null/non-empty fields are applied. The secret value is never modified.
+type PatchSecretRequest struct {
+	Description   *string `json:"description"`             // null = no change, "" = clear
+	InjectionMode string  `json:"injectionMode,omitempty"` // "" = no change
+	Type          string  `json:"type,omitempty"`           // "" = no change
+	Target        string  `json:"target,omitempty"`         // "" = no change
+	AllowProgeny  *bool   `json:"allowProgeny,omitempty"`   // null = no change
+}
+
 // metaToStoreSecret converts a secret.SecretMeta to a store.Secret for API response compatibility.
 func metaToStoreSecret(m secret.SecretMeta) store.Secret {
 	return store.Secret{
@@ -795,6 +805,8 @@ func (s *Server) handleSecretByKey(w http.ResponseWriter, r *http.Request) {
 		s.getSecret(w, r, key)
 	case http.MethodPut:
 		s.setSecret(w, r, key)
+	case http.MethodPatch:
+		s.patchSecret(w, r, key)
 	case http.MethodDelete:
 		s.deleteSecret(w, r, key)
 	default:
@@ -958,6 +970,95 @@ func (s *Server) setSecret(w http.ResponseWriter, r *http.Request, key string) {
 		Secret:  &result,
 		Created: created,
 	})
+}
+
+func (s *Server) patchSecret(w http.ResponseWriter, r *http.Request, key string) {
+	ctx := r.Context()
+
+	r.Body = http.MaxBytesReader(w, r.Body, 128*1024)
+
+	var req PatchSecretRequest
+	if err := readJSON(r, &req); err != nil {
+		BadRequest(w, "Invalid request body: "+err.Error())
+		return
+	}
+
+	// Validate type if provided
+	if req.Type != "" {
+		switch req.Type {
+		case store.SecretTypeEnvironment, store.SecretTypeVariable, store.SecretTypeFile:
+			// valid
+		default:
+			ValidationError(w, "type must be one of: environment, variable, file", map[string]interface{}{
+				"field": "type",
+				"value": req.Type,
+			})
+			return
+		}
+	}
+
+	// Validate target for file type constraints if both are provided
+	if req.Target != "" && req.Type == store.SecretTypeFile {
+		if strings.Contains(req.Target, "..") {
+			BadRequest(w, "target path must not contain '..'")
+			return
+		}
+		if !strings.HasPrefix(req.Target, "/") && !strings.HasPrefix(req.Target, "~/") {
+			ValidationError(w, "file secret target must be an absolute path (or start with ~/)", map[string]interface{}{
+				"field": "target",
+				"value": req.Target,
+			})
+			return
+		}
+	}
+
+	scope := r.URL.Query().Get("scope")
+	if scope == "" {
+		scope = store.ScopeUser
+	}
+
+	scopeID, ok := s.resolveEnvSecretAccess(w, r, scope, r.URL.Query().Get("scopeId"), true)
+	if !ok {
+		return
+	}
+
+	// allowProgeny is only valid on user-scoped secrets
+	if req.AllowProgeny != nil && *req.AllowProgeny && scope != store.ScopeUser {
+		ValidationError(w, "allowProgeny is only supported on user-scoped secrets", map[string]interface{}{
+			"field": "allowProgeny",
+			"scope": scope,
+		})
+		return
+	}
+
+	input := &secret.UpdateMetaInput{
+		Name:          key,
+		Scope:         scope,
+		ScopeID:       scopeID,
+		Description:   req.Description,
+		InjectionMode: req.InjectionMode,
+		SecretType:    req.Type,
+		Target:        req.Target,
+		AllowProgeny:  req.AllowProgeny,
+	}
+
+	if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+		input.UpdatedBy = userIdent.ID()
+	}
+
+	meta, err := s.secretBackend.UpdateMeta(ctx, input)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// Manage implicit progeny policy lifecycle if AllowProgeny changed
+	if req.AllowProgeny != nil {
+		s.ensureProgenyPolicy(ctx, meta)
+	}
+
+	result := metaToStoreSecret(*meta)
+	writeJSON(w, http.StatusOK, result)
 }
 
 func (s *Server) deleteSecret(w http.ResponseWriter, r *http.Request, key string) {
@@ -1774,7 +1875,7 @@ func (s *Server) handleProjectSecretByKey(w http.ResponseWriter, r *http.Request
 	}
 
 	// Authorize access
-	isWrite := r.Method == http.MethodPut || r.Method == http.MethodDelete
+	isWrite := r.Method == http.MethodPut || r.Method == http.MethodPatch || r.Method == http.MethodDelete
 	identity := GetIdentityFromContext(ctx)
 	if identity == nil {
 		Unauthorized(w)
@@ -1898,6 +1999,52 @@ func (s *Server) handleProjectSecretByKey(w http.ResponseWriter, r *http.Request
 		}
 		result := metaToStoreSecret(*meta)
 		writeJSON(w, http.StatusOK, SetSecretResponse{Secret: &result, Created: created})
+
+	case http.MethodPatch:
+		r.Body = http.MaxBytesReader(w, r.Body, 128*1024)
+		var req PatchSecretRequest
+		if err := readJSON(r, &req); err != nil {
+			BadRequest(w, "Invalid request body: "+err.Error())
+			return
+		}
+		if req.Type != "" {
+			switch req.Type {
+			case store.SecretTypeEnvironment, store.SecretTypeVariable, store.SecretTypeFile:
+			default:
+				ValidationError(w, "type must be one of: environment, variable, file", map[string]interface{}{"field": "type", "value": req.Type})
+				return
+			}
+		}
+		if req.Target != "" && req.Type == store.SecretTypeFile {
+			if strings.Contains(req.Target, "..") {
+				BadRequest(w, "target path must not contain '..'")
+				return
+			}
+			if !strings.HasPrefix(req.Target, "/") && !strings.HasPrefix(req.Target, "~/") {
+				ValidationError(w, "file secret target must be an absolute path (or start with ~/)", map[string]interface{}{"field": "target", "value": req.Target})
+				return
+			}
+		}
+		patchInput := &secret.UpdateMetaInput{
+			Name:          key,
+			Scope:         store.ScopeProject,
+			ScopeID:       projectID,
+			Description:   req.Description,
+			InjectionMode: req.InjectionMode,
+			SecretType:    req.Type,
+			Target:        req.Target,
+			AllowProgeny:  req.AllowProgeny,
+		}
+		if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+			patchInput.UpdatedBy = userIdent.ID()
+		}
+		patchMeta, err := s.secretBackend.UpdateMeta(ctx, patchInput)
+		if err != nil {
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		patchResult := metaToStoreSecret(*patchMeta)
+		writeJSON(w, http.StatusOK, patchResult)
 
 	case http.MethodDelete:
 		if err := s.secretBackend.Delete(ctx, key, store.ScopeProject, projectID); err != nil {
@@ -2454,7 +2601,7 @@ func (s *Server) handleBrokerSecretByKey(w http.ResponseWriter, r *http.Request,
 	}
 
 	// Authorize access: broker self-access or user CheckAccess
-	isWrite := r.Method == http.MethodPut || r.Method == http.MethodDelete
+	isWrite := r.Method == http.MethodPut || r.Method == http.MethodPatch || r.Method == http.MethodDelete
 	if brokerIdent := GetBrokerIdentityFromContext(ctx); brokerIdent != nil && brokerIdent.BrokerID() == brokerID {
 		// Broker accessing its own secrets — allowed
 	} else {
@@ -2572,6 +2719,52 @@ func (s *Server) handleBrokerSecretByKey(w http.ResponseWriter, r *http.Request,
 		}
 		result := metaToStoreSecret(*meta)
 		writeJSON(w, http.StatusOK, SetSecretResponse{Secret: &result, Created: created})
+
+	case http.MethodPatch:
+		r.Body = http.MaxBytesReader(w, r.Body, 128*1024)
+		var req PatchSecretRequest
+		if err := readJSON(r, &req); err != nil {
+			BadRequest(w, "Invalid request body: "+err.Error())
+			return
+		}
+		if req.Type != "" {
+			switch req.Type {
+			case store.SecretTypeEnvironment, store.SecretTypeVariable, store.SecretTypeFile:
+			default:
+				ValidationError(w, "type must be one of: environment, variable, file", map[string]interface{}{"field": "type", "value": req.Type})
+				return
+			}
+		}
+		if req.Target != "" && req.Type == store.SecretTypeFile {
+			if strings.Contains(req.Target, "..") {
+				BadRequest(w, "target path must not contain '..'")
+				return
+			}
+			if !strings.HasPrefix(req.Target, "/") && !strings.HasPrefix(req.Target, "~/") {
+				ValidationError(w, "file secret target must be an absolute path (or start with ~/)", map[string]interface{}{"field": "target", "value": req.Target})
+				return
+			}
+		}
+		patchInput := &secret.UpdateMetaInput{
+			Name:          key,
+			Scope:         store.ScopeRuntimeBroker,
+			ScopeID:       brokerID,
+			Description:   req.Description,
+			InjectionMode: req.InjectionMode,
+			SecretType:    req.Type,
+			Target:        req.Target,
+			AllowProgeny:  req.AllowProgeny,
+		}
+		if userIdent := GetUserIdentityFromContext(ctx); userIdent != nil {
+			patchInput.UpdatedBy = userIdent.ID()
+		}
+		patchMeta, err := s.secretBackend.UpdateMeta(ctx, patchInput)
+		if err != nil {
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		patchResult := metaToStoreSecret(*patchMeta)
+		writeJSON(w, http.StatusOK, patchResult)
 
 	case http.MethodDelete:
 		if err := s.secretBackend.Delete(ctx, key, store.ScopeRuntimeBroker, brokerID); err != nil {

--- a/pkg/hub/handlers_env_secrets_test.go
+++ b/pkg/hub/handlers_env_secrets_test.go
@@ -231,3 +231,288 @@ func TestPatchSecret_BrokerScope_AllowProgenyRejected(t *testing.T) {
 		t.Errorf("PATCH with allowProgeny at broker scope: expected 422, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
+
+// =============================================================================
+// R1: File-type target path validation bypass
+// =============================================================================
+
+// TestPatchSecret_UserScope_PathTraversalOnFileSecret verifies that PATCH with
+// a path traversal target on an existing file-type secret (without type in
+// request) is rejected with 400.
+func TestPatchSecret_UserScope_PathTraversalOnFileSecret(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
+	srv.SetSecretBackend(localBackend)
+
+	// Create a file-type secret at user scope
+	createBody := SetSecretRequest{
+		Value:  base64.StdEncoding.EncodeToString([]byte("file-content")),
+		Type:   "file",
+		Target: "/tmp/safe-file.txt",
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/FILE_TRAV_KEY", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH with path traversal target (no type in request) — should be rejected
+	patchBody := PatchSecretRequest{
+		Target: "../../etc/shadow",
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/secrets/FILE_TRAV_KEY", patchBody)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("PATCH with path traversal on file secret: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestPatchSecret_UserScope_RelativeTargetOnFileSecret verifies that PATCH with
+// a relative (non-absolute) target on an existing file-type secret is rejected.
+func TestPatchSecret_UserScope_RelativeTargetOnFileSecret(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
+	srv.SetSecretBackend(localBackend)
+
+	// Create a file-type secret at user scope
+	createBody := SetSecretRequest{
+		Value:  base64.StdEncoding.EncodeToString([]byte("file-content")),
+		Type:   "file",
+		Target: "/tmp/safe-file.txt",
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/FILE_REL_KEY", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH with relative target (no type in request) — should be rejected
+	patchBody := PatchSecretRequest{
+		Target: "relative/path",
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/secrets/FILE_REL_KEY", patchBody)
+	if rec.Code < 400 || rec.Code >= 500 {
+		t.Errorf("PATCH with relative target on file secret: expected 4xx, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestPatchSecret_ProjectScope_PathTraversalOnFileSecret verifies that PATCH
+// with a path traversal target on an existing file-type project secret is rejected.
+func TestPatchSecret_ProjectScope_PathTraversalOnFileSecret(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:      tid("project_file_trav"),
+		Name:    "File Traversal Project",
+		Slug:    "file-trav-project",
+		OwnerID: DevUserID,
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	// Create a file-type secret at project scope
+	createBody := SetSecretRequest{
+		Value:  base64.StdEncoding.EncodeToString([]byte("file-content")),
+		Type:   "file",
+		Target: "/tmp/project-file.txt",
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/projects/"+project.ID+"/secrets/PROJ_FILE_TRAV", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH with path traversal target (no type) — should be rejected
+	patchBody := PatchSecretRequest{
+		Target: "../../etc/shadow",
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/projects/"+project.ID+"/secrets/PROJ_FILE_TRAV", patchBody)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("PATCH with path traversal on project file secret: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestPatchSecret_BrokerScope_PathTraversalOnFileSecret verifies that PATCH
+// with a path traversal target on an existing file-type broker secret is rejected.
+func TestPatchSecret_BrokerScope_PathTraversalOnFileSecret(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	broker := &store.RuntimeBroker{
+		ID:      tid("broker_file_trav"),
+		Name:    "File Traversal Broker",
+		Slug:    "file-trav-broker",
+		Status:  store.BrokerStatusOnline,
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	if err := s.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create broker: %v", err)
+	}
+
+	// Create a file-type secret at broker scope
+	createBody := SetSecretRequest{
+		Value:  base64.StdEncoding.EncodeToString([]byte("file-content")),
+		Type:   "file",
+		Target: "/tmp/broker-file.txt",
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/runtime-brokers/"+broker.ID+"/secrets/BROKER_FILE_TRAV", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH with path traversal target (no type) — should be rejected
+	patchBody := PatchSecretRequest{
+		Target: "../../etc/shadow",
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/runtime-brokers/"+broker.ID+"/secrets/BROKER_FILE_TRAV", patchBody)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("PATCH with path traversal on broker file secret: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// =============================================================================
+// R2: Missing injectionMode validation
+// =============================================================================
+
+// TestPatchSecret_UserScope_InvalidInjectionMode verifies that PATCH with an
+// invalid injectionMode is rejected.
+func TestPatchSecret_UserScope_InvalidInjectionMode(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
+	srv.SetSecretBackend(localBackend)
+
+	// Create a secret at user scope
+	createBody := SetSecretRequest{
+		Value: base64.StdEncoding.EncodeToString([]byte("secret-value")),
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/INJ_INVALID_KEY", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH with invalid injectionMode — should be rejected
+	patchBody := PatchSecretRequest{
+		InjectionMode: "invalid",
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/secrets/INJ_INVALID_KEY", patchBody)
+	if rec.Code < 400 || rec.Code >= 500 {
+		t.Errorf("PATCH with invalid injectionMode: expected 4xx, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestPatchSecret_UserScope_ValidInjectionMode verifies that PATCH with a
+// valid injectionMode succeeds.
+func TestPatchSecret_UserScope_ValidInjectionMode(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
+	srv.SetSecretBackend(localBackend)
+
+	// Create a secret at user scope
+	createBody := SetSecretRequest{
+		Value: base64.StdEncoding.EncodeToString([]byte("secret-value")),
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/INJ_VALID_KEY", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH with valid injectionMode "always" — should succeed
+	patchBody := PatchSecretRequest{
+		InjectionMode: "always",
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/secrets/INJ_VALID_KEY", patchBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH with valid injectionMode: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var result store.Secret
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result.InjectionMode != "always" {
+		t.Errorf("expected injectionMode %q, got %q", "always", result.InjectionMode)
+	}
+}
+
+// TestPatchSecret_ProjectScope_InvalidInjectionMode verifies that PATCH with an
+// invalid injectionMode at project scope is rejected.
+func TestPatchSecret_ProjectScope_InvalidInjectionMode(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:      tid("project_inj_invalid"),
+		Name:    "Injection Invalid Project",
+		Slug:    "inj-invalid-project",
+		OwnerID: DevUserID,
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	// Create a secret at project scope
+	createBody := SetSecretRequest{
+		Value: base64.StdEncoding.EncodeToString([]byte("secret-value")),
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/projects/"+project.ID+"/secrets/PROJ_INJ_KEY", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH with invalid injectionMode — should be rejected
+	patchBody := PatchSecretRequest{
+		InjectionMode: "invalid",
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/projects/"+project.ID+"/secrets/PROJ_INJ_KEY", patchBody)
+	if rec.Code < 400 || rec.Code >= 500 {
+		t.Errorf("PATCH with invalid injectionMode at project scope: expected 4xx, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestPatchSecret_BrokerScope_InvalidInjectionMode verifies that PATCH with an
+// invalid injectionMode at broker scope is rejected.
+func TestPatchSecret_BrokerScope_InvalidInjectionMode(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	broker := &store.RuntimeBroker{
+		ID:      tid("broker_inj_invalid"),
+		Name:    "Injection Invalid Broker",
+		Slug:    "inj-invalid-broker",
+		Status:  store.BrokerStatusOnline,
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	if err := s.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create broker: %v", err)
+	}
+
+	// Create a secret at broker scope
+	createBody := SetSecretRequest{
+		Value: base64.StdEncoding.EncodeToString([]byte("secret-value")),
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/runtime-brokers/"+broker.ID+"/secrets/BROKER_INJ_KEY", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH with invalid injectionMode — should be rejected
+	patchBody := PatchSecretRequest{
+		InjectionMode: "invalid",
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/runtime-brokers/"+broker.ID+"/secrets/BROKER_INJ_KEY", patchBody)
+	if rec.Code < 400 || rec.Code >= 500 {
+		t.Errorf("PATCH with invalid injectionMode at broker scope: expected 4xx, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/pkg/hub/handlers_env_secrets_test.go
+++ b/pkg/hub/handlers_env_secrets_test.go
@@ -18,9 +18,9 @@
 //
 // Contract under test:
 //   - Project-scope PATCH returns 200 with updated metadata
-//   - Project-scope PATCH with allowProgeny=true returns 422
+//   - Project-scope PATCH with allowProgeny=true returns 400
 //   - Broker-scope PATCH returns 200 with updated metadata
-//   - Broker-scope PATCH with allowProgeny=true returns 422
+//   - Broker-scope PATCH with allowProgeny=true returns 400
 
 package hub
 
@@ -95,7 +95,7 @@ func TestPatchSecret_ProjectScope_ReturnsUpdatedMetadata(t *testing.T) {
 }
 
 // TestPatchSecret_ProjectScope_AllowProgenyRejected verifies that PATCH with
-// allowProgeny=true at project scope returns 422.
+// allowProgeny=true at project scope returns 400.
 func TestPatchSecret_ProjectScope_AllowProgenyRejected(t *testing.T) {
 	srv, s := testServer(t)
 	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
@@ -130,7 +130,7 @@ func TestPatchSecret_ProjectScope_AllowProgenyRejected(t *testing.T) {
 	}
 	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/projects/"+project.ID+"/secrets/PROJ_PROGENY_KEY", patchBody)
 	if rec.Code != http.StatusBadRequest {
-		t.Errorf("PATCH with allowProgeny at project scope: expected 422, got %d: %s", rec.Code, rec.Body.String())
+		t.Errorf("PATCH with allowProgeny at project scope: expected 400, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -193,7 +193,7 @@ func TestPatchSecret_BrokerScope_ReturnsUpdatedMetadata(t *testing.T) {
 }
 
 // TestPatchSecret_BrokerScope_AllowProgenyRejected verifies that PATCH with
-// allowProgeny=true at broker scope returns 422.
+// allowProgeny=true at broker scope returns 400.
 func TestPatchSecret_BrokerScope_AllowProgenyRejected(t *testing.T) {
 	srv, s := testServer(t)
 	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
@@ -228,7 +228,7 @@ func TestPatchSecret_BrokerScope_AllowProgenyRejected(t *testing.T) {
 	}
 	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/runtime-brokers/"+broker.ID+"/secrets/BROKER_PROGENY_KEY", patchBody)
 	if rec.Code != http.StatusBadRequest {
-		t.Errorf("PATCH with allowProgeny at broker scope: expected 422, got %d: %s", rec.Code, rec.Body.String())
+		t.Errorf("PATCH with allowProgeny at broker scope: expected 400, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
@@ -372,6 +372,39 @@ func TestPatchSecret_BrokerScope_PathTraversalOnFileSecret(t *testing.T) {
 	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/runtime-brokers/"+broker.ID+"/secrets/BROKER_FILE_TRAV", patchBody)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("PATCH with path traversal on broker file secret: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// =============================================================================
+// R3-1: Type change to file bypasses stored-target validation
+// =============================================================================
+
+// TestPatchSecret_UserScope_TypeChangeToFileValidatesStoredTarget verifies that
+// changing type to "file" without providing a target validates the stored target
+// (which defaults to the key name, a relative path) and rejects it.
+func TestPatchSecret_UserScope_TypeChangeToFileValidatesStoredTarget(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
+	srv.SetSecretBackend(localBackend)
+
+	// Create an environment-type secret (target defaults to key name "MY_KEY")
+	createBody := SetSecretRequest{
+		Value: base64.StdEncoding.EncodeToString([]byte("secret-value")),
+		Type:  "environment",
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/MY_KEY", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH with type=file but no target — stored target "MY_KEY" is relative,
+	// so validation should reject it.
+	patchBody := PatchSecretRequest{
+		Type: "file",
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/secrets/MY_KEY", patchBody)
+	if rec.Code < 400 || rec.Code >= 500 {
+		t.Errorf("PATCH type change to file with relative stored target: expected 4xx, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/pkg/hub/handlers_env_secrets_test.go
+++ b/pkg/hub/handlers_env_secrets_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+// Package hub – tests for PATCH on project-scoped and broker-scoped secrets.
+//
+// Contract under test:
+//   - Project-scope PATCH returns 200 with updated metadata
+//   - Project-scope PATCH with allowProgeny=true returns 422
+//   - Broker-scope PATCH returns 200 with updated metadata
+//   - Broker-scope PATCH with allowProgeny=true returns 422
+
+package hub
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// TestPatchSecret_ProjectScope_ReturnsUpdatedMetadata verifies that PATCH on a
+// project-scoped secret returns 200 with updated metadata fields.
+func TestPatchSecret_ProjectScope_ReturnsUpdatedMetadata(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:      tid("project_patch_meta"),
+		Name:    "Patch Meta Project",
+		Slug:    "patch-meta-project",
+		OwnerID: DevUserID,
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	// Create a secret at project scope via PUT
+	createBody := SetSecretRequest{
+		Value:         base64.StdEncoding.EncodeToString([]byte("project-secret-value")),
+		Description:   "Original project description",
+		InjectionMode: "as_needed",
+		Type:          "environment",
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/projects/"+project.ID+"/secrets/PROJ_PATCH_KEY", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH to update description and injection mode
+	newDesc := "Updated project description"
+	patchBody := PatchSecretRequest{
+		Description:   &newDesc,
+		InjectionMode: "always",
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/projects/"+project.ID+"/secrets/PROJ_PATCH_KEY", patchBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var result store.Secret
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result.Description != "Updated project description" {
+		t.Errorf("expected description %q, got %q", "Updated project description", result.Description)
+	}
+	if result.InjectionMode != "always" {
+		t.Errorf("expected injectionMode %q, got %q", "always", result.InjectionMode)
+	}
+	if result.Version < 2 {
+		t.Errorf("expected version >= 2 after PATCH, got %d", result.Version)
+	}
+}
+
+// TestPatchSecret_ProjectScope_AllowProgenyRejected verifies that PATCH with
+// allowProgeny=true at project scope returns 422.
+func TestPatchSecret_ProjectScope_AllowProgenyRejected(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:      tid("project_patch_progeny"),
+		Name:    "Patch Progeny Project",
+		Slug:    "patch-progeny-project",
+		OwnerID: DevUserID,
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	// Create a secret at project scope
+	createBody := SetSecretRequest{
+		Value: base64.StdEncoding.EncodeToString([]byte("project-secret")),
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/projects/"+project.ID+"/secrets/PROJ_PROGENY_KEY", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH with allowProgeny=true — should be rejected
+	allowProgeny := true
+	patchBody := PatchSecretRequest{
+		AllowProgeny: &allowProgeny,
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/projects/"+project.ID+"/secrets/PROJ_PROGENY_KEY", patchBody)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("PATCH with allowProgeny at project scope: expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestPatchSecret_BrokerScope_ReturnsUpdatedMetadata verifies that PATCH on a
+// broker-scoped secret returns 200 with updated metadata fields.
+func TestPatchSecret_BrokerScope_ReturnsUpdatedMetadata(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	broker := &store.RuntimeBroker{
+		ID:      tid("broker_patch_meta"),
+		Name:    "Patch Meta Broker",
+		Slug:    "patch-meta-broker",
+		Status:  store.BrokerStatusOnline,
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	if err := s.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create broker: %v", err)
+	}
+
+	// Create a secret at broker scope via PUT
+	createBody := SetSecretRequest{
+		Value:         base64.StdEncoding.EncodeToString([]byte("broker-secret-value")),
+		Description:   "Original broker description",
+		InjectionMode: "as_needed",
+		Type:          "environment",
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/runtime-brokers/"+broker.ID+"/secrets/BROKER_PATCH_KEY", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH to update description and injection mode
+	newDesc := "Updated broker description"
+	patchBody := PatchSecretRequest{
+		Description:   &newDesc,
+		InjectionMode: "always",
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/runtime-brokers/"+broker.ID+"/secrets/BROKER_PATCH_KEY", patchBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var result store.Secret
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result.Description != "Updated broker description" {
+		t.Errorf("expected description %q, got %q", "Updated broker description", result.Description)
+	}
+	if result.InjectionMode != "always" {
+		t.Errorf("expected injectionMode %q, got %q", "always", result.InjectionMode)
+	}
+	if result.Version < 2 {
+		t.Errorf("expected version >= 2 after PATCH, got %d", result.Version)
+	}
+}
+
+// TestPatchSecret_BrokerScope_AllowProgenyRejected verifies that PATCH with
+// allowProgeny=true at broker scope returns 422.
+func TestPatchSecret_BrokerScope_AllowProgenyRejected(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	broker := &store.RuntimeBroker{
+		ID:      tid("broker_patch_progeny"),
+		Name:    "Patch Progeny Broker",
+		Slug:    "patch-progeny-broker",
+		Status:  store.BrokerStatusOnline,
+		Created: time.Now(),
+		Updated: time.Now(),
+	}
+	if err := s.CreateRuntimeBroker(ctx, broker); err != nil {
+		t.Fatalf("failed to create broker: %v", err)
+	}
+
+	// Create a secret at broker scope
+	createBody := SetSecretRequest{
+		Value: base64.StdEncoding.EncodeToString([]byte("broker-secret")),
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/runtime-brokers/"+broker.ID+"/secrets/BROKER_PROGENY_KEY", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH with allowProgeny=true — should be rejected
+	allowProgeny := true
+	patchBody := PatchSecretRequest{
+		AllowProgeny: &allowProgeny,
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/runtime-brokers/"+broker.ID+"/secrets/BROKER_PROGENY_KEY", patchBody)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("PATCH with allowProgeny at broker scope: expected 422, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/pkg/hub/handlers_integrations_activate_secrets_test.go
+++ b/pkg/hub/handlers_integrations_activate_secrets_test.go
@@ -67,6 +67,10 @@ func (m *migrationSecretBackend) GetMeta(_ context.Context, name, _, _ string) (
 	return &secret.SecretMeta{Name: name}, nil
 }
 
+func (m *migrationSecretBackend) UpdateMeta(_ context.Context, _ *secret.UpdateMetaInput) (*secret.SecretMeta, error) {
+	return nil, nil
+}
+
 func (m *migrationSecretBackend) Resolve(context.Context, string, string, string, *secret.ResolveOpts) ([]secret.SecretWithValue, error) {
 	return nil, nil
 }

--- a/pkg/hub/handlers_secret_patch_test.go
+++ b/pkg/hub/handlers_secret_patch_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+// Package hub – tests for PATCH /api/v1/secrets/{key} (metadata-only updates).
+//
+// Contract under test:
+//   - PATCH returns 200 with updated metadata
+//   - PATCH does not modify the stored secret value
+//   - PATCH on nonexistent secret returns 404
+//   - PATCH with invalid type returns 422
+
+package hub
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/secret"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// TestPatchSecret_ReturnsUpdatedMetadata verifies PATCH returns 200 with
+// the updated metadata fields.
+func TestPatchSecret_ReturnsUpdatedMetadata(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
+	srv.SetSecretBackend(localBackend)
+
+	// Create a secret first via PUT
+	createBody := SetSecretRequest{
+		Value:         base64.StdEncoding.EncodeToString([]byte("my-secret-value")),
+		Description:   "Original description",
+		InjectionMode: "as_needed",
+		Type:          "environment",
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/PATCH_TEST_KEY", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH to update description and injection mode
+	newDesc := "Updated description"
+	patchBody := PatchSecretRequest{
+		Description:   &newDesc,
+		InjectionMode: "always",
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/secrets/PATCH_TEST_KEY", patchBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var result store.Secret
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if result.Description != "Updated description" {
+		t.Errorf("expected description %q, got %q", "Updated description", result.Description)
+	}
+	if result.InjectionMode != "always" {
+		t.Errorf("expected injectionMode %q, got %q", "always", result.InjectionMode)
+	}
+	if result.Version < 2 {
+		t.Errorf("expected version >= 2 after PATCH, got %d", result.Version)
+	}
+}
+
+// TestPatchSecret_ValueUnchanged verifies that PATCH does not modify the stored
+// secret value — a subsequent GET/read should return the original.
+func TestPatchSecret_ValueUnchanged(t *testing.T) {
+	srv, s := testServer(t)
+	localBackend := secret.NewLocalBackend(s, "test-hub-id", "test-secret")
+	srv.SetSecretBackend(localBackend)
+	ctx := context.Background()
+
+	// Create a secret
+	originalValue := "super-secret-value"
+	createBody := SetSecretRequest{
+		Value: base64.StdEncoding.EncodeToString([]byte(originalValue)),
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/VALUE_CHECK_KEY", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH to update description
+	desc := "New description"
+	patchBody := PatchSecretRequest{
+		Description: &desc,
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/secrets/VALUE_CHECK_KEY", patchBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PATCH expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Read the secret value to verify it's unchanged
+	sv, err := localBackend.Get(ctx, "VALUE_CHECK_KEY", store.ScopeUser, DevUserID)
+	if err != nil {
+		t.Fatalf("Get after PATCH failed: %v", err)
+	}
+	if sv.Value != originalValue {
+		t.Errorf("expected value %q unchanged after PATCH, got %q", originalValue, sv.Value)
+	}
+}
+
+// TestPatchSecret_NotFound verifies that PATCH returns 404 for a nonexistent secret.
+func TestPatchSecret_NotFound(t *testing.T) {
+	srv, s := testServer(t)
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
+
+	desc := "test"
+	patchBody := PatchSecretRequest{
+		Description: &desc,
+	}
+	rec := doRequest(t, srv, http.MethodPatch, "/api/v1/secrets/NONEXISTENT_KEY", patchBody)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("PATCH on nonexistent secret: expected 404, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestPatchSecret_InvalidType verifies that PATCH returns 400 for an invalid type.
+func TestPatchSecret_InvalidType(t *testing.T) {
+	srv, s := testServer(t)
+	srv.SetSecretBackend(secret.NewLocalBackend(s, "test-hub-id", "test-secret"))
+
+	// Create a secret first
+	createBody := SetSecretRequest{
+		Value: base64.StdEncoding.EncodeToString([]byte("value")),
+	}
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/secrets/TYPE_CHECK_KEY", createBody)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT (create) expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// PATCH with invalid type
+	patchBody := PatchSecretRequest{
+		Type: "invalid_type",
+	}
+	rec = doRequest(t, srv, http.MethodPatch, "/api/v1/secrets/TYPE_CHECK_KEY", patchBody)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("PATCH with invalid type: expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/pkg/hub/httpdispatcher_noauth_github_token_test.go
+++ b/pkg/hub/httpdispatcher_noauth_github_token_test.go
@@ -74,6 +74,10 @@ func (m *mockGitTokenSecretBackend) GetMeta(_ context.Context, _, _, _ string) (
 	return nil, nil
 }
 
+func (m *mockGitTokenSecretBackend) UpdateMeta(_ context.Context, _ *secret.UpdateMetaInput) (*secret.SecretMeta, error) {
+	return nil, nil
+}
+
 func (m *mockGitTokenSecretBackend) Resolve(_ context.Context, _, _, _ string, _ *secret.ResolveOpts) ([]secret.SecretWithValue, error) {
 	return m.secrets, nil
 }

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -3461,6 +3461,9 @@ func (m *mockSecretBackend) List(ctx context.Context, filter secret.Filter) ([]s
 func (m *mockSecretBackend) GetMeta(ctx context.Context, name, scope, scopeID string) (*secret.SecretMeta, error) {
 	return nil, nil
 }
+func (m *mockSecretBackend) UpdateMeta(ctx context.Context, input *secret.UpdateMetaInput) (*secret.SecretMeta, error) {
+	return nil, nil
+}
 func (m *mockSecretBackend) Resolve(ctx context.Context, userID, projectID, brokerID string, opts *secret.ResolveOpts) ([]secret.SecretWithValue, error) {
 	return m.secrets, nil
 }

--- a/pkg/hub/oidckeys_test.go
+++ b/pkg/hub/oidckeys_test.go
@@ -90,6 +90,10 @@ func (m *oidcMockSecretBackend) GetMeta(_ context.Context, _, _, _ string) (*sec
 	return nil, nil
 }
 
+func (m *oidcMockSecretBackend) UpdateMeta(_ context.Context, _ *secret.UpdateMetaInput) (*secret.SecretMeta, error) {
+	return nil, nil
+}
+
 func (m *oidcMockSecretBackend) Resolve(_ context.Context, _, _, _ string, _ *secret.ResolveOpts) ([]secret.SecretWithValue, error) {
 	return nil, nil
 }

--- a/pkg/hubclient/secrets.go
+++ b/pkg/hubclient/secrets.go
@@ -113,13 +113,13 @@ type AgentSetSecretResponse struct {
 // UpdateSecretMetaRequest is the request for metadata-only secret updates (PATCH).
 // Only non-null/non-empty fields are applied. The secret value is never modified.
 type UpdateSecretMetaRequest struct {
-	Description   *string `json:"description,omitempty"`    // null = no change, "" = clear
-	InjectionMode string  `json:"injectionMode,omitempty"`  // "" = no change
-	Type          string  `json:"type,omitempty"`            // "" = no change
-	Target        string  `json:"target,omitempty"`          // "" = no change
-	AllowProgeny  *bool   `json:"allowProgeny,omitempty"`    // null = no change
-	Scope         string  `json:"scope,omitempty"`           // Scope type (default: user)
-	ScopeID       string  `json:"scopeId,omitempty"`         // Required for project/runtime_broker scope
+	Description   *string `json:"description,omitempty"`   // null = no change, "" = clear
+	InjectionMode string  `json:"injectionMode,omitempty"` // "" = no change
+	Type          string  `json:"type,omitempty"`          // "" = no change
+	Target        string  `json:"target,omitempty"`        // "" = no change
+	AllowProgeny  *bool   `json:"allowProgeny,omitempty"`  // null = no change
+	Scope         string  `json:"scope,omitempty"`         // Scope type (default: user)
+	ScopeID       string  `json:"scopeId,omitempty"`       // Required for project/runtime_broker scope
 }
 
 // List returns secret metadata for the specified scope.

--- a/pkg/hubclient/secrets.go
+++ b/pkg/hubclient/secrets.go
@@ -40,6 +40,10 @@ type SecretService interface {
 	// agent's token. Use this instead of Set when running as an agent.
 	AgentSet(ctx context.Context, agentID, key string, req *AgentSetSecretRequest) (*AgentSetSecretResponse, error)
 
+	// UpdateMeta updates only the metadata of an existing secret (PATCH).
+	// The secret value is not modified.
+	UpdateMeta(ctx context.Context, key string, req *UpdateSecretMetaRequest) (*Secret, error)
+
 	// Delete removes a secret.
 	Delete(ctx context.Context, key string, opts *SecretScopeOptions) error
 }
@@ -104,6 +108,18 @@ type AgentSetSecretResponse struct {
 	Scope   string `json:"scope"`
 	ScopeID string `json:"scopeId,omitempty"`
 	Created bool   // Derived from HTTP status code (201 = created, 204 = updated)
+}
+
+// UpdateSecretMetaRequest is the request for metadata-only secret updates (PATCH).
+// Only non-null/non-empty fields are applied. The secret value is never modified.
+type UpdateSecretMetaRequest struct {
+	Description   *string `json:"description,omitempty"`    // null = no change, "" = clear
+	InjectionMode string  `json:"injectionMode,omitempty"`  // "" = no change
+	Type          string  `json:"type,omitempty"`            // "" = no change
+	Target        string  `json:"target,omitempty"`          // "" = no change
+	AllowProgeny  *bool   `json:"allowProgeny,omitempty"`    // null = no change
+	Scope         string  `json:"scope,omitempty"`           // Scope type (default: user)
+	ScopeID       string  `json:"scopeId,omitempty"`         // Required for project/runtime_broker scope
 }
 
 // List returns secret metadata for the specified scope.
@@ -178,6 +194,28 @@ func (s *secretService) AgentSet(ctx context.Context, agentID, key string, req *
 	}
 	result.Created = true
 	return result, nil
+}
+
+// UpdateMeta updates only the metadata of an existing secret (PATCH).
+func (s *secretService) UpdateMeta(ctx context.Context, key string, req *UpdateSecretMetaRequest) (*Secret, error) {
+	query := url.Values{}
+	if req.Scope != "" {
+		query.Set("scope", req.Scope)
+	}
+	if req.ScopeID != "" {
+		query.Set("scopeId", req.ScopeID)
+	}
+
+	path := "/api/v1/secrets/" + url.PathEscape(key)
+	if len(query) > 0 {
+		path += "?" + query.Encode()
+	}
+
+	resp, err := s.c.patch(ctx, path, req, nil)
+	if err != nil {
+		return nil, err
+	}
+	return apiclient.DecodeResponse[Secret](resp)
 }
 
 // Delete removes a secret.

--- a/pkg/secret/gcpbackend.go
+++ b/pkg/secret/gcpbackend.go
@@ -228,6 +228,24 @@ func (b *GCPBackend) Set(ctx context.Context, input *SetSecretInput) (bool, *Sec
 	return created, meta, nil
 }
 
+func (b *GCPBackend) UpdateMeta(ctx context.Context, input *UpdateMetaInput) (*SecretMeta, error) {
+	// Metadata-only update: only modify the Hub DB record.
+	// Do NOT create a new GCP SM version — the secret value is unchanged.
+	meta := &store.SecretMetaUpdate{
+		Description:   input.Description,
+		InjectionMode: input.InjectionMode,
+		SecretType:    input.SecretType,
+		Target:        input.Target,
+		AllowProgeny:  input.AllowProgeny,
+		UpdatedBy:     input.UpdatedBy,
+	}
+	updated, err := b.store.UpdateSecretMeta(ctx, input.Name, input.Scope, input.ScopeID, meta)
+	if err != nil {
+		return nil, err
+	}
+	return fromStoreSecretMeta(updated), nil
+}
+
 func (b *GCPBackend) Delete(ctx context.Context, name, scope, scopeID string) error {
 	smName := b.gcpSecretName(name, scope, scopeID)
 	fullName := fmt.Sprintf("projects/%s/secrets/%s", b.projectID, smName)

--- a/pkg/secret/localbackend.go
+++ b/pkg/secret/localbackend.go
@@ -87,6 +87,22 @@ func (b *LocalBackend) Set(ctx context.Context, input *SetSecretInput) (bool, *S
 	return created, fromStoreSecretMeta(stored), nil
 }
 
+func (b *LocalBackend) UpdateMeta(ctx context.Context, input *UpdateMetaInput) (*SecretMeta, error) {
+	meta := &store.SecretMetaUpdate{
+		Description:   input.Description,
+		InjectionMode: input.InjectionMode,
+		SecretType:    input.SecretType,
+		Target:        input.Target,
+		AllowProgeny:  input.AllowProgeny,
+		UpdatedBy:     input.UpdatedBy,
+	}
+	updated, err := b.store.UpdateSecretMeta(ctx, input.Name, input.Scope, input.ScopeID, meta)
+	if err != nil {
+		return nil, err
+	}
+	return fromStoreSecretMeta(updated), nil
+}
+
 func (b *LocalBackend) Delete(ctx context.Context, name, scope, scopeID string) error {
 	return b.store.DeleteSecret(ctx, name, scope, scopeID)
 }

--- a/pkg/secret/localbackend_test.go
+++ b/pkg/secret/localbackend_test.go
@@ -1287,3 +1287,169 @@ func TestLocalBackend_DecryptRawValue_NilKeyPlaintextValue(t *testing.T) {
 		t.Errorf("expected %q, got %q", "plain-legacy-value", value)
 	}
 }
+
+// =============================================================================
+// UpdateMeta tests
+// =============================================================================
+
+func TestLocalBackend_UpdateMeta(t *testing.T) {
+	backend, _ := createTestBackend(t)
+	ctx := context.Background()
+
+	// Create a secret first
+	_, _, err := backend.Set(ctx, &SetSecretInput{
+		Name:          "META_SECRET",
+		Value:         "original-value",
+		SecretType:    TypeEnvironment,
+		Scope:         ScopeUser,
+		ScopeID:       "user-1",
+		Description:   "Original description",
+		InjectionMode: "as_needed",
+		CreatedBy:     "user-1",
+		UpdatedBy:     "user-1",
+	})
+	if err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	// Update description only
+	newDesc := "Updated description"
+	meta, err := backend.UpdateMeta(ctx, &UpdateMetaInput{
+		Name:        "META_SECRET",
+		Scope:       ScopeUser,
+		ScopeID:     "user-1",
+		Description: &newDesc,
+		UpdatedBy:   "user-1",
+	})
+	if err != nil {
+		t.Fatalf("UpdateMeta failed: %v", err)
+	}
+	if meta.Description != "Updated description" {
+		t.Errorf("expected description %q, got %q", "Updated description", meta.Description)
+	}
+
+	// Verify the secret value is unchanged
+	sv, err := backend.Get(ctx, "META_SECRET", ScopeUser, "user-1")
+	if err != nil {
+		t.Fatalf("Get after UpdateMeta failed: %v", err)
+	}
+	if sv.Value != "original-value" {
+		t.Errorf("expected value to be unchanged %q, got %q", "original-value", sv.Value)
+	}
+}
+
+func TestLocalBackend_UpdateMeta_NotFound(t *testing.T) {
+	backend, _ := createTestBackend(t)
+	ctx := context.Background()
+
+	newDesc := "test"
+	_, err := backend.UpdateMeta(ctx, &UpdateMetaInput{
+		Name:        "NONEXISTENT",
+		Scope:       ScopeUser,
+		ScopeID:     "user-1",
+		Description: &newDesc,
+	})
+	if err != store.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestLocalBackend_UpdateMeta_VersionIncrement(t *testing.T) {
+	backend, _ := createTestBackend(t)
+	ctx := context.Background()
+
+	// Create a secret
+	_, meta1, err := backend.Set(ctx, &SetSecretInput{
+		Name:       "VERSION_META",
+		Value:      "value",
+		SecretType: TypeEnvironment,
+		Scope:      ScopeUser,
+		ScopeID:    "user-1",
+	})
+	if err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	// Update metadata
+	newDesc := "Updated"
+	meta2, err := backend.UpdateMeta(ctx, &UpdateMetaInput{
+		Name:        "VERSION_META",
+		Scope:       ScopeUser,
+		ScopeID:     "user-1",
+		Description: &newDesc,
+	})
+	if err != nil {
+		t.Fatalf("UpdateMeta failed: %v", err)
+	}
+	if meta2.Version <= meta1.Version {
+		t.Errorf("expected version to increment: v1=%d, v2=%d", meta1.Version, meta2.Version)
+	}
+}
+
+func TestLocalBackend_UpdateMeta_PartialFields(t *testing.T) {
+	backend, _ := createTestBackend(t)
+	ctx := context.Background()
+
+	// Create a secret with multiple metadata fields
+	_, _, err := backend.Set(ctx, &SetSecretInput{
+		Name:          "PARTIAL_META",
+		Value:         "secret-value",
+		SecretType:    TypeEnvironment,
+		Scope:         ScopeUser,
+		ScopeID:       "user-1",
+		Description:   "Original",
+		InjectionMode: "as_needed",
+		AllowProgeny:  false,
+	})
+	if err != nil {
+		t.Fatalf("Set failed: %v", err)
+	}
+
+	// Update only injection mode — description and AllowProgeny should remain unchanged
+	meta, err := backend.UpdateMeta(ctx, &UpdateMetaInput{
+		Name:          "PARTIAL_META",
+		Scope:         ScopeUser,
+		ScopeID:       "user-1",
+		InjectionMode: "always",
+	})
+	if err != nil {
+		t.Fatalf("UpdateMeta failed: %v", err)
+	}
+
+	if meta.InjectionMode != "always" {
+		t.Errorf("expected injectionMode %q, got %q", "always", meta.InjectionMode)
+	}
+	if meta.Description != "Original" {
+		t.Errorf("expected description to remain %q, got %q", "Original", meta.Description)
+	}
+	if meta.AllowProgeny != false {
+		t.Errorf("expected allowProgeny to remain false, got %v", meta.AllowProgeny)
+	}
+
+	// Now update AllowProgeny only
+	allowTrue := true
+	meta2, err := backend.UpdateMeta(ctx, &UpdateMetaInput{
+		Name:         "PARTIAL_META",
+		Scope:        ScopeUser,
+		ScopeID:      "user-1",
+		AllowProgeny: &allowTrue,
+	})
+	if err != nil {
+		t.Fatalf("UpdateMeta (progeny) failed: %v", err)
+	}
+	if !meta2.AllowProgeny {
+		t.Error("expected allowProgeny to be true after update")
+	}
+	if meta2.InjectionMode != "always" {
+		t.Errorf("expected injectionMode to remain %q, got %q", "always", meta2.InjectionMode)
+	}
+
+	// Verify value is still intact
+	sv, err := backend.Get(ctx, "PARTIAL_META", ScopeUser, "user-1")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if sv.Value != "secret-value" {
+		t.Errorf("expected value unchanged %q, got %q", "secret-value", sv.Value)
+	}
+}

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -94,6 +94,20 @@ type SecretWithValue struct {
 	Value string `json:"-"` // Never serialized
 }
 
+// UpdateMetaInput contains fields for a metadata-only secret update.
+// Only non-zero fields are updated. The secret value is never touched.
+type UpdateMetaInput struct {
+	Name          string
+	Scope         string
+	ScopeID       string
+	Description   *string // pointer to distinguish "" (clear) from nil (no change)
+	InjectionMode string  // "" means no change
+	SecretType    string  // "" means no change
+	Target        string  // "" means no change
+	AllowProgeny  *bool   // pointer to distinguish false from nil
+	UpdatedBy     string
+}
+
 // SetSecretInput provides the data needed to create or update a secret.
 type SetSecretInput struct {
 	Name          string // Secret key name
@@ -140,6 +154,10 @@ type SecretBackend interface {
 
 	// GetMeta retrieves secret metadata without the value.
 	GetMeta(ctx context.Context, name, scope, scopeID string) (*SecretMeta, error)
+
+	// UpdateMeta updates only the metadata of an existing secret.
+	// The secret value is not modified. Returns ErrNotFound if the secret doesn't exist.
+	UpdateMeta(ctx context.Context, input *UpdateMetaInput) (*SecretMeta, error)
 
 	// Resolve collects and merges secrets from all applicable scopes for an agent.
 	// Scopes are resolved in order, lowest first: runtime_broker < hub < project < user.

--- a/pkg/secretmigration/secretmigration_test.go
+++ b/pkg/secretmigration/secretmigration_test.go
@@ -84,6 +84,10 @@ func (f *fakeBackend) GetMeta(context.Context, string, string, string) (*secret.
 	return nil, nil
 }
 
+func (f *fakeBackend) UpdateMeta(_ context.Context, _ *secret.UpdateMetaInput) (*secret.SecretMeta, error) {
+	return nil, nil
+}
+
 func (f *fakeBackend) Resolve(context.Context, string, string, string, *secret.ResolveOpts) ([]secret.SecretWithValue, error) {
 	return nil, nil
 }

--- a/pkg/store/entadapter/secret_store.go
+++ b/pkg/store/entadapter/secret_store.go
@@ -194,6 +194,63 @@ func (s *SecretStore) UpdateSecret(ctx context.Context, secret *store.Secret) er
 	return nil
 }
 
+// UpdateSecretMeta updates only metadata columns of an existing secret without
+// touching the encrypted value. The version is incremented automatically.
+func (s *SecretStore) UpdateSecretMeta(ctx context.Context, key, scope, scopeID string, meta *store.SecretMetaUpdate) (*store.Secret, error) {
+	// Fetch the existing secret to validate existence and get current state.
+	existing, err := s.GetSecret(ctx, key, scope, scopeID)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	existing.Version++
+	existing.Updated = now
+
+	update := s.client.Secret.Update().
+		Where(
+			entsecret.KeyEQ(key),
+			entsecret.ScopeEQ(scope),
+			entsecret.ScopeIDEQ(scopeID),
+		).
+		SetVersion(existing.Version).
+		SetUpdated(now)
+
+	if meta.UpdatedBy != "" {
+		update.SetUpdatedBy(meta.UpdatedBy)
+		existing.UpdatedBy = meta.UpdatedBy
+	}
+	if meta.Description != nil {
+		update.SetDescription(*meta.Description)
+		existing.Description = *meta.Description
+	}
+	if meta.InjectionMode != "" {
+		update.SetInjectionMode(entsecret.InjectionMode(meta.InjectionMode))
+		existing.InjectionMode = meta.InjectionMode
+	}
+	if meta.SecretType != "" {
+		update.SetSecretType(entsecret.SecretType(meta.SecretType))
+		existing.SecretType = meta.SecretType
+	}
+	if meta.Target != "" {
+		update.SetTarget(meta.Target)
+		existing.Target = meta.Target
+	}
+	if meta.AllowProgeny != nil {
+		update.SetAllowProgeny(*meta.AllowProgeny)
+		existing.AllowProgeny = *meta.AllowProgeny
+	}
+
+	n, err := update.Save(ctx)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	if n == 0 {
+		return nil, store.ErrNotFound
+	}
+	return existing, nil
+}
+
 // UpsertSecret creates or updates a secret, keyed by (key, scope, scopeID).
 func (s *SecretStore) UpsertSecret(ctx context.Context, secret *store.Secret) (bool, error) {
 	now := time.Now()

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -1153,6 +1153,17 @@ type Secret struct {
 	UpdatedBy string `json:"updatedBy,omitempty"`
 }
 
+// SecretMetaUpdate contains fields for a metadata-only secret update.
+// Only non-zero fields are applied. The encrypted value is never modified.
+type SecretMetaUpdate struct {
+	Description   *string // pointer: nil = no change, "" = clear
+	InjectionMode string  // "" = no change
+	SecretType    string  // "" = no change
+	Target        string  // "" = no change
+	AllowProgeny  *bool   // pointer: nil = no change
+	UpdatedBy     string
+}
+
 // SecretType constants define how a secret is projected into the agent container.
 const (
 	SecretTypeEnvironment = "environment" // Injected as environment variable (default)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -745,6 +745,11 @@ type SecretStore interface {
 	// Returns ErrNotFound if the secret doesn't exist.
 	GetSecretValue(ctx context.Context, key, scope, scopeID string) (encryptedValue string, err error)
 
+	// UpdateSecretMeta updates metadata fields of an existing secret without
+	// modifying the encrypted value. Increments the version automatically.
+	// Returns the updated secret. Returns ErrNotFound if the secret doesn't exist.
+	UpdateSecretMeta(ctx context.Context, key, scope, scopeID string, meta *SecretMetaUpdate) (*Secret, error)
+
 	// ListProgenySecrets returns user-scoped secrets with allowProgeny=true
 	// whose createdBy is in the given set of ancestor IDs.
 	// Note: EncryptedValue is NOT populated in the returned secrets.

--- a/web/src/components/shared/secret-list.ts
+++ b/web/src/components/shared/secret-list.ts
@@ -46,7 +46,7 @@ export class ScionSecretList extends LitElement {
 
   // Create/Update dialog
   @state() private dialogOpen = false;
-  @state() private dialogMode: 'create' | 'update' = 'create';
+  @state() private dialogMode: 'create' | 'update' | 'edit-settings' = 'create';
   @state() private dialogKey = '';
   @state() private dialogValue = '';
   @state() private dialogDescription = '';
@@ -130,6 +130,19 @@ export class ScionSecretList extends LitElement {
     this.dialogOpen = true;
   }
 
+  private openEditSettingsDialog(secret: Secret): void {
+    this.dialogMode = 'edit-settings';
+    this.dialogKey = secret.key;
+    this.dialogValue = '';
+    this.dialogDescription = secret.description || '';
+    this.dialogType = secret.type;
+    this.dialogTarget = secret.target || '';
+    this.dialogInjectionMode = secret.injectionMode || 'as_needed';
+    this.dialogAllowProgeny = secret.allowProgeny || false;
+    this.dialogError = null;
+    this.dialogOpen = true;
+  }
+
   private closeDialog(): void {
     this.dialogOpen = false;
   }
@@ -143,7 +156,9 @@ export class ScionSecretList extends LitElement {
       return;
     }
 
-    if (!this.dialogValue) {
+    const isEditSettings = this.dialogMode === 'edit-settings';
+
+    if (!isEditSettings && !this.dialogValue) {
       this.dialogError = 'Value is required';
       return;
     }
@@ -152,26 +167,48 @@ export class ScionSecretList extends LitElement {
     this.dialogError = null;
 
     try {
-      const body: Record<string, unknown> = {
-        value: btoa(
-          Array.from(new TextEncoder().encode(this.dialogValue), (b) =>
-            String.fromCharCode(b)
-          ).join('')
-        ),
-        scope: this.scope,
-        description: this.dialogDescription || undefined,
-        type: this.dialogType,
-        target: this.dialogTarget || undefined,
-        injectionMode: this.dialogInjectionMode,
-        allowProgeny: this.scope === 'user' ? this.dialogAllowProgeny : undefined,
-      };
+      let body: Record<string, unknown>;
+      let method: string;
+
+      if (isEditSettings) {
+        // PATCH: metadata-only update, no value
+        body = {
+          description: this.dialogDescription,
+          type: this.dialogType,
+          target: this.dialogTarget || undefined,
+          injectionMode: this.dialogInjectionMode,
+          allowProgeny: this.scope === 'user' ? this.dialogAllowProgeny : undefined,
+        };
+        method = 'PATCH';
+      } else {
+        // PUT: full update including value
+        body = {
+          value: btoa(
+            Array.from(new TextEncoder().encode(this.dialogValue), (b) =>
+              String.fromCharCode(b)
+            ).join('')
+          ),
+          scope: this.scope,
+          description: this.dialogDescription || undefined,
+          type: this.dialogType,
+          target: this.dialogTarget || undefined,
+          injectionMode: this.dialogInjectionMode,
+          allowProgeny: this.scope === 'user' ? this.dialogAllowProgeny : undefined,
+        };
+        method = 'PUT';
+      }
 
       if (this.scope === 'project') {
         body.scopeId = this.scopeId;
       }
 
-      const response = await apiFetch(`${this.apiBasePath}/secrets/${encodeURIComponent(key)}`, {
-        method: 'PUT',
+      const url =
+        isEditSettings && this.scope !== 'project'
+          ? `${this.apiBasePath}/secrets/${encodeURIComponent(key)}?scope=${this.scope}`
+          : `${this.apiBasePath}/secrets/${encodeURIComponent(key)}`;
+
+      const response = await apiFetch(url, {
+        method,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       });
@@ -417,6 +454,12 @@ export class ScionSecretList extends LitElement {
         </td>
         <td class="actions-cell">
           <sl-icon-button
+            name="pencil"
+            label="Edit settings"
+            ?disabled=${isDeleting}
+            @click=${() => this.openEditSettingsDialog(secret)}
+          ></sl-icon-button>
+          <sl-icon-button
             name="arrow-clockwise"
             label="Update value"
             ?disabled=${isDeleting}
@@ -456,7 +499,12 @@ export class ScionSecretList extends LitElement {
 
   private renderDialog() {
     const isCreate = this.dialogMode === 'create';
-    const title = isCreate ? 'Add Secret' : 'Update Secret';
+    const isEditSettings = this.dialogMode === 'edit-settings';
+    const title = isEditSettings
+      ? 'Edit Secret Settings'
+      : isCreate
+        ? 'Add Secret'
+        : 'Update Secret';
 
     return html`
       <sl-dialog label=${title} ?open=${this.dialogOpen} @sl-request-close=${this.closeDialog}>
@@ -472,38 +520,42 @@ export class ScionSecretList extends LitElement {
             required
           ></sl-input>
 
-          ${this.dialogType === 'file'
-            ? html`
-                <sl-textarea
-                  class="secret-value"
-                  label="Value"
-                  placeholder="Paste file contents (e.g. private key)"
-                  value=${this.dialogValue}
-                  rows="6"
-                  resize="vertical"
-                  @sl-input=${(e: Event) => {
-                    this.dialogValue = (e.target as HTMLTextAreaElement).value;
-                  }}
-                  required
-                ></sl-textarea>
-              `
-            : html`
-                <sl-input
-                  label="Value"
-                  placeholder="Secret value"
-                  value=${this.dialogValue}
-                  type="password"
-                  @sl-input=${(e: Event) => {
-                    this.dialogValue = (e.target as HTMLInputElement).value;
-                  }}
-                  required
-                ></sl-input>
-              `}
+          ${isEditSettings
+            ? nothing
+            : this.dialogType === 'file'
+              ? html`
+                  <sl-textarea
+                    class="secret-value"
+                    label="Value"
+                    placeholder="Paste file contents (e.g. private key)"
+                    value=${this.dialogValue}
+                    rows="6"
+                    resize="vertical"
+                    @sl-input=${(e: Event) => {
+                      this.dialogValue = (e.target as HTMLTextAreaElement).value;
+                    }}
+                    required
+                  ></sl-textarea>
+                `
+              : html`
+                  <sl-input
+                    label="Value"
+                    placeholder="Secret value"
+                    value=${this.dialogValue}
+                    type="password"
+                    @sl-input=${(e: Event) => {
+                      this.dialogValue = (e.target as HTMLInputElement).value;
+                    }}
+                    required
+                  ></sl-input>
+                `}
 
-          <div class="dialog-hint">
-            <sl-icon name="info-circle"></sl-icon>
-            Secret values are encrypted and can never be retrieved after saving.
-          </div>
+          ${isEditSettings
+            ? nothing
+            : html`<div class="dialog-hint">
+                <sl-icon name="info-circle"></sl-icon>
+                Secret values are encrypted and can never be retrieved after saving.
+              </div>`}
 
           <sl-select
             label="Type"
@@ -591,7 +643,7 @@ export class ScionSecretList extends LitElement {
           ?disabled=${this.dialogLoading}
           @click=${this.handleSave}
         >
-          ${isCreate ? 'Create' : 'Update'}
+          ${isCreate ? 'Create' : isEditSettings ? 'Save' : 'Update'}
         </sl-button>
       </sl-dialog>
     `;


### PR DESCRIPTION
Fixes #1258 - secret metadata-only updates

- Add PATCH method to secrets API for updating metadata without value
- New UpdateMeta backend method (local + GCP) - no new SM version
- CLI scion hub secret update subcommand
- Web UI edit-settings dialog
- Security: scope validation, injectionMode validation, file target path traversal protection
- PR #1259, CI green, R4 reviewer APPROVE