### PR TITLE
fix: skip env-gather when noAuth is true

### DIFF
--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -487,7 +487,7 @@ func (s *Server) createAgent(w http.ResponseWriter, r *http.Request) {
 
 	// Env-gather: if GatherEnv is true, evaluate env completeness before building full context.
 	// This needs the resolved project path and merged env to determine which keys are missing.
-	if req.GatherEnv {
+	if req.GatherEnv && !req.NoAuth {
 		// Build a preliminary merged env for env-gather evaluation
 		env := make(map[string]string)
 		for k, v := range req.ResolvedEnv {

--- a/pkg/runtimebroker/handlers_envgather_test.go
+++ b/pkg/runtimebroker/handlers_envgather_test.go
@@ -752,7 +752,7 @@ profiles:
 		"id": "agent-uuid-noauth",
 		"gatherEnv": true,
 		"noAuth": true,
-		"grovePath": "` + projectDir + `",
+		"projectPath": "` + projectDir + `",
 		"config": {"template": "claude", "profile": "default"}
 	}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(body))

--- a/pkg/runtimebroker/handlers_envgather_test.go
+++ b/pkg/runtimebroker/handlers_envgather_test.go
@@ -730,6 +730,51 @@ profiles:
 	}
 }
 
+// TestEnvGather_NoAuthSkipsEnvGather tests that env-gather is skipped when
+// NoAuth is true, even when GatherEnv is also true. When NoAuth is set, the hub
+// intentionally strips credentials, so the broker must not report them as missing.
+func TestEnvGather_NoAuthSkipsEnvGather(t *testing.T) {
+	settings := `
+schema_version: "1"
+harness_configs:
+  claude:
+    harness: claude
+    env:
+      ANTHROPIC_API_KEY: ""
+profiles:
+  default:
+    runtime: mock
+`
+	srv, mgr, projectDir := newTestServerWithProjectPath(t, settings)
+
+	body := `{
+		"name": "test-agent-noauth",
+		"id": "agent-uuid-noauth",
+		"gatherEnv": true,
+		"noAuth": true,
+		"grovePath": "` + projectDir + `",
+		"config": {"template": "claude", "profile": "default"}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(w, req)
+
+	// Should create the agent normally (201), NOT return 202 with env requirements.
+	if w.Code == http.StatusAccepted {
+		t.Fatalf("expected env-gather to be skipped for noAuth, but got 202: %s", w.Body.String())
+	}
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Agent was started (env gather skipped)
+	if mgr.lastEnv == nil {
+		t.Fatal("expected env to be set")
+	}
+}
+
 // TestEnvGather_SecretAutoUpgrade tests that when all required env keys are
 // satisfied by resolved secrets, the env-gather check passes through without
 // returning 202. The agent proceeds to creation (which may fail for other


### PR DESCRIPTION
Fixes #1275 - noAuth agent create failure

- Guard broker env-gather block with !req.NoAuth
- PR #1278, CI green, reviewer APPROVE