### PR TITLE
fix: auth preflight recognizes passthrough GCP identity mode

### DIFF
--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -39,6 +39,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	scionrt "github.com/GoogleCloudPlatform/scion/pkg/runtime"
 	"github.com/GoogleCloudPlatform/scion/pkg/storage"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/templatecache"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -2178,7 +2179,7 @@ func (s *Server) extractRequiredEnvKeys(req CreateAgentRequest, hydratedHarnessC
 		// Both "assign" (broker-managed SA) and "passthrough" (ambient GCE
 		// metadata) provide credentials, so either satisfies GCP auth needs.
 		gcpSAAssigned := req.Config != nil && req.Config.GCPIdentity != nil &&
-			(req.Config.GCPIdentity.MetadataMode == "assign" || req.Config.GCPIdentity.MetadataMode == "passthrough")
+			(req.Config.GCPIdentity.MetadataMode == store.GCPMetadataModeAssign || req.Config.GCPIdentity.MetadataMode == store.GCPMetadataModePassthrough)
 
 		// When auth type is unset (auto-detect), check if resolved file secrets
 		// or a GCP service account can satisfy an alternative auth method before

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -2174,9 +2174,11 @@ func (s *Server) extractRequiredEnvKeys(req CreateAgentRequest, hydratedHarnessC
 			authType = req.Config.HarnessAuth
 		}
 
-		// Determine if a GCP service account is assigned via identity config.
+		// Determine if GCP credentials are available via identity config.
+		// Both "assign" (broker-managed SA) and "passthrough" (ambient GCE
+		// metadata) provide credentials, so either satisfies GCP auth needs.
 		gcpSAAssigned := req.Config != nil && req.Config.GCPIdentity != nil &&
-			req.Config.GCPIdentity.MetadataMode == "assign"
+			(req.Config.GCPIdentity.MetadataMode == "assign" || req.Config.GCPIdentity.MetadataMode == "passthrough")
 
 		// When auth type is unset (auto-detect), check if resolved file secrets
 		// or a GCP service account can satisfy an alternative auth method before

--- a/pkg/runtimebroker/handlers_envgather_test.go
+++ b/pkg/runtimebroker/handlers_envgather_test.go
@@ -2112,3 +2112,93 @@ profiles:
 		t.Errorf("GOOGLE_CLOUD_PROJECT should not be in Alternatives (it is satisfied)")
 	}
 }
+
+// TestEnvGather_VertexAI_PassthroughSkipsADC tests that vertex-ai auth with
+// GCPIdentity.MetadataMode=="passthrough" does not require the gcloud-adc
+// file secret. Passthrough means the agent can reach the real GCE metadata
+// server for credentials, so the ADC file is unnecessary — same as "assign".
+// Regression test for https://github.com/ptone/scion/issues/1276.
+func TestEnvGather_VertexAI_PassthroughSkipsADC(t *testing.T) {
+	srv, _, projectDir := newTestServerWithHarnessConfig(t, "claude",
+		"harness: claude\nimage: test-image\nuser: scion\nauth_selected_type: vertex-ai\n"+claudeAuthBlock,
+		`
+schema_version: "1"
+harness_configs:
+  claude:
+    harness: claude
+profiles:
+  default:
+    runtime: mock
+`)
+
+	// Provide project and region so those are satisfied, plus gcpIdentity
+	// with passthrough mode — but NO ADC file secret.
+	body := `{
+		"name": "test-agent-vertex-passthrough",
+		"id": "agent-uuid-vpt",
+		"gatherEnv": true,
+		"grovePath": "` + projectDir + `",
+		"resolvedEnv": {
+			"GOOGLE_CLOUD_PROJECT": "my-project",
+			"GOOGLE_CLOUD_REGION": "us-central1"
+		},
+		"config": {
+			"template": "claude",
+			"profile": "default",
+			"gcpIdentity": {"metadata_mode": "passthrough"}
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(w, req)
+
+	// With passthrough, ADC file is not needed → 201 (all auth satisfied).
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 (passthrough should skip ADC requirement), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestEnvGather_VertexAI_AssignSkipsADC tests that vertex-ai auth with
+// GCPIdentity.MetadataMode=="assign" does not require the gcloud-adc file
+// secret. This is the pre-existing behavior; the test exists as a complement
+// to TestEnvGather_VertexAI_PassthroughSkipsADC.
+func TestEnvGather_VertexAI_AssignSkipsADC(t *testing.T) {
+	srv, _, projectDir := newTestServerWithHarnessConfig(t, "claude",
+		"harness: claude\nimage: test-image\nuser: scion\nauth_selected_type: vertex-ai\n"+claudeAuthBlock,
+		`
+schema_version: "1"
+harness_configs:
+  claude:
+    harness: claude
+profiles:
+  default:
+    runtime: mock
+`)
+
+	body := `{
+		"name": "test-agent-vertex-assign",
+		"id": "agent-uuid-vas",
+		"gatherEnv": true,
+		"grovePath": "` + projectDir + `",
+		"resolvedEnv": {
+			"GOOGLE_CLOUD_PROJECT": "my-project",
+			"GOOGLE_CLOUD_REGION": "us-central1"
+		},
+		"config": {
+			"template": "claude",
+			"profile": "default",
+			"gcpIdentity": {"metadata_mode": "assign", "sa_email": "test@proj.iam.gserviceaccount.com", "project_id": "my-project"}
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 (assign should skip ADC requirement), got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/pkg/runtimebroker/handlers_envgather_test.go
+++ b/pkg/runtimebroker/handlers_envgather_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/runtime"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
 // claudeAuthBlock is the declarative auth metadata for the claude harness,
@@ -2113,61 +2114,34 @@ profiles:
 	}
 }
 
-// TestEnvGather_VertexAI_PassthroughSkipsADC tests that vertex-ai auth with
-// GCPIdentity.MetadataMode=="passthrough" does not require the gcloud-adc
-// file secret. Passthrough means the agent can reach the real GCE metadata
-// server for credentials, so the ADC file is unnecessary — same as "assign".
+// TestEnvGather_VertexAI_GCPIdentitySkipsADC tests that vertex-ai auth with
+// GCPIdentity.MetadataMode set to "assign" or "passthrough" does not require
+// the gcloud-adc file secret. Both modes provide GCP credentials (assign via
+// broker-managed SA, passthrough via ambient GCE metadata), so the ADC file
+// is unnecessary.
 // Regression test for https://github.com/ptone/scion/issues/1276.
-func TestEnvGather_VertexAI_PassthroughSkipsADC(t *testing.T) {
-	srv, _, projectDir := newTestServerWithHarnessConfig(t, "claude",
-		"harness: claude\nimage: test-image\nuser: scion\nauth_selected_type: vertex-ai\n"+claudeAuthBlock,
-		`
-schema_version: "1"
-harness_configs:
-  claude:
-    harness: claude
-profiles:
-  default:
-    runtime: mock
-`)
-
-	// Provide project and region so those are satisfied, plus gcpIdentity
-	// with passthrough mode — but NO ADC file secret.
-	body := `{
-		"name": "test-agent-vertex-passthrough",
-		"id": "agent-uuid-vpt",
-		"gatherEnv": true,
-		"grovePath": "` + projectDir + `",
-		"resolvedEnv": {
-			"GOOGLE_CLOUD_PROJECT": "my-project",
-			"GOOGLE_CLOUD_REGION": "us-central1"
+func TestEnvGather_VertexAI_GCPIdentitySkipsADC(t *testing.T) {
+	tests := []struct {
+		name            string
+		metadataMode    string
+		gcpIdentityJSON string
+	}{
+		{
+			name:            store.GCPMetadataModePassthrough,
+			metadataMode:    store.GCPMetadataModePassthrough,
+			gcpIdentityJSON: `{"metadata_mode": "passthrough"}`,
 		},
-		"config": {
-			"template": "claude",
-			"profile": "default",
-			"gcpIdentity": {"metadata_mode": "passthrough"}
-		}
-	}`
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-
-	srv.Handler().ServeHTTP(w, req)
-
-	// With passthrough, ADC file is not needed → 201 (all auth satisfied).
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201 (passthrough should skip ADC requirement), got %d: %s", w.Code, w.Body.String())
+		{
+			name:            store.GCPMetadataModeAssign,
+			metadataMode:    store.GCPMetadataModeAssign,
+			gcpIdentityJSON: `{"metadata_mode": "assign", "sa_email": "test@proj.iam.gserviceaccount.com", "project_id": "my-project"}`,
+		},
 	}
-}
-
-// TestEnvGather_VertexAI_AssignSkipsADC tests that vertex-ai auth with
-// GCPIdentity.MetadataMode=="assign" does not require the gcloud-adc file
-// secret. This is the pre-existing behavior; the test exists as a complement
-// to TestEnvGather_VertexAI_PassthroughSkipsADC.
-func TestEnvGather_VertexAI_AssignSkipsADC(t *testing.T) {
-	srv, _, projectDir := newTestServerWithHarnessConfig(t, "claude",
-		"harness: claude\nimage: test-image\nuser: scion\nauth_selected_type: vertex-ai\n"+claudeAuthBlock,
-		`
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, _, projectDir := newTestServerWithHarnessConfig(t, "claude",
+				"harness: claude\nimage: test-image\nuser: scion\nauth_selected_type: vertex-ai\n"+claudeAuthBlock,
+				`
 schema_version: "1"
 harness_configs:
   claude:
@@ -2177,28 +2151,31 @@ profiles:
     runtime: mock
 `)
 
-	body := `{
-		"name": "test-agent-vertex-assign",
-		"id": "agent-uuid-vas",
-		"gatherEnv": true,
-		"grovePath": "` + projectDir + `",
-		"resolvedEnv": {
-			"GOOGLE_CLOUD_PROJECT": "my-project",
-			"GOOGLE_CLOUD_REGION": "us-central1"
-		},
-		"config": {
-			"template": "claude",
-			"profile": "default",
-			"gcpIdentity": {"metadata_mode": "assign", "sa_email": "test@proj.iam.gserviceaccount.com", "project_id": "my-project"}
-		}
-	}`
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
+			body := `{
+				"name": "test-agent-vertex-` + tt.metadataMode + `",
+				"id": "agent-uuid-` + tt.metadataMode + `",
+				"gatherEnv": true,
+				"grovePath": "` + projectDir + `",
+				"resolvedEnv": {
+					"GOOGLE_CLOUD_PROJECT": "my-project",
+					"GOOGLE_CLOUD_REGION": "us-central1"
+				},
+				"config": {
+					"template": "claude",
+					"profile": "default",
+					"gcpIdentity": ` + tt.gcpIdentityJSON + `
+				}
+			}`
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
 
-	srv.Handler().ServeHTTP(w, req)
+			srv.Handler().ServeHTTP(w, req)
 
-	if w.Code != http.StatusCreated {
-		t.Fatalf("expected 201 (assign should skip ADC requirement), got %d: %s", w.Code, w.Body.String())
+			if w.Code != http.StatusCreated {
+				t.Fatalf("expected 201 (%s should skip ADC requirement), got %d: %s",
+					tt.metadataMode, w.Code, w.Body.String())
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #1276 - auth preflight passthrough

- Add passthrough MetadataMode to gcpSAAssigned condition
- PR #1277, CI green, reviewer APPROVE