### PR TITLE
fix(security): refuse dev auth on non-loopback interfaces (P0-S1)

### DIFF
--- a/.design/project-log/p0-security-fixes.md
+++ b/.design/project-log/p0-security-fixes.md
@@ -1,0 +1,75 @@
+# P0 Security Fixes: Dev Auth Loopback Guard (S1) & Deploy Flag Verification (S2)
+
+**Date:** 2026-08-25
+**Branch:** `scion/p0-security-fixes`
+**Author:** dev-p0-security
+
+## Summary
+
+Implemented security fix S1 (dev auth loopback guard) and verified S2 (no
+`--no-invoker-iam-check` in deploy defaults) from the Cloud Run Instances +
+Sandboxes design doc (§4.11).
+
+## S1: Dev Auth Loopback Guard
+
+### Problem
+
+`devAuthMiddleware` auto-logs-in any cookieless request as an admin user when
+`DevAuthToken` is set. Combined with `Host = "0.0.0.0"` (the default in multiple
+places) and a public `run.app` URL, this creates a publicly reachable,
+unauthenticated admin UI.
+
+### Changes
+
+1. **`IsLoopbackHost` helper** (`pkg/hub/web.go`): New exported function that
+   checks whether a host string is a loopback address (`127.0.0.0/8`, `::1`, or
+   `"localhost"`). Returns false for all-interface addresses (`0.0.0.0`, `::`),
+   non-loopback IPs, empty strings, and non-localhost hostnames.
+
+2. **Primary validation in `initWebServer`** (`cmd/server_foreground.go`): After
+   `webHost` is resolved, returns an error if `devAuthToken` is non-empty and the
+   host is not loopback. Error message explains the conflict and how to fix it.
+
+3. **Defense-in-depth in `NewWebServer`** (`pkg/hub/web.go`): After the host
+   default is applied, calls `log.Fatalf` if dev auth is combined with a
+   non-loopback host. This protects against any code path that constructs a
+   `WebServer` directly without going through `initWebServer`.
+
+4. **Test helper fix** (`pkg/hub/web_test.go`): Updated `newDevAuthWebServer` to
+   explicitly set `Host: "127.0.0.1"` so existing dev-auth tests comply with the
+   new guard.
+
+### Tests
+
+- `TestIsLoopbackHost`: Table-driven tests covering IPv4 loopback, IPv6 loopback,
+  `localhost`, `0.0.0.0`, `::`, private IPs, empty string, and non-localhost
+  hostnames.
+- `TestNewWebServer_DevAuth_NonLoopback_Rejected`: Verifies `NewWebServer`
+  succeeds with dev auth on loopback addresses and succeeds without dev auth on
+  any address.
+- `TestInitWebServer_DevAuth_NonLoopback_Rejected`: Table-driven tests verifying
+  `initWebServer` returns an error for dev auth with `0.0.0.0`, empty host, and
+  public IPs, while allowing dev auth on `127.0.0.1` and any host without dev auth.
+
+## S2: Deploy Flag Verification
+
+### Finding
+
+Confirmed that `--no-invoker-iam-check` does not appear anywhere in the codebase
+(grepped all `.go`, `.sh`, `.yaml`, `.yml`, `.md` files). The existing deploy script
+at `scripts/cloudrun/deploy.sh` correctly uses `--no-allow-unauthenticated --iap`.
+
+### Change
+
+Added a security comment block before the `gcloud run deploy` command in
+`scripts/cloudrun/deploy.sh` explaining why `--no-invoker-iam-check` must never be
+added, referencing the design doc's S2 requirement.
+
+## Files Changed
+
+- `pkg/hub/web.go` — Added `IsLoopbackHost`, `"net"` import, defense-in-depth guard
+- `cmd/server_foreground.go` — Added primary dev-auth loopback validation
+- `pkg/hub/web_test.go` — Added `IsLoopbackHost` and `NewWebServer` guard tests,
+  fixed `newDevAuthWebServer` helper
+- `cmd/server_foreground_test.go` — Added `initWebServer` dev-auth rejection tests
+- `scripts/cloudrun/deploy.sh` — Added preventive comment about `--no-invoker-iam-check`

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -2184,6 +2184,16 @@ func initWebServer(ctx context.Context, cfg *config.GlobalConfig, hubSrv *hub.Se
 		webHost = "0.0.0.0"
 	}
 
+	// Refuse to start when dev auth is enabled on a non-loopback interface.
+	// Dev auth auto-logs in every request as admin — exposing it on a public
+	// address would create an unauthenticated admin endpoint.
+	if devAuthToken != "" && !hub.IsLoopbackHost(webHost) {
+		return nil, fmt.Errorf(
+			"dev auth cannot be enabled when the server is bound to a non-loopback address (%s). "+
+				"Dev auth auto-logs in all requests as admin and must only be used on localhost. "+
+				"Either bind to 127.0.0.1/::1/localhost (--host 127.0.0.1) or disable dev auth", webHost)
+	}
+
 	// Allow env var overrides for session/OAuth config
 	sessionSecret := resolveSessionSecret()
 	baseURL := webBaseURL

--- a/cmd/server_foreground_test.go
+++ b/cmd/server_foreground_test.go
@@ -15,8 +15,10 @@
 package cmd
 
 import (
+	"context"
 	"testing"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -175,4 +177,69 @@ func TestValidateHostedHAPreflight(t *testing.T) {
 		assert.Equal(t, "123-abc.apps.googleusercontent.com", cfg.Auth.Transport.OIDCAudience,
 			"preflight should trim the transport audience so downstream token minting uses the canonical value")
 	})
+}
+
+func TestInitWebServer_DevAuth_NonLoopback_Rejected(t *testing.T) {
+	tests := []struct {
+		name        string
+		host        string
+		devAuth     string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "dev auth with 0.0.0.0 rejected",
+			host:        "0.0.0.0",
+			devAuth:     "some-token",
+			wantErr:     true,
+			errContains: "dev auth cannot be enabled",
+		},
+		{
+			name:        "dev auth with empty host (defaults to 0.0.0.0) rejected",
+			host:        "",
+			devAuth:     "some-token",
+			wantErr:     true,
+			errContains: "non-loopback address",
+		},
+		{
+			name:        "dev auth with public IP rejected",
+			host:        "192.168.1.1",
+			devAuth:     "some-token",
+			wantErr:     true,
+			errContains: "non-loopback address",
+		},
+		{
+			name:    "dev auth with 127.0.0.1 allowed",
+			host:    "127.0.0.1",
+			devAuth: "some-token",
+			wantErr: false,
+		},
+		{
+			name:    "no dev auth with 0.0.0.0 allowed",
+			host:    "0.0.0.0",
+			devAuth: "",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.GlobalConfig{}
+			cfg.Hub.Host = tt.host
+
+			_, err := initWebServer(context.Background(), cfg, nil, tt.devAuth, false, "", nil, nil)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				// initWebServer may fail for other reasons (e.g., missing deps)
+				// but it should NOT fail with a dev-auth error.
+				if err != nil {
+					assert.NotContains(t, err.Error(), "dev auth cannot be enabled",
+						"should not reject dev auth on loopback host")
+				}
+			}
+		})
+	}
 }

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -24,7 +24,9 @@ import (
 	"fmt"
 	"html/template"
 	"io/fs"
+	"log"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -434,6 +436,17 @@ func (ws *WebServer) logger() *slog.Logger {
 	return slog.Default()
 }
 
+// IsLoopbackHost reports whether host is a loopback address (127.0.0.0/8,
+// ::1, or "localhost"). It returns false for non-loopback IPs (including
+// "0.0.0.0" and "::") and for unresolvable hostnames.
+func IsLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
 // NewWebServer creates a new web frontend server.
 func NewWebServer(cfg WebServerConfig) *WebServer {
 	if cfg.Port == 0 {
@@ -441,6 +454,15 @@ func NewWebServer(cfg WebServerConfig) *WebServer {
 	}
 	if cfg.Host == "" {
 		cfg.Host = "0.0.0.0"
+	}
+
+	// Defense-in-depth: refuse to start dev auth on a non-loopback interface.
+	// The primary check is in initWebServer (cmd layer), but this guard
+	// protects against any code path that constructs a WebServer directly.
+	if cfg.DevAuthToken != "" && !IsLoopbackHost(cfg.Host) {
+		log.Fatalf("dev auth cannot be enabled when the server is bound to a non-loopback address (%s). "+
+			"Dev auth auto-logs in all requests as admin and must only be used on localhost. "+
+			"Either bind to 127.0.0.1/::1/localhost (--host 127.0.0.1) or disable dev auth.", cfg.Host)
 	}
 
 	ws := &WebServer{

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -122,6 +122,7 @@ func newTestWebServer(t *testing.T, cfg WebServerConfig) *WebServer {
 func newDevAuthWebServer(t *testing.T, overrides ...func(*WebServerConfig)) *WebServer {
 	t.Helper()
 	cfg := WebServerConfig{
+		Host:         "127.0.0.1",
 		DevAuthToken: "test-dev-token-12345",
 	}
 	for _, fn := range overrides {
@@ -3367,7 +3368,6 @@ func TestProxyAuthMiddleware_ExistingSession_NoUpdateWhenRoleUnchanged(t *testin
 	assert.False(t, sessionReSet, "session cookie should NOT be re-set when role is unchanged")
 }
 
-// ---------------------------------------------------------------------------
 // Live operational settings propagation — regression tests for issue #1270
 // ---------------------------------------------------------------------------
 
@@ -3440,4 +3440,83 @@ func TestServer_ImplementsAccessSettingsProvider(t *testing.T) {
 		"AuthorizedDomains must return a defensive copy")
 
 	assert.Equal(t, "invite_only", provider.UserAccessMode())
+}
+
+// ---------------------------------------------------------------------------
+// isLoopbackHost
+// ---------------------------------------------------------------------------
+
+func TestIsLoopbackHost(t *testing.T) {
+	tests := []struct {
+		host string
+		want bool
+	}{
+		// Safe: loopback addresses
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"localhost", true},
+
+		// Unsafe: all-interfaces addresses
+		{"0.0.0.0", false},
+		{"::", false},
+
+		// Unsafe: non-loopback IPs
+		{"192.168.1.1", false},
+		{"10.0.0.1", false},
+		{"172.16.0.1", false},
+
+		// Unsafe: empty string (not a valid loopback)
+		{"", false},
+
+		// Unsafe: unresolvable hostname (not "localhost")
+		{"example.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			got := IsLoopbackHost(tt.host)
+			assert.Equal(t, tt.want, got, "IsLoopbackHost(%q)", tt.host)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NewWebServer dev-auth + non-loopback guard
+// ---------------------------------------------------------------------------
+
+func TestNewWebServer_DevAuth_NonLoopback_Rejected(t *testing.T) {
+	// NewWebServer calls log.Fatalf when dev auth is combined with a
+	// non-loopback host. We cannot easily intercept log.Fatalf in a unit
+	// test without replacing the default logger, so instead we validate
+	// that the guard logic (IsLoopbackHost) correctly identifies non-loopback
+	// addresses, and that constructing a WebServer with dev auth + loopback
+	// succeeds without panicking.
+
+	// Positive case: dev auth with loopback should succeed.
+	ws := NewWebServer(WebServerConfig{
+		Host:         "127.0.0.1",
+		DevAuthToken: "test-token",
+	})
+	assert.NotNil(t, ws)
+	assert.Equal(t, "127.0.0.1", ws.config.Host)
+
+	// Also verify localhost works.
+	ws2 := NewWebServer(WebServerConfig{
+		Host:         "localhost",
+		DevAuthToken: "test-token",
+	})
+	assert.NotNil(t, ws2)
+
+	// IPv6 loopback.
+	ws3 := NewWebServer(WebServerConfig{
+		Host:         "::1",
+		DevAuthToken: "test-token",
+	})
+	assert.NotNil(t, ws3)
+
+	// No dev auth token: any host should be fine.
+	ws4 := NewWebServer(WebServerConfig{
+		Host: "0.0.0.0",
+	})
+	assert.NotNil(t, ws4)
 }

--- a/scripts/cloudrun/deploy.sh
+++ b/scripts/cloudrun/deploy.sh
@@ -142,6 +142,11 @@ deploy_service() {
   local settings_secret="$1"
   local session_secret="$2"
 
+  # SECURITY: The flags --no-allow-unauthenticated and --iap are critical.
+  # Never add --no-invoker-iam-check — that flag would bypass Cloud Run's IAM
+  # invoker check and expose the service to unauthenticated traffic, defeating
+  # the IAP gate. See design doc S2 requirement in
+  # .design/projects/single-node/cloudrun-instances-sandboxes.md §4.11.
   gcloud run deploy "$SERVICE_NAME" \
     --image "$IMAGE" \
     --region "$REGION" \


### PR DESCRIPTION
## Summary

**P0 security fix.** `devAuthMiddleware` auto-logs-in every cookieless request as **admin**. Bound to `0.0.0.0` — the default in hosted mode — that is a publicly reachable, unauthenticated admin UI.

Adds startup validation at two layers so the combination cannot boot: `initWebServer` returns an error, and `NewWebServer` fails fatally.

Also verifies S2 (`--no-invoker-iam-check` absent from deploy defaults) and adds a preventive comment in the deploy script.

6 files, +259. Cherry-picked from `scion/dev-rebase-1294` commit `f0b84e12`. CI green on the fork branch.

## Ordering note for reviewers

The single-node Cloud Run tier (fork PR `ptone/scion#1282`) **deliberately carries no copy of this guard** — the duplicate was removed from that branch so the fix lands here, once.

That makes this a **hard prerequisite**: the tier ships a `deploy-instance` command that stands up a publicly reachable hub, so it must not land before this guard is in upstream `main`.

Ref: `ptone/scion#1265`
