### PR TITLE
feat(harness): pre-fetch models.dev catalog in opencode provisioner

### DIFF
--- a/harnesses/opencode/provision.py
+++ b/harnesses/opencode/provision.py
@@ -305,7 +305,6 @@ def _prefetch_models_catalog(ctx: sh.ProvisionContext) -> None:
 
     This is best-effort — a fetch failure is logged but never fails provision.
     """
-    import urllib.error
     import urllib.request
 
     cache_dir = os.path.join(ctx.home, ".cache", "opencode")

--- a/harnesses/opencode/provision.py
+++ b/harnesses/opencode/provision.py
@@ -286,7 +286,48 @@ def provision(ctx: sh.ProvisionContext) -> None:
         resolved_model = os.environ.get("SCION_MODEL", "").strip()
     _write_model_config(resolved_model)
 
+    _prefetch_models_catalog(ctx)
+
     ctx.info(f"method={resolved.method}" + (f" model={resolved_model}" if resolved_model else ""))
+
+
+# ---------------------------------------------------------------------------
+# Models catalog pre-fetch
+# ---------------------------------------------------------------------------
+
+
+def _prefetch_models_catalog(ctx: sh.ProvisionContext) -> None:
+    """Pre-fetch latest models.dev catalog so opencode has fresh model data.
+
+    opencode bakes a models.dev snapshot at build time; when new models are
+    released after the image is built, its validation rejects them.  Writing a
+    fresh catalog to the cache location before opencode starts avoids this.
+
+    This is best-effort — a fetch failure is logged but never fails provision.
+    """
+    import urllib.error
+    import urllib.request
+
+    cache_dir = os.path.join(ctx.home, ".cache", "opencode")
+    os.makedirs(cache_dir, exist_ok=True)
+    cache_path = os.path.join(cache_dir, "models.json")
+
+    try:
+        req = urllib.request.Request(
+            "https://models.opencode.ai/api.json",
+            headers={"User-Agent": "scion-opencode-provision/1.0"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = resp.read()
+        # Sanity-check: a real catalog is several KB of JSON.
+        if len(data) > 100:
+            with open(cache_path, "wb") as f:
+                f.write(data)
+            ctx.info(f"pre-fetched models catalog ({len(data)} bytes)")
+        else:
+            ctx.info("models catalog response too small, skipping")
+    except (urllib.error.URLError, OSError, ValueError) as e:
+        ctx.info(f"models catalog pre-fetch failed (non-fatal): {e}")
 
 
 if __name__ == "__main__":

--- a/harnesses/opencode/provision.py
+++ b/harnesses/opencode/provision.py
@@ -318,8 +318,13 @@ def _prefetch_models_catalog(ctx: sh.ProvisionContext) -> None:
         )
         with urllib.request.urlopen(req, timeout=10) as resp:
             data = resp.read(10 * 1024 * 1024)  # 10MB cap
-        # Sanity-check: a real catalog is several KB of JSON.
+        # Sanity-check: a real catalog is several KB of valid JSON.
         if len(data) > 100:
+            try:
+                json.loads(data)
+            except ValueError:
+                ctx.info("models catalog response is not valid JSON, skipping")
+                return
             tmp_path = cache_path + ".tmp"
             with open(tmp_path, "wb") as f:
                 f.write(data)

--- a/harnesses/opencode/provision.py
+++ b/harnesses/opencode/provision.py
@@ -318,15 +318,17 @@ def _prefetch_models_catalog(ctx: sh.ProvisionContext) -> None:
             headers={"User-Agent": "scion-opencode-provision/1.0"},
         )
         with urllib.request.urlopen(req, timeout=10) as resp:
-            data = resp.read()
+            data = resp.read(10 * 1024 * 1024)  # 10MB cap
         # Sanity-check: a real catalog is several KB of JSON.
         if len(data) > 100:
-            with open(cache_path, "wb") as f:
+            tmp_path = cache_path + ".tmp"
+            with open(tmp_path, "wb") as f:
                 f.write(data)
+            os.replace(tmp_path, cache_path)
             ctx.info(f"pre-fetched models catalog ({len(data)} bytes)")
         else:
             ctx.info("models catalog response too small, skipping")
-    except (urllib.error.URLError, OSError, ValueError) as e:
+    except Exception as e:
         ctx.info(f"models catalog pre-fetch failed (non-fatal): {e}")
 
 


### PR DESCRIPTION
## Summary

Adds a best-effort pre-fetch step to the opencode provisioner that downloads the latest models catalog from models.opencode.ai during provision and writes it to opencode cache location (~/.cache/opencode/models.json).

## Motivation

opencode bakes a models.dev snapshot at build time. When new models are released after the image is built, opencode model validation rejects them. Pre-fetching the catalog during provision ensures fresh model data is available before opencode starts.

## Changes

Single file: harnesses/opencode/provision.py

- New function _prefetch_models_catalog(ctx): fetches https://models.opencode.ai/api.json with 10s timeout, writes to cache with atomic tmp+replace pattern
- Best-effort: broad except Exception catches all errors, logs via ctx.info(), never fails provision
- 10MB read cap for defense in depth
- Called after auth resolution, before provision returns
- Stdlib only (urllib.request), no external dependencies

Related: ptone/scion#1283
