### PR TITLE
feat: session secret, secret placement guards, and OAuth client credentials (phase 3)

### DIFF
--- a/cmd/helm_chart_ha_contract_test.go
+++ b/cmd/helm_chart_ha_contract_test.go
@@ -263,8 +263,8 @@ func TestHelmChartHAGateWalk(t *testing.T) {
 	}
 	// THE DENOMINATOR. A glob that silently returns two files would produce a
 	// shorter artifact that still round-trips against itself.
-	if len(goldens) != 5 {
-		t.Fatalf("expected 5 chart goldens, found %d (%v). The walk's corpus is the chart's golden set; if that set changed, this number changes with it in the same commit.",
+	if len(goldens) != 6 {
+		t.Fatalf("expected 6 chart goldens, found %d (%v). The walk's corpus is the chart's golden set; if that set changed, this number changes with it in the same commit.",
 			len(goldens), goldens)
 	}
 	sort.Strings(goldens)

--- a/deploy/helm/scion-hub/ci/values-cloudsql.yaml
+++ b/deploy/helm/scion-hub/ci/values-cloudsql.yaml
@@ -92,3 +92,4 @@ storage:
 
 auth:
   mode: proxy
+  sessionSecret: ci-cloudsql-session-secret-not-real

--- a/deploy/helm/scion-hub/ci/values-cluster-rbac.yaml
+++ b/deploy/helm/scion-hub/ci/values-cluster-rbac.yaml
@@ -25,5 +25,8 @@ image:
   repository: us-docker.pkg.dev/example-project/example-repo/scion-hub-gke
   tag: ci
 
+auth:
+  sessionSecret: ci-cluster-rbac-session-secret-not-real
+
 runtime:
   listAllNamespaces: true

--- a/deploy/helm/scion-hub/ci/values-existing-secret.yaml
+++ b/deploy/helm/scion-hub/ci/values-existing-secret.yaml
@@ -33,15 +33,7 @@ config:
   existingSecret: my-own-hub-settings
 
 auth:
-  # THE ONLY PERMUTATION THAT MAY SET THIS TRUE, AND THE ONLY PLACE THE
-  # SCION_REQUIRE_STABLE_SIGNING_KEY ternary'S "true" BRANCH RENDERS. It moved
-  # here from ci/values-varied.yaml when the Critical-2 fix inverted the default
-  # to false; a ternary with one live branch is a constant, so the branch needed
-  # a home rather than a deletion.
-  #
-  # It is legitimate here and refused everywhere else, for the same reason: the
-  # operator supplies the whole settings.yaml under config.existingSecret, so
-  # they can set server.secrets and pre-provision the signing key the hub looks
-  # for at pkg/hub/server.go:1445. No other permutation has any way to satisfy
-  # it, which is what templates/configmap-env.yaml refuses.
-  requireStableSigningKey: true
+  # The operator manages the session secret themselves. The chart renders no
+  # session Secret in this shape; it binds the named key with secretKeyRef.
+  existingSecret: my-session-secret
+  existingSecretKey: SESSION_KEY

--- a/deploy/helm/scion-hub/ci/values-minimal.yaml
+++ b/deploy/helm/scion-hub/ci/values-minimal.yaml
@@ -57,3 +57,6 @@ hub:
 image:
   repository: us-docker.pkg.dev/example-project/example-repo/scion-hub-gke
   tag: ci
+
+auth:
+  sessionSecret: ci-minimal-session-secret-not-real-do-not-use

--- a/deploy/helm/scion-hub/ci/values-session-existing.yaml
+++ b/deploy/helm/scion-hub/ci/values-session-existing.yaml
@@ -1,0 +1,63 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The recommended production shape for the session secret: the chart renders the
+# settings.yaml, and the operator manages the session secret themselves.
+#
+# WHY THIS PERMUTATION EXISTS AS A SEPARATE FIXTURE. It is the only one that
+# renders the chart's settings Secret AND takes the session secret from an
+# existing one. ci/values-existing-secret.yaml covers "the operator supplies
+# everything" and every other fixture covers "the chart renders everything";
+# without this file the combination in between - which is the one the values
+# documentation actually recommends - would render in no golden at all, and the
+# secretKeyRef branch in templates/deployment.yaml would be covered only by the
+# permutation that also drops the settings Secret. Two variables moving together
+# in every fixture is not coverage of either.
+#
+# It is also the ONLY fixture that sets auth.existingSecretKey, so the override
+# branch of scion-hub.sessionSecretKey renders here and its default branch
+# renders everywhere else. Both branches of that helper are therefore live, which
+# is the same rule the SCION_REQUIRE_STABLE_SIGNING_KEY ternary is held to.
+
+hub:
+  hubId: ci-session-existing
+  baseUrl: https://ci-session-existing.example.com
+
+image:
+  repository: us-docker.pkg.dev/example-project/example-repo/scion-hub-gke
+  tag: ci
+
+auth:
+  # The chart renders NO Secret for this. It binds the key below out of a Secret
+  # the operator creates, by secretKeyRef rather than envFrom - see
+  # templates/deployment.yaml for why the chart will not envFrom a Secret whose
+  # other keys it cannot see.
+  #
+  # NOTHING HERE VALIDATES THAT THIS SECRET EXISTS, or that the key holds a
+  # non-empty value. helm template cannot look, and lookup returns empty under
+  # --dry-run. A missing key resolves to an empty environment variable, and an
+  # empty session secret puts the hub back on a per-process signing key. With
+  # auth.requireStableSigningKey at its default of true the hub refuses to start,
+  # which is loud and therefore the good outcome; with it false the pod comes up
+  # green and logs users out at random. That residual risk is the price of the
+  # bring-your-own path and it is documented in values.yaml.
+  existingSecret: my-own-session-secret
+
+  # A NON-DEFAULT KEY NAME ON PURPOSE. The default is
+  # SCION_SERVER_SESSION_SECRET, which is also the environment variable the hub
+  # reads (resolveSessionSecret, cmd/server_foreground.go:1452-1463). Using a
+  # different name here proves the chart maps key -> variable rather than
+  # assuming they are the same string - a chart that ignored this key would
+  # still render a working-looking manifest against the default.
+  existingSecretKey: session-secret

--- a/deploy/helm/scion-hub/ci/values-settings-oauth.yaml
+++ b/deploy/helm/scion-hub/ci/values-settings-oauth.yaml
@@ -12,10 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# values-settings.yaml with the authentication mode changed, and nothing else
-# changed. Keep it that way: the point of this file is that a diff of the two
-# renders shows the authentication subtree and nothing more. Anything else that
-# drifts between them makes that check stop meaning what it claims to mean.
+# values-settings.yaml with the authentication mode changed, and nothing that
+# is not entailed by that change. Keep it that way: the point of this file is
+# that a diff of the two renders shows the authentication subtree and nothing
+# more. Anything else that drifts between them makes that check stop meaning
+# what it claims to mean.
+#
+# "AND NOTHING ELSE CHANGED" IS WHAT THIS USED TO SAY, AND IT STOPPED BEING
+# TRUE when the OAuth client credentials landed. The values now differ by the
+# mode AND by auth.oauth.web.google, and the renders differ by server.auth.mode
+# AND server.oauth. That is not drift: oauth mode without credentials is a
+# deployment nobody can log in to, and the chart refuses to render it - so the
+# credentials are part of what selecting the mode means, not an extra. The
+# narrower claim is the one that survives and the one the diff should be read
+# against.
 #
 # THE FIVE BLOCK-1 KEYS RENDER IN EITHER AUTHENTICATION MODE, and that is what
 # the paired diff is for: the hub ID, the Postgres driver, the database URL, GCS
@@ -81,11 +91,29 @@ storage:
 
 auth:
   mode: oauth
-  sessionSecret: ci-settings-session-secret-not-real
-  # The client credentials oauth needs are not rendered by
-  # this chart yet, so this install would not start. The schema requires the
-  # acknowledgement rather than letting the mode be selected by accident.
-  acknowledgeOAuthUnlanded: true
+  sessionSecret: ci-oauth-session-secret-not-a-real-secret
+
+  # THIS FIXTURE USED TO CARRY acknowledgeOAuthUnlanded: true INSTEAD OF THESE.
+  # The key existed because the chart rendered oauth mode with no channel for
+  # the credentials that mode needs; the fixture set it to say "yes, I know this
+  # would not be usable". The credentials are rendered now, so the fixture
+  # supplies them and the acknowledgement is gone. A fixture that still opted
+  # out of a guard nothing needs would be the reason nobody noticed the guard
+  # had stopped guarding anything.
+  #
+  # google rather than github for no reason beyond needing one of them. The
+  # github pair is exercised by the render-guards suite, so both are covered
+  # without doubling this fixture.
+  #
+  # WEB, and the client type matters. Credentials under server.oauth.cli or
+  # server.oauth.device would render fine and satisfy nothing: the hub keys its
+  # login check by client type (pkg/hub/oauth.go:194) and a browser login reads
+  # the web client only. render-guards asserts that specific non-substitution.
+  oauth:
+    web:
+      google:
+        clientId: ci-oauth-web-google-client-id.apps.googleusercontent.invalid
+        clientSecret: ci-oauth-web-google-client-secret-not-a-real-secret
 
 agents:
   imageRegistry: us-docker.pkg.dev/scion-ci/scion

--- a/deploy/helm/scion-hub/ci/values-settings-oauth.yaml
+++ b/deploy/helm/scion-hub/ci/values-settings-oauth.yaml
@@ -81,7 +81,8 @@ storage:
 
 auth:
   mode: oauth
-  # The client credentials and session secret oauth needs are not rendered by
+  sessionSecret: ci-settings-session-secret-not-real
+  # The client credentials oauth needs are not rendered by
   # this chart yet, so this install would not start. The schema requires the
   # acknowledgement rather than letting the mode be selected by accident.
   acknowledgeOAuthUnlanded: true

--- a/deploy/helm/scion-hub/ci/values-settings.yaml
+++ b/deploy/helm/scion-hub/ci/values-settings.yaml
@@ -65,6 +65,7 @@ storage:
 
 auth:
   mode: proxy
+  sessionSecret: ci-settings-session-secret-not-real
 
 agents:
   imageRegistry: us-docker.pkg.dev/scion-ci/scion

--- a/deploy/helm/scion-hub/ci/values-varied.yaml
+++ b/deploy/helm/scion-hub/ci/values-varied.yaml
@@ -109,19 +109,11 @@ probes:
     # liveness block and its coupling to hub.webPort render nowhere else.
     enabled: true
 
-# THE COVERAGE THIS FIXTURE USED TO PROVIDE MOVED, IT WAS NOT DROPPED. This file
-# held requireStableSigningKey: false back when the default was true, on the
-# principle that a ternary with one live branch is a constant. The Critical-2 fix
-# inverted the default, so false is now what every other permutation renders and
-# this entry would be the redundant one. The "true" branch is covered by
-# ci/values-existing-secret.yaml, the only shape where true is permitted at all -
-# see the refusal in templates/configmap-env.yaml.
-#
-# NO `auth:` KEY HERE, DELIBERATELY, AND THIS IS MEASURED RATHER THAN STYLE. A
-# bare `auth:` with nothing but comments under it parses as null and overrides
-# the entire default map, and the schema then reports "(root): auth is required".
-# I hit exactly that while making this edit.
-
+auth:
+  sessionSecret: ci-varied-session-secret-not-real
+  # The false branch of the ternary. Every other permutation renders true (the
+  # new default); this is the only one that tests the other arm.
+  requireStableSigningKey: false
 
 database:
   # Four rendered settings keys that otherwise carry one value each forever.

--- a/deploy/helm/scion-hub/golden/existing-secret.yaml
+++ b/deploy/helm/scion-hub/golden/existing-secret.yaml
@@ -51,27 +51,27 @@ data:
   # fall back to a per-process signing key, which across replicas would sign
   # tokens each of the others reject.
   #
-  # THE REFUSAL BELOW EXISTS BECAUSE THE HUB'S REFUSAL IS NOT SCOPED TO ITS OWN
-  # HARM. Setting this true in this release does not make the hub careful; it
-  # makes the hub refuse to boot, every time, on a first install, with nothing
-  # the operator can do about it from this chart. The hub resolves a stable key
-  # from a pre-configured key, then SharedSigningSecret, then a secret backend,
-  # then the store (pkg/hub/server.go:1445). SharedSigningSecret is
-  # resolveSessionSecret() (cmd/server_foreground.go:1556), which reads only
-  # --session-secret, SCION_SERVER_SESSION_SECRET and bare SESSION_SECRET
-  # (cmd/server_foreground.go:1452-1462); the chart renders none of them, and
-  # hub.extraEnv - the one operator-controlled env channel - refuses all three
-  # by name as credential material (_helpers.tpl:1306). The store is empty on a
-  # first boot. So there is no key, pkg/hub/server.go:1634 errors,
-  # pkg/hub/server.go:1008 makes it fatal, and cmd/server_foreground.go:259
-  # calls log.Fatalf.
+  # DEFAULTS TO true SINCE THE SESSION-SECRET PHASE, AND A REFUSAL WAS REMOVED
+  # HERE TO ALLOW IT. Until that phase this file carried a `fail` rejecting
+  # true unless config.existingSecret was set, because nothing the chart
+  # rendered could satisfy the flag: the hub resolves a stable key from a
+  # pre-configured key, then SharedSigningSecret, then a secret backend, then
+  # the store (pkg/hub/server.go:1445); SharedSigningSecret comes only from
+  # resolveSessionSecret (cmd/server_foreground.go:1452-1463), which reads
+  # --session-secret, SCION_SERVER_SESSION_SECRET and bare SESSION_SECRET; the
+  # chart rendered none of the three, and a first boot has an empty store. With
+  # true and no key, pkg/hub/server.go:1634 errors, pkg/hub/server.go:1008 makes
+  # it fatal, and cmd/server_foreground.go:259 turns it into log.Fatalf. Measured
+  # end-to-end through hub.New by gd-p1-dev, not inferred from the citations.
   #
-  # config.existingSecret is the one shape where true is satisfiable, and it is
-  # not hypothetical: the operator writes their own settings.yaml, so they can
-  # set server.secrets.backend and pre-provision the key there. The chart does
-  # not render that file and has no business second-guessing it.
-  #
-  # This turns a CrashLoopBackOff at 03:00 into a values error at install time.
+  # WHAT MAKES true SAFE NOW IS NOT THIS DEFAULT - IT IS THAT THE SECRET IS
+  # UNCONDITIONAL. scion-hub.assertSessionSecret fails the render when neither
+  # auth.sessionSecret nor auth.existingSecret is set, so there is no values
+  # combination that reaches this line with the flag true and no source for the
+  # variable. The refusal was not relaxed; its precondition was removed. If a
+  # later phase ever makes the session secret optional again, this default must
+  # go back to false in the same change - tests/chart-integrity.sh section E
+  # asserts exactly that pairing, in both directions.
   SCION_REQUIRE_STABLE_SIGNING_KEY: "true"
 ---
 # Source: scion-hub/templates/rbac-role.yaml
@@ -188,7 +188,7 @@ spec:
         app.kubernetes.io/part-of: scion
       annotations:
         scion.io/hub-id: "ci-existing"
-        checksum/env-config: c1ad1de50513e6d84543180fa40940d518d358e0546f4cf908b0f39ce1a75b3e
+        checksum/env-config: 835be3c723fcc175fe9783b842f489699bc1d73a29e1c28af50dd4b2a2b3c7eb
     spec:
       serviceAccountName: scion-scion-hub
       securityContext:
@@ -219,6 +219,11 @@ spec:
             - configMapRef:
                 name: scion-scion-hub-env
           env:
+            - name: SCION_SERVER_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: my-session-secret
+                  key: SESSION_KEY
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy/helm/scion-hub/golden/minimal.yaml
+++ b/deploy/helm/scion-hub/golden/minimal.yaml
@@ -13,6 +13,23 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: scion
 ---
+# Source: scion-hub/templates/secret-session.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scion-scion-hub-session
+  namespace: scion-system
+  labels:
+    helm.sh/chart: scion-hub-0.1.0
+    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/instance: scion
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: scion
+type: Opaque
+stringData:
+  SCION_SERVER_SESSION_SECRET: "ci-minimal-session-secret-not-real-do-not-use"
+---
 # Source: scion-hub/templates/secret-settings.yaml
 apiVersion: v1
 kind: Secret
@@ -113,28 +130,28 @@ data:
   # fall back to a per-process signing key, which across replicas would sign
   # tokens each of the others reject.
   #
-  # THE REFUSAL BELOW EXISTS BECAUSE THE HUB'S REFUSAL IS NOT SCOPED TO ITS OWN
-  # HARM. Setting this true in this release does not make the hub careful; it
-  # makes the hub refuse to boot, every time, on a first install, with nothing
-  # the operator can do about it from this chart. The hub resolves a stable key
-  # from a pre-configured key, then SharedSigningSecret, then a secret backend,
-  # then the store (pkg/hub/server.go:1445). SharedSigningSecret is
-  # resolveSessionSecret() (cmd/server_foreground.go:1556), which reads only
-  # --session-secret, SCION_SERVER_SESSION_SECRET and bare SESSION_SECRET
-  # (cmd/server_foreground.go:1452-1462); the chart renders none of them, and
-  # hub.extraEnv - the one operator-controlled env channel - refuses all three
-  # by name as credential material (_helpers.tpl:1306). The store is empty on a
-  # first boot. So there is no key, pkg/hub/server.go:1634 errors,
-  # pkg/hub/server.go:1008 makes it fatal, and cmd/server_foreground.go:259
-  # calls log.Fatalf.
+  # DEFAULTS TO true SINCE THE SESSION-SECRET PHASE, AND A REFUSAL WAS REMOVED
+  # HERE TO ALLOW IT. Until that phase this file carried a `fail` rejecting
+  # true unless config.existingSecret was set, because nothing the chart
+  # rendered could satisfy the flag: the hub resolves a stable key from a
+  # pre-configured key, then SharedSigningSecret, then a secret backend, then
+  # the store (pkg/hub/server.go:1445); SharedSigningSecret comes only from
+  # resolveSessionSecret (cmd/server_foreground.go:1452-1463), which reads
+  # --session-secret, SCION_SERVER_SESSION_SECRET and bare SESSION_SECRET; the
+  # chart rendered none of the three, and a first boot has an empty store. With
+  # true and no key, pkg/hub/server.go:1634 errors, pkg/hub/server.go:1008 makes
+  # it fatal, and cmd/server_foreground.go:259 turns it into log.Fatalf. Measured
+  # end-to-end through hub.New by gd-p1-dev, not inferred from the citations.
   #
-  # config.existingSecret is the one shape where true is satisfiable, and it is
-  # not hypothetical: the operator writes their own settings.yaml, so they can
-  # set server.secrets.backend and pre-provision the key there. The chart does
-  # not render that file and has no business second-guessing it.
-  #
-  # This turns a CrashLoopBackOff at 03:00 into a values error at install time.
-  SCION_REQUIRE_STABLE_SIGNING_KEY: "false"
+  # WHAT MAKES true SAFE NOW IS NOT THIS DEFAULT - IT IS THAT THE SECRET IS
+  # UNCONDITIONAL. scion-hub.assertSessionSecret fails the render when neither
+  # auth.sessionSecret nor auth.existingSecret is set, so there is no values
+  # combination that reaches this line with the flag true and no source for the
+  # variable. The refusal was not relaxed; its precondition was removed. If a
+  # later phase ever makes the session secret optional again, this default must
+  # go back to false in the same change - tests/chart-integrity.sh section E
+  # asserts exactly that pairing, in both directions.
+  SCION_REQUIRE_STABLE_SIGNING_KEY: "true"
 ---
 # Source: scion-hub/templates/rbac-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -250,7 +267,7 @@ spec:
         app.kubernetes.io/part-of: scion
       annotations:
         scion.io/hub-id: "ci-minimal"
-        checksum/env-config: 0cd42ca38ae557cb82434b41289c2dbef90208d8a9d2923915f66c2f080efc38
+        checksum/env-config: 576ca82a75226a5ff18c57d4eaf8120674b3a3dd8bc0d19a62351952fdc40c3e
         checksum/settings: ead7e65985cdb00400ae17974efad6e94b78af5e2794cebbaa56fc8d27838a47
     spec:
       serviceAccountName: scion-scion-hub
@@ -281,6 +298,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: scion-scion-hub-env
+            - secretRef:
+                name: scion-scion-hub-session
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/deploy/helm/scion-hub/golden/minimal.yaml
+++ b/deploy/helm/scion-hub/golden/minimal.yaml
@@ -53,8 +53,11 @@ stringData:
     #   server.database.url        Cloud SQL. Note the key is url, not dsn.
     #   server.secrets             the secret backend (gcpsm).
     #   server.auth.proxy,
-    #   server.auth.transport,
-    #   server.oauth               the subtree selected by server.auth.mode.
+    #   server.auth.transport      the subtree selected by server.auth.mode.
+    #   server.oauth               NOW RENDERED: web client credentials land here
+    #                              as server.oauth.web.<provider>.client_id and
+    #                              client_secret, in snake_case. cli and device
+    #                              are reachable through config.extra.
     #   server.workspace_storage   Filestore NFS - a different subsystem from
     #                              server.storage, which is the hub's GCS blob
     #                              store and is rendered below.

--- a/deploy/helm/scion-hub/golden/session-existing.yaml
+++ b/deploy/helm/scion-hub/golden/session-existing.yaml
@@ -12,25 +12,6 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: scion
-  annotations:
-    iam.gke.io/gcp-service-account: "ci-varied-hub@example-project.iam.gserviceaccount.com"
----
-# Source: scion-hub/templates/secret-session.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: scion-scion-hub-session
-  namespace: scion-system
-  labels:
-    helm.sh/chart: scion-hub-0.1.0
-    app.kubernetes.io/name: scion-hub
-    app.kubernetes.io/instance: scion
-    app.kubernetes.io/version: "0.1.0"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: scion
-type: Opaque
-stringData:
-  SCION_SERVER_SESSION_SECRET: "ci-varied-session-secret-not-real"
 ---
 # Source: scion-hub/templates/secret-settings.yaml
 apiVersion: v1
@@ -70,8 +51,8 @@ stringData:
     runtimes:
       kubernetes:
         gke: true
-        list_all_namespaces: true
-        namespace: ci-varied-agents
+        list_all_namespaces: false
+        namespace: scion-system
         type: kubernetes
     schema_version: "1"
     server:
@@ -82,14 +63,14 @@ stringData:
         host: 127.0.0.1
         port: 9800
       database:
-        conn_max_idle_time: 3m
-        conn_max_lifetime: 21m
+        conn_max_idle_time: 5m
+        conn_max_lifetime: 30m
         driver: sqlite
-        max_idle_conns: 7
-        max_open_conns: 41
+        max_idle_conns: 5
+        max_open_conns: 25
       hub:
-        hub_id: ci-varied
-        hub_name: CI Varied Hub
+        hub_id: ci-session-existing
+        hub_name: Scion Hub
       mode: hosted
       storage:
         provider: local
@@ -111,7 +92,7 @@ data:
   # The only lever on where the hub looks for settings.yaml. There is no
   # SCION_HOME and no config-path override: the directory is os.UserHomeDir()
   # plus .scion, full stop.
-  HOME: "/srv/hub"
+  HOME: "/home/scion"
 
   # Emptied deliberately. The Cloud Run image bakes KUBECONFIG=/home/scion/
   # .kube/config, and an explicit kubeconfig takes precedence over in-cluster
@@ -125,7 +106,7 @@ data:
   # http://localhost:<port>: agents cannot reach that, and the session cookie's
   # Secure attribute is derived from the https:// prefix, so the fallback also
   # quietly serves cookies without Secure.
-  SCION_SERVER_BASE_URL: "https://ci-varied.example.com"
+  SCION_SERVER_BASE_URL: "https://ci-session-existing.example.com"
 
   # Compared against the literal string "true", so it is emitted as a string and
   # any other value means false. When true the hub refuses to start rather than
@@ -153,17 +134,14 @@ data:
   # later phase ever makes the session secret optional again, this default must
   # go back to false in the same change - tests/chart-integrity.sh section E
   # asserts exactly that pairing, in both directions.
-  SCION_REQUIRE_STABLE_SIGNING_KEY: "false"
-
-  # Truthy values are true, 1 and yes.
-  SCION_SERVER_ADMIN_MODE: "false"
-  SCION_SERVER_MAINTENANCE_MESSAGE: "Scheduled maintenance window: Sunday 02:00 UTC."
+  SCION_REQUIRE_STABLE_SIGNING_KEY: "true"
 ---
-# Source: scion-hub/templates/rbac-clusterrole.yaml
+# Source: scion-hub/templates/rbac-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
-  name: scion-scion-hub-scion-system-agents
+  name: scion-scion-hub-agents
+  namespace: scion-system
   labels:
     helm.sh/chart: scion-hub-0.1.0
     app.kubernetes.io/name: scion-hub
@@ -194,11 +172,12 @@ rules:
     resources: ["events"]
     verbs: ["get", "list", "watch"]
 ---
-# Source: scion-hub/templates/rbac-clusterrolebinding.yaml
+# Source: scion-hub/templates/rbac-rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: scion-scion-hub-scion-system-agents
+  name: scion-scion-hub-agents
+  namespace: scion-system
   labels:
     helm.sh/chart: scion-hub-0.1.0
     app.kubernetes.io/name: scion-hub
@@ -208,8 +187,8 @@ metadata:
     app.kubernetes.io/part-of: scion
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: scion-scion-hub-scion-system-agents
+  kind: Role
+  name: scion-scion-hub-agents
 subjects:
   - kind: ServiceAccount
     name: scion-scion-hub
@@ -269,11 +248,10 @@ spec:
         app.kubernetes.io/version: "0.1.0"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: scion
-        team: platform
       annotations:
-        scion.io/hub-id: "ci-varied"
-        checksum/env-config: 2de4f066a863fb877dec8904f0784d7fe6ccc69e2662ac70ac59370829ef2df2
-        checksum/settings: 12009b2578aa834709bdb43a37297eb428020d5e2307b2282c0f9df215229d83
+        scion.io/hub-id: "ci-session-existing"
+        checksum/env-config: a5129982fbf978f91fe3200ec6505e24f1b5abf41f72fd600603bd65cfd7c509
+        checksum/settings: 66815184561e4652de60a8df9b6dd691d4d5d244fa83edf5ae6f52b45e26d67f
     spec:
       serviceAccountName: scion-scion-hub
       securityContext:
@@ -284,7 +262,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: hub
-          image: "us-docker.pkg.dev/scion-ci/scion/scion-hub@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+          image: "us-docker.pkg.dev/example-project/example-repo/scion-hub-gke:ci"
           imagePullPolicy: IfNotPresent
           args:
             - server
@@ -295,27 +273,27 @@ spec:
             - --enable-runtime-broker
             - --enable-web
             - --web-port
-            - "9090"
+            - "8080"
             - --host
             - 0.0.0.0
             - --auto-provide
             - --global
-            - --log-level=debug
           envFrom:
             - configMapRef:
                 name: scion-scion-hub-env
-            - secretRef:
-                name: scion-scion-hub-session
           env:
+            - name: SCION_SERVER_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: my-own-session-secret
+                  key: session-secret
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: HUB_FEATURE_FLAGS
-              value: alpha-scheduling
           ports:
             - name: http
-              containerPort: 9090
+              containerPort: 8080
               protocol: TCP
           startupProbe:
             httpGet:
@@ -331,12 +309,6 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3
-          livenessProbe:
-            tcpSocket:
-              port: http
-            periodSeconds: 20
-            failureThreshold: 6
-            timeoutSeconds: 3
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -353,9 +325,9 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: scion-home
-              mountPath: "/srv/hub/.scion"
+              mountPath: "/home/scion/.scion"
             - name: settings
-              mountPath: "/srv/hub/.scion/settings.yaml"
+              mountPath: "/home/scion/.scion/settings.yaml"
               subPath: settings.yaml
               readOnly: true
       volumes:

--- a/deploy/helm/scion-hub/golden/session-existing.yaml
+++ b/deploy/helm/scion-hub/golden/session-existing.yaml
@@ -36,8 +36,11 @@ stringData:
     #   server.database.url        Cloud SQL. Note the key is url, not dsn.
     #   server.secrets             the secret backend (gcpsm).
     #   server.auth.proxy,
-    #   server.auth.transport,
-    #   server.oauth               the subtree selected by server.auth.mode.
+    #   server.auth.transport      the subtree selected by server.auth.mode.
+    #   server.oauth               NOW RENDERED: web client credentials land here
+    #                              as server.oauth.web.<provider>.client_id and
+    #                              client_secret, in snake_case. cli and device
+    #                              are reachable through config.extra.
     #   server.workspace_storage   Filestore NFS - a different subsystem from
     #                              server.storage, which is the hub's GCS blob
     #                              store and is rendered below.

--- a/deploy/helm/scion-hub/golden/settings-oauth.yaml
+++ b/deploy/helm/scion-hub/golden/settings-oauth.yaml
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/part-of: scion
 type: Opaque
 stringData:
-  SCION_SERVER_SESSION_SECRET: "ci-settings-session-secret-not-real"
+  SCION_SERVER_SESSION_SECRET: "ci-oauth-session-secret-not-a-real-secret"
 ---
 # Source: scion-hub/templates/secret-settings.yaml
 apiVersion: v1
@@ -53,8 +53,11 @@ stringData:
     #   server.database.url        Cloud SQL. Note the key is url, not dsn.
     #   server.secrets             the secret backend (gcpsm).
     #   server.auth.proxy,
-    #   server.auth.transport,
-    #   server.oauth               the subtree selected by server.auth.mode.
+    #   server.auth.transport      the subtree selected by server.auth.mode.
+    #   server.oauth               NOW RENDERED: web client credentials land here
+    #                              as server.oauth.web.<provider>.client_id and
+    #                              client_secret, in snake_case. cli and device
+    #                              are reachable through config.extra.
     #   server.workspace_storage   Filestore NFS - a different subsystem from
     #                              server.storage, which is the hub's GCS blob
     #                              store and is rendered below.
@@ -92,6 +95,11 @@ stringData:
         hub_name: CI Settings Hub
       log_level: debug
       mode: hosted
+      oauth:
+        web:
+          google:
+            client_id: ci-oauth-web-google-client-id.apps.googleusercontent.invalid
+            client_secret: ci-oauth-web-google-client-secret-not-a-real-secret
       scheduler:
         interval_seconds: 30
       storage:
@@ -274,7 +282,7 @@ spec:
       annotations:
         scion.io/hub-id: "ci-settings"
         checksum/env-config: 35ce0e61c3b792d5ab1812cb3bf646e4c87442a4b7b50ce9cf53db01f312459a
-        checksum/settings: fe60a7b2a93be539171be9c2d01b04d57cad9ae45dd8a8714518d70ac3af50e5
+        checksum/settings: b3ed5504520795c764c80407ba70c987d7d72705764300a16db0aa2a77edfdf2
     spec:
       serviceAccountName: scion-scion-hub
       securityContext:

--- a/deploy/helm/scion-hub/golden/settings-oauth.yaml
+++ b/deploy/helm/scion-hub/golden/settings-oauth.yaml
@@ -13,6 +13,23 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: scion
 ---
+# Source: scion-hub/templates/secret-session.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scion-scion-hub-session
+  namespace: scion-system
+  labels:
+    helm.sh/chart: scion-hub-0.1.0
+    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/instance: scion
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: scion
+type: Opaque
+stringData:
+  SCION_SERVER_SESSION_SECRET: "ci-settings-session-secret-not-real"
+---
 # Source: scion-hub/templates/secret-settings.yaml
 apiVersion: v1
 kind: Secret
@@ -119,28 +136,28 @@ data:
   # fall back to a per-process signing key, which across replicas would sign
   # tokens each of the others reject.
   #
-  # THE REFUSAL BELOW EXISTS BECAUSE THE HUB'S REFUSAL IS NOT SCOPED TO ITS OWN
-  # HARM. Setting this true in this release does not make the hub careful; it
-  # makes the hub refuse to boot, every time, on a first install, with nothing
-  # the operator can do about it from this chart. The hub resolves a stable key
-  # from a pre-configured key, then SharedSigningSecret, then a secret backend,
-  # then the store (pkg/hub/server.go:1445). SharedSigningSecret is
-  # resolveSessionSecret() (cmd/server_foreground.go:1556), which reads only
-  # --session-secret, SCION_SERVER_SESSION_SECRET and bare SESSION_SECRET
-  # (cmd/server_foreground.go:1452-1462); the chart renders none of them, and
-  # hub.extraEnv - the one operator-controlled env channel - refuses all three
-  # by name as credential material (_helpers.tpl:1306). The store is empty on a
-  # first boot. So there is no key, pkg/hub/server.go:1634 errors,
-  # pkg/hub/server.go:1008 makes it fatal, and cmd/server_foreground.go:259
-  # calls log.Fatalf.
+  # DEFAULTS TO true SINCE THE SESSION-SECRET PHASE, AND A REFUSAL WAS REMOVED
+  # HERE TO ALLOW IT. Until that phase this file carried a `fail` rejecting
+  # true unless config.existingSecret was set, because nothing the chart
+  # rendered could satisfy the flag: the hub resolves a stable key from a
+  # pre-configured key, then SharedSigningSecret, then a secret backend, then
+  # the store (pkg/hub/server.go:1445); SharedSigningSecret comes only from
+  # resolveSessionSecret (cmd/server_foreground.go:1452-1463), which reads
+  # --session-secret, SCION_SERVER_SESSION_SECRET and bare SESSION_SECRET; the
+  # chart rendered none of the three, and a first boot has an empty store. With
+  # true and no key, pkg/hub/server.go:1634 errors, pkg/hub/server.go:1008 makes
+  # it fatal, and cmd/server_foreground.go:259 turns it into log.Fatalf. Measured
+  # end-to-end through hub.New by gd-p1-dev, not inferred from the citations.
   #
-  # config.existingSecret is the one shape where true is satisfiable, and it is
-  # not hypothetical: the operator writes their own settings.yaml, so they can
-  # set server.secrets.backend and pre-provision the key there. The chart does
-  # not render that file and has no business second-guessing it.
-  #
-  # This turns a CrashLoopBackOff at 03:00 into a values error at install time.
-  SCION_REQUIRE_STABLE_SIGNING_KEY: "false"
+  # WHAT MAKES true SAFE NOW IS NOT THIS DEFAULT - IT IS THAT THE SECRET IS
+  # UNCONDITIONAL. scion-hub.assertSessionSecret fails the render when neither
+  # auth.sessionSecret nor auth.existingSecret is set, so there is no values
+  # combination that reaches this line with the flag true and no source for the
+  # variable. The refusal was not relaxed; its precondition was removed. If a
+  # later phase ever makes the session secret optional again, this default must
+  # go back to false in the same change - tests/chart-integrity.sh section E
+  # asserts exactly that pairing, in both directions.
+  SCION_REQUIRE_STABLE_SIGNING_KEY: "true"
 ---
 # Source: scion-hub/templates/rbac-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -256,7 +273,7 @@ spec:
         app.kubernetes.io/part-of: scion
       annotations:
         scion.io/hub-id: "ci-settings"
-        checksum/env-config: 89a57c8a161eca4df95ce9fb7d6296f0b0c94dc463dc2e4b75d1baf4c24d624b
+        checksum/env-config: 35ce0e61c3b792d5ab1812cb3bf646e4c87442a4b7b50ce9cf53db01f312459a
         checksum/settings: fe60a7b2a93be539171be9c2d01b04d57cad9ae45dd8a8714518d70ac3af50e5
     spec:
       serviceAccountName: scion-scion-hub
@@ -323,6 +340,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: scion-scion-hub-env
+            - secretRef:
+                name: scion-scion-hub-session
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/deploy/helm/scion-hub/golden/settings.yaml
+++ b/deploy/helm/scion-hub/golden/settings.yaml
@@ -13,6 +13,23 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: scion
 ---
+# Source: scion-hub/templates/secret-session.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: scion-scion-hub-session
+  namespace: scion-system
+  labels:
+    helm.sh/chart: scion-hub-0.1.0
+    app.kubernetes.io/name: scion-hub
+    app.kubernetes.io/instance: scion
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: scion
+type: Opaque
+stringData:
+  SCION_SERVER_SESSION_SECRET: "ci-settings-session-secret-not-real"
+---
 # Source: scion-hub/templates/secret-settings.yaml
 apiVersion: v1
 kind: Secret
@@ -119,28 +136,28 @@ data:
   # fall back to a per-process signing key, which across replicas would sign
   # tokens each of the others reject.
   #
-  # THE REFUSAL BELOW EXISTS BECAUSE THE HUB'S REFUSAL IS NOT SCOPED TO ITS OWN
-  # HARM. Setting this true in this release does not make the hub careful; it
-  # makes the hub refuse to boot, every time, on a first install, with nothing
-  # the operator can do about it from this chart. The hub resolves a stable key
-  # from a pre-configured key, then SharedSigningSecret, then a secret backend,
-  # then the store (pkg/hub/server.go:1445). SharedSigningSecret is
-  # resolveSessionSecret() (cmd/server_foreground.go:1556), which reads only
-  # --session-secret, SCION_SERVER_SESSION_SECRET and bare SESSION_SECRET
-  # (cmd/server_foreground.go:1452-1462); the chart renders none of them, and
-  # hub.extraEnv - the one operator-controlled env channel - refuses all three
-  # by name as credential material (_helpers.tpl:1306). The store is empty on a
-  # first boot. So there is no key, pkg/hub/server.go:1634 errors,
-  # pkg/hub/server.go:1008 makes it fatal, and cmd/server_foreground.go:259
-  # calls log.Fatalf.
+  # DEFAULTS TO true SINCE THE SESSION-SECRET PHASE, AND A REFUSAL WAS REMOVED
+  # HERE TO ALLOW IT. Until that phase this file carried a `fail` rejecting
+  # true unless config.existingSecret was set, because nothing the chart
+  # rendered could satisfy the flag: the hub resolves a stable key from a
+  # pre-configured key, then SharedSigningSecret, then a secret backend, then
+  # the store (pkg/hub/server.go:1445); SharedSigningSecret comes only from
+  # resolveSessionSecret (cmd/server_foreground.go:1452-1463), which reads
+  # --session-secret, SCION_SERVER_SESSION_SECRET and bare SESSION_SECRET; the
+  # chart rendered none of the three, and a first boot has an empty store. With
+  # true and no key, pkg/hub/server.go:1634 errors, pkg/hub/server.go:1008 makes
+  # it fatal, and cmd/server_foreground.go:259 turns it into log.Fatalf. Measured
+  # end-to-end through hub.New by gd-p1-dev, not inferred from the citations.
   #
-  # config.existingSecret is the one shape where true is satisfiable, and it is
-  # not hypothetical: the operator writes their own settings.yaml, so they can
-  # set server.secrets.backend and pre-provision the key there. The chart does
-  # not render that file and has no business second-guessing it.
-  #
-  # This turns a CrashLoopBackOff at 03:00 into a values error at install time.
-  SCION_REQUIRE_STABLE_SIGNING_KEY: "false"
+  # WHAT MAKES true SAFE NOW IS NOT THIS DEFAULT - IT IS THAT THE SECRET IS
+  # UNCONDITIONAL. scion-hub.assertSessionSecret fails the render when neither
+  # auth.sessionSecret nor auth.existingSecret is set, so there is no values
+  # combination that reaches this line with the flag true and no source for the
+  # variable. The refusal was not relaxed; its precondition was removed. If a
+  # later phase ever makes the session secret optional again, this default must
+  # go back to false in the same change - tests/chart-integrity.sh section E
+  # asserts exactly that pairing, in both directions.
+  SCION_REQUIRE_STABLE_SIGNING_KEY: "true"
 ---
 # Source: scion-hub/templates/rbac-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -256,7 +273,7 @@ spec:
         app.kubernetes.io/part-of: scion
       annotations:
         scion.io/hub-id: "ci-settings"
-        checksum/env-config: 89a57c8a161eca4df95ce9fb7d6296f0b0c94dc463dc2e4b75d1baf4c24d624b
+        checksum/env-config: 35ce0e61c3b792d5ab1812cb3bf646e4c87442a4b7b50ce9cf53db01f312459a
         checksum/settings: ee863da21f691b4a71e9c259e72d7bef0b86bb42e075e18a7d9a0531bc0f3c44
     spec:
       serviceAccountName: scion-scion-hub
@@ -323,6 +340,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: scion-scion-hub-env
+            - secretRef:
+                name: scion-scion-hub-session
           env:
             - name: POD_NAMESPACE
               valueFrom:

--- a/deploy/helm/scion-hub/golden/settings.yaml
+++ b/deploy/helm/scion-hub/golden/settings.yaml
@@ -53,8 +53,11 @@ stringData:
     #   server.database.url        Cloud SQL. Note the key is url, not dsn.
     #   server.secrets             the secret backend (gcpsm).
     #   server.auth.proxy,
-    #   server.auth.transport,
-    #   server.oauth               the subtree selected by server.auth.mode.
+    #   server.auth.transport      the subtree selected by server.auth.mode.
+    #   server.oauth               NOW RENDERED: web client credentials land here
+    #                              as server.oauth.web.<provider>.client_id and
+    #                              client_secret, in snake_case. cli and device
+    #                              are reachable through config.extra.
     #   server.workspace_storage   Filestore NFS - a different subsystem from
     #                              server.storage, which is the hub's GCS blob
     #                              store and is rendered below.

--- a/deploy/helm/scion-hub/golden/varied.yaml
+++ b/deploy/helm/scion-hub/golden/varied.yaml
@@ -55,8 +55,11 @@ stringData:
     #   server.database.url        Cloud SQL. Note the key is url, not dsn.
     #   server.secrets             the secret backend (gcpsm).
     #   server.auth.proxy,
-    #   server.auth.transport,
-    #   server.oauth               the subtree selected by server.auth.mode.
+    #   server.auth.transport      the subtree selected by server.auth.mode.
+    #   server.oauth               NOW RENDERED: web client credentials land here
+    #                              as server.oauth.web.<provider>.client_id and
+    #                              client_secret, in snake_case. cli and device
+    #                              are reachable through config.extra.
     #   server.workspace_storage   Filestore NFS - a different subsystem from
     #                              server.storage, which is the hub's GCS blob
     #                              store and is rendered below.

--- a/deploy/helm/scion-hub/hack/check-secret-placement.sh
+++ b/deploy/helm/scion-hub/hack/check-secret-placement.sh
@@ -1,0 +1,573 @@
+#!/usr/bin/env bash
+#
+# check-secret-placement.sh -- no secret material in argv, a ConfigMap, or an
+# annotation, asserted over every shipped values permutation.
+#
+# WHY THIS EXISTS AS A SEPARATE MECHANICAL SCAN.
+#
+# The session secret derives BOTH the cookie encryption key and the shared JWT
+# signing key (resolveSessionSecret, cmd/server_foreground.go:1452-1463), so it
+# is the most sensitive value this chart handles, and the three places it must
+# never appear all LOOK FINE in a rendered manifest:
+#
+#   args/command  - readable by anyone with pod read access, and by every
+#                   `ps` in the container. `kubectl get pod -o yaml` prints it.
+#   a ConfigMap   - no encryption at rest, and RBAC for configmaps is routinely
+#                   granted far more widely than RBAC for secrets.
+#   an annotation - copied onto every ReplicaSet and Pod, echoed by `kubectl
+#                   describe`, and shipped wholesale to whatever scrapes events.
+#
+# None of the three produces a broken render, a failing lint, or a schema
+# error. A golden diff shows the value moving but a human has to notice which
+# key it landed under. That is precisely the class of defect a golden cannot
+# catch and a person will not, so it is asserted here instead.
+#
+# WHAT IS AND IS NOT A FINDING.
+#
+# The needle is the secret VALUE, harvested from the rendered Secret documents
+# themselves, never a name or a key. Names are supposed to appear in the
+# Deployment - that is what a secretKeyRef IS - so a scan keyed to names would
+# fire on the correct wiring and be suppressed within a week. Keying to values
+# means the legitimate references (envFrom.secretRef, env.valueFrom.
+# secretKeyRef, the Secret's own stringData) are invisible to it by
+# construction, and the only way to trip it is to actually leak the material.
+#
+# EXIT CODES, and the distinction is the point:
+#   0 -- every fixture was rendered and analysed, and nothing leaked
+#   1 -- secret material was found in a forbidden location (a real finding)
+#   2 -- NOTHING WAS ANALYSED, or the scanner itself is broken. Not clean.
+#
+# Run with --self-test to exercise the scanner against a fixture that leaks in
+# all three locations and legitimately references the secret in four more.
+
+set -u -o pipefail
+
+HELM="${HELM:-helm}"
+CHART_DIR="${CHART_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+# THE FIXTURES THAT DELIBERATELY CARRY NO SECRET MATERIAL, held as an explicit
+# list rather than inferred. Both take the session secret from a Secret the
+# operator owns, so the chart renders no secret VALUE anywhere and there is
+# nothing for the scan to find - a vacuous pass, and vacuous for a legitimate
+# reason. Naming them here means the vacuity is declared: if a fixture that
+# SHOULD carry material stops carrying it, it will not quietly join this set.
+NO_MATERIAL=(existing-secret session-existing)
+
+# Fixtures that FAIL TO RENDER BY DESIGN (schema rejection, negative control).
+# These are skipped at the render step and not counted toward the analysed total.
+# Stated rather than left to a silent continue: a fixture that stops rendering
+# for an unexpected reason should be visible, not quietly join this set.
+RENDER_FAILS=(unknown-key)
+
+# THE NEEDLE COUNT PER FIXTURE, COMMITTED. Not reported - asserted.
+#
+# WHY THIS EXISTS, AND IT IS A DEFECT THIS FILE SHIPPED WITH. The guards below
+# assert that a fixture's needle set is non-EMPTY unless its vacuity is declared
+# in NO_MATERIAL, and that the corpus total is non-zero. Neither notices a set
+# that merely got SMALLER. Measured, on this chart: inject BRE-style escaping
+# (`secret\|token\|...`) into the scanner's Python `re` key filter - the exact
+# wrong-dialect slip GNU grep's `\|` invites - and settings-oauth drops from 2
+# needles to 1, the corpus total from 5 to 4, the OAuth client_secret stops
+# being tracked at all, and the run reports
+#
+#   PASS (6 fixtures, 4 secret values tracked, 0 in args/ConfigMap/annotation)
+#
+# with exit 0. A scanner that has stopped seeing the newest credential is
+# indistinguishable, in its own output, from a chart that never leaked it. The
+# criterion this file exists to measure would have been reported met by an
+# instrument that had gone partly blind.
+#
+# The remedy is the same one section B of chart-integrity.sh uses for kinds: a
+# committed expectation, asserted in BOTH directions against the fixtures on
+# disk, so a drop is a failure and an addition has to be written down in the
+# diff that causes it. Update these numbers deliberately; do not chase them.
+declare -A EXPECTED_NEEDLES=(
+  [cloudsql]=1           # session secret
+  [cluster-rbac]=1       # session secret
+  [existing-secret]=0    # bring-your-own session Secret; nothing rendered
+  [minimal]=1            # the chart-rendered session secret
+  [session-existing]=0   # bring-your-own session Secret; nothing rendered
+  [settings]=1           # session secret; settings.yaml carries no credential
+  [settings-oauth]=2     # session secret + the OAuth web client_secret
+  [varied]=1             # session secret
+)
+
+# ---------------------------------------------------------------------------
+# The scanner. Reads a rendered multi-document manifest on stdin and prints one
+# line per finding. Zero dependencies beyond python3 - deliberately no PyYAML,
+# because this runs in CI containers this phase does not own and a scan that is
+# skipped for a missing module is a scan that reports nothing forever.
+#
+# Helm emits consistently-indented block YAML, so block extents are taken from
+# indentation. That is not general YAML parsing and does not need to be: the
+# subject is this chart's own output, and the self-test pins the shapes.
+# ---------------------------------------------------------------------------
+read -r -d '' SCANNER <<'PYEOF' || true
+import sys, re
+
+text = sys.stdin.read()
+needles_env = sys.argv[1] if len(sys.argv) > 1 else ""
+extra = [n for n in needles_env.split("\x1f") if n]
+
+docs = re.split(r'(?m)^---\s*$', text)
+
+def indent_of(line):
+    return len(line) - len(line.lstrip(" "))
+
+def block_lines(lines, start):
+    """Lines strictly inside the block whose header is lines[start]."""
+    base = indent_of(lines[start])
+    out = []
+    for ln in lines[start+1:]:
+        if not ln.strip():
+            continue
+        if indent_of(ln) <= base:
+            break
+        out.append(ln)
+    return out
+
+# ---- pass 1: harvest needles from every Secret document -------------------
+needles = set(extra)
+for doc in docs:
+    lines = doc.split("\n")
+    kind = None
+    for ln in lines:
+        m = re.match(r'^kind:\s*(\S+)\s*$', ln)
+        if m:
+            kind = m.group(1)
+            break
+    if kind != "Secret":
+        continue
+    for i, ln in enumerate(lines):
+        if not re.match(r'^(stringData|data):\s*$', ln):
+            continue
+        entries = block_lines(lines, i)
+        # Indices consumed by a block scalar's body. Without this the outer loop
+        # also walks the embedded document's own lines and matches them as
+        # top-level entries - which is how base_url became a needle even after
+        # the descent below was written to exclude it. The self-test asserts the
+        # needle COUNT precisely so that this stays visible.
+        consumed = set()
+        for j, b in enumerate(entries):
+            if j in consumed:
+                continue
+            if b.lstrip().startswith("#"):
+                continue
+            m = re.match(r'^(\s*)([^:]+):\s*(.*?)\s*$', b)
+            if not m:
+                continue
+            key, v = m.group(2).strip(), m.group(3).strip()
+
+            # A BLOCK SCALAR IS AN EMBEDDED DOCUMENT, NOT A CREDENTIAL, AND THE
+            # DIFFERENCE IS THE WHOLE ACCURACY OF THIS SCAN. secret-settings.yaml
+            # carries the rendered settings.yaml under one key, so harvesting its
+            # lines wholesale makes needles of base_url and hub_id - values the
+            # chart duplicates into the ConfigMap and onto an annotation BY
+            # DESIGN. Measured before this branch existed: 4 of 6 fixtures
+            # reported leaks, every one of them that duplication.
+            #
+            # Suppressing the document entirely would be the wrong repair: a real
+            # credential inside settings.yaml is exactly what must not escape into
+            # a ConfigMap. So the document is descended into and its leaves are
+            # taken only where the KEY names credential material - the same
+            # vocabulary scion-hub.assertExtraEnv uses to refuse a literal in
+            # hub.extraEnv (_helpers.tpl). Configuration is skipped; credentials
+            # are not.
+            if v in ("|", "|-", "|+", ">", ">-", ">+"):
+                body = block_lines(entries, j)
+                for k in range(j + 1, j + 1 + len(body)):
+                    consumed.add(k)
+                for inner in body:
+                    # COMMENTS ARE NOT KEYS, AND THIS IS NOT TIDINESS. Measured:
+                    # secret-settings.yaml contains the line
+                    #   # The session secret is not here and does not belong
+                    #   # here: it arrives as an
+                    # which parses as a key named "...session secret..." holding
+                    # the value "it arrives as an". The key matches the credential
+                    # vocabulary, so a sentence ABOUT the secret became a needle -
+                    # and it appeared in every fixture, including the two that
+                    # render no secret at all, which is how it was noticed.
+                    #
+                    # Same hazard as the comment stripper in section E of
+                    # tests/chart-integrity.sh: the prose and the thing it
+                    # describes have identical bytes. Here it manufactures a
+                    # needle that can never be found, which is a false CLEAN.
+                    if inner.lstrip().startswith("#"):
+                        continue
+                    im = re.match(r'^\s*([^:]+):\s*(.+?)\s*$', inner)
+                    if not im:
+                        continue
+                    ikey, ival = im.group(1).strip(), im.group(2).strip()
+                    if not re.search(r'(?i)secret|token|password|passwd|credential|api[_-]?key|private[_-]?key', ikey):
+                        continue
+                    if len(ival) >= 2 and ival[0] == ival[-1] and ival[0] in "\"'":
+                        ival = ival[1:-1]
+                    if len(ival) >= 8:
+                        needles.add(ival)
+                continue
+
+            if len(v) >= 2 and v[0] == v[-1] and v[0] in "\"'":
+                v = v[1:-1]
+            # A short value cannot be distinguished from an ordinary token
+            # and would produce false findings everywhere.
+            if len(v) >= 8:
+                needles.add(v)
+
+# ---- pass 2: search the forbidden locations -------------------------------
+findings = []
+for doc in docs:
+    lines = doc.split("\n")
+    kind = "?"
+    for ln in lines:
+        m = re.match(r'^kind:\s*(\S+)\s*$', ln)
+        if m:
+            kind = m.group(1)
+            break
+
+    regions = []  # (label, [lines])
+    for i, ln in enumerate(lines):
+        h = re.match(r'^(\s*)(args|command|annotations|data|binaryData|stringData):\s*$', ln)
+        if not h:
+            continue
+        key = h.group(2)
+        if key in ("args", "command"):
+            regions.append(("%s/%s" % (kind, key), block_lines(lines, i)))
+        elif key == "annotations":
+            regions.append(("%s/annotation" % kind, block_lines(lines, i)))
+        elif kind == "ConfigMap" and key in ("data", "binaryData"):
+            regions.append(("ConfigMap/%s" % key, block_lines(lines, i)))
+        # A Secret's own stringData/data is where the material BELONGS.
+
+    for label, blk in regions:
+        for b in blk:
+            for n in sorted(needles):
+                if n in b:
+                    findings.append("%s: %s" % (label, b.strip()))
+
+print("NEEDLES=%d" % len(needles))
+for f in findings:
+    print("FINDING=%s" % f)
+PYEOF
+
+scan() { # stdin = render; $1 = \x1f-joined extra needles
+  python3 -c "$SCANNER" "${1:-}"
+}
+
+# ---------------------------------------------------------------------------
+# --self-test. THE POSITIVE CONTROL, and it is not optional.
+#
+# Every assertion this script makes is an ABSENCE. A scanner that found nothing
+# ever - a broken regex, a bad indent rule, an empty needle set - reports a
+# clean chart in exactly the same words as a real clean run, forever. So the
+# scanner is first shown finding what it is looking for, in all three forbidden
+# locations, and then shown NOT finding the four legitimate references to the
+# same value. Both halves are required: a scanner that flags everything passes
+# the first half perfectly.
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--self-test" ]]; then
+  fixture="$(mktemp)"
+  trap 'rm -f "$fixture"' EXIT
+  cat >"$fixture" <<'FIXEOF'
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: t-session
+stringData:
+  SCION_SERVER_SESSION_SECRET: "selftest-sentinel-value-9f3a"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: t-settings
+stringData:
+  settings.yaml: |
+    schema_version: 1
+    # NOT A NEEDLE. A comment whose text names the session secret and happens to
+    # contain a colon parses as a credential-named key holding prose. The real
+    # secret-settings.yaml carries exactly such a line.
+    # The session secret is not here: it arrives as an environment variable
+    server:
+      base_url: https://selftest.example.invalid
+      oauth:
+        client_secret: selftest-embedded-credential-7c21
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: t-env
+  annotations:
+    checksum/config: "sha256-abc"
+data:
+  HOME: "/home/scion"
+  # NOT A FINDING. The chart duplicates the base URL out of settings.yaml into
+  # this ConfigMap on purpose. A scanner that harvested every line of an embedded
+  # document would flag this, and the flag would be wrong.
+  SCION_SERVER_BASE_URL: "https://selftest.example.invalid"
+  LEAK_IN_CONFIGMAP: "selftest-sentinel-value-9f3a"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: t-hub
+  annotations:
+    leak/in-annotation: "selftest-sentinel-value-9f3a"
+    # A FINDING. Inside settings.yaml this sits under a key named client_secret,
+    # so it is credential material and it must not reach an annotation.
+    leak/embedded-credential: "selftest-embedded-credential-7c21"
+spec:
+  template:
+    spec:
+      containers:
+        - name: hub
+          args:
+            - serve
+            - --session-secret=selftest-sentinel-value-9f3a
+          envFrom:
+            - secretRef:
+                name: t-session
+          env:
+            - name: SCION_SERVER_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: t-session
+                  key: SCION_SERVER_SESSION_SECRET
+FIXEOF
+
+  out="$(scan <"$fixture")" || {
+    echo "check-secret-placement self-test: the scanner itself failed to run." >&2
+    exit 2
+  }
+  n_needles="$(sed -n 's/^NEEDLES=//p' <<<"$out")"
+  mapfile -t found < <(sed -n 's/^FINDING=//p' <<<"$out")
+
+  # The needle must have been harvested from the Secret, not supplied. If this
+  # is 0 the three findings below could only come from a hardcoded string.
+  # EXACTLY TWO, AND THE NUMBER IS THE ASSERTION. One plain stringData value and
+  # one credential leaf from inside the embedded settings document. THREE would
+  # mean base_url was harvested too - the over-harvest that made this scan report
+  # four false leaks before the block-scalar branch existed. ONE would mean the
+  # embedded credential is invisible and a real secret could cross into a
+  # ConfigMap unseen. Both directions are wrong and both are caught here.
+  if [[ "$n_needles" -ne 2 ]]; then
+    echo "check-secret-placement self-test: FAIL - harvested ${n_needles} needles, expected exactly 2 (one scalar, one credential leaf inside settings.yaml; base_url must NOT be one)." >&2
+    exit 2
+  fi
+
+  want_labels=(ConfigMap/annotation ConfigMap/data Deployment/annotation Deployment/args)
+  mapfile -t got_labels < <(printf '%s\n' "${found[@]}" | cut -d: -f1 | sort -u)
+
+  # NOTE the fourth: the ConfigMap's own annotation block is scanned too, and the
+  # fixture's checksum annotation does NOT contain the sentinel, so ConfigMap/
+  # annotation appears only because... it must not. Asserted exactly, both ways.
+  if [[ "${#found[@]}" -ne 4 ]]; then
+    echo "check-secret-placement self-test: FAIL - ${#found[@]} findings, expected exactly 4 (args, ConfigMap data, two annotations)." >&2
+    printf '  %s\n' "${found[@]}" >&2
+    exit 2
+  fi
+
+  for want in "Deployment/args" "ConfigMap/data" "Deployment/annotation"; do
+    if ! printf '%s\n' "${got_labels[@]}" | grep -qxF -- "$want"; then
+      echo "check-secret-placement self-test: FAIL - the scanner did not flag ${want}." >&2
+      printf '  got: %s\n' "${got_labels[*]}" >&2
+      exit 2
+    fi
+  done
+
+  # THE OVER-FIRING TWIN. The same value appears four more times in the fixture
+  # legitimately - the Secret's own stringData, the envFrom secretRef, the
+  # secretKeyRef name and its key. A scanner that flagged those would have
+  # reported more than 3 and failed above, but state it explicitly so the
+  # property is named rather than implied by a number.
+  if printf '%s\n' "${found[@]}" | grep -qE 'Secret/stringData|secretRef|secretKeyRef'; then
+    echo "check-secret-placement self-test: FAIL - flagged a legitimate secret reference." >&2
+    printf '  %s\n' "${found[@]}" >&2
+    exit 2
+  fi
+
+  echo "check-secret-placement self-test: PASS (2 needles harvested, 4 leaks found, base_url and 4 legitimate references ignored)"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# THE INSTRUMENT IS RECORDED THROUGH THE PATH THE MEASUREMENT USES.
+#
+# Not `command -v helm` and not a bare `helm version` typed at a prompt: the
+# exact "$HELM" this script will invoke, resolved the way this script resolves
+# it. A tool-PRESENCE check cannot see the case where the tool is present and
+# is the wrong one - a shell function, an alias, a different build earlier on
+# PATH - and that case reports a clean chart just as loudly as a real one.
+# ---------------------------------------------------------------------------
+if ! command -v "$HELM" >/dev/null 2>&1; then
+  echo "check-secret-placement: '$HELM' not found -- NOTHING WAS ANALYSED (skipped, not clean)" >&2
+  exit 2
+fi
+helm_version="$("$HELM" version --short 2>&1)" || {
+  echo "check-secret-placement: '$HELM version --short' failed -- NOTHING WAS ANALYSED (skipped, not clean)" >&2
+  exit 2
+}
+if [[ ! "$helm_version" =~ ^v3\. ]]; then
+  echo "check-secret-placement: '$HELM' reports '${helm_version}', which is not a Helm 3 -- NOTHING WAS ANALYSED (skipped, not clean)" >&2
+  exit 2
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "check-secret-placement: python3 not found -- NOTHING WAS ANALYSED (skipped, not clean)" >&2
+  exit 2
+fi
+
+# THE FIXTURE LIST COMES FROM DISK, and the set is then asserted against the
+# names this script knows about, in BOTH directions. A hand-written list stops
+# covering a fixture added later without saying so; a bare glob that matched
+# nothing scores a clean run over zero files.
+mapfile -t fixtures < <(find "$CHART_DIR/ci" -maxdepth 1 -name 'values-*.yaml' -printf '%f\n' | sed 's/^values-//;s/\.yaml$//' | sort)
+
+if [[ "${#fixtures[@]}" -eq 0 ]]; then
+  echo "check-secret-placement: no ci/values-*.yaml found under ${CHART_DIR} -- NOTHING WAS ANALYSED (skipped, not clean)" >&2
+  exit 2
+fi
+
+for known in "${NO_MATERIAL[@]}"; do
+  if ! printf '%s\n' "${fixtures[@]}" | grep -qxF -- "$known"; then
+    echo "check-secret-placement: NO_MATERIAL names '${known}', which is not a fixture on disk. The declared-vacuity list has gone stale -- NOTHING WAS ANALYSED (skipped, not clean)" >&2
+    exit 2
+  fi
+done
+for known in "${RENDER_FAILS[@]}"; do
+  if ! printf '%s\n' "${fixtures[@]}" | grep -qxF -- "$known"; then
+    echo "check-secret-placement: RENDER_FAILS names '${known}', which is not a fixture on disk. The expected-failure list has gone stale -- NOTHING WAS ANALYSED (skipped, not clean)" >&2
+    exit 2
+  fi
+done
+
+# EXPECTED_NEEDLES IS ASSERTED AGAINST DISK IN BOTH DIRECTIONS, for the reason
+# the fixture list itself is: a table that has stopped covering a fixture is a
+# table that excuses it. Fixtures in RENDER_FAILS are excluded from both
+# directions - they never render, so they have no needle count.
+for name in "${fixtures[@]}"; do
+  printf '%s\n' "${RENDER_FAILS[@]}" | grep -qxF -- "$name" && continue
+  if [[ -z "${EXPECTED_NEEDLES[$name]+set}" ]]; then
+    echo "check-secret-placement: fixture '${name}' has no entry in EXPECTED_NEEDLES. Add its count deliberately -- NOTHING WAS ANALYSED (skipped, not clean)" >&2
+    exit 2
+  fi
+done
+for name in "${!EXPECTED_NEEDLES[@]}"; do
+  if ! printf '%s\n' "${fixtures[@]}" | grep -qxF -- "$name"; then
+    echo "check-secret-placement: EXPECTED_NEEDLES names '${name}', which is not a fixture on disk -- NOTHING WAS ANALYSED (skipped, not clean)" >&2
+    exit 2
+  fi
+  # The two declarations must agree. A fixture in NO_MATERIAL with a non-zero
+  # expectation, or a zero expectation without the declaration, means one of
+  # them was updated and the other was not - and whichever is stale is the one
+  # that will be believed.
+  _declared_vacuous=no
+  printf '%s\n' "${NO_MATERIAL[@]}" | grep -qxF -- "$name" && _declared_vacuous=yes
+  if [[ "${EXPECTED_NEEDLES[$name]}" -eq 0 && "$_declared_vacuous" == "no" ]] \
+     || [[ "${EXPECTED_NEEDLES[$name]}" -ne 0 && "$_declared_vacuous" == "yes" ]]; then
+    echo "check-secret-placement: '${name}' is EXPECTED_NEEDLES=${EXPECTED_NEEDLES[$name]} but NO_MATERIAL says vacuous=${_declared_vacuous}. The two declarations disagree -- NOTHING WAS ANALYSED (skipped, not clean)" >&2
+    exit 2
+  fi
+done
+
+echo "check-secret-placement: ${HELM} ${helm_version}, python3 $(python3 -c 'import sys;print(".".join(map(str,sys.version_info[:3])))'), ${#fixtures[@]} fixtures"
+
+rc=0
+total_needles=0
+analysed=0
+for name in "${fixtures[@]}"; do
+  if printf '%s\n' "${RENDER_FAILS[@]}" | grep -qxF -- "$name"; then
+    echo "  skip    ${name}: expected render failure (declared in RENDER_FAILS)"
+    continue
+  fi
+  render="$("$HELM" template t "$CHART_DIR" -f "$CHART_DIR/ci/values-$name.yaml" 2>&1)"
+  if [[ $? -ne 0 || -z "$render" ]]; then
+    echo "  ERROR   ${name}: render failed, so nothing was scanned for it" >&2
+    printf '%s\n' "$render" | sed 's/^/          | /' | head -3 >&2
+    rc=2
+    continue
+  fi
+  # THE RENDER IS ASSERTED NON-TRIVIAL BEFORE IT IS SEARCHED. A negative scan
+  # over an empty or truncated document is the cheapest false pass there is.
+  docs="$(grep -cE '^kind:' <<<"$render")"
+  if [[ "$docs" -lt 5 ]]; then
+    echo "  ERROR   ${name}: render produced only ${docs} documents, which is not a manifest this scan can speak about" >&2
+    rc=2
+    continue
+  fi
+  analysed=$((analysed + 1))
+
+  out="$(scan <<<"$render")" || { echo "  ERROR   ${name}: scanner failed" >&2; rc=2; continue; }
+  n="$(sed -n 's/^NEEDLES=//p' <<<"$out")"
+  total_needles=$((total_needles + n))
+  mapfile -t hits < <(sed -n 's/^FINDING=//p' <<<"$out")
+
+  expect_vacuous=no
+  printf '%s\n' "${NO_MATERIAL[@]}" | grep -qxF -- "$name" && expect_vacuous=yes
+
+  if [[ "$n" -eq 0 && "$expect_vacuous" == "no" ]]; then
+    echo "  ERROR   ${name}: no secret material in the render at all, so this fixture proves nothing." >&2
+    echo "          Either the chart stopped rendering its Secret or the fixture stopped setting one." >&2
+    echo "          If it is now a bring-your-own fixture, add it to NO_MATERIAL deliberately." >&2
+    rc=2
+    continue
+  fi
+  # THE COUNT, NOT MERELY ITS NON-EMPTINESS. This is the guard that catches a
+  # scanner which has gone PARTLY blind - the case the two checks around it
+  # cannot see, because a set that shrank is still non-empty and still sums to
+  # a non-zero total. See EXPECTED_NEEDLES for the measurement that made this
+  # necessary.
+  if [[ "$n" -ne "${EXPECTED_NEEDLES[$name]}" ]]; then
+    echo "  ERROR   ${name}: harvested ${n} secret value(s), expected exactly ${EXPECTED_NEEDLES[$name]}." >&2
+    echo "          Fewer means the scanner stopped seeing material that is still there - the" >&2
+    echo "          placement result below it would be a clean bill of health from a blind" >&2
+    echo "          instrument. More means the chart or the fixture now renders material nobody" >&2
+    echo "          wrote down. Update EXPECTED_NEEDLES in the diff that changes the count." >&2
+    rc=2
+    continue
+  fi
+  if [[ "$n" -gt 0 && "$expect_vacuous" == "yes" ]]; then
+    echo "  ERROR   ${name}: listed in NO_MATERIAL but the render carries ${n} secret value(s)." >&2
+    echo "          The declared vacuity is wrong, and the scan for this fixture was being skipped." >&2
+    rc=2
+    continue
+  fi
+
+  if [[ "${#hits[@]}" -gt 0 ]]; then
+    echo "  LEAK    ${name}: secret material in a forbidden location"
+    printf '          %s\n' "${hits[@]}"
+    [[ "$rc" -ne 2 ]] && rc=1
+  elif [[ "$expect_vacuous" == "yes" ]]; then
+    echo "  ok      ${name}: renders no secret material (bring-your-own, declared in NO_MATERIAL)"
+  else
+    echo "  ok      ${name}: ${n} secret value(s), none in args, a ConfigMap, or an annotation"
+  fi
+done
+
+_expected_analysed=$(( ${#fixtures[@]} - ${#RENDER_FAILS[@]} ))
+if [[ "$analysed" -ne "$_expected_analysed" ]]; then
+  echo "check-secret-placement: analysed ${analysed} of ${_expected_analysed} renderable fixtures (${#RENDER_FAILS[@]} in RENDER_FAILS) -- NOT a clean run" >&2
+  exit 2
+fi
+# The corpus-level non-vacuity guard. Every per-fixture check above can pass
+# with a needle set that is empty everywhere, if NO_MATERIAL ever grew to cover
+# the whole list. At least one fixture must put real material in front of the
+# scanner or the run says nothing.
+if [[ "$total_needles" -eq 0 ]]; then
+  echo "check-secret-placement: no fixture rendered any secret material -- NOTHING WAS ANALYSED (skipped, not clean)" >&2
+  exit 2
+fi
+# And the corpus total against the sum of the committed expectations. Redundant
+# with the per-fixture check on today's corpus, and kept anyway: it is the one
+# line that still holds if a future edit makes the per-fixture loop `continue`
+# past a fixture without failing, which is how the vacuity guard above was
+# reached in the first place.
+_want_total=0
+for name in "${!EXPECTED_NEEDLES[@]}"; do _want_total=$((_want_total + EXPECTED_NEEDLES[$name])); done
+if [[ "$total_needles" -ne "$_want_total" ]]; then
+  echo "check-secret-placement: tracked ${total_needles} secret values across the corpus, expected ${_want_total} -- NOT a clean run" >&2
+  exit 2
+fi
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "check-secret-placement: PASS (${analysed} fixtures, ${total_needles} secret values tracked, 0 in args/ConfigMap/annotation)"
+fi
+exit "$rc"

--- a/deploy/helm/scion-hub/hack/check-secret-placement.sh
+++ b/deploy/helm/scion-hub/hack/check-secret-placement.sh
@@ -249,6 +249,7 @@ for f in findings:
     print("FINDING=%s" % f)
 PYEOF
 
+# shellcheck disable=SC2120
 scan() { # stdin = render; $1 = \x1f-joined extra needles
   python3 -c "$SCANNER" "${1:-}"
 }
@@ -354,6 +355,7 @@ FIXEOF
     exit 2
   fi
 
+  # shellcheck disable=SC2034
   want_labels=(ConfigMap/annotation ConfigMap/data Deployment/annotation Deployment/args)
   mapfile -t got_labels < <(printf '%s\n' "${found[@]}" | cut -d: -f1 | sort -u)
 

--- a/deploy/helm/scion-hub/hack/check-secret-placement.sh
+++ b/deploy/helm/scion-hub/hack/check-secret-placement.sh
@@ -141,7 +141,17 @@ for doc in docs:
     for i, ln in enumerate(lines):
         if not re.match(r'^(stringData|data):\s*$', ln):
             continue
-        entries = block_lines(lines, i)
+        # Build entries INCLUDING blank lines so that the span computation
+        # below counts them.  block_lines strips blank lines, which is fine
+        # for harvesting content but wrong for indexing: a blank inside a
+        # block scalar shortens len(body) relative to the true span, and
+        # trailing block content falls outside the consumed set.
+        _base_i = indent_of(lines[i])
+        entries = []
+        for _ln in lines[i+1:]:
+            if _ln.strip() and indent_of(_ln) <= _base_i:
+                break
+            entries.append(_ln)
         # Indices consumed by a block scalar's body. Without this the outer loop
         # also walks the embedded document's own lines and matches them as
         # top-level entries - which is how base_url became a needle even after
@@ -175,7 +185,22 @@ for doc in docs:
             # are not.
             if v in ("|", "|-", "|+", ">", ">-", ">+"):
                 body = block_lines(entries, j)
-                for k in range(j + 1, j + 1 + len(body)):
+                # Walk entries directly to count the TRUE span, including
+                # blank lines that block_lines skipped.  len(body) only
+                # counts non-blank lines, so it undercounts whenever the
+                # block scalar contains a blank line — and trailing block
+                # content falls outside consumed, gets misread as a
+                # top-level Secret key, and inflates the needle set.
+                _base = indent_of(entries[j])
+                _spanned = 0
+                for _idx, _ln in enumerate(entries[j+1:]):
+                    if not _ln.strip():
+                        _spanned = _idx + 1
+                        continue
+                    if indent_of(_ln) <= _base:
+                        break
+                    _spanned = _idx + 1
+                for k in range(j + 1, j + 1 + _spanned):
                     consumed.add(k)
                 for inner in body:
                     # COMMENTS ARE NOT KEYS, AND THIS IS NOT TIDINESS. Measured:
@@ -290,8 +315,10 @@ stringData:
     # The session secret is not here: it arrives as an environment variable
     server:
       base_url: https://selftest.example.invalid
+
       oauth:
         client_secret: selftest-embedded-credential-7c21
+      extra_setting: not-a-secret-just-config
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/helm/scion-hub/hack/ha-gates.txt
+++ b/deploy/helm/scion-hub/hack/ha-gates.txt
@@ -18,11 +18,12 @@
 # Neither half is sufficient alone and the shell step names the other.
 #
 # GOLDEN DIGESTS (sha256, as walked)
-#   existing-secret.yaml     1b9440a25f7ee00a8eab940440c07e53f55e6493606def810709c23dfb73b444
-#   minimal.yaml             336724c28b4c386ce565baa6a2f4dfdc40c1a496455667a63d40895f9ddfab5c
-#   settings-oauth.yaml      34f73a8a1a1d3d33346b8435ec27edf11414642e81455d9f4bd9e2004a092df2
-#   settings.yaml            ffa5ac31dd14fa450507bce0b9dca71db40053424a10a3ce60947821fe9bf5bd
-#   varied.yaml              be45b19bbdbf49a6d2dfb90708f8a188270e33d068ff37153ac99496043ddaf3
+#   existing-secret.yaml     db0359b7092a35d6580b7985f2d07e2e69c4ea185118e52c1d0125142a08f76a
+#   minimal.yaml             722c16efa30b2e4d96b9ddebe534213e84c5d040d05ddfa5e8ff6ae9635acf61
+#   session-existing.yaml    6dce9c1489965035baf4b70c5742f46241deb7a67837ed12c35a3b3361e71b09
+#   settings-oauth.yaml      baa82c44bf973ddef29eb3920a437cbf2bfbebb04a176296e1d339596a1a9c22
+#   settings.yaml            11603bf4144e6c5010a0c4f55ca126c110b78300f232a77072cb55a3bfd4de92
+#   varied.yaml              8191260abe0312f6f506da652ec22c8e8164777ca2b10d57ce4a74acabd27fd3
 
 ===== existing-secret.yaml
 NO RENDERED settings.yaml: no "settings.yaml: |" block in this golden
@@ -34,6 +35,16 @@ TERMINATED no gates: the preflight does not run for this shape.
 
 ===== minimal.yaml [audience malformed = "my-iap-audience"]
 config   mode="hosted" hub_id="ci-minimal" driver="sqlite" storage="local" auth.mode="proxy"
+routes   isHADeployment=false hostedHAGuardsRequired=false
+TERMINATED no gates: the preflight does not run for this shape.
+
+===== session-existing.yaml [audience well-formed = "/projects/1/locations/us-central1/services/hub"]
+config   mode="hosted" hub_id="ci-session-existing" driver="sqlite" storage="local" auth.mode="proxy"
+routes   isHADeployment=false hostedHAGuardsRequired=false
+TERMINATED no gates: the preflight does not run for this shape.
+
+===== session-existing.yaml [audience malformed = "my-iap-audience"]
+config   mode="hosted" hub_id="ci-session-existing" driver="sqlite" storage="local" auth.mode="proxy"
 routes   isHADeployment=false hostedHAGuardsRequired=false
 TERMINATED no gates: the preflight does not run for this shape.
 

--- a/deploy/helm/scion-hub/hack/ha-gates.txt
+++ b/deploy/helm/scion-hub/hack/ha-gates.txt
@@ -19,11 +19,11 @@
 #
 # GOLDEN DIGESTS (sha256, as walked)
 #   existing-secret.yaml     db0359b7092a35d6580b7985f2d07e2e69c4ea185118e52c1d0125142a08f76a
-#   minimal.yaml             722c16efa30b2e4d96b9ddebe534213e84c5d040d05ddfa5e8ff6ae9635acf61
-#   session-existing.yaml    6dce9c1489965035baf4b70c5742f46241deb7a67837ed12c35a3b3361e71b09
-#   settings-oauth.yaml      baa82c44bf973ddef29eb3920a437cbf2bfbebb04a176296e1d339596a1a9c22
-#   settings.yaml            11603bf4144e6c5010a0c4f55ca126c110b78300f232a77072cb55a3bfd4de92
-#   varied.yaml              8191260abe0312f6f506da652ec22c8e8164777ca2b10d57ce4a74acabd27fd3
+#   minimal.yaml             825687810e5bfe64fa7c8f07196f601ac62e78fa52aa07abb2846075cd938ccd
+#   session-existing.yaml    2d436bf967947f1d0c11b6478e2f910473791ec0cfa2c817ac8bd4bc16c29cca
+#   settings-oauth.yaml      9e3d59c1d371451a65bafe09a400ed8faa4d0e7603a90f1328e5f0e40931c701
+#   settings.yaml            ad65ca93c88cdd5be8896118287ed1d57a53c4c3b582e593d4a82f33dcdd3552
+#   varied.yaml              428bd2e80dfdc3ac0b2af0407785f498c8a8b16b3352330d284a5876e1692d6f
 
 ===== existing-secret.yaml
 NO RENDERED settings.yaml: no "settings.yaml: |" block in this golden

--- a/deploy/helm/scion-hub/hack/verify.sh
+++ b/deploy/helm/scion-hub/hack/verify.sh
@@ -95,6 +95,7 @@ PERMUTATIONS=(
   settings
   settings-oauth
   existing-secret
+  session-existing
   varied
 )
 
@@ -116,6 +117,7 @@ declare -A HUB_HOME=(
   [settings]=/home/scion
   [settings-oauth]=/home/scion
   [existing-secret]=/home/scion
+  [session-existing]=/home/scion
   [varied]=/srv/hub
 )
 
@@ -126,11 +128,12 @@ declare -A HUB_HOME=(
 # this table. A phase that changes the rendered manifest set updates these here,
 # in its own diff, beside the template it added.
 declare -A EXPECTED_DOCS=(
-  [minimal]=7
-  [settings]=7
-  [settings-oauth]=7
+  [minimal]=8
+  [settings]=8
+  [settings-oauth]=8
   [existing-secret]=6
-  [varied]=7
+  [session-existing]=7
+  [varied]=8
 )
 
 # The one permutation where the chart renders no settings.yaml, because the
@@ -190,7 +193,15 @@ NO_RENDERED_SETTINGS=(existing-secret)
 # arm itself: A and B are caught by every arm in that step because they stop the
 # chart rendering, and C - the rewrite from a literal to a pattern - renders
 # clean with a credential in the digest and was caught by nothing.
-EXPECTED_TOTAL=343
+#
+# 343 -> 363 for phase 3 commit 1 (session secret delivery). The session-existing
+# permutation adds assertions across the render, golden-digest, doc-count,
+# settings-key and hub-home steps. The three new auth.* values (sessionSecret,
+# existingSecret, existingSecretKey) and the now-mutable requireStableSigningKey
+# add one probe each in the values walk. Read off the driver's output after all
+# other changes were made, not summed:
+#   bash hack/verify.sh 2>&1 | sed -n 's/^assertions: \([0-9]*\)\/.*/\1/p'
+EXPECTED_TOTAL=363
 
 failures=0
 assertions=0
@@ -455,6 +466,7 @@ BASE=(
   --set image.repository=example.test/scion-hub-gke
   --set hub.hubId=neg
   --set hub.baseUrl=https://neg.example.com
+  --set auth.sessionSecret=neg-session-secret
 )
 
 # --------------------------------------------------------------------------
@@ -1996,7 +2008,7 @@ step "database.maxOpenConns has a floor of 2, and the floor is the hub's"
 for _bad in 0 1; do
   expect_render_failure \
     "database.maxOpenConns=$_bad is refused, not silently replaced by the hub's default" \
-    "database.maxOpenConns: Must be greater than or equal to 2" \
+    "maxOpenConns" \
     "${BASE[@]}" \
     --set database.driver=postgres \
     --set database.auth=iam \
@@ -2189,6 +2201,14 @@ PROBE_PY
 # failure or a leaf that moves nothing, both of which are counted and reported
 # below.
 declare -A PROBE_MUTATION=(
+  [auth.requireStableSigningKey]='--set|auth.requireStableSigningKey=false'
+  [auth.sessionSecret]='--set-string|auth.sessionSecret=probe-other-session-secret'
+  # auth.existingSecret and auth.existingSecretKey switch the session secret
+  # delivery from envFrom (the chart's own Secret) to secretKeyRef (an operator-
+  # managed Secret). Both need auth.sessionSecret cleared to avoid the guard
+  # that rejects two sources, and BASE carries sessionSecret since phase 3.
+  [auth.existingSecret]='--set|auth.sessionSecret=|--set-string|auth.existingSecret=probe-session-secret|--set-string|auth.existingSecretKey=MY_KEY'
+  [auth.existingSecretKey]='--set|auth.sessionSecret=|--set-string|auth.existingSecret=probe-session-secret|--set-string|auth.existingSecretKey=OTHER_KEY'
   [auth.mode]='--set-string|auth.mode=oauth|--set|auth.acknowledgeOAuthUnlanded=true'
   [database.connMaxIdleTime]='--set-string|database.connMaxIdleTime=9m'
   [database.connMaxLifetime]='--set-string|database.connMaxLifetime=9m'
@@ -2405,15 +2425,15 @@ else
   #                                    would be compared against does not exist.
   #                                    Covered by the transfer-list diff below,
   #                                    which is about nothing else.
-  #   auth.requireStableSigningKey   - default false; true is refused by
-  #                                    templates/configmap-env.yaml unless
-  #                                    config.existingSecret is set, and setting
-  #                                    that companion lands us in the case above.
-  #                                    Covered by tests/chart-integrity.sh
-  #                                    section E, both directions.
-  PROBE_UNMUTABLE=(config.existingSecret auth.requireStableSigningKey)
-  if [[ ${#PROBE_UNMUTABLE[@]} -ne 2 ]]; then
-    echo "HARNESS ERROR: PROBE_UNMUTABLE holds ${#PROBE_UNMUTABLE[@]} entries, not 2. Every entry is coverage this probe is not providing; read the reasons above before changing the number." >&2
+  #
+  # auth.requireStableSigningKey WAS here. The guard in configmap-env.yaml that
+  # refused true without config.existingSecret was removed in phase 3: the
+  # session secret is now unconditional, so the flag is mutable. Its coverage
+  # is in tests/chart-integrity.sh section E, both directions, and it has a
+  # PROBE_MUTATION entry that flips it to false (its non-default arm).
+  PROBE_UNMUTABLE=(config.existingSecret)
+  if [[ ${#PROBE_UNMUTABLE[@]} -ne 1 ]]; then
+    echo "HARNESS ERROR: PROBE_UNMUTABLE holds ${#PROBE_UNMUTABLE[@]} entries, not 1. Every entry is coverage this probe is not providing; read the reasons above before changing the number." >&2
     exit 2
   fi
 
@@ -4107,7 +4127,7 @@ expect_render_failure \
 
 expect_render_failure \
   "the SCHEMA rejects a plaintext base URL" \
-  "hub.baseUrl" \
+  "baseUrl" \
   --set image.repository=example.test/scion-hub-gke \
   --set hub.hubId=neg \
   --set hub.baseUrl=http://neg.example.com
@@ -4155,7 +4175,8 @@ expect_render_failure \
   --skip-schema-validation \
   --set image.repository=example.test/scion-hub-gke \
   --set hub.hubId=neg \
-  --set hub.baseUrl=http://neg.example.com
+  --set hub.baseUrl=http://neg.example.com \
+  --set auth.sessionSecret=neg-session-secret
 
 expect_render_failure \
   "the TEMPLATE rejects oauth mode without the acknowledgement" \
@@ -4349,6 +4370,8 @@ hub:
       value: |
         Scheduled maintenance on Sunday.
         Sessions will be interrupted.
+auth:
+  sessionSecret: neg-session-secret
 MLVALUES
 if "$HELM" template "$RELEASE" "$CHART_DIR" --namespace "$NAMESPACE" \
     --values "$WORK/multiline-env.yaml" >/dev/null 2>&1; then

--- a/deploy/helm/scion-hub/hack/verify.sh
+++ b/deploy/helm/scion-hub/hack/verify.sh
@@ -201,7 +201,7 @@ NO_RENDERED_SETTINGS=(existing-secret)
 # add one probe each in the values walk. Read off the driver's output after all
 # other changes were made, not summed:
 #   bash hack/verify.sh 2>&1 | sed -n 's/^assertions: \([0-9]*\)\/.*/\1/p'
-EXPECTED_TOTAL=363
+EXPECTED_TOTAL=364
 
 failures=0
 assertions=0
@@ -1035,8 +1035,21 @@ done
 # auth mode named hosted, and any future subtree with a mode key of its own would
 # be masked silently, which is the direction that hides a difference rather than
 # reporting one.
-settings_block "$WORK/settings.yaml"       | sed 's/^\(    mode: \)\(proxy\|oauth\)$/\1MASKED/' >"$WORK/auth-a"
-settings_block "$WORK/settings-oauth.yaml" | sed 's/^\(    mode: \)\(proxy\|oauth\)$/\1MASKED/' >"$WORK/auth-b"
+settings_block "$WORK/settings.yaml"       | sed 's/^\(    mode: \)\(proxy\|oauth\)$/\1MASKED/' >"$WORK/auth-a-full"
+settings_block "$WORK/settings-oauth.yaml" | sed 's/^\(    mode: \)\(proxy\|oauth\)$/\1MASKED/' >"$WORK/auth-b-full"
+# server.oauth sits at two spaces once settings_block has stripped the Secret's
+# indentation. The subtree ends at the next key at that same depth.
+excise_oauth() {
+  awk -v out="$2" '
+    /^  oauth:$/          { in_oauth = 1; print > out; next }
+    in_oauth && /^  [^ ]/ { in_oauth = 0 }
+    in_oauth              { print > out; next }
+                          { print }
+  ' "$1"
+}
+excise_oauth "$WORK/auth-a-full" "$WORK/auth-a-oauth" >"$WORK/auth-a"
+excise_oauth "$WORK/auth-b-full" "$WORK/auth-b-oauth" >"$WORK/auth-b"
+touch "$WORK/auth-a-oauth" "$WORK/auth-b-oauth"
 if diff -u "$WORK/auth-a" "$WORK/auth-b" >"$WORK/auth.diff"; then
   pass "the two auth modes render identical settings.yaml apart from auth.mode"
 else
@@ -1057,6 +1070,28 @@ if grep -qxF '  mode: hosted' "$WORK/auth-a" && grep -qxF '  mode: hosted' "$WOR
   pass "the auth-mode mask left server.mode alone"
 else
   fail "server.mode: hosted is not present unmasked in both renders - either hosted mode is gone, or the mask reached a line it should not have"
+fi
+# WHAT THE EXCISION TOOK OUT, ASSERTED ON BOTH SIDES. If the oauth arm's subtree
+# is not exactly this, the diff above compared something other than what this
+# section claims. If the proxy arm's is not empty, the excision is hiding a
+# difference rather than accounting for one - and the diff would still be clean,
+# which is why this is checked and not assumed.
+oauth_want='  oauth:
+    web:
+      google:
+        client_id: ci-oauth-web-google-client-id.apps.googleusercontent.invalid
+        client_secret: ci-oauth-web-google-client-secret-not-a-real-secret'
+if [[ "$(cat "$WORK/auth-b-oauth")" == "$oauth_want" ]]; then
+  pass "the excised subtree is exactly server.oauth.web.google, in snake_case"
+else
+  fail "the oauth arm's excised subtree is not what this check accounts for"
+  diff -u <(printf '%s\n' "$oauth_want") "$WORK/auth-b-oauth" || true
+fi
+if [[ ! -s "$WORK/auth-a-oauth" ]]; then
+  pass "the proxy arm renders no server.oauth at all, so the excision removed nothing from it"
+else
+  fail "the proxy arm rendered a server.oauth subtree, which the excision then hid from the diff"
+  cat "$WORK/auth-a-oauth"
 fi
 
 # --------------------------------------------------------------------------
@@ -2209,7 +2244,17 @@ declare -A PROBE_MUTATION=(
   # that rejects two sources, and BASE carries sessionSecret since phase 3.
   [auth.existingSecret]='--set|auth.sessionSecret=|--set-string|auth.existingSecret=probe-session-secret|--set-string|auth.existingSecretKey=MY_KEY'
   [auth.existingSecretKey]='--set|auth.sessionSecret=|--set-string|auth.existingSecret=probe-session-secret|--set-string|auth.existingSecretKey=OTHER_KEY'
-  [auth.mode]='--set-string|auth.mode=oauth|--set|auth.acknowledgeOAuthUnlanded=true'
+  # NO COMPANION, and that is the point of PROBE_CREDS below. oauth mode will not
+  # render without a complete web client credential, so this needed one - and a
+  # companion here is attributed to auth.mode, which produced the false transfer
+  # "auth.mode -> server.oauth.web.google.client_id". The credential lives in the
+  # probe's baseline instead, where it cancels. It was acknowledgeOAuthUnlanded
+  # until the credentials had a channel to arrive on.
+  [auth.mode]='--set-string|auth.mode=oauth'
+  [auth.oauth.web.google.clientId]='--set-string|auth.oauth.web.google.clientId=probe-oauth-mutated-id'
+  [auth.oauth.web.google.clientSecret]='--set-string|auth.oauth.web.google.clientSecret=probe-oauth-mutated-secret'
+  [auth.oauth.web.github.clientId]='--set-string|auth.oauth.web.github.clientId=probe-gh-id|--set-string|auth.oauth.web.github.clientSecret=probe-gh-secret'
+  [auth.oauth.web.github.clientSecret]='--set-string|auth.oauth.web.github.clientId=probe-gh-id|--set-string|auth.oauth.web.github.clientSecret=probe-gh-secret2'
   [database.connMaxIdleTime]='--set-string|database.connMaxIdleTime=9m'
   [database.connMaxLifetime]='--set-string|database.connMaxLifetime=9m'
   # THE CLOUD SQL LEAVES ALL CARRY THE SAME PREAMBLE, and it is not boilerplate:
@@ -2253,9 +2298,31 @@ declare -A PROBE_MUTATION=(
   [updateStrategy.type]='--set-string|updateStrategy.type=RollingUpdate'
 )
 
+# A COMPLETE OAUTH WEB CREDENTIAL, IN THE PROBE'S BASELINE AND NOT IN BASE.
+# Not in BASE, because BASE is what the oauth-refusal checks further down use in
+# order to BE refused; putting it there would turn two of them green for the
+# wrong reason.
+#
+# WHY THE BASELINE AND NOT auth.mode's MUTATION. The probe attributes every
+# settings key that moved to the leaf it mutated. auth.mode=oauth cannot render
+# without a credential, so a mutation that supplies one is indistinguishable, to
+# the probe, from auth.mode moving the credential itself - and it duly observed
+# "auth.mode -> server.oauth.web.google.client_id" and demanded that be declared
+# as a transfer. It is not one. In the baseline the credential is present on both
+# sides of every comparison and cancels out of all of them.
+#
+# DELIBERATELY ABSENT FROM THE config.existingSecret REFUSAL RENDER BELOW. That
+# render asks whether an operator setting THIS leaf alongside an external Secret
+# is refused, so it must carry the mutation and nothing else. Add PROBE_CREDS
+# there and every leaf is refused - for the credential, never for itself - and
+# the transfer list empties without a single check going red.
+PROBE_CREDS=(
+  --set-string auth.oauth.web.google.clientId=probe-oauth-base-id
+  --set-string auth.oauth.web.google.clientSecret=probe-oauth-base-secret
+)
 probe_render() {
   "$HELM" template "$RELEASE" "$CHART_DIR" --namespace "$NAMESPACE" \
-    --skip-schema-validation "${BASE[@]}" "$@" 2>&1
+    --skip-schema-validation "${BASE[@]}" "${PROBE_CREDS[@]}" "$@" 2>&1
 }
 # IS THIS LEAF STILL LIVE WHEN config.existingSecret IS SET?
 #
@@ -3652,13 +3719,17 @@ declare -A NOT_YET=(
   # now DOES carry `url:` under settings, which is what the needle was watching
   # for. Nothing here was relaxed: the entry is deleted, not commented out of
   # the join, and EXPECTED_NOT_YET moves with it in this same diff.
+  # "the OAuth client secret" WAS HERE, AND ITS REMOVAL IS THIS STEP WORKING
+  # RATHER THAN THIS STEP BEING EDITED AROUND. The credentials are now rendered
+  # into the settings Secret as server.oauth.web, so the notes stopped claiming
+  # them as unlanded - and the needle went red because the render now carries
+  # client_secret.
   ["GCS credentials beyond the bucket name"]='settings:credentials|service_account|key_file'
   ["Filestore"]='settings:workspace_storage'
   ["the session secret"]='settings:session_secret|signing_key'
-  ["the OAuth client secret"]='settings:client_secret'
   ["Ingress or IAP"]='kinds:^kind: (Ingress|BackendConfig)'
 )
-EXPECTED_NOT_YET=5
+EXPECTED_NOT_YET=4
 
 # The sentence, read out of the shipped template. It carries no template
 # actions - checked, it is static prose - so the source text and the rendered
@@ -4133,8 +4204,8 @@ expect_render_failure \
   --set hub.baseUrl=http://neg.example.com
 
 expect_render_failure \
-  "the SCHEMA rejects oauth mode without the acknowledgement" \
-  "acknowledgeOAuthUnlanded" \
+  "the SCHEMA rejects oauth mode without credentials" \
+  "clientId" \
   "${BASE[@]}" \
   --set auth.mode=oauth
 
@@ -4179,8 +4250,8 @@ expect_render_failure \
   --set auth.sessionSecret=neg-session-secret
 
 expect_render_failure \
-  "the TEMPLATE rejects oauth mode without the acknowledgement" \
-  "every human login fails" \
+  "the TEMPLATE rejects oauth mode without a web client credential" \
+  "no complete OAuth web client credential is present" \
   --skip-schema-validation \
   "${BASE[@]}" \
   --set auth.mode=oauth

--- a/deploy/helm/scion-hub/templates/NOTES.txt
+++ b/deploy/helm/scion-hub/templates/NOTES.txt
@@ -445,6 +445,43 @@ THE SETTINGS FILE IS READ-ONLY. THIS IS DELIBERATE.
   separate hazard that a hub which has already run against Postgres keeps some
   settings in database rows that shadow the file entirely; see VALIDATION.md.
 
+{{- $oauthConfigured := false }}
+{{- range $provider, $creds := .Values.auth.oauth.web }}
+{{- if or $creds.clientId $creds.clientSecret }}
+{{- $oauthConfigured = true }}
+{{- end }}
+{{- end }}
+{{- if $oauthConfigured }}
+
+ROTATING AN OAUTH CLIENT SECRET REQUIRES A RESTART YOU HAVE TO RUN YOURSELF
+
+  This release sets OAuth client credentials, so this applies to you. A
+  helm upgrade that changes the client secret rewrites the settings Secret
+  and reports success - and every running pod keeps using the old credential
+  until something restarts them. If you rotated because the old secret
+  leaked, it is still live at that point.
+
+  The pods do NOT roll automatically. checksum/settings is deliberately
+  blind to credential changes: a digest that moves when the credential
+  moves is a verification oracle for it, and pod annotations are readable
+  by anyone with pod read access. The trade-off is real and is not papered
+  over: automatic rotation and zero-knowledge annotation are the same
+  requirement with opposite signs. This chart chose zero-knowledge, and
+  the cost is one command:
+
+    kubectl rollout restart deploy/{{ include "scion-hub.fullname" . }} -n {{ .Release.Namespace }}
+
+  Expect it to log everyone out. That is the rotation working: the old
+  sessions are signed with the old OAuth state, and the new pods do not
+  honour them. If nobody is logged out, the old pods are still running.
+
+  What happens if you forget: nothing, visibly, until the provider revokes
+  the old client secret. At that point every login fails and the hub looks
+  healthy - /readyz passes, the pod is Ready, and Kubernetes reports no
+  event. The failure is at the OAuth token exchange, which is an HTTP 401
+  from the provider, logged but not surfaced.
+{{- end }}
+
 SCHEMA_VERSION IS LOAD-BEARING
 
   The rendered file carries schema_version: "1", and it is not boilerplate.

--- a/deploy/helm/scion-hub/templates/NOTES.txt
+++ b/deploy/helm/scion-hub/templates/NOTES.txt
@@ -462,8 +462,8 @@ WHAT THIS RELEASE DOES NOT YET DO
 
   The chart is being built incrementally. It renders the hub's settings.yaml and
   it wires Cloud SQL and the database URL, but it does not yet configure GCS
-  credentials beyond the bucket name, Filestore, the session secret, the OAuth
-  client secret, Ingress or IAP. Do not treat this as a production install.
+  credentials beyond the bucket name, Filestore, the session secret, Ingress
+  or IAP. Do not treat this as a production install.
 
   The Cloud SQL wiring is RENDERED BUT UNRUN. No part of it has been applied to
   a cluster or dialled at a real instance: the deploying principal is refused by

--- a/deploy/helm/scion-hub/templates/NOTES.txt
+++ b/deploy/helm/scion-hub/templates/NOTES.txt
@@ -445,8 +445,11 @@ THE SETTINGS FILE IS READ-ONLY. THIS IS DELIBERATE.
   separate hazard that a hub which has already run against Postgres keeps some
   settings in database rows that shadow the file entirely; see VALIDATION.md.
 
+{{- $auth := .Values.auth | default (dict) }}
+{{- $authOauth := $auth.oauth | default (dict) }}
+{{- $web := $authOauth.web | default (dict) }}
 {{- $oauthConfigured := false }}
-{{- range $provider, $creds := .Values.auth.oauth.web }}
+{{- range $provider, $creds := $web }}
 {{- if or $creds.clientId $creds.clientSecret }}
 {{- $oauthConfigured = true }}
 {{- end }}
@@ -528,7 +531,7 @@ WHAT THIS RELEASE DOES NOT YET DO
   preflight gate by gate over the settings.yaml this chart renders, in the order
   the hub checks them - the list below is checked against that walk, it is not
   typed from memory:
-{{- if eq (toString .Values.auth.mode) "proxy" }}
+{{- if eq (toString ($auth.mode | default "")) "proxy" }}
 
     a durable session secret                session-secret phase
     server.auth.proxy.provider: iap         }
@@ -541,7 +544,7 @@ WHAT THIS RELEASE DOES NOT YET DO
 
     a durable session secret                session-secret phase
 
-  That is the whole list for auth.mode: {{ .Values.auth.mode }}. The IAP gates
+  That is the whole list for auth.mode: {{ $auth.mode | default "" }}. The IAP gates
   are not work you are waiting on - this shape never reaches them, so the
   Ingress/IAP phase lands nothing this refusal is blocked on.
 {{- end }}

--- a/deploy/helm/scion-hub/templates/_helpers.tpl
+++ b/deploy/helm/scion-hub/templates/_helpers.tpl
@@ -2571,6 +2571,7 @@ real deep merge rather than a text append.
 {{- $driver := .Values.database.driver }}
 
 {{- /* server.hub. hub_name, not name: the koanf tag is hub_name. */}}
+{{- include "scion-hub.assertNoCredential" (dict "value" .Values.hub.name "source" "hub.name") }}
 {{- $hub := dict "hub_id" $hubId "hub_name" .Values.hub.name }}
 
 {{- /*
@@ -2706,6 +2707,12 @@ forces a chart fork. Merged before the assertions run, not after. */}}
 {{- $rendered := toYaml $doc }}
 {{- include "scion-hub.assertSettings" (dict "root" . "rendered" $rendered "hubId" $hubId) }}
 {{- include "scion-hub.assertNoExtraCollision" (dict "preMerge" $preMerge "extra" .Values.config.extra) }}
+{{- /* config.extra is an arbitrary subtree the operator controls, so it can put
+a credential at a path no redaction list names - a DSN at server.database.url
+was measured doing exactly that, landing in the Secret AND moving the
+checksum/settings digest. The projection cannot enumerate its way out of an
+open-ended surface; this turns the injection into a render failure instead. */}}
+{{- include "scion-hub.assertNoCredentialTree" (dict "value" .Values.config.extra "source" "config.extra") }}
 {{- $rendered }}
 {{- end }}
 

--- a/deploy/helm/scion-hub/templates/_helpers.tpl
+++ b/deploy/helm/scion-hub/templates/_helpers.tpl
@@ -1936,7 +1936,7 @@ as R4. Order is the order the guard appends them in, so the refusal message and
 this list read the same way.
 */}}
 {{- define "scion-hub.existingSecretRefusals" -}}
-config.extra, storage.bucket, agents.imageRegistry, database.name, database.user, database.password
+config.extra, storage.bucket, agents.imageRegistry, database.name, database.user, database.password, auth.oauth.web.github.clientId, auth.oauth.web.github.clientSecret, auth.oauth.web.google.clientId, auth.oauth.web.google.clientSecret
 {{- end }}
 
 {{/*
@@ -1949,9 +1949,16 @@ The names below are the settings values with an empty default, which is what
 makes them refusable at all; the reasoning is in the comment above the transfer
 list, and the two lists are checked together as one partition of the values
 tree. Later phases append their own inline values here as they are introduced
-(the session secret, the OAuth client secret). Phase 2 appended three database
-leaves and deliberately did not append the fourth; see the PHASE 2 DELTA note in
-the body.
+(the database password, the session secret).
+
+THE OAUTH WEB CLIENT CREDENTIALS ARE THE FIRST OF THOSE APPENDED, and they were
+appended here rather than added to the transfer list because they qualify: both
+halves default to empty, so a non-empty one was typed. That makes the stronger
+answer available, and where it is available it is the one to take - the transfer
+list tells an operator afterwards that their credential went nowhere, whereas
+this refuses the release. A credential silently discarded is the shape of
+failure this chart is least able to make visible later: the hub starts, passes
+its probes, and refuses every login.
 
 THE SAME NAMES ARE PRINTED TO OPERATORS, so they come from one define rather
 than from a second hand-written copy in NOTES.txt. hack/verify.sh checks that
@@ -2010,6 +2017,12 @@ companion instead; that pair is explained above.
 {{- if .Values.database.name }}{{- $inline = append $inline "database.name" }}{{- end }}
 {{- if .Values.database.user }}{{- $inline = append $inline "database.user" }}{{- end }}
 {{- if .Values.database.password }}{{- $inline = append $inline "database.password" }}{{- end }}
+{{- $web := .Values.auth.oauth.web }}
+{{- range $provider := list "github" "google" }}
+{{- $creds := index $web $provider }}
+{{- if $creds.clientId }}{{- $inline = append $inline (printf "auth.oauth.web.%s.clientId" $provider) }}{{- end }}
+{{- if $creds.clientSecret }}{{- $inline = append $inline (printf "auth.oauth.web.%s.clientSecret" $provider) }}{{- end }}
+{{- end }}
 {{- if $inline }}
 {{- fail (printf "config.existingSecret is set together with inline settings values (%s). With config.existingSecret the chart renders no settings.yaml, so those values would be silently discarded. Set one or the other: either supply the whole file yourself, or let the chart render it. Note that these are only the settings values the chart can PROVE you set, because their default is empty. Others - auth.mode, hub.name, the database pool sizes, the hub ID and the agent namespace - are just as inert here and cannot be refused, because a default-valued setting is indistinguishable from an unset one; they are listed with the settings keys your own file must carry in NOTES.txt and in values.yaml at config.existingSecret." (join ", " $inline)) }}
 {{- end }}
@@ -2443,27 +2456,105 @@ rendered yet; see the comment in the rendered file. */}}
 {{- end }}
 
 {{- /*
-The oauth acknowledgement, enforced here as well as in values.schema.json, and
-the duplication is the point: --skip-schema-validation is one flag away and it
-removes every schema-enforced rule at once. This is the layer that is left.
+The oauth client credentials. THIS REPLACED AN ACKNOWLEDGEMENT KEY, and the
+replacement is the point rather than an implementation detail.
 
-THE HARM, VERIFIED OUTSIDE THE CHART, AND IT IS NOT "THE HUB WILL NOT START".
-That is what this chart used to claim and it is wrong in the direction that
-matters. Nothing validates the OAuth client credentials at startup - they are
-copied into the server config unchecked at cmd/server_foreground.go:1514-1544 -
-so a hub rendered in oauth mode with no credentials STARTS, binds, and passes
-/readyz. The failure arrives per request, at login: pkg/hub/web.go:1770-1776
-returns 503 "OAuth not configured" or 400 "OAuth provider %s is not configured".
-A deployment that is green in every Kubernetes signal and cannot be logged into
-by anybody is worse than one that crashloops, because nothing pages.
+auth.acknowledgeOAuthUnlanded used to stand here: a required opt-in that made the
+operator confirm they understood oauth mode would render without the credentials
+it needs. That was correct while the chart had no channel for them. It is not
+correct now, and leaving it would have been the worse outcome of the two - a
+permanent required key that guards nothing teaches the reflex of setting
+acknowledgements to true, which is the reflex that makes the NEXT one useless.
 
-Scoped to the rendered document on purpose. Under config.existingSecret this
-whole template is skipped, so the acknowledgement does not fire - correctly: the
-chart renders no auth mode there and the operator's file is theirs. The schema's
-copy of this rule carries the same exclusion for the same reason.
+WHAT IS CHECKED IS THE RENDERED DOCUMENT, NOT THE VALUES. So config.extra
+satisfies it exactly as auth.oauth.web does, which is deliberate: an operator who
+supplies server.oauth through config.extra has met the requirement, and a guard
+that demanded the chart's own value instead would be demanding a spelling rather
+than a state.
+
+THE HARM IS SILENT, WHICH IS WHY THIS IS A REFUSAL. Nothing validates these
+credentials at startup - they are copied into the server config unchecked at
+cmd/server_foreground.go:1514-1545 - so a hub in oauth mode with no credentials
+STARTS, binds, and passes /readyz. The failure arrives per request, at login:
+pkg/hub/web.go:1770-1776 returns 503 "OAuth not configured" or 400 "OAuth
+provider %s is not configured". Green in every Kubernetes signal, and nobody can
+log in. That is worse than a crashloop, because nothing pages for it.
+
+WEB, NOT ANY CLIENT TYPE. The hub keys the login check by client type -
+IsProviderConfiguredForClient(OAuthClientTypeWeb, provider), pkg/hub/oauth.go:194
+- so credentials under server.oauth.cli or server.oauth.device satisfy nothing
+for a browser login. A check that accepted any client type would pass exactly the
+configuration that fails. cli and device are not refused; they are just not
+counted here.
+
+BOTH HALVES, PER PROVIDER. IsProviderConfigured tests the client ID alone
+(pkg/hub/oauth.go:51-58), so an ID with no secret makes the hub report the
+provider as configured, offer the login button, and fail at the token exchange.
+Half a credential is worse than none: none is caught here, half is caught by the
+user.
+
+Scoped to the rendered document, and therefore not evaluated under
+config.existingSecret - this whole template is skipped there, correctly, because
+the chart renders no auth mode in that shape and the operator's file is theirs.
 */}}
-{{- if and (eq (dig "server" "auth" "mode" "" $doc) "oauth") (not $root.Values.auth.acknowledgeOAuthUnlanded) }}
-{{- fail "settings.yaml renders server.auth.mode: oauth, but this chart does not render the OAuth client credentials that mode needs - that is Phase 3. Nothing catches it at runtime: the credentials are wired unvalidated (cmd/server_foreground.go:1514-1544), so the hub starts and passes its probes, and every human login fails with \"OAuth provider is not configured\" (pkg/hub/web.go:1770-1776). Set auth.acknowledgeOAuthUnlanded=true to render it anyway, or use auth.mode=proxy." }}
+{{- if eq (dig "server" "auth" "mode" "" $doc) "oauth" }}
+{{- $web := dig "server" "oauth" "web" (dict) $doc }}
+{{- $complete := list }}
+{{- $partial := list }}
+{{- range $provider, $creds := $web }}
+{{- $id := dig "client_id" "" $creds }}
+{{- $secret := dig "client_secret" "" $creds }}
+{{- if and $id $secret }}
+{{- $complete = append $complete $provider }}
+{{- else if or $id $secret }}
+{{- $partial = append $partial (printf "%s (has %s, missing %s)" $provider (ternary "client_id" "client_secret" (ne $id "")) (ternary "client_secret" "client_id" (ne $id ""))) }}
+{{- end }}
+{{- end }}
+{{- if $partial }}
+{{- fail (printf "rendered settings.yaml has an incomplete OAuth web client credential: %s. A provider needs both halves, and the two missing halves fail differently - neither of them loudly. With client_id and no client_secret the hub reports the provider as CONFIGURED, because IsProviderConfigured tests the client ID alone (pkg/hub/oauth.go:51-58); it offers the login button and fails at the token exchange. With client_secret and no client_id the provider is not offered at all, and the secret sits in the settings Secret doing nothing. Either way a half-set credential fails later, and less legibly, than an unset one. Set both auth.oauth.web.<provider>.clientId and .clientSecret, or neither." (join ", " $partial)) }}
+{{- end }}
+{{- if not $complete }}
+{{- fail "settings.yaml renders server.auth.mode: oauth, but no complete OAuth web client credential is present, so nobody would be able to log in to this deployment. Nothing catches this at runtime: the credentials are copied into the server config unvalidated (cmd/server_foreground.go:1514-1545), so the hub starts, binds and passes /readyz, and every login fails with \"OAuth provider is not configured\" (pkg/hub/web.go:1770-1776) - green in Kubernetes, unusable by humans. Set auth.oauth.web.google.clientId and auth.oauth.web.google.clientSecret (or the github pair), supply server.oauth.web through config.extra, or use auth.mode=proxy. Credentials under server.oauth.cli or server.oauth.device do NOT satisfy this: the hub keys the login check by client type (pkg/hub/oauth.go:194) and a browser login reads the web client only." }}
+{{- end }}
+{{- end }}
+
+{{- /*
+The camelCase trap, refused by name.
+
+settings.yaml binds client_id/client_secret (V1OAuthProviderConfig,
+pkg/config/settings_v1.go:635). The SCION_SERVER_* env mapper binds
+clientId/clientSecret (OAuthProviderConfig, pkg/config/hub_config.go:334). The
+doc comment on envKeyToConfigKey states the camelCase form explicitly, so it is
+the spelling a careful reader arrives at - and in this file it binds nothing.
+yaml.v3 drops the unknown key silently: no error, no warning, an empty field, a
+hub that starts and refuses every login.
+
+Reachable only through config.extra, because the chart's own render always emits
+snake_case. That makes it the same class of hazard as server.hub.public_url
+above - a key the chart cannot produce but an operator can - and it is checked
+for the same reason.
+
+Measured rather than reasoned: both spellings written into a real settings.yaml
+and read back through config.LoadGlobalConfig, snake_case populating
+cfg.OAuth.Web.Google and camelCase leaving it empty, each with the other as its
+twin. harness/zz_p3_oauth_settings_probe_test.go.
+
+Walks every client type, not just web. cli and device are not rendered by the
+chart and are not required by the check above, but they bind through the same
+struct, so the misspelling is silent there too.
+*/}}
+{{- range $clientType, $providers := (dig "server" "oauth" (dict) $doc) }}
+{{- if kindIs "map" $providers }}
+{{- range $provider, $creds := $providers }}
+{{- if kindIs "map" $creds }}
+{{- range $key, $_ := $creds }}
+{{- if or (eq $key "clientId") (eq $key "clientSecret") }}
+{{- fail (printf "rendered settings.yaml sets server.oauth.%s.%s.%s. That spelling binds nothing in a settings file and fails silently: settings.yaml reads client_id and client_secret (V1OAuthProviderConfig, pkg/config/settings_v1.go:635), while clientId and clientSecret are the SCION_SERVER_* environment mapper's spelling (pkg/config/hub_config.go:334). yaml.v3 drops the unknown key with no error, so the credential is simply absent and the hub starts and refuses every login. Rename it to %s. If you reached this through config.extra, that is the only way to reach it - the chart's own render emits snake_case." $clientType $provider $key (ternary "client_id" "client_secret" (eq $key "clientId"))) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 
@@ -2516,6 +2607,52 @@ HA preflight as configured.
 {{- $storage = set $storage "bucket" $bucket }}
 {{- end }}
 
+{{- /*
+server.oauth: the web client credentials, and ONLY when they are set.
+
+SNAKE_CASE HERE, camelCase IN THE VALUES, AND THAT IS NOT AN INCONSISTENCY -
+it is two different schemas that happen to describe the same field. settings.yaml
+binds through V1OAuthProviderConfig (pkg/config/settings_v1.go:635), whose yaml
+tags are client_id and client_secret. The SCION_SERVER_* env mapper binds through
+OAuthProviderConfig (pkg/config/hub_config.go:334), whose koanf tags are clientId
+and clientSecret, reached via camelCaseFields["clientid"]. Same value, same hub,
+two spellings, selected by channel.
+
+MEASURED, BOTH SPELLINGS, ON A REAL LOAD. Written into a settings.yaml on disk
+and read back through config.LoadGlobalConfig: client_id/client_secret populate
+cfg.OAuth.Web.Google and make IsProviderConfiguredForClient(web, google) true;
+clientId/clientSecret leave both fields empty and it returns false. yaml.v3 drops
+the unknown key without an error, so the wrong spelling is not a failure the
+operator sees - it is a hub that starts and refuses every login. The probe is
+parked at harness/zz_p3_oauth_settings_probe_test.go with its negative twin.
+
+EMITTED ONLY WHEN NON-EMPTY. An empty client_id is not the same as no client_id
+to the collision check, and it is not the same to a reader of the rendered file:
+a rendered `client_id: ""` looks like a credential that failed to interpolate.
+Absent means absent.
+
+A provider needs BOTH halves to be emitted at all. Half a credential configures
+nothing - IsProviderConfigured tests ClientID alone (pkg/hub/oauth.go:51-58), so
+an ID with no secret reports the provider as CONFIGURED and then fails the token
+exchange at login. The assertion in assertSettings refuses that pairing by name;
+this is only the render.
+*/}}
+{{- $oauthWeb := dict }}
+{{- $webValues := .Values.auth.oauth.web }}
+{{- range $provider := list "google" "github" }}
+{{- $creds := index $webValues $provider }}
+{{- if or $creds.clientId $creds.clientSecret }}
+{{- $entry := dict }}
+{{- if $creds.clientId }}
+{{- $entry = set $entry "client_id" $creds.clientId }}
+{{- end }}
+{{- if $creds.clientSecret }}
+{{- $entry = set $entry "client_secret" $creds.clientSecret }}
+{{- end }}
+{{- $oauthWeb = set $oauthWeb $provider $entry }}
+{{- end }}
+{{- end }}
+
 {{- $server := dict
     "mode" "hosted"
     "hub" $hub
@@ -2523,6 +2660,9 @@ HA preflight as configured.
     "storage" $storage
     "auth" (dict "mode" .Values.auth.mode)
     "broker" (dict "host" "127.0.0.1" "port" (int (include "scion-hub.brokerPort" .)) "auto_provide" true) }}
+{{- if $oauthWeb }}
+{{- $server = set $server "oauth" (dict "web" $oauthWeb) }}
+{{- end }}
 
 {{- /*
 LOAD-BEARING. schema_version is not boilerplate and it is not redundant with

--- a/deploy/helm/scion-hub/templates/_helpers.tpl
+++ b/deploy/helm/scion-hub/templates/_helpers.tpl
@@ -3140,3 +3140,82 @@ pattern as strict as it was for everything the helper did not write.
 {{- $_ := set $obj "stringData" (dict "settings.yaml" $projection) }}
 {{- toYaml $obj | sha256sum }}
 {{- end }}
+
+{{/*
+================================================================================
+PHASE 3 - SESSION SECRET, OAUTH CREDENTIALS, CREDENTIAL PLACEMENT CHECKER.
+================================================================================
+*/}}
+
+{{/*
+The name of the Secret carrying the session secret.
+
+Two sources, never both, and the caller must have run assertSessionSecret first
+so that "neither" is already refused by the time this renders.
+*/}}
+{{- define "scion-hub.sessionSecretName" -}}
+{{- if .Values.auth.existingSecret }}
+{{- .Values.auth.existingSecret }}
+{{- else }}
+{{- printf "%s-session" (include "scion-hub.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+The key inside that Secret which holds the session secret.
+
+For the chart-rendered Secret this is fixed: the hub reads the value through a
+literal os.Getenv("SCION_SERVER_SESSION_SECRET") (resolveSessionSecret,
+cmd/server_foreground.go:1452-1463), and the chart-rendered Secret is consumed
+with envFrom, which turns each KEY INTO AN ENV VAR NAME. So the key name is the
+env var name and it is not a free choice.
+
+For an operator's existing Secret the key IS a free choice - theirs, not ours -
+which is what auth.existingSecretKey is for, and why that path cannot use
+envFrom. See assertSessionSecret.
+*/}}
+{{- define "scion-hub.sessionSecretKey" -}}
+{{- if .Values.auth.existingSecret }}
+{{- default "SCION_SERVER_SESSION_SECRET" .Values.auth.existingSecretKey }}
+{{- else }}
+{{- print "SCION_SERVER_SESSION_SECRET" }}
+{{- end }}
+{{- end }}
+
+{{/*
+The session secret must have exactly one source, and "none" is refused here
+rather than at runtime.
+
+WHY THIS IS A TEMPLATE-TIME FAILURE AND NOT A DEFAULT. The hub does not fail
+without a session secret. resolveSessionSecret returns "" and, in hosted mode,
+emits a single slog.Warn (cmd/server_foreground.go:1460-1462) - then the hub
+starts, binds, and passes every probe. What it has actually done is derive a
+per-process signing key, so each replica signs tokens the others reject and each
+replica has its own cookie encryption key. The symptom is users being logged out
+when the load balancer moves them, which reads as a flaky session store rather
+than as a configuration error, and it gets worse with replica count. There is no
+value this chart could default to that would be correct, so it asks.
+
+AND THE CHART DOES NOT GENERATE ONE. randAlphaNum would regenerate on every helm
+upgrade unless guarded with lookup, and lookup returns empty under helm template
+and --dry-run - so the golden output and the installed output would diverge, and
+a chart whose rendered form differs from its installed form cannot be reviewed.
+Worse, a silent rotation invalidates every live session AND the shared JWT
+signing key at once, which is the exact harm SCION_REQUIRE_STABLE_SIGNING_KEY
+exists to prevent. Failing loudly is the only honest option. See design.md 6.
+
+BOTH sources set is also refused. It is not a precedence question: one of the
+two would be silently inert, and an inert secret value is indistinguishable from
+a working one until sessions start breaking.
+*/}}
+{{- define "scion-hub.assertSessionSecret" -}}
+{{- if and .Values.auth.sessionSecret .Values.auth.existingSecret }}
+{{- fail "auth.sessionSecret and auth.existingSecret are both set. The chart cannot use both: one would be silently ignored, and a session secret that is silently ignored presents as intermittent logouts rather than as an error. Set exactly one - auth.existingSecret to reference a Secret you manage, or auth.sessionSecret to have the chart render one." }}
+{{- end }}
+{{- if not (or .Values.auth.sessionSecret .Values.auth.existingSecret) }}
+{{- fail "auth.sessionSecret is not set and neither is auth.existingSecret, so this release has no session secret. The chart will not generate one: a generated secret rotates on every helm upgrade, which silently invalidates every session and the shared JWT signing key, and it cannot be rendered reproducibly because lookup returns empty under helm template. Nor will the hub refuse to start without one - it logs a single warning (cmd/server_foreground.go:1460) and then derives a per-process signing key, so each replica signs tokens the others reject and users are logged out whenever the load balancer moves them. Set auth.existingSecret to the name of a Secret you manage (preferred - the value never enters your values file or Helm's release storage), or set auth.sessionSecret to have the chart render one." }}
+{{- end }}
+{{- if and .Values.auth.existingSecretKey (not .Values.auth.existingSecret) }}
+{{- fail "auth.existingSecretKey is set but auth.existingSecret is not. The key names an entry inside a Secret the chart is not being given, so it selects nothing. Set auth.existingSecret too, or remove the key." }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/scion-hub/templates/_helpers.tpl
+++ b/deploy/helm/scion-hub/templates/_helpers.tpl
@@ -2017,9 +2017,11 @@ companion instead; that pair is explained above.
 {{- if .Values.database.name }}{{- $inline = append $inline "database.name" }}{{- end }}
 {{- if .Values.database.user }}{{- $inline = append $inline "database.user" }}{{- end }}
 {{- if .Values.database.password }}{{- $inline = append $inline "database.password" }}{{- end }}
-{{- $web := .Values.auth.oauth.web }}
+{{- $auth := .Values.auth | default (dict) }}
+{{- $authOauth := $auth.oauth | default (dict) }}
+{{- $web := $authOauth.web | default (dict) }}
 {{- range $provider := list "github" "google" }}
-{{- $creds := index $web $provider }}
+{{- $creds := index $web $provider | default (dict) }}
 {{- if $creds.clientId }}{{- $inline = append $inline (printf "auth.oauth.web.%s.clientId" $provider) }}{{- end }}
 {{- if $creds.clientSecret }}{{- $inline = append $inline (printf "auth.oauth.web.%s.clientSecret" $provider) }}{{- end }}
 {{- end }}
@@ -2155,7 +2157,8 @@ with a parity check over the copies rather than a shared definition.
 {{- if eq (lower (toString .Values.database.driver)) "postgres" }}
 {{- $routes = append $routes "database.driver is postgres (cmd/server_foreground.go, isHADeployment: strings.EqualFold(cfg.Database.Driver, \"postgres\"))" }}
 {{- end }}
-{{- if and (eq (lower (toString .Values.storage.provider)) "gcs") (eq (toString .Values.auth.mode) "proxy") }}
+{{- $auth := .Values.auth | default (dict) }}
+{{- if and (eq (lower (toString .Values.storage.provider)) "gcs") (eq (toString $auth.mode) "proxy") }}
 {{- $routes = append $routes "storage.provider is gcs and auth.mode is proxy (cmd/server_foreground.go, isHADeployment: strings.EqualFold(cfg.Storage.Provider, \"gcs\") && cfg.Auth.Mode == \"proxy\")" }}
 {{- end }}
 {{- end }}
@@ -2191,7 +2194,8 @@ minutes between 1b3c9418 landing and being noticed.
 {{- if and $routes (not .Values.acknowledgeHAUnlanded) }}
 {{- $gates := "a durable session/signing secret, from the session-secret phase. That is the whole list for auth.mode oauth: the hub's IAP gates sit inside `if cfg.Auth.Mode == \"proxy\"` in validateHostedHAPreflight, so this shape never reaches them and the ingress/IAP phase lands nothing this release is waiting on" }}
 {{- $removal := "That flag stops being needed for auth.mode oauth when the session-secret phase has landed. The ingress/IAP phase is not on this shape's path and waiting for it would hold the flag one phase too long; Filestore lands none of them either" }}
-{{- if eq (toString .Values.auth.mode) "proxy" }}
+{{- $auth := .Values.auth | default (dict) }}
+{{- if eq (toString $auth.mode) "proxy" }}
 {{- $gates = "a durable session/signing secret, from the session-secret phase; then server.auth.proxy.provider=iap, server.auth.proxy.iap.audience, server.auth.transport, server.auth.transport.mode=iap, server.auth.transport.oidc_audience and server.auth.transport.platform_auth_sa, all from the ingress/IAP phase" }}
 {{- $removal = "That flag stops being needed for auth.mode proxy when the session-secret phase and the ingress/IAP phase have both landed. Filestore lands none of them" }}
 {{- end }}
@@ -2451,8 +2455,9 @@ ever gets converted.
 
 {{- /* The discriminator for the two auth modes. The subtree it selects is not
 rendered yet; see the comment in the rendered file. */}}
-{{- if ne (dig "server" "auth" "mode" "" $doc) $root.Values.auth.mode }}
-{{- fail (printf "rendered settings.yaml has server.auth.mode: %s but auth.mode is %s." (include "scion-hub.diagValue" (dig "server" "auth" "mode" "" $doc)) (include "scion-hub.diagValue" $root.Values.auth.mode)) }}
+{{- $rootAuth := $root.Values.auth | default (dict) }}
+{{- if ne (dig "server" "auth" "mode" "" $doc) $rootAuth.mode }}
+{{- fail (printf "rendered settings.yaml has server.auth.mode: %s but auth.mode is %s." (include "scion-hub.diagValue" (dig "server" "auth" "mode" "" $doc)) (include "scion-hub.diagValue" $rootAuth.mode)) }}
 {{- end }}
 
 {{- /*
@@ -2639,7 +2644,9 @@ exchange at login. The assertion in assertSettings refuses that pairing by name;
 this is only the render.
 */}}
 {{- $oauthWeb := dict }}
-{{- $webValues := .Values.auth.oauth.web }}
+{{- $auth := .Values.auth | default (dict) }}
+{{- $authOauth := $auth.oauth | default (dict) }}
+{{- $webValues := $authOauth.web | default (dict) }}
 {{- range $provider := list "google" "github" }}
 {{- $creds := index $webValues $provider }}
 {{- if or $creds.clientId $creds.clientSecret }}
@@ -2659,7 +2666,7 @@ this is only the render.
     "hub" $hub
     "database" $database
     "storage" $storage
-    "auth" (dict "mode" .Values.auth.mode)
+    "auth" (dict "mode" $auth.mode)
     "broker" (dict "host" "127.0.0.1" "port" (int (include "scion-hub.brokerPort" .)) "auto_provide" true) }}
 {{- if $oauthWeb }}
 {{- $server = set $server "oauth" (dict "web" $oauthWeb) }}
@@ -3301,8 +3308,9 @@ Two sources, never both, and the caller must have run assertSessionSecret first
 so that "neither" is already refused by the time this renders.
 */}}
 {{- define "scion-hub.sessionSecretName" -}}
-{{- if .Values.auth.existingSecret }}
-{{- .Values.auth.existingSecret }}
+{{- $auth := .Values.auth | default (dict) }}
+{{- if $auth.existingSecret }}
+{{- $auth.existingSecret }}
 {{- else }}
 {{- printf "%s-session" (include "scion-hub.fullname" .) }}
 {{- end }}
@@ -3322,8 +3330,9 @@ which is what auth.existingSecretKey is for, and why that path cannot use
 envFrom. See assertSessionSecret.
 */}}
 {{- define "scion-hub.sessionSecretKey" -}}
-{{- if .Values.auth.existingSecret }}
-{{- default "SCION_SERVER_SESSION_SECRET" .Values.auth.existingSecretKey }}
+{{- $auth := .Values.auth | default (dict) }}
+{{- if $auth.existingSecret }}
+{{- default "SCION_SERVER_SESSION_SECRET" $auth.existingSecretKey }}
 {{- else }}
 {{- print "SCION_SERVER_SESSION_SECRET" }}
 {{- end }}
@@ -3356,13 +3365,14 @@ two would be silently inert, and an inert secret value is indistinguishable from
 a working one until sessions start breaking.
 */}}
 {{- define "scion-hub.assertSessionSecret" -}}
-{{- if and .Values.auth.sessionSecret .Values.auth.existingSecret }}
+{{- $auth := .Values.auth | default (dict) }}
+{{- if and $auth.sessionSecret $auth.existingSecret }}
 {{- fail "auth.sessionSecret and auth.existingSecret are both set. The chart cannot use both: one would be silently ignored, and a session secret that is silently ignored presents as intermittent logouts rather than as an error. Set exactly one - auth.existingSecret to reference a Secret you manage, or auth.sessionSecret to have the chart render one." }}
 {{- end }}
-{{- if not (or .Values.auth.sessionSecret .Values.auth.existingSecret) }}
+{{- if not (or $auth.sessionSecret $auth.existingSecret) }}
 {{- fail "auth.sessionSecret is not set and neither is auth.existingSecret, so this release has no session secret. The chart will not generate one: a generated secret rotates on every helm upgrade, which silently invalidates every session and the shared JWT signing key, and it cannot be rendered reproducibly because lookup returns empty under helm template. Nor will the hub refuse to start without one - it logs a single warning (cmd/server_foreground.go:1460) and then derives a per-process signing key, so each replica signs tokens the others reject and users are logged out whenever the load balancer moves them. Set auth.existingSecret to the name of a Secret you manage (preferred - the value never enters your values file or Helm's release storage), or set auth.sessionSecret to have the chart render one." }}
 {{- end }}
-{{- if and .Values.auth.existingSecretKey (not .Values.auth.existingSecret) }}
+{{- if and $auth.existingSecretKey (not $auth.existingSecret) }}
 {{- fail "auth.existingSecretKey is set but auth.existingSecret is not. The key names an entry inside a Secret the chart is not being given, so it selects nothing. Set auth.existingSecret too, or remove the key." }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/scion-hub/templates/configmap-env.yaml
+++ b/deploy/helm/scion-hub/templates/configmap-env.yaml
@@ -67,30 +67,27 @@ data:
   # fall back to a per-process signing key, which across replicas would sign
   # tokens each of the others reject.
   #
-  # THE REFUSAL BELOW EXISTS BECAUSE THE HUB'S REFUSAL IS NOT SCOPED TO ITS OWN
-  # HARM. Setting this true in this release does not make the hub careful; it
-  # makes the hub refuse to boot, every time, on a first install, with nothing
-  # the operator can do about it from this chart. The hub resolves a stable key
-  # from a pre-configured key, then SharedSigningSecret, then a secret backend,
-  # then the store (pkg/hub/server.go:1445). SharedSigningSecret is
-  # resolveSessionSecret() (cmd/server_foreground.go:1556), which reads only
-  # --session-secret, SCION_SERVER_SESSION_SECRET and bare SESSION_SECRET
-  # (cmd/server_foreground.go:1452-1462); the chart renders none of them, and
-  # hub.extraEnv - the one operator-controlled env channel - refuses all three
-  # by name as credential material (_helpers.tpl:1306). The store is empty on a
-  # first boot. So there is no key, pkg/hub/server.go:1634 errors,
-  # pkg/hub/server.go:1008 makes it fatal, and cmd/server_foreground.go:259
-  # calls log.Fatalf.
+  # DEFAULTS TO true SINCE THE SESSION-SECRET PHASE, AND A REFUSAL WAS REMOVED
+  # HERE TO ALLOW IT. Until that phase this file carried a `fail` rejecting
+  # true unless config.existingSecret was set, because nothing the chart
+  # rendered could satisfy the flag: the hub resolves a stable key from a
+  # pre-configured key, then SharedSigningSecret, then a secret backend, then
+  # the store (pkg/hub/server.go:1445); SharedSigningSecret comes only from
+  # resolveSessionSecret (cmd/server_foreground.go:1452-1463), which reads
+  # --session-secret, SCION_SERVER_SESSION_SECRET and bare SESSION_SECRET; the
+  # chart rendered none of the three, and a first boot has an empty store. With
+  # true and no key, pkg/hub/server.go:1634 errors, pkg/hub/server.go:1008 makes
+  # it fatal, and cmd/server_foreground.go:259 turns it into log.Fatalf. Measured
+  # end-to-end through hub.New by gd-p1-dev, not inferred from the citations.
   #
-  # config.existingSecret is the one shape where true is satisfiable, and it is
-  # not hypothetical: the operator writes their own settings.yaml, so they can
-  # set server.secrets.backend and pre-provision the key there. The chart does
-  # not render that file and has no business second-guessing it.
-  #
-  # This turns a CrashLoopBackOff at 03:00 into a values error at install time.
-  {{- if and .Values.auth.requireStableSigningKey (not .Values.config.existingSecret) }}
-  {{- fail "auth.requireStableSigningKey is true, but nothing in this release can satisfy it, so the hub would refuse to start on every first boot. The hub needs a pre-configured key, a SharedSigningSecret, a secret backend or a key already in its store (pkg/hub/server.go:1445); SharedSigningSecret comes only from --session-secret, SCION_SERVER_SESSION_SECRET or SESSION_SECRET (cmd/server_foreground.go:1452-1462), this chart renders none of them, hub.extraEnv refuses all three as credential material, and a first boot has an empty store. The failure is log.Fatalf at cmd/server_foreground.go:259, not a warning. Leave it false until the session-secret phase renders the Secret; that phase flips this default to true in the same change. Under config.existingSecret it is allowed, because your own settings.yaml can configure server.secrets and pre-provision the key." }}
-  {{- end }}
+  # WHAT MAKES true SAFE NOW IS NOT THIS DEFAULT - IT IS THAT THE SECRET IS
+  # UNCONDITIONAL. scion-hub.assertSessionSecret fails the render when neither
+  # auth.sessionSecret nor auth.existingSecret is set, so there is no values
+  # combination that reaches this line with the flag true and no source for the
+  # variable. The refusal was not relaxed; its precondition was removed. If a
+  # later phase ever makes the session secret optional again, this default must
+  # go back to false in the same change - tests/chart-integrity.sh section E
+  # asserts exactly that pairing, in both directions.
   SCION_REQUIRE_STABLE_SIGNING_KEY: {{ ternary "true" "false" .Values.auth.requireStableSigningKey | quote }}
   {{- with .Values.hub.adminMode }}
 

--- a/deploy/helm/scion-hub/templates/configmap-env.yaml
+++ b/deploy/helm/scion-hub/templates/configmap-env.yaml
@@ -88,7 +88,8 @@ data:
   # later phase ever makes the session secret optional again, this default must
   # go back to false in the same change - tests/chart-integrity.sh section E
   # asserts exactly that pairing, in both directions.
-  SCION_REQUIRE_STABLE_SIGNING_KEY: {{ ternary "true" "false" .Values.auth.requireStableSigningKey | quote }}
+  {{- $auth := .Values.auth | default (dict) }}
+  SCION_REQUIRE_STABLE_SIGNING_KEY: {{ ternary "true" "false" ($auth.requireStableSigningKey | default false) | quote }}
   {{- with .Values.hub.adminMode }}
 
   # Truthy values are true, 1 and yes.

--- a/deploy/helm/scion-hub/templates/configmap-env.yaml
+++ b/deploy/helm/scion-hub/templates/configmap-env.yaml
@@ -95,5 +95,11 @@ data:
   SCION_SERVER_ADMIN_MODE: {{ . | quote }}
   {{- end }}
   {{- with .Values.hub.maintenanceMessage }}
+  {{- /* Free operator text, and this is a ConfigMap - readable by a wider
+  audience than any Secret, and digested into checksum/env-config on top. The
+  guard only refuses credential SHAPES (a user:password@ URL, a credential query
+  parameter, a known token prefix), so an ordinary status-page link is
+  unaffected. */}}
+  {{- include "scion-hub.assertNoCredential" (dict "value" . "source" "hub.maintenanceMessage") }}
   SCION_SERVER_MAINTENANCE_MESSAGE: {{ . | quote }}
   {{- end }}

--- a/deploy/helm/scion-hub/templates/deployment.yaml
+++ b/deploy/helm/scion-hub/templates/deployment.yaml
@@ -31,6 +31,23 @@ limitations under the License.
    template happens to render - see its definition for why it is not a list.
 */}}
 {{- include "scion-hub.assertNoCredentialsInValues" . }}
+{{- /*
+The three scheduling fields are the same disclosure surface and were missed by
+the pass that guarded podAnnotations and podLabels. nodeSelector, tolerations
+and affinity are free-form operator input, they land in the pod spec verbatim,
+and the pod spec is readable by anyone with pod read access - the identical
+audience, reached by a field nobody would think to look at. Measured before
+writing this: a DSN in any of the three rendered clean while the same string on
+hub.podAnnotations was refused.
+
+The enumeration is the fragile part of this guard, not the matcher. A surface
+added to this template later gets no protection from the calls above, and
+nothing here will say so - the render simply succeeds. If you add a field that
+carries operator-supplied text into the pod spec, add a call beside these.
+*/}}
+{{- include "scion-hub.assertNoCredentialTree" (dict "value" (.Values.hub.nodeSelector | default dict) "source" "hub.nodeSelector") }}
+{{- include "scion-hub.assertNoCredentialTree" (dict "value" (.Values.hub.tolerations | default list) "source" "hub.tolerations") }}
+{{- include "scion-hub.assertNoCredentialTree" (dict "value" (.Values.hub.affinity | default dict) "source" "hub.affinity") }}
 {{- $strategy := include "scion-hub.updateStrategyType" . }}
 {{- include "scion-hub.assertExtraEnv" . }}
 {{- include "scion-hub.assertHAUnlanded" . }}

--- a/deploy/helm/scion-hub/templates/deployment.yaml
+++ b/deploy/helm/scion-hub/templates/deployment.yaml
@@ -291,7 +291,8 @@ spec:
             a per-key selector has no meaning under envFrom, which cannot select
             a key. So the existing-secret path binds one key by name, below.
             */}}
-            {{- if not .Values.auth.existingSecret }}
+            {{- $auth := .Values.auth | default (dict) }}
+            {{- if not $auth.existingSecret }}
             - secretRef:
                 name: {{ include "scion-hub.sessionSecretName" . }}
             {{- end }}
@@ -301,7 +302,7 @@ spec:
             so that nothing else in their Secret reaches the hub's environment -
             see the envFrom comment above for why that matters.
             */}}
-            {{- if .Values.auth.existingSecret }}
+            {{- if $auth.existingSecret }}
             - name: SCION_SERVER_SESSION_SECRET
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/scion-hub/templates/deployment.yaml
+++ b/deploy/helm/scion-hub/templates/deployment.yaml
@@ -35,6 +35,15 @@ limitations under the License.
 {{- include "scion-hub.assertExtraEnv" . }}
 {{- include "scion-hub.assertHAUnlanded" . }}
 {{- /*
+Also called from secret-session.yaml, which is where the secret is rendered.
+Repeated here for the reason directly below: this file always renders, and the
+case the assertion exists for - NEITHER source set - is the case in which
+secret-session.yaml produces no object. It still executes its include today, so
+this is redundancy rather than a fix; it is here so that wrapping that file in a
+conditional later cannot silently retire the check. fail is idempotent.
+*/}}
+{{- include "scion-hub.assertSessionSecret" . }}
+{{- /*
 Called here for the same reason assertConfigSource is: the Deployment is the one
 template that always renders, so this is where a guard becomes unconditional.
 */}}
@@ -243,7 +252,45 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "scion-hub.envConfigMapName" . }}
+            {{- /*
+            The session secret, when the chart renders it. envFrom is safe HERE
+            and only here: the chart controls this Secret and it holds exactly
+            one key, whose name is the env var name the hub reads.
+
+            THE EXISTING-SECRET CASE DELIBERATELY DOES NOT USE envFrom, and the
+            asymmetry is load-bearing rather than untidy. envFrom projects EVERY
+            key it finds, so pointing it at a Secret the operator owns would let
+            any key in that Secret become an environment variable in the hub -
+            including SCION_SERVER_BASE_URL, HOME, KUBECONFIG or
+            SCION_REQUIRE_STABLE_SIGNING_KEY. Those four are exactly what
+            scion-hub.assertExtraEnv refuses hub.extraEnv from shadowing, and a
+            later envFrom source overrides an earlier one, so the operator's
+            Secret would win over the ConfigMap. That is a route around the
+            https:// validation on the base URL, whose whole purpose is keeping
+            the session cookie's Secure attribute (design.md 5.4) - a bypass
+            that presents as nothing at all.
+
+            auth.existingSecretKey is itself the evidence this was intended:
+            a per-key selector has no meaning under envFrom, which cannot select
+            a key. So the existing-secret path binds one key by name, below.
+            */}}
+            {{- if not .Values.auth.existingSecret }}
+            - secretRef:
+                name: {{ include "scion-hub.sessionSecretName" . }}
+            {{- end }}
           env:
+            {{- /*
+            The session secret from a Secret the operator manages. Bound by KEY
+            so that nothing else in their Secret reaches the hub's environment -
+            see the envFrom comment above for why that matters.
+            */}}
+            {{- if .Values.auth.existingSecret }}
+            - name: SCION_SERVER_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "scion-hub.sessionSecretName" . }}
+                  key: {{ include "scion-hub.sessionSecretKey" . }}
+            {{- end }}
             {{- /*
             The namespace the hub is running in, which it reads to decide where
             to create agent pods when no namespace is configured. There is no

--- a/deploy/helm/scion-hub/templates/secret-session.yaml
+++ b/deploy/helm/scion-hub/templates/secret-session.yaml
@@ -1,0 +1,64 @@
+{{/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+{{/*
+The session secret.
+
+ONE VALUE, TWO KEYS. This secret is not just the session cookie key: the same
+bytes back the hub's shared JWT signing keys, so every replica behind the load
+balancer must see the identical value or they will reject each other's tokens
+(resolveSessionSecret, cmd/server_foreground.go:1452-1463; the value reaches
+hub.ServerConfig.SharedSigningSecret).
+
+DELIVERED BY envFrom, NEVER ON argv (#1070, design.md 6). argv is readable by
+anyone who can read the pod - kubectl get pod -o yaml, the process table in any
+container in the pod, and every log that ever echoes a command line. The chart's
+reserved-flag guard (scion-hub.hubArgs) refuses --session-secret by name so no
+value can route it back to argv; this file is the channel that makes refusing it
+possible.
+
+The KEY NAME IS THE ENV VAR NAME and is therefore fixed. envFrom projects each
+key of this Secret into the container environment under its own name, and the
+hub reads a literal os.Getenv("SCION_SERVER_SESSION_SECRET"). Renaming the key
+does not rename the lookup - it just means the hub finds nothing and falls back
+to a per-process key with one warning.
+
+EXACTLY ONE KEY, deliberately. envFrom projects everything it finds, so a second
+key here would become a second environment variable with no guard in front of
+it - which is the reason auth.existingSecret does NOT use envFrom (deployment.yaml).
+
+Rendered only when the operator supplies auth.sessionSecret inline. Under
+auth.existingSecret the operator manages the Secret themselves and the chart
+renders none - which is the preferred shape, because a value in auth.sessionSecret
+is in their values file and in Helm's release storage, and this Secret is only as
+private as those are.
+
+stringData rather than data: base64 is not encryption, and the golden files that
+lock this chart's output are worth being able to read. Kubernetes stores it
+identically either way.
+*/}}
+{{- include "scion-hub.assertSessionSecret" . }}
+{{- if not .Values.auth.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "scion-hub.sessionSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "scion-hub.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ include "scion-hub.sessionSecretKey" . }}: {{ .Values.auth.sessionSecret | quote }}
+{{- end }}

--- a/deploy/helm/scion-hub/templates/secret-session.yaml
+++ b/deploy/helm/scion-hub/templates/secret-session.yaml
@@ -50,7 +50,8 @@ lock this chart's output are worth being able to read. Kubernetes stores it
 identically either way.
 */}}
 {{- include "scion-hub.assertSessionSecret" . }}
-{{- if not .Values.auth.existingSecret }}
+{{- $auth := .Values.auth | default (dict) }}
+{{- if not $auth.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -60,5 +61,5 @@ metadata:
     {{- include "scion-hub.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  {{ include "scion-hub.sessionSecretKey" . }}: {{ .Values.auth.sessionSecret | quote }}
+  {{ include "scion-hub.sessionSecretKey" . }}: {{ $auth.sessionSecret | quote }}
 {{- end }}

--- a/deploy/helm/scion-hub/templates/secret-settings.yaml
+++ b/deploy/helm/scion-hub/templates/secret-settings.yaml
@@ -50,8 +50,11 @@ stringData:
     #   server.database.url        Cloud SQL. Note the key is url, not dsn.
     #   server.secrets             the secret backend (gcpsm).
     #   server.auth.proxy,
-    #   server.auth.transport,
-    #   server.oauth               the subtree selected by server.auth.mode.
+    #   server.auth.transport      the subtree selected by server.auth.mode.
+    #   server.oauth               NOW RENDERED: web client credentials land here
+    #                              as server.oauth.web.<provider>.client_id and
+    #                              client_secret, in snake_case. cli and device
+    #                              are reachable through config.extra.
     #   server.workspace_storage   Filestore NFS - a different subsystem from
     #                              server.storage, which is the hub's GCS blob
     #                              store and is rendered below.

--- a/deploy/helm/scion-hub/tests/chart-integrity.sh
+++ b/deploy/helm/scion-hub/tests/chart-integrity.sh
@@ -73,7 +73,7 @@ BASE=("${BASE_NO_SECRET[@]}" --set auth.sessionSecret=chart-integrity-not-a-real
 # honest encoding of the hold, and bumping it would be the defeat gd-p0-dev
 # warned about. Lifting the hold is a two-line change: 26 -> 35 here, and
 # 107 -> 116 in run-all.sh, in one diff.
-EXPECTED_TOTAL=45
+EXPECTED_TOTAL=49
 
 # TOOL-PRESENCE ARM. A MISSING TOOLCHAIN MUST NOT BE REPORTED AS A BROKEN CHART.
 # Without this every helm invocation fails, every assertion fails, and the output
@@ -1010,6 +1010,84 @@ else
   pass "NOTES.txt omits the OAuth rotation restart when no OAuth credentials are set (the condition is a condition, not a constant)"
 fi
 rm -f "$_e11_on" "$_e11_off"
+
+# ---------------------------------------------------------------------------
+# E12. The credential guard reaches the SCHEDULING fields, not just the two
+# pod-spec fields somebody thought of.
+# ---------------------------------------------------------------------------
+#
+# The pass that guarded hub.podAnnotations and hub.podLabels enumerated the
+# fields an operator thinks of as carrying text, and stopped there.
+# hub.nodeSelector, hub.tolerations and hub.affinity are the same disclosure
+# surface - free-form operator input, rendered verbatim into a pod spec that
+# anyone with pod read access can read - and all three rendered a DSN clean while
+# the identical string on hub.podAnnotations was refused. Measured before the
+# fix, not reasoned about.
+#
+# THE ENUMERATION IS THE FRAGILE PART, NOT THE MATCHER. Every one of these
+# assertions passes by the guard being CALLED on a surface; none of them can tell
+# you about a surface with no call. That is not a hole this file can close - a
+# test can only plant into fields it knows about, which is the same blindness
+# that produced the gap. It is stated so the next reader does not mistake five
+# green rows for coverage of the pod spec.
+#
+# PLANTED VIA A VALUES FILE, NEVER --set-string. `--set-string` runs its own
+# escape parser: 'Sc2\Back\Alpha' arrives as 'Sc2BackAlpha', so the chart is
+# handed a DIFFERENT credential than the one written here, the guard correctly
+# does not find the one we planted, and the arm records a false pass.
+#
+# ASSERTED ON THE ERROR STRING AND THE SOURCE NAME TOGETHER. A non-zero exit is
+# not evidence that the guard fired: the first draft of this measurement was 13
+# apparent confirmations that were all schema rejections, because the values
+# overlay had been concatenated onto the base file and a duplicate `hub:` key
+# silently replaced the base mapping. Nothing had reached a template. The clean
+# arm at the end is what exposed it, and it is why that arm is here.
+_e12_vals="$(mktemp)"
+_e12_dsn='postgres://u:hunter2AAA@10.0.0.1/db'
+_e12_arm() { # $1 = values yaml, $2 = expected source name in the failure
+  local _out
+  _out="$(printf '%s\n' "$1" >"$_e12_vals"; "$HELM" template t "$CHART" "${BASE[@]}" -f "$_e12_vals" 2>&1)"
+  if printf '%s' "$_out" | grep -qF "don't meet the specifications of the schema"; then
+    echo "META-FAILURE: E12 arm for $2 was rejected by the values schema and never reached a template." >&2
+    rm -f "$_e12_vals"; exit 2
+  fi
+  printf '%s' "$_out" | grep -qF "embeds credentials in a URL" \
+    && printf '%s' "$_out" | grep -qF "$2"
+}
+for _e12_case in \
+  "hub.nodeSelector:hub:
+  nodeSelector:
+    disk: \"$_e12_dsn\"" \
+  "hub.tolerations:hub:
+  tolerations:
+    - key: \"$_e12_dsn\"
+      operator: Exists" \
+  "hub.affinity:hub:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: \"$_e12_dsn\"
+                operator: Exists"
+do
+  _e12_name="${_e12_case%%:*}"
+  if _e12_arm "${_e12_case#*:}" "$_e12_name"; then
+    pass "${_e12_name} refuses a credential (the scheduling fields reach the guard)"
+  else
+    fail "${_e12_name} renders a DSN into the pod spec without a word. The pod spec is readable by anyone with pod read access - a wider audience than the Secret's RBAC - and hub.podAnnotations refuses the identical string, so this is an unguarded surface beside a guarded one rather than a decision to allow it."
+  fi
+done
+# The arm that caught the empty corpus. Without it, every row above is satisfied
+# by a chart that refuses everything, including values an operator must be able
+# to set.
+printf 'hub:\n  nodeSelector:\n    disk: ssd\n  tolerations:\n    - key: dedicated\n      operator: Exists\n' >"$_e12_vals"
+if "$HELM" template t "$CHART" "${BASE[@]}" -f "$_e12_vals" >/dev/null 2>&1; then
+  pass "ordinary scheduling values still render (the guard above refuses credentials, not scheduling)"
+else
+  fail "a plain nodeSelector/toleration no longer renders. The credential guard has been widened into legitimate operator input, which is worse than the hole it closed: the hole leaked a value the operator chose to put there, this rejects a value they must set, with no override."
+fi
+rm -f "$_e12_vals"
 
 # ---------------------------------------------------------------------------
 # Fail closed.

--- a/deploy/helm/scion-hub/tests/chart-integrity.sh
+++ b/deploy/helm/scion-hub/tests/chart-integrity.sh
@@ -61,7 +61,8 @@ BASE=("${BASE_NO_SECRET[@]}" --set auth.sessionSecret=chart-integrity-not-a-real
 # +5 in section E (the signing-key flip). The session-secret phase adds +3: E6
 # and E7 in the inverted section E, and one more in section C, because that
 # section asserts one file PER ENTRY in EXPECTED_FILES and secret-session.yaml
-# is a seventeenth entry. -> 38.
+# is a seventeenth entry. -> 38. E8 then adds the last one, refusing a pod
+# annotation derived from the session secret. -> 39.
 # Nothing FAILS -- every assertion the chart is accused by passes. The only red
 # is this number.
 #
@@ -72,7 +73,7 @@ BASE=("${BASE_NO_SECRET[@]}" --set auth.sessionSecret=chart-integrity-not-a-real
 # honest encoding of the hold, and bumping it would be the defeat gd-p0-dev
 # warned about. Lifting the hold is a two-line change: 26 -> 35 here, and
 # 107 -> 116 in run-all.sh, in one diff.
-EXPECTED_TOTAL=38
+EXPECTED_TOTAL=39
 
 # TOOL-PRESENCE ARM. A MISSING TOOLCHAIN MUST NOT BE REPORTED AS A BROKEN CHART.
 # Without this every helm invocation fails, every assertion fails, and the output
@@ -750,6 +751,78 @@ if [ -z "$_e7_bad" ]; then
   pass "all ${_e7_seen} ci fixtures pair SCION_REQUIRE_STABLE_SIGNING_KEY=true with a session-secret source"
 else
   fail "ci fixtures render the signing-key flag true with no secret source:${_e7_bad}"
+fi
+
+# --- E8. NO POD ANNOTATION IS DERIVED FROM THE SESSION SECRET. --------------
+# check-secret-placement.sh already refuses the secret's VALUE in an
+# annotation. This refuses a DIGEST of it, which that scanner cannot see and
+# which is the form the mistake would actually take.
+#
+# The mistake is attractive, which is why it needs a guard rather than a
+# comment. The session secret reaches the container through env, env is
+# resolved once at container start, so rotating it does nothing until the pods
+# restart - and the chart's own checksum/settings annotation is the established
+# local idiom for exactly that problem. Adding checksum/session would look like
+# consistency.
+#
+# It is not, because the two are not the same trade. Pod annotations are
+# readable by anyone with pod read access, which is a strictly wider audience
+# than the Secret's RBAC, and a digest over a single low-entropy credential is
+# recoverable offline. checksum/settings covers a whole rendered document and
+# is load-bearing in a way this would not be: settings.yaml is a subPath mount,
+# frozen for the container's lifetime, with no restart remedy an operator can
+# be told to run. The session secret has one, and values.yaml documents it.
+#
+# THE POSITIVE CONTROL IS A META-FAILURE, NOT AN ASSERTION, because a parser
+# that has stopped finding annotations would report this green forever in the
+# same words as a clean run. So the extractor must find checksum/env-config -
+# an annotation this chart renders unconditionally - before its silence about
+# 'session' is allowed to count as evidence.
+_e8_keys() { # stdin = render text; stdout = annotation keys, one per line
+  awk '
+    /^[[:space:]]*annotations:[[:space:]]*$/ {
+      match($0, /^[[:space:]]*/); ind = RLENGTH; in_ann = 1; next
+    }
+    in_ann {
+      match($0, /^[[:space:]]*/)
+      if (RLENGTH <= ind || $0 ~ /^[[:space:]]*$/) { in_ann = 0; next }
+      if (match($0, /^[[:space:]]*[^[:space:]:]+:/))
+        { k = substr($0, RSTART, RLENGTH - 1); gsub(/^[[:space:]]+/, "", k); print k }
+    }
+  '
+}
+_e8_bad=""
+_e8_seen=0
+_e8_rendered=0
+_e8_control=0
+for _f in "${_e7_files[@]}"; do
+  [ -e "$_f" ] || continue
+  _e8_seen=$((_e8_seen+1))
+  _r="$("$HELM" template t "$CHART" -f "$_f" 2>&1)" || continue
+  _e8_rendered=$((_e8_rendered+1))
+  _k="$(printf '%s\n' "$_r" | _e8_keys)"
+  printf '%s\n' "$_k" | grep -qx 'checksum/env-config' && _e8_control=$((_e8_control+1))
+  _hit="$(printf '%s\n' "$_k" | grep -i 'session' | tr '\n' ' ')"
+  [ -n "$_hit" ] && _e8_bad="${_e8_bad} [$(basename "$_f"): ${_hit}]"
+done
+if [ "$_e8_seen" -ne "$_e7_ondisk" ]; then
+  echo "META-FAILURE: E8 evaluated ${_e8_seen} fixtures but ${_e7_ondisk} exist on disk." >&2
+  exit 2
+fi
+if [ "$_e8_rendered" -eq 0 ]; then
+  echo "META-FAILURE: E8 found no renderable fixtures among ${_e8_seen} on disk." >&2
+  exit 2
+fi
+if [ "$_e8_control" -ne "$_e8_rendered" ]; then
+  echo "META-FAILURE: E8's annotation extractor found checksum/env-config in ${_e8_control}" >&2
+  echo "  of ${_e8_rendered} renderable fixtures. Every renderable fixture renders it, so the" >&2
+  echo "  extractor is broken and its silence about 'session' is not evidence about the chart." >&2
+  exit 2
+fi
+if [ -z "$_e8_bad" ]; then
+  pass "no pod annotation in ${_e8_seen} ci fixtures is derived from the session secret"
+else
+  fail "a pod annotation names or digests the session secret:${_e8_bad} -- see values.yaml on why checksum/session is deliberately absent"
 fi
 
 # ---------------------------------------------------------------------------

--- a/deploy/helm/scion-hub/tests/chart-integrity.sh
+++ b/deploy/helm/scion-hub/tests/chart-integrity.sh
@@ -869,6 +869,7 @@ _e9_C="$(_e9_run --set-string auth.oauth.web.google.clientSecret=E9-ARM-A-SECRET
 # ambiguous and the comparison meaningless.
 for _e9_n in A B C; do
   eval "_e9_v=\"\$_e9_${_e9_n}\""
+  # shellcheck disable=SC2154
   _e9_d="$(_e9_dig "$_e9_v")"
   _e9_c="$(printf '%s\n' "$_e9_d" | grep -c . || true)"
   if [ "$_e9_c" -ne 1 ]; then

--- a/deploy/helm/scion-hub/tests/chart-integrity.sh
+++ b/deploy/helm/scion-hub/tests/chart-integrity.sh
@@ -38,18 +38,30 @@ set -u -o pipefail
 HELM="${HELM:-helm}"
 CHART="${CHART:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 
-# Minimum values that make the chart render. All three are `required` with no default by design.
+# Minimum values that make the chart render. All four are `required` or enforced by a `fail`,
+# with no default, by design.
 # hub.baseUrl became required in Phase 1: the hub's own fallback is a localhost URL that agents
 # cannot reach and that disables the session cookie's Secure attribute, so there is no safe
 # default. Before it was added here every render in this file returned empty, which section D's
 # empty-render guard reported correctly rather than scoring it as zero channels.
-BASE=(--set image.repository=example.invalid/scion-hub --set hub.hubId=h --set hub.baseUrl=https://h.example.invalid)
+#
+# auth.sessionSecret became required in the session-secret phase, for the same reason and with
+# the same consequence if it is left out: scion-hub.assertSessionSecret fails the render, so
+# every BASE render in this file returns an ERROR STRING rather than manifests, and sections A
+# and B accuse the chart of dropping templates it never dropped. The chart will not default it -
+# a generated secret rotates on every upgrade - so the harness supplies one, exactly as it
+# supplies a base URL.
+BASE_NO_SECRET=(--set image.repository=example.invalid/scion-hub --set hub.hubId=h --set hub.baseUrl=https://h.example.invalid)
+BASE=("${BASE_NO_SECRET[@]}" --set auth.sessionSecret=chart-integrity-not-a-real-secret)
 
 # HELD AT 26 ON PURPOSE, AND THIS SCRIPT THEREFORE EXITS 2.
 #
 # The true Phase 1 figure is 35: 26 as adopted, +2 kinds (ConfigMap, Secret) in
 # section B, +2 files (configmap-env.yaml, secret-settings.yaml) in section C,
-# +5 in section E (the signing-key flip).
+# +5 in section E (the signing-key flip). The session-secret phase adds +3: E6
+# and E7 in the inverted section E, and one more in section C, because that
+# section asserts one file PER ENTRY in EXPECTED_FILES and secret-session.yaml
+# is a seventeenth entry. -> 38.
 # Nothing FAILS -- every assertion the chart is accused by passes. The only red
 # is this number.
 #
@@ -60,7 +72,7 @@ BASE=(--set image.repository=example.invalid/scion-hub --set hub.hubId=h --set h
 # honest encoding of the hold, and bumping it would be the defeat gd-p0-dev
 # warned about. Lifting the hold is a two-line change: 26 -> 35 here, and
 # 107 -> 116 in run-all.sh, in one diff.
-EXPECTED_TOTAL=35
+EXPECTED_TOTAL=38
 
 # TOOL-PRESENCE ARM. A MISSING TOOLCHAIN MUST NOT BE REPORTED AS A BROKEN CHART.
 # Without this every helm invocation fails, every assertion fails, and the output
@@ -94,35 +106,27 @@ fail() { executed=$((executed+1)); failed=$((failed+1)); echo "FAIL  $1"; }
 # what rejected it. This is the difference between testing the guard and testing any guard.
 # ---------------------------------------------------------------------------
 
-schema_rejects() { # $1 = --set expr, $2 = expected path in the schema error
-  local out
-  out="$("$HELM" template t "$CHART" "${BASE[@]}" --set "$1" 2>&1)"
-  # -F ON THE SECOND ARM, AND THE REASON IS F24 IN MINIATURE. $2 is a schema
-  # path and the paths in this file include '(root)'. Under -E those parentheses
-  # are a capture group, so the pattern matches "- root: Additional property" and
-  # NOT the literal text helm prints - measured: naming -E here turned a passing
-  # assertion red. -F cannot carry the ^ anchor, so the anchor is spent to keep
-  # the dialect honest; "- (root): Additional property" is distinctive enough in
-  # a helm error that the loss is nominal, and the first arm still asserts the
-  # sentence. The alternative - escaping $2 at every call site - puts the
-  # correctness of the check in the caller's hands, which is where this kind of
-  # thing goes wrong quietly.
-  #
-  # AND THE `--`, WHICH IS NOT DECORATION. Dropping the ^ anchor makes the
-  # pattern start with "- ", and grep reads a leading dash as an option: the
-  # first attempt printed "grep: invalid option -- ' '" on stderr and the
-  # assertion went red. It is visible here only because this harness does not
-  # redirect stderr away, which is the rule that caught it.
-  if printf '%s' "$out" | grep -qE "Additional property .* is not allowed" \
-     && printf '%s' "$out" | grep -qF -- "- $2: Additional property"; then
-    pass "schema rejects unknown key ($1) at '$2'"
+schema_rejects() { # $1 = --set expr, $2 = leaf name (the key the schema should reject)
+  local out rc
+  out="$("$HELM" template t "$CHART" "${BASE[@]}" --set "$1" 2>&1)"; rc=$?
+  # Match the key name in the schema error. Helm ≤3.16 prints
+  #   "- (root): Additional property bogusKey is not allowed"
+  # while Helm ≥3.17 prints
+  #   "- at '': additional properties 'bogusKey' not allowed"
+  # Both formats contain the key name; matching on that is portable across
+  # versions. The render must also fail (non-zero exit); a successful render
+  # means the schema is absent or not enforcing.
+  if [ "$rc" -ne 0 ] \
+     && printf '%s' "$out" | grep -qi "additional propert" \
+     && printf '%s' "$out" | grep -qF "$2"; then
+    pass "schema rejects unknown key ($1) naming '$2'"
   else
-    fail "schema did NOT reject unknown key ($1) at '$2' -- values.schema.json missing or not enforcing"
+    fail "schema did NOT reject unknown key ($1) naming '$2' -- values.schema.json missing or not enforcing"
   fi
 }
 
-schema_rejects "bogusKeyNotInSchema=1" "(root)"
-schema_rejects "hub.bogusNested=1"     "hub"
+schema_rejects "bogusKeyNotInSchema=1" "bogusKeyNotInSchema"
+schema_rejects "hub.bogusNested=1"     "bogusNested"
 
 # POSITIVE TWIN. Without this, a schema that rejects EVERYTHING passes both cases above.
 if "$HELM" template t "$CHART" "${BASE[@]}" >/dev/null 2>&1; then
@@ -141,29 +145,51 @@ RENDER="$("$HELM" template t "$CHART" "${BASE[@]}" 2>/dev/null)" || RENDER=""
 # ConfigMap and Secret are Phase 1's, and they were the two kinds this loop did
 # not name -- so the manifests the phase added were the only ones nothing
 # asserted by kind, which is the general shape of how a per-phase enumeration
-# goes short. The total below is DERIVED from this list rather than written
-# beside it: a hand-listed set with a separately-maintained count is two facts
-# that can disagree, and the comment asking the next person to update both is a
-# request, not a mechanism.
-EXPECTED_KINDS=(ConfigMap Deployment Role RoleBinding Secret Service ServiceAccount)
+# goes short.
+# NOW A KIND -> COUNT TABLE, BECAUSE THE SESSION-SECRET PHASE BROKE THE
+# ASSUMPTION THE OLD ONE ENCODED. This was a flat list of kinds, and the total
+# was derived from its LENGTH - which silently assumed exactly one manifest per
+# kind. The base render now contains TWO Secrets, the settings Secret and the
+# session Secret, so that assumption is false and the derivation was off by one.
+#
+# The twin's own comment named this exact case in advance - "a template that
+# started emitting a second Secret ... satisfies every iteration above" - so the
+# fix keeps its property rather than bumping a number past it. The count moves
+# INTO the table, the per-kind loop asserts an exact count instead of mere
+# presence, and the total is still derived from one structure rather than
+# maintained beside it. Strictly stronger than what it replaces: a stray second
+# Deployment is now caught by its own kind's assertion and not only in aggregate.
+declare -A EXPECTED_KINDS=(
+  [ConfigMap]=1
+  [Deployment]=1
+  [Role]=1
+  [RoleBinding]=1
+  [Secret]=2
+  [Service]=1
+  [ServiceAccount]=1
+)
 
-for k in "${EXPECTED_KINDS[@]}"; do
-  if printf '%s\n' "$RENDER" | grep -qxF "kind: $k"; then
-    pass "render contains kind: $k"
+_kind_total=0
+for k in $(printf '%s\n' "${!EXPECTED_KINDS[@]}" | sort); do
+  want="${EXPECTED_KINDS[$k]}"
+  _kind_total=$((_kind_total + want))
+  got="$(printf '%s\n' "$RENDER" | grep -cx "kind: $k")"
+  if [ "$got" -eq "$want" ]; then
+    pass "render contains ${want}x kind: $k"
   else
-    fail "render is MISSING kind: $k -- template dropped (check .helmignore breadth)"
+    fail "render contains ${got}x kind: $k, expected ${want} -- template dropped (check .helmignore breadth) or an unexpected manifest appeared"
   fi
 done
 
-# THE TWIN, AND IT IS NOT THE LOOP AGAIN. The loop says each named kind is
-# present; it is silent on anything present that is NOT named. A template that
-# started emitting a second Secret, or a stray manifest from an over-broad
-# range, satisfies every iteration above.
-kinds="$(printf '%s\n' "$RENDER" | grep -cE '^kind:')"
-if [ "$kinds" -eq "${#EXPECTED_KINDS[@]}" ]; then
-  pass "render emits exactly ${#EXPECTED_KINDS[@]} manifests"
+# THE TWIN, AND IT IS NOT THE LOOP AGAIN. The loop says each named kind appears
+# the expected number of times; it is silent on any kind present that is NOT
+# named at all. A stray manifest of some kind nobody listed satisfies every
+# iteration above.
+kinds="$(printf '%s\n' "$RENDER" | grep -c '^kind:')"
+if [ "$kinds" -eq "$_kind_total" ]; then
+  pass "render emits exactly ${_kind_total} manifests"
 else
-  fail "render emits ${kinds} manifests, expected ${#EXPECTED_KINDS[@]} -- add it to EXPECTED_KINDS deliberately, or find out what it is"
+  fail "render emits ${kinds} manifests, expected ${_kind_total} -- add it to EXPECTED_KINDS deliberately, or find out what it is"
 fi
 
 # ---------------------------------------------------------------------------
@@ -188,6 +214,7 @@ EXPECTED_FILES=(
   scion-hub/templates/rbac-clusterrolebinding.yaml
   scion-hub/templates/rbac-role.yaml
   scion-hub/templates/rbac-rolebinding.yaml
+  scion-hub/templates/secret-session.yaml
   scion-hub/templates/secret-settings.yaml
   scion-hub/templates/service.yaml
   scion-hub/templates/serviceaccount.yaml
@@ -396,57 +423,89 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# E. The signing-key flip.  (5 assertions)
+# E. The signing-key flip.  (7 assertions)
 #
-# WHAT THIS PROTECTS, AND IT IS NOT THE FIX.
+# THE SECRET HAS LANDED. THIS SECTION HAS BEEN INVERTED, NOT RETIRED.
 #
-# auth.requireStableSigningKey defaults to false in this release because nothing
-# in this release can satisfy true: the hub resolves a stable key from a
+# Phase 1 wrote this section while auth.requireStableSigningKey defaulted to
+# false and true was UNSATISFIABLE: the hub resolves a stable key from a
 # pre-configured key, SharedSigningSecret, a secret backend or its store
-# (pkg/hub/server.go:1445), SharedSigningSecret comes only from --session-secret,
+# (pkg/hub/server.go:1445); SharedSigningSecret comes only from --session-secret,
 # SCION_SERVER_SESSION_SECRET or bare SESSION_SECRET
-# (cmd/server_foreground.go:1452-1462), and the chart renders none of the three.
+# (cmd/server_foreground.go:1452-1462); and the chart rendered none of the three.
 # With true and no key, pkg/hub/server.go:1634 errors, pkg/hub/server.go:1008
-# makes it fatal, cmd/server_foreground.go:259 calls log.Fatalf.
+# makes it fatal, cmd/server_foreground.go:259 calls log.Fatalf. So E2 asserted a
+# `fail` in configmap-env.yaml that REFUSED true, and E5 was a tripwire waiting
+# for the day the Secret landed and nobody flipped the default back.
 #
-# The failure mode this section exists for is the OPPOSITE one, and it is the
-# one a check written to protect the fix will miss: the session-secret phase
-# lands the Secret and nobody flips the default back. A `false` default satisfies
-# every negative assertion vacuously and forever. So the LANDING limb is keyed to
-# the DEFAULT RENDER, not to the permutation set, and it goes red the day the
-# default render gains a source and stays red until this default reads true.
+# The session-secret phase is that day. templates/secret-session.yaml renders the
+# Secret, scion-hub.assertSessionSecret makes it unconditional, and the default is
+# now true. The tripwire fired and was answered.
 #
-# Keyed to the default deliberately: an operator who supplies their own secret
-# and leaves the flag false is doing something legitimate and must not trip it.
+# E2 IS INVERTED RATHER THAN DELETED, ON A RULING, AND THE REASON IS GENERAL. The
+# input Phase 1 refused - true with no config.existingSecret - is now the input
+# that must RENDER. Deleting the assertion would leave that transition untested in
+# both directions: nothing would catch the guard being reinstated by a bad merge,
+# and nothing would record that the refusal was removed on purpose. An inverted
+# assertion carries the history a deleted one throws away.
+#
+# THE DANGEROUS DIRECTION HAS ALSO FLIPPED, WHICH IS WHY E5 KEEPS BOTH ARMS.
+# Under Phase 1 the harm was flag=false with a source present (silent logouts).
+# Now the harm is flag=true with NO source present (every pod log.Fatalf on first
+# boot), and that is reachable in one edit: delete secret-session.yaml, or make
+# assertSessionSecret conditional, and the default render loses its only source
+# while the default stays true. E6 and E7 close that off from the other side.
 # ---------------------------------------------------------------------------
 
+# "DEFAULT" HERE MEANS BASE, WHICH NOW CARRIES A SESSION SECRET - see the BASE
+# definition at the top. That is the default in the sense that matters: what an
+# operator gets having supplied the one value the chart refuses to invent for
+# them. BASE_NO_SECRET is the same render without it, and it does not produce
+# manifests at all; that failure is E6's subject.
 _DEFAULT_RENDER="$("$HELM" template t "$CHART" "${BASE[@]}" 2>&1)"
 
 # THE SUBJECT IS THE RENDER WITH FULL-LINE COMMENTS REMOVED, AND THAT IS NOT
 # TIDINESS - IT IS THE DIFFERENCE BETWEEN RED AND GREEN TODAY.
 #
 # configmap-env.yaml documents this exact mechanism in a plain YAML `#` comment,
-# which means the comment RENDERS, which means the default render contains the
-# string SCION_SERVER_SESSION_SECRET right now. A naive probe reads that as "the
-# default render carries a session-secret source", the LANDING limb then demands
-# the default be flipped to true, and the chart would be driven into precisely
-# the boot failure this whole section exists to prevent - by a detector satisfied
-# by a sentence ABOUT sources. Same shape as section D's quotation problem: the
-# explanatory prose and the thing it describes have identical bytes.
+# which means the comment RENDERS, which means every render of this chart -
+# including one with no session secret in it anywhere - contains the string
+# SCION_SERVER_SESSION_SECRET. A probe that cannot tell a source from a sentence
+# ABOUT sources is therefore permanently satisfied, and cannot report the absence
+# of the real thing.
 #
 # FULL-LINE comments only - first non-space character is `#`. A trailing comment
 # after a value is left alone, because `#` inside a quoted YAML scalar is legal
-# and stripping to end-of-line would delete real content. Under-stripping yields
-# a false RED, which is the safe direction; over-stripping would yield a false
-# GREEN. An env var name and an argv flag are never on a full-line comment.
+# and stripping to end-of-line would delete real content.
 #
-# LOAD-BEARING TODAY, MEASURED, NOT ASSERTED. On the default render at this head:
-#   with the stripper:    (no sources)
-#   without the stripper: --session-secret SCION_SERVER_SESSION_SECRET SESSION_SECRET
-# So the corpus is its own coverage control - remove the stripper and E5 goes red
-# immediately, and its remedy text tells you to set the default to true, which is
-# the log.Fatalf. A detector that recommends the harm is worse than no detector.
-_strip_comment_lines() { grep -vE '^[[:space:]]*#'; }
+# THE SAFE DIRECTION REVERSED WHEN THE DEFAULT DID, and the stripper must now be
+# read the other way round. Under Phase 1, under-stripping gave a false RED and
+# over-stripping a false GREEN. Now the probe's job is to confirm a source is
+# PRESENT, so it is OVER-stripping that yields the false red and UNDER-stripping
+# that yields the false green. Control 2 below is the one carrying the weight,
+# and it is the control that would have been dropped as redundant.
+#
+# STILL LOAD-BEARING, RE-MEASURED AT THE SESSION-SECRET HEAD, AND NOW IT GUARDS
+# THE OPPOSITE DIRECTION. Phase 1 recorded that the stripper was what kept the
+# default render reading as "no sources"; that reading is now obsolete, because
+# the render really does carry one. Measured here, four renders:
+#
+#   secret-session.yaml PRESENT, with the stripper:  SCION_SERVER_SESSION_SECRET
+#   secret-session.yaml PRESENT, no stripper:        --session-secret SCION_SERVER_SESSION_SECRET SESSION_SECRET
+#   secret-session.yaml DELETED, with the stripper:  (no sources)   <- E5 fires
+#   secret-session.yaml DELETED, no stripper:        --session-secret SCION_SERVER_SESSION_SECRET SESSION_SECRET
+#
+# The last two lines are the whole argument. Deleting the Secret template while
+# the default stays true is the log.Fatalf-on-every-pod regression E5 now exists
+# to catch, and WITHOUT the stripper that deletion is invisible: configmap-env.
+# yaml's own explanatory comment names all three source spellings, so the probe
+# keeps finding "sources" in prose after the real one is gone and E5 stays green
+# through the outage. The stripper is the only reason the alarm can fire at all.
+#
+# Same shape as section D's quotation problem, and the same shape as before -
+# the explanatory prose and the thing it describes have identical bytes - but the
+# consequence of getting it wrong has moved from a false red to a FALSE GREEN.
+_strip_comment_lines() { grep -v '^[[:space:]]*#'; }
 
 _secret_sources() { # stdin = render text; stdout = space-separated distinct tokens
   _strip_comment_lines \
@@ -461,16 +520,27 @@ _secret_sources() { # stdin = render text; stdout = space-separated distinct tok
 # CONTROL 1 - the apparatus fires. A full-line comment naming a source vanishes.
 # The fixture is the real line out of today's default render, not an invention.
 if printf '%s\n' '  # --session-secret, SCION_SERVER_SESSION_SECRET and bare SESSION_SECRET' \
-     | _secret_sources | grep -qE .; then
+     | _secret_sources | grep -q .; then
   echo "META-FAILURE: the comment stripper did not strip a full-line YAML comment." >&2
-  echo "  The LANDING limb would read the chart's own documentation as a secret source" >&2
-  echo "  and demand a default flip that makes every pod log.Fatalf on first boot." >&2
+  echo "  Every limb below would read the chart's own documentation as a secret source." >&2
+  echo "  E5 and E7 would then score green on a chart that renders NO session secret at" >&2
+  echo "  all - the deleted-template regression, invisible, with the default still true" >&2
+  echo "  and every pod hitting log.Fatalf at cmd/server_foreground.go:259 on first boot." >&2
   exit 2
 fi
-# CONTROL 2 - the apparatus does not over-fire, and this is the twin that
-# matters. A stripper that deleted everything passes control 1 perfectly and
-# silences the real thing. Three fixtures because the three source spellings sit
-# at three different indents and one of them is an argv element.
+# CONTROL 2 - the apparatus does not over-fire. A stripper that deleted
+# everything passes control 1 perfectly.
+#
+# UNDER THE INVERTED SECTION THIS CONTROL PROTECTS AGAINST A FALSE RED, NOT A
+# FALSE GREEN, and it is retained for that reason rather than in spite of it. An
+# over-firing stripper now makes E5 and E7 accuse a correct chart of shipping
+# true with no secret source. The remedy text on that failure tells the reader to
+# set the default back to false, which reintroduces the silent-logout bug Phase 1
+# wrote this section to prevent. A detector that recommends the harm is worse
+# than no detector - the same sentence as before, pointing the other way.
+#
+# Four fixtures because the three source spellings sit at three different indents
+# and one of them is an argv element.
 #
 # THE DENOMINATOR IS ASSERTED, NOT DISPLAYED (gd-em, 08:22). Both loops below
 # score "no misses" over whatever the heredoc contains, and an empty heredoc
@@ -531,25 +601,37 @@ else
   fail "session-secret probe MISSED seeded source(s):${_e1_missed} -- every limb below is vacuous"
 fi
 
-# --- E2. NEGATIVE. The chart refuses an unsatisfiable true. -----------------
-# Asserting the error TEXT, not merely a non-zero exit: several `fail`s and the
-# schema also exit non-zero, so "it was rejected" alone does not prove THIS guard
-# rejected it. The text asserted is the harm citation, because that is the part
-# an operator needs and the part a weakened message would drop first.
-_e2="$("$HELM" template t "$CHART" "${BASE[@]}" --set auth.requireStableSigningKey=true 2>&1)"
-if printf '%s' "$_e2" | grep -qF 'auth.requireStableSigningKey is true' \
-   && printf '%s' "$_e2" | grep -qF 'cmd/server_foreground.go:259'; then
-  pass "chart refuses requireStableSigningKey=true with no secret source, citing the log.Fatalf"
+# --- E2. INVERTED. The input Phase 1 refused is the input that must render. --
+# Phase 1 asserted here that `--set auth.requireStableSigningKey=true` WITHOUT
+# config.existingSecret was rejected by a `fail` in configmap-env.yaml citing
+# cmd/server_foreground.go:259. That `fail` is deleted and this asserts its
+# absence by asserting the success it blocked - the same input, the opposite
+# verdict, which is what makes a bad merge reinstating the guard visible.
+#
+# ASSERTING THE RENDERED VALUE, NOT MERELY A ZERO EXIT. A chart that rendered
+# successfully while emitting "false" - because someone rewired the ternary
+# rather than the guard - would pass an exit-code check and ship the bug.
+#
+# The old refusal's own text is asserted ABSENT alongside, because the guard
+# could also be reinstated somewhere that leaves this particular render working;
+# the string is the guard's fingerprint and it should exist nowhere now.
+_e2="$("$HELM" template t "$CHART" "${BASE[@]}" \
+         --set auth.requireStableSigningKey=true 2>&1)"
+if printf '%s\n' "$_e2" | grep -q 'SCION_REQUIRE_STABLE_SIGNING_KEY: "true"' \
+   && ! printf '%s\n' "$_e2" | grep -q 'auth.requireStableSigningKey is true'; then
+  pass "requireStableSigningKey=true renders without config.existingSecret (Phase 1's refusal is gone)"
 else
-  fail "chart did NOT refuse requireStableSigningKey=true, or the refusal stopped naming its harm"
+  fail "requireStableSigningKey=true did NOT render true without config.existingSecret -- Phase 1's guard is back, or the ternary was rewired"
   printf '%s\n' "$_e2" | sed 's/^/        | /' | head -3
 fi
 
-# --- E3. POSITIVE TWIN OF E2. The guard is not refusing everything. ---------
-# config.existingSecret is the one shape where true is satisfiable: the operator
-# writes their own settings.yaml and can configure server.secrets there. Without
-# this assertion, a guard hardened into an unconditional refusal scores E2 green.
-_e3="$("$HELM" template t "$CHART" "${BASE[@]}" --set auth.requireStableSigningKey=true \
+# --- E3. POSITIVE TWIN OF E2. Nothing refuses true anywhere. ----------------
+# config.existingSecret was the ONE shape where true was satisfiable under Phase
+# 1, so it is the shape a reinstated guard would most plausibly keep working.
+# Kept as E2's twin for that reason: E2 alone cannot distinguish "no guard" from
+# "a guard with this one exemption", which is exactly the state Phase 1 shipped.
+_e3="$("$HELM" template t "$CHART" "${BASE[@]}" \
+         --set auth.requireStableSigningKey=true \
          --set config.existingSecret=operator-settings 2>&1)"
 if printf '%s\n' "$_e3" | grep -qF 'SCION_REQUIRE_STABLE_SIGNING_KEY: "true"'; then
   pass "requireStableSigningKey=true is permitted under config.existingSecret"
@@ -570,26 +652,104 @@ else
   printf '%s\n' "$_DEFAULT_RENDER" | sed 's/^/        | /' | head -3
 fi
 
-# --- E5. LANDING. The limb that fires when the secret arrives. --------------
+# --- E5. LANDED. The same two arms, with the live one now the second. -------
+# BOTH ARMS ARE KEPT AND THEIR ROLES HAVE SWAPPED. Under Phase 1 the first arm
+# was the tripwire and the second was documented as unreachable. The secret has
+# landed and the default is true, so the first arm is now the unreachable one -
+# retained because a phase that makes the session secret optional again would
+# otherwise remove the last check on the silent-logout combination - and the
+# SECOND arm is the live tripwire, one edit away from firing: delete
+# secret-session.yaml, or put a condition back on scion-hub.assertSessionSecret,
+# and the render loses its only source while this default stays true.
 _e5_src="$(printf '%s\n' "$_DEFAULT_RENDER" | _secret_sources)"
 if [ -n "$_e5_src" ] && [ "$_e4_flag" = "false" ]; then
-  fail "THE SESSION SECRET HAS LANDED AND THE DEFAULT WAS NOT FLIPPED."
-  echo "        the default render now carries: ${_e5_src}"
-  echo "        values.yaml still defaults auth.requireStableSigningKey to false, so this"
+  fail "A SESSION SECRET IS RENDERED AND THE DEFAULT IS BACK TO false."
+  echo "        the default render carries: ${_e5_src}"
+  echo "        values.yaml defaults auth.requireStableSigningKey to false, so this"
   echo "        release ships replicas that sign tokens each other reject - silently,"
   echo "        presenting as intermittent logouts rather than as a configuration error."
   echo "        SET IT TO true. This assertion stays red until you do."
-# THIS ARM IS UNREACHABLE FROM THE DEFAULT RENDER TODAY AND IS KEPT ANYWAY.
-# configmap-env.yaml's guard refuses true-without-existingSecret before any
-# manifest is produced, so a default of true makes the render fail outright and
-# E4 catches it first. The arm is here because that guard is one `{{- if }}` and
-# a future phase that relaxes it - to allow true under some new secret shape -
-# would otherwise silently remove the last check on this combination. Stated
-# rather than deleted so nobody counts it as coverage it is not providing.
 elif [ -z "$_e5_src" ] && [ "$_e4_flag" = "true" ]; then
-  fail "default is true but the default render carries no session-secret source -- every pod would log.Fatalf at cmd/server_foreground.go:259 on first boot"
+  fail "THE SESSION SECRET STOPPED RENDERING AND THE DEFAULT IS STILL true."
+  echo "        the default render carries no session-secret source at all, so every pod"
+  echo "        would log.Fatalf at cmd/server_foreground.go:259 on first boot - the whole"
+  echo "        release dead, not degraded. Either restore the rendered secret or set"
+  echo "        auth.requireStableSigningKey back to false IN THE SAME DIFF."
 else
   pass "signing-key default agrees with the default render's secret sources (flag=\"${_e4_flag}\", sources=${_e5_src:-none})"
+fi
+
+# --- E6. NEGATIVE. No secret at all is refused, and refused BY NAME. --------
+# The twin of E2/E3, and the assertion that makes the true default defensible:
+# true is only safe because there is no way to render without a secret. This is
+# the acceptance criterion "install with neither auth.sessionSecret nor
+# auth.existingSecret fails at template time with a message naming the value".
+#
+# BOTH VALUE NAMES ARE ASSERTED, not the failure. Several other `fail`s and the
+# schema also exit non-zero, so a non-zero exit does not prove THIS guard fired;
+# and an operator who is told only "no session secret" does not learn which of
+# the two values to set. A message that named just one would send everyone who
+# wanted the bring-your-own path down the inline one.
+_e6="$("$HELM" template t "$CHART" "${BASE_NO_SECRET[@]}" 2>&1)"
+if printf '%s\n' "$_e6" | grep -q 'auth.sessionSecret' \
+   && printf '%s\n' "$_e6" | grep -q 'auth.existingSecret' \
+   && ! printf '%s\n' "$_e6" | grep -q 'SCION_REQUIRE_STABLE_SIGNING_KEY'; then
+  pass "render with no session secret is refused, naming auth.sessionSecret and auth.existingSecret"
+else
+  fail "render with no session secret was NOT refused, or the refusal stopped naming both values"
+  printf '%s\n' "$_e6" | sed 's/^/        | /' | head -3
+fi
+
+# --- E7. THE PAIRING, OVER THE WHOLE FIXTURE CORPUS. ------------------------
+# E5 checks one render. This checks every shipped permutation, and it is the
+# assertion the signing-key flip owes: NO combination of values the chart
+# supports may render SCION_REQUIRE_STABLE_SIGNING_KEY="true" with no session
+# secret source. That is the pod-wide log.Fatalf, and a default that is safe on
+# the default render is not the same claim as one that is safe everywhere -
+# ci/values-varied.yaml sets the flag false, and any fixture may set it either
+# way, so the invariant is the PAIRING and not either value alone.
+#
+# THE DENOMINATOR IS ASSERTED AGAINST THE FILES ON DISK, IN BOTH DIRECTIONS. A
+# loop over a glob that matched nothing scores "no violations" and reports the
+# vacuous green; a loop whose list was hand-copied silently stops covering a
+# fixture added later. So the count comes from the glob, is required to be
+# non-zero, and is required to equal the number of ci/values-*.yaml files.
+_e7_bad=""
+_e7_seen=0
+_e7_files=("$CHART"/ci/values-*.yaml)
+for _f in "${_e7_files[@]}"; do
+  [ -e "$_f" ] || continue
+  _e7_seen=$((_e7_seen+1))
+  if ! _r="$("$HELM" template t "$CHART" -f "$_f" 2>&1)"; then
+    # A fixture that FAILS TO RENDER cannot ship a pod. The harm is a
+    # successful render of flag=true with no source, not a refused render.
+    # Negative-control fixtures (values-unknown-key.yaml) and fixtures whose
+    # schema rejects them are expected to fail here.
+    continue
+  fi
+  _flag="$(printf '%s\n' "$_r" | sed -n 's/^[[:space:]]*SCION_REQUIRE_STABLE_SIGNING_KEY:[[:space:]]*"\(.*\)"[[:space:]]*$/\1/p' | head -1)"
+  if [ -z "$_flag" ]; then
+    _e7_bad="${_e7_bad} [$(basename "$_f"): rendered no readable flag]"
+    continue
+  fi
+  if [ "$_flag" = "true" ] && [ -z "$(printf '%s\n' "$_r" | _secret_sources)" ]; then
+    _e7_bad="${_e7_bad} [$(basename "$_f"): flag true, no secret source]"
+  fi
+done
+if [ "$_e7_seen" -eq 0 ]; then
+  echo "META-FAILURE: E7 evaluated no ci/values-*.yaml fixtures." >&2
+  echo "  A loop over an empty list reports the same green as one that passed." >&2
+  exit 2
+fi
+_e7_ondisk="$(find "$CHART/ci" -maxdepth 1 -name 'values-*.yaml' | wc -l | tr -d ' ')"
+if [ "$_e7_seen" -ne "$_e7_ondisk" ]; then
+  echo "META-FAILURE: E7 evaluated ${_e7_seen} fixtures but ${_e7_ondisk} exist on disk." >&2
+  exit 2
+fi
+if [ -z "$_e7_bad" ]; then
+  pass "all ${_e7_seen} ci fixtures pair SCION_REQUIRE_STABLE_SIGNING_KEY=true with a session-secret source"
+else
+  fail "ci fixtures render the signing-key flag true with no secret source:${_e7_bad}"
 fi
 
 # ---------------------------------------------------------------------------

--- a/deploy/helm/scion-hub/tests/chart-integrity.sh
+++ b/deploy/helm/scion-hub/tests/chart-integrity.sh
@@ -73,7 +73,7 @@ BASE=("${BASE_NO_SECRET[@]}" --set auth.sessionSecret=chart-integrity-not-a-real
 # honest encoding of the hold, and bumping it would be the defeat gd-p0-dev
 # warned about. Lifting the hold is a two-line change: 26 -> 35 here, and
 # 107 -> 116 in run-all.sh, in one diff.
-EXPECTED_TOTAL=39
+EXPECTED_TOTAL=45
 
 # TOOL-PRESENCE ARM. A MISSING TOOLCHAIN MUST NOT BE REPORTED AS A BROKEN CHART.
 # Without this every helm invocation fails, every assertion fails, and the output
@@ -824,6 +824,192 @@ if [ -z "$_e8_bad" ]; then
 else
   fail "a pod annotation names or digests the session secret:${_e8_bad} -- see values.yaml on why checksum/session is deliberately absent"
 fi
+
+# ---------------------------------------------------------------------------
+# E9. checksum/settings digests a REDACTED PROJECTION, not the document.
+# ---------------------------------------------------------------------------
+#
+# E8 guards the annotation surface on the NAME axis: no annotation KEY may name
+# the session secret. It cannot see this one, because checksum/settings names
+# nothing - the credential is in what the digest was TAKEN OVER, not in the key.
+# That is the derivation axis and until this check it had no guard at all, on the
+# one surface where the chart digests a Secret.
+#
+# The exposure was measured rather than argued: the digest preimage was recovered
+# byte for byte and then used to predict helm's digest for three client secrets
+# that had never been rendered, 3 of 3, at ~300k guesses/sec on one core. Against
+# a provider-issued secret that is CONFIRMATION of a candidate an attacker
+# already holds, not recovery - including against superseded values still in the
+# ReplicaSet revision history. Lower bar than recovery, and the real one.
+#
+# WHY ARM 0 EXISTS, AND IT IS THE ONLY ARM THAT MATTERS. Arms 1 and 2 ask whether
+# two digests are equal. If the two renders were IDENTICAL, the digests would be
+# equal for a reason that has nothing to do with redaction, and this check would
+# print PASS forever while measuring nothing. That is not hypothetical: the
+# author's first run of this comparison by hand used a --set that changed a value
+# to what it already was, and read the resulting "unchanged" as a defect in the
+# projection. An inert arm renders exactly like a working one. So arm 0 asserts
+# the two inputs really do differ, BY VALUE, in both directions, and it is a
+# META-FAILURE rather than an assertion: if the inputs did not differ, nothing
+# was analysed and a green line here would be a lie rather than a wrong answer.
+#
+# Arm 2 is the positive control for arm 1. Deleting the annotation, or hashing a
+# constant, would satisfy arm 1 perfectly - and would silently break every
+# settings upgrade, because settings.yaml is a subPath mount frozen for the
+# container's lifetime. Arm 1 alone cannot tell "the secret is redacted" from
+# "the digest is dead". Arm 2 can, and it is why both are here.
+_e9_fx="$CHART/ci/values-settings-oauth.yaml"
+_e9_run() { "$HELM" template t "$CHART" -f "$_e9_fx" "$@" 2>&1; }
+_e9_dig() { printf '%s\n' "$1" | sed -n 's/^[[:space:]]*checksum\/settings:[[:space:]]*//p'; }
+_e9_A="$(_e9_run --set-string auth.oauth.web.google.clientSecret=E9-ARM-A-SECRET)"
+_e9_B="$(_e9_run --set-string auth.oauth.web.google.clientSecret=E9-ARM-B-SECRET)"
+_e9_C="$(_e9_run --set-string auth.oauth.web.google.clientSecret=E9-ARM-A-SECRET --set-string hub.name=E9ArmCRename)"
+# Arm 0a: each arm must render exactly one checksum/settings, non-empty. Zero
+# would make every equality below vacuously true; two would make "the digest"
+# ambiguous and the comparison meaningless.
+for _e9_n in A B C; do
+  eval "_e9_v=\"\$_e9_${_e9_n}\""
+  _e9_d="$(_e9_dig "$_e9_v")"
+  _e9_c="$(printf '%s\n' "$_e9_d" | grep -c . || true)"
+  if [ "$_e9_c" -ne 1 ]; then
+    echo "META-FAILURE: E9 arm ${_e9_n} rendered ${_e9_c} checksum/settings annotations, expected exactly 1." >&2
+    echo "  Nothing was analysed: the comparisons below would be over an absent or ambiguous value." >&2
+    exit 2
+  fi
+done
+_e9_dA="$(_e9_dig "$_e9_A")"; _e9_dB="$(_e9_dig "$_e9_B")"; _e9_dC="$(_e9_dig "$_e9_C")"
+# Arm 0b: the inputs really differ, in both directions. Checked by value, on the
+# rendered Secret, so a --set that silently failed to apply cannot pass as a
+# collapse.
+_e9_ina="$(printf '%s\n' "$_e9_A" | grep -cF -- 'E9-ARM-A-SECRET' || true)"
+_e9_inb="$(printf '%s\n' "$_e9_B" | grep -cF -- 'E9-ARM-B-SECRET' || true)"
+_e9_xa="$(printf '%s\n' "$_e9_A" | grep -cF -- 'E9-ARM-B-SECRET' || true)"
+_e9_xb="$(printf '%s\n' "$_e9_B" | grep -cF -- 'E9-ARM-A-SECRET' || true)"
+if [ "$_e9_ina" -ne 1 ] || [ "$_e9_inb" -ne 1 ] || [ "$_e9_xa" -ne 0 ] || [ "$_e9_xb" -ne 0 ]; then
+  echo "META-FAILURE: E9's two arms were supposed to differ by exactly the client secret." >&2
+  echo "  Expected A:own=1 B:own=1 A:other=0 B:other=0; got A:own=${_e9_ina} B:own=${_e9_inb} A:other=${_e9_xa} B:other=${_e9_xb}." >&2
+  echo "  The --set did not land, so the two renders are not distinguishable and NOTHING WAS ANALYSED." >&2
+  exit 2
+fi
+if [ "$_e9_dA" = "$_e9_dB" ]; then
+  pass "checksum/settings is unchanged by rotating the OAuth client secret (the digest is a projection, not an oracle)"
+else
+  fail "checksum/settings CHANGED when only the OAuth client secret changed (${_e9_dA} -> ${_e9_dB}). The annotation is a digest over the credential again, which publishes an offline verification oracle for it to everyone with pod read access - a wider audience than the Secret's RBAC. See scion-hub.settingsChecksum."
+fi
+if [ "$_e9_dA" != "$_e9_dC" ]; then
+  pass "checksum/settings still moves when a non-secret settings field changes (the projection did not kill the annotation)"
+else
+  fail "checksum/settings did NOT move when hub.name changed. The redaction has gone too far or the digest is a constant - and settings.yaml is a subPath mount the kubelet never refreshes, so every configuration upgrade would now report success and change nothing."
+fi
+
+# ---------------------------------------------------------------------------
+# E10. A SHORT client secret must not be REFUSED, and must still be redacted.
+# ---------------------------------------------------------------------------
+#
+# THIS IS A REGRESSION TEST FOR A DEFECT THIS HARNESS DID NOT FIND. The value
+# half of scion-hub.settingsChecksum searches the finished projection for each
+# credential it redacted, and the search is a plain substring test. A client
+# secret of "def" is a substring of the word "default" in the rendered settings,
+# so the chart REFUSED a perfectly valid install and told the maintainer to add
+# a redaction path that does not exist. Found by an arm run for an unrelated
+# reason - rendering NOTES.txt with credentials set - not by E9, which uses
+# long values and could never have exhibited it.
+#
+# Both assertions are needed and they pull against each other. The first says
+# the render is not refused; on its own, deleting the whole value check passes
+# it. The second says a short secret is still absent from the digest, which is
+# the property the value check exists to protect - and it is asserted the only
+# way it can be from outside: two different short secrets must produce ONE
+# digest. E9's arm 2 remains the control that the digest is not simply dead.
+_e10_run() { "$HELM" template t "$CHART" "${BASE[@]}" --set auth.mode=oauth \
+  --set-string auth.oauth.web.google.clientId=e10-client-id \
+  --set-string auth.oauth.web.google.clientSecret="$1" 2>&1; }
+_e10_a="$(_e10_run def)"
+_e10_b="$(_e10_run ghi)"
+if printf '%s\n' "$_e10_a" | grep -qE '^Error:'; then
+  fail "a three-character OAuth client secret was REFUSED: $(printf '%s\n' "$_e10_a" | head -1). The value-based backstop in scion-hub.settingsChecksum is colliding with ordinary rendered text - see the floor documented there. A refusal an operator cannot act on is worse than the check being absent."
+else
+  pass "a short OAuth client secret renders (the value backstop's substring test does not collide with ordinary settings text)"
+fi
+_e10_da="$(_e9_dig "$_e10_a")"; _e10_db="$(_e9_dig "$_e10_b")"
+_e10_ca="$(printf '%s\n' "$_e10_da" | grep -c . || true)"
+if [ "$_e10_ca" -ne 1 ] || [ "$(printf '%s\n' "$_e10_db" | grep -c . || true)" -ne 1 ]; then
+  echo "META-FAILURE: E10 did not render exactly one checksum/settings per arm (got ${_e10_ca} and $(printf '%s\n' "$_e10_db" | grep -c . || true))." >&2
+  echo "  Nothing was analysed: the equality below would be over an absent value." >&2
+  exit 2
+fi
+if [ "$_e10_da" = "$_e10_db" ]; then
+  pass "two different short OAuth client secrets produce one checksum/settings (the length floor narrowed the check, not the redaction)"
+else
+  fail "checksum/settings differs between two SHORT client secrets (${_e10_da} -> ${_e10_db}). The redaction is length-dependent, so the oracle is restored for exactly the credentials with the least entropy to guess."
+fi
+
+# ---------------------------------------------------------------------------
+# E11. The rotation restart NOTES.txt owes the operator, because E9 removed it.
+# ---------------------------------------------------------------------------
+#
+# E9 asserts that rotating an OAuth client secret does NOT move
+# checksum/settings. That is the fix, and it deletes a real behaviour: before the
+# redaction, a credential rotation rolled the pods, as a side effect of the
+# credential being inside the digest. The same side effect was the verification
+# oracle. They were one mechanism and they are gone together.
+#
+# The replacement is prose - values.yaml next to auth.oauth.web.*.clientSecret,
+# and NOTES.txt, which is the only one of the two an operator sees without going
+# looking. scion-hub.settingsChecksum's comment says "delete either of those and
+# you have deleted the behaviour, not the annotation." That was an unasserted
+# claim about a file nothing tested, which is the shape of every stale comment in
+# this chart's history, so it is asserted here.
+#
+# RENDERING NOTES.txt WITHOUT A CLUSTER. `helm template` evaluates NOTES.txt but
+# never prints it, and this helm has no --notes. The technique is hack/verify.sh's
+# and is copied deliberately rather than reinvented: copy the chart, rename
+# templates/NOTES.txt to a .txt manifest name, --show-only that file with --debug
+# (helm exits non-zero because the prose is not YAML; --debug renders it anyway).
+# The copy is compared byte-for-byte against the original first - otherwise this
+# section could be measuring a file that is not the chart's NOTES.
+_e11_render() { # $1 = out file, rest = helm args
+  local _o="$1"; shift
+  local _d; _d="$(mktemp -d)"
+  cp -a "$CHART" "$_d/c"
+  mv "$_d/c/templates/NOTES.txt" "$_d/c/templates/zz-notes-probe.txt"
+  if ! cmp -s "$CHART/templates/NOTES.txt" "$_d/c/templates/zz-notes-probe.txt"; then
+    rm -rf "$_d"
+    echo "META-FAILURE: E11's NOTES probe is not byte-identical to templates/NOTES.txt." >&2
+    exit 2
+  fi
+  "$HELM" template t "$_d/c" --debug --show-only templates/zz-notes-probe.txt "$@" 2>/dev/null \
+    | sed -n '/^# Source: .*zz-notes-probe\.txt$/,$p' >"$_o"
+  rm -rf "$_d"
+}
+_e11_on="$(mktemp)"; _e11_off="$(mktemp)"
+_e11_render "$_e11_on" "${BASE[@]}" --set auth.mode=oauth \
+  --set-string auth.oauth.web.google.clientId=e11-client-id \
+  --set-string auth.oauth.web.google.clientSecret=e11-client-secret-value
+_e11_render "$_e11_off" "${BASE[@]}"
+# Arm 0: BOTH renders must be non-empty and must contain a section that is in
+# NOTES.txt unconditionally. Without this the "absent" assertion below is
+# satisfied by a probe that rendered nothing at all, which is the standing defect
+# in every absence check: a broken harness and a clean chart look identical.
+for _e11_f in "$_e11_on" "$_e11_off"; do
+  if [ ! -s "$_e11_f" ] || ! grep -qF 'SCHEMA_VERSION IS LOAD-BEARING' "$_e11_f"; then
+    echo "META-FAILURE: E11's NOTES probe rendered nothing usable ($(wc -c <"$_e11_f") bytes, unconditional anchor $(grep -cF 'SCHEMA_VERSION IS LOAD-BEARING' "$_e11_f" || true))." >&2
+    echo "  Nothing was analysed: the absence assertion below would pass against an empty file." >&2
+    rm -f "$_e11_on" "$_e11_off"
+    exit 2
+  fi
+done
+if grep -qF 'ROTATING AN OAUTH CLIENT SECRET' "$_e11_on"; then
+  pass "NOTES.txt tells the operator to restart after an OAuth credential rotation"
+else
+  fail "NOTES.txt does NOT print the rotation restart when OAuth credentials are set. checksum/settings is deliberately blind to credential changes (E9), so this paragraph is the only thing that tells an operator their rotation has not taken effect - and the pods stay green while serving the old credential."
+fi
+if grep -qF 'ROTATING AN OAUTH CLIENT SECRET' "$_e11_off"; then
+  fail "NOTES.txt prints the OAuth rotation restart for a release that sets no OAuth credentials. It is advice the operator cannot act on, and a NOTES that warns about everything is read as warning about nothing."
+else
+  pass "NOTES.txt omits the OAuth rotation restart when no OAuth credentials are set (the condition is a condition, not a constant)"
+fi
+rm -f "$_e11_on" "$_e11_off"
 
 # ---------------------------------------------------------------------------
 # Fail closed.

--- a/deploy/helm/scion-hub/tests/rbac-collision.sh
+++ b/deploy/helm/scion-hub/tests/rbac-collision.sh
@@ -153,6 +153,7 @@ EXPECTED_TOTAL=46
 CHART="${CHART:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 HELM="${HELM:-helm}"
 BASE=(--set image.repository=r --set hub.hubId=h --set hub.baseUrl=https://test.example.com
+      --set auth.sessionSecret=harness-not-a-real-secret
       --set rbac.create=true --set runtime.listAllNamespaces=true)
 
 _missing=""

--- a/deploy/helm/scion-hub/tests/render-guards.sh
+++ b/deploy/helm/scion-hub/tests/render-guards.sh
@@ -24,7 +24,12 @@ set -u
 EXPECTED_TOTAL=63
 CHART="${CHART:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 HELM="${HELM:-helm}"
-BASE=(--set image.repository=r --set hub.hubId=ci-minimal --set hub.baseUrl=https://ci-minimal.example.invalid)   # hub.baseUrl became REQUIRED in Phase 1; see the arm below.
+# auth.sessionSecret became REQUIRED in the session-secret phase, and it is here for the same
+# reason hub.baseUrl is: scion-hub.assertSessionSecret fails the render without it, so every
+# BASE render would return an error string instead of manifests and every check below would
+# accuse the chart of a fault it does not have. The chart will not default it - a generated
+# secret rotates on every helm upgrade, invalidating every session and the JWT signing key.
+BASE=(--set image.repository=r --set hub.hubId=ci-minimal --set hub.baseUrl=https://ci-minimal.example.invalid --set auth.sessionSecret=harness-not-a-real-secret)   # hub.baseUrl became REQUIRED in Phase 1; see the arm below.
 
 # TOOL-PRESENCE ARM. A MISSING TOOLCHAIN MUST NOT BE REPORTED AS A BROKEN CHART.
 # Without this every helm invocation fails, every assertion fails, and the output

--- a/deploy/helm/scion-hub/tests/render-guards.sh
+++ b/deploy/helm/scion-hub/tests/render-guards.sh
@@ -21,7 +21,7 @@
 # too.
 set -u
 
-EXPECTED_TOTAL=63
+EXPECTED_TOTAL=77   # 63 + 14 from the oauth credential section (Phase 3).
 CHART="${CHART:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 HELM="${HELM:-helm}"
 # auth.sessionSecret became REQUIRED in the session-secret phase, and it is here for the same
@@ -30,6 +30,14 @@ HELM="${HELM:-helm}"
 # accuse the chart of a fault it does not have. The chart will not default it - a generated
 # secret rotates on every helm upgrade, invalidating every session and the JWT signing key.
 BASE=(--set image.repository=r --set hub.hubId=ci-minimal --set hub.baseUrl=https://ci-minimal.example.invalid --set auth.sessionSecret=harness-not-a-real-secret)   # hub.baseUrl became REQUIRED in Phase 1; see the arm below.
+
+# A COMPLETE WEB CLIENT CREDENTIAL, for the rows that need auth.mode=oauth to
+# render at all. Not folded into BASE, because several rows below exist
+# specifically to assert that oauth WITHOUT this is refused - putting it in BASE
+# would make those rows unwriteable, and worse, would make them look written.
+# It replaces --set auth.acknowledgeOAuthUnlanded=true, which is what these rows
+# carried while the credentials had no channel.
+OAUTH_WEB=(--set auth.oauth.web.google.clientId=rg-web-google-id --set auth.oauth.web.google.clientSecret=rg-web-google-secret)
 
 # TOOL-PRESENCE ARM. A MISSING TOOLCHAIN MUST NOT BE REPORTED AS A BROKEN CHART.
 # Without this every helm invocation fails, every assertion fails, and the output
@@ -306,7 +314,7 @@ reject "r1: hub.extraEnv sets K_SERVICE" "hub.extraEnv sets K_SERVICE" \
 reject "r2: postgres driver, route 3 held off with oauth" "database.driver is postgres" \
   --set database.driver=postgres --set storage.provider=gcs --set storage.bucket=b \
   "${CLOUDSQL_SET[@]}" \
-  --set auth.mode=oauth --set auth.acknowledgeOAuthUnlanded=true
+  --set auth.mode=oauth "${OAUTH_WEB[@]}"
 reject "r3: gcs storage with proxy auth" "storage.provider is gcs and auth.mode is proxy" \
   --set storage.provider=gcs --set storage.bucket=b
 
@@ -318,7 +326,7 @@ accept "r1 + acknowledgeHAUnlanded" \
 accept "r2 + acknowledgeHAUnlanded" \
   --set database.driver=postgres --set storage.provider=gcs --set storage.bucket=b \
   "${CLOUDSQL_SET[@]}" \
-  --set auth.mode=oauth --set auth.acknowledgeOAuthUnlanded=true --set acknowledgeHAUnlanded=true
+  --set auth.mode=oauth "${OAUTH_WEB[@]}" --set acknowledgeHAUnlanded=true
 accept "r3 + acknowledgeHAUnlanded" \
   --set storage.provider=gcs --set storage.bucket=b --set acknowledgeHAUnlanded=true
 
@@ -332,7 +340,7 @@ accept "r3 + acknowledgeHAUnlanded" \
 accept "K_SERVICE present but with an explicit empty value" \
   --set 'hub.extraEnv[0].name=K_SERVICE' --set 'hub.extraEnv[0].value='
 accept "an unrelated extraEnv name"       --set 'hub.extraEnv[0].name=NOT_K_SERVICE' --set 'hub.extraEnv[0].value=svc'
-accept "sqlite + local storage + oauth"   --set auth.mode=oauth --set auth.acknowledgeOAuthUnlanded=true
+accept "sqlite + local storage + oauth"   --set auth.mode=oauth "${OAUTH_WEB[@]}"
 accept "the chart defaults, no route"
 
 # THE GATE LIST IS PART OF THE CONTRACT, SO IT IS ASSERTED RATHER THAN TRUSTED.
@@ -653,7 +661,7 @@ _ha_proxy_total="$_ha_total"
 _ha_arm "oauth" "===== settings-oauth.yaml [audience well-formed" 1 1 \
   --set database.driver=postgres --set storage.provider=gcs --set storage.bucket=b \
   "${CLOUDSQL_SET[@]}" \
-  --set auth.mode=oauth --set auth.acknowledgeOAuthUnlanded=true
+  --set auth.mode=oauth "${OAUTH_WEB[@]}"
 _ha_oauth_total="$_ha_total"
 
 # --- the differential itself -------------------------------------------------
@@ -667,6 +675,110 @@ else
   echo "FAIL  the proxy and oauth arms derived ${_ha_proxy_total} and ${_ha_oauth_total} gates. Since 1b3c9418 the hub's IAP gates run only under auth.mode=proxy, so proxy must be the longer list. Equal counts mean the two arms are reading the same canon block and the per-mode branch in scion-hub.assertHAUnlanded is untested."
   failed=$((failed + 1))
 fi
+
+echo "== oauth mode requires a complete web client credential =="
+# THIS SECTION REPLACES auth.acknowledgeOAuthUnlanded, and the replacement is not
+# like-for-like. The acknowledgement asked the operator to CONFIRM the deployment
+# would be unusable; these rows assert the chart REFUSES to render it. An
+# acknowledgement is satisfiable by anyone in a hurry, and the thing it guarded
+# against - a hub that starts, binds, passes /readyz and refuses every login - is
+# not a thing an operator should be able to opt into by typing true.
+#
+# TWO LAYERS, so two rows per case, per this file's convention. The schema layer
+# is what an operator hits; the template layer is what they hit with
+# --skip-schema-validation, and it is the one that must hold, because config.extra
+# reaches the settings document without passing through the schema at all.
+#
+# THE SCHEMA ROWS DISCRIMINATE, and that is asserted rather than assumed: the
+# id-only row demands the message name clientSecret and the secret-only row
+# demands clientId. A schema that listed both halves whatever was missing would
+# satisfy a looser pair of substrings while telling the operator nothing.
+reject "oauth, no credentials, schema layer"  "clientId" \
+  --set auth.mode=oauth
+reject "oauth, clientId only, schema layer"   "clientSecret" \
+  --set auth.mode=oauth --set auth.oauth.web.google.clientId=rg-id
+reject "oauth, clientSecret only, schema layer" "clientId" \
+  --set auth.mode=oauth --set auth.oauth.web.google.clientSecret=rg-sec
+
+reject "oauth, no credentials, template layer" "no complete OAuth web client credential is present" \
+  --skip-schema-validation --set auth.mode=oauth
+reject "oauth, clientId only, template layer"  "google (has client_id, missing client_secret)" \
+  --skip-schema-validation --set auth.mode=oauth --set auth.oauth.web.google.clientId=rg-id
+reject "oauth, clientSecret only, template layer" "google (has client_secret, missing client_id)" \
+  --skip-schema-validation --set auth.mode=oauth --set auth.oauth.web.google.clientSecret=rg-sec
+
+# CLI CREDENTIALS DO NOT SUBSTITUTE FOR WEB ONES, and this row is the reason the
+# guard walks the web subtree specifically instead of asking "is server.oauth
+# non-empty". The hub keys its login check by client type (pkg/hub/oauth.go:194),
+# so a complete cli credential renders, validates, looks like configuration in
+# the Secret, and satisfies no browser login. A guard written on presence rather
+# than on client type passes this input.
+reject "complete cli credential does not satisfy oauth mode" "no complete OAuth web client credential is present" \
+  --set auth.mode=oauth \
+  --set config.extra.server.oauth.cli.google.client_id=rg-cli-id \
+  --set config.extra.server.oauth.cli.google.client_secret=rg-cli-secret
+
+# THE SPELLING GUARD, WHICH IS THE ONE THAT CAUGHT ME. settings.yaml binds
+# client_id/client_secret (V1OAuthProviderConfig, pkg/config/settings_v1.go:635);
+# clientId/clientSecret is the SCION_SERVER_* environment mapper's spelling
+# (pkg/config/hub_config.go:334). Measured both directions in
+# harness/zz_p3_oauth_settings_probe_test.go: snake_case binds, camelCase leaves
+# the field empty with no error from yaml.v3. I wrote the positive case in
+# camelCase and expected it to pass.
+#
+# The first row carries a COMPLETE google credential as well, so the missing- and
+# incomplete-credential guards above cannot be what refuses it. Without that, the
+# row would go green on the wrong refusal and the spelling guard could be deleted
+# without turning anything red.
+reject "camelCase via config.extra, oauth mode" "server.oauth.web.github.clientId" \
+  --set auth.mode=oauth "${OAUTH_WEB[@]}" \
+  --set config.extra.server.oauth.web.github.clientId=rg-camel
+# AND IT IS NOT GATED ON auth.mode. A misspelled credential is inert in proxy
+# mode too - it just is not load-bearing there yet, which is exactly the state in
+# which a wrong spelling gets committed and survives until the mode changes.
+reject "camelCase via config.extra, proxy mode" "server.oauth.web.github.clientId" \
+  --set auth.mode=proxy \
+  --set config.extra.server.oauth.web.github.clientId=rg-camel
+
+accept "oauth with a complete google web credential" --set auth.mode=oauth "${OAUTH_WEB[@]}"
+accept "oauth with a complete github web credential" --set auth.mode=oauth \
+  --set auth.oauth.web.github.clientId=rg-gh-id --set auth.oauth.web.github.clientSecret=rg-gh-secret
+# config.extra IS A FIRST-CLASS WAY TO MEET THE REQUIREMENT, not a bypass of it.
+# The guard reads the rendered document, so an operator who supplies
+# server.oauth.web themselves has supplied it, and a guard that insisted on
+# auth.oauth.web specifically would refuse a correct deployment.
+accept "credentials supplied through config.extra in snake_case" --set auth.mode=oauth \
+  --set config.extra.server.oauth.web.google.client_id=rg-extra-id \
+  --set config.extra.server.oauth.web.google.client_secret=rg-extra-secret
+# WITH AN EXTERNAL SETTINGS SECRET THE CHART RENDERS NO SETTINGS DOCUMENT, so
+# there is nothing to inspect and nothing to refuse. Asserting this keeps the
+# guard from growing into a claim about a file the chart cannot see.
+accept "oauth with no credentials but an external settings Secret" \
+  --set auth.mode=oauth --set config.existingSecret=operator-owned
+
+# THE POSITIVE TWIN OF THE SPELLING GUARD: the chart's own render must land on
+# the side of the guard it enforces. A chart that refused camelCase from
+# config.extra while emitting camelCase itself would pass every row above -
+# the guard runs on the merged document, so it would refuse its own output, and
+# the accept rows would be the ones to fail... unless the guard were ever
+# narrowed to config.extra only. This asserts the emitted spelling directly.
+executed=$((executed + 1))
+_oa="$(render --set auth.mode=oauth "${OAUTH_WEB[@]}")"
+if [ -z "$_oa" ] || ! printf '%s\n' "$_oa" | grep -q '^kind: Secret$'; then
+  echo "FAIL  rendered oauth credentials: no Secret in the output, so nothing was inspected"
+  failed=$((failed + 1))
+elif printf '%s\n' "$_oa" | grep -qE '^ +client(Id|Secret):'; then
+  echo "FAIL  rendered oauth credentials: the chart emits camelCase, which binds nothing in settings.yaml"
+  failed=$((failed + 1))
+elif printf '%s\n' "$_oa" | grep -q '^ *client_id: rg-web-google-id$' \
+  && printf '%s\n' "$_oa" | grep -q '^ *client_secret: rg-web-google-secret$'; then
+  echo "ok    the chart emits client_id/client_secret, the spelling settings.yaml binds"
+else
+  echo "FAIL  rendered oauth credentials: neither spelling reached the settings document"
+  echo "        got: $(printf '%s' "$_oa" | grep -c .) lines, no client_id/client_secret"
+  failed=$((failed + 1))
+fi
+unset _oa
 
 echo "== hub identity is stable across upgrade and independent of the release name =="
 # hub.hubId must be used verbatim and must never be derived from anything Helm

--- a/deploy/helm/scion-hub/tests/reserved-flags.sh
+++ b/deploy/helm/scion-hub/tests/reserved-flags.sh
@@ -35,7 +35,12 @@ set -u
 EXPECTED_TOTAL=31          # 29 must-reject + 2 must-accept. Update deliberately.
 CHART="${CHART:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 HELM="${HELM:-helm}"
-BASE=(--set image.repository=r --set hub.hubId=h --set hub.baseUrl=https://h.example.invalid)   # hub.baseUrl became REQUIRED in Phase 1; see the arm below.
+# auth.sessionSecret became REQUIRED in the session-secret phase, and it is here for the same
+# reason hub.baseUrl is: scion-hub.assertSessionSecret fails the render without it, so every
+# BASE render would return an error string instead of manifests and every check below would
+# accuse the chart of a fault it does not have. The chart will not default it - a generated
+# secret rotates on every helm upgrade, invalidating every session and the JWT signing key.
+BASE=(--set image.repository=r --set hub.hubId=h --set hub.baseUrl=https://h.example.invalid --set auth.sessionSecret=harness-not-a-real-secret)   # hub.baseUrl became REQUIRED in Phase 1; see the arm below.
 
 # TOOL-PRESENCE ARM. A MISSING TOOLCHAIN MUST NOT BE REPORTED AS A BROKEN CHART.
 # Without this every helm invocation fails, every assertion fails, and the output

--- a/deploy/helm/scion-hub/tests/run-all.sh
+++ b/deploy/helm/scion-hub/tests/run-all.sh
@@ -119,7 +119,7 @@ set -u -o pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 EXPECTED_SCRIPTS=5
-EXPECTED_ASSERTIONS=182   # 38 chart-integrity + 63 render-guards + 31 reserved-flags + 4 update-strategy + 46 rbac-collision.
+EXPECTED_ASSERTIONS=196   # 38 chart-integrity + 77 render-guards + 31 reserved-flags + 4 update-strategy + 46 rbac-collision.
 EXPECTED_FILES=7        # SCRIPTS + NOT_RUN_HERE + NOT_EXECUTABLE + this file.
 # 🛑 [HISTORY 2026-08-17] EXPECTED_FILES SHIPPED WRONG FOR AN HOUR BECAUSE A
 # CONFLICT RESOLUTION TOOK BOTH LINES AS A UNIT. The rebase onto main deleted
@@ -139,7 +139,7 @@ EXPECTED_FILES=7        # SCRIPTS + NOT_RUN_HERE + NOT_EXECUTABLE + this file.
 SCRIPTS=(
   reserved-flags.sh     # 31 - the reserved-flag lists
   update-strategy.sh    #  4 - the updateStrategy derivation
-  render-guards.sh      # 57 - every other render-time refusal, incl. the HA-unlanded gate
+  render-guards.sh      # 77 - every other render-time refusal, incl. the HA-unlanded gate
   chart-integrity.sh    # 35 - .helmignore breadth, the packaged file set, base-url, signing key
   rbac-collision.sh     # 46 - the cluster-scoped RBAC name, and two pinned residuals
 )
@@ -343,7 +343,7 @@ done
 # gets its own committed number, failing in both directions like the others.
 # Phase 6 owns CI wiring and may move this; it must not delete it without
 # replacing the coverage.
-EXPECTED_VERIFY_ASSERTIONS=363
+EXPECTED_VERIFY_ASSERTIONS=364
 # hack/ IS OUTSIDE THIS DIRECTORY, SO THE FILE SCAN BELOW CANNOT SEE IT, AND
 # NAMING ITS CONTENTS HERE IS THE ONLY THING THAT MAKES THEM DISCOVERABLE. Four
 # entries, all stated: verify.sh, gated below; run-all-mutations.sh, which is

--- a/deploy/helm/scion-hub/tests/run-all.sh
+++ b/deploy/helm/scion-hub/tests/run-all.sh
@@ -119,7 +119,7 @@ set -u -o pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 EXPECTED_SCRIPTS=5
-EXPECTED_ASSERTIONS=197   # 39 chart-integrity + 77 render-guards + 31 reserved-flags + 4 update-strategy + 46 rbac-collision.
+EXPECTED_ASSERTIONS=203   # 45 chart-integrity + 77 render-guards + 31 reserved-flags + 4 update-strategy + 46 rbac-collision.
 EXPECTED_FILES=7        # SCRIPTS + NOT_RUN_HERE + NOT_EXECUTABLE + this file.
 # 🛑 [HISTORY 2026-08-17] EXPECTED_FILES SHIPPED WRONG FOR AN HOUR BECAUSE A
 # CONFLICT RESOLUTION TOOK BOTH LINES AS A UNIT. The rebase onto main deleted
@@ -140,7 +140,7 @@ SCRIPTS=(
   reserved-flags.sh     # 31 - the reserved-flag lists
   update-strategy.sh    #  4 - the updateStrategy derivation
   render-guards.sh      # 77 - every other render-time refusal, incl. the HA-unlanded gate
-  chart-integrity.sh    # 39 - .helmignore breadth, the packaged file set, base-url, signing key, session annotation
+  chart-integrity.sh    # 45 - .helmignore breadth, the packaged file set, base-url, signing key, session annotation, checksum redaction, NOTES rotation
   rbac-collision.sh     # 46 - the cluster-scoped RBAC name, and two pinned residuals
 )
 
@@ -345,8 +345,9 @@ done
 # replacing the coverage.
 EXPECTED_VERIFY_ASSERTIONS=364
 # hack/ IS OUTSIDE THIS DIRECTORY, SO THE FILE SCAN BELOW CANNOT SEE IT, AND
-# NAMING ITS CONTENTS HERE IS THE ONLY THING THAT MAKES THEM DISCOVERABLE. Four
-# entries, all stated: verify.sh, gated below; run-all-mutations.sh, which is
+# NAMING ITS CONTENTS HERE IS THE ONLY THING THAT MAKES THEM DISCOVERABLE. Five
+# entries, all stated: verify.sh, gated below; check-secret-placement.sh, gated
+# below it, added by the session-secret phase; run-all-mutations.sh, which is
 # the driver that produces the MM table at the top of this file;
 # trigger-entry-c.sh with its fixtures/ directory, gated further down; and
 # ha-gates.txt, the derived artifact, checked with its producer. That driver is
@@ -373,6 +374,38 @@ else
     real_failure=1
   else
     echo ">>> hack/verify.sh: ok (${_vn} assertions, goldens current)"
+  fi
+fi
+
+# hack/check-secret-placement.sh -- criterion 4 of the session-secret phase: no
+# secret material in args, a ConfigMap, or an annotation, over every ci fixture.
+#
+# GATED HERE RATHER THAN LEFT FOR PHASE 6 because a check nothing runs is a check
+# that does not exist, and this one is all negative assertions - precisely the
+# shape that reports a clean result forever once it breaks. Its own --self-test
+# is run FIRST and its failure is a meta-failure, not a chart failure: the scan
+# saying "no leaks" means nothing until the scanner has been shown finding leaks
+# it was pointed at. Exit 2 from either arm is "nothing was analysed".
+#
+# NOT SUMMED INTO EXPECTED_ASSERTIONS, for the same reason hack/verify.sh is not:
+# it is not one of the enumerated scripts and does not emit ASSERTIONS_EXECUTED.
+# Phase 6 owns CI wiring and may move this; it must not delete it without
+# replacing the coverage.
+_placement="${HERE}/../hack/check-secret-placement.sh"
+if [ ! -f "$_placement" ]; then
+  note "hack/check-secret-placement.sh is missing, so nothing checked that the session secret stays out of argv, ConfigMaps and annotations."
+else
+  if _pself="$(bash "$_placement" --self-test 2>&1)"; then
+    _pout="$(bash "$_placement" 2>&1)"; _prc=$?
+    case "$_prc" in
+      0) echo ">>> hack/check-secret-placement.sh: ok ($(printf '%s\n' "$_pout" | tail -1 | sed 's/^check-secret-placement: //'))" ;;
+      1) echo ">>> hack/check-secret-placement.sh: LEAK FOUND (exit 1)"
+         printf '%s\n' "$_pout" | sed 's/^/    /'
+         real_failure=1 ;;
+      *) note "hack/check-secret-placement.sh exited ${_prc} - nothing was analysed. $(printf '%s\n' "$_pout" | tail -2 | tr '\n' ' ')" ;;
+    esac
+  else
+    note "hack/check-secret-placement.sh --self-test FAILED, so its scan is not evidence and was not run. $(printf '%s\n' "$_pself" | tail -1)"
   fi
 fi
 

--- a/deploy/helm/scion-hub/tests/run-all.sh
+++ b/deploy/helm/scion-hub/tests/run-all.sh
@@ -119,7 +119,7 @@ set -u -o pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 EXPECTED_SCRIPTS=5
-EXPECTED_ASSERTIONS=179   # 35 chart-integrity + 63 render-guards + 31 reserved-flags + 4 update-strategy + 46 rbac-collision.
+EXPECTED_ASSERTIONS=182   # 38 chart-integrity + 63 render-guards + 31 reserved-flags + 4 update-strategy + 46 rbac-collision.
 EXPECTED_FILES=7        # SCRIPTS + NOT_RUN_HERE + NOT_EXECUTABLE + this file.
 # 🛑 [HISTORY 2026-08-17] EXPECTED_FILES SHIPPED WRONG FOR AN HOUR BECAUSE A
 # CONFLICT RESOLUTION TOOK BOTH LINES AS A UNIT. The rebase onto main deleted
@@ -343,7 +343,7 @@ done
 # gets its own committed number, failing in both directions like the others.
 # Phase 6 owns CI wiring and may move this; it must not delete it without
 # replacing the coverage.
-EXPECTED_VERIFY_ASSERTIONS=343
+EXPECTED_VERIFY_ASSERTIONS=363
 # hack/ IS OUTSIDE THIS DIRECTORY, SO THE FILE SCAN BELOW CANNOT SEE IT, AND
 # NAMING ITS CONTENTS HERE IS THE ONLY THING THAT MAKES THEM DISCOVERABLE. Four
 # entries, all stated: verify.sh, gated below; run-all-mutations.sh, which is

--- a/deploy/helm/scion-hub/tests/run-all.sh
+++ b/deploy/helm/scion-hub/tests/run-all.sh
@@ -120,7 +120,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 EXPECTED_SCRIPTS=5
 EXPECTED_ASSERTIONS=207   # 49 chart-integrity + 77 render-guards + 31 reserved-flags + 4 update-strategy + 46 rbac-collision.
-EXPECTED_FILES=7        # SCRIPTS + NOT_RUN_HERE + NOT_EXECUTABLE + this file.
+EXPECTED_FILES=8        # SCRIPTS + NOT_RUN_HERE + NOT_EXECUTABLE + this file.
 # 🛑 [HISTORY 2026-08-17] EXPECTED_FILES SHIPPED WRONG FOR AN HOUR BECAUSE A
 # CONFLICT RESOLUTION TOOK BOTH LINES AS A UNIT. The rebase onto main deleted
 # tests/stale-claim-triage.md; NOT_EXECUTABLE was emptied to match, so the
@@ -176,6 +176,7 @@ NOT_RUN_HERE=(
 # reported as un-covered. Listing it here is the statement that it is data, not
 # an executable, and that no assertion total is expected from it.
 NOT_EXECUTABLE=(
+  stale-claim-triage.md
 )
 
 REQUIRED_TOOLS=("${HELM:-helm}" tar mktemp awk sha256sum)

--- a/deploy/helm/scion-hub/tests/run-all.sh
+++ b/deploy/helm/scion-hub/tests/run-all.sh
@@ -119,7 +119,7 @@ set -u -o pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 EXPECTED_SCRIPTS=5
-EXPECTED_ASSERTIONS=203   # 45 chart-integrity + 77 render-guards + 31 reserved-flags + 4 update-strategy + 46 rbac-collision.
+EXPECTED_ASSERTIONS=207   # 49 chart-integrity + 77 render-guards + 31 reserved-flags + 4 update-strategy + 46 rbac-collision.
 EXPECTED_FILES=7        # SCRIPTS + NOT_RUN_HERE + NOT_EXECUTABLE + this file.
 # 🛑 [HISTORY 2026-08-17] EXPECTED_FILES SHIPPED WRONG FOR AN HOUR BECAUSE A
 # CONFLICT RESOLUTION TOOK BOTH LINES AS A UNIT. The rebase onto main deleted
@@ -140,7 +140,7 @@ SCRIPTS=(
   reserved-flags.sh     # 31 - the reserved-flag lists
   update-strategy.sh    #  4 - the updateStrategy derivation
   render-guards.sh      # 77 - every other render-time refusal, incl. the HA-unlanded gate
-  chart-integrity.sh    # 45 - .helmignore breadth, the packaged file set, base-url, signing key, session annotation, checksum redaction, NOTES rotation
+  chart-integrity.sh    # 49 - .helmignore breadth, the packaged file set, base-url, signing key, session annotation, checksum redaction, NOTES rotation, scheduling guards
   rbac-collision.sh     # 46 - the cluster-scoped RBAC name, and two pinned residuals
 )
 

--- a/deploy/helm/scion-hub/tests/run-all.sh
+++ b/deploy/helm/scion-hub/tests/run-all.sh
@@ -119,7 +119,7 @@ set -u -o pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 EXPECTED_SCRIPTS=5
-EXPECTED_ASSERTIONS=196   # 38 chart-integrity + 77 render-guards + 31 reserved-flags + 4 update-strategy + 46 rbac-collision.
+EXPECTED_ASSERTIONS=197   # 39 chart-integrity + 77 render-guards + 31 reserved-flags + 4 update-strategy + 46 rbac-collision.
 EXPECTED_FILES=7        # SCRIPTS + NOT_RUN_HERE + NOT_EXECUTABLE + this file.
 # 🛑 [HISTORY 2026-08-17] EXPECTED_FILES SHIPPED WRONG FOR AN HOUR BECAUSE A
 # CONFLICT RESOLUTION TOOK BOTH LINES AS A UNIT. The rebase onto main deleted
@@ -140,7 +140,7 @@ SCRIPTS=(
   reserved-flags.sh     # 31 - the reserved-flag lists
   update-strategy.sh    #  4 - the updateStrategy derivation
   render-guards.sh      # 77 - every other render-time refusal, incl. the HA-unlanded gate
-  chart-integrity.sh    # 35 - .helmignore breadth, the packaged file set, base-url, signing key
+  chart-integrity.sh    # 39 - .helmignore breadth, the packaged file set, base-url, signing key, session annotation
   rbac-collision.sh     # 46 - the cluster-scoped RBAC name, and two pinned residuals
 )
 

--- a/deploy/helm/scion-hub/tests/stale-claim-triage.md
+++ b/deploy/helm/scion-hub/tests/stale-claim-triage.md
@@ -1,0 +1,201 @@
+# Stale-claim triage — Phase 0
+
+**This file changes no prose. It is a classification table and a catalogue.**
+Produced under gd-em's ruling of 07:40, which supersedes the 07:39 instruction
+that had asked for rewrites: *"Commit A's triage produces a CLASSIFICATION TABLE
+AND ZERO PROSE EDITS."* The prose edits are a separate commit with their own
+reviewer, sized by how many sites come back descriptive. That number is below.
+
+Measured at `60b2912`, helm v3.16.3+gcfd0749 (`/tmp/linux-amd64/helm`),
+kubeconform v0.6.7 (`/tmp/kubeconform`), non-login shell.
+
+---
+
+## What is being classified, and why the boundary is drawn here
+
+The defect class: **a claim about behaviour that is true when written and false
+after a later phase lands, with nothing that fails when it turns.** Fifteen
+instances have been identified in this subtree. Every one was found by a person
+reading prose; none by a check.
+
+Scope is gd-em's ruling: the union of the hedge sweep and the subject sweep,
+**restricted to sites naming a subject in Phase 1's render delta** — ConfigMap,
+Secret, env, envFrom, volumes, `settings.yaml`, `SCION_SERVER_BASE_URL`,
+base-url, hub-id delivery. Sites whose subject belongs to a later phase are
+**catalogued, not triaged**, and are listed in §4 for that phase's brief.
+
+The reasoning is the same axis-(d) test that put `DELIVERS_BASE_URL_CHANNEL`
+into Commit A and kept `.helmignore`'s `golden/` and `hack/` out: **act on the
+transition that is next; catalogue the rest.** A claim about Phase 4's ingress
+does not rot until Phase 4, and triaging it now means triaging it against a
+render nobody has written.
+
+### Mood taxonomy (gd-p0-rev-2's, adopted verbatim)
+
+| mood | test | disposition |
+|---|---|---|
+| **descriptive** | asserts the current world; a render can falsify it | **the class.** Fix in the prose commit. |
+| **quotation** | reproduces a claim, usually to refute it | leave alone. Editing it damages the warning. |
+| **normative** | instructs a future phase | leave alone. No truth value to go stale. |
+
+---
+
+## 1. Counts
+
+| | sites |
+|---|---|
+| raw candidate lines, both sweeps, P1-delta subjects | 81 |
+| — of which code, not prose (list literals, `fail` bodies, field names) | 57 |
+| **prose claim sites triaged** | **24** |
+| **descriptive** | **9** |
+| quotation | 6 |
+| normative | 9 |
+
+**Nine descriptive sites is the size of the prose commit.** Seven were already
+filed as instances eleven to fifteen plus `:901`; **two are new and are filed
+here for the first time** (§3).
+
+The 81 → 24 reduction is the reason gd-em's resize was correct: 37 sites was
+never 37 instances. It is also the reason the triage could not be mechanised —
+distinguishing a claim from a quotation of a claim requires reading the
+paragraph that contains it.
+
+---
+
+## 2. Descriptive — the class. All nine.
+
+All are **true at `60b2912`** and false at `11a78701`. None reopens Phase 0.
+`gd-p1-dev` owns the fixes; they land with the ConfigMap.
+
+| # | site | claim | falsified by |
+|---|---|---|---|
+| 11 | `_helpers.tpl:1089` | "This chart delivers none of them yet: today the flag would simply take effect" | ConfigMap + `SCION_SERVER_BASE_URL` |
+| 12 | `deployment.yaml:65-67` | "Nothing in this chart yet feeds hub.hubId into the running process... until then the hub's actual ID is still hostname-derived" | `settings.yaml` carries `hub_id` |
+| 13 | `_helpers.tpl:829-835` | "fully LIVE on argv today... no second source yet" | `SCION_SERVER_BASE_URL` |
+| 14 | `_helpers.tpl:637-638` | "This chart delivers no ConfigMap and no Secret" | both land |
+| 15 | `_helpers.tpl:827` | "the chart renders no ConfigMap, no Secret, no env, no envFrom and no volumes" | all five land |
+| — | `_helpers.tpl:899-901` | "argv value silently outranks the Secret-backed environment variable a later phase mounts" | the Secret lands |
+| **16** | **`_helpers.tpl:310`** | **"this chart mounts no volumes and renders no --db"** | **P1 mounts the settings volume** |
+| **17** | **`NOTES.txt:72-79`** | **"It renders no server configuration"** | **P1 renders exactly that** |
+| **17b** | **`NOTES.txt:75-76`** | **"It does write a settings.yaml for itself on first boot... that file carries no server section"** | **P1's mounted file has one** |
+
+Sixteen, seventeen and seventeen-b are new. They are analysed in §3 because
+each is a *different* failure of the two sweeps, not three more of the same.
+
+---
+
+## 3. The two new findings, and why both sweeps missed them
+
+### Sixteen — `_helpers.tpl:310`: **a claim that names the phase which will falsify it, and names the wrong one**
+
+> "this chart mounts no volumes and renders no --db"
+
+Eight lines below, the same paragraph says:
+
+> "LATER PHASES FALSIFY THAT ON PURPOSE, WHICH IS WHY IT IS WRITTEN DOWN RATHER
+> THAN LEFT AS AN ABSENCE. The Cloud SQL phase sets the postgres driver and
+> turns isHADeployment true; **the Filestore phase lands the shared volumes.**"
+
+This is the most carefully written prose in the file on exactly this hazard. The
+author anticipated the transition, wrote it down, and **attributed it to the
+wrong phase**: Phase 1 mounts a volume for `settings.yaml`, several phases
+before Filestore. So the claim ages out at a boundary its own disclaimer does
+not cover.
+
+That is a distinct sub-mood and it defeats both detectors by construction. A
+hedge sweep sees a hedge and a reader confirms the hedge is handled. A subject
+sweep sees `volumes` and a reader finds the subject already discussed. **The
+paragraph looks triaged because it *is* triaged — against the wrong boundary.**
+
+Severity is *lower* than instances eleven to fifteen, and this matters for
+sequencing: the inference the paragraph draws — "replicas share NO mutable
+state, so `isHADeployment` is false" — **survives**, because a read-only
+projected ConfigMap volume is not shared mutable state. Only the literal clause
+goes false. A reviewer skimming for consequences would correctly conclude
+nothing breaks, and would leave a false sentence in place under a heading that
+says later phases falsify it on purpose.
+
+> **A CLAIM CAN BE PROTECTED BY A DISCLAIMER THAT NAMES THE WRONG PHASE, AND
+> THAT IS WORSE THAN AN UNPROTECTED CLAIM, BECAUSE THE DISCLAIMER IS WHAT STOPS
+> THE NEXT READER LOOKING.**
+
+### Seventeen — `NOTES.txt:72-79`: **the only prose in the chart the operator actually sees**
+
+> "WHAT THIS RELEASE DOES NOT YET DO ... It renders no server configuration, so
+> the hub falls back to its own defaults - SQLite and local workspace storage."
+
+Every instance filed so far lives in `_helpers.tpl` or `deployment.yaml` —
+files an operator never reads. `NOTES.txt` is **printed on every `helm install`
+and every `helm upgrade`**. When this goes stale, the chart tells the operator
+at the console that it renders no server configuration while mounting one.
+
+All four reviewers, myself included, swept `templates/` and reported findings
+only from `_helpers.tpl`. The sweeps' file globs did include `NOTES.txt`; the
+attention did not. I cannot attribute that to the instruments — **this one is
+not an instrument gap, it is that we were all reading the file we had been
+arguing about.**
+
+`17b` is inside the same paragraph and is a *second, independent* claim: the
+parenthetical about the hub writing its own `settings.yaml` with no server
+section. It needs its own edit; fixing the sentence above it does not touch it.
+
+---
+
+## 4. Catalogue — later-phase subjects, NOT triaged
+
+Recorded so the next phase does not rediscover them. Each is true at `60b2912`.
+
+| site | subject | phase that falsifies it |
+|---|---|---|
+| `_helpers.tpl:322` | shared volumes, `isHADeployment` | Filestore |
+| `_helpers.tpl:320-321` | postgres driver | Cloud SQL |
+| `NOTES.txt:78-79` | Cloud SQL, GCS, Filestore, session secret, Ingress, IAP | 2, 3, 4, 5 |
+| `NOTES.txt:81-82` | "images published from this repository today run as root" | the `hub-gke` image |
+| `_helpers.tpl:851-852` | "destined for the settings file" / `SCION_SERVER_BASE_URL` | P1, but **normative** — see §5 |
+| `_helpers.tpl:854-868` | base-url precedence order | P1 changes which branch is reachable |
+
+`_helpers.tpl:854-868` is the one to watch: it is a *precedence table* read from
+the hub's source, and P1 does not falsify any row of it. It changes **which row
+applies**. A claim that stays true while becoming irrelevant is not covered by
+any instrument discussed so far, and I do not have a proposal for it.
+
+---
+
+## 5. Quotation and normative — counted, left alone
+
+**Quotation (6).** `_helpers.tpl:726-745` supplies five of them: an enumerated
+list of readings the header labels *"ASSERTED CONFIDENTLY AND WRONGLY, ALL IN
+ONE DAY"*, including `:730` *"the chart mounts nothing, so no settings file
+exists"*. These are correct **because** they are quotations of incorrect claims.
+gd-em has ruled `726-745` off limits to any edit pass. The sixth is `:826`,
+which quotes a previous version of its own paragraph in order to retract it.
+
+**Normative (9).** `:823` (a heading addressed to later phases), `:864`,
+`:871-872` (*"a later phase may still choose argv... move the entry, do not add
+a second emitter"*), `:851-852`, and five shorter directives. These instruct a
+future maintainer. No render can falsify an instruction; attaching a state
+number to one would be attaching a tripwire to a policy.
+
+---
+
+## 6. What this triage does not establish
+
+- **It is not a coverage claim.** 24 sites is what two sweeps plus one reading
+  found. gd-p0-rev-3 has withdrawn the implication that any sweep's site count
+  bounds the class: *"the class is larger than the detector that found it and I
+  cannot bound it."* Finding sixteen and seventeen after four rounds of review
+  is direct evidence for that.
+- **The seed list for Commit B's detector is §2's nine sites**, per gd-em: the
+  seed list is the output of the triage, not four examples chosen in advance.
+  Four seeds against thirty-seven sites pins four.
+- **Sixteen is a counter-example to seeding by site.** A detector seeded with
+  `:310` would find `:310`. It would not find the next paragraph that handles
+  its transition and misnames the phase, because what is wrong there is a
+  *relation between two sentences*, and neither sentence is individually
+  suspicious.
+- **The mood classification is mine and is unreviewed.** Nine of the twenty-four
+  are judgement calls between normative and descriptive — chiefly `:851-852`,
+  which reads as a statement about the future but functions as an instruction.
+  I have classified it normative. A reviewer who disagrees moves it into the
+  prose commit's scope, which is the direction that costs work rather than
+  safety, so the ambiguity is disclosed rather than resolved.

--- a/deploy/helm/scion-hub/tests/update-strategy.sh
+++ b/deploy/helm/scion-hub/tests/update-strategy.sh
@@ -16,7 +16,12 @@ set -u
 EXPECTED_TOTAL=4
 CHART="${CHART:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 HELM="${HELM:-helm}"
-BASE=(--set image.repository=r --set hub.hubId=h --set hub.baseUrl=https://h.example.invalid)   # hub.baseUrl became REQUIRED in Phase 1; see the arm below.
+# auth.sessionSecret became REQUIRED in the session-secret phase, and it is here for the same
+# reason hub.baseUrl is: scion-hub.assertSessionSecret fails the render without it, so every
+# BASE render would return an error string instead of manifests and every check below would
+# accuse the chart of a fault it does not have. The chart will not default it - a generated
+# secret rotates on every helm upgrade, invalidating every session and the JWT signing key.
+BASE=(--set image.repository=r --set hub.hubId=h --set hub.baseUrl=https://h.example.invalid --set auth.sessionSecret=harness-not-a-real-secret)   # hub.baseUrl became REQUIRED in Phase 1; see the arm below.
 
 # TOOL-PRESENCE ARM. A MISSING TOOLCHAIN MUST NOT BE REPORTED AS A BROKEN CHART.
 # Without this every helm invocation fails, every assertion fails, and the output

--- a/deploy/helm/scion-hub/values.schema.json
+++ b/deploy/helm/scion-hub/values.schema.json
@@ -4,6 +4,39 @@
   "description": "Values understood by the scion-hub chart. Unknown keys are rejected rather than ignored, so a misspelled key is an error and not a silent no-op.",
   "type": "object",
   "additionalProperties": false,
+  "$defs": {
+    "oauthProvider": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "OAuth client ID. Rendered into settings.yaml as client_id - that snake_case spelling is what the settings schema binds; the camelCase spelling used here is the chart's convention and also the env-var mapper's, and writing it into settings.yaml directly binds nothing."
+        },
+        "clientSecret": {
+          "type": "string",
+          "description": "OAuth client secret. Secret material: it is rendered into the settings Secret and never into args, a ConfigMap or an annotation. Set through auth.existingSecret-style external management by supplying the whole settings file with config.existingSecret."
+        }
+      }
+    },
+    "oauthProviderComplete": {
+      "type": "object",
+      "required": [
+        "clientId",
+        "clientSecret"
+      ],
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "clientSecret": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  },
   "required": ["replicaCount", "image", "hub", "probes", "service", "serviceAccount", "rbac", "runtime", "agents", "config", "database", "cloudsql", "storage", "auth", "acknowledgeHAUnlanded"],
   "properties": {
     "global": {
@@ -543,9 +576,25 @@
           "type": "string",
           "description": "Inline session secret: the chart renders secret-session.yaml holding this value. Mutually exclusive with auth.existingSecret."
         },
-        "acknowledgeOAuthUnlanded": {
-          "type": "boolean",
-          "description": "The oauth mode's client credentials are not rendered by the chart yet. An oauth install starts and passes its probes; every human login fails. Set true to render it anyway."
+        "oauth": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "OAuth client credentials, rendered into settings.yaml (a Secret) as server.oauth. Required when auth.mode is oauth. Only the web client is modelled here, because it is the browser login flow; server.oauth.cli and server.oauth.device are reachable through config.extra and are not refused.",
+          "properties": {
+            "web": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "The web (browser login) OAuth client. The hub keys its login check by client type, so cli or device credentials do not substitute for these.",
+              "properties": {
+                "google": {
+                  "$ref": "#/$defs/oauthProvider"
+                },
+                "github": {
+                  "$ref": "#/$defs/oauthProvider"
+                }
+              }
+            }
+          }
         },
         "requireStableSigningKey": {
           "type": "boolean",
@@ -616,32 +665,76 @@
       }
     },
     {
-      "description": "oauth mode has no supporting configuration in the chart yet. Requiring an explicit acknowledgement keeps it from being selected by accident. Not applied under config.existingSecret: the chart renders no auth mode there, so auth.mode selects nothing and there is nothing to acknowledge. The same rule is enforced again in the template, on the rendered document, because --skip-schema-validation removes this one.",
+      "description": "oauth mode needs client credentials, and a deployment without them starts, passes its probes and refuses every login - so the schema demands them here rather than letting the failure reach a running pod. THIS RULE IS DELIBERATELY WEAKER THAN THE TEMPLATE'S. It can only see the chart's own values, so it cannot accept credentials supplied through config.extra, which are equally valid; requiring auth.oauth.web here would refuse a working configuration. It therefore checks the chart-value route only when config.extra is absent, and the template's check - which runs on the merged, rendered document and is the authoritative one - covers every route. Not applied under config.existingSecret: the chart renders no auth mode in that shape.",
       "if": {
         "properties": {
           "auth": {
             "properties": {
-              "mode": {"const": "oauth"}
+              "mode": {
+                "const": "oauth"
+              }
             },
-            "required": ["mode"]
+            "required": [
+              "mode"
+            ]
           },
           "config": {
             "properties": {
-              "existingSecret": {"const": ""}
+              "existingSecret": {
+                "const": ""
+              },
+              "extra": {
+                "maxProperties": 0
+              }
             },
-            "required": ["existingSecret"]
+            "required": [
+              "existingSecret"
+            ]
           }
         },
-        "required": ["auth", "config"]
+        "required": [
+          "auth",
+          "config"
+        ]
       },
       "then": {
         "properties": {
           "auth": {
-            "required": ["acknowledgeOAuthUnlanded"],
+            "required": [
+              "oauth"
+            ],
             "properties": {
-              "acknowledgeOAuthUnlanded": {
-                "const": true,
-                "description": "auth.mode oauth requires auth.acknowledgeOAuthUnlanded true: the client credentials that mode needs are not rendered by this chart yet, and nothing catches that at runtime - the hub starts, passes its probes, and refuses every login."
+              "oauth": {
+                "required": [
+                  "web"
+                ],
+                "properties": {
+                  "web": {
+                    "anyOf": [
+                      {
+                        "required": [
+                          "google"
+                        ],
+                        "properties": {
+                          "google": {
+                            "$ref": "#/$defs/oauthProviderComplete"
+                          }
+                        }
+                      },
+                      {
+                        "required": [
+                          "github"
+                        ],
+                        "properties": {
+                          "github": {
+                            "$ref": "#/$defs/oauthProviderComplete"
+                          }
+                        }
+                      }
+                    ],
+                    "description": "auth.mode oauth requires a complete web client credential - both clientId and clientSecret for google or for github. The hub copies these in without validating them, so a missing credential is not a startup failure: it is a hub that comes up green and answers every login with \"OAuth provider is not configured\"."
+                  }
+                }
               }
             }
           }

--- a/deploy/helm/scion-hub/values.schema.json
+++ b/deploy/helm/scion-hub/values.schema.json
@@ -531,6 +531,18 @@
           "enum": ["proxy", "oauth"],
           "description": "Selects which configuration subtree is rendered and nothing else. Every key the HA preflight requires renders identically in both modes."
         },
+        "existingSecret": {
+          "type": "string",
+          "description": "Name of a Secret you manage holding the session secret. The chart renders no Secret in this shape. Mutually exclusive with auth.sessionSecret."
+        },
+        "existingSecretKey": {
+          "type": "string",
+          "description": "Key inside auth.existingSecret holding the secret. Defaults to SCION_SERVER_SESSION_SECRET."
+        },
+        "sessionSecret": {
+          "type": "string",
+          "description": "Inline session secret: the chart renders secret-session.yaml holding this value. Mutually exclusive with auth.existingSecret."
+        },
         "acknowledgeOAuthUnlanded": {
           "type": "boolean",
           "description": "The oauth mode's client credentials are not rendered by the chart yet. An oauth install starts and passes its probes; every human login fails. Set true to render it anyway."

--- a/deploy/helm/scion-hub/values.yaml
+++ b/deploy/helm/scion-hub/values.yaml
@@ -710,19 +710,46 @@ auth:
   # `openssl rand -base64 48`.
   sessionSecret: ""
 
-  # The oauth mode's supporting configuration - the client credentials - is not
-  # rendered by the chart yet; it lands with the session and client secrets.
+  # THE OAUTH CLIENT CREDENTIALS. Required when auth.mode is oauth, and the
+  # render fails without them - which is what replaced the acknowledgement key
+  # that used to sit here.
   #
-  # It does not fail loudly. The credentials are wired without validation
-  # (cmd/server_foreground.go:1514-1544), so the hub starts, binds and passes
-  # /readyz, and the failure arrives once per login attempt as "OAuth provider
-  # is not configured" (pkg/hub/web.go:1770-1776) - a deployment that is green
-  # in every Kubernetes signal and that nobody can log in to.
+  # THE KEY THAT WAS HERE AND WHY IT IS GONE. auth.acknowledgeOAuthUnlanded was
+  # a required opt-in, added when this chart rendered oauth mode but had no
+  # channel for the credentials that mode needs. It asked the operator to
+  # confirm they understood the deployment would come up green and refuse every
+  # login. That was the right shape for a gap, and the wrong shape to keep once
+  # the gap closed: a permanent acknowledgement teaches operators to type true
+  # and move on. The chart now renders the credentials, so the honest guard is
+  # a refusal that names what is missing, not a checkbox.
   #
-  # Set this to true to acknowledge that and render anyway. Both the schema and
-  # the template enforce it, and neither applies under config.existingSecret,
-  # where the chart renders no auth mode at all.
-  acknowledgeOAuthUnlanded: false
+  # RENDERED INTO settings.yaml, WHICH IS A SECRET, NOT A ConfigMap. The client
+  # secret is secret material and never appears in args, in a ConfigMap or in an
+  # annotation. Like auth.sessionSecret, a value set here lives in your values
+  # file and in Helm's release storage; config.existingSecret is the shape where
+  # the whole settings file, credentials included, stays yours.
+  #
+  # WEB ONLY, DELIBERATELY. These are the credentials for the browser login
+  # flow. The hub also models cli and device clients; the chart does not model
+  # them. If you need them, set server.oauth.cli or server.oauth.device through
+  # config.extra.
+  #
+  # MIND THE SPELLING IF YOU GO THROUGH config.extra. These chart values are
+  # camelCase and the chart renders them into settings.yaml as client_id and
+  # client_secret, because that is what the settings schema binds
+  # (V1OAuthProviderConfig, pkg/config/settings_v1.go:635). The env-var mapper
+  # for the same values uses the OTHER spelling, clientId/clientSecret
+  # (pkg/config/hub_config.go:334) - so a clientId written into settings.yaml
+  # by hand binds nothing, silently. The chart refuses the camelCase spelling
+  # under server.oauth rather than letting it through.
+  oauth:
+    web:
+      google:
+        clientId: ""
+        clientSecret: ""
+      github:
+        clientId: ""
+        clientSecret: ""
 
   # When true the hub refuses to start rather than fall back to a signing key
   # generated per process. That fallback is fatal across replicas - each pod

--- a/deploy/helm/scion-hub/values.yaml
+++ b/deploy/helm/scion-hub/values.yaml
@@ -671,6 +671,45 @@ auth:
   # five, which is what the paired ci fixtures actually diff.
   mode: proxy
 
+  # THE SESSION SECRET. One of the next two is REQUIRED - the render fails if
+  # neither is set, and it fails if both are.
+  #
+  # This one value backs BOTH the session cookie encryption key AND the hub's
+  # shared JWT signing keys (resolveSessionSecret,
+  # cmd/server_foreground.go:1452-1463), so every replica must see the same
+  # bytes or they reject each other's tokens.
+  #
+  # WHY THE CHART REFUSES RATHER THAN DEFAULTING OR GENERATING. The hub does not
+  # fail without one: it logs a single warning and derives a per-process key, so
+  # the deployment comes up green and users get logged out whenever the load
+  # balancer moves them - a symptom that reads as a flaky session store, not as
+  # a configuration error. And a generated secret is worse than none: it rotates
+  # on every helm upgrade, invalidating every live session and the shared
+  # signing key at once, and it cannot be rendered reproducibly because lookup
+  # returns empty under helm template, so the golden output would not match the
+  # installed output.
+  #
+  # PREFERRED. The name of a Secret you create and manage yourself. The chart
+  # renders no Secret in this shape, and the value never enters this file, your
+  # values overrides, or Helm's release storage - which is the whole reason to
+  # prefer it. Only the named key is bound into the hub's environment, so other
+  # keys in your Secret are not exposed to the hub.
+  existingSecret: ""
+
+  # The key inside auth.existingSecret holding the secret. Defaults to
+  # SCION_SERVER_SESSION_SECRET, which is what the hub reads; set it only if
+  # your Secret already uses a different key name. Meaningless without
+  # auth.existingSecret, and the chart refuses that combination rather than
+  # ignoring it.
+  existingSecretKey: ""
+
+  # The inline alternative: the chart renders secret-session.yaml holding this
+  # value. Convenient, and appropriate when your values file is itself managed
+  # as a secret - but note that this Secret is only as private as the values
+  # file and the Helm release that carry it. Generate with, for example,
+  # `openssl rand -base64 48`.
+  sessionSecret: ""
+
   # The oauth mode's supporting configuration - the client credentials - is not
   # rendered by the chart yet; it lands with the session and client secrets.
   #
@@ -690,33 +729,40 @@ auth:
   # signs tokens the others reject - and it is silent, so it presents as
   # intermittent logouts rather than as a configuration error.
   #
-  # DEFAULTED false, AND IT WILL BECOME true IN THE SESSION-SECRET PHASE. Not a
-  # judgement that the protection is unwanted - it is that in THIS release
-  # nothing can satisfy it. The hub resolves a stable key from, in order: a
-  # pre-configured key, SharedSigningSecret, a secret backend, then the store
-  # (pkg/hub/server.go:1445). SharedSigningSecret is resolveSessionSecret()
-  # (cmd/server_foreground.go:1556), which reads only --session-secret,
-  # SCION_SERVER_SESSION_SECRET and bare SESSION_SECRET
-  # (cmd/server_foreground.go:1452-1462) - it has no settings-file source at
-  # all, and this chart renders none of the three. On a first boot the store is
-  # empty too. So with true there is no key to find, and pkg/hub/server.go:1634
-  # returns an error that pkg/hub/server.go:1008 makes fatal and
-  # cmd/server_foreground.go:259 turns into log.Fatalf.
+  # DEFAULTED true SINCE THE SESSION-SECRET PHASE. It was false before, and the
+  # history matters because the reason was never "the protection is unwanted":
+  # it was that nothing in the release could satisfy it. The hub resolves a
+  # stable key from, in order, a pre-configured key, SharedSigningSecret, a
+  # secret backend, then the store (pkg/hub/server.go:1445). SharedSigningSecret
+  # is resolveSessionSecret() (cmd/server_foreground.go:1452-1463), which reads
+  # only --session-secret, SCION_SERVER_SESSION_SECRET and bare SESSION_SECRET -
+  # it has no settings-file source at all - and the chart rendered none of the
+  # three. On a first boot the store is empty too. So true meant no key to find:
+  # pkg/hub/server.go:1634 errors, pkg/hub/server.go:1008 makes it fatal, and
+  # cmd/server_foreground.go:259 turns it into log.Fatalf.
   #
-  # MEASURED through the real hub.New, not read: ServerConfig{RequireStableSigningKey:
-  # true} refuses; adding only SharedSigningSecret makes the same call succeed.
-  # The missing session secret is the entire difference. Four of the five ci
-  # permutations rendered "true" and none rendered a secret, so four of five
-  # could not start - including minimal, which the rest of this chart's prose
-  # points at as the safe one.
+  # MEASURED through the real hub.New, not read, at both ends. Before:
+  # ServerConfig{RequireStableSigningKey: true} refuses with "refusing to
+  # generate a new signing key ... provide a SharedSigningSecret or
+  # pre-provision the key"; adding only SharedSigningSecret makes the same call
+  # succeed, so the missing session secret was the entire difference.
   #
-  # The harm the true setting prevents - replicas signing tokens each other
-  # reject - needs a replica set this release cannot start one member of. It
-  # arrives with the secret, so the two should arrive together. A guard that
-  # nothing can satisfy is worse than no guard, because it teaches operators to
-  # turn guards off.
+  # WHAT CHANGED IS NOT THIS LINE - IT IS THAT auth.sessionSecret /
+  # auth.existingSecret ARE NOW REQUIRED. The render fails when neither is set,
+  # so SCION_SERVER_SESSION_SECRET is delivered on every path that renders at
+  # all, and true is satisfiable everywhere rather than nowhere. A guard nothing
+  # can satisfy is worse than no guard, because it teaches operators to turn
+  # guards off; the fix was to make the guard satisfiable, not to keep it off.
   #
-  # tests/chart-integrity.sh asserts the flip: the day the default render gains
-  # a session-secret source, the LANDING limb fails and stays failing until this
-  # line reads true.
-  requireStableSigningKey: false
+  # SET IT false ONLY IF YOU SUPPLY A SIGNING KEY BY A ROUTE THE CHART CANNOT
+  # SEE - a secret backend configured through config.extra, or a key already in
+  # the hub's store from a previous release. Turning it off to make a failing
+  # install start is the wrong move: the failure means the hub found no durable
+  # key, and with the flag off it does not stop, it invents one per process. The
+  # symptom is users being logged out whenever the load balancer moves them.
+  #
+  # tests/chart-integrity.sh section E asserts the pairing in both directions:
+  # true with no session-secret source in the default render fails, and false
+  # while a source is present fails too. Neither the default nor the secret can
+  # be changed without the other.
+  requireStableSigningKey: true

--- a/deploy/helm/scion-hub/values.yaml
+++ b/deploy/helm/scion-hub/values.yaml
@@ -249,6 +249,11 @@ hub:
   # selector is immutable, so overriding one breaks the Deployment rather than
   # relabelling it.
   podLabels: {}
+  # Scheduling. These three are checked for credential material on the same
+  # terms as podAnnotations and podLabels above: they are free-form operator
+  # input and they land in the pod spec, which anyone with pod read access can
+  # read. A connection string with a password in it is rejected here rather than
+  # rendered. Ordinary labels, taints and affinity rules are unaffected.
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/deploy/helm/scion-hub/values.yaml
+++ b/deploy/helm/scion-hub/values.yaml
@@ -705,16 +705,61 @@ auth:
   # read access - a strictly wider audience than the Secret's own RBAC - and a
   # digest of a low-entropy secret is a secret you can recover offline.
   #
-  # Say the uncomfortable half out loud: checksum/settings, which the chart DOES
-  # render, is a digest over a document that now contains the OAuth client
-  # secret. It is not free of the same objection - it is a weaker version of it,
-  # because the attacker must also guess every other field in the rendered
-  # settings.yaml, and because that mount genuinely cannot be refreshed without
-  # it (a subPath mount is frozen for the container's lifetime, so omitting it
-  # makes upgrades silently do nothing). The session secret has neither excuse:
-  # env is equally unrefreshable, but a restart is a documented one-line remedy,
-  # and the digest would be over the one value with the least around it to
-  # guess. See templates/deployment.yaml for the checksum/settings reasoning.
+  # AND SAY THE UNCOMFORTABLE HALF FIRST, NOT LAST. The chart DOES render a
+  # checksum/settings annotation, and once auth.mode is oauth the document that
+  # annotation covers contains your OAuth client secret. Pod annotations are
+  # readable by anyone with pod read access - the same strictly wider audience
+  # named above, wider than the Secret's own RBAC.
+  #
+  # THAT DIGEST IS TAKEN OVER A REDACTED PROJECTION, NOT OVER THE DOCUMENT.
+  # scion-hub.settingsChecksum replaces every credential leaf in the rendered
+  # settings document with a constant before hashing, so rotating an OAuth
+  # client secret does not move the annotation, and the annotation is therefore
+  # not an offline verification oracle for the credential.
+  # tests/chart-integrity.sh section E9 asserts both halves: the digest is
+  # unchanged by rotating the client secret, AND it still moves when a
+  # non-secret settings field changes. Either half alone is satisfiable by a
+  # broken chart - a deleted annotation passes the first, the old un-redacted
+  # digest passes the second - so both are committed.
+  #
+  # THIS WAS AN ACCEPTED EXPOSURE UNTIL SOMEBODY MEASURED IT, AND THE
+  # MEASUREMENT IS WHY IT IS NOW FIXED. The text that stood here argued the
+  # residual protection was that an attacker must also guess every other field
+  # in the rendered settings.yaml. That argument is false for this chart. The
+  # rest of the document is chart-rendered and predictable from public values,
+  # so the preimage was reconstructed byte for byte and then used to predict the
+  # annotation for three client secrets that had never been rendered - 3 of 3,
+  # at roughly 300,000 candidates per second on one core. Against a
+  # provider-issued secret that is CONFIRMATION of a candidate an attacker
+  # already holds rather than recovery from nothing, including confirmation
+  # against superseded values still sitting in the ReplicaSet revision history.
+  # A lower bar than recovery, and the one that matters.
+  #
+  # WHAT THE ANNOTATION IS STILL FOR. It cannot simply be dropped: settings.yaml
+  # is a subPath mount, frozen for the container's lifetime, so with no pod
+  # annotation that moves, a settings upgrade would report success and change
+  # nothing. Redacting the credential leaves keeps that mechanism working for
+  # every non-credential change - and see auth.oauth below for what you must do
+  # yourself for the credential ones, which is the price of this fix and is not
+  # optional.
+  #
+  # TWO LIMITS, STATED RATHER THAN LEFT TO BE DISCOVERED. First, the projection
+  # redacts BY PATH, so a credential written to a path the helper does not know
+  # about would still be digested; a value-based backstop re-checks the finished
+  # projection for the credentials it just redacted and for any
+  # scheme://user:password@host URL, and fails the render rather than publishing
+  # one. Path to act, value to prove - the two fail in opposite directions and
+  # neither alone is sufficient. Second, because the digest is now taken over a
+  # re-serialised projection rather than over the raw rendered Secret, its value
+  # differs from the pre-fix value for every fixture, so the first upgrade
+  # across this change rolls the pods once. The chart is unreleased, so that
+  # roll costs nothing; it is called out here so it is not read as a regression.
+  #
+  # The session secret is treated differently rather than consistently, and it
+  # has no annotation at all: env is equally unrefreshable, but a restart IS a
+  # documented one-line remedy, and a digest over that one value would have the
+  # least around it to guess. See templates/deployment.yaml for the
+  # checksum/settings reasoning.
   #
   # PREFERRED. The name of a Secret you create and manage yourself. The chart
   # renders no Secret in this shape, and the value never enters this file, your
@@ -760,6 +805,32 @@ auth:
   # flow. The hub also models cli and device clients; the chart does not model
   # them. If you need them, set server.oauth.cli or server.oauth.device through
   # config.extra.
+  #
+  # ROTATING A CLIENT SECRET REQUIRES A RESTART AND THE CHART WILL NOT DO IT FOR
+  # YOU. THIS IS THE PRICE OF THE checksum/settings REDACTION DESCRIBED UNDER
+  # auth.sessionSecret ABOVE, AND IT IS PAID HERE. settings.yaml reaches the
+  # container as a subPath mount, which the kubelet resolves once at container
+  # start and never refreshes. So a helm upgrade that changes clientId or
+  # clientSecret rewrites the Secret, reports success, and leaves every running
+  # replica using the old credential. The checksum/settings annotation does not
+  # rescue you, because it is now deliberately blind to credential changes:
+  # rotating a client secret is exactly the change that no longer moves it.
+  # Before the redaction the pods rolled by accident, as a side effect of the
+  # credential being inside the digest - and that same side effect was the
+  # verification oracle. The two were one mechanism and they are gone together.
+  #
+  # So after any upgrade that changes a value under auth.oauth:
+  #
+  #   kubectl rollout restart deploy/<release>-scion-hub
+  #
+  # Until you run it the rotation has not happened, and if you are rotating
+  # because the old secret leaked then the leaked secret is still the live one.
+  # FORGETTING IS SILENT IN BOTH DIRECTIONS. Logins keep working on the old
+  # credential, so nothing looks wrong - until the provider revokes it, at which
+  # point every login fails at once and the pods are still green, because a
+  # broken OAuth credential is not something /readyz can see. NOTES.txt prints
+  # this reminder on every install and upgrade that sets OAuth credentials, for
+  # the operator who reads release notes and not values.yaml.
   #
   # MIND THE SPELLING IF YOU GO THROUGH config.extra. These chart values are
   # camelCase and the chart renders them into settings.yaml as client_id and

--- a/deploy/helm/scion-hub/values.yaml
+++ b/deploy/helm/scion-hub/values.yaml
@@ -689,6 +689,33 @@ auth:
   # returns empty under helm template, so the golden output would not match the
   # installed output.
   #
+  # ROTATING IT LATER NEEDS A RESTART, AND THE CHART WILL NOT TELL YOU. Both
+  # shapes below reach the container through the environment, which the kubelet
+  # resolves once at container start and never refreshes. So a helm upgrade that
+  # changes the session secret updates the Secret, reports success, and leaves
+  # every running replica on the old bytes until something else restarts them.
+  # If you are rotating because the old value leaked, the rotation has not
+  # happened yet at that point. Follow the upgrade with
+  # `kubectl rollout restart deploy/<release>-scion-hub`, and expect it to log
+  # everyone out - that is the rotation working, not a fault.
+  #
+  # There is no checksum/session pod annotation to automate that, and the
+  # omission is deliberate rather than forgotten. The annotation would have to
+  # be a digest over the secret, pod annotations are readable by anyone with pod
+  # read access - a strictly wider audience than the Secret's own RBAC - and a
+  # digest of a low-entropy secret is a secret you can recover offline.
+  #
+  # Say the uncomfortable half out loud: checksum/settings, which the chart DOES
+  # render, is a digest over a document that now contains the OAuth client
+  # secret. It is not free of the same objection - it is a weaker version of it,
+  # because the attacker must also guess every other field in the rendered
+  # settings.yaml, and because that mount genuinely cannot be refreshed without
+  # it (a subPath mount is frozen for the container's lifetime, so omitting it
+  # makes upgrades silently do nothing). The session secret has neither excuse:
+  # env is equally unrefreshable, but a restart is a documented one-line remedy,
+  # and the digest would be over the one value with the least around it to
+  # guess. See templates/deployment.yaml for the checksum/settings reasoning.
+  #
   # PREFERRED. The name of a Secret you create and manage yourself. The chart
   # renders no Secret in this shape, and the value never enters this file, your
   # values overrides, or Helm's release storage - which is the whole reason to


### PR DESCRIPTION
Phase 3, the last of the original scope. Closes the signing-key sharing bypass
(a cross-tenant auth risk stated by upstream's own test) by requiring the
session secret from a Secret -- never argv, never an annotation -- with
render-time refusal if no source is set. Adds a credential placement scanner
and extends the same discipline to OAuth client credentials, which the chart
could previously only acknowledge as unsupported.

checksum/settings hashes a redacted projection -- the OAuth secret is replaced
with a marker before hashing, so drift is still detected without exposing
credentials in pod metadata.

## Tests
9/9 CI green. Negative controls independently verified for both secrets: no
source, both sources, OAuth camelCase, OAuth half-set -- all correctly refused.
