### PR TITLE
fix(image-build): right-size the omni build timeout and unbreak local gcloud builds

### DIFF
--- a/image-build/cloudbuild-omni.yaml
+++ b/image-build/cloudbuild-omni.yaml
@@ -189,4 +189,4 @@ substitutions:
 options:
   dynamicSubstitutions: true
   machineType: 'E2_HIGHCPU_8'
-timeout: 14400s
+timeout: 2400s # 40 minutes - measured 641s (build 9a1b9766, 2026-08-27)


### PR DESCRIPTION
Two small, independent build-plumbing fixes.

## Changes

**`image-build/cloudbuild-omni.yaml` timeout 14400s -> 2400s, with a provenance comment.** The measured build is 641s, so 14400s was ~4.5% utilised and would never fire. 14400s appears in three files and never with a justification comment, while every timeout anyone reasoned about carries one and sits far lower. The comment matters more than the number: a constant with no reason invites the next person to copy it forward.

**Empty `image-build/.gitignore`.** gcloud 582.0.0 fails with `Could not read ignore file .gitignore` when building from that directory even when `--ignore-file` points elsewhere.

- [x] Tests pass (build config only)
- [x] Documentation changes included (n/a)