### PR TITLE
docs(design): correct and complete the single-node Cloud Run design doc

### DIFF
--- a/.design/hosted/cloud-run-single-node.md
+++ b/.design/hosted/cloud-run-single-node.md
@@ -64,7 +64,7 @@ criteria in §10.
 - **Durability of agent workspaces.** Workspaces live on ephemeral storage and are
   lost on redeploy (§5).
 - **Per-agent resource isolation guarantees.** All agents share the Instance's CPU
-  and memory budget.
+  and memory budget. See §9.1 for measured agent counts at each Instance size.
 - **Replacing the Cloudflare Tunnel design.** That targets ingress for self-hosted
   nodes. A Cloud Run Instance has its own `run.app` ingress and needs no tunnel. The
   two are siblings, not competitors.
@@ -309,6 +309,11 @@ front of it. Turning IAP on did not remove this footgun; it *relocated* it. Beca
 the open configuration is now the supported one, the deploy command must gate on it
 rather than merely warn.
 
+**Verified 2026-08-27.** The deploy sets `invokerIamDisabled: true`, so the Cloud Run
+invoker check is off and IAP is the sole perimeter. A six-way header × token ×
+audience matrix confirmed that IAP rejects all unauthenticated and mis-audienced
+requests, and that the hub is unreachable without a valid IAP assertion.
+
 ### 6.2 The hub work was already done
 
 Auditing before designing showed the hub's IAP verification already exists and
@@ -409,13 +414,31 @@ definition, not a redesign.
 ### 9.1 Within this tier
 
 - **Ephemeral only.** No workspace or control-plane durability (§5).
-- **No per-agent resource limits.** All agents share the Instance budget.
+- **No per-agent resource limits.** All agents share the Instance budget. Measured
+  agent counts on a single observation (repeatability unmeasured):
+
+  | Instance size | Idle agents | Working agents |
+  |---|---|---|
+  | 4 CPU / 8 GiB (default) | 20 | 6 |
+  | 8 CPU / 32 GiB (maximum) | 51 | 14 |
+
+  No per-CPU or per-GiB scaling rule is derivable from these two points: 4× memory
+  and 2× CPU bought roughly 3× idle and 2× working capacity — non-linear in both
+  resources.
 - **Image-pull failures on first deploy are hard to diagnose.** The messages come
   from the Cloud Run sandbox launcher, not from Scion, and name a cache mirror rather
   than the requested image. Routed as platform feedback.
 - **Sandbox stderr can be lost**, which makes an agent that dies during provisioning
   harder to diagnose than it should be. The general Scion path is well instrumented;
   the loss is specific to this runtime's sandbox handling.
+- **No per-agent observability.** The Instance budget is shared (above) and also
+  invisible. Cloud Monitoring covers `cloud_run_revision` (Services) but not
+  `cloud_run_instance`; `getStats` returns hardcoded zeros; the hub agent list is
+  wrong in both directions; sandboxes are gVisor processes invisible to Cloud
+  Monitoring; `sshd` is absent from the omni image. The only working signal today is
+  agent create latency. This is a known gap we intend to close, staged in two parts:
+  per-agent logging (ptone/scion#1310) and CPU/memory visibility
+  (ptone/scion#1311).
 
 ### 9.2 Upstream dependencies
 
@@ -483,4 +506,5 @@ Additionally, for review:
 10. Autodetect selects `cloudrun-sandbox` on an Instance and does not select it
     anywhere else (§4.3).
 11. The omni image is produced by the chained build, and no harness version is pinned
-    in two places (§4.1).
+    in two places (§4.1). **Verified — run.** The chained build produces the omni
+    image and the result is verified by digest.

--- a/.design/hosted/cloud-run-single-node.md
+++ b/.design/hosted/cloud-run-single-node.md
@@ -283,7 +283,13 @@ what makes ADC work inside a sandbox.
 ## 5. Durability — Tier 0, pure ephemeral
 
 Workspaces and the SQLite control plane live on the Instance's ephemeral filesystem.
-A redeploy loses both.
+Two events destroy that state:
+
+- **Redeploy** — chosen by the operator, who can save work first.
+- **Exceeding the agent ceiling** (ptone/scion#1303) — not chosen and, on this tier,
+  not currently anticipatable. There is no per-agent memory or CPU instrument (§9.1),
+  so nothing warns before the Instance is destroyed and self-recovers empty. See §9.1
+  for measured agent counts at each Instance size.
 
 This is a deliberate trade for G5, not an oversight. The tier is aimed at cheap,
 fast, disposable deployments. Operators who need durability want the GCE VM baseline

--- a/.design/hosted/cloud-run-single-node.md
+++ b/.design/hosted/cloud-run-single-node.md
@@ -244,7 +244,7 @@ eight upstream commits the branch was behind. I concluded the predicted conflict
 been overtaken by landing order, wrote that here, and told the rebase developer
 explicitly not to go looking for it.
 
-That measurement was accurate and the conclusion drawn from it was not. #1302 — the
+That measurement was accurate and the conclusion drawn from it was not. GoogleCloudPlatform/scion#1302 — the
 Instances runtime, the *other* half of the pair this section is about — merged
 upstream as `83ee4bd9` roughly twenty minutes after I measured. Re-measured at 00:49,
 the branch was behind by eleven rather than eight, and the conflict surface was
@@ -425,37 +425,37 @@ surfaced first.
 
 | Issue | Problem |
 |---|---|
-| #1273 | A hosted hub drops template and harness-config identity on agent create, and the broker then falls back to a local disk search that is always empty in hosted mode. |
-| #1274 | `GitCloneConfig.Depth` is documented as `0 = full clone` and implemented as depth 1, in three independent call sites. A depth-1 workspace cannot push to any remote but origin. |
-| #1275 | `noAuth: true` on agent create makes a request fail that succeeds without it. |
-| #1276 | The auth preflight counts only `metadata_mode: assign` as an assigned GCP identity, so a host with ambient credentials from the real metadata server never satisfies `skipped_when_gcp_service_account_assigned`. Runtime-agnostic: affects GCE and GKE workload identity too. |
+| ptone/scion#1273 | A hosted hub drops template and harness-config identity on agent create, and the broker then falls back to a local disk search that is always empty in hosted mode. |
+| ptone/scion#1274 | `GitCloneConfig.Depth` is documented as `0 = full clone` and implemented as depth 1, in three independent call sites. A depth-1 workspace cannot push to any remote but origin. |
+| ptone/scion#1275 | `noAuth: true` on agent create makes a request fail that succeeds without it. |
+| ptone/scion#1276 | The auth preflight counts only `metadata_mode: assign` as an assigned GCP identity, so a host with ambient credentials from the real metadata server never satisfies `skipped_when_gcp_service_account_assigned`. Runtime-agnostic: affects GCE and GKE workload identity too. |
 
-Until #1273 and #1276 land, this tier needs deploy-time workarounds. They are
+Until ptone/scion#1273 and ptone/scion#1276 land, this tier needs deploy-time workarounds. They are
 stopgaps and should be removed when the fixes arrive.
 
 **Update, 2026-08-27 — three of the four have landed upstream.**
 
 | Issue | Fix | Landed as |
 |---|---|---|
-| #1273 | resolve implicit `default` template when none is specified | `fc523ecd` (PR #1305) |
-| #1275 | skip env-gather when `noAuth` is true | `6edf6ed0` (PR #1304) |
-| #1276 | auth preflight recognises passthrough GCP identity mode | `a30368aa` (PR #1306) |
+| ptone/scion#1273 | resolve implicit `default` template when none is specified | `fc523ecd` (PR GoogleCloudPlatform/scion#1305) |
+| ptone/scion#1275 | skip env-gather when `noAuth` is true | `6edf6ed0` (PR GoogleCloudPlatform/scion#1304) |
+| ptone/scion#1276 | auth preflight recognises passthrough GCP identity mode | `a30368aa` (PR GoogleCloudPlatform/scion#1306) |
 
-So **the deploy-time stopgaps for #1273 and #1276 are now obsolete and should be
+So **the deploy-time stopgaps for ptone/scion#1273 and ptone/scion#1276 are now obsolete and should be
 deleted.** They were operator settings rather than code, which is why this tier never
 had to carry a workaround for them and never blocked on them — the §1 walkthrough was
 completed end to end on 2026-08-25 with all four open.
 
-**#1274 remains open** and is the one with a live consequence: a depth-1 workspace
+**ptone/scion#1274 remains open** and is the one with a live consequence: a depth-1 workspace
 cannot push to any remote but `origin`. That constrains §1's final step to
 origin-only pushes. It is a real limitation of the tier as shipped, not a
 theoretical one.
 
-A fifth defect was filed after this section was first written — **#1281**, session-end
+A fifth defect was filed after this section was first written — **ptone/scion#1281**, session-end
 telemetry rejected with a 400 because `SessionID` is dropped in `Finalize()`, so
 `exit_code` is never persisted. Also open, also not blocking.
 
-A sixth, the `WebServer` access-settings split-brain, was **fixed upstream by #1300**
+A sixth, the `WebServer` access-settings split-brain, was **fixed upstream by GoogleCloudPlatform/scion#1300**
 (`AccessSettingsProvider`) before it was ever filed from here. All browser login paths
 now read live settings, so tightening access mode in the admin UI reaches browser
 logins. Verified by reading the merged code, **not yet exercised on a live deployment** —


### PR DESCRIPTION
`.design/hosted/cloud-run-single-node.md` merged upstream carrying 18 bare `#NNNN` issue references. Fork and upstream numbers are independent, so 13 of them resolve to unrelated upstream PRs. Three sections are also now behind what has been measured.

## Changes

**All 18 references fully qualified**, resolved individually per repo (13 `ptone/scion`, 5 `GoogleCloudPlatform/scion`). One table cites a fork issue and an upstream PR in the same row, so a blanket prefix would have been wrong.

**Sec 5** now names both state-loss events. It previously named only redeploy; exceeding the agent ceiling also destroys the Instance, and unlike a redeploy it is not chosen and cannot currently be anticipated.

**Sec 6.1** records that IAP-as-sole-perimeter is now verified, and how.

**Sec 9.1** gains measured agent counts per Instance size, an explicit note that no per-CPU or per-GiB rule is derivable, and an observability gap entry.

**Sec 10 AC 11** moves from reasoned to run.

## Notes

Capacity figures are single observations with unmeasured repeatability, and say so. No `Fixes #N`: the tracking issues are fork-only and would resolve upstream to unrelated PRs.

- [x] Tests pass (docs-only)
- [x] Documentation changes included