### PR TITLE
fix: validate agent-supplied thread_id against DM key format at ingress

### DIFF
--- a/pkg/hub/attachments_agent_test.go
+++ b/pkg/hub/attachments_agent_test.go
@@ -287,7 +287,7 @@ func TestOutboundMessage_AttachmentsLinkedToMessage(t *testing.T) {
 		Recipient:   "user:human@example.com",
 		Msg:         "here is the screenshot",
 		Attachments: []string{staged},
-		ThreadID:    "dm:" + recipient.ID + "+" + agent.ID,
+		ThreadID:    "dm:agent:" + agent.ID + ":user:" + recipient.ID,
 	})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+agent.ID+"/outbound-message", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -115,6 +115,13 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Validate DM key format when the thread_id looks like a DM key.
+	// Non-DM thread IDs (topic UUIDs, etc.) pass through as-is.
+	if req.ThreadID != "" && strings.HasPrefix(req.ThreadID, "dm:") && !validDMKey(req.ThreadID) {
+		BadRequest(w, "invalid DM key format")
+		return
+	}
+
 	agent, err := s.store.GetAgent(ctx, id)
 	if err != nil {
 		writeErrorFromErr(w, err, "")
@@ -547,6 +554,13 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		structuredMsg.SenderID = senderID
 	} else {
 		ValidationError(w, "message or structured_message is required", nil)
+		return
+	}
+
+	// Validate DM key format when the thread_id looks like a DM key.
+	if structuredMsg != nil && structuredMsg.ThreadID != "" &&
+		strings.HasPrefix(structuredMsg.ThreadID, "dm:") && !validDMKey(structuredMsg.ThreadID) {
+		BadRequest(w, "invalid DM key format")
 		return
 	}
 

--- a/pkg/hub/handlers_broker_inbound.go
+++ b/pkg/hub/handlers_broker_inbound.go
@@ -94,6 +94,12 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate DM key format when the thread_id looks like a DM key.
+	if req.Message.ThreadID != "" && strings.HasPrefix(req.Message.ThreadID, "dm:") && !validDMKey(req.Message.ThreadID) {
+		BadRequest(w, "invalid DM key format")
+		return
+	}
+
 	// Look up the agent
 	agent, err := s.store.GetAgentBySlug(r.Context(), projectID, agentSlug)
 	if err != nil {
@@ -222,12 +228,6 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 		if u, err := s.store.GetUserByEmail(r.Context(), senderEmail); err == nil {
 			senderUserID = u.ID
 		}
-	}
-
-	// Validate DM key format when the thread_id looks like a DM key.
-	if req.Message.ThreadID != "" && strings.HasPrefix(req.Message.ThreadID, "dm:") && !validDMKey(req.Message.ThreadID) {
-		BadRequest(w, "invalid DM key format")
-		return
 	}
 
 	// F5 fix (Phase 6): Persist the inbound message and publish an SSE event

--- a/pkg/hub/handlers_broker_inbound.go
+++ b/pkg/hub/handlers_broker_inbound.go
@@ -224,6 +224,12 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Validate DM key format when the thread_id looks like a DM key.
+	if req.Message.ThreadID != "" && strings.HasPrefix(req.Message.ThreadID, "dm:") && !validDMKey(req.Message.ThreadID) {
+		BadRequest(w, "invalid DM key format")
+		return
+	}
+
 	// F5 fix (Phase 6): Persist the inbound message and publish an SSE event
 	// so that messages from external channels (Discord, Telegram) appear in
 	// the web chat — both live and after a refresh. This mirrors the


### PR DESCRIPTION
## Summary
- Validates agent-supplied `thread_id` against the canonical DM key format (`dm:agent:<id>:user:<id>`) at all 3 message ingress points: `handleAgentOutboundMessage`, `handleAgentMessage`, and `handleBrokerInbound`
- Malformed DM keys are rejected with 400 Bad Request before any dispatch or persistence
- Fixes malformed test key in `attachments_agent_test.go` to use canonical format
- Full audit: all other ThreadID sites are downstream propagation fed from now-validated ingress

Fork staging: ptone/scion#1315

## Test plan
- [x] `go test ./pkg/hub/... -v` — all pass
- [x] `go build` / `go vet` / `gofmt` — clean
- [x] `npx tsc --noEmit` / `npx vitest run` — clean
- [x] CI green on fork staging PR ptone/scion#1315
- [x] Code review: APPROVE (2 rounds — validation ordering fix in handleBrokerInbound)