### PR TITLE
docs(single-node): document the --image-registry flag

### DIFF
--- a/docs-site/src/content/docs/hosted/single-node/hub-setup-cloudrun.md
+++ b/docs-site/src/content/docs/hosted/single-node/hub-setup-cloudrun.md
@@ -156,6 +156,10 @@ and target `omni`:
 image-build/scripts/build-images.sh --target omni --registry $YOUR_REGISTRY --push
 ```
 
+The deploy derives the agent image registry from `--image` automatically; if
+derivation fails, the error names `--image-registry` as the explicit override.
+When this value is wrong, agent creation fails — not the deploy itself.
+
 ---
 
 ## 1. Deploy
@@ -209,6 +213,7 @@ Instance is open to the internet with only Hub session auth in front of it.
 | `--memory` | `8Gi` | Memory allocation |
 | `--admin-email` | deployer's gcloud account | Override the Hub admin email |
 | `--service-account` | (default compute SA) | GCP service account for the Instance |
+| `--image-registry` | derived from `--image` | Override the image registry the broker uses to pull agent images |
 
 ---
 


### PR DESCRIPTION
The Cloud Run single-node tutorial documented 8 of the 9 flags on `scion deploy-instance`. `--image-registry` was missing.

It sets `SCION_IMAGE_REGISTRY`, which the broker needs in order to pull agent images. It is not required — the value is derived from `--image`, and the derivation failure message already names the flag — so this is documented as an escape hatch rather than a decision the reader has to make.

Worth knowing because when the value is wrong the deploy still succeeds and the failure lands later, on agent creation.

5 insertions, one file: a sentence at the end of the Container image section and a row in the Optional flags table.

Raised by ptone