### PR TITLE
fix(security): validate DM key ownership at message ingress — prevent cross-project injection

### DIFF
--- a/pkg/hub/dm_injection_security_test.go
+++ b/pkg/hub/dm_injection_security_test.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/eventbus"
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/go-jose/go-jose/v4/jwt"
+)
+
+// nullSpokeEventBus is a no-op EventBus used as a non-inprocess spoke in the
+// FanOutEventBus so that ListChannels() returns "web" without triggering
+// handler panics. It accepts nil handlers and discards published messages.
+type nullSpokeEventBus struct{}
+
+func (nullSpokeEventBus) Publish(context.Context, string, *messages.StructuredMessage) error {
+	return nil
+}
+func (nullSpokeEventBus) Subscribe(string, eventbus.EventHandler) (eventbus.Subscription, error) {
+	return nullSub{}, nil
+}
+func (nullSpokeEventBus) Close() error { return nil }
+
+type nullSub struct{}
+
+func (nullSub) Unsubscribe() error { return nil }
+
+// TestDMKeyIngress_UnauthorizedAgentCanInjectIntoForeignDM reproduces a
+// security defect: message ingress validates DM key format but never checks
+// that the sending agent is a participant named in the key. An agent in
+// project P1 can write into a DM conversation between agent B (in project P2)
+// and user V, and user V will see the injected message when reading that
+// conversation's history.
+//
+// The test asserts the correct security invariant (the injection must be
+// blocked). It is expected to FAIL on code that lacks the membership check,
+// proving the defect exists.
+func TestDMKeyIngress_UnauthorizedAgentCanInjectIntoForeignDM(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// ---------------------------------------------------------------
+	// Identities
+	// ---------------------------------------------------------------
+
+	// User V (the victim) is the dev user — doRequest authenticates as DevUserID.
+	// The dev user is seeded automatically by testServer, so no CreateUser needed.
+	victimUserID := DevUserID
+
+	// Project P1 — the attacker's project.
+	p1 := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "attacker-project",
+		Slug:       "attacker-project",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, p1); err != nil {
+		t.Fatalf("CreateProject P1: %v", err)
+	}
+
+	// Project P2 — the victim's project (agent B lives here).
+	p2 := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "victim-project",
+		Slug:       "victim-project",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, p2); err != nil {
+		t.Fatalf("CreateProject P2: %v", err)
+	}
+
+	// Agent A — attacker, lives in P1.
+	agentA := &store.Agent{
+		ID:         api.NewUUID(),
+		Name:       "attacker-agent",
+		Slug:       "attacker-agent",
+		ProjectID:  p1.ID,
+		Phase:      "running",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, agentA); err != nil {
+		t.Fatalf("CreateAgent A: %v", err)
+	}
+
+	// Agent B — legitimate, lives in P2.
+	agentB := &store.Agent{
+		ID:         api.NewUUID(),
+		Name:       "legit-agent",
+		Slug:       "legit-agent",
+		ProjectID:  p2.ID,
+		Phase:      "running",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, agentB); err != nil {
+		t.Fatalf("CreateAgent B: %v", err)
+	}
+
+	// The DM conversation between agent B and user V.
+	dmKey := fmt.Sprintf("dm:agent:%s:user:%s", agentB.ID, victimUserID)
+
+	// ---------------------------------------------------------------
+	// Broker setup — "web" spoke is required for channel validation.
+	// ---------------------------------------------------------------
+	inprocessBus := eventbus.NewInProcessEventBus(slog.Default())
+	fanout := eventbus.NewFanOutEventBus([]eventbus.NamedEventBus{
+		{Name: eventbus.InProcessBusName, Bus: inprocessBus},
+		{Name: "web", Bus: nullSpokeEventBus{}},
+	}, slog.Default())
+
+	events := NewChannelEventPublisher()
+	defer events.Close()
+
+	proxy := NewMessageBrokerProxy(fanout, s, events, func() AgentDispatcher { return nil }, slog.Default())
+	proxy.Start()
+	t.Cleanup(proxy.Stop)
+
+	srv.SetMessageBrokerProxy(proxy)
+
+	// Ensure user-message subscriptions exist for both projects so that
+	// deliverToUser is called and messages are persisted.
+	proxy.subscribeProjectUserMessages(p1.ID)
+	proxy.subscribeProjectUserMessages(p2.ID)
+
+	// ---------------------------------------------------------------
+	// Helper: send an outbound message as the given agent.
+	// ---------------------------------------------------------------
+	sendOutbound := func(agent *store.Agent, projectID, msg, channel, threadID string) *httptest.ResponseRecorder {
+		t.Helper()
+		body, err := json.Marshal(OutboundMessageRequest{
+			RecipientID: victimUserID,
+			Recipient:   "user:Victim User",
+			Msg:         msg,
+			Channel:     channel,
+			ThreadID:    threadID,
+		})
+		if err != nil {
+			t.Fatalf("marshal outbound request: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost,
+			"/api/v1/agents/"+agent.ID+"/outbound-message",
+			bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req = req.WithContext(contextWithIdentity(req.Context(),
+			&agentIdentityWrapper{&AgentTokenClaims{
+				Claims:    jwt.Claims{Subject: agent.ID},
+				ProjectID: projectID,
+			}}))
+		rr := httptest.NewRecorder()
+		srv.handleAgentOutboundMessage(rr, req, agent.ID)
+		return rr
+	}
+
+	// ---------------------------------------------------------------
+	// Step 1: Agent B sends a legitimate message into the B↔V DM.
+	// This is the "floor" — if V cannot read this, the test is broken.
+	// ---------------------------------------------------------------
+	rr := sendOutbound(agentB, p2.ID, "legitimate message from B", "web", dmKey)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Floor message (agent B → V): expected 200, got %d: %s",
+			rr.Code, rr.Body.String())
+	}
+
+	// Allow async broker delivery to persist the message.
+	time.Sleep(300 * time.Millisecond)
+
+	// ---------------------------------------------------------------
+	// Step 2: Agent A (project P1) injects a message into the B↔V DM.
+	// A is NOT a participant in this DM. On correct code the write must
+	// be rejected; on the current defective code it succeeds.
+	// ---------------------------------------------------------------
+	rr = sendOutbound(agentA, p1.ID, "INJECTED by attacker agent A", "web", dmKey)
+
+	// If the ingress correctly checks membership, we'd expect a 403 here.
+	// On the defective code path, the write succeeds (200).
+	// We proceed regardless and check the *effect* (whether V can read it).
+
+	// Allow async broker delivery.
+	time.Sleep(300 * time.Millisecond)
+
+	// ---------------------------------------------------------------
+	// Step 3: User V reads the B↔V conversation history.
+	// doRequest authenticates as the dev user (DevUserID = victimUserID).
+	// ---------------------------------------------------------------
+	rec := doRequest(t, srv, http.MethodGet,
+		"/api/v1/chat/conversations/"+dmKey+"/messages", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("ConversationHistory: expected 200, got %d: %s",
+			rec.Code, rec.Body.String())
+	}
+
+	var histResp chatHistoryResponse
+	if err := json.NewDecoder(rec.Body).Decode(&histResp); err != nil {
+		t.Fatalf("decode conversation history: %v", err)
+	}
+
+	// ---------------------------------------------------------------
+	// Floor assertion: V must see B's legitimate message.
+	// If this fails, the test setup is broken and proves nothing.
+	// ---------------------------------------------------------------
+	foundLegit := false
+	for _, msg := range histResp.Messages {
+		if msg.Msg == "legitimate message from B" {
+			foundLegit = true
+			break
+		}
+	}
+	if !foundLegit {
+		t.Fatal("Floor check failed: user V cannot see agent B's legitimate " +
+			"message in the B↔V DM — test infrastructure is broken, not the code under test")
+	}
+
+	// ---------------------------------------------------------------
+	// Security invariant: V must NOT see agent A's injected message.
+	//
+	// Agent A is in a different project (P1) and is not a participant in
+	// the dm:agent:<B>:user:<V> conversation. Correct code must reject
+	// the write at ingress. If V can read A's message, the authorization
+	// check is missing.
+	// ---------------------------------------------------------------
+	for _, msg := range histResp.Messages {
+		if msg.Msg == "INJECTED by attacker agent A" {
+			t.Error("SECURITY DEFECT: agent A (project P1) injected a message " +
+				"into the B↔V DM (project P2) and user V can read it. " +
+				"The ingress handler validates DM key format but does not check " +
+				"that the authenticated agent is a named participant in the key.")
+		}
+	}
+}

--- a/pkg/hub/dm_injection_security_test.go
+++ b/pkg/hub/dm_injection_security_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // nullSpokeEventBus is a no-op EventBus used as a non-inprocess spoke in the
@@ -69,9 +71,16 @@ func TestDMKeyIngress_UnauthorizedAgentCanInjectIntoForeignDM(t *testing.T) {
 	// Identities
 	// ---------------------------------------------------------------
 
-	// User V (the victim) is the dev user — doRequest authenticates as DevUserID.
-	// The dev user is seeded automatically by testServer, so no CreateUser needed.
-	victimUserID := DevUserID
+	// User V (the victim) — a distinct user, not the dev user.
+	victimUser := &store.User{
+		ID:          tid("victim-user"),
+		Email:       "victim@test.com",
+		DisplayName: "Victim User",
+		Role:        store.UserRoleMember,
+		Status:      "active",
+	}
+	require.NoError(t, s.CreateUser(ctx, victimUser))
+	victimUserID := victimUser.ID
 
 	// Project P1 — the attacker's project.
 	p1 := &store.Project{
@@ -80,9 +89,7 @@ func TestDMKeyIngress_UnauthorizedAgentCanInjectIntoForeignDM(t *testing.T) {
 		Slug:       "attacker-project",
 		Visibility: store.VisibilityPrivate,
 	}
-	if err := s.CreateProject(ctx, p1); err != nil {
-		t.Fatalf("CreateProject P1: %v", err)
-	}
+	require.NoError(t, s.CreateProject(ctx, p1))
 
 	// Project P2 — the victim's project (agent B lives here).
 	p2 := &store.Project{
@@ -91,9 +98,7 @@ func TestDMKeyIngress_UnauthorizedAgentCanInjectIntoForeignDM(t *testing.T) {
 		Slug:       "victim-project",
 		Visibility: store.VisibilityPrivate,
 	}
-	if err := s.CreateProject(ctx, p2); err != nil {
-		t.Fatalf("CreateProject P2: %v", err)
-	}
+	require.NoError(t, s.CreateProject(ctx, p2))
 
 	// Agent A — attacker, lives in P1.
 	agentA := &store.Agent{
@@ -104,9 +109,7 @@ func TestDMKeyIngress_UnauthorizedAgentCanInjectIntoForeignDM(t *testing.T) {
 		Phase:      "running",
 		Visibility: store.VisibilityPrivate,
 	}
-	if err := s.CreateAgent(ctx, agentA); err != nil {
-		t.Fatalf("CreateAgent A: %v", err)
-	}
+	require.NoError(t, s.CreateAgent(ctx, agentA))
 
 	// Agent B — legitimate, lives in P2.
 	agentB := &store.Agent{
@@ -117,9 +120,7 @@ func TestDMKeyIngress_UnauthorizedAgentCanInjectIntoForeignDM(t *testing.T) {
 		Phase:      "running",
 		Visibility: store.VisibilityPrivate,
 	}
-	if err := s.CreateAgent(ctx, agentB); err != nil {
-		t.Fatalf("CreateAgent B: %v", err)
-	}
+	require.NoError(t, s.CreateAgent(ctx, agentB))
 
 	// The DM conversation between agent B and user V.
 	dmKey := fmt.Sprintf("dm:agent:%s:user:%s", agentB.ID, victimUserID)
@@ -159,9 +160,7 @@ func TestDMKeyIngress_UnauthorizedAgentCanInjectIntoForeignDM(t *testing.T) {
 			Channel:     channel,
 			ThreadID:    threadID,
 		})
-		if err != nil {
-			t.Fatalf("marshal outbound request: %v", err)
-		}
+		require.NoError(t, err)
 		req := httptest.NewRequest(http.MethodPost,
 			"/api/v1/agents/"+agent.ID+"/outbound-message",
 			bytes.NewReader(body))
@@ -177,17 +176,39 @@ func TestDMKeyIngress_UnauthorizedAgentCanInjectIntoForeignDM(t *testing.T) {
 	}
 
 	// ---------------------------------------------------------------
+	// Helper: fetch conversation history for victim user.
+	// ---------------------------------------------------------------
+	fetchHistory := func() chatHistoryResponse {
+		t.Helper()
+		rec := doRequestAsUser(t, srv, victimUser, http.MethodGet,
+			"/api/v1/chat/conversations/"+dmKey+"/messages", nil)
+		require.Equal(t, http.StatusOK, rec.Code, "ConversationHistory: %s", rec.Body.String())
+
+		var resp chatHistoryResponse
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		return resp
+	}
+
+	// ---------------------------------------------------------------
 	// Step 1: Agent B sends a legitimate message into the B↔V DM.
 	// This is the "floor" — if V cannot read this, the test is broken.
 	// ---------------------------------------------------------------
 	rr := sendOutbound(agentB, p2.ID, "legitimate message from B", "web", dmKey)
-	if rr.Code != http.StatusOK {
-		t.Fatalf("Floor message (agent B → V): expected 200, got %d: %s",
-			rr.Code, rr.Body.String())
-	}
+	require.Equal(t, http.StatusOK, rr.Code,
+		"Floor message (agent B → V): expected 200, got %d: %s", rr.Code, rr.Body.String())
 
-	// Allow async broker delivery to persist the message.
-	time.Sleep(300 * time.Millisecond)
+	// Poll until the legitimate message is visible (replaces time.Sleep).
+	require.Eventually(t, func() bool {
+		resp := fetchHistory()
+		for _, msg := range resp.Messages {
+			if msg.Msg == "legitimate message from B" {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 50*time.Millisecond,
+		"Floor check failed: user V cannot see agent B's legitimate "+
+			"message in the B↔V DM — test infrastructure is broken")
 
 	// ---------------------------------------------------------------
 	// Step 2: Agent A (project P1) injects a message into the B↔V DM.
@@ -196,28 +217,21 @@ func TestDMKeyIngress_UnauthorizedAgentCanInjectIntoForeignDM(t *testing.T) {
 	// ---------------------------------------------------------------
 	rr = sendOutbound(agentA, p1.ID, "INJECTED by attacker agent A", "web", dmKey)
 
-	// If the ingress correctly checks membership, we'd expect a 403 here.
+	// If the ingress correctly checks membership, we'd expect a 400 here.
 	// On the defective code path, the write succeeds (200).
 	// We proceed regardless and check the *effect* (whether V can read it).
 
-	// Allow async broker delivery.
-	time.Sleep(300 * time.Millisecond)
+	// Allow time for any async delivery to settle (poll briefly).
+	assert.Eventually(t, func() bool {
+		// We're waiting for delivery to settle, not for the message to appear.
+		// A short settle period is sufficient.
+		return true
+	}, 500*time.Millisecond, 50*time.Millisecond)
 
 	// ---------------------------------------------------------------
 	// Step 3: User V reads the B↔V conversation history.
-	// doRequest authenticates as the dev user (DevUserID = victimUserID).
 	// ---------------------------------------------------------------
-	rec := doRequest(t, srv, http.MethodGet,
-		"/api/v1/chat/conversations/"+dmKey+"/messages", nil)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("ConversationHistory: expected 200, got %d: %s",
-			rec.Code, rec.Body.String())
-	}
-
-	var histResp chatHistoryResponse
-	if err := json.NewDecoder(rec.Body).Decode(&histResp); err != nil {
-		t.Fatalf("decode conversation history: %v", err)
-	}
+	histResp := fetchHistory()
 
 	// ---------------------------------------------------------------
 	// Floor assertion: V must see B's legitimate message.
@@ -230,10 +244,9 @@ func TestDMKeyIngress_UnauthorizedAgentCanInjectIntoForeignDM(t *testing.T) {
 			break
 		}
 	}
-	if !foundLegit {
-		t.Fatal("Floor check failed: user V cannot see agent B's legitimate " +
+	require.True(t, foundLegit,
+		"Floor check failed: user V cannot see agent B's legitimate "+
 			"message in the B↔V DM — test infrastructure is broken, not the code under test")
-	}
 
 	// ---------------------------------------------------------------
 	// Security invariant: V must NOT see agent A's injected message.
@@ -250,5 +263,28 @@ func TestDMKeyIngress_UnauthorizedAgentCanInjectIntoForeignDM(t *testing.T) {
 				"The ingress handler validates DM key format but does not check " +
 				"that the authenticated agent is a named participant in the key.")
 		}
+	}
+
+	// ---------------------------------------------------------------
+	// Step 4 (control): Agent A sends to a DIFFERENT thread (its own
+	// legitimate DM key with the victim). Verify the control message
+	// does NOT appear in B↔V's DM history — this pins the visibility
+	// mechanism to the DM key.
+	// ---------------------------------------------------------------
+	controlDMKey := fmt.Sprintf("dm:agent:%s:user:%s", agentA.ID, victimUserID)
+	controlRR := sendOutbound(agentA, p1.ID, "control message from A in own DM", "web", controlDMKey)
+	if controlRR.Code == http.StatusOK {
+		// If the control message was accepted, wait for delivery to settle
+		// then verify it does NOT appear in B↔V history.
+		assert.Eventually(t, func() bool { return true },
+			500*time.Millisecond, 50*time.Millisecond)
+	}
+
+	// Re-fetch the B↔V conversation and verify control message is absent.
+	histResp = fetchHistory()
+	for _, msg := range histResp.Messages {
+		assert.NotEqual(t, "control message from A in own DM", msg.Msg,
+			"Control message from agent A's own DM leaked into agent B's DM with user V — "+
+				"visibility is not properly scoped to the DM key")
 	}
 }

--- a/pkg/hub/dm_injection_security_test.go
+++ b/pkg/hub/dm_injection_security_test.go
@@ -216,10 +216,8 @@ func TestDMKeyIngress_UnauthorizedAgentCanInjectIntoForeignDM(t *testing.T) {
 	// be rejected; on the current defective code it succeeds.
 	// ---------------------------------------------------------------
 	rr = sendOutbound(agentA, p1.ID, "INJECTED by attacker agent A", "web", dmKey)
-
-	// If the ingress correctly checks membership, we'd expect a 400 here.
-	// On the defective code path, the write succeeds (200).
-	// We proceed regardless and check the *effect* (whether V can read it).
+	require.Equal(t, http.StatusBadRequest, rr.Code,
+		"Agent A is not a participant in the B↔V DM; the write must be rejected")
 
 	// Allow time for any async delivery to settle (poll briefly).
 	assert.Eventually(t, func() bool {

--- a/pkg/hub/dm_injection_security_test.go
+++ b/pkg/hub/dm_injection_security_test.go
@@ -219,12 +219,8 @@ func TestDMKeyIngress_UnauthorizedAgentCanInjectIntoForeignDM(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, rr.Code,
 		"Agent A is not a participant in the B↔V DM; the write must be rejected")
 
-	// Allow time for any async delivery to settle (poll briefly).
-	assert.Eventually(t, func() bool {
-		// We're waiting for delivery to settle, not for the message to appear.
-		// A short settle period is sufficient.
-		return true
-	}, 500*time.Millisecond, 50*time.Millisecond)
+	// No async settle needed: the injection was rejected synchronously
+	// (StatusBadRequest), so no message was created or delivered.
 
 	// ---------------------------------------------------------------
 	// Step 3: User V reads the B↔V conversation history.
@@ -272,10 +268,26 @@ func TestDMKeyIngress_UnauthorizedAgentCanInjectIntoForeignDM(t *testing.T) {
 	controlDMKey := fmt.Sprintf("dm:agent:%s:user:%s", agentA.ID, victimUserID)
 	controlRR := sendOutbound(agentA, p1.ID, "control message from A in own DM", "web", controlDMKey)
 	if controlRR.Code == http.StatusOK {
-		// If the control message was accepted, wait for delivery to settle
-		// then verify it does NOT appear in B↔V history.
-		assert.Eventually(t, func() bool { return true },
-			500*time.Millisecond, 50*time.Millisecond)
+		// Poll until the control message is visible in its own DM,
+		// confirming delivery has settled before checking B↔V isolation.
+		require.Eventually(t, func() bool {
+			rec := doRequestAsUser(t, srv, victimUser, http.MethodGet,
+				"/api/v1/chat/conversations/"+controlDMKey+"/messages", nil)
+			if rec.Code != http.StatusOK {
+				return false
+			}
+			var resp chatHistoryResponse
+			if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+				return false
+			}
+			for _, m := range resp.Messages {
+				if m.Msg == "control message from A in own DM" {
+					return true
+				}
+			}
+			return false
+		}, 5*time.Second, 100*time.Millisecond,
+			"control message should be visible in agent A's own DM")
 	}
 
 	// Re-fetch the B↔V conversation and verify control message is absent.

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -594,11 +594,18 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 
 	// Ownership check: verify the DM key IDs match the actual participants.
 	// The agent in the DM key must match the target agent; the user must match
-	// the sender (for user→agent messages).
+	// the AUTHENTICATED identity (not the client-supplied SenderID, which can
+	// be spoofed).
 	if structuredMsg != nil && structuredMsg.ThreadID != "" &&
 		strings.HasPrefix(structuredMsg.ThreadID, "dm:") {
 		dmAgentID, dmUserID := parseDMKeyIDs(structuredMsg.ThreadID)
-		if dmAgentID != agent.ID || dmUserID != structuredMsg.SenderID {
+		var authenticatedUserID string
+		if user := GetUserIdentityFromContext(ctx); user != nil {
+			authenticatedUserID = user.ID()
+		} else if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+			authenticatedUserID = agentIdent.ID()
+		}
+		if dmAgentID != agent.ID || dmUserID != authenticatedUserID {
 			BadRequest(w, "DM thread_id does not match the sender and recipient")
 			return
 		}

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -174,6 +174,17 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// Ownership check: verify the DM key IDs match the actual sender (agent)
+	// and recipient (user). The early format check above rejects malformed keys;
+	// this catches well-formed keys with wrong participant IDs.
+	if req.ThreadID != "" && strings.HasPrefix(req.ThreadID, "dm:") {
+		dmAgentID, dmUserID := parseDMKeyIDs(req.ThreadID)
+		if dmAgentID != agent.ID || dmUserID != recipientID {
+			BadRequest(w, "DM thread_id does not match the sender and recipient")
+			return
+		}
+	}
+
 	// Reply affinity (Phase 6, AC22): when the agent sends an untagged reply
 	// (no explicit channel), check webchat_conversation_context for the
 	// (recipient, project, agent) triple. If a row exists, route to the
@@ -579,6 +590,18 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 	if err != nil {
 		writeErrorFromErr(w, err, "")
 		return
+	}
+
+	// Ownership check: verify the DM key IDs match the actual participants.
+	// The agent in the DM key must match the target agent; the user must match
+	// the sender (for user→agent messages).
+	if structuredMsg != nil && structuredMsg.ThreadID != "" &&
+		strings.HasPrefix(structuredMsg.ThreadID, "dm:") {
+		dmAgentID, dmUserID := parseDMKeyIDs(structuredMsg.ThreadID)
+		if dmAgentID != agent.ID || dmUserID != structuredMsg.SenderID {
+			BadRequest(w, "DM thread_id does not match the sender and recipient")
+			return
+		}
 	}
 
 	// Wake handling: if requested, resume a suspended agent before message delivery.

--- a/pkg/hub/handlers_broker_inbound.go
+++ b/pkg/hub/handlers_broker_inbound.go
@@ -139,6 +139,10 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
+		// Cache the resolved user ID so downstream DM-ownership and
+		// persistence blocks can reuse it without redundant DB lookups.
+		req.Message.SenderID = senderUser.ID
+
 		userIdent := NewAuthenticatedUser(senderUser.ID, senderUser.Email, senderUser.DisplayName, senderUser.Role, "integration")
 		decision := s.authzService.CheckAccess(r.Context(), userIdent, agentResource(agent), ActionAttach)
 		if !decision.Allowed {
@@ -158,14 +162,9 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 	// match the sender.
 	if req.Message.ThreadID != "" && strings.HasPrefix(req.Message.ThreadID, "dm:") {
 		dmAgentID, dmUserID := parseDMKeyIDs(req.Message.ThreadID)
-		// Resolve sender user ID: prefer the message field, fall back to email lookup.
+		// SenderID was cached by the upstream permission check for "user:"
+		// senders, so no additional DB lookup is needed here.
 		senderID := req.Message.SenderID
-		if senderID == "" && strings.HasPrefix(req.Message.Sender, "user:") {
-			senderEmail := strings.TrimPrefix(req.Message.Sender, "user:")
-			if u, err := s.store.GetUserByEmail(r.Context(), senderEmail); err == nil {
-				senderID = u.ID
-			}
-		}
 		if dmAgentID != agent.ID || dmUserID != senderID {
 			BadRequest(w, "DM thread_id does not match the sender and recipient")
 			return
@@ -236,18 +235,9 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 		"type", req.Message.Type,
 	)
 
-	// Resolve the sender's user ID before persisting the message. The
-	// upstream permission check already did a user lookup for "user:" senders,
-	// but req.Message.SenderID may still be empty if the originating plugin
-	// didn't populate it.  Resolving early guarantees that both the persisted
-	// storeMsg and the webChatStore calls below use a valid ID.
+	// The sender user ID was resolved and cached in req.Message.SenderID
+	// during the upstream permission check for "user:" senders.
 	senderUserID := req.Message.SenderID
-	if senderUserID == "" && strings.HasPrefix(req.Message.Sender, "user:") {
-		senderEmail := strings.TrimPrefix(req.Message.Sender, "user:")
-		if u, err := s.store.GetUserByEmail(r.Context(), senderEmail); err == nil {
-			senderUserID = u.ID
-		}
-	}
 
 	// F5 fix (Phase 6): Persist the inbound message and publish an SSE event
 	// so that messages from external channels (Discord, Telegram) appear in

--- a/pkg/hub/handlers_broker_inbound.go
+++ b/pkg/hub/handlers_broker_inbound.go
@@ -153,6 +153,25 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Ownership check: verify the DM key IDs match the actual participants.
+	// The agent in the DM key must match the resolved agent; the user must
+	// match the sender.
+	if req.Message.ThreadID != "" && strings.HasPrefix(req.Message.ThreadID, "dm:") {
+		dmAgentID, dmUserID := parseDMKeyIDs(req.Message.ThreadID)
+		// Resolve sender user ID: prefer the message field, fall back to email lookup.
+		senderID := req.Message.SenderID
+		if senderID == "" && strings.HasPrefix(req.Message.Sender, "user:") {
+			senderEmail := strings.TrimPrefix(req.Message.Sender, "user:")
+			if u, err := s.store.GetUserByEmail(r.Context(), senderEmail); err == nil {
+				senderID = u.ID
+			}
+		}
+		if dmAgentID != agent.ID || dmUserID != senderID {
+			BadRequest(w, "DM thread_id does not match the sender and recipient")
+			return
+		}
+	}
+
 	// Reject messages to non-running agents.
 	if phase := state.Phase(agent.Phase); phase != state.PhaseRunning {
 		var msg string

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -2927,8 +2927,10 @@ func (s *Server) handleChatSearch(w http.ResponseWriter, r *http.Request) {
 // Helper functions
 // ---------------------------------------------------------------------------
 
-// isDMParticipant checks whether the given userID is one of the two
-// participants encoded in a DM conversation key by parsing tokens exactly.
+// isDMParticipant checks whether the given userID occupies a "user" slot in
+// a DM conversation key.  It matches only slots whose kind label is "user",
+// so an agent principal cannot inadvertently satisfy a user-slot check and
+// vice-versa.
 func isDMParticipant(key, userID string) bool {
 	// DM key formats:
 	//   dm:agent:<agentUUID>:user:<userUUID>
@@ -2937,7 +2939,8 @@ func isDMParticipant(key, userID string) bool {
 	if len(parts) < 5 {
 		return false
 	}
-	return parts[2] == userID || parts[4] == userID
+	return (parts[1] == "user" && parts[2] == userID) ||
+		(parts[3] == "user" && parts[4] == userID)
 }
 
 // dmUserParticipants returns the user IDs named in a DM key, skipping the agent
@@ -2989,6 +2992,21 @@ func parseAgentDMKey(key string) string {
 		return parts[2]
 	}
 	return ""
+}
+
+// parseDMKeyIDs extracts the agent UUID and user UUID from a DM key of the form
+// dm:agent:<agentUUID>:user:<userUUID>. Returns ("", "") if the key does not
+// match this format. The caller should validate format with validDMKey first.
+func parseDMKeyIDs(key string) (agentID, userID string) {
+	parts := strings.Split(key, ":")
+	if len(parts) != 5 {
+		return "", ""
+	}
+	// Accept dm:agent:<id>:user:<id> only — the canonical agent-DM format.
+	if parts[0] == "dm" && parts[1] == "agent" && parts[3] == "user" {
+		return parts[2], parts[4]
+	}
+	return "", ""
 }
 
 // resolveProjectFromDMKey attempts to derive a project ID from a DM key.

--- a/pkg/hub/handlers_chat_v2_test.go
+++ b/pkg/hub/handlers_chat_v2_test.go
@@ -45,7 +45,7 @@ func TestIsDMParticipant(t *testing.T) {
 		want   bool
 	}{
 		{"dm:agent:a1:user:u1", "u1", true},
-		{"dm:agent:a1:user:u1", "a1", true},
+		{"dm:agent:a1:user:u1", "a1", false}, // agent slot — user principal must not match
 		{"dm:agent:a1:user:u1", "u2", false},
 		{"dm:user:u1:user:u2", "u1", true},
 		{"dm:user:u1:user:u2", "u2", true},
@@ -1585,6 +1585,32 @@ func TestParseAgentDMKey(t *testing.T) {
 	for _, tt := range tests {
 		if got := parseAgentDMKey(tt.key); got != tt.want {
 			t.Errorf("parseAgentDMKey(%q) = %q, want %q", tt.key, got, tt.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseDMKeyIDs tests
+// ---------------------------------------------------------------------------
+
+func TestParseDMKeyIDs(t *testing.T) {
+	tests := []struct {
+		key       string
+		wantAgent string
+		wantUser  string
+	}{
+		{"dm:agent:aaaa-bbbb:user:cccc-dddd", "aaaa-bbbb", "cccc-dddd"},
+		{"dm:user:aaaa:user:bbbb", "", ""},   // not an agent-DM
+		{"dm:agent:1234:agent:5678", "", ""}, // second slot is not user
+		{"dm:agent:abc", "", ""},             // truncated
+		{"not-a-dm", "", ""},                 // garbage
+		{"", "", ""},                         // empty
+	}
+	for _, tt := range tests {
+		gotAgent, gotUser := parseDMKeyIDs(tt.key)
+		if gotAgent != tt.wantAgent || gotUser != tt.wantUser {
+			t.Errorf("parseDMKeyIDs(%q) = (%q, %q), want (%q, %q)",
+				tt.key, gotAgent, gotUser, tt.wantAgent, tt.wantUser)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Closes the cross-project DM injection vulnerability where an authenticated agent could write into another agent's DM conversation by supplying a well-formed but unauthorized DM key.

- Adds ownership validation at all 3 message ingress points: DM key IDs must match the authenticated sender and resolved recipient
- Uses authenticated identity from request context (not client-supplied SenderID) to prevent spoofing
- Tightens `isDMParticipant` to match only user-kind slots (agent slot no longer satisfies user-slot check)
- Adds `parseDMKeyIDs` helper for canonical DM key extraction
- Includes regression test (cross-project injection scenario) with control message and polling

Fork staging: ptone/scion#1318

## Test plan
- [x] `go test ./pkg/hub/... -v` — all pass including new security regression test
- [x] `go build` / `go vet` / `gofmt` / `golangci-lint` — clean
- [x] `npx tsc --noEmit` / `npx vitest run` — clean
- [x] CI green on fork staging PR ptone/scion#1318
- [x] Code review: APPROVE (4 rounds — format validation, ordering fix, auth identity fix, final approval)