### PR TITLE
feat: Admin permission registry, routeGuard Decide path, and hub-admin role (P2-A1)

### DIFF
--- a/.design/project-log/pf-p2a-infra.md
+++ b/.design/project-log/pf-p2a-infra.md
@@ -1,0 +1,87 @@
+# Project Log: PR-A1 Admin Permission Registry + D4 Infrastructure
+
+**Date:** 2026-08-27
+**Agent:** dev-pf-p2a-infra
+**Branch:** scion/pf-p2a-infra
+**Base:** 3aeb772 (Permissions Foundation Phase 1)
+
+## Summary
+
+Implemented Layer 1 of the D4 (admin as code bypass) resolution: the infrastructure that enables incremental handler conversion from inline admin checks to permission-based authorization.
+
+## What Was Built
+
+### 1. Permission Registry Additions (`pkg/hub/permissions/registry.go`)
+
+- Added `ResourceHub = "hub"` resource type constant
+- Added 5 new action constants: `ActionInvite`, `ActionSuspend`, `ActionPromote`, `ActionClone`, `ActionExecute`
+- Added 28 new hub-level permissions covering settings, config, maintenance, diagnostics, health, admin mode, integrations, lifecycle hooks, allow list, project defaults, auth reset, scheduler, federation, teams manifest, validate, GitHub app, and metrics
+- Added 7 extensions to existing resource types: `user.invite`, `user.suspend`, `user.promote`, `user.list`, `project.clone`, `project.list`, `skill.register`
+- Total: 35 new permission IDs in the registry (57 → 92)
+
+### 2. routeGuard Update (`pkg/hub/route_metadata.go`)
+
+Updated the `RouteHubAdmin` case in `routeGuard` to:
+- Check if `meta.Permission` is set (non-empty string)
+- If set: call `Decide()` with the declared permission, constructing an `AuthzRequest` with the permission ID
+- If NOT set: fall back to existing `requireAdmin` behavior
+
+This makes incremental conversion safe — routes with no Permission in their metadata behave exactly as before.
+
+### 3. Role Binding Permission Evaluation (`pkg/hub/authz.go`)
+
+- Added `Permission` field to `AuthzRequest` struct for canonical permission ID
+- Added role binding permission check step in `checkAccessForUser()` (between SA assign baseline and policy evaluation)
+- When a permission ID is provided, the system resolves the user's effective permissions from role bindings and checks if the requested permission is granted
+- This enables the D4 "second path": non-super-admin users with the correct permissions through role bindings get access
+
+### 4. Hub-Admin Role Definition
+
+- Added `SystemRoleHubAdmin = "hub-admin"` constant (`pkg/store/models.go`)
+- Added `hubAdminPermissionIDs()` function with curated permission set (`pkg/hub/seed.go`)
+- Added hub-admin to `seedRoleDefinitions()` between super-admin and hub-member
+
+**Hub-admin includes:** user management (read/list/update/invite), all group operations, hub settings/config/health, integrations, lifecycle hooks, allow list, project defaults, scheduler, federation, teams manifest, GitHub app, metrics, validate, project oversight, skill registries
+
+**Excluded (super-admin only):** maintenance, auth reset, diagnostics, admin mode, all policy operations, user suspend/promote
+
+### 5. Tests
+
+**Bypass Census Test** (`pkg/hub/bypass_census_test.go`):
+- Scans all non-test `.go` files in `pkg/hub/` for admin bypass patterns
+- Maintains an allowlist of ~80 authorized bypass locations
+- Fails when a new bypass appears outside the allowlist
+- Allowlist will shrink as handlers are converted in PR-A2 through PR-A6
+
+**RouteGuard Permission Test** (`pkg/hub/routeguard_permission_test.go`):
+- 8 test cases covering both the permission-based and fallback paths
+- Validates super-admin allowed through admin bypass
+- Validates hub-admin allowed through role binding grant (D4 second path!)
+- Validates member denied, unauthenticated denied
+- Validates hub-admin denied for super-admin-only permissions
+- Validates requireAdmin fallback for unconverted routes
+
+### 6. Frontend UAT Scope Update
+
+Updated `web/src/components/shared/token-list.ts` AVAILABLE_SCOPES to include new UAT scopes (hub:settings:read/update, hub:config:read/update, hub:health:read, hub:integrations:read/update, project:clone, user:invite).
+
+## Decisions Made
+
+1. **Role binding evaluation position:** Added after the SA assign baseline (step 2.7) and before policy evaluation (step 3), maintaining the existing authorization hierarchy
+2. **Permission field on AuthzRequest:** Added as an optional field rather than modifying the Resource/Action contract, preserving backward compatibility for all existing CheckAccess callers
+3. **Hub-admin permissions as explicit set:** Used a curated allowlist rather than a derivation rule, matching the architect's recommendation that the permission set is a product decision
+
+## Pre-existing Issues
+
+- `TestHandleAdminServerConfig_Get` fails on main (pre-existing, not caused by this PR)
+
+## Files Changed
+
+- `pkg/hub/permissions/registry.go` — 35 new permission entries + 6 new constants
+- `pkg/hub/route_metadata.go` — routeGuard RouteHubAdmin case updated
+- `pkg/hub/authz.go` — Permission field on AuthzRequest, role binding check step, 5 new Action constants
+- `pkg/hub/seed.go` — hub-admin role seeding + hubAdminPermissionIDs()
+- `pkg/store/models.go` — SystemRoleHubAdmin constant
+- `pkg/hub/bypass_census_test.go` — new test file
+- `pkg/hub/routeguard_permission_test.go` — new test file
+- `web/src/components/shared/token-list.ts` — updated AVAILABLE_SCOPES

--- a/pkg/hub/authz.go
+++ b/pkg/hub/authz.go
@@ -475,7 +475,7 @@ func decorateDecision(decision Decision, principal PrincipalContext, credential 
 }
 
 // checkAccessForUser evaluates access for a user principal.
-func (a *AuthzService) checkAccessForUser(ctx context.Context, user UserIdentity, resource Resource, action Action, permissionID ...string) Decision {
+func (a *AuthzService) checkAccessForUser(ctx context.Context, user UserIdentity, resource Resource, action Action, permissionID string) Decision {
 	// 0. If the identity is scoped (UAT), enforce project + scope constraints first.
 	if scopedIdentity, ok := user.(*ScopedUserIdentity); ok {
 		if denied := a.enforceUATConstraints(scopedIdentity, resource, action); denied != nil {
@@ -578,21 +578,17 @@ func (a *AuthzService) checkAccessForUser(ctx context.Context, user UserIdentity
 	// the path that enables scoped admin: a non-super-admin user with the
 	// hub-admin role binding can access hub operations they have permissions
 	// for, without holding the super-admin bypass.
-	permID := ""
-	if len(permissionID) > 0 {
-		permID = permissionID[0]
-	}
-	if permID != "" {
+	if permissionID != "" {
 		effectivePerms, err := a.getEffectivePermissions(ctx, "user", user.ID(), store.RoleScopeSystem, "")
 		if err != nil {
 			a.logger.Warn("failed to get effective permissions for user", "userID", user.ID(), "error", err.Error())
 		} else {
 			for _, p := range effectivePerms {
-				if p == permID {
+				if p == permissionID {
 					return Decision{
 						Allowed:       true,
 						Reason:        "role binding grant",
-						MatchedGrant:  permID,
+						MatchedGrant:  permissionID,
 						PrincipalKind: PrincipalKindUser,
 					}
 				}

--- a/pkg/hub/authz.go
+++ b/pkg/hub/authz.go
@@ -51,7 +51,12 @@ const (
 	// it — currently attaching a GCP service account to an agent. Declared here
 	// so policies can be written against it; the assignment call sites still
 	// check ActionRead and are converted separately.
-	ActionAssign Action = "assign"
+	ActionAssign  Action = "assign"
+	ActionInvite  Action = "invite"
+	ActionSuspend Action = "suspend"
+	ActionPromote Action = "promote"
+	ActionClone   Action = "clone"
+	ActionExecute Action = "execute"
 )
 
 // Resource represents the target of an authorization check.
@@ -116,7 +121,8 @@ type AuthzRequest struct {
 	Credential CredentialContext
 	Resource   Resource
 	Action     Action
-	Explain    bool // When true, collect step-by-step trace in Decision
+	Permission string // Canonical permission ID (e.g., "hub.settings.read"); when set, role binding evaluation uses this instead of Resource+Action.
+	Explain    bool   // When true, collect step-by-step trace in Decision
 }
 
 // AuthzRequestFromContext builds a request from authentication middleware
@@ -201,7 +207,9 @@ func (a *AuthzService) SetDecisionAuditEmitter(emitter DecisionAuditEmitter) {
 }
 
 // CheckAccess evaluates whether the given identity is allowed to perform
-// the specified action on the resource.
+// the specified action on the resource. Legacy callers that do not know a
+// canonical permission ID pass an empty string; the role-binding evaluation
+// step is skipped when no permission is supplied.
 func (a *AuthzService) CheckAccess(ctx context.Context, identity Identity, resource Resource, action Action) Decision {
 	return a.Decide(ctx, AuthzRequest{
 		Principal:  principalContextForIdentity(identity),
@@ -256,7 +264,7 @@ func (a *AuthzService) Decide(ctx context.Context, request AuthzRequest) Decisio
 		if credential.Kind == CredentialKindUAT {
 			user = NewScopedUserIdentity(user, credential.ProjectID, credential.Scopes)
 		}
-		decision = a.checkAccessForUser(ctx, user, request.Resource, request.Action)
+		decision = a.checkAccessForUser(ctx, user, request.Resource, request.Action, request.Permission)
 	case PrincipalKindAgent, PrincipalKindFederatedAgent:
 		agent, ok := principal.Identity.(AgentIdentity)
 		if !ok {
@@ -467,7 +475,7 @@ func decorateDecision(decision Decision, principal PrincipalContext, credential 
 }
 
 // checkAccessForUser evaluates access for a user principal.
-func (a *AuthzService) checkAccessForUser(ctx context.Context, user UserIdentity, resource Resource, action Action) Decision {
+func (a *AuthzService) checkAccessForUser(ctx context.Context, user UserIdentity, resource Resource, action Action, permissionID ...string) Decision {
 	// 0. If the identity is scoped (UAT), enforce project + scope constraints first.
 	if scopedIdentity, ok := user.(*ScopedUserIdentity); ok {
 		if denied := a.enforceUATConstraints(scopedIdentity, resource, action); denied != nil {
@@ -564,7 +572,35 @@ func (a *AuthzService) checkAccessForUser(ctx context.Context, user UserIdentity
 		}
 	}
 
-	// 3. Build principal refs: direct user + effective groups
+	// 3. Role binding permission check (Phase 2 D4 second-path).
+	// When a canonical permission ID is supplied, check whether the user
+	// holds that permission through any system-scoped role binding. This is
+	// the path that enables scoped admin: a non-super-admin user with the
+	// hub-admin role binding can access hub operations they have permissions
+	// for, without holding the super-admin bypass.
+	permID := ""
+	if len(permissionID) > 0 {
+		permID = permissionID[0]
+	}
+	if permID != "" {
+		effectivePerms, err := a.getEffectivePermissions(ctx, "user", user.ID(), store.RoleScopeSystem, "")
+		if err != nil {
+			a.logger.Warn("failed to get effective permissions for user", "userID", user.ID(), "error", err.Error())
+		} else {
+			for _, p := range effectivePerms {
+				if p == permID {
+					return Decision{
+						Allowed:       true,
+						Reason:        "role binding grant",
+						MatchedGrant:  permID,
+						PrincipalKind: PrincipalKindUser,
+					}
+				}
+			}
+		}
+	}
+
+	// 4. Build principal refs: direct user + effective groups
 	principals := []store.PrincipalRef{
 		{Type: "user", ID: user.ID()},
 	}
@@ -577,7 +613,7 @@ func (a *AuthzService) checkAccessForUser(ctx context.Context, user UserIdentity
 		principals = append(principals, store.PrincipalRef{Type: "group", ID: gid})
 	}
 
-	// 4. Fetch and evaluate policies
+	// 5. Fetch and evaluate policies
 	policies, err := a.store.GetPoliciesForPrincipals(ctx, principals)
 	if err != nil {
 		a.logger.Warn("failed to get policies for principals", "error", err)

--- a/pkg/hub/bypass_census_test.go
+++ b/pkg/hub/bypass_census_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestBypassCensus is a regression test that detects new admin bypass patterns
+// in pkg/hub/. It maintains an allowlist of authorized bypass locations. As
+// handlers are converted from inline admin checks to permission-based checks
+// (PR-A2 through PR-A6), entries are removed from the allowlist. Any new
+// bypass appearing outside the allowlist causes this test to fail.
+//
+// The final state (after all D4 conversion PRs) will have only the engine-
+// internal keeps plus the deprecated requireAdmin helper and the routeGuard
+// fallback.
+func TestBypassCensus(t *testing.T) {
+	// Patterns that indicate an admin bypass site.
+	patterns := []*regexp.Regexp{
+		// Category A: inline Role() != "admin" checks in handlers
+		regexp.MustCompile(`\.Role\(\)\s*!=\s*"admin"`),
+		// Category B: IsUnscopedLocalPlatformAdmin calls (outside authorized engine files)
+		regexp.MustCompile(`IsUnscopedLocalPlatformAdmin\(`),
+		// Category C: requireAdmin call sites
+		regexp.MustCompile(`requireAdmin\(`),
+	}
+
+	// Authorized bypass locations. Each entry is "filename:lineContent" where
+	// lineContent is a substring that must appear on the matching line. This
+	// provides both file-level and line-level specificity.
+	//
+	// As handlers are converted to permission-based checks, entries are removed
+	// from this allowlist. The test fails if a new bypass appears that is not
+	// in this list.
+	type allowEntry struct {
+		file        string // base filename
+		lineSubstr  string // substring that must appear on the matching line
+		description string // why this is allowed
+	}
+
+	allowlist := []allowEntry{
+		// ─── Engine-internal keeps (permanent) ───────────────────────────
+		// These are part of the authorization engine, not handler-level bypasses.
+		{file: "authz.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "checkAccessForUser admin bypass (KEEP)"},
+		{file: "authz.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "AuthorizeReadBatch short-circuit (KEEP)"},
+		{file: "authz.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "Decide explain trace admin check"},
+		{file: "authz_candelegate.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "CanDelegate super-admin bypass (KEEP)"},
+		{file: "authz_delegation_ceiling.go", lineSubstr: "IsSystemAdmin", description: "delegation ceiling system admin check (KEEP)"},
+
+		// ─── Authorization infrastructure (permanent or deprecating) ─────
+		{file: "authorize.go", lineSubstr: "func (s *Server) requireAdmin(", description: "requireAdmin helper definition (DEPRECATE later)"},
+		{file: "authorize.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "requireAdmin implementation"},
+		{file: "authorize.go", lineSubstr: "requireAdmin(w, r)", description: "requireAdminHandler wrapper"},
+		{file: "route_metadata.go", lineSubstr: "requireAdmin(w, r)", description: "routeGuard fallback for unconverted routes (temporary)"},
+		{file: "identity.go", lineSubstr: "IsUnscopedLocalPlatformAdmin", description: "IsUnscopedLocalPlatformAdmin definition"},
+		{file: "identity.go", lineSubstr: `user.Role() != "admin"`, description: "IsUnscopedLocalPlatformAdmin implementation"},
+		{file: "authz.go", lineSubstr: "IsUnscopedLocalPlatformAdmin", description: "comment reference"},
+
+		// ─── Capabilities (will be updated in PR-A7) ─────────────────────
+		{file: "capabilities.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "capability computation (PR-A7)"},
+		{file: "capabilities.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "capability computation (PR-A7)"},
+		{file: "capabilities.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "capability computation (PR-A7)"},
+
+		// ─── Audit explain endpoint (will be updated in PR-A7) ───────────
+		{file: "audit_authz.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "explain endpoint admin check (PR-A7)"},
+
+		// ─── Handler-level bypasses (will be removed in PR-A2 through PR-A6) ──
+
+		// Settings and config (PR-A2)
+		{file: "admin_settings.go", lineSubstr: `user.Role() != "admin"`, description: "get settings (PR-A2)"},
+		{file: "admin_settings.go", lineSubstr: `user.Role() != "admin"`, description: "set settings (PR-A2)"},
+		{file: "admin_settings_db.go", lineSubstr: `user.Role() != "admin"`, description: "db settings (PR-A2)"},
+		{file: "admin_project_defaults.go", lineSubstr: `user.Role() != "admin"`, description: "project defaults (PR-A2)"},
+
+		// User management (PR-A3)
+		{file: "admin_allow_list.go", lineSubstr: `user.Role() != "admin"`, description: "get allow list (PR-A3)"},
+		{file: "admin_allow_list.go", lineSubstr: `user.Role() != "admin"`, description: "set allow list (PR-A3)"},
+		{file: "admin_invites.go", lineSubstr: `user.Role() != "admin"`, description: "list invites (PR-A3)"},
+		{file: "admin_invites.go", lineSubstr: `user.Role() != "admin"`, description: "delete invite (PR-A3)"},
+		{file: "admin_user_invite.go", lineSubstr: `user.Role() != "admin"`, description: "invite user (PR-A3)"},
+		{file: "admin_user_invite.go", lineSubstr: `user.Role() != "admin"`, description: "bulk invite (PR-A3)"},
+		{file: "admin_validate.go", lineSubstr: `user.Role() != "admin"`, description: "validate resources (PR-A3)"},
+
+		// Operations (PR-A4)
+		{file: "admin_maintenance.go", lineSubstr: `user.Role() != "admin"`, description: "list maintenance (PR-A4)"},
+		{file: "admin_maintenance.go", lineSubstr: `user.Role() != "admin"`, description: "run maintenance (PR-A4)"},
+		{file: "admin_maintenance.go", lineSubstr: `user.Role() != "admin"`, description: "check updates (PR-A4)"},
+		{file: "admin_maintenance.go", lineSubstr: `user.Role() != "admin"`, description: "restart (PR-A4)"},
+		{file: "admin_mode.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "admin mode read bypass (PR-A4)"},
+		{file: "admin_mode.go", lineSubstr: `user.Role() != "admin"`, description: "admin mode update (PR-A4)"},
+		{file: "admin_mode.go", lineSubstr: `user.Role() != "admin"`, description: "admin mode status (PR-A4)"},
+		{file: "admin_reset_auth.go", lineSubstr: `user.Role() != "admin"`, description: "reset auth (PR-A4)"},
+		{file: "handlers_diagnostics.go", lineSubstr: `user.Role() != "admin"`, description: "get logs (PR-A4)"},
+		{file: "handlers_diagnostics.go", lineSubstr: `user.Role() != "admin"`, description: "stream logs (PR-A4)"},
+		{file: "handlers_health_summary.go", lineSubstr: `user.Role() != "admin"`, description: "health summary (PR-A4)"},
+
+		// Integrations and hooks (PR-A5)
+		{file: "handlers_integrations.go", lineSubstr: `user.Role() != "admin"`, description: "update integration (PR-A5)"},
+		{file: "handlers_integrations.go", lineSubstr: `user.Role() != "admin"`, description: "delete integration (PR-A5)"},
+		{file: "handlers_lifecycle_hooks.go", lineSubstr: `user.Role() != "admin"`, description: "create lifecycle hook (PR-A5)"},
+		{file: "handlers_lifecycle_hooks.go", lineSubstr: `user.Role() != "admin"`, description: "update lifecycle hook (PR-A5)"},
+		{file: "handlers_teams_manifest.go", lineSubstr: `user.Role() != "admin"`, description: "teams manifest (PR-A5)"},
+		{file: "passthrough_gate.go", lineSubstr: `userIdent.Role() != "admin"`, description: "passthrough gate (PR-A5)"},
+
+		// Resource handlers with existing types (PR-A6)
+		{file: "handlers_policies.go", lineSubstr: "requireAdmin(w, r)", description: "create policy (PR-A6)"},
+		{file: "handlers_policies.go", lineSubstr: "requireAdmin(w, r)", description: "update policy (PR-A6)"},
+		{file: "handlers_policies.go", lineSubstr: "requireAdmin(w, r)", description: "delete policy (PR-A6)"},
+		{file: "handlers_policies.go", lineSubstr: "requireAdmin(w, r)", description: "bind policy (PR-A6)"},
+		{file: "handlers_policies.go", lineSubstr: "requireAdmin(w, r)", description: "unbind policy (PR-A6)"},
+		{file: "handlers_policies.go", lineSubstr: "requireAdmin(w, r)", description: "policy CRUD (PR-A6)"},
+		{file: "handlers_policies.go", lineSubstr: `callerUser.Role() != "admin"`, description: "policy evaluate admin check (PR-A6)"},
+		{file: "skill_registry_handlers.go", lineSubstr: "requireAdmin(w, r)", description: "skill registry list (PR-A6)"},
+		{file: "skill_registry_handlers.go", lineSubstr: "requireAdmin(w, r)", description: "skill registry create (PR-A6)"},
+		{file: "skill_registry_handlers.go", lineSubstr: "requireAdmin(w, r)", description: "skill registry update (PR-A6)"},
+		{file: "skill_registry_handlers.go", lineSubstr: "requireAdmin(w, r)", description: "skill registry delete (PR-A6)"},
+		{file: "skill_registry_handlers.go", lineSubstr: "requireAdmin(w, r)", description: "skill registry sync (PR-A6)"},
+		{file: "skill_registry_handlers.go", lineSubstr: "requireAdmin(w, r)", description: "skill registry import (PR-A6)"},
+		{file: "skill_registry_handlers.go", lineSubstr: "requireAdmin(w, r)", description: "skill registry CRUD (PR-A6)"},
+		{file: "skill_registry_handlers.go", lineSubstr: "requireAdmin(w, r)", description: "skill registry CRUD (PR-A6)"},
+		{file: "handlers_gcp_identity.go", lineSubstr: `user.Role() != "admin"`, description: "GCP identity admin check (PR-A6)"},
+		{file: "handlers_gcp_identity_scoped.go", lineSubstr: `user.Role() != "admin"`, description: "GCP identity scoped admin check (PR-A6)"},
+		{file: "project_clone.go", lineSubstr: `user.Role() != "admin"`, description: "project clone admin check (PR-A6)"},
+		{file: "project_template_handlers.go", lineSubstr: `user.Role() != "admin"`, description: "project template admin check (PR-A6)"},
+		{file: "handlers_agents_core.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "agent list admin filter (PR-A6)"},
+		{file: "handlers_brokers.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "broker list admin filter (PR-A6)"},
+		{file: "handlers_groups.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "group list admin filter (PR-A6)"},
+		{file: "handlers_groups.go", lineSubstr: "isPlatformAdmin", description: "group membership admin check (PR-A6)"},
+		{file: "handlers_projects_core.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "project list admin filter (PR-A6)"},
+		{file: "harness_config_handlers.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "harness config list admin filter (PR-A6)"},
+		{file: "template_handlers.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "template list admin filter (PR-A6)"},
+		{file: "port_forward_handlers.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(userIdent)", description: "port forward admin check (PR-A6)"},
+		{file: "handlers_agent_lifecycle.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(userIdent)", description: "agent lifecycle admin check (PR-A6)"},
+		{file: "handlers_agent_lifecycle.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(userIdent)", description: "agent lifecycle admin check (PR-A6)"},
+		{file: "handlers_skills_injection.go", lineSubstr: "requireAdmin(w, r)", description: "hub injected skills admin check (PR-A6)"},
+		{file: "hub_pre_start_hook_handlers.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(identity)", description: "pre-start hook admin check (PR-A6)"},
+		{file: "hub_pre_start_hook_handlers.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(identity)", description: "pre-start hook admin check (PR-A6)"},
+
+		// ─── Auth/identity infrastructure (non-bypass references) ────────
+		{file: "handlers_auth.go", lineSubstr: "IsUnscopedLocalPlatformAdmin", description: "admin reconciliation comment reference"},
+		{file: "handlers_auth.go", lineSubstr: "IsUnscopedLocalPlatformAdmin", description: "admin reconciliation helper"},
+		{file: "authz_candelegate.go", lineSubstr: "requireAdmin", description: "comment reference in CanDelegate"},
+	}
+
+	// Build the allow map: file -> list of allowed substrings with counts
+	type allowKey struct {
+		file       string
+		lineSubstr string
+	}
+	allowCounts := map[allowKey]int{}
+	for _, entry := range allowlist {
+		key := allowKey{file: entry.file, lineSubstr: entry.lineSubstr}
+		allowCounts[key]++
+	}
+
+	hubDir := "." // pkg/hub is the current package directory in test context
+	entries, err := os.ReadDir(hubDir)
+	if err != nil {
+		t.Fatalf("failed to read hub directory: %v", err)
+	}
+
+	var violations []string
+	matchCounts := map[allowKey]int{}
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(hubDir, name))
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", name, err)
+		}
+
+		lines := strings.Split(string(data), "\n")
+		for lineNum, line := range lines {
+			for _, pattern := range patterns {
+				if !pattern.MatchString(line) {
+					continue
+				}
+
+				// Check if this match is in the allowlist
+				allowed := false
+				for _, entry := range allowlist {
+					if entry.file == name && strings.Contains(line, entry.lineSubstr) {
+						key := allowKey{file: entry.file, lineSubstr: entry.lineSubstr}
+						if matchCounts[key] < allowCounts[key] {
+							matchCounts[key]++
+							allowed = true
+							break
+						}
+					}
+				}
+
+				if !allowed {
+					violations = append(violations, fmt.Sprintf(
+						"%s:%d: %s\n  matched: %s",
+						name, lineNum+1, strings.TrimSpace(line), pattern.String(),
+					))
+				}
+			}
+		}
+	}
+
+	if len(violations) > 0 {
+		t.Errorf("bypass census: %d unauthorized admin bypass site(s) found.\n"+
+			"Each site below uses an inline admin check instead of the permission-based\n"+
+			"Decide pipeline. Either convert the handler to use route metadata permissions\n"+
+			"(preferred) or add the site to the allowlist in this test with justification.\n\n%s",
+			len(violations), strings.Join(violations, "\n\n"))
+	}
+}

--- a/pkg/hub/permissions/registry.go
+++ b/pkg/hub/permissions/registry.go
@@ -31,6 +31,7 @@ const (
 	ResourcePolicy            = "policy"
 	ResourceBroker            = "broker"
 	ResourceGCPServiceAccount = "gcp_service_account"
+	ResourceHub               = "hub"
 
 	ActionCreate       = "create"
 	ActionRead         = "read"
@@ -48,6 +49,11 @@ const (
 	ActionVerify       = "verify"
 	ActionMint         = "mint"
 	ActionAssign       = "assign"
+	ActionInvite       = "invite"
+	ActionSuspend      = "suspend"
+	ActionPromote      = "promote"
+	ActionClone        = "clone"
+	ActionExecute      = "execute"
 
 	UATScopeAgentManage = "agent:manage"
 )
@@ -147,6 +153,45 @@ var Registry = []Permission{
 	{ID: "gcp_service_account.verify", Resource: ResourceGCPServiceAccount, Action: ActionVerify, CapabilityKind: CapabilityResource, Description: "Verify GCP service accounts", Enforcement: []string{"pkg/hub/handlers_gcp_identity.go"}},
 	{ID: "gcp_service_account.mint", Resource: ResourceGCPServiceAccount, Action: ActionMint, CapabilityKind: CapabilityScope, Description: "Mint GCP service account tokens", Enforcement: []string{"pkg/hub/handlers_gcp_identity.go"}},
 	{ID: "gcp_service_account.assign", Resource: ResourceGCPServiceAccount, Action: ActionAssign, CapabilityKind: CapabilityResource, Description: "Assign GCP service accounts to agents", Enforcement: []string{"pkg/hub/handlers_gcp_identity.go", "pkg/hub/authz.go"}},
+
+	// Hub resource type — hub-level administrative operations (Phase 2 D4 resolution)
+	{ID: "hub.settings.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, UATScope: "hub:settings:read", Description: "Read hub settings", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.settings.update", Resource: ResourceHub, Action: ActionUpdate, CapabilityKind: CapabilityScope, UATScope: "hub:settings:update", Description: "Update hub settings", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.config.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, UATScope: "hub:config:read", Description: "Read server configuration", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.config.update", Resource: ResourceHub, Action: ActionUpdate, CapabilityKind: CapabilityScope, UATScope: "hub:config:update", Description: "Update server configuration", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.maintenance.execute", Resource: ResourceHub, Action: ActionExecute, CapabilityKind: CapabilityScope, Description: "Execute maintenance operations", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.diagnostics.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, Description: "Read diagnostics and logs", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.health.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, UATScope: "hub:health:read", Description: "Read health summary", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.admin_mode.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, Description: "Read admin mode state", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.admin_mode.update", Resource: ResourceHub, Action: ActionUpdate, CapabilityKind: CapabilityScope, Description: "Update admin mode", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.integrations.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, UATScope: "hub:integrations:read", Description: "Read integrations", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.integrations.update", Resource: ResourceHub, Action: ActionUpdate, CapabilityKind: CapabilityScope, UATScope: "hub:integrations:update", Description: "Update integrations", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.lifecycle_hooks.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, Description: "Read lifecycle hooks", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.lifecycle_hooks.update", Resource: ResourceHub, Action: ActionUpdate, CapabilityKind: CapabilityScope, Description: "Update lifecycle hooks", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.allow_list.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, Description: "Read allow list", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.allow_list.update", Resource: ResourceHub, Action: ActionUpdate, CapabilityKind: CapabilityScope, Description: "Update allow list", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.project_defaults.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, Description: "Read project defaults", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.project_defaults.update", Resource: ResourceHub, Action: ActionUpdate, CapabilityKind: CapabilityScope, Description: "Update project defaults", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.auth_reset.execute", Resource: ResourceHub, Action: ActionExecute, CapabilityKind: CapabilityScope, Description: "Reset all auth", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.scheduler.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, Description: "Read scheduler", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.scheduler.update", Resource: ResourceHub, Action: ActionUpdate, CapabilityKind: CapabilityScope, Description: "Update scheduler", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.federation.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, Description: "Read federation config", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.federation.update", Resource: ResourceHub, Action: ActionUpdate, CapabilityKind: CapabilityScope, Description: "Update federation config", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.teams_manifest.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, Description: "Read teams manifest", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.teams_manifest.update", Resource: ResourceHub, Action: ActionUpdate, CapabilityKind: CapabilityScope, Description: "Update teams manifest", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.validate.execute", Resource: ResourceHub, Action: ActionExecute, CapabilityKind: CapabilityScope, Description: "Validate resources", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.github_app.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, Description: "Read GitHub app configuration", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.github_app.update", Resource: ResourceHub, Action: ActionUpdate, CapabilityKind: CapabilityScope, Description: "Update GitHub app configuration", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "hub.metrics.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, Description: "Read metrics dashboard", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+
+	// Extensions to existing resource types (Phase 2 D4 resolution)
+	{ID: "user.invite", Resource: ResourceUser, Action: ActionInvite, CapabilityKind: CapabilityScope, UATScope: "user:invite", Description: "Invite users", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "user.suspend", Resource: ResourceUser, Action: ActionSuspend, CapabilityKind: CapabilityResource, Description: "Suspend users", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "user.promote", Resource: ResourceUser, Action: ActionPromote, CapabilityKind: CapabilityResource, Description: "Promote or demote users", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "user.list", Resource: ResourceUser, Action: ActionList, CapabilityKind: CapabilityScope, Description: "List users", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "project.clone", Resource: ResourceProject, Action: ActionClone, CapabilityKind: CapabilityResource, UATScope: "project:clone", Description: "Clone projects", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "project.list", Resource: ResourceProject, Action: ActionList, CapabilityKind: CapabilityScope, Description: "List projects", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+	{ID: "skill.register", Resource: ResourceSkill, Action: ActionRegister, CapabilityKind: CapabilityScope, Description: "Register skills in registries", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
 
 	{ID: "agent.status_update", Resource: ResourceAgent, Action: "status_update", AgentScopes: []string{"agent:status:update"}, Description: "Update own agent status", NonRouteUse: []string{"agent token self-status endpoint"}},
 	{ID: "agent.log_append", Resource: ResourceAgent, Action: "log_append", AgentScopes: []string{"agent:log:append"}, Description: "Append own agent logs", NonRouteUse: []string{"agent token log append endpoint"}},

--- a/pkg/hub/route_metadata.go
+++ b/pkg/hub/route_metadata.go
@@ -858,6 +858,12 @@ func (s *Server) routeGuard(meta RouteMetadata, next http.HandlerFunc) http.Hand
 			next(w, r)
 		case RouteHubAdmin:
 			if meta.Permission != "" {
+				// Validate route metadata completeness
+				if meta.Resource == "" || meta.Action == "" {
+					writeError(w, http.StatusInternalServerError, ErrCodeRuntimeError,
+						"route misconfigured: Resource and Action must be set when Permission is set", nil)
+					return
+				}
 				// D4 conversion: permission-based check via Decide.
 				// Routes that declare a Permission in their metadata are
 				// evaluated through the authorization pipeline, which

--- a/pkg/hub/route_metadata.go
+++ b/pkg/hub/route_metadata.go
@@ -857,11 +857,45 @@ func (s *Server) routeGuard(meta RouteMetadata, next http.HandlerFunc) http.Hand
 			// the handler where resource IDs, ownership, and visibility are known.
 			next(w, r)
 		case RouteHubAdmin:
-			// Delegate to existing requireAdmin — already handles scoped/federated rejection
-			if _, ok := s.requireAdmin(w, r); !ok {
-				return
+			if meta.Permission != "" {
+				// D4 conversion: permission-based check via Decide.
+				// Routes that declare a Permission in their metadata are
+				// evaluated through the authorization pipeline, which
+				// preserves the super-admin bypass and enables scoped
+				// admin access through role bindings.
+				identity := GetIdentityFromContext(r.Context())
+				if identity == nil {
+					writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "authentication required", nil)
+					return
+				}
+				user, ok := identity.(UserIdentity)
+				if !ok {
+					logAuthzDenial(r, identity, Resource{Type: meta.Resource}, Action(meta.Action), "non-user identity")
+					Forbidden(w)
+					return
+				}
+				decision := s.authzService.Decide(r.Context(), AuthzRequest{
+					Principal:  principalContextForIdentity(user),
+					Credential: credentialContextForIdentity(user),
+					Resource:   Resource{Type: meta.Resource, ID: "hub"},
+					Action:     Action(meta.Action),
+					Permission: meta.Permission,
+				})
+				if !decision.Allowed {
+					logAuthzDenial(r, identity, Resource{Type: meta.Resource, ID: "hub"}, Action(meta.Action), decision.Reason)
+					Forbidden(w)
+					return
+				}
+				next(w, r)
+			} else {
+				// Fallback: unconverted route still uses requireAdmin.
+				// This makes incremental D4 conversion safe — routes
+				// without a declared Permission behave exactly as before.
+				if _, ok := s.requireAdmin(w, r); !ok {
+					return
+				}
+				next(w, r)
 			}
-			next(w, r)
 		case RouteWorkstation:
 			// Delegate to existing requireWorkstation check
 			s.requireWorkstation(http.HandlerFunc(next)).ServeHTTP(w, r)

--- a/pkg/hub/routeguard_permission_test.go
+++ b/pkg/hub/routeguard_permission_test.go
@@ -1,0 +1,257 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// TestRouteGuardPermissionBasedPath verifies the updated RouteHubAdmin case
+// in routeGuard. When a route declares a Permission in its metadata, the guard
+// calls Decide instead of requireAdmin. When no Permission is set, it falls
+// back to requireAdmin.
+func TestRouteGuardPermissionBasedPath(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// Seed role definitions so hub-admin exists
+	seedRoleDefinitions(ctx, s)
+
+	// Create users with different roles
+	adminUser := &store.User{
+		ID: tid("admin-rg"), Email: "admin-rg@test.com", DisplayName: "Admin",
+		Role: "admin", Status: "active",
+	}
+	memberUser := &store.User{
+		ID: tid("member-rg"), Email: "member-rg@test.com", DisplayName: "Member",
+		Role: "member", Status: "active",
+	}
+	hubAdminUser := &store.User{
+		ID: tid("hub-admin-rg"), Email: "hub-admin-rg@test.com", DisplayName: "Hub Admin",
+		Role: "member", Status: "active",
+	}
+	if err := s.CreateUser(ctx, adminUser); err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	if err := s.CreateUser(ctx, memberUser); err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	if err := s.CreateUser(ctx, hubAdminUser); err != nil {
+		t.Fatalf("create hub-admin user: %v", err)
+	}
+
+	// Give hub-admin user a hub-admin role binding
+	hubAdminRD, err := s.GetRoleDefinitionByName(ctx, store.SystemRoleHubAdmin, store.RoleScopeSystem)
+	if err != nil {
+		t.Fatalf("get hub-admin role definition: %v", err)
+	}
+	_, err = s.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: hubAdminRD.ID,
+		PrincipalType:    "user",
+		PrincipalID:      hubAdminUser.ID,
+		ScopeType:        store.RoleScopeSystem,
+	})
+	if err != nil {
+		t.Fatalf("create hub-admin role binding: %v", err)
+	}
+
+	// A handler that returns 200 — this is the "next" handler after the guard passes.
+	okHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}
+
+	// Test cases for the permission-based path
+	t.Run("permission_set_super_admin_allowed", func(t *testing.T) {
+		meta := RouteMetadata{
+			Pattern:        "/test/perm-admin",
+			RouteID:        "test.perm.admin",
+			Classification: RouteHubAdmin,
+			Permission:     "hub.settings.read",
+			Resource:       "hub",
+			Action:         "read",
+		}
+		handler := srv.routeGuard(meta, okHandler)
+
+		admin := NewAuthenticatedUser(tid("admin-rg"), "admin-rg@test.com", "Admin", "admin", "api")
+		req := httptest.NewRequest(http.MethodGet, "/test/perm-admin", nil)
+		req = req.WithContext(contextWithIdentity(ctx, admin))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("super-admin with permission-based route: got %d, want 200; body: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("permission_set_member_denied", func(t *testing.T) {
+		meta := RouteMetadata{
+			Pattern:        "/test/perm-member",
+			RouteID:        "test.perm.member",
+			Classification: RouteHubAdmin,
+			Permission:     "hub.settings.read",
+			Resource:       "hub",
+			Action:         "read",
+		}
+		handler := srv.routeGuard(meta, okHandler)
+
+		member := NewAuthenticatedUser(tid("member-rg"), "member-rg@test.com", "Member", "member", "api")
+		req := httptest.NewRequest(http.MethodGet, "/test/perm-member", nil)
+		req = req.WithContext(contextWithIdentity(ctx, member))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("member with permission-based route: got %d, want 403; body: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("permission_set_hub_admin_allowed", func(t *testing.T) {
+		// This validates the D4 second-path: a non-super-admin user with the
+		// right permission through role bindings IS allowed.
+		meta := RouteMetadata{
+			Pattern:        "/test/perm-hubadmin",
+			RouteID:        "test.perm.hubadmin",
+			Classification: RouteHubAdmin,
+			Permission:     "hub.settings.read",
+			Resource:       "hub",
+			Action:         "read",
+		}
+		handler := srv.routeGuard(meta, okHandler)
+
+		hubAdmin := NewAuthenticatedUser(tid("hub-admin-rg"), "hub-admin-rg@test.com", "Hub Admin", "member", "api")
+		req := httptest.NewRequest(http.MethodGet, "/test/perm-hubadmin", nil)
+		req = req.WithContext(contextWithIdentity(ctx, hubAdmin))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("hub-admin with permission-based route: got %d, want 200; body: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("permission_set_hub_admin_denied_superadmin_only_perm", func(t *testing.T) {
+		// Hub-admin should be denied for permissions excluded from the hub-admin role.
+		meta := RouteMetadata{
+			Pattern:        "/test/perm-hubadmin-denied",
+			RouteID:        "test.perm.hubadmin.denied",
+			Classification: RouteHubAdmin,
+			Permission:     "hub.maintenance.execute",
+			Resource:       "hub",
+			Action:         "execute",
+		}
+		handler := srv.routeGuard(meta, okHandler)
+
+		hubAdmin := NewAuthenticatedUser(tid("hub-admin-rg"), "hub-admin-rg@test.com", "Hub Admin", "member", "api")
+		req := httptest.NewRequest(http.MethodPost, "/test/perm-hubadmin-denied", nil)
+		req = req.WithContext(contextWithIdentity(ctx, hubAdmin))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("hub-admin with super-admin-only permission: got %d, want 403; body: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("permission_set_unauthenticated_denied", func(t *testing.T) {
+		meta := RouteMetadata{
+			Pattern:        "/test/perm-unauth",
+			RouteID:        "test.perm.unauth",
+			Classification: RouteHubAdmin,
+			Permission:     "hub.settings.read",
+			Resource:       "hub",
+			Action:         "read",
+		}
+		handler := srv.routeGuard(meta, okHandler)
+
+		req := httptest.NewRequest(http.MethodGet, "/test/perm-unauth", nil)
+		req = req.WithContext(ctx)
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("unauthenticated with permission-based route: got %d, want 401; body: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("no_permission_fallback_admin_allowed", func(t *testing.T) {
+		// When no Permission is set, the guard falls back to requireAdmin.
+		meta := RouteMetadata{
+			Pattern:        "/test/no-perm-admin",
+			RouteID:        "test.noperm.admin",
+			Classification: RouteHubAdmin,
+			// No Permission, Resource, Action set
+		}
+		handler := srv.routeGuard(meta, okHandler)
+
+		admin := NewAuthenticatedUser(tid("admin-rg"), "admin-rg@test.com", "Admin", "admin", "api")
+		req := httptest.NewRequest(http.MethodGet, "/test/no-perm-admin", nil)
+		req = req.WithContext(contextWithIdentity(ctx, admin))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("admin with requireAdmin fallback: got %d, want 200; body: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("no_permission_fallback_member_denied", func(t *testing.T) {
+		meta := RouteMetadata{
+			Pattern:        "/test/no-perm-member",
+			RouteID:        "test.noperm.member",
+			Classification: RouteHubAdmin,
+		}
+		handler := srv.routeGuard(meta, okHandler)
+
+		member := NewAuthenticatedUser(tid("member-rg"), "member-rg@test.com", "Member", "member", "api")
+		req := httptest.NewRequest(http.MethodGet, "/test/no-perm-member", nil)
+		req = req.WithContext(contextWithIdentity(ctx, member))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("member with requireAdmin fallback: got %d, want 403; body: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("no_permission_fallback_hub_admin_denied", func(t *testing.T) {
+		// With the requireAdmin fallback, even hub-admin is denied because
+		// requireAdmin checks IsUnscopedLocalPlatformAdmin (role == "admin").
+		// This demonstrates the behavioral difference between the old and new paths.
+		meta := RouteMetadata{
+			Pattern:        "/test/no-perm-hubadmin",
+			RouteID:        "test.noperm.hubadmin",
+			Classification: RouteHubAdmin,
+		}
+		handler := srv.routeGuard(meta, okHandler)
+
+		hubAdmin := NewAuthenticatedUser(tid("hub-admin-rg"), "hub-admin-rg@test.com", "Hub Admin", "member", "api")
+		req := httptest.NewRequest(http.MethodGet, "/test/no-perm-hubadmin", nil)
+		req = req.WithContext(contextWithIdentity(ctx, hubAdmin))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("hub-admin with requireAdmin fallback: got %d, want 403; body: %s", rr.Code, rr.Body.String())
+		}
+	})
+}

--- a/pkg/hub/seed.go
+++ b/pkg/hub/seed.go
@@ -421,6 +421,7 @@ func seedDevUser(ctx context.Context, s store.Store, cfg DevUserConfig) {
 // already exist. It is called once during Hub initialization and is idempotent.
 func seedRoleDefinitions(ctx context.Context, s store.Store) {
 	allPermIDs := allPermissionIDs()
+	hubAdminPermIDs := hubAdminPermissionIDs()
 	readListPermIDs := permissionIDsByActions("read", "list")
 	readOnlyPermIDs := permissionIDsByActions("read")
 
@@ -441,6 +442,7 @@ func seedRoleDefinitions(ctx context.Context, s store.Store) {
 		permissions []string
 	}{
 		{store.SystemRoleSuperAdmin, "Full platform administrator with all permissions", store.RoleScopeSystem, allPermIDs},
+		{store.SystemRoleHubAdmin, "Hub administrator with scopeable admin permissions", store.RoleScopeSystem, hubAdminPermIDs},
 		{store.SystemRoleHubMember, "Hub member with read access and project creation", store.RoleScopeSystem, readListPermIDs},
 		{store.SystemRoleHubViewer, "Hub viewer with read-only access", store.RoleScopeSystem, readOnlyPermIDs},
 		{store.ProjectRoleOwner, "Project owner with full project permissions", store.RoleScopeProject, projectAllPermIDs},
@@ -486,6 +488,73 @@ func allPermissionIDs() []string {
 	ids := make([]string, len(permissions.Registry))
 	for i, p := range permissions.Registry {
 		ids[i] = p.ID
+	}
+	return ids
+}
+
+// hubAdminPermissionIDs returns the curated permission set for the hub-admin
+// role. This is a subset of all permissions — it excludes super-admin-only
+// operations (maintenance, auth reset, diagnostics, admin mode, policies,
+// user suspend/promote) and non-route internal permissions.
+func hubAdminPermissionIDs() []string {
+	// Explicit set of permission IDs included in the hub-admin role.
+	// This set is a product decision; changes require architect or sponsor review.
+	included := map[string]bool{
+		// User management (not suspend/promote — those remain super-admin-only)
+		"user.read":   true,
+		"user.list":   true,
+		"user.update": true,
+		"user.invite": true,
+		// Group management
+		"group.read":         true,
+		"group.list":         true,
+		"group.create":       true,
+		"group.update":       true,
+		"group.delete":       true,
+		"group.addMember":    true,
+		"group.removeMember": true,
+		// Hub settings (read + update, but not maintenance/reset)
+		"hub.settings.read":           true,
+		"hub.settings.update":         true,
+		"hub.config.read":             true,
+		"hub.config.update":           true,
+		"hub.health.read":             true,
+		"hub.integrations.read":       true,
+		"hub.integrations.update":     true,
+		"hub.lifecycle_hooks.read":    true,
+		"hub.lifecycle_hooks.update":  true,
+		"hub.allow_list.read":         true,
+		"hub.allow_list.update":       true,
+		"hub.project_defaults.read":   true,
+		"hub.project_defaults.update": true,
+		"hub.scheduler.read":          true,
+		"hub.scheduler.update":        true,
+		"hub.federation.read":         true,
+		"hub.federation.update":       true,
+		"hub.teams_manifest.read":     true,
+		"hub.teams_manifest.update":   true,
+		"hub.github_app.read":         true,
+		"hub.github_app.update":       true,
+		"hub.metrics.read":            true,
+		"hub.validate.execute":        true,
+		// Project oversight
+		"project.read":   true,
+		"project.list":   true,
+		"project.update": true,
+		// Skill registries
+		"skill.read":     true,
+		"skill.list":     true,
+		"skill.create":   true,
+		"skill.update":   true,
+		"skill.delete":   true,
+		"skill.register": true,
+	}
+
+	var ids []string
+	for _, p := range permissions.Registry {
+		if included[p.ID] {
+			ids = append(ids, p.ID)
+		}
 	}
 	return ids
 }

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -2383,6 +2383,7 @@ const (
 // System role names
 const (
 	SystemRoleSuperAdmin = "super-admin"
+	SystemRoleHubAdmin   = "hub-admin"
 	SystemRoleHubMember  = "hub-member"
 	SystemRoleHubViewer  = "hub-viewer"
 )

--- a/web/src/components/shared/token-list.ts
+++ b/web/src/components/shared/token-list.ts
@@ -44,19 +44,28 @@ interface AccessToken {
 }
 
 const AVAILABLE_SCOPES = [
-  { value: 'project:read', label: 'project:read', description: 'Read project metadata' },
-  { value: 'project:update', label: 'project:update', description: 'Update projects' },
-  { value: 'agent:read', label: 'agent:read', description: 'Read agent status/metadata' },
-  { value: 'agent:list', label: 'agent:list', description: 'List agents in the project' },
+  { value: 'agent:attach', label: 'agent:attach', description: 'Attach to agent sessions' },
   { value: 'agent:create', label: 'agent:create', description: 'Create agents' },
   { value: 'agent:delete', label: 'agent:delete', description: 'Delete agents' },
-  { value: 'agent:attach', label: 'agent:attach', description: 'Attach to agent sessions' },
-  { value: 'agent:port_access', label: 'agent:port_access', description: 'Access forwarded ports' },
+  { value: 'agent:list', label: 'agent:list', description: 'List agents in the project' },
   {
     value: 'agent:manage',
     label: 'agent:manage',
     description: 'All agent actions (convenience alias)',
   },
+  { value: 'agent:port_access', label: 'agent:port_access', description: 'Access forwarded ports' },
+  { value: 'agent:read', label: 'agent:read', description: 'Read agent status/metadata' },
+  { value: 'hub:config:read', label: 'hub:config:read', description: 'Read server configuration' },
+  { value: 'hub:config:update', label: 'hub:config:update', description: 'Update server configuration' },
+  { value: 'hub:health:read', label: 'hub:health:read', description: 'Read health summary' },
+  { value: 'hub:integrations:read', label: 'hub:integrations:read', description: 'Read integrations' },
+  { value: 'hub:integrations:update', label: 'hub:integrations:update', description: 'Update integrations' },
+  { value: 'hub:settings:read', label: 'hub:settings:read', description: 'Read hub settings' },
+  { value: 'hub:settings:update', label: 'hub:settings:update', description: 'Update hub settings' },
+  { value: 'project:clone', label: 'project:clone', description: 'Clone projects' },
+  { value: 'project:read', label: 'project:read', description: 'Read project metadata' },
+  { value: 'project:update', label: 'project:update', description: 'Update projects' },
+  { value: 'user:invite', label: 'user:invite', description: 'Invite users' },
 ] as const;
 
 @customElement('scion-token-list')


### PR DESCRIPTION
## Summary
- 35 new admin permission IDs (28 hub + 7 extensions)
- routeGuard permission-based Decide path with requireAdmin fallback
- Role binding permission check in checkAccessForUser (D4 second-path)
- Hub-admin system role seeded with scopeable permission subset
- Bypass census regression test + 8 routeGuard tests