### PR TITLE
docs(design): record the gcloud release-track dependency the deploy p…

### DIFF
--- a/.design/hosted/cloud-run-single-node.md
+++ b/.design/hosted/cloud-run-single-node.md
@@ -211,6 +211,25 @@ Two related deploy-time consequences of the missing `K_SERVICE`:
 - The logging paths conclude "not on Cloud Run" and stand up their own Cloud Logging
   client, but an Instance's stdout is already captured. Likely duplicate ingestion.
 
+**The same principle governs the deploy path, for a different reason.** Creating the
+Instance requires the v1 `gcloud` surface, because v1 is what carries
+`sandboxLauncher`. That surface is not on every Cloud SDK. `gcloud beta run instances`
+is **absent at 575.0.0**, where the `instances` noun is alpha-only, and **present at
+582.0.0**. Versions 576–581 are unmeasured, so **this design states no version floor**.
+Writing one down would publish a number nobody has checked.
+
+Two consequences for tooling:
+
+- **Probe for the noun; do not compare version strings.** The deploy script must
+  refuse early with a message that names the missing command. A hardcoded floor would
+  reject working installations anywhere in the unmeasured range — a gate that rejects
+  a good install is worse than the error it replaces.
+- **`gcloud`'s own advice on failure is a wrong fix.** It suggests
+  `gcloud alpha run instances`. The alpha surface uses `create` rather than `deploy`
+  and has no `--sandbox-launcher`, so following it produces an Instance whose scion
+  server crashes on startup. The diagnostic has to say so, because the platform's
+  suggestion is actively misleading.
+
 ### 4.4 The runtime is named `cloudrun-sandbox`
 
 `cloudrun-instances` is taken by a real implementation of the opposite topology

--- a/.design/hosted/cloud-run-single-node.md
+++ b/.design/hosted/cloud-run-single-node.md
@@ -211,12 +211,15 @@ Two related deploy-time consequences of the missing `K_SERVICE`:
 - The logging paths conclude "not on Cloud Run" and stand up their own Cloud Logging
   client, but an Instance's stdout is already captured. Likely duplicate ingestion.
 
-**The same principle governs the deploy path, for a different reason.** Creating the
-Instance requires the v1 `gcloud` surface, because v1 is what carries
-`sandboxLauncher`. That surface is not on every Cloud SDK. `gcloud beta run instances`
-is **absent at 575.0.0**, where the `instances` noun is alpha-only, and **present at
-582.0.0**. Versions 576–581 are unmeasured, so **this design states no version floor**.
-Writing one down would publish a number nobody has checked.
+**The same principle governs the deploy path, for a different reason.** Creating this
+tier's Instance requires the `gcloud beta run instances` command, which speaks the v1
+API — the only surface that carries `sandboxLauncher`. The v2 API will happily create
+an Instance without it, so the constraint is not "v2 cannot create Instances"; it is
+that a `sandboxLauncher`-less Instance is a different artifact, and one whose scion
+server cannot start. That command is not on every Cloud SDK: it is **absent at
+575.0.0**, where the `instances` noun is alpha-only, and **present at 582.0.0**.
+Versions 576–581 are unmeasured, so **this design states no version floor**. Writing
+one down would publish a number nobody has checked.
 
 Two consequences for tooling:
 


### PR DESCRIPTION
…ath relies on

Section 4.3 already argues that runtime selection must probe for a capability rather than infer it from a product name. The deploy path has the same shape and the design never said so.

Creating the Instance needs the v1 gcloud surface, because v1 carries sandboxLauncher. That surface is absent at Cloud SDK 575.0.0 (the instances noun is alpha-only there) and present at 582.0.0. 576-581 is unmeasured, so no version floor is stated here - publishing an unchecked number is the failure this note exists to prevent.

Also records that gcloud's own suggestion on failure, 'try gcloud alpha run instances', is a wrong fix: alpha uses create rather than deploy and has no --sandbox-launcher, so following it yields an Instance whose server crashes on startup.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
