### PR TITLE
feat: Convert integrations and hooks admin handlers to permission checks (P2-A5)

### DIFF
--- a/.design/project-log/pf-p2a-integ-fix2.md
+++ b/.design/project-log/pf-p2a-integ-fix2.md
@@ -1,0 +1,41 @@
+# Project Log: pf-p2a-integ-fix2 — Consolidate inline Decide boilerplate
+
+**Date:** 2026-08-27
+**Branch:** `scion/pf-p2a-integ`
+**Agent:** dev-pf-p2a-integ-fix2
+
+## Summary
+
+Extracted a `requireWritePermission` Server helper method to consolidate
+three instances of identical inline authorization boilerplate across the
+integrations and lifecycle hooks handlers.
+
+## Changes
+
+### New file: `pkg/hub/authz_helpers.go`
+- Added `Server.requireWritePermission(w, r, permission) (UserIdentity, bool)`
+- Encapsulates: identity extraction, UserIdentity type assertion, Decide call
+  with hub resource + update action + given permission string
+- Returns the authenticated user alongside the bool so lifecycle hooks callers
+  can pass it to CRUD methods without re-extracting
+
+### Modified: `pkg/hub/handlers_integrations.go`
+- `handleAdminIntegrationByName`: replaced 18-line inline Decide block with
+  single `requireWritePermission` call for PUT/POST/DELETE methods
+
+### Modified: `pkg/hub/handlers_lifecycle_hooks.go`
+- `handleAdminLifecycleHooks` (POST case): replaced inline Decide block,
+  using returned `user` for `createLifecycleHook`
+- `handleAdminLifecycleHookByID` (PUT/DELETE case): replaced inline Decide
+  block, using returned `user` for `updateLifecycleHook`/`deleteLifecycleHook`
+
+### Fixed: `pkg/hub/handlers_integrations_test.go`
+- `TestUpdateConfig_NonHA_NeedsConfigFile`: added missing `authzService`
+  initialization (pre-existing nil-pointer bug — the test was panicking
+  before this change as well)
+
+## Verification
+
+- `make ci` passes
+- `go test ./pkg/hub/... -count=1` passes (all tests, non-cached)
+- Pure refactor: no behavioral change, existing tests validate correctness

--- a/.design/project-log/pf-p2a-integ.md
+++ b/.design/project-log/pf-p2a-integ.md
@@ -1,0 +1,80 @@
+# PR-A5: Integrations and Hooks Handler Conversion
+
+**Date:** 2026-08-27
+**Agent:** dev-pf-p2a-integ
+**Branch:** scion/pf-p2a-integ
+
+## Summary
+
+Converted 6 inline admin bypass sites across 4 handler files from
+`user.Role() != "admin"` checks to permission-based checks via route
+metadata and inline `Decide` calls. This is part of the D4 permission
+framework migration (Phase 2).
+
+## Changes
+
+### Route Metadata (`route_metadata.go`)
+
+Added Permission/Resource/Action fields to 5 route entries:
+
+| Pattern | Permission | Notes |
+|---------|-----------|-------|
+| `/api/v1/admin/integrations` | `hub.integrations.read` | GET only at guard |
+| `/api/v1/admin/integrations/teams/manifest` | `hub.teams_manifest.read` | GET only |
+| `/api/v1/admin/integrations/` | `hub.integrations.read` | GET at guard; PUT/POST/DELETE inline |
+| `/api/v1/admin/lifecycle-hooks` | `hub.lifecycle_hooks.read` | GET at guard; POST inline |
+| `/api/v1/admin/lifecycle-hooks/` | `hub.lifecycle_hooks.read` | GET at guard; PUT/DELETE inline |
+
+### Handler Conversions (6 bypass sites)
+
+1. **`handlers_integrations.go:handleAdminIntegrations`** -- Removed inline
+   admin check. Route guard handles read permission for GET.
+
+2. **`handlers_integrations.go:handleAdminIntegrationByName`** -- Removed
+   inline admin check. Added inline `Decide` for `hub.integrations.update`
+   on PUT/POST/DELETE methods.
+
+3. **`handlers_lifecycle_hooks.go:handleAdminLifecycleHooks`** -- Removed
+   inline admin check. Added inline `Decide` for
+   `hub.lifecycle_hooks.update` on POST method.
+
+4. **`handlers_lifecycle_hooks.go:handleAdminLifecycleHookByID`** -- Removed
+   inline admin check. Added inline `Decide` for
+   `hub.lifecycle_hooks.update` on PUT/DELETE methods.
+
+5. **`handlers_teams_manifest.go:handleTeamsManifestDownload`** -- Removed
+   inline admin check. Route guard handles read permission for GET.
+
+6. **`passthrough_gate.go:authorizePassthroughIdentity`** -- Replaced inline
+   `userIdent.Role() != "admin"` with `Decide` call for
+   `hub.integrations.update`. This preserves the compound check (admin OR
+   broker owner) while routing through the authorization pipeline.
+
+### Bypass Census (`bypass_census_test.go`)
+
+Removed 6 PR-A5 entries from the allowlist.
+
+### Tests
+
+- Added `TestIntegrationsHooksPermissionConversion` (27 sub-tests) covering:
+  - Route guard checks for all 5 route patterns (super-admin, hub-admin, member)
+  - Inline Decide checks for dual-method routes (read-only user denied writes)
+  - Unauthenticated requests denied
+- Updated existing auth tests in `handlers_integrations_test.go`,
+  `handlers_lifecycle_hooks_test.go`, and `handlers_teams_manifest_test.go`
+  to go through the route guard.
+- Updated `route_classification_test.go` to provide authzService for
+  scoped admin UAT rejection test.
+- Added `!no_sqlite` build tags to test files that now depend on `testServer`.
+
+### Test Files with Build Tag Changes
+
+- `handlers_integrations_test.go` -- added `!no_sqlite`
+- `handlers_integrations_activate_secrets_test.go` -- added `!no_sqlite`
+- `update_completion_test.go` -- added `!no_sqlite`
+- `handlers_teams_manifest_test.go` -- added `!no_sqlite`
+
+## Verification
+
+`make ci` passes (fmt-check, lint, compat-literals, check-authz-guards,
+test-fast, build).

--- a/pkg/hub/authz_helpers.go
+++ b/pkg/hub/authz_helpers.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import "net/http"
+
+// requireWritePermission checks that the authenticated user has the specified
+// permission on the hub resource with an "update" action. It writes an error
+// response and returns a zero UserIdentity + false if denied.
+// Returns the authenticated user and true if the caller should proceed.
+func (s *Server) requireWritePermission(w http.ResponseWriter, r *http.Request, permission string) (UserIdentity, bool) {
+	identity := GetIdentityFromContext(r.Context())
+	if identity == nil {
+		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "authentication required", nil)
+		return nil, false
+	}
+	user, ok := identity.(UserIdentity)
+	if !ok {
+		Forbidden(w)
+		return nil, false
+	}
+	decision := s.authzService.Decide(r.Context(), AuthzRequest{
+		Principal:  principalContextForIdentity(user),
+		Credential: credentialContextForIdentity(user),
+		Resource:   Resource{Type: "hub", ID: "hub"},
+		Action:     Action("update"),
+		Permission: permission,
+	})
+	if !decision.Allowed {
+		Forbidden(w)
+		return nil, false
+	}
+	return user, true
+}

--- a/pkg/hub/bypass_census_test.go
+++ b/pkg/hub/bypass_census_test.go
@@ -92,14 +92,6 @@ func TestBypassCensus(t *testing.T) {
 		// The AdminModeMiddleware bypass at admin_mode.go:113 remains as infrastructure.
 		{file: "admin_mode.go", lineSubstr: "IsUnscopedLocalPlatformAdmin(user)", description: "AdminModeMiddleware admin bypass (infrastructure, KEEP)"},
 
-		// Integrations and hooks (PR-A5)
-		{file: "handlers_integrations.go", lineSubstr: `user.Role() != "admin"`, description: "update integration (PR-A5)"},
-		{file: "handlers_integrations.go", lineSubstr: `user.Role() != "admin"`, description: "delete integration (PR-A5)"},
-		{file: "handlers_lifecycle_hooks.go", lineSubstr: `user.Role() != "admin"`, description: "create lifecycle hook (PR-A5)"},
-		{file: "handlers_lifecycle_hooks.go", lineSubstr: `user.Role() != "admin"`, description: "update lifecycle hook (PR-A5)"},
-		{file: "handlers_teams_manifest.go", lineSubstr: `user.Role() != "admin"`, description: "teams manifest (PR-A5)"},
-		{file: "passthrough_gate.go", lineSubstr: `userIdent.Role() != "admin"`, description: "passthrough gate (PR-A5)"},
-
 		// Resource handlers with existing types (PR-A6)
 		{file: "handlers_policies.go", lineSubstr: "requireAdmin(w, r)", description: "create policy (PR-A6)"},
 		{file: "handlers_policies.go", lineSubstr: "requireAdmin(w, r)", description: "update policy (PR-A6)"},

--- a/pkg/hub/handlers_integ_hooks_authz_test.go
+++ b/pkg/hub/handlers_integ_hooks_authz_test.go
@@ -1,0 +1,338 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// TestIntegrationsHooksPermissionConversion verifies the PR-A5 permission-based
+// conversion for integrations and lifecycle hooks routes:
+//  1. Super-admin is allowed for all converted endpoints.
+//  2. Hub-admin with correct permission is allowed.
+//  3. Hub-admin with read-only permission can GET but not PUT/DELETE (dual-method routes).
+//  4. Regular member is denied for all.
+func TestIntegrationsHooksPermissionConversion(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	seedRoleDefinitions(ctx, s)
+
+	adminUser := &store.User{
+		ID: tid("admin-ih"), Email: "admin-ih@test.com", DisplayName: "Admin",
+		Role: "admin", Status: "active",
+	}
+	memberUser := &store.User{
+		ID: tid("member-ih"), Email: "member-ih@test.com", DisplayName: "Member",
+		Role: "member", Status: "active",
+	}
+	hubAdminUser := &store.User{
+		ID: tid("hub-admin-ih"), Email: "hub-admin-ih@test.com", DisplayName: "Hub Admin",
+		Role: "member", Status: "active",
+	}
+	for _, u := range []*store.User{adminUser, memberUser, hubAdminUser} {
+		if err := s.CreateUser(ctx, u); err != nil {
+			t.Fatalf("create user %s: %v", u.Email, err)
+		}
+	}
+
+	// Grant hub-admin role binding.
+	hubAdminRD, err := s.GetRoleDefinitionByName(ctx, store.SystemRoleHubAdmin, store.RoleScopeSystem)
+	if err != nil {
+		t.Fatalf("get hub-admin role definition: %v", err)
+	}
+	_, err = s.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: hubAdminRD.ID,
+		PrincipalType:    "user",
+		PrincipalID:      hubAdminUser.ID,
+		ScopeType:        store.RoleScopeSystem,
+	})
+	if err != nil {
+		t.Fatalf("create hub-admin role binding: %v", err)
+	}
+
+	okHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+
+	adminIdent := NewAuthenticatedUser(tid("admin-ih"), "admin-ih@test.com", "Admin", "admin", "api")
+	memberIdent := NewAuthenticatedUser(tid("member-ih"), "member-ih@test.com", "Member", "member", "api")
+	hubAdminIdent := NewAuthenticatedUser(tid("hub-admin-ih"), "hub-admin-ih@test.com", "Hub Admin", "member", "api")
+
+	// -----------------------------------------------------------------------
+	// Route guard tests: these test the routeGuard metadata entries directly.
+	// -----------------------------------------------------------------------
+
+	routeGuardTests := []struct {
+		name       string
+		pattern    string
+		method     string
+		identity   Identity
+		wantStatus int
+	}{
+		// /api/v1/admin/integrations — hub.integrations.read
+		{"integrations_GET_super_admin", "/api/v1/admin/integrations", http.MethodGet, adminIdent, http.StatusOK},
+		{"integrations_GET_hub_admin", "/api/v1/admin/integrations", http.MethodGet, hubAdminIdent, http.StatusOK},
+		{"integrations_GET_member_denied", "/api/v1/admin/integrations", http.MethodGet, memberIdent, http.StatusForbidden},
+
+		// /api/v1/admin/integrations/teams/manifest — hub.teams_manifest.read
+		{"teams_manifest_GET_super_admin", "/api/v1/admin/integrations/teams/manifest", http.MethodGet, adminIdent, http.StatusOK},
+		{"teams_manifest_GET_hub_admin", "/api/v1/admin/integrations/teams/manifest", http.MethodGet, hubAdminIdent, http.StatusOK},
+		{"teams_manifest_GET_member_denied", "/api/v1/admin/integrations/teams/manifest", http.MethodGet, memberIdent, http.StatusForbidden},
+
+		// /api/v1/admin/integrations/ — hub.integrations.read (route guard)
+		{"integration_byname_GET_super_admin", "/api/v1/admin/integrations/", http.MethodGet, adminIdent, http.StatusOK},
+		{"integration_byname_GET_hub_admin", "/api/v1/admin/integrations/", http.MethodGet, hubAdminIdent, http.StatusOK},
+		{"integration_byname_GET_member_denied", "/api/v1/admin/integrations/", http.MethodGet, memberIdent, http.StatusForbidden},
+
+		// /api/v1/admin/lifecycle-hooks — hub.lifecycle_hooks.read
+		{"lifecycle_hooks_GET_super_admin", "/api/v1/admin/lifecycle-hooks", http.MethodGet, adminIdent, http.StatusOK},
+		{"lifecycle_hooks_GET_hub_admin", "/api/v1/admin/lifecycle-hooks", http.MethodGet, hubAdminIdent, http.StatusOK},
+		{"lifecycle_hooks_GET_member_denied", "/api/v1/admin/lifecycle-hooks", http.MethodGet, memberIdent, http.StatusForbidden},
+
+		// /api/v1/admin/lifecycle-hooks/ — hub.lifecycle_hooks.read
+		{"lifecycle_hook_byid_GET_super_admin", "/api/v1/admin/lifecycle-hooks/", http.MethodGet, adminIdent, http.StatusOK},
+		{"lifecycle_hook_byid_GET_hub_admin", "/api/v1/admin/lifecycle-hooks/", http.MethodGet, hubAdminIdent, http.StatusOK},
+		{"lifecycle_hook_byid_GET_member_denied", "/api/v1/admin/lifecycle-hooks/", http.MethodGet, memberIdent, http.StatusForbidden},
+
+		// Unauthenticated
+		{"integrations_GET_unauth", "/api/v1/admin/integrations", http.MethodGet, nil, http.StatusUnauthorized},
+		{"lifecycle_hooks_GET_unauth", "/api/v1/admin/lifecycle-hooks", http.MethodGet, nil, http.StatusUnauthorized},
+	}
+
+	for _, tc := range routeGuardTests {
+		t.Run("routeGuard/"+tc.name, func(t *testing.T) {
+			meta, ok := routeMetadataTable[tc.pattern]
+			if !ok {
+				t.Fatalf("no route metadata for pattern %q", tc.pattern)
+			}
+			handler := srv.routeGuard(meta, okHandler)
+
+			req := httptest.NewRequest(tc.method, tc.pattern, nil)
+			reqCtx := ctx
+			if tc.identity != nil {
+				reqCtx = contextWithIdentity(ctx, tc.identity)
+			}
+			req = req.WithContext(reqCtx)
+			rr := httptest.NewRecorder()
+			handler(rr, req)
+
+			if rr.Code != tc.wantStatus {
+				t.Errorf("got %d, want %d; body: %s", rr.Code, tc.wantStatus, rr.Body.String())
+			}
+		})
+	}
+
+	// -----------------------------------------------------------------------
+	// Inline Decide tests: for dual-method routes, test that the handler-level
+	// inline Decide blocks write operations for read-only users.
+	// -----------------------------------------------------------------------
+
+	// Create a custom role with only read permissions (no update).
+	readOnlyPerms := []string{
+		"hub.integrations.read",
+		"hub.lifecycle_hooks.read",
+		"hub.teams_manifest.read",
+	}
+	readOnlyRD, err := s.CreateRoleDefinition(ctx, &store.RoleDefinition{
+		Name:        "integ-read-only",
+		Description: "Read-only access to integrations/hooks",
+		ScopeType:   store.RoleScopeSystem,
+		Permissions: readOnlyPerms,
+	})
+	if err != nil {
+		t.Fatalf("create read-only role def: %v", err)
+	}
+
+	readOnlyUser := &store.User{
+		ID: tid("readonly-ih"), Email: "readonly-ih@test.com", DisplayName: "ReadOnly",
+		Role: "member", Status: "active",
+	}
+	if err := s.CreateUser(ctx, readOnlyUser); err != nil {
+		t.Fatalf("create read-only user: %v", err)
+	}
+	_, err = s.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: readOnlyRD.ID,
+		PrincipalType:    "user",
+		PrincipalID:      readOnlyUser.ID,
+		ScopeType:        store.RoleScopeSystem,
+	})
+	if err != nil {
+		t.Fatalf("create read-only role binding: %v", err)
+	}
+
+	readOnlyIdent := NewAuthenticatedUser(tid("readonly-ih"), "readonly-ih@test.com", "ReadOnly", "member", "api")
+
+	// Test inline Decide in handleAdminIntegrationByName: read-only user can
+	// GET through the route guard but is blocked for PUT/POST/DELETE by inline Decide.
+	t.Run("inline/integration_byname_PUT_readonly_denied", func(t *testing.T) {
+		meta := routeMetadataTable["/api/v1/admin/integrations/"]
+		// Wrap the actual handler — it uses inline Decide for writes.
+		handler := srv.routeGuard(meta, srv.handleAdminIntegrationByName)
+
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/integrations/test-plugin/config", nil)
+		req = req.WithContext(contextWithIdentity(ctx, readOnlyIdent))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("read-only user PUT integration: got %d, want 403; body: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("inline/integration_byname_POST_readonly_denied", func(t *testing.T) {
+		meta := routeMetadataTable["/api/v1/admin/integrations/"]
+		handler := srv.routeGuard(meta, srv.handleAdminIntegrationByName)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations/test-plugin/update", nil)
+		req = req.WithContext(contextWithIdentity(ctx, readOnlyIdent))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("read-only user POST integration: got %d, want 403; body: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("inline/integration_byname_DELETE_readonly_denied", func(t *testing.T) {
+		meta := routeMetadataTable["/api/v1/admin/integrations/"]
+		handler := srv.routeGuard(meta, srv.handleAdminIntegrationByName)
+
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/integrations/test-plugin", nil)
+		req = req.WithContext(contextWithIdentity(ctx, readOnlyIdent))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("read-only user DELETE integration: got %d, want 403; body: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	// Verify super-admin can PUT through the inline Decide.
+	t.Run("inline/integration_byname_PUT_super_admin_allowed", func(t *testing.T) {
+		meta := routeMetadataTable["/api/v1/admin/integrations/"]
+		handler := srv.routeGuard(meta, srv.handleAdminIntegrationByName)
+
+		// PUT to a non-existent plugin — we expect it to pass the authz check
+		// and reach the handler logic (likely returning 404 for the missing plugin).
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/integrations/nonexistent/config", nil)
+		req = req.WithContext(contextWithIdentity(ctx, adminIdent))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		// The handler should NOT return 403 — it passed the permission check.
+		if rr.Code == http.StatusForbidden {
+			t.Errorf("super-admin PUT integration: got 403 unexpectedly; body: %s", rr.Body.String())
+		}
+	})
+
+	// Test inline Decide in handleAdminLifecycleHooks: read-only user blocked for POST.
+	t.Run("inline/lifecycle_hooks_POST_readonly_denied", func(t *testing.T) {
+		meta := routeMetadataTable["/api/v1/admin/lifecycle-hooks"]
+		handler := srv.routeGuard(meta, srv.handleAdminLifecycleHooks)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/lifecycle-hooks", nil)
+		req = req.WithContext(contextWithIdentity(ctx, readOnlyIdent))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("read-only user POST lifecycle hook: got %d, want 403; body: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	// Test inline Decide in handleAdminLifecycleHookByID: read-only user blocked for PUT/DELETE.
+	t.Run("inline/lifecycle_hook_byid_PUT_readonly_denied", func(t *testing.T) {
+		meta := routeMetadataTable["/api/v1/admin/lifecycle-hooks/"]
+		handler := srv.routeGuard(meta, srv.handleAdminLifecycleHookByID)
+
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/lifecycle-hooks/some-id", nil)
+		req = req.WithContext(contextWithIdentity(ctx, readOnlyIdent))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("read-only user PUT lifecycle hook: got %d, want 403; body: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("inline/lifecycle_hook_byid_DELETE_readonly_denied", func(t *testing.T) {
+		meta := routeMetadataTable["/api/v1/admin/lifecycle-hooks/"]
+		handler := srv.routeGuard(meta, srv.handleAdminLifecycleHookByID)
+
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/lifecycle-hooks/some-id", nil)
+		req = req.WithContext(contextWithIdentity(ctx, readOnlyIdent))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("read-only user DELETE lifecycle hook: got %d, want 403; body: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	// Verify member (no permissions at all) is denied for write operations.
+	t.Run("inline/integration_byname_PUT_member_denied", func(t *testing.T) {
+		meta := routeMetadataTable["/api/v1/admin/integrations/"]
+		handler := srv.routeGuard(meta, srv.handleAdminIntegrationByName)
+
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/integrations/test-plugin/config", nil)
+		req = req.WithContext(contextWithIdentity(ctx, memberIdent))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		if rr.Code != http.StatusForbidden {
+			t.Errorf("member PUT integration: got %d, want 403; body: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	// Verify hub-admin (has update permissions) can PUT through inline Decide.
+	t.Run("inline/integration_byname_PUT_hub_admin_allowed", func(t *testing.T) {
+		meta := routeMetadataTable["/api/v1/admin/integrations/"]
+		handler := srv.routeGuard(meta, srv.handleAdminIntegrationByName)
+
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/integrations/nonexistent/config", nil)
+		req = req.WithContext(contextWithIdentity(ctx, hubAdminIdent))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		// Should pass authz (not 403). The handler will likely return 404
+		// or 405 for the nonexistent plugin — that's fine.
+		if rr.Code == http.StatusForbidden {
+			t.Errorf("hub-admin PUT integration: got 403 unexpectedly; body: %s", rr.Body.String())
+		}
+	})
+
+	t.Run("inline/lifecycle_hooks_POST_hub_admin_allowed", func(t *testing.T) {
+		meta := routeMetadataTable["/api/v1/admin/lifecycle-hooks"]
+		handler := srv.routeGuard(meta, srv.handleAdminLifecycleHooks)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/lifecycle-hooks", nil)
+		req = req.WithContext(contextWithIdentity(ctx, hubAdminIdent))
+		rr := httptest.NewRecorder()
+		handler(rr, req)
+
+		// Should pass authz. Will likely return 400 for invalid body — not 403.
+		if rr.Code == http.StatusForbidden {
+			t.Errorf("hub-admin POST lifecycle hook: got 403 unexpectedly; body: %s", rr.Body.String())
+		}
+	})
+}

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -219,18 +219,25 @@ func (s *Server) handleAdminIntegrationByName(w http.ResponseWriter, r *http.Req
 	switch r.Method {
 	case http.MethodPut, http.MethodPost, http.MethodDelete:
 		identity := GetIdentityFromContext(r.Context())
-		if user, ok := identity.(UserIdentity); ok {
-			decision := s.authzService.Decide(r.Context(), AuthzRequest{
-				Principal:  principalContextForIdentity(user),
-				Credential: credentialContextForIdentity(user),
-				Resource:   Resource{Type: "hub", ID: "hub"},
-				Action:     Action("update"),
-				Permission: "hub.integrations.update",
-			})
-			if !decision.Allowed {
-				Forbidden(w)
-				return
-			}
+		if identity == nil {
+			writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "authentication required", nil)
+			return
+		}
+		user, ok := identity.(UserIdentity)
+		if !ok {
+			Forbidden(w)
+			return
+		}
+		decision := s.authzService.Decide(r.Context(), AuthzRequest{
+			Principal:  principalContextForIdentity(user),
+			Credential: credentialContextForIdentity(user),
+			Resource:   Resource{Type: "hub", ID: "hub"},
+			Action:     Action("update"),
+			Permission: "hub.integrations.update",
+		})
+		if !decision.Allowed {
+			Forbidden(w)
+			return
 		}
 	}
 

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -218,25 +218,7 @@ func (s *Server) handleAdminIntegrationByName(w http.ResponseWriter, r *http.Req
 	// checks the read permission. Writes need hub.integrations.update.
 	switch r.Method {
 	case http.MethodPut, http.MethodPost, http.MethodDelete:
-		identity := GetIdentityFromContext(r.Context())
-		if identity == nil {
-			writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "authentication required", nil)
-			return
-		}
-		user, ok := identity.(UserIdentity)
-		if !ok {
-			Forbidden(w)
-			return
-		}
-		decision := s.authzService.Decide(r.Context(), AuthzRequest{
-			Principal:  principalContextForIdentity(user),
-			Credential: credentialContextForIdentity(user),
-			Resource:   Resource{Type: "hub", ID: "hub"},
-			Action:     Action("update"),
-			Permission: "hub.integrations.update",
-		})
-		if !decision.Allowed {
-			Forbidden(w)
+		if _, ok := s.requireWritePermission(w, r, "hub.integrations.update"); !ok {
 			return
 		}
 	}

--- a/pkg/hub/handlers_integrations.go
+++ b/pkg/hub/handlers_integrations.go
@@ -199,13 +199,8 @@ var pluginBuildMu sync.Map
 // --- Route dispatchers ---
 
 // handleAdminIntegrations dispatches GET /api/v1/admin/integrations.
+// Authorization: route guard checks hub.integrations.read for GET.
 func (s *Server) handleAdminIntegrations(w http.ResponseWriter, r *http.Request) {
-	user := GetUserIdentityFromContext(r.Context())
-	if user == nil || user.Role() != "admin" {
-		Forbidden(w)
-		return
-	}
-
 	switch r.Method {
 	case http.MethodGet:
 		s.handleListIntegrations(w, r)
@@ -216,11 +211,27 @@ func (s *Server) handleAdminIntegrations(w http.ResponseWriter, r *http.Request)
 
 // handleAdminIntegrationByName dispatches requests under
 // /api/v1/admin/integrations/{name}[/config|/restart|/health].
+// Authorization: route guard checks hub.integrations.read for GET.
+// Write operations (PUT/POST/DELETE) require hub.integrations.update via inline Decide.
 func (s *Server) handleAdminIntegrationByName(w http.ResponseWriter, r *http.Request) {
-	user := GetUserIdentityFromContext(r.Context())
-	if user == nil || user.Role() != "admin" {
-		Forbidden(w)
-		return
+	// Inline authorization for write operations — the route guard only
+	// checks the read permission. Writes need hub.integrations.update.
+	switch r.Method {
+	case http.MethodPut, http.MethodPost, http.MethodDelete:
+		identity := GetIdentityFromContext(r.Context())
+		if user, ok := identity.(UserIdentity); ok {
+			decision := s.authzService.Decide(r.Context(), AuthzRequest{
+				Principal:  principalContextForIdentity(user),
+				Credential: credentialContextForIdentity(user),
+				Resource:   Resource{Type: "hub", ID: "hub"},
+				Action:     Action("update"),
+				Permission: "hub.integrations.update",
+			})
+			if !decision.Allowed {
+				Forbidden(w)
+				return
+			}
+		}
 	}
 
 	// Parse: /api/v1/admin/integrations/{name}[/{action}[/{sub}]]

--- a/pkg/hub/handlers_integrations_activate_secrets_test.go
+++ b/pkg/hub/handlers_integrations_activate_secrets_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_sqlite
+
 package hub
 
 import (

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -1793,7 +1793,7 @@ func TestUpdateConfig_NonHA_NeedsConfigFile(t *testing.T) {
 	mgr.plugins["telegram"] = map[string]string{}
 	// selfManaged is false → non-HA path
 
-	srv := &Server{dbDriver: "postgres"}
+	srv := &Server{dbDriver: "postgres", authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")

--- a/pkg/hub/handlers_integrations_test.go
+++ b/pkg/hub/handlers_integrations_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_sqlite
+
 package hub
 
 import (
@@ -30,6 +32,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/integrationupdate"
 	"github.com/GoogleCloudPlatform/scion/pkg/eventbus"
 	"github.com/GoogleCloudPlatform/scion/pkg/plugin"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/store/enttest"
 	"github.com/google/uuid"
 )
@@ -210,24 +213,41 @@ func (m *mockIntegrationManager) GetGRPCBrokerAdapter(name string) plugin.GRPCBr
 
 // --- Auth tests ---
 
-func TestIntegrations_Unauthenticated(t *testing.T) {
-	srv := &Server{}
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations", nil)
-	rr := httptest.NewRecorder()
-	srv.handleAdminIntegrations(rr, req)
+// Auth tests for integrations endpoints.
+//
+// Authorization for these routes moved from inline handler checks to the
+// route guard (PR-A5 permission conversion). The guard is tested in
+// TestIntegrationsHooksPermissionConversion. The tests below verify the
+// guard wiring by calling guarded() so the route metadata is applied.
 
-	if rr.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d", rr.Code)
+func TestIntegrations_Unauthenticated(t *testing.T) {
+	srv, _ := testServer(t)
+	ctx := context.Background()
+	handler := srv.guarded("/api/v1/admin/integrations", srv.handleAdminIntegrations)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations", nil)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
 	}
 }
 
 func TestIntegrations_NonAdmin(t *testing.T) {
-	srv := &Server{}
-	member := NewAuthenticatedUser("u1", "member@example.com", "Member", "member", "cli")
+	srv, s := testServer(t)
+	ctx := context.Background()
+	seedRoleDefinitions(ctx, s)
+	memberU := &store.User{ID: tid("integ-member"), Email: "member@example.com", DisplayName: "Member", Role: "member", Status: "active"}
+	if err := s.CreateUser(ctx, memberU); err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	handler := srv.guarded("/api/v1/admin/integrations", srv.handleAdminIntegrations)
+	member := NewAuthenticatedUser(tid("integ-member"), "member@example.com", "Member", "member", "cli")
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations", nil)
-	req = req.WithContext(contextWithIdentity(req.Context(), member))
+	req = req.WithContext(contextWithIdentity(ctx, member))
 	rr := httptest.NewRecorder()
-	srv.handleAdminIntegrations(rr, req)
+	handler(rr, req)
 
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", rr.Code)
@@ -235,23 +255,33 @@ func TestIntegrations_NonAdmin(t *testing.T) {
 }
 
 func TestIntegrationByName_Unauthenticated(t *testing.T) {
-	srv := &Server{}
+	srv, _ := testServer(t)
+	ctx := context.Background()
+	handler := srv.guarded("/api/v1/admin/integrations/", srv.handleAdminIntegrationByName)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/telegram", nil)
+	req = req.WithContext(ctx)
 	rr := httptest.NewRecorder()
-	srv.handleAdminIntegrationByName(rr, req)
+	handler(rr, req)
 
-	if rr.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d", rr.Code)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
 	}
 }
 
 func TestIntegrationByName_NonAdmin(t *testing.T) {
-	srv := &Server{}
-	member := NewAuthenticatedUser("u1", "member@example.com", "Member", "member", "cli")
+	srv, s := testServer(t)
+	ctx := context.Background()
+	seedRoleDefinitions(ctx, s)
+	memberU := &store.User{ID: tid("integ-member2"), Email: "member2@example.com", DisplayName: "Member2", Role: "member", Status: "active"}
+	if err := s.CreateUser(ctx, memberU); err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	handler := srv.guarded("/api/v1/admin/integrations/", srv.handleAdminIntegrationByName)
+	member := NewAuthenticatedUser(tid("integ-member2"), "member2@example.com", "Member2", "member", "cli")
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/telegram", nil)
-	req = req.WithContext(contextWithIdentity(req.Context(), member))
+	req = req.WithContext(contextWithIdentity(ctx, member))
 	rr := httptest.NewRecorder()
-	srv.handleAdminIntegrationByName(rr, req)
+	handler(rr, req)
 
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", rr.Code)
@@ -261,7 +291,7 @@ func TestIntegrationByName_NonAdmin(t *testing.T) {
 // --- List endpoint ---
 
 func TestListIntegrations_Empty(t *testing.T) {
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations", nil)
 	req = req.WithContext(contextWithIdentity(req.Context(), admin))
@@ -287,7 +317,7 @@ func TestListIntegrations_WithPlugins(t *testing.T) {
 	mgr.plugins["discord"] = map[string]string{"guild_id": "12345"}
 	mgr.selfManaged["discord"] = true
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -337,7 +367,7 @@ func TestListIntegrations_WithPlugins(t *testing.T) {
 }
 
 func TestListIntegrations_MethodNotAllowed(t *testing.T) {
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations", nil)
 	req = req.WithContext(contextWithIdentity(req.Context(), admin))
@@ -353,7 +383,7 @@ func TestListIntegrations_MethodNotAllowed(t *testing.T) {
 
 func TestGetIntegration_NotFound(t *testing.T) {
 	mgr := newMockIntegrationManager()
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -375,7 +405,7 @@ func TestGetIntegration_OK(t *testing.T) {
 		"bot_token":      "should-be-filtered",
 	}
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -414,19 +444,25 @@ func TestGetIntegration_OK(t *testing.T) {
 }
 
 func TestGetIntegration_MethodNotAllowed(t *testing.T) {
-	mgr := newMockIntegrationManager()
-	mgr.plugins["telegram"] = map[string]string{}
-	srv := &Server{}
-	srv.pluginManager = mgr
+	srv, s := testServer(t)
+	ctx := context.Background()
+	seedRoleDefinitions(ctx, s)
+	adminU := &store.User{ID: tid("integ-admin-ma"), Email: "admin-ma@example.com", DisplayName: "Admin", Role: "admin", Status: "active"}
+	if err := s.CreateUser(ctx, adminU); err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
 
-	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
+	admin := NewAuthenticatedUser(tid("integ-admin-ma"), "admin-ma@example.com", "Admin", "admin", "cli")
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/integrations/telegram", nil)
-	req = req.WithContext(contextWithIdentity(req.Context(), admin))
+	req = req.WithContext(contextWithIdentity(ctx, admin))
 	rr := httptest.NewRecorder()
 	srv.handleAdminIntegrationByName(rr, req)
 
+	// DELETE on a name with no action path (e.g. /integrations/telegram) is
+	// not a supported endpoint. The handler returns 404 "integration endpoint"
+	// via the default case after the empty-action GET-only check.
 	if rr.Code != http.StatusMethodNotAllowed {
-		t.Fatalf("expected 405, got %d", rr.Code)
+		t.Fatalf("expected 405, got %d; body: %s", rr.Code, rr.Body.String())
 	}
 }
 
@@ -436,7 +472,7 @@ func TestIntegrationHealth_OK(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.plugins["telegram"] = map[string]string{}
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -466,7 +502,7 @@ func TestIntegrationHealth_OK(t *testing.T) {
 
 func TestIntegrationHealth_NotFound(t *testing.T) {
 	mgr := newMockIntegrationManager()
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -486,7 +522,7 @@ func TestRestartIntegration_OK(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.plugins["telegram"] = map[string]string{}
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -518,7 +554,7 @@ func TestRestartIntegration_WithSpokeWired(t *testing.T) {
 
 	proxy := NewMessageBrokerProxy(fanout, nil, nil, nil, slog.Default())
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 	srv.SetMessageBrokerProxy(proxy)
 
@@ -557,7 +593,7 @@ func TestRestartIntegration_WithoutSpokeWired(t *testing.T) {
 
 	proxy := NewMessageBrokerProxy(fanout, nil, nil, nil, slog.Default())
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 	srv.SetMessageBrokerProxy(proxy)
 
@@ -590,7 +626,7 @@ func TestRestartIntegration_WithoutSpokeWired(t *testing.T) {
 }
 
 func TestValidateIntegrationWiring_NoProxy(t *testing.T) {
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	warnings := srv.validateIntegrationWiring("discord")
 	if len(warnings) != 1 {
 		t.Fatalf("expected 1 warning, got %d", len(warnings))
@@ -616,7 +652,7 @@ func TestEnsureBrokerSpoke_AddsWhenMissing(t *testing.T) {
 	}, slog.Default())
 
 	proxy := NewMessageBrokerProxy(fanout, nil, nil, nil, slog.Default())
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 	srv.SetMessageBrokerProxy(proxy)
 
@@ -647,7 +683,7 @@ func TestEnsureBrokerSpoke_NoopWhenAlreadyPresent(t *testing.T) {
 	}, slog.Default())
 
 	proxy := NewMessageBrokerProxy(fanout, nil, nil, nil, slog.Default())
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 	srv.SetMessageBrokerProxy(proxy)
 
@@ -663,7 +699,7 @@ func TestEnsureBrokerSpoke_NoProxyIsNoop(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.plugins["discord"] = map[string]string{}
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 	// No proxy set — should not panic.
 	srv.ensureBrokerSpoke(mgr, "discord")
@@ -671,7 +707,7 @@ func TestEnsureBrokerSpoke_NoProxyIsNoop(t *testing.T) {
 
 func TestRestartIntegration_NotFound(t *testing.T) {
 	mgr := newMockIntegrationManager()
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -688,7 +724,7 @@ func TestRestartIntegration_NotFound(t *testing.T) {
 func TestRestartIntegration_MethodNotAllowed(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.plugins["telegram"] = map[string]string{}
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -829,7 +865,7 @@ func TestUpdateConfig_NoConfigFile(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.plugins["telegram"] = map[string]string{}
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -854,7 +890,7 @@ func TestUpdateConfig_WithConfigFile(t *testing.T) {
 		"webhook_listen": ":9094",
 	}
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -890,7 +926,7 @@ func TestUpdateConfig_InstalledButNotLoaded(t *testing.T) {
 
 	mgr := newMockIntegrationManager() // telegram NOT loaded in the manager
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -930,7 +966,7 @@ func TestUpdateConfig_InstalledButNotLoaded_ActivationFailureIsNonFatal(t *testi
 	mgr := newMockIntegrationManager()
 	mgr.loadOneErr = fmt.Errorf("bot_token is required")
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -950,7 +986,7 @@ func TestUpdateConfig_InvalidBody(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.plugins["telegram"] = map[string]string{}
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -968,7 +1004,7 @@ func TestUpdateConfig_UnknownSecretKey(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.plugins["telegram"] = map[string]string{}
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -989,7 +1025,7 @@ func TestUpdateConfig_NotFound(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
 	mgr := newMockIntegrationManager()
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -1126,7 +1162,7 @@ func TestPluginNameFromKey(t *testing.T) {
 func TestIntegrationByName_UnknownAction(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.plugins["telegram"] = map[string]string{}
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -1147,7 +1183,7 @@ func TestUpdateIntegration_SelfManaged_SQLite(t *testing.T) {
 	mgr.plugins["telegram"] = map[string]string{}
 	mgr.deploymentModes["telegram"] = plugin.DeploymentModeHA
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 	// dbDriver is empty → requirePostgres returns 409
 
@@ -1164,7 +1200,7 @@ func TestUpdateIntegration_SelfManaged_SQLite(t *testing.T) {
 
 func TestUpdateIntegration_NotFound(t *testing.T) {
 	mgr := newMockIntegrationManager()
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -1182,7 +1218,7 @@ func TestUpdateIntegration_NoRepoPath(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.plugins["telegram"] = map[string]string{}
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -1201,7 +1237,7 @@ func TestUpdateIntegration_BuildError(t *testing.T) {
 	mgr.plugins["telegram"] = map[string]string{}
 	mgr.updateErr = fmt.Errorf("go build failed: exit status 1")
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.config.MaintenanceConfig.RepoPath = "/some/repo"
 	srv.pluginManager = mgr
 
@@ -1223,7 +1259,7 @@ func TestUpdateIntegration_BuildError(t *testing.T) {
 // --- Install endpoint ---
 
 func TestInstallIntegration_NilPluginManager(t *testing.T) {
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/integrations/telegram/install", nil)
@@ -1240,7 +1276,7 @@ func TestInstallIntegration_AlreadyInstalled(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.plugins["telegram"] = map[string]string{}
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -1257,7 +1293,7 @@ func TestInstallIntegration_AlreadyInstalled(t *testing.T) {
 func TestInstallIntegration_UnknownPlugin(t *testing.T) {
 	mgr := newMockIntegrationManager()
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -1292,7 +1328,7 @@ func TestInstallIntegration_PreservesExistingConfigFile(t *testing.T) {
 
 	mgr := newMockIntegrationManager()
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 	srv.config.MaintenanceConfig.RepoPath = repoDir
 
@@ -1318,7 +1354,7 @@ func TestInstallIntegration_PreservesExistingConfigFile(t *testing.T) {
 // --- Available integrations endpoint ---
 
 func TestListAvailableIntegrations_NoRepoPath(t *testing.T) {
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/available", nil)
@@ -1350,7 +1386,7 @@ func TestListAvailableIntegrations_WithSource(t *testing.T) {
 	// telegram is NOT installed, discord is NOT installed either
 	// but only telegram has a source dir
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.config.MaintenanceConfig.RepoPath = repoDir
 	srv.pluginManager = mgr
 
@@ -1384,7 +1420,7 @@ func TestListAvailableIntegrations_IncludesSlack(t *testing.T) {
 
 	mgr := newMockIntegrationManager()
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.config.MaintenanceConfig.RepoPath = repoDir
 	srv.pluginManager = mgr
 
@@ -1424,7 +1460,7 @@ func TestListAvailableIntegrations_ExcludesInstalled(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.plugins["telegram"] = map[string]string{} // already installed
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.config.MaintenanceConfig.RepoPath = repoDir
 	srv.pluginManager = mgr
 
@@ -1450,7 +1486,7 @@ func TestListAvailableIntegrations_ExcludesInstalled(t *testing.T) {
 // --- Mode 3 (HA) integration tests ---
 
 func TestRequirePostgres_SQLite(t *testing.T) {
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	// dbDriver is empty — SQLite or unconfigured
 	rr := httptest.NewRecorder()
 	ok := srv.requirePostgres(rr)
@@ -1698,7 +1734,7 @@ func TestGetUpdateStatus_InvalidID(t *testing.T) {
 }
 
 func TestGetUpdateStatus_SQLiteReturns409(t *testing.T) {
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	mgr := newMockIntegrationManager()
 	mgr.plugins["discord"] = map[string]string{}
 	srv.pluginManager = mgr
@@ -1776,7 +1812,7 @@ func TestIsHAIntegration(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.deploymentModes["discord"] = plugin.DeploymentModeHA
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 
 	if !srv.isHAIntegration(mgr, "discord") {
 		t.Error("expected discord (HA mode) to be HA")
@@ -1876,7 +1912,7 @@ func TestListIntegrations_DeploymentMode(t *testing.T) {
 	mgr.plugins["discord"] = map[string]string{}
 	mgr.selfManaged["discord"] = true
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -1916,7 +1952,7 @@ func TestGetIntegration_DeploymentMode(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.plugins["telegram"] = map[string]string{}
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -1945,7 +1981,7 @@ func TestIsHAIntegration_Modes(t *testing.T) {
 	mgr.plugins["discord"] = map[string]string{}
 	mgr.deploymentModes["discord"] = plugin.DeploymentModeHA
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	if srv.isHAIntegration(mgr, "telegram") {
@@ -2081,7 +2117,7 @@ func TestGetIntegration_ReadsFromConfigFile(t *testing.T) {
 		"hub_url":        "https://hub.example.com",
 	}
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -2180,7 +2216,7 @@ func TestUpdateIntegration_SelfManagedRejected(t *testing.T) {
 	mgr.plugins["a2a-bridge"] = map[string]string{}
 	mgr.selfManaged["a2a-bridge"] = true
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -2206,7 +2242,7 @@ func TestInstallIntegration_SelfManaged_CreatesAdminConfig(t *testing.T) {
 
 	mgr := newMockIntegrationManager()
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 	srv.config.HubEndpoint = "http://hub.example.com:8080"
 
@@ -2340,7 +2376,7 @@ func TestCreateBridgeConfigTemplate_PreservesExisting(t *testing.T) {
 	// stat-before-create guard in handleInstallSelfManaged (the function itself
 	// always writes). Here we verify the guard at the handler level.
 	mgr := newMockIntegrationManager()
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 	srv.config.HubEndpoint = "http://other-hub:8080"
 
@@ -2385,7 +2421,7 @@ func TestInstallIntegration_SelfManaged_RegisteredButNotLoaded(t *testing.T) {
 
 	mgr := newMockIntegrationManager() // a2a-bridge NOT in mgr.plugins
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -2412,7 +2448,7 @@ func TestInstallIntegration_SelfManaged_AlreadyInstalled(t *testing.T) {
 	mgr := newMockIntegrationManager()
 	mgr.plugins["a2a-bridge"] = map[string]string{}
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 
 	admin := NewAuthenticatedUser("u1", "admin@example.com", "Admin", "admin", "cli")
@@ -2435,7 +2471,7 @@ func TestListAvailableIntegrations_IncludesA2ABridge(t *testing.T) {
 
 	mgr := newMockIntegrationManager()
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.config.MaintenanceConfig.RepoPath = repoDir
 	srv.pluginManager = mgr
 
@@ -2477,7 +2513,7 @@ func TestListAvailableIntegrations_IncludesDescription(t *testing.T) {
 
 	mgr := newMockIntegrationManager()
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.config.MaintenanceConfig.RepoPath = repoDir
 	srv.pluginManager = mgr
 
@@ -2513,7 +2549,7 @@ func TestUpdateIntegration_SelfManaged_DevModeRebuild_NoSource(t *testing.T) {
 	mgr.plugins["a2a-bridge"] = map[string]string{}
 	mgr.selfManaged["a2a-bridge"] = true
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 	srv.config.MaintenanceConfig.RepoPath = t.TempDir() // RepoPath set but no source dir
 
@@ -2533,7 +2569,7 @@ func TestUpdateIntegration_SelfManaged_NoRepoPath(t *testing.T) {
 	mgr.plugins["a2a-bridge"] = map[string]string{}
 	mgr.selfManaged["a2a-bridge"] = true
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 	// No RepoPath set → should reject with guidance
 
@@ -2563,7 +2599,7 @@ func TestUpdateIntegration_SelfManaged_DevModeRebuild_SourceExists(t *testing.T)
 	mgr.plugins["a2a-bridge"] = map[string]string{}
 	mgr.selfManaged["a2a-bridge"] = true
 
-	srv := &Server{}
+	srv := &Server{authzService: NewAuthzService(nil, slog.Default())}
 	srv.pluginManager = mgr
 	srv.config.MaintenanceConfig.RepoPath = repoPath
 

--- a/pkg/hub/handlers_lifecycle_hooks.go
+++ b/pkg/hub/handlers_lifecycle_hooks.go
@@ -88,6 +88,10 @@ func (s *Server) handleAdminLifecycleHooks(w http.ResponseWriter, r *http.Reques
 	case http.MethodPost:
 		// Inline authorization for write — route guard only checks read.
 		identity := GetIdentityFromContext(r.Context())
+		if identity == nil {
+			writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "authentication required", nil)
+			return
+		}
 		user, ok := identity.(UserIdentity)
 		if !ok {
 			Forbidden(w)
@@ -127,6 +131,10 @@ func (s *Server) handleAdminLifecycleHookByID(w http.ResponseWriter, r *http.Req
 	case http.MethodPut, http.MethodDelete:
 		// Inline authorization for write — route guard only checks read.
 		identity := GetIdentityFromContext(r.Context())
+		if identity == nil {
+			writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "authentication required", nil)
+			return
+		}
 		user, ok := identity.(UserIdentity)
 		if !ok {
 			Forbidden(w)

--- a/pkg/hub/handlers_lifecycle_hooks.go
+++ b/pkg/hub/handlers_lifecycle_hooks.go
@@ -79,17 +79,31 @@ func (r *storeGCPServiceAccountResolver) GetGCPServiceAccount(ctx context.Contex
 
 // handleAdminLifecycleHooks handles GET (list) and POST (create) on
 // /api/v1/admin/lifecycle-hooks.
+// Authorization: route guard checks hub.lifecycle_hooks.read for GET.
+// POST requires hub.lifecycle_hooks.update via inline Decide.
 func (s *Server) handleAdminLifecycleHooks(w http.ResponseWriter, r *http.Request) {
-	user := GetUserIdentityFromContext(r.Context())
-	if user == nil || user.Role() != "admin" {
-		Forbidden(w)
-		return
-	}
-
 	switch r.Method {
 	case http.MethodGet:
 		s.listLifecycleHooks(w, r)
 	case http.MethodPost:
+		// Inline authorization for write — route guard only checks read.
+		identity := GetIdentityFromContext(r.Context())
+		user, ok := identity.(UserIdentity)
+		if !ok {
+			Forbidden(w)
+			return
+		}
+		decision := s.authzService.Decide(r.Context(), AuthzRequest{
+			Principal:  principalContextForIdentity(user),
+			Credential: credentialContextForIdentity(user),
+			Resource:   Resource{Type: "hub", ID: "hub"},
+			Action:     Action("update"),
+			Permission: "hub.lifecycle_hooks.update",
+		})
+		if !decision.Allowed {
+			Forbidden(w)
+			return
+		}
 		s.createLifecycleHook(w, r, user)
 	default:
 		MethodNotAllowed(w)
@@ -98,13 +112,9 @@ func (s *Server) handleAdminLifecycleHooks(w http.ResponseWriter, r *http.Reques
 
 // handleAdminLifecycleHookByID handles GET / PUT / DELETE on
 // /api/v1/admin/lifecycle-hooks/{id}.
+// Authorization: route guard checks hub.lifecycle_hooks.read for GET.
+// PUT/DELETE require hub.lifecycle_hooks.update via inline Decide.
 func (s *Server) handleAdminLifecycleHookByID(w http.ResponseWriter, r *http.Request) {
-	user := GetUserIdentityFromContext(r.Context())
-	if user == nil || user.Role() != "admin" {
-		Forbidden(w)
-		return
-	}
-
 	id := extractID(r, "/api/v1/admin/lifecycle-hooks")
 	if id == "" {
 		BadRequest(w, "lifecycle hook ID is required")
@@ -114,10 +124,30 @@ func (s *Server) handleAdminLifecycleHookByID(w http.ResponseWriter, r *http.Req
 	switch r.Method {
 	case http.MethodGet:
 		s.getLifecycleHook(w, r, id)
-	case http.MethodPut:
-		s.updateLifecycleHook(w, r, id, user)
-	case http.MethodDelete:
-		s.deleteLifecycleHook(w, r, id, user)
+	case http.MethodPut, http.MethodDelete:
+		// Inline authorization for write — route guard only checks read.
+		identity := GetIdentityFromContext(r.Context())
+		user, ok := identity.(UserIdentity)
+		if !ok {
+			Forbidden(w)
+			return
+		}
+		decision := s.authzService.Decide(r.Context(), AuthzRequest{
+			Principal:  principalContextForIdentity(user),
+			Credential: credentialContextForIdentity(user),
+			Resource:   Resource{Type: "hub", ID: "hub"},
+			Action:     Action("update"),
+			Permission: "hub.lifecycle_hooks.update",
+		})
+		if !decision.Allowed {
+			Forbidden(w)
+			return
+		}
+		if r.Method == http.MethodPut {
+			s.updateLifecycleHook(w, r, id, user)
+		} else {
+			s.deleteLifecycleHook(w, r, id, user)
+		}
 	default:
 		MethodNotAllowed(w)
 	}

--- a/pkg/hub/handlers_lifecycle_hooks.go
+++ b/pkg/hub/handlers_lifecycle_hooks.go
@@ -87,25 +87,8 @@ func (s *Server) handleAdminLifecycleHooks(w http.ResponseWriter, r *http.Reques
 		s.listLifecycleHooks(w, r)
 	case http.MethodPost:
 		// Inline authorization for write — route guard only checks read.
-		identity := GetIdentityFromContext(r.Context())
-		if identity == nil {
-			writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "authentication required", nil)
-			return
-		}
-		user, ok := identity.(UserIdentity)
+		user, ok := s.requireWritePermission(w, r, "hub.lifecycle_hooks.update")
 		if !ok {
-			Forbidden(w)
-			return
-		}
-		decision := s.authzService.Decide(r.Context(), AuthzRequest{
-			Principal:  principalContextForIdentity(user),
-			Credential: credentialContextForIdentity(user),
-			Resource:   Resource{Type: "hub", ID: "hub"},
-			Action:     Action("update"),
-			Permission: "hub.lifecycle_hooks.update",
-		})
-		if !decision.Allowed {
-			Forbidden(w)
 			return
 		}
 		s.createLifecycleHook(w, r, user)
@@ -130,25 +113,8 @@ func (s *Server) handleAdminLifecycleHookByID(w http.ResponseWriter, r *http.Req
 		s.getLifecycleHook(w, r, id)
 	case http.MethodPut, http.MethodDelete:
 		// Inline authorization for write — route guard only checks read.
-		identity := GetIdentityFromContext(r.Context())
-		if identity == nil {
-			writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "authentication required", nil)
-			return
-		}
-		user, ok := identity.(UserIdentity)
+		user, ok := s.requireWritePermission(w, r, "hub.lifecycle_hooks.update")
 		if !ok {
-			Forbidden(w)
-			return
-		}
-		decision := s.authzService.Decide(r.Context(), AuthzRequest{
-			Principal:  principalContextForIdentity(user),
-			Credential: credentialContextForIdentity(user),
-			Resource:   Resource{Type: "hub", ID: "hub"},
-			Action:     Action("update"),
-			Permission: "hub.lifecycle_hooks.update",
-		})
-		if !decision.Allowed {
-			Forbidden(w)
 			return
 		}
 		if r.Method == http.MethodPut {

--- a/pkg/hub/handlers_lifecycle_hooks_test.go
+++ b/pkg/hub/handlers_lifecycle_hooks_test.go
@@ -17,6 +17,7 @@
 package hub
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -139,82 +140,128 @@ func TestLifecycleHook_Create_ValidationError_UntrustedVarInHeader(t *testing.T)
 // Tests: Authz
 // ---------------------------------------------------------------------------
 
-func TestLifecycleHook_Create_Forbidden_NonAdmin(t *testing.T) {
-	srv := &Server{}
+// Auth tests below validate authorization via the route guard and inline
+// Decide checks (PR-A5 permission conversion). Non-admin users are denied
+// by the route guard for GET (read permission) and by inline Decide for
+// write operations (POST/PUT/DELETE).
 
-	member := NewAuthenticatedUser("u1", "member@example.com", "Member", "member", "cli")
+func TestLifecycleHook_Create_Forbidden_NonAdmin(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+	seedRoleDefinitions(ctx, s)
+	memberU := &store.User{ID: tid("lh-member1"), Email: "member@example.com", DisplayName: "Member", Role: "member", Status: "active"}
+	if err := s.CreateUser(ctx, memberU); err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	handler := srv.guarded("/api/v1/admin/lifecycle-hooks", srv.handleAdminLifecycleHooks)
+
+	member := NewAuthenticatedUser(tid("lh-member1"), "member@example.com", "Member", "member", "cli")
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/lifecycle-hooks", nil)
-	req = req.WithContext(contextWithIdentity(req.Context(), member))
+	req = req.WithContext(contextWithIdentity(ctx, member))
 	rec := httptest.NewRecorder()
-	srv.handleAdminLifecycleHooks(rec, req)
+	handler(rec, req)
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
 func TestLifecycleHook_Create_Forbidden_Unauthenticated(t *testing.T) {
-	srv := &Server{}
+	srv, _ := testServer(t)
+	ctx := context.Background()
+	handler := srv.guarded("/api/v1/admin/lifecycle-hooks", srv.handleAdminLifecycleHooks)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/lifecycle-hooks", nil)
+	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
-	srv.handleAdminLifecycleHooks(rec, req)
+	handler(rec, req)
 
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
 func TestLifecycleHook_Get_Forbidden_NonAdmin(t *testing.T) {
-	srv := &Server{}
+	srv, s := testServer(t)
+	ctx := context.Background()
+	seedRoleDefinitions(ctx, s)
+	memberU := &store.User{ID: tid("lh-member2"), Email: "member2@example.com", DisplayName: "Member", Role: "member", Status: "active"}
+	if err := s.CreateUser(ctx, memberU); err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	handler := srv.guarded("/api/v1/admin/lifecycle-hooks/", srv.handleAdminLifecycleHookByID)
 
-	member := NewAuthenticatedUser("u1", "member@example.com", "Member", "member", "cli")
+	member := NewAuthenticatedUser(tid("lh-member2"), "member2@example.com", "Member", "member", "cli")
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/lifecycle-hooks/some-id", nil)
-	req = req.WithContext(contextWithIdentity(req.Context(), member))
+	req = req.WithContext(contextWithIdentity(ctx, member))
 	rec := httptest.NewRecorder()
-	srv.handleAdminLifecycleHookByID(rec, req)
+	handler(rec, req)
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
 func TestLifecycleHook_List_Forbidden_NonAdmin(t *testing.T) {
-	srv := &Server{}
+	srv, s := testServer(t)
+	ctx := context.Background()
+	seedRoleDefinitions(ctx, s)
+	memberU := &store.User{ID: tid("lh-member3"), Email: "member3@example.com", DisplayName: "Member", Role: "member", Status: "active"}
+	if err := s.CreateUser(ctx, memberU); err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	handler := srv.guarded("/api/v1/admin/lifecycle-hooks", srv.handleAdminLifecycleHooks)
 
-	member := NewAuthenticatedUser("u1", "member@example.com", "Member", "member", "cli")
+	member := NewAuthenticatedUser(tid("lh-member3"), "member3@example.com", "Member", "member", "cli")
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/lifecycle-hooks", nil)
-	req = req.WithContext(contextWithIdentity(req.Context(), member))
+	req = req.WithContext(contextWithIdentity(ctx, member))
 	rec := httptest.NewRecorder()
-	srv.handleAdminLifecycleHooks(rec, req)
+	handler(rec, req)
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
 func TestLifecycleHook_Update_Forbidden_NonAdmin(t *testing.T) {
-	srv := &Server{}
+	srv, s := testServer(t)
+	ctx := context.Background()
+	seedRoleDefinitions(ctx, s)
+	memberU := &store.User{ID: tid("lh-member4"), Email: "member4@example.com", DisplayName: "Member", Role: "member", Status: "active"}
+	if err := s.CreateUser(ctx, memberU); err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	handler := srv.guarded("/api/v1/admin/lifecycle-hooks/", srv.handleAdminLifecycleHookByID)
 
-	member := NewAuthenticatedUser("u1", "member@example.com", "Member", "member", "cli")
+	member := NewAuthenticatedUser(tid("lh-member4"), "member4@example.com", "Member", "member", "cli")
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/lifecycle-hooks/some-id", nil)
-	req = req.WithContext(contextWithIdentity(req.Context(), member))
+	req = req.WithContext(contextWithIdentity(ctx, member))
 	rec := httptest.NewRecorder()
-	srv.handleAdminLifecycleHookByID(rec, req)
+	handler(rec, req)
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
 
 func TestLifecycleHook_Update_Forbidden_Unauthenticated(t *testing.T) {
-	srv := &Server{}
+	srv, _ := testServer(t)
+	ctx := context.Background()
+	handler := srv.guarded("/api/v1/admin/lifecycle-hooks/", srv.handleAdminLifecycleHookByID)
 
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/admin/lifecycle-hooks/some-id", nil)
+	req = req.WithContext(ctx)
 	rec := httptest.NewRecorder()
-	srv.handleAdminLifecycleHookByID(rec, req)
+	handler(rec, req)
 
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
 func TestLifecycleHook_Delete_Forbidden_NonAdmin(t *testing.T) {
-	srv := &Server{}
+	srv, s := testServer(t)
+	ctx := context.Background()
+	seedRoleDefinitions(ctx, s)
+	memberU := &store.User{ID: tid("lh-member5"), Email: "member5@example.com", DisplayName: "Member", Role: "member", Status: "active"}
+	if err := s.CreateUser(ctx, memberU); err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	handler := srv.guarded("/api/v1/admin/lifecycle-hooks/", srv.handleAdminLifecycleHookByID)
 
-	member := NewAuthenticatedUser("u1", "member@example.com", "Member", "member", "cli")
+	member := NewAuthenticatedUser(tid("lh-member5"), "member5@example.com", "Member", "member", "cli")
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/admin/lifecycle-hooks/some-id", nil)
-	req = req.WithContext(contextWithIdentity(req.Context(), member))
+	req = req.WithContext(contextWithIdentity(ctx, member))
 	rec := httptest.NewRecorder()
-	srv.handleAdminLifecycleHookByID(rec, req)
+	handler(rec, req)
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }

--- a/pkg/hub/handlers_teams_manifest.go
+++ b/pkg/hub/handlers_teams_manifest.go
@@ -97,15 +97,10 @@ type teamsBotCommand struct {
 
 // handleTeamsManifestDownload generates and returns a Teams app manifest .zip.
 // GET /api/v1/admin/integrations/teams/manifest
+// Authorization: route guard checks hub.teams_manifest.read.
 func (s *Server) handleTeamsManifestDownload(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		MethodNotAllowed(w)
-		return
-	}
-
-	user := GetUserIdentityFromContext(r.Context())
-	if user == nil || user.Role() != "admin" {
-		Forbidden(w)
 		return
 	}
 

--- a/pkg/hub/handlers_teams_manifest_test.go
+++ b/pkg/hub/handlers_teams_manifest_test.go
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_sqlite
+
 package hub
 
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"encoding/json"
 	"image/color"
 	"image/png"
@@ -25,28 +28,45 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
 // --- Teams Manifest handler tests ---
 
-func TestHandleTeamsManifestDownload_AuthGate_Unauthenticated(t *testing.T) {
-	srv := &Server{}
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/teams/manifest", nil)
-	rr := httptest.NewRecorder()
-	srv.handleTeamsManifestDownload(rr, req)
+// Auth tests below validate authorization via the route guard (PR-A5
+// permission conversion). Unauthenticated requests get 401; non-admin
+// members get 403 from the route guard's Decide check.
 
-	if rr.Code != http.StatusForbidden {
-		t.Fatalf("expected 403 for unauthenticated request, got %d", rr.Code)
+func TestHandleTeamsManifestDownload_AuthGate_Unauthenticated(t *testing.T) {
+	srv, _ := testServer(t)
+	ctx := context.Background()
+	handler := srv.guarded("/api/v1/admin/integrations/teams/manifest", srv.handleTeamsManifestDownload)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/teams/manifest", nil)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for unauthenticated request, got %d", rr.Code)
 	}
 }
 
 func TestHandleTeamsManifestDownload_AuthGate_NonAdmin(t *testing.T) {
-	srv := &Server{}
-	member := NewAuthenticatedUser("u1", "member@example.com", "Member", "member", "cli")
+	srv, s := testServer(t)
+	ctx := context.Background()
+	seedRoleDefinitions(ctx, s)
+	memberU := &store.User{ID: tid("tm-member"), Email: "member@example.com", DisplayName: "Member", Role: "member", Status: "active"}
+	if err := s.CreateUser(ctx, memberU); err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	handler := srv.guarded("/api/v1/admin/integrations/teams/manifest", srv.handleTeamsManifestDownload)
+
+	member := NewAuthenticatedUser(tid("tm-member"), "member@example.com", "Member", "member", "cli")
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/integrations/teams/manifest", nil)
-	req = req.WithContext(contextWithIdentity(req.Context(), member))
+	req = req.WithContext(contextWithIdentity(ctx, member))
 	rr := httptest.NewRecorder()
-	srv.handleTeamsManifestDownload(rr, req)
+	handler(rr, req)
 
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("expected 403 for non-admin, got %d", rr.Code)

--- a/pkg/hub/passthrough_gate.go
+++ b/pkg/hub/passthrough_gate.go
@@ -103,7 +103,22 @@ func (s *Server) authorizePassthroughIdentity(
 		return false
 	}
 
-	if userIdent.Role() != "admin" && broker.CreatedBy != userIdent.ID() {
+	// Permission-based admin check via Decide replaces the former
+	// inline role check. The super-admin bypass and scoped-admin access
+	// are preserved through the authorization pipeline.
+	isAdmin := false
+	decision := s.authzService.Decide(ctx, AuthzRequest{
+		Principal:  principalContextForIdentity(userIdent),
+		Credential: credentialContextForIdentity(userIdent),
+		Resource:   Resource{Type: "hub", ID: "hub"},
+		Action:     Action("update"),
+		Permission: "hub.integrations.update",
+	})
+	if decision.Allowed {
+		isAdmin = true
+	}
+
+	if !isAdmin && broker.CreatedBy != userIdent.ID() {
 		logAuthzDenial(r, userIdent, brokerResource(broker), ActionDispatch,
 			"not broker owner or admin")
 		writeError(w, http.StatusForbidden, ErrCodeForbidden,

--- a/pkg/hub/route_classification_test.go
+++ b/pkg/hub/route_classification_test.go
@@ -17,6 +17,7 @@ package hub
 import (
 	"bytes"
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"

--- a/pkg/hub/route_classification_test.go
+++ b/pkg/hub/route_classification_test.go
@@ -17,7 +17,6 @@ package hub
 import (
 	"bytes"
 	"context"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"

--- a/pkg/hub/route_metadata.go
+++ b/pkg/hub/route_metadata.go
@@ -664,10 +664,12 @@ var routeMetadataTable = map[string]RouteMetadata{
 	"/api/v1/admin/lifecycle-hooks": {
 		Pattern: "/api/v1/admin/lifecycle-hooks", RouteID: "admin.lifecycleHooks",
 		Classification: RouteHubAdmin,
+		Permission:     "hub.lifecycle_hooks.read", Resource: "hub", Action: "read",
 	},
 	"/api/v1/admin/lifecycle-hooks/": {
 		Pattern: "/api/v1/admin/lifecycle-hooks/", RouteID: "admin.lifecycleHooks.byId",
 		Classification: RouteHubAdmin,
+		Permission:     "hub.lifecycle_hooks.read", Resource: "hub", Action: "read",
 	},
 	"/api/v1/admin/validate-resources": {
 		Pattern: "/api/v1/admin/validate-resources", RouteID: "admin.validateResources",
@@ -677,14 +679,17 @@ var routeMetadataTable = map[string]RouteMetadata{
 	"/api/v1/admin/integrations": {
 		Pattern: "/api/v1/admin/integrations", RouteID: "admin.integrations",
 		Classification: RouteHubAdmin,
+		Permission:     "hub.integrations.read", Resource: "hub", Action: "read",
 	},
 	"/api/v1/admin/integrations/teams/manifest": {
 		Pattern: "/api/v1/admin/integrations/teams/manifest", RouteID: "admin.integrations.teamsManifest",
 		Classification: RouteHubAdmin,
+		Permission:     "hub.teams_manifest.read", Resource: "hub", Action: "read",
 	},
 	"/api/v1/admin/integrations/": {
 		Pattern: "/api/v1/admin/integrations/", RouteID: "admin.integrations.byName",
 		Classification: RouteHubAdmin,
+		Permission:     "hub.integrations.read", Resource: "hub", Action: "read",
 	},
 	"/api/v1/admin/diagnostics/logs/stream": {
 		Pattern: "/api/v1/admin/diagnostics/logs/stream", RouteID: "admin.diagnostics.logsStream",

--- a/pkg/hub/update_completion_test.go
+++ b/pkg/hub/update_completion_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !no_sqlite
+
 package hub
 
 import (


### PR DESCRIPTION
## Summary
- 6 inline admin checks converted to permission-based route guards
- Explicit denial for non-UserIdentity in inline Decide checks
- 27 test cases, make ci passes
- Code review: APPROVE