### PR TITLE
feat: Add quota management API endpoints (P2-B3)

### DIFF
--- a/.design/project-log/pf-p2b-api-fix2.md
+++ b/.design/project-log/pf-p2b-api-fix2.md
@@ -1,0 +1,41 @@
+# PR-B3 Upstream Review Fix — Quota API
+
+**Date:** 2026-08-28
+**Branch:** `scion/pf-p2b-api`
+**Author:** dev-pf-p2b-api-fix2
+
+## Summary
+
+Fixed 1 HIGH and 6 MEDIUM findings from upstream review on the quota API endpoints (PR-B3).
+
+## Changes
+
+### HIGH: quotaService nil panic in getMyUsage
+- Added nil guard at the top of `getMyUsage` that returns an empty `myUsageResponse` when `quotaService` is nil, preventing a panic when the store doesn't support quotas.
+
+### MEDIUM-1: authzService nil check
+- Added nil guard in `requireWritePermissionForQuota` before calling `s.authzService.Decide()`. Returns 403 Forbidden when authzService is nil.
+
+### MEDIUM-2: Trailing slash on by-ID routes
+- Added `strings.TrimSuffix(path, "/")` in `handleAdminLimitByID` before splitting the path. The `handleAdminEntitlementByID` and `handleAdminUsageByLimit` use `extractID()` which already handles trailing content via `strings.Index`.
+
+### MEDIUM-3 & MEDIUM-4: TrimSpace on limit definition names
+- Added `strings.TrimSpace(req.Name)` in both `createLimitDefinition` and `updateLimitDefinition` before the empty-name check, so whitespace-only names are properly rejected.
+
+### MEDIUM-5 & MEDIUM-6: SubjectType/SubjectID validation on entitlements
+- Added validation for empty `SubjectType` and `SubjectID` in both `createEntitlement` and `updateEntitlement`, returning 400 Bad Request when either is missing.
+
+## Tests Added
+
+- `TestQuotaAPI_UsageMe_NilQuotaService` — verifies empty response (not panic) when quotaService is nil
+- `TestQuotaAPI_GetLimitDefinition_TrailingSlash` — verifies trailing slash still resolves
+- `TestQuotaAPI_CreateLimitDefinition_WhitespaceOnlyName` — verifies whitespace-only name rejected
+- `TestQuotaAPI_UpdateLimitDefinition_WhitespaceOnlyName` — same for update
+- `TestQuotaAPI_CreateEntitlement_EmptySubjectType` — verifies empty subject_type rejected
+- `TestQuotaAPI_CreateEntitlement_EmptySubjectID` — verifies empty subject_id rejected
+- `TestQuotaAPI_UpdateEntitlement_EmptySubjectType` — same for update
+- `TestQuotaAPI_UpdateEntitlement_EmptySubjectID` — same for update
+
+## Verification
+
+`make ci` passes with all new and existing tests green.

--- a/.design/project-log/pf-p2b-api.md
+++ b/.design/project-log/pf-p2b-api.md
@@ -1,0 +1,61 @@
+# Project Log: PR-B3 — Quota API Endpoints
+
+**Date:** 2026-08-28
+**Agent:** dev-pf-p2b-api
+**Branch:** scion/pf-p2b-api
+**PR:** PR-B3 (Permissions Phase 2B — Quota Management API)
+
+## Summary
+
+Implemented the quota management API layer — 13 endpoints across 3 resource types (limit definitions, entitlement bindings, usage queries) plus a self-service `/usage/me` endpoint for regular users. This builds on PR-B1 (schema/store) and PR-B2 (QuotaService enforcement).
+
+## Changes
+
+### Permissions (`pkg/hub/permissions/registry.go`)
+- Added `ResourceQuota = "quota"` constant
+- Added 4 permission entries: `quota.read`, `quota.create`, `quota.update`, `quota.delete`
+- All use `CapabilityScope` kind
+
+### Hub-Admin Role (`pkg/hub/seed.go`)
+- Added all 4 quota permissions to the `hubAdminPermissionIDs` curated set
+
+### API Handlers (`pkg/hub/handlers_quota.go` — new, ~470 lines)
+- **Limit Definitions:** GET/POST `/admin/limits`, GET/PUT/DELETE `/admin/limits/:id`
+- **Entitlement Bindings:** GET/POST `/admin/limits/:id/entitlements`, GET/PUT/DELETE `/admin/entitlements/:id`
+- **Usage Queries:** GET `/admin/usage`, GET `/admin/usage/:limitID`, GET `/usage/me`
+- System-seeded limit definitions (`System == true`) are protected from deletion (returns 403)
+- Write operations use inline `Decide()` authorization checks
+- Nested entitlements route parsed via path decomposition in `handleAdminLimitByID`
+
+### Route Metadata (`pkg/hub/route_metadata.go`)
+- 6 new entries: 5 `RouteHubAdmin` quota routes + 1 `RouteAuthenticated` for `/usage/me`
+
+### Route Registration (`pkg/hub/server.go`)
+- 6 new `HandleFunc` calls with `guarded()` wrappers
+
+### Tests (`pkg/hub/handlers_quota_test.go` — new, ~420 lines)
+- 33 tests covering:
+  - Full CRUD for limit definitions (create, read, list, update, delete)
+  - Cannot-delete-system-seeded invariant
+  - Full CRUD for entitlement bindings
+  - Usage summary and per-limit usage queries
+  - `/usage/me` accessible by non-admin users
+  - Admin endpoints denied for non-admin users and unauthenticated requests
+  - Hub-admin access verification
+  - Method-not-allowed checks
+
+### Route Classification Test (`pkg/hub/route_classification_test.go`)
+- Added 6 new route entries to `routePermissionClassifications` map
+
+## Verification
+
+- `make ci` passes (fmt-check, lint, compat-literals, check-authz-guards, test-fast, build)
+- All 33 new tests pass
+
+## Design Decisions
+
+1. **Usage queries at system scope:** The `/usage/me` endpoint resolves effective limits and counts active reservations at system scope. Project-scoped usage would require iterating over the user's projects, which is deferred to a future enhancement.
+
+2. **Inline write authorization:** Following the `handlers_lifecycle_hooks.go` pattern, write operations (POST/PUT/DELETE) use `requireWritePermissionForQuota()` with inline `Decide()` calls, since the route guard only checks the read permission at the route metadata level.
+
+3. **No store interface changes:** Per the brief's boundaries, no modifications were made to the QuotaStore interface. The handlers compose existing store methods.

--- a/pkg/hub/handlers_quota.go
+++ b/pkg/hub/handlers_quota.go
@@ -1,0 +1,665 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/google/uuid"
+)
+
+// ---------------------------------------------------------------------------
+// Request / Response types
+// ---------------------------------------------------------------------------
+
+// createLimitDefinitionRequest is the payload for POST /api/v1/admin/limits.
+type createLimitDefinitionRequest struct {
+	Name         string `json:"name"`
+	ResourceType string `json:"resourceType"`
+	Unit         string `json:"unit"`
+	Description  string `json:"description"`
+	DefaultValue int64  `json:"defaultValue"`
+}
+
+// updateLimitDefinitionRequest is the payload for PUT /api/v1/admin/limits/:id.
+type updateLimitDefinitionRequest struct {
+	Name         string `json:"name"`
+	ResourceType string `json:"resourceType"`
+	Unit         string `json:"unit"`
+	Description  string `json:"description"`
+	DefaultValue int64  `json:"defaultValue"`
+}
+
+// createEntitlementBindingRequest is the payload for POST /api/v1/admin/limits/:id/entitlements.
+type createEntitlementBindingRequest struct {
+	SubjectType string `json:"subjectType"`
+	SubjectID   string `json:"subjectId"`
+	ScopeType   string `json:"scopeType"`
+	ScopeID     string `json:"scopeId"`
+	Value       int64  `json:"value"`
+}
+
+// updateEntitlementBindingRequest is the payload for PUT /api/v1/admin/entitlements/:id.
+type updateEntitlementBindingRequest struct {
+	SubjectType string `json:"subjectType"`
+	SubjectID   string `json:"subjectId"`
+	ScopeType   string `json:"scopeType"`
+	ScopeID     string `json:"scopeId"`
+	Value       int64  `json:"value"`
+}
+
+// listLimitDefinitionsResponse wraps the list result for the API.
+type listLimitDefinitionsResponse struct {
+	Items      []*store.LimitDefinition `json:"items"`
+	TotalCount int                      `json:"totalCount"`
+}
+
+// listEntitlementBindingsResponse wraps the list result for the API.
+type listEntitlementBindingsResponse struct {
+	Items      []*store.EntitlementBinding `json:"items"`
+	TotalCount int                         `json:"totalCount"`
+}
+
+// usageSummaryEntry represents a single limit's usage summary.
+type usageSummaryEntry struct {
+	LimitDefinition *store.LimitDefinition `json:"limitDefinition"`
+	ActiveCount     int                    `json:"activeCount"`
+}
+
+// usageSummaryResponse wraps the admin usage summary.
+type usageSummaryResponse struct {
+	Items []usageSummaryEntry `json:"items"`
+}
+
+// usageByLimitResponse wraps the admin usage-by-limit result.
+type usageByLimitResponse struct {
+	LimitDefinition *store.LimitDefinition    `json:"limitDefinition"`
+	Reservations    []*store.UsageReservation `json:"reservations"`
+	TotalActive     int                       `json:"totalActive"`
+}
+
+// myUsageEntry represents one limit's current/max for the current user.
+type myUsageEntry struct {
+	LimitDefinition *store.LimitDefinition `json:"limitDefinition"`
+	Current         int64                  `json:"current"`
+	Max             int64                  `json:"max"` // 0 = unlimited
+}
+
+// myUsageResponse wraps the /usage/me result.
+type myUsageResponse struct {
+	Items []myUsageEntry `json:"items"`
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers: Limit Definitions
+// ---------------------------------------------------------------------------
+
+// handleAdminLimits handles GET (list) and POST (create) on
+// /api/v1/admin/limits.
+// Authorization: route guard checks quota.read for GET.
+// POST requires quota.create via inline Decide.
+func (s *Server) handleAdminLimits(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listLimitDefinitions(w, r)
+	case http.MethodPost:
+		user, ok := s.requireWritePermissionForQuota(w, r, "quota.create", "create")
+		if !ok {
+			return
+		}
+		s.createLimitDefinition(w, r, user)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// handleAdminLimitByID handles GET / PUT / DELETE on
+// /api/v1/admin/limits/:id, and delegates to handleLimitEntitlements for
+// /api/v1/admin/limits/:id/entitlements.
+func (s *Server) handleAdminLimitByID(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/limits/")
+	parts := strings.SplitN(path, "/", 2)
+	limitID := parts[0]
+	if limitID == "" {
+		BadRequest(w, "limit definition ID is required")
+		return
+	}
+	if len(parts) > 1 && parts[1] == "entitlements" {
+		s.handleLimitEntitlements(w, r, limitID)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		s.getLimitDefinition(w, r, limitID)
+	case http.MethodPut:
+		user, ok := s.requireWritePermissionForQuota(w, r, "quota.update", "update")
+		if !ok {
+			return
+		}
+		s.updateLimitDefinition(w, r, limitID, user)
+	case http.MethodDelete:
+		user, ok := s.requireWritePermissionForQuota(w, r, "quota.delete", "delete")
+		if !ok {
+			return
+		}
+		s.deleteLimitDefinition(w, r, limitID, user)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers: Entitlement Bindings
+// ---------------------------------------------------------------------------
+
+// handleLimitEntitlements handles GET (list) and POST (create) entitlement
+// bindings nested under a limit definition: /api/v1/admin/limits/:id/entitlements.
+func (s *Server) handleLimitEntitlements(w http.ResponseWriter, r *http.Request, limitID string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listEntitlements(w, r, limitID)
+	case http.MethodPost:
+		user, ok := s.requireWritePermissionForQuota(w, r, "quota.create", "create")
+		if !ok {
+			return
+		}
+		s.createEntitlement(w, r, limitID, user)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// handleAdminEntitlementByID handles GET / PUT / DELETE on
+// /api/v1/admin/entitlements/:id.
+func (s *Server) handleAdminEntitlementByID(w http.ResponseWriter, r *http.Request) {
+	id := extractID(r, "/api/v1/admin/entitlements")
+	if id == "" {
+		BadRequest(w, "entitlement binding ID is required")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		s.getEntitlement(w, r, id)
+	case http.MethodPut:
+		user, ok := s.requireWritePermissionForQuota(w, r, "quota.update", "update")
+		if !ok {
+			return
+		}
+		s.updateEntitlement(w, r, id, user)
+	case http.MethodDelete:
+		user, ok := s.requireWritePermissionForQuota(w, r, "quota.delete", "delete")
+		if !ok {
+			return
+		}
+		s.deleteEntitlement(w, r, id, user)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers: Usage Queries
+// ---------------------------------------------------------------------------
+
+// handleAdminUsage handles GET on /api/v1/admin/usage.
+func (s *Server) handleAdminUsage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+	s.getUsageSummary(w, r)
+}
+
+// handleAdminUsageByLimit handles GET on /api/v1/admin/usage/:limitID.
+func (s *Server) handleAdminUsageByLimit(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+	limitID := extractID(r, "/api/v1/admin/usage")
+	if limitID == "" {
+		BadRequest(w, "limit definition ID is required")
+		return
+	}
+	s.getUsageByLimit(w, r, limitID)
+}
+
+// handleUsageMe handles GET on /api/v1/usage/me.
+func (s *Server) handleUsageMe(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+	s.getMyUsage(w, r)
+}
+
+// ---------------------------------------------------------------------------
+// CRUD: Limit Definitions
+// ---------------------------------------------------------------------------
+
+func (s *Server) createLimitDefinition(w http.ResponseWriter, r *http.Request, user UserIdentity) {
+	var req createLimitDefinitionRequest
+	if err := readJSON(r, &req); err != nil {
+		BadRequest(w, "invalid request body: "+err.Error())
+		return
+	}
+
+	if req.Name == "" {
+		BadRequest(w, "name is required")
+		return
+	}
+
+	now := time.Now()
+	def := &store.LimitDefinition{
+		ID:           uuid.New().String(),
+		Name:         req.Name,
+		ResourceType: req.ResourceType,
+		Unit:         req.Unit,
+		Description:  req.Description,
+		DefaultValue: req.DefaultValue,
+		System:       false,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+
+	created, err := s.store.CreateLimitDefinition(r.Context(), def)
+	if err != nil {
+		if errors.Is(err, store.ErrAlreadyExists) {
+			Conflict(w, "a limit definition with this name already exists")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	slog.Info("limit definition created",
+		"limit_id", created.ID, "name", created.Name, "actor", user.Email())
+
+	writeJSON(w, http.StatusCreated, created)
+}
+
+func (s *Server) getLimitDefinition(w http.ResponseWriter, r *http.Request, id string) {
+	def, err := s.store.GetLimitDefinition(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Limit Definition")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	writeJSON(w, http.StatusOK, def)
+}
+
+func (s *Server) listLimitDefinitions(w http.ResponseWriter, r *http.Request) {
+	defs, err := s.store.ListLimitDefinitions(r.Context())
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	if defs == nil {
+		defs = []*store.LimitDefinition{}
+	}
+	writeJSON(w, http.StatusOK, listLimitDefinitionsResponse{
+		Items:      defs,
+		TotalCount: len(defs),
+	})
+}
+
+func (s *Server) updateLimitDefinition(w http.ResponseWriter, r *http.Request, id string, user UserIdentity) {
+	var req updateLimitDefinitionRequest
+	if err := readJSON(r, &req); err != nil {
+		BadRequest(w, "invalid request body: "+err.Error())
+		return
+	}
+
+	existing, err := s.store.GetLimitDefinition(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Limit Definition")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	existing.Name = req.Name
+	existing.ResourceType = req.ResourceType
+	existing.Unit = req.Unit
+	existing.Description = req.Description
+	existing.DefaultValue = req.DefaultValue
+	existing.UpdatedAt = time.Now()
+
+	updated, err := s.store.UpdateLimitDefinition(r.Context(), existing)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Limit Definition")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	slog.Info("limit definition updated",
+		"limit_id", updated.ID, "name", updated.Name, "actor", user.Email())
+
+	writeJSON(w, http.StatusOK, updated)
+}
+
+func (s *Server) deleteLimitDefinition(w http.ResponseWriter, r *http.Request, id string, user UserIdentity) {
+	// Fetch first to check system flag and include name in logs.
+	def, err := s.store.GetLimitDefinition(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Limit Definition")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// System-seeded limit definitions cannot be deleted.
+	if def.System {
+		writeForbidden(w, "system-seeded limit definitions cannot be deleted")
+		return
+	}
+
+	if err := s.store.DeleteLimitDefinition(r.Context(), id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Limit Definition")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	slog.Info("limit definition deleted",
+		"limit_id", def.ID, "name", def.Name, "actor", user.Email())
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ---------------------------------------------------------------------------
+// CRUD: Entitlement Bindings
+// ---------------------------------------------------------------------------
+
+func (s *Server) createEntitlement(w http.ResponseWriter, r *http.Request, limitID string, user UserIdentity) {
+	var req createEntitlementBindingRequest
+	if err := readJSON(r, &req); err != nil {
+		BadRequest(w, "invalid request body: "+err.Error())
+		return
+	}
+
+	// Validate the referenced limit definition exists.
+	if _, err := s.store.GetLimitDefinition(r.Context(), limitID); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Limit Definition")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	now := time.Now()
+	binding := &store.EntitlementBinding{
+		ID:                uuid.New().String(),
+		LimitDefinitionID: limitID,
+		SubjectType:       req.SubjectType,
+		SubjectID:         req.SubjectID,
+		ScopeType:         req.ScopeType,
+		ScopeID:           req.ScopeID,
+		Value:             req.Value,
+		CreatedBy:         user.Email(),
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+
+	created, err := s.store.CreateEntitlementBinding(r.Context(), binding)
+	if err != nil {
+		if errors.Is(err, store.ErrAlreadyExists) {
+			Conflict(w, "an entitlement binding with these parameters already exists")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	slog.Info("entitlement binding created",
+		"binding_id", created.ID, "limit_id", limitID, "actor", user.Email())
+
+	writeJSON(w, http.StatusCreated, created)
+}
+
+func (s *Server) getEntitlement(w http.ResponseWriter, r *http.Request, id string) {
+	binding, err := s.store.GetEntitlementBinding(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Entitlement Binding")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	writeJSON(w, http.StatusOK, binding)
+}
+
+func (s *Server) listEntitlements(w http.ResponseWriter, r *http.Request, limitID string) {
+	bindings, err := s.store.ListEntitlementBindings(r.Context(), limitID)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	if bindings == nil {
+		bindings = []*store.EntitlementBinding{}
+	}
+	writeJSON(w, http.StatusOK, listEntitlementBindingsResponse{
+		Items:      bindings,
+		TotalCount: len(bindings),
+	})
+}
+
+func (s *Server) updateEntitlement(w http.ResponseWriter, r *http.Request, id string, user UserIdentity) {
+	var req updateEntitlementBindingRequest
+	if err := readJSON(r, &req); err != nil {
+		BadRequest(w, "invalid request body: "+err.Error())
+		return
+	}
+
+	existing, err := s.store.GetEntitlementBinding(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Entitlement Binding")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	existing.SubjectType = req.SubjectType
+	existing.SubjectID = req.SubjectID
+	existing.ScopeType = req.ScopeType
+	existing.ScopeID = req.ScopeID
+	existing.Value = req.Value
+	existing.UpdatedAt = time.Now()
+
+	updated, err := s.store.UpdateEntitlementBinding(r.Context(), existing)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Entitlement Binding")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	slog.Info("entitlement binding updated",
+		"binding_id", updated.ID, "actor", user.Email())
+
+	writeJSON(w, http.StatusOK, updated)
+}
+
+func (s *Server) deleteEntitlement(w http.ResponseWriter, r *http.Request, id string, user UserIdentity) {
+	if err := s.store.DeleteEntitlementBinding(r.Context(), id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Entitlement Binding")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	slog.Info("entitlement binding deleted",
+		"binding_id", id, "actor", user.Email())
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ---------------------------------------------------------------------------
+// Usage Queries
+// ---------------------------------------------------------------------------
+
+func (s *Server) getUsageSummary(w http.ResponseWriter, r *http.Request) {
+	defs, err := s.store.ListLimitDefinitions(r.Context())
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	entries := make([]usageSummaryEntry, 0, len(defs))
+	for _, def := range defs {
+		reservations, err := s.store.ListActiveReservations(r.Context(), def.ID, store.QuotaScopeSystem, "")
+		activeCount := 0
+		if err == nil {
+			activeCount = len(reservations)
+		}
+		entries = append(entries, usageSummaryEntry{
+			LimitDefinition: def,
+			ActiveCount:     activeCount,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, usageSummaryResponse{Items: entries})
+}
+
+func (s *Server) getUsageByLimit(w http.ResponseWriter, r *http.Request, limitID string) {
+	def, err := s.store.GetLimitDefinition(r.Context(), limitID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Limit Definition")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	reservations, err := s.store.ListActiveReservations(r.Context(), limitID, store.QuotaScopeSystem, "")
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	if reservations == nil {
+		reservations = []*store.UsageReservation{}
+	}
+
+	writeJSON(w, http.StatusOK, usageByLimitResponse{
+		LimitDefinition: def,
+		Reservations:    reservations,
+		TotalActive:     len(reservations),
+	})
+}
+
+func (s *Server) getMyUsage(w http.ResponseWriter, r *http.Request) {
+	identity := GetIdentityFromContext(r.Context())
+	if identity == nil {
+		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "authentication required", nil)
+		return
+	}
+
+	userID := identity.ID()
+
+	defs, err := s.store.ListLimitDefinitions(r.Context())
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	entries := make([]myUsageEntry, 0, len(defs))
+	for _, def := range defs {
+		// Resolve effective limit for this user at system scope.
+		effectiveLimit, err := s.quotaService.ResolveEffectiveLimit(
+			r.Context(), def.ID, userID, store.QuotaScopeSystem, "")
+		if err != nil {
+			slog.Warn("failed to resolve effective limit for user",
+				"limit_id", def.ID, "user_id", userID, "error", err)
+			effectiveLimit = def.DefaultValue
+		}
+
+		// Count active reservations for this user at system scope.
+		current, err := s.store.CountActiveReservations(
+			r.Context(), def.ID, userID, store.QuotaScopeSystem, "")
+		if err != nil {
+			slog.Warn("failed to count active reservations for user",
+				"limit_id", def.ID, "user_id", userID, "error", err)
+			current = 0
+		}
+
+		entries = append(entries, myUsageEntry{
+			LimitDefinition: def,
+			Current:         current,
+			Max:             effectiveLimit,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, myUsageResponse{Items: entries})
+}
+
+// ---------------------------------------------------------------------------
+// Authorization helper
+// ---------------------------------------------------------------------------
+
+// requireWritePermissionForQuota checks that the authenticated user has the
+// specified quota permission. It uses the same pattern as requireWritePermission
+// but with the "quota" resource type.
+func (s *Server) requireWritePermissionForQuota(w http.ResponseWriter, r *http.Request, permission string, action string) (UserIdentity, bool) {
+	identity := GetIdentityFromContext(r.Context())
+	if identity == nil {
+		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "authentication required", nil)
+		return nil, false
+	}
+	user, ok := identity.(UserIdentity)
+	if !ok {
+		Forbidden(w)
+		return nil, false
+	}
+	decision := s.authzService.Decide(r.Context(), AuthzRequest{
+		Principal:  principalContextForIdentity(user),
+		Credential: credentialContextForIdentity(user),
+		Resource:   Resource{Type: "quota", ID: "hub"},
+		Action:     Action(action),
+		Permission: permission,
+	})
+	if !decision.Allowed {
+		Forbidden(w)
+		return nil, false
+	}
+	return user, true
+}

--- a/pkg/hub/handlers_quota.go
+++ b/pkg/hub/handlers_quota.go
@@ -268,6 +268,11 @@ func (s *Server) createLimitDefinition(w http.ResponseWriter, r *http.Request, u
 		return
 	}
 
+	if req.DefaultValue < 0 {
+		BadRequest(w, "default_value must be non-negative (0 means unlimited)")
+		return
+	}
+
 	now := time.Now()
 	def := &store.LimitDefinition{
 		ID:           uuid.New().String(),
@@ -332,6 +337,16 @@ func (s *Server) updateLimitDefinition(w http.ResponseWriter, r *http.Request, i
 		return
 	}
 
+	if req.Name == "" {
+		BadRequest(w, "name is required")
+		return
+	}
+
+	if req.DefaultValue < 0 {
+		BadRequest(w, "default_value must be non-negative (0 means unlimited)")
+		return
+	}
+
 	existing, err := s.store.GetLimitDefinition(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
@@ -339,6 +354,12 @@ func (s *Server) updateLimitDefinition(w http.ResponseWriter, r *http.Request, i
 			return
 		}
 		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	// System-seeded limit definitions cannot be modified.
+	if existing.System {
+		writeForbidden(w, "system-seeded limit definitions cannot be modified")
 		return
 	}
 
@@ -406,6 +427,11 @@ func (s *Server) createEntitlement(w http.ResponseWriter, r *http.Request, limit
 	var req createEntitlementBindingRequest
 	if err := readJSON(r, &req); err != nil {
 		BadRequest(w, "invalid request body: "+err.Error())
+		return
+	}
+
+	if req.Value < 0 {
+		BadRequest(w, "value must be non-negative (0 means unlimited)")
 		return
 	}
 
@@ -484,6 +510,11 @@ func (s *Server) updateEntitlement(w http.ResponseWriter, r *http.Request, id st
 		return
 	}
 
+	if req.Value < 0 {
+		BadRequest(w, "value must be non-negative (0 means unlimited)")
+		return
+	}
+
 	existing, err := s.store.GetEntitlementBinding(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
@@ -548,7 +579,10 @@ func (s *Server) getUsageSummary(w http.ResponseWriter, r *http.Request) {
 	for _, def := range defs {
 		reservations, err := s.store.ListActiveReservations(r.Context(), def.ID, store.QuotaScopeSystem, "")
 		activeCount := 0
-		if err == nil {
+		if err != nil {
+			slog.Error("failed to list active reservations for usage summary",
+				"limit_id", def.ID, "error", err)
+		} else {
 			activeCount = len(reservations)
 		}
 		entries = append(entries, usageSummaryEntry{

--- a/pkg/hub/handlers_quota.go
+++ b/pkg/hub/handlers_quota.go
@@ -135,6 +135,7 @@ func (s *Server) handleAdminLimits(w http.ResponseWriter, r *http.Request) {
 // /api/v1/admin/limits/:id/entitlements.
 func (s *Server) handleAdminLimitByID(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/limits/")
+	path = strings.TrimSuffix(path, "/")
 	parts := strings.SplitN(path, "/", 2)
 	limitID := parts[0]
 	if limitID == "" {
@@ -263,6 +264,7 @@ func (s *Server) createLimitDefinition(w http.ResponseWriter, r *http.Request, u
 		return
 	}
 
+	req.Name = strings.TrimSpace(req.Name)
 	if req.Name == "" {
 		BadRequest(w, "name is required")
 		return
@@ -337,6 +339,7 @@ func (s *Server) updateLimitDefinition(w http.ResponseWriter, r *http.Request, i
 		return
 	}
 
+	req.Name = strings.TrimSpace(req.Name)
 	if req.Name == "" {
 		BadRequest(w, "name is required")
 		return
@@ -430,6 +433,15 @@ func (s *Server) createEntitlement(w http.ResponseWriter, r *http.Request, limit
 		return
 	}
 
+	if req.SubjectType == "" {
+		BadRequest(w, "subject_type is required")
+		return
+	}
+	if req.SubjectID == "" {
+		BadRequest(w, "subject_id is required")
+		return
+	}
+
 	if req.Value < 0 {
 		BadRequest(w, "value must be non-negative (0 means unlimited)")
 		return
@@ -507,6 +519,15 @@ func (s *Server) updateEntitlement(w http.ResponseWriter, r *http.Request, id st
 	var req updateEntitlementBindingRequest
 	if err := readJSON(r, &req); err != nil {
 		BadRequest(w, "invalid request body: "+err.Error())
+		return
+	}
+
+	if req.SubjectType == "" {
+		BadRequest(w, "subject_type is required")
+		return
+	}
+	if req.SubjectID == "" {
+		BadRequest(w, "subject_id is required")
 		return
 	}
 
@@ -628,6 +649,12 @@ func (s *Server) getMyUsage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if s.quotaService == nil {
+		// When quota service is unavailable, return empty usage.
+		writeJSON(w, http.StatusOK, myUsageResponse{Items: []myUsageEntry{}})
+		return
+	}
+
 	userID := identity.ID()
 
 	defs, err := s.store.ListLimitDefinitions(r.Context())
@@ -681,6 +708,10 @@ func (s *Server) requireWritePermissionForQuota(w http.ResponseWriter, r *http.R
 	}
 	user, ok := identity.(UserIdentity)
 	if !ok {
+		Forbidden(w)
+		return nil, false
+	}
+	if s.authzService == nil {
 		Forbidden(w)
 		return nil, false
 	}

--- a/pkg/hub/handlers_quota_test.go
+++ b/pkg/hub/handlers_quota_test.go
@@ -601,3 +601,175 @@ func TestQuotaAPI_UsageMe_MethodNotAllowed(t *testing.T) {
 	rec := doRequest(t, srv, http.MethodPost, "/api/v1/usage/me", nil)
 	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
 }
+
+// ---------------------------------------------------------------------------
+// Tests: Fix R1 — Route guard permission: by-ID paths use quota.read
+// ---------------------------------------------------------------------------
+
+func TestQuotaAPI_RouteMetadata_ByIDPathsUseReadPermission(t *testing.T) {
+	// Verify the route guard for by-ID paths uses quota.read (not quota.update),
+	// so that users with only read permission can GET individual resources.
+	limitByID := routeMetadataTable["/api/v1/admin/limits/"]
+	assert.Equal(t, "quota.read", limitByID.Permission,
+		"limit by-ID route guard should require quota.read")
+	assert.Equal(t, "read", limitByID.Action)
+
+	entByID := routeMetadataTable["/api/v1/admin/entitlements/"]
+	assert.Equal(t, "quota.read", entByID.Permission,
+		"entitlement by-ID route guard should require quota.read")
+	assert.Equal(t, "read", entByID.Action)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Fix R3 — updateLimitDefinition rejects blank name
+// ---------------------------------------------------------------------------
+
+func TestQuotaAPI_UpdateLimitDefinition_BlankName(t *testing.T) {
+	srv, _ := testServer(t)
+
+	created := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "update_blank_name", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/admin/limits/"+created.ID, updateLimitDefinitionRequest{
+		Name:         "",
+		ResourceType: "agent",
+		Unit:         "count",
+		DefaultValue: 5,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Fix M1 — System-seeded limits cannot be updated
+// ---------------------------------------------------------------------------
+
+func TestQuotaAPI_UpdateLimitDefinition_SystemSeeded(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// Create a system-seeded limit directly in the store.
+	systemDef, err := s.CreateLimitDefinition(ctx, &store.LimitDefinition{
+		Name:         "system_update_test",
+		ResourceType: "agent",
+		Unit:         "count",
+		DefaultValue: 100,
+		System:       true,
+	})
+	require.NoError(t, err)
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/admin/limits/"+systemDef.ID, updateLimitDefinitionRequest{
+		Name:         "renamed_system_limit",
+		ResourceType: "agent",
+		Unit:         "count",
+		DefaultValue: 200,
+	})
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	// Verify it was not modified.
+	rec = doRequest(t, srv, http.MethodGet, "/api/v1/admin/limits/"+systemDef.ID, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var def store.LimitDefinition
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&def))
+	assert.Equal(t, "system_update_test", def.Name)
+	assert.Equal(t, int64(100), def.DefaultValue)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Fix M2 — Negative value validation
+// ---------------------------------------------------------------------------
+
+func TestQuotaAPI_CreateLimitDefinition_NegativeDefaultValue(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/limits", createLimitDefinitionRequest{
+		Name:         "neg_default_limit",
+		ResourceType: "agent",
+		Unit:         "count",
+		DefaultValue: -5,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestQuotaAPI_UpdateLimitDefinition_NegativeDefaultValue(t *testing.T) {
+	srv, _ := testServer(t)
+
+	created := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "neg_update_limit", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/admin/limits/"+created.ID, updateLimitDefinitionRequest{
+		Name:         "neg_update_limit",
+		ResourceType: "agent",
+		Unit:         "count",
+		DefaultValue: -10,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestQuotaAPI_CreateEntitlement_NegativeValue(t *testing.T) {
+	srv, _ := testServer(t)
+
+	limit := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "neg_ent_create_limit", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/limits/"+limit.ID+"/entitlements", createEntitlementBindingRequest{
+		SubjectType: "user",
+		SubjectID:   "user-1",
+		ScopeType:   "system",
+		Value:       -1,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestQuotaAPI_UpdateEntitlement_NegativeValue(t *testing.T) {
+	srv, _ := testServer(t)
+
+	limit := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "neg_ent_update_limit", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+	binding := createEntitlementViaAPI(t, srv, limit.ID, createEntitlementBindingRequest{
+		SubjectType: "user",
+		SubjectID:   "user-1",
+		ScopeType:   "system",
+		Value:       10,
+	})
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/admin/entitlements/"+binding.ID, updateEntitlementBindingRequest{
+		SubjectType: "user",
+		SubjectID:   "user-1",
+		ScopeType:   "system",
+		Value:       -5,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// Zero values are valid (0 means unlimited).
+func TestQuotaAPI_CreateLimitDefinition_ZeroDefaultValue(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/limits", createLimitDefinitionRequest{
+		Name:         "zero_default_limit",
+		ResourceType: "agent",
+		Unit:         "count",
+		DefaultValue: 0,
+	})
+	assert.Equal(t, http.StatusCreated, rec.Code)
+}
+
+func TestQuotaAPI_CreateEntitlement_ZeroValue(t *testing.T) {
+	srv, _ := testServer(t)
+
+	limit := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "zero_ent_limit", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/limits/"+limit.ID+"/entitlements", createEntitlementBindingRequest{
+		SubjectType: "user",
+		SubjectID:   "user-1",
+		ScopeType:   "system",
+		Value:       0,
+	})
+	assert.Equal(t, http.StatusCreated, rec.Code)
+}

--- a/pkg/hub/handlers_quota_test.go
+++ b/pkg/hub/handlers_quota_test.go
@@ -1,0 +1,603 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// createLimitViaAPI creates a limit definition through the handler and returns it.
+func createLimitViaAPI(t *testing.T, srv *Server, req createLimitDefinitionRequest) *store.LimitDefinition {
+	t.Helper()
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/limits", req)
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+	var def store.LimitDefinition
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&def))
+	return &def
+}
+
+// createEntitlementViaAPI creates an entitlement binding through the handler.
+func createEntitlementViaAPI(t *testing.T, srv *Server, limitID string, req createEntitlementBindingRequest) *store.EntitlementBinding {
+	t.Helper()
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/limits/"+limitID+"/entitlements", req)
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+	var binding store.EntitlementBinding
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&binding))
+	return &binding
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Limit Definition CRUD
+// ---------------------------------------------------------------------------
+
+func TestQuotaAPI_CreateLimitDefinition(t *testing.T) {
+	srv, _ := testServer(t)
+
+	def := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name:         "test_limit",
+		ResourceType: "agent",
+		Unit:         "count",
+		Description:  "Test limit",
+		DefaultValue: 10,
+	})
+
+	assert.NotEmpty(t, def.ID)
+	assert.Equal(t, "test_limit", def.Name)
+	assert.Equal(t, "agent", def.ResourceType)
+	assert.Equal(t, "count", def.Unit)
+	assert.Equal(t, int64(10), def.DefaultValue)
+	assert.False(t, def.System)
+}
+
+func TestQuotaAPI_CreateLimitDefinition_MissingName(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/limits", createLimitDefinitionRequest{
+		ResourceType: "agent",
+		Unit:         "count",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestQuotaAPI_CreateLimitDefinition_DuplicateName(t *testing.T) {
+	srv, _ := testServer(t)
+
+	createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name:         "duplicate_limit",
+		ResourceType: "agent",
+		Unit:         "count",
+		DefaultValue: 5,
+	})
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/limits", createLimitDefinitionRequest{
+		Name:         "duplicate_limit",
+		ResourceType: "agent",
+		Unit:         "count",
+		DefaultValue: 10,
+	})
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+func TestQuotaAPI_GetLimitDefinition(t *testing.T) {
+	srv, _ := testServer(t)
+
+	created := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name:         "get_limit",
+		ResourceType: "project",
+		Unit:         "count",
+		Description:  "Get test",
+		DefaultValue: 5,
+	})
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/limits/"+created.ID, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var def store.LimitDefinition
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&def))
+	assert.Equal(t, created.ID, def.ID)
+	assert.Equal(t, "get_limit", def.Name)
+}
+
+func TestQuotaAPI_GetLimitDefinition_NotFound(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/limits/"+tid("nonexistent"), nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestQuotaAPI_ListLimitDefinitions(t *testing.T) {
+	srv, _ := testServer(t)
+
+	createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "list_limit_1", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+	createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "list_limit_2", ResourceType: "project", Unit: "count", DefaultValue: 10,
+	})
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/limits", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp listLimitDefinitionsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.GreaterOrEqual(t, resp.TotalCount, 2)
+}
+
+func TestQuotaAPI_UpdateLimitDefinition(t *testing.T) {
+	srv, _ := testServer(t)
+
+	created := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "update_limit", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/admin/limits/"+created.ID, updateLimitDefinitionRequest{
+		Name:         "updated_limit",
+		ResourceType: "agent",
+		Unit:         "count",
+		Description:  "Updated description",
+		DefaultValue: 20,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var updated store.LimitDefinition
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&updated))
+	assert.Equal(t, "updated_limit", updated.Name)
+	assert.Equal(t, int64(20), updated.DefaultValue)
+	assert.Equal(t, "Updated description", updated.Description)
+}
+
+func TestQuotaAPI_UpdateLimitDefinition_NotFound(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/admin/limits/"+tid("nonexistent"), updateLimitDefinitionRequest{
+		Name: "nope", ResourceType: "agent", Unit: "count",
+	})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestQuotaAPI_DeleteLimitDefinition(t *testing.T) {
+	srv, _ := testServer(t)
+
+	created := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "delete_limit", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+
+	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/admin/limits/"+created.ID, nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Verify it's gone.
+	rec = doRequest(t, srv, http.MethodGet, "/api/v1/admin/limits/"+created.ID, nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestQuotaAPI_DeleteLimitDefinition_SystemSeeded(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// Create a system-seeded limit directly in the store.
+	systemDef, err := s.CreateLimitDefinition(ctx, &store.LimitDefinition{
+		Name:         "system_limit",
+		ResourceType: "agent",
+		Unit:         "count",
+		DefaultValue: 100,
+		System:       true,
+	})
+	require.NoError(t, err)
+
+	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/admin/limits/"+systemDef.ID, nil)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+
+	// Verify it still exists.
+	rec = doRequest(t, srv, http.MethodGet, "/api/v1/admin/limits/"+systemDef.ID, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestQuotaAPI_DeleteLimitDefinition_NotFound(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/admin/limits/"+tid("nonexistent"), nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Entitlement Binding CRUD
+// ---------------------------------------------------------------------------
+
+func TestQuotaAPI_CreateEntitlement(t *testing.T) {
+	srv, _ := testServer(t)
+
+	limit := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "ent_create_limit", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+
+	binding := createEntitlementViaAPI(t, srv, limit.ID, createEntitlementBindingRequest{
+		SubjectType: store.EntitlementSubjectUser,
+		SubjectID:   "user-1",
+		ScopeType:   store.QuotaScopeSystem,
+		ScopeID:     "",
+		Value:       10,
+	})
+
+	assert.NotEmpty(t, binding.ID)
+	assert.Equal(t, limit.ID, binding.LimitDefinitionID)
+	assert.Equal(t, store.EntitlementSubjectUser, binding.SubjectType)
+	assert.Equal(t, "user-1", binding.SubjectID)
+	assert.Equal(t, int64(10), binding.Value)
+}
+
+func TestQuotaAPI_CreateEntitlement_LimitNotFound(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/limits/"+tid("nonexistent")+"/entitlements", createEntitlementBindingRequest{
+		SubjectType: store.EntitlementSubjectUser,
+		SubjectID:   "user-1",
+		ScopeType:   store.QuotaScopeSystem,
+		Value:       10,
+	})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestQuotaAPI_GetEntitlement(t *testing.T) {
+	srv, _ := testServer(t)
+
+	limit := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "ent_get_limit", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+	binding := createEntitlementViaAPI(t, srv, limit.ID, createEntitlementBindingRequest{
+		SubjectType: store.EntitlementSubjectUser,
+		SubjectID:   "user-1",
+		ScopeType:   store.QuotaScopeSystem,
+		Value:       10,
+	})
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/entitlements/"+binding.ID, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got store.EntitlementBinding
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+	assert.Equal(t, binding.ID, got.ID)
+}
+
+func TestQuotaAPI_GetEntitlement_NotFound(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/entitlements/"+tid("nonexistent"), nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestQuotaAPI_ListEntitlements(t *testing.T) {
+	srv, _ := testServer(t)
+
+	limit := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "ent_list_limit", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+	createEntitlementViaAPI(t, srv, limit.ID, createEntitlementBindingRequest{
+		SubjectType: store.EntitlementSubjectUser,
+		SubjectID:   "user-1",
+		ScopeType:   store.QuotaScopeSystem,
+		Value:       10,
+	})
+	createEntitlementViaAPI(t, srv, limit.ID, createEntitlementBindingRequest{
+		SubjectType: store.EntitlementSubjectGroup,
+		SubjectID:   "group-1",
+		ScopeType:   store.QuotaScopeSystem,
+		Value:       20,
+	})
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/limits/"+limit.ID+"/entitlements", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp listEntitlementBindingsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, 2, resp.TotalCount)
+}
+
+func TestQuotaAPI_UpdateEntitlement(t *testing.T) {
+	srv, _ := testServer(t)
+
+	limit := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "ent_update_limit", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+	binding := createEntitlementViaAPI(t, srv, limit.ID, createEntitlementBindingRequest{
+		SubjectType: store.EntitlementSubjectUser,
+		SubjectID:   "user-1",
+		ScopeType:   store.QuotaScopeSystem,
+		Value:       10,
+	})
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/admin/entitlements/"+binding.ID, updateEntitlementBindingRequest{
+		SubjectType: store.EntitlementSubjectUser,
+		SubjectID:   "user-1",
+		ScopeType:   store.QuotaScopeSystem,
+		Value:       50,
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var updated store.EntitlementBinding
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&updated))
+	assert.Equal(t, int64(50), updated.Value)
+}
+
+func TestQuotaAPI_DeleteEntitlement(t *testing.T) {
+	srv, _ := testServer(t)
+
+	limit := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "ent_delete_limit", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+	binding := createEntitlementViaAPI(t, srv, limit.ID, createEntitlementBindingRequest{
+		SubjectType: store.EntitlementSubjectUser,
+		SubjectID:   "user-1",
+		ScopeType:   store.QuotaScopeSystem,
+		Value:       10,
+	})
+
+	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/admin/entitlements/"+binding.ID, nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Verify it's gone.
+	rec = doRequest(t, srv, http.MethodGet, "/api/v1/admin/entitlements/"+binding.ID, nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Usage Queries
+// ---------------------------------------------------------------------------
+
+func TestQuotaAPI_GetUsageSummary(t *testing.T) {
+	srv, _ := testServer(t)
+
+	createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "usage_summary_limit", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/usage", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp usageSummaryResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.NotEmpty(t, resp.Items)
+}
+
+func TestQuotaAPI_GetUsageByLimit(t *testing.T) {
+	srv, _ := testServer(t)
+
+	limit := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "usage_by_limit", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/usage/"+limit.ID, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp usageByLimitResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, limit.ID, resp.LimitDefinition.ID)
+	assert.Equal(t, 0, resp.TotalActive)
+}
+
+func TestQuotaAPI_GetUsageByLimit_NotFound(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/usage/"+tid("nonexistent"), nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: /usage/me (self-service, no admin required)
+// ---------------------------------------------------------------------------
+
+func TestQuotaAPI_UsageMe_Authenticated(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+	seedRoleDefinitions(ctx, s)
+
+	// Create a non-admin user.
+	memberU := &store.User{
+		ID:          tid("quota-member"),
+		Email:       "quota-member@example.com",
+		DisplayName: "Quota Member",
+		Role:        "member",
+		Status:      "active",
+	}
+	require.NoError(t, s.CreateUser(ctx, memberU))
+
+	rec := doRequestAsUser(t, srv, memberU, http.MethodGet, "/api/v1/usage/me", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp myUsageResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	// Should return items (may be empty if no limits are defined).
+	assert.NotNil(t, resp.Items)
+}
+
+func TestQuotaAPI_UsageMe_Unauthenticated(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequestNoAuth(t, srv, http.MethodGet, "/api/v1/usage/me", nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestQuotaAPI_UsageMe_WithLimits(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+	seedRoleDefinitions(ctx, s)
+
+	// Create a limit and a user.
+	limit, err := s.CreateLimitDefinition(ctx, &store.LimitDefinition{
+		Name:         "me_test_limit",
+		ResourceType: "agent",
+		Unit:         "count",
+		Description:  "test",
+		DefaultValue: 5,
+	})
+	require.NoError(t, err)
+
+	memberU := &store.User{
+		ID:          tid("quota-member-2"),
+		Email:       "quota-member-2@example.com",
+		DisplayName: "Quota Member 2",
+		Role:        "member",
+		Status:      "active",
+	}
+	require.NoError(t, s.CreateUser(ctx, memberU))
+
+	rec := doRequestAsUser(t, srv, memberU, http.MethodGet, "/api/v1/usage/me", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp myUsageResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.NotEmpty(t, resp.Items)
+
+	// Find our limit in the response.
+	var found bool
+	for _, entry := range resp.Items {
+		if entry.LimitDefinition.ID == limit.ID {
+			found = true
+			assert.Equal(t, int64(0), entry.Current) // no reservations yet
+			assert.Equal(t, int64(5), entry.Max)     // default value
+			break
+		}
+	}
+	assert.True(t, found, "expected to find limit %s in usage/me response", limit.ID)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Admin permission enforcement
+// ---------------------------------------------------------------------------
+
+func TestQuotaAPI_AdminLimits_Forbidden_NonAdmin(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+	seedRoleDefinitions(ctx, s)
+	memberU := &store.User{
+		ID: tid("quota-nonadmin1"), Email: "qa-nonadmin1@example.com",
+		DisplayName: "Member", Role: "member", Status: "active",
+	}
+	require.NoError(t, s.CreateUser(ctx, memberU))
+	handler := srv.guarded("/api/v1/admin/limits", srv.handleAdminLimits)
+
+	member := NewAuthenticatedUser(tid("quota-nonadmin1"), "qa-nonadmin1@example.com", "Member", "member", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/limits", nil)
+	req = req.WithContext(contextWithIdentity(ctx, member))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestQuotaAPI_AdminLimits_Forbidden_Unauthenticated(t *testing.T) {
+	srv, _ := testServer(t)
+	ctx := context.Background()
+	handler := srv.guarded("/api/v1/admin/limits", srv.handleAdminLimits)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/limits", nil)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestQuotaAPI_AdminEntitlements_Forbidden_NonAdmin(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+	seedRoleDefinitions(ctx, s)
+	memberU := &store.User{
+		ID: tid("quota-nonadmin2"), Email: "qa-nonadmin2@example.com",
+		DisplayName: "Member", Role: "member", Status: "active",
+	}
+	require.NoError(t, s.CreateUser(ctx, memberU))
+	handler := srv.guarded("/api/v1/admin/entitlements/", srv.handleAdminEntitlementByID)
+
+	member := NewAuthenticatedUser(tid("quota-nonadmin2"), "qa-nonadmin2@example.com", "Member", "member", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/entitlements/some-id", nil)
+	req = req.WithContext(contextWithIdentity(ctx, member))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestQuotaAPI_AdminUsage_Forbidden_NonAdmin(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+	seedRoleDefinitions(ctx, s)
+	memberU := &store.User{
+		ID: tid("quota-nonadmin3"), Email: "qa-nonadmin3@example.com",
+		DisplayName: "Member", Role: "member", Status: "active",
+	}
+	require.NoError(t, s.CreateUser(ctx, memberU))
+	handler := srv.guarded("/api/v1/admin/usage", srv.handleAdminUsage)
+
+	member := NewAuthenticatedUser(tid("quota-nonadmin3"), "qa-nonadmin3@example.com", "Member", "member", "cli")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/usage", nil)
+	req = req.WithContext(contextWithIdentity(ctx, member))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Hub-admin with quota permissions can access admin endpoints
+// ---------------------------------------------------------------------------
+
+func TestQuotaAPI_HubAdmin_CanAccessLimits(t *testing.T) {
+	srv, _ := testServer(t)
+	// The dev auth token creates a super-admin by default, which should have access.
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/limits", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestQuotaAPI_HubAdmin_CanAccessUsage(t *testing.T) {
+	srv, _ := testServer(t)
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/usage", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Method not allowed
+// ---------------------------------------------------------------------------
+
+func TestQuotaAPI_Limits_MethodNotAllowed(t *testing.T) {
+	srv, _ := testServer(t)
+	rec := doRequest(t, srv, http.MethodPatch, "/api/v1/admin/limits", nil)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestQuotaAPI_Usage_MethodNotAllowed(t *testing.T) {
+	srv, _ := testServer(t)
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/usage", nil)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestQuotaAPI_UsageMe_MethodNotAllowed(t *testing.T) {
+	srv, _ := testServer(t)
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/usage/me", nil)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}

--- a/pkg/hub/handlers_quota_test.go
+++ b/pkg/hub/handlers_quota_test.go
@@ -773,3 +773,164 @@ func TestQuotaAPI_CreateEntitlement_ZeroValue(t *testing.T) {
 	})
 	assert.Equal(t, http.StatusCreated, rec.Code)
 }
+
+// ---------------------------------------------------------------------------
+// Tests: Fix B3 — nil quotaService returns empty usage (HIGH)
+// ---------------------------------------------------------------------------
+
+func TestQuotaAPI_UsageMe_NilQuotaService(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+	seedRoleDefinitions(ctx, s)
+
+	memberU := &store.User{
+		ID:          tid("quota-nil-qs"),
+		Email:       "quota-nil-qs@example.com",
+		DisplayName: "Nil QS User",
+		Role:        "member",
+		Status:      "active",
+	}
+	require.NoError(t, s.CreateUser(ctx, memberU))
+
+	// Nil out the quotaService to simulate a store that doesn't support quotas.
+	srv.quotaService = nil
+
+	rec := doRequestAsUser(t, srv, memberU, http.MethodGet, "/api/v1/usage/me", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp myUsageResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Empty(t, resp.Items, "nil quotaService should return empty usage items")
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Fix B3 — trailing slash on by-ID routes (MEDIUM-2)
+// ---------------------------------------------------------------------------
+
+func TestQuotaAPI_GetLimitDefinition_TrailingSlash(t *testing.T) {
+	srv, _ := testServer(t)
+
+	created := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "trailing_slash_limit", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+
+	// Request with trailing slash — should still find the resource.
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/limits/"+created.ID+"/", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var def store.LimitDefinition
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&def))
+	assert.Equal(t, created.ID, def.ID)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Fix B3 — whitespace-only names rejected (MEDIUM-3 / MEDIUM-4)
+// ---------------------------------------------------------------------------
+
+func TestQuotaAPI_CreateLimitDefinition_WhitespaceOnlyName(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/limits", createLimitDefinitionRequest{
+		Name:         "   ",
+		ResourceType: "agent",
+		Unit:         "count",
+		DefaultValue: 5,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestQuotaAPI_UpdateLimitDefinition_WhitespaceOnlyName(t *testing.T) {
+	srv, _ := testServer(t)
+
+	created := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "ws_update_limit", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/admin/limits/"+created.ID, updateLimitDefinitionRequest{
+		Name:         "   ",
+		ResourceType: "agent",
+		Unit:         "count",
+		DefaultValue: 5,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Fix B3 — empty SubjectType/SubjectID rejected (MEDIUM-5 / MEDIUM-6)
+// ---------------------------------------------------------------------------
+
+func TestQuotaAPI_CreateEntitlement_EmptySubjectType(t *testing.T) {
+	srv, _ := testServer(t)
+
+	limit := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "ent_empty_st_create", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/limits/"+limit.ID+"/entitlements", createEntitlementBindingRequest{
+		SubjectType: "",
+		SubjectID:   "user-1",
+		ScopeType:   "system",
+		Value:       10,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestQuotaAPI_CreateEntitlement_EmptySubjectID(t *testing.T) {
+	srv, _ := testServer(t)
+
+	limit := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "ent_empty_sid_create", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/limits/"+limit.ID+"/entitlements", createEntitlementBindingRequest{
+		SubjectType: "user",
+		SubjectID:   "",
+		ScopeType:   "system",
+		Value:       10,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestQuotaAPI_UpdateEntitlement_EmptySubjectType(t *testing.T) {
+	srv, _ := testServer(t)
+
+	limit := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "ent_empty_st_update", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+	binding := createEntitlementViaAPI(t, srv, limit.ID, createEntitlementBindingRequest{
+		SubjectType: "user",
+		SubjectID:   "user-1",
+		ScopeType:   "system",
+		Value:       10,
+	})
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/admin/entitlements/"+binding.ID, updateEntitlementBindingRequest{
+		SubjectType: "",
+		SubjectID:   "user-1",
+		ScopeType:   "system",
+		Value:       20,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestQuotaAPI_UpdateEntitlement_EmptySubjectID(t *testing.T) {
+	srv, _ := testServer(t)
+
+	limit := createLimitViaAPI(t, srv, createLimitDefinitionRequest{
+		Name: "ent_empty_sid_update", ResourceType: "agent", Unit: "count", DefaultValue: 5,
+	})
+	binding := createEntitlementViaAPI(t, srv, limit.ID, createEntitlementBindingRequest{
+		SubjectType: "user",
+		SubjectID:   "user-1",
+		ScopeType:   "system",
+		Value:       10,
+	})
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/admin/entitlements/"+binding.ID, updateEntitlementBindingRequest{
+		SubjectType: "user",
+		SubjectID:   "",
+		ScopeType:   "system",
+		Value:       20,
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/pkg/hub/permissions/registry.go
+++ b/pkg/hub/permissions/registry.go
@@ -32,6 +32,7 @@ const (
 	ResourceBroker            = "broker"
 	ResourceGCPServiceAccount = "gcp_service_account"
 	ResourceHub               = "hub"
+	ResourceQuota             = "quota"
 
 	ActionCreate       = "create"
 	ActionRead         = "read"
@@ -183,6 +184,12 @@ var Registry = []Permission{
 	{ID: "hub.github_app.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, Description: "Read GitHub app configuration", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
 	{ID: "hub.github_app.update", Resource: ResourceHub, Action: ActionUpdate, CapabilityKind: CapabilityScope, Description: "Update GitHub app configuration", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
 	{ID: "hub.metrics.read", Resource: ResourceHub, Action: ActionRead, CapabilityKind: CapabilityScope, Description: "Read metrics dashboard", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},
+
+	// Quota management (Phase 2B — Limits/Quotas)
+	{ID: "quota.read", Resource: ResourceQuota, Action: ActionRead, CapabilityKind: CapabilityScope, Description: "Read limit definitions, entitlements, and usage", Enforcement: []string{"pkg/hub/handlers_quota.go"}},
+	{ID: "quota.create", Resource: ResourceQuota, Action: ActionCreate, CapabilityKind: CapabilityScope, Description: "Create limit definitions and entitlement bindings", Enforcement: []string{"pkg/hub/handlers_quota.go"}},
+	{ID: "quota.update", Resource: ResourceQuota, Action: ActionUpdate, CapabilityKind: CapabilityScope, Description: "Update limit definitions and entitlement bindings", Enforcement: []string{"pkg/hub/handlers_quota.go"}},
+	{ID: "quota.delete", Resource: ResourceQuota, Action: ActionDelete, CapabilityKind: CapabilityScope, Description: "Delete limit definitions and entitlement bindings", Enforcement: []string{"pkg/hub/handlers_quota.go"}},
 
 	// Extensions to existing resource types (Phase 2 D4 resolution)
 	{ID: "user.invite", Resource: ResourceUser, Action: ActionInvite, CapabilityKind: CapabilityScope, UATScope: "user:invite", Description: "Invite users", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},

--- a/pkg/hub/route_classification_test.go
+++ b/pkg/hub/route_classification_test.go
@@ -180,6 +180,12 @@ var routePermissionClassifications = map[string]string{
 	"/api/v1/system/fs/mkdir":                   "workstation:filesystem",
 	"/api/v1/system/fs/validate-path":           "workstation:filesystem",
 	"/api/v1/authz/explain":                     "authenticated:authz-explain",
+	"/api/v1/admin/limits":                      "hub-admin:quota",
+	"/api/v1/admin/limits/":                     "hub-admin:quota",
+	"/api/v1/admin/entitlements/":               "hub-admin:quota",
+	"/api/v1/admin/usage":                       "hub-admin:quota",
+	"/api/v1/admin/usage/":                      "hub-admin:quota",
+	"/api/v1/usage/me":                          "authenticated:quota-usage",
 }
 
 func TestRegisteredRoutesHavePermissionClassification(t *testing.T) {

--- a/pkg/hub/route_metadata.go
+++ b/pkg/hub/route_metadata.go
@@ -732,12 +732,12 @@ var routeMetadataTable = map[string]RouteMetadata{
 	"/api/v1/admin/limits/": {
 		Pattern: "/api/v1/admin/limits/", RouteID: "admin.limits.byId",
 		Classification: RouteHubAdmin,
-		Permission:     "quota.update", Resource: "quota", Action: "update",
+		Permission:     "quota.read", Resource: "quota", Action: "read",
 	},
 	"/api/v1/admin/entitlements/": {
 		Pattern: "/api/v1/admin/entitlements/", RouteID: "admin.entitlements.byId",
 		Classification: RouteHubAdmin,
-		Permission:     "quota.update", Resource: "quota", Action: "update",
+		Permission:     "quota.read", Resource: "quota", Action: "read",
 	},
 	"/api/v1/admin/usage": {
 		Pattern: "/api/v1/admin/usage", RouteID: "admin.usage",

--- a/pkg/hub/route_metadata.go
+++ b/pkg/hub/route_metadata.go
@@ -722,6 +722,43 @@ var routeMetadataTable = map[string]RouteMetadata{
 	},
 
 	// -------------------------------------------------------------------------
+	// Hub admin: Quota management (PR-B3)
+	// -------------------------------------------------------------------------
+	"/api/v1/admin/limits": {
+		Pattern: "/api/v1/admin/limits", RouteID: "admin.limits",
+		Classification: RouteHubAdmin,
+		Permission:     "quota.read", Resource: "quota", Action: "read",
+	},
+	"/api/v1/admin/limits/": {
+		Pattern: "/api/v1/admin/limits/", RouteID: "admin.limits.byId",
+		Classification: RouteHubAdmin,
+		Permission:     "quota.update", Resource: "quota", Action: "update",
+	},
+	"/api/v1/admin/entitlements/": {
+		Pattern: "/api/v1/admin/entitlements/", RouteID: "admin.entitlements.byId",
+		Classification: RouteHubAdmin,
+		Permission:     "quota.update", Resource: "quota", Action: "update",
+	},
+	"/api/v1/admin/usage": {
+		Pattern: "/api/v1/admin/usage", RouteID: "admin.usage",
+		Classification: RouteHubAdmin,
+		Permission:     "quota.read", Resource: "quota", Action: "read",
+	},
+	"/api/v1/admin/usage/": {
+		Pattern: "/api/v1/admin/usage/", RouteID: "admin.usage.byLimit",
+		Classification: RouteHubAdmin,
+		Permission:     "quota.read", Resource: "quota", Action: "read",
+	},
+
+	// -------------------------------------------------------------------------
+	// Authenticated: Usage self-service
+	// -------------------------------------------------------------------------
+	"/api/v1/usage/me": {
+		Pattern: "/api/v1/usage/me", RouteID: "usage.me",
+		Classification: RouteAuthenticated,
+	},
+
+	// -------------------------------------------------------------------------
 	// Hub admin: GitHub App
 	// -------------------------------------------------------------------------
 	"/api/v1/github-app": {

--- a/pkg/hub/seed.go
+++ b/pkg/hub/seed.go
@@ -537,6 +537,11 @@ func hubAdminPermissionIDs() []string {
 		"hub.github_app.update":       true,
 		"hub.metrics.read":            true,
 		"hub.validate.execute":        true,
+		// Quota management
+		"quota.read":   true,
+		"quota.create": true,
+		"quota.update": true,
+		"quota.delete": true,
 		// Project oversight
 		"project.read":   true,
 		"project.list":   true,

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3838,6 +3838,14 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/metrics/", s.guarded("/api/v1/metrics/", s.handleMetricsDashboard))
 	s.mux.HandleFunc("/api/v1/admin/metrics-dashboard", s.guarded("/api/v1/admin/metrics-dashboard", s.handleAdminMetricsDashboard)) // legacy backward-compat
 
+	// Quota management (PR-B3)
+	s.mux.HandleFunc("/api/v1/admin/limits", s.guarded("/api/v1/admin/limits", s.handleAdminLimits))
+	s.mux.HandleFunc("/api/v1/admin/limits/", s.guarded("/api/v1/admin/limits/", s.handleAdminLimitByID))
+	s.mux.HandleFunc("/api/v1/admin/entitlements/", s.guarded("/api/v1/admin/entitlements/", s.handleAdminEntitlementByID))
+	s.mux.HandleFunc("/api/v1/admin/usage", s.guarded("/api/v1/admin/usage", s.handleAdminUsage))
+	s.mux.HandleFunc("/api/v1/admin/usage/", s.guarded("/api/v1/admin/usage/", s.handleAdminUsageByLimit))
+	s.mux.HandleFunc("/api/v1/usage/me", s.guarded("/api/v1/usage/me", s.handleUsageMe))
+
 	// Notification endpoints (user-facing)
 	s.mux.HandleFunc("/api/v1/notifications", s.guarded("/api/v1/notifications", s.handleNotifications))
 	s.mux.HandleFunc("/api/v1/notifications/", s.guarded("/api/v1/notifications/", s.handleNotificationRoutes))


### PR DESCRIPTION
## Summary
- 13 quota API endpoints: limit/entitlement CRUD + usage queries
- Route guard read/write permission split
- System limit modification protection
- Negative value rejection + name validation on update
- Completes Track 2 (Limits/Quotas)

## Test plan
- make ci passes
- Code review: APPROVE (after 5 findings fixed)
- Security audit: PASS