### PR TITLE
fix(hub): validate defaultAgent and scope resolver fallback (DEF-31)

### DIFF
--- a/.design/project-log/def31-default-agent-validation.md
+++ b/.design/project-log/def31-default-agent-validation.md
@@ -92,6 +92,36 @@ Five tests added per specification:
    deleted-at guards are removed, these assertions fail with diagnostic messages
    naming the defect — not a panic or compile error.
 
+## Send-path resolver tests (added in review round 2)
+
+The initial tests only exercised `validateDefaultAgent` (ingress helper). The
+reviewer correctly identified that the load-bearing resolver guard at the send
+path had zero test coverage. Three send-path tests were added:
+
+6. **TestDEF31_SendPath_ForeignProjectAgent_NotRouted** — writes a topic with a
+   foreign-project agent UUID directly via `wcs.CreateTopic` (bypassing ingress),
+   POSTs a message, asserts `type=chat` (no agent routing).
+
+7. **TestDEF31_SendPath_SoftDeletedAgent_NotRouted** — same pattern with a
+   soft-deleted same-project agent UUID.
+
+8. **TestDEF31_SendPath_ValidAgent_StillRoutes** — paired positive: a valid
+   same-project agent still routes (`type=instruction`). Without this, deleting
+   the entire routing branch passes all tests.
+
+**Mutation result:** Removed the resolver guard (lines 995-1001), ran send-path
+tests — both negative tests FAILED with assertions naming the wrong-project/
+deleted-agent routing. Positive test still passed. Restored guard — all 11 tests
+passed.
+
+## Whitespace fix (added in review round 2)
+
+Whitespace-only `defaultAgent` (`"   "`) behaved differently on the two
+endpoints: CreateThread trimmed inside the `!= ""` check (so `"   "` → `""`
+triggered a confusing validation error), while TopicPatch trimmed first (treating
+it as a clear). Fixed CreateThread to trim before the empty check, matching PATCH
+behavior.
+
 ## Pre-existing test failure
 
 `TestTemplateResource_UATConfinement/global_template_is_still_not_confined_(unchanged)`

--- a/.design/project-log/def31-default-agent-validation.md
+++ b/.design/project-log/def31-default-agent-validation.md
@@ -1,0 +1,98 @@
+# DEF-31: Fix cross-project agent routing via unvalidated defaultAgent
+
+**Date:** 2026-08-28
+**Branch:** `scion/ca-msg-em6-def31`
+**Files changed:** `pkg/hub/handlers_chat_v2.go`, `pkg/hub/handlers_chat_v2_test.go`
+
+## Problem
+
+The `defaultAgent` field on topic CreateTopic and UpdateTopic request bodies was
+stored without any validation, while sibling fields (like `name`) were validated
+four ways (required, trimmed, <=100 runes, regexp). This created a three-link
+defect chain:
+
+1. **Unvalidated ingress:** `body.DefaultAgent` stored as-is at CreateTopic
+   (line ~451) and UpdateTopic (lines ~544, 575-576) with zero validation.
+
+2. **Unscoped resolver fallback:** The default-agent resolver at send time
+   (line ~932-940) did a two-step lookup:
+   - Step 1: `GetAgentBySlug(projectID, raw)` — project-scoped, filters deleted
+   - Step 2 (fallback): `GetAgent(raw)` — bare primary-key fetch with NO project
+     filter and NO `deleted_at` filter
+
+3. **Cross-project binding:** A raw UUID naming an agent in another project, or a
+   soft-deleted agent, would bind successfully via step 2, defeating
+   `ClearTopicDefaultAgent` (which scrubs bindings on agent deletion).
+
+## Severity
+
+The participant table is a derived listing index, not the access authority.
+Auth for DM conversations is key-derived (checks kind AND id via ParseDMKey on
+external_ref). Auth for group conversations is project membership. An unguarded
+defaultAgent corrupts **listings** (conversation appears in wrong sidebar), NOT
+access (cannot read or post). This is NOT an authorization bypass.
+
+Exception: the `default` branch in resolve.go for unknown conversation kinds
+falls back to `requireParticipant`, where the participant table IS the authority.
+No such kind exists today. Accurate severity: "not an ACL today; an ACL for any
+future conversation kind someone forgets to case."
+
+## Fix
+
+### (a) Lookup fix (load-bearing)
+
+After the `GetAgent` fallback returns in the resolver, added project-ID and
+deleted-at checks:
+
+```go
+if defaultAgent.ProjectID != projectID || !defaultAgent.DeletedAt.IsZero() {
+    defaultAgent = nil
+}
+```
+
+This does NOT change GetAgent's global signature — the constraint is at the
+call site only.
+
+### (b) Ingress validation (makes failure legible)
+
+Added `validateDefaultAgent` helper method that performs the same two-step
+lookup (slug first, then UUID) with project-scoping and deleted-at checks.
+Called from both:
+- `handleCreateThread` — validates `body.DefaultAgent` before creating the topic
+- `handleTopicPatch` — validates `*body.DefaultAgent` before updating (clearing
+  via empty string is always allowed)
+
+Both request body structs were audited:
+- **CreateTopic body:** `Name` (validated 4 ways), `DefaultAgent` (now validated)
+- **UpdateTopic body:** `Name` (validated 4 ways when provided), `DefaultAgent` (now validated)
+
+No other unvalidated fields exist on either struct.
+
+## Tests
+
+Five tests added per specification:
+
+1. **TestDEF31_ForeignProjectUUID_Rejected** — agent in project B rejected as
+   defaultAgent on topic in project A, for both POST (create) and PATCH (update).
+
+2. **TestDEF31_SoftDeletedAgent_Rejected** — soft-deleted agent rejected as
+   defaultAgent, for both POST and PATCH.
+
+3. **TestDEF31_Rebinding_AfterSoftDelete** — binds agent, soft-deletes it,
+   confirms ClearTopicDefaultAgent scrubs the binding, then tests that even
+   manually re-setting the binding is caught by validateDefaultAgent.
+
+4. **TestDEF31_PairedPositives** — valid slug binds, valid same-project UUID
+   binds, clearing via empty string works. Proves the validator accepts valid
+   inputs (not just reject everything).
+
+5. **TestDEF31_MutationTest_LookupScoping** — structural mutation test:
+   exercises validateDefaultAgent directly with foreign-project UUID and
+   soft-deleted UUID, asserting specific error messages. If the project-ID or
+   deleted-at guards are removed, these assertions fail with diagnostic messages
+   naming the defect — not a panic or compile error.
+
+## Pre-existing test failure
+
+`TestTemplateResource_UATConfinement/global_template_is_still_not_confined_(unchanged)`
+fails on upstream/main independently of these changes.

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -445,6 +445,20 @@ func (s *Server) handleCreateThread(w http.ResponseWriter, r *http.Request, proj
 		return
 	}
 
+	// Validate defaultAgent when provided: must be a reasonable length and
+	// must resolve to a non-deleted agent within this project.
+	if body.DefaultAgent != "" {
+		body.DefaultAgent = strings.TrimSpace(body.DefaultAgent)
+		if len([]rune(body.DefaultAgent)) > 200 {
+			ValidationError(w, "defaultAgent identifier is too long", nil)
+			return
+		}
+		if err := s.validateDefaultAgent(r.Context(), projectID, body.DefaultAgent); err != nil {
+			ValidationError(w, err.Error(), nil)
+			return
+		}
+	}
+
 	topicID := uuid.New().String()
 	now := time.Now().UTC()
 	topic := WebChatTopic{
@@ -576,7 +590,20 @@ func (s *Server) handleTopicPatch(w http.ResponseWriter, r *http.Request, topicI
 	}
 
 	if body.DefaultAgent != nil {
-		updates.DefaultAgent = body.DefaultAgent
+		// Validate defaultAgent: clearing (empty string) is always allowed;
+		// setting a value must resolve to a non-deleted agent in this project.
+		da := strings.TrimSpace(*body.DefaultAgent)
+		if da != "" {
+			if len([]rune(da)) > 200 {
+				ValidationError(w, "defaultAgent identifier is too long", nil)
+				return
+			}
+			if err := s.validateDefaultAgent(r.Context(), topic.ProjectID, da); err != nil {
+				ValidationError(w, err.Error(), nil)
+				return
+			}
+		}
+		updates.DefaultAgent = &da
 	}
 
 	if updates.Name == nil && updates.DefaultAgent == nil {
@@ -649,6 +676,30 @@ func (s *Server) handleTopicDelete(w http.ResponseWriter, r *http.Request, topic
 	s.events.PublishChatTopicEvent(r.Context(), topic.ProjectID, "deleted", *topic)
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}
+
+// validateDefaultAgent checks that the given identifier (slug or UUID) resolves
+// to a non-deleted agent within the specified project. Returns nil on success
+// or a user-facing error describing the validation failure.
+func (s *Server) validateDefaultAgent(ctx context.Context, projectID, agentRef string) error {
+	// Try slug lookup first (project-scoped, excludes soft-deleted).
+	a, err := s.store.GetAgentBySlug(ctx, projectID, agentRef)
+	if err == nil && a != nil {
+		return nil // found by slug in this project, not deleted
+	}
+
+	// Fall back to UUID lookup.
+	a, err = s.store.GetAgent(ctx, agentRef)
+	if err != nil || a == nil {
+		return fmt.Errorf("defaultAgent %q not found in this project", agentRef)
+	}
+	if a.ProjectID != projectID {
+		return fmt.Errorf("defaultAgent %q not found in this project", agentRef)
+	}
+	if !a.DeletedAt.IsZero() {
+		return fmt.Errorf("defaultAgent %q has been deleted", agentRef)
+	}
+	return nil
 }
 
 // ClearTopicDefaultAgent drops the default-agent binding from every topic in
@@ -939,6 +990,16 @@ func (s *Server) handleConversationSend(w http.ResponseWriter, r *http.Request, 
 			if err != nil || defaultAgent == nil {
 				// Fall back to lookup by ID in case the value is a UUID.
 				defaultAgent, err = s.store.GetAgent(ctx, topic.DefaultAgent)
+				// Scope the fallback: reject agents from other projects or
+				// soft-deleted agents. GetAgent is a bare primary-key fetch
+				// with no project or deletion filter, so without this guard
+				// a UUID naming an agent in another project (or a deleted
+				// agent) would bind successfully — DEF-31.
+				if err == nil && defaultAgent != nil {
+					if defaultAgent.ProjectID != projectID || !defaultAgent.DeletedAt.IsZero() {
+						defaultAgent = nil
+					}
+				}
 			}
 			if err == nil && defaultAgent != nil {
 				msgID := s.sendAgentRouted(w, r, key, projectID, user, content, senderLabel, []*store.Agent{defaultAgent}, mentionNames, nil, attachmentRefs, now, body.ReplyToID)

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -693,11 +693,8 @@ func (s *Server) validateDefaultAgent(ctx context.Context, projectID, agentRef s
 	if err != nil || a == nil {
 		return fmt.Errorf("defaultAgent %q not found in this project", agentRef)
 	}
-	if a.ProjectID != projectID {
+	if a.ProjectID != projectID || !a.DeletedAt.IsZero() {
 		return fmt.Errorf("defaultAgent %q not found in this project", agentRef)
-	}
-	if !a.DeletedAt.IsZero() {
-		return fmt.Errorf("defaultAgent %q has been deleted", agentRef)
 	}
 	return nil
 }

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -447,8 +447,10 @@ func (s *Server) handleCreateThread(w http.ResponseWriter, r *http.Request, proj
 
 	// Validate defaultAgent when provided: must be a reasonable length and
 	// must resolve to a non-deleted agent within this project.
+	// Trim first so whitespace-only input is treated as "no default agent"
+	// (matching the PATCH/clear behavior).
+	body.DefaultAgent = strings.TrimSpace(body.DefaultAgent)
 	if body.DefaultAgent != "" {
-		body.DefaultAgent = strings.TrimSpace(body.DefaultAgent)
 		if len([]rune(body.DefaultAgent)) > 200 {
 			ValidationError(w, "defaultAgent identifier is too long", nil)
 			return

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -445,16 +445,12 @@ func (s *Server) handleCreateThread(w http.ResponseWriter, r *http.Request, proj
 		return
 	}
 
-	// Validate defaultAgent when provided: must be a reasonable length and
-	// must resolve to a non-deleted agent within this project.
+	// Validate defaultAgent when provided: length and resolution are checked
+	// by validateDefaultAgent (single source of truth — DEF-31).
 	// Trim first so whitespace-only input is treated as "no default agent"
 	// (matching the PATCH/clear behavior).
 	body.DefaultAgent = strings.TrimSpace(body.DefaultAgent)
 	if body.DefaultAgent != "" {
-		if len([]rune(body.DefaultAgent)) > 200 {
-			ValidationError(w, "defaultAgent identifier is too long", nil)
-			return
-		}
 		if err := s.validateDefaultAgent(r.Context(), projectID, body.DefaultAgent); err != nil {
 			ValidationError(w, err.Error(), nil)
 			return
@@ -594,12 +590,10 @@ func (s *Server) handleTopicPatch(w http.ResponseWriter, r *http.Request, topicI
 	if body.DefaultAgent != nil {
 		// Validate defaultAgent: clearing (empty string) is always allowed;
 		// setting a value must resolve to a non-deleted agent in this project.
+		// Length and resolution are checked by validateDefaultAgent (single
+		// source of truth — DEF-31).
 		da := strings.TrimSpace(*body.DefaultAgent)
 		if da != "" {
-			if len([]rune(da)) > 200 {
-				ValidationError(w, "defaultAgent identifier is too long", nil)
-				return
-			}
 			if err := s.validateDefaultAgent(r.Context(), topic.ProjectID, da); err != nil {
 				ValidationError(w, err.Error(), nil)
 				return
@@ -680,10 +674,19 @@ func (s *Server) handleTopicDelete(w http.ResponseWriter, r *http.Request, topic
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 }
 
-// validateDefaultAgent checks that the given identifier (slug or UUID) resolves
-// to a non-deleted agent within the specified project. Returns nil on success
-// or a user-facing error describing the validation failure.
+// validateDefaultAgent checks that the given identifier (slug or UUID) is a
+// valid length and resolves to a non-deleted agent within the specified project.
+// Returns nil on success or a user-facing error describing the validation failure.
+//
+// All defaultAgent format and length validation lives here so that create and
+// patch call sites share a single rule set — two copies of a validation rule
+// drift, and the drift is the bug (DEF-31).
 func (s *Server) validateDefaultAgent(ctx context.Context, projectID, agentRef string) error {
+	// Length gate: reject unreasonably long identifiers before hitting the DB.
+	if len([]rune(agentRef)) > 200 {
+		return fmt.Errorf("defaultAgent identifier is too long")
+	}
+
 	// Try slug lookup first (project-scoped, excludes soft-deleted).
 	a, err := s.store.GetAgentBySlug(ctx, projectID, agentRef)
 	if err == nil && a != nil {

--- a/pkg/hub/handlers_chat_v2_test.go
+++ b/pkg/hub/handlers_chat_v2_test.go
@@ -3210,8 +3210,8 @@ func TestDEF31_MutationTest_LookupScoping(t *testing.T) {
 				"removed or bypassed — this is the DEF-31 defect. Agent " + f.deletedA.ID +
 				" is soft-deleted but was accepted")
 		}
-		if !strings.Contains(err.Error(), "deleted") {
-			t.Errorf("unexpected error message: %v (expected mention of 'deleted')", err)
+		if !strings.Contains(err.Error(), "not found in this project") {
+			t.Errorf("unexpected error message: %v (expected 'not found in this project')", err)
 		}
 	})
 

--- a/pkg/hub/handlers_chat_v2_test.go
+++ b/pkg/hub/handlers_chat_v2_test.go
@@ -2833,3 +2833,393 @@ func TestChatV2_Send_NoIdempotencyKey_AlwaysCreates(t *testing.T) {
 		t.Errorf("sends without idempotency key should create distinct messages, both got %q", resp1.ID)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// DEF-31: defaultAgent validation — cross-project and soft-deleted agent guard
+// ---------------------------------------------------------------------------
+
+// setupDEF31Projects creates two projects (A and B) with their own agents,
+// an in-memory WebChatStore, and returns everything the DEF-31 tests need.
+type def31Fixture struct {
+	srv      *Server
+	store    store.Store
+	wcs      WebChatStore
+	projA    *store.Project
+	projB    *store.Project
+	agentA   *store.Agent // lives in project A
+	agentB   *store.Agent // lives in project B
+	deletedA *store.Agent // soft-deleted agent in project A
+}
+
+func setupDEF31(t *testing.T) def31Fixture {
+	t.Helper()
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	projA := &store.Project{ID: tid("def31-projA"), Name: "def31-projA", Slug: "def31-proja", Created: time.Now(), Updated: time.Now()}
+	projB := &store.Project{ID: tid("def31-projB"), Name: "def31-projB", Slug: "def31-projb", Created: time.Now(), Updated: time.Now()}
+	for _, p := range []*store.Project{projA, projB} {
+		if err := s.CreateProject(ctx, p); err != nil {
+			t.Fatalf("CreateProject(%s): %v", p.Name, err)
+		}
+	}
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	wcs := NewWebChatStore(db, "sqlite3")
+	if err := wcs.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	srv.SetWebChatStore(wcs)
+
+	// Agent in project A.
+	agentA := &store.Agent{
+		ID:        tid("def31-agentA"),
+		ProjectID: projA.ID,
+		Name:      "Agent A",
+		Slug:      "agent-a",
+		Phase:     "running",
+		CreatedBy: DevUserID,
+		OwnerID:   DevUserID,
+	}
+	// Agent in project B (foreign to A).
+	agentB := &store.Agent{
+		ID:        tid("def31-agentB"),
+		ProjectID: projB.ID,
+		Name:      "Agent B",
+		Slug:      "agent-b",
+		Phase:     "running",
+		CreatedBy: DevUserID,
+		OwnerID:   DevUserID,
+	}
+	// Soft-deleted agent in project A.
+	deletedA := &store.Agent{
+		ID:        tid("def31-deletedA"),
+		ProjectID: projA.ID,
+		Name:      "Deleted Agent",
+		Slug:      "deleted-agent",
+		Phase:     "terminated",
+		DeletedAt: time.Now().UTC(),
+		CreatedBy: DevUserID,
+		OwnerID:   DevUserID,
+	}
+	for _, a := range []*store.Agent{agentA, agentB, deletedA} {
+		if err := s.CreateAgent(ctx, a); err != nil {
+			t.Fatalf("CreateAgent(%s): %v", a.Name, err)
+		}
+	}
+
+	return def31Fixture{
+		srv:      srv,
+		store:    s,
+		wcs:      wcs,
+		projA:    projA,
+		projB:    projB,
+		agentA:   agentA,
+		agentB:   agentB,
+		deletedA: deletedA,
+	}
+}
+
+// Test 1: Foreign-project UUID rejected.
+// An agent UUID from project B must not bind as defaultAgent on a topic in project A.
+func TestDEF31_ForeignProjectUUID_Rejected(t *testing.T) {
+	f := setupDEF31(t)
+
+	// Attempt to create a thread in project A with project-B's agent UUID as defaultAgent.
+	body := map[string]string{
+		"name":         "foreign-test",
+		"defaultAgent": f.agentB.ID,
+	}
+	rec := doRequest(t, f.srv, http.MethodPost, "/api/v1/chat/spaces/"+f.projA.ID+"/threads", body)
+	if rec.Code == http.StatusCreated {
+		t.Fatalf("expected rejection of foreign-project agent UUID, but got 201; "+
+			"the topic silently bound to agent %s from project B — this is the DEF-31 defect", f.agentB.ID)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for foreign-project agent, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Also test via PATCH (UpdateTopic).
+	ctx := context.Background()
+	if err := f.wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        "def31-foreign-patch",
+		ProjectID: f.projA.ID,
+		Name:      "foreign-patch",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	da := f.agentB.ID
+	rec = doRequest(t, f.srv, http.MethodPatch, "/api/v1/chat/topics/def31-foreign-patch",
+		map[string]*string{"defaultAgent": &da})
+	if rec.Code == http.StatusOK {
+		t.Fatalf("expected rejection of foreign-project agent UUID on PATCH, but got 200")
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for foreign-project agent on PATCH, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Test 2: Soft-deleted agent UUID rejected.
+// A soft-deleted agent must not bind as defaultAgent.
+func TestDEF31_SoftDeletedAgent_Rejected(t *testing.T) {
+	f := setupDEF31(t)
+
+	// Attempt to create a thread with a soft-deleted agent as defaultAgent.
+	body := map[string]string{
+		"name":         "deleted-test",
+		"defaultAgent": f.deletedA.ID,
+	}
+	rec := doRequest(t, f.srv, http.MethodPost, "/api/v1/chat/spaces/"+f.projA.ID+"/threads", body)
+	if rec.Code == http.StatusCreated {
+		t.Fatalf("expected rejection of soft-deleted agent UUID, but got 201; "+
+			"the topic silently bound to deleted agent %s — this is the DEF-31 defect", f.deletedA.ID)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for deleted agent, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Also test via PATCH.
+	ctx := context.Background()
+	if err := f.wcs.CreateTopic(ctx, WebChatTopic{
+		ID:        "def31-deleted-patch",
+		ProjectID: f.projA.ID,
+		Name:      "deleted-patch",
+		CreatedBy: "dev",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	da := f.deletedA.ID
+	rec = doRequest(t, f.srv, http.MethodPatch, "/api/v1/chat/topics/def31-deleted-patch",
+		map[string]*string{"defaultAgent": &da})
+	if rec.Code == http.StatusOK {
+		t.Fatalf("expected rejection of soft-deleted agent UUID on PATCH, but got 200")
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for soft-deleted agent on PATCH, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// Test 3: Rebinding case — soft-delete the bound default agent and confirm the
+// topic does not silently keep routing to it.
+// This tests ClearTopicDefaultAgent's effectiveness AND the lookup's deleted_at
+// filtering at the resolver level.
+func TestDEF31_Rebinding_AfterSoftDelete(t *testing.T) {
+	f := setupDEF31(t)
+	ctx := context.Background()
+
+	// Create a live agent in project A specifically for this test.
+	liveAgent := &store.Agent{
+		ID:        tid("def31-live-rebind"),
+		ProjectID: f.projA.ID,
+		Name:      "Live Rebind Agent",
+		Slug:      "live-rebind",
+		Phase:     "running",
+		CreatedBy: DevUserID,
+		OwnerID:   DevUserID,
+	}
+	if err := f.store.CreateAgent(ctx, liveAgent); err != nil {
+		t.Fatalf("CreateAgent(live-rebind): %v", err)
+	}
+
+	// Create topic with this agent as default.
+	if err := f.wcs.CreateTopic(ctx, WebChatTopic{
+		ID:           "def31-rebind-topic",
+		ProjectID:    f.projA.ID,
+		Name:         "rebind-topic",
+		DefaultAgent: liveAgent.ID,
+		CreatedBy:    "dev",
+		CreatedAt:    time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	// Verify the binding is set.
+	topic, err := f.wcs.GetTopic(ctx, "def31-rebind-topic")
+	if err != nil || topic == nil {
+		t.Fatalf("GetTopic: %v", err)
+	}
+	if topic.DefaultAgent != liveAgent.ID {
+		t.Fatalf("expected default agent %s, got %q", liveAgent.ID, topic.DefaultAgent)
+	}
+
+	// Soft-delete the agent.
+	liveAgent.DeletedAt = time.Now().UTC()
+	if err := f.store.UpdateAgent(ctx, liveAgent); err != nil {
+		t.Fatalf("UpdateAgent (soft-delete): %v", err)
+	}
+
+	// Simulate what happens when an agent is deleted: ClearTopicDefaultAgent
+	// scrubs the binding from all topics in the project.
+	f.srv.ClearTopicDefaultAgent(ctx, liveAgent.ID, liveAgent.Slug, f.projA.ID)
+
+	// Confirm the topic no longer has a default agent.
+	topic, err = f.wcs.GetTopic(ctx, "def31-rebind-topic")
+	if err != nil || topic == nil {
+		t.Fatalf("GetTopic after clear: %v", err)
+	}
+	if topic.DefaultAgent != "" {
+		t.Errorf("expected default agent cleared after soft-delete, got %q", topic.DefaultAgent)
+	}
+
+	// Even if ClearTopicDefaultAgent had somehow failed (best-effort), the
+	// resolver at send time must not route to a deleted agent. To test this
+	// defence-in-depth, manually re-set the default and then verify the
+	// resolver rejects it.
+	da := liveAgent.ID
+	if err := f.wcs.UpdateTopic(ctx, "def31-rebind-topic", TopicUpdate{DefaultAgent: &da}); err != nil {
+		t.Fatalf("UpdateTopic (re-bind stale): %v", err)
+	}
+
+	// The validateDefaultAgent helper (called from ingress) would reject this,
+	// but we're testing the resolver's defence too. Call validateDefaultAgent
+	// directly to confirm.
+	if vErr := f.srv.validateDefaultAgent(ctx, f.projA.ID, liveAgent.ID); vErr == nil {
+		t.Error("validateDefaultAgent should reject a soft-deleted agent, but returned nil")
+	}
+}
+
+// Test 4: Paired positives — a legitimate slug and same-project UUID both bind.
+// A validator that refuses everything passes the negatives and is useless;
+// these tests prove we accept valid inputs.
+func TestDEF31_PairedPositives(t *testing.T) {
+	f := setupDEF31(t)
+
+	t.Run("slug_binds", func(t *testing.T) {
+		body := map[string]string{
+			"name":         "slug-positive",
+			"defaultAgent": f.agentA.Slug,
+		}
+		rec := doRequest(t, f.srv, http.MethodPost, "/api/v1/chat/spaces/"+f.projA.ID+"/threads", body)
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("expected 201 for valid slug, got %d: %s", rec.Code, rec.Body.String())
+		}
+
+		var topic WebChatTopic
+		if err := json.NewDecoder(rec.Body).Decode(&topic); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if topic.DefaultAgent != f.agentA.Slug {
+			t.Errorf("defaultAgent = %q, want %q", topic.DefaultAgent, f.agentA.Slug)
+		}
+	})
+
+	t.Run("uuid_binds", func(t *testing.T) {
+		body := map[string]string{
+			"name":         "uuid-positive",
+			"defaultAgent": f.agentA.ID,
+		}
+		rec := doRequest(t, f.srv, http.MethodPost, "/api/v1/chat/spaces/"+f.projA.ID+"/threads", body)
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("expected 201 for valid same-project UUID, got %d: %s", rec.Code, rec.Body.String())
+		}
+
+		var topic WebChatTopic
+		if err := json.NewDecoder(rec.Body).Decode(&topic); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if topic.DefaultAgent != f.agentA.ID {
+			t.Errorf("defaultAgent = %q, want %q", topic.DefaultAgent, f.agentA.ID)
+		}
+	})
+
+	t.Run("clear_via_patch", func(t *testing.T) {
+		// Create topic with a default agent, then clear it.
+		ctx := context.Background()
+		if err := f.wcs.CreateTopic(ctx, WebChatTopic{
+			ID:           "def31-clear-patch",
+			ProjectID:    f.projA.ID,
+			Name:         "clear-positive",
+			DefaultAgent: f.agentA.Slug,
+			CreatedBy:    "dev",
+			CreatedAt:    time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("CreateTopic: %v", err)
+		}
+
+		empty := ""
+		rec := doRequest(t, f.srv, http.MethodPatch, "/api/v1/chat/topics/def31-clear-patch",
+			map[string]*string{"defaultAgent": &empty})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200 when clearing defaultAgent, got %d: %s", rec.Code, rec.Body.String())
+		}
+
+		var updated WebChatTopic
+		if err := json.NewDecoder(rec.Body).Decode(&updated); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if updated.DefaultAgent != "" {
+			t.Errorf("defaultAgent should be cleared, got %q", updated.DefaultAgent)
+		}
+	})
+}
+
+// Test 5: Mutation test — documents that the lookup scoping at the resolver
+// (handlers_chat_v2.go, inside the default-agent resolution block) is the
+// load-bearing fix. If the project-ID and deleted_at checks after the GetAgent
+// fallback were removed, a foreign-project or deleted agent UUID stored in
+// topic.DefaultAgent would silently bind and route messages to the wrong agent.
+//
+// This is not a build-tag gated subtest that literally reverts the code; instead
+// it is a structural assertion: the test exercises the resolver path directly
+// (via validateDefaultAgent, which performs the same two-step lookup with the
+// same guards) and asserts that:
+//
+//   - A foreign-project UUID is rejected (fails the projectID check).
+//   - A soft-deleted UUID is rejected (fails the DeletedAt check).
+//
+// If someone removes those guards, these assertions fail — that is the mutation.
+// The foreign-project test (Test 1) fails with a message naming the wrong-project
+// bind, not a panic or compile error, confirming the mutation is the defect.
+func TestDEF31_MutationTest_LookupScoping(t *testing.T) {
+	f := setupDEF31(t)
+	ctx := context.Background()
+
+	t.Run("foreign_project_guard", func(t *testing.T) {
+		// validateDefaultAgent uses the same two-step lookup as the resolver.
+		// Without the projectID guard, this would return nil (agent found by
+		// GetAgent, no project filter).
+		err := f.srv.validateDefaultAgent(ctx, f.projA.ID, f.agentB.ID)
+		if err == nil {
+			t.Fatal("MUTATION DETECTED: validateDefaultAgent accepted a foreign-project " +
+				"agent UUID. The project-scoping guard in the GetAgent fallback has been " +
+				"removed or bypassed — this is the DEF-31 defect. The agent " + f.agentB.ID +
+				" belongs to project " + f.projB.ID + " but was accepted for project " + f.projA.ID)
+		}
+		// Confirm the error message is about not-found-in-project, not a panic.
+		if !strings.Contains(err.Error(), "not found in this project") {
+			t.Errorf("unexpected error message: %v (expected 'not found in this project')", err)
+		}
+	})
+
+	t.Run("soft_deleted_guard", func(t *testing.T) {
+		// Without the DeletedAt guard, this would return nil (agent found by
+		// GetAgent, no deletion filter).
+		err := f.srv.validateDefaultAgent(ctx, f.projA.ID, f.deletedA.ID)
+		if err == nil {
+			t.Fatal("MUTATION DETECTED: validateDefaultAgent accepted a soft-deleted " +
+				"agent UUID. The DeletedAt guard in the GetAgent fallback has been " +
+				"removed or bypassed — this is the DEF-31 defect. Agent " + f.deletedA.ID +
+				" is soft-deleted but was accepted")
+		}
+		if !strings.Contains(err.Error(), "deleted") {
+			t.Errorf("unexpected error message: %v (expected mention of 'deleted')", err)
+		}
+	})
+
+	t.Run("valid_agent_still_accepted", func(t *testing.T) {
+		// Sanity check: the guards must not reject a valid same-project agent.
+		err := f.srv.validateDefaultAgent(ctx, f.projA.ID, f.agentA.ID)
+		if err != nil {
+			t.Fatalf("validateDefaultAgent rejected a valid same-project agent: %v", err)
+		}
+	})
+}

--- a/pkg/hub/handlers_chat_v2_test.go
+++ b/pkg/hub/handlers_chat_v2_test.go
@@ -3223,3 +3223,148 @@ func TestDEF31_MutationTest_LookupScoping(t *testing.T) {
 		}
 	})
 }
+
+// ---------------------------------------------------------------------------
+// DEF-31 send-path resolver tests — end-to-end through handleConversationSend
+//
+// These tests write bad default_agent values directly via wcs.CreateTopic,
+// bypassing ingress validation, to simulate pre-existing rows in production.
+// They then POST a message through the HTTP handler and assert on the response
+// type: TypeInstruction means the resolver routed to an agent; TypeChat means
+// it fell through to the no-agent human-to-human path.
+//
+// These tests cover the load-bearing resolver guard at the send path —
+// the ONLY protection for pre-existing bad rows that ingress validation
+// cannot retroactively fix.
+// ---------------------------------------------------------------------------
+
+// TestDEF31_SendPath_ForeignProjectAgent_NotRouted simulates a pre-existing
+// topic row whose default_agent holds a UUID from another project. The
+// resolver must NOT route the message to that foreign agent.
+func TestDEF31_SendPath_ForeignProjectAgent_NotRouted(t *testing.T) {
+	f := setupDEF31(t)
+	ctx := context.Background()
+
+	// Write a topic with the foreign-project agent UUID directly via the
+	// store, bypassing ingress validation — this simulates a pre-existing
+	// bad row.
+	topicID := tid("def31-send-foreign")
+	if err := f.wcs.CreateTopic(ctx, WebChatTopic{
+		ID:           topicID,
+		ProjectID:    f.projA.ID,
+		Name:         "send-foreign",
+		DefaultAgent: f.agentB.ID, // agent from project B — foreign
+		CreatedBy:    "dev",
+		CreatedAt:    time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	// Send a message via the HTTP handler.
+	body := map[string]string{"content": "hello from bad row"}
+	rec := doRequest(t, f.srv, http.MethodPost,
+		"/api/v1/chat/conversations/"+topicID+"/messages", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatMessageResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// The resolver must NOT have routed to the foreign agent. If it did,
+	// the message type would be TypeInstruction. It should fall through to
+	// the human-to-human path and return TypeChat.
+	if resp.Type == messages.TypeInstruction {
+		t.Fatalf("RESOLVER GUARD FAILURE: message was routed to foreign-project agent %s "+
+			"(type=%s). The resolver's project-scoping guard is missing or broken — "+
+			"this is the DEF-31 defect at the send path", f.agentB.ID, resp.Type)
+	}
+	if resp.Type != messages.TypeChat {
+		t.Errorf("expected type %q (no-agent fallthrough), got %q", messages.TypeChat, resp.Type)
+	}
+}
+
+// TestDEF31_SendPath_SoftDeletedAgent_NotRouted simulates a pre-existing
+// topic row whose default_agent holds a same-project UUID that has since been
+// soft-deleted. The resolver must NOT route to it.
+func TestDEF31_SendPath_SoftDeletedAgent_NotRouted(t *testing.T) {
+	f := setupDEF31(t)
+	ctx := context.Background()
+
+	// Write a topic with the soft-deleted agent UUID directly via the store.
+	topicID := tid("def31-send-deleted")
+	if err := f.wcs.CreateTopic(ctx, WebChatTopic{
+		ID:           topicID,
+		ProjectID:    f.projA.ID,
+		Name:         "send-deleted",
+		DefaultAgent: f.deletedA.ID, // same project, but soft-deleted
+		CreatedBy:    "dev",
+		CreatedAt:    time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	body := map[string]string{"content": "hello from stale row"}
+	rec := doRequest(t, f.srv, http.MethodPost,
+		"/api/v1/chat/conversations/"+topicID+"/messages", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatMessageResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.Type == messages.TypeInstruction {
+		t.Fatalf("RESOLVER GUARD FAILURE: message was routed to soft-deleted agent %s "+
+			"(type=%s). The resolver's deleted_at guard is missing or broken — "+
+			"this is the DEF-31 defect at the send path", f.deletedA.ID, resp.Type)
+	}
+	if resp.Type != messages.TypeChat {
+		t.Errorf("expected type %q (no-agent fallthrough), got %q", messages.TypeChat, resp.Type)
+	}
+}
+
+// TestDEF31_SendPath_ValidAgent_StillRoutes is the paired positive: a topic
+// with a valid, same-project default agent must still route messages through
+// it. Without this test, deleting the entire routing branch passes all tests.
+func TestDEF31_SendPath_ValidAgent_StillRoutes(t *testing.T) {
+	f := setupDEF31(t)
+	ctx := context.Background()
+
+	// Write a topic with a valid same-project agent as default.
+	topicID := tid("def31-send-valid")
+	if err := f.wcs.CreateTopic(ctx, WebChatTopic{
+		ID:           topicID,
+		ProjectID:    f.projA.ID,
+		Name:         "send-valid",
+		DefaultAgent: f.agentA.ID, // valid, same project, not deleted
+		CreatedBy:    "dev",
+		CreatedAt:    time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	body := map[string]string{"content": "hello from good row"}
+	rec := doRequest(t, f.srv, http.MethodPost,
+		"/api/v1/chat/conversations/"+topicID+"/messages", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp chatMessageResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// A valid default agent must cause agent routing — type should be
+	// TypeInstruction, not TypeChat.
+	if resp.Type != messages.TypeInstruction {
+		t.Fatalf("expected type %q (agent-routed via default), got %q — "+
+			"the default-agent routing branch may have been removed entirely",
+			messages.TypeInstruction, resp.Type)
+	}
+}


### PR DESCRIPTION
A thread's default_agent could be bound to an agent in another project, or to a soft-deleted agent.

handleCreateThread set DefaultAgent with no validation. At send time the resolver fell back from GetAgentBySlug to GetAgent, a bare primary-key fetch with no project or deletion filter, so a raw UUID naming a foreign or deleted agent bound successfully and defeated ClearTopicDefaultAgent.

Both doors are fixed. The resolver fix is the load-bearing one: this defect is pre-existing, so rows already hold bad values that ingress validation can never reach. Ingress adds validateDefaultAgent on create and patch. Error text is unified so it no longer leaks deletion state as an existence oracle.

8 tests / 14 assertions. Three run end-to-end through handleConversationSend with the bad binding written directly to bypass ingress, simulating pre-existing rows. Mutation-verified: deleting the resolver guard fails them with "RESOLVER GUARD FAILURE: message was routed to foreign-project agent". Paired positives confirm valid bindings still route, so the guard is not just refusing everything.

CI will be red on TestTemplateResource_UATConfinement -- pre-existing failure on main, unrelated