### PR TITLE
ci: guard direct writes to conversation and participant tables

### DIFF
--- a/.design/project-log/2026-08-28-ci-conversation-minting-guard.md
+++ b/.design/project-log/2026-08-28-ci-conversation-minting-guard.md
@@ -1,0 +1,39 @@
+# CI: Conversation-Minting Guard
+
+**Date:** 2026-08-28
+**Agent:** ca-msg-em6 (dev-ci-guard)
+**Branch:** `scion/ca-msg-em6-ci-guard`
+
+## Summary
+
+Lifted the conversation-minting CI guard from the tranche C branch
+(`scion/ca-msg-em9-unify`, authored by ca-msg-em9) and applied it as a
+standalone commit against `upstream/main`.
+
+## What was done
+
+1. **Created `hack/check-conversation-upsert-guard.sh`** — a textual guard that
+   ensures conversation-minting methods and raw SQL INSERTs are confined to
+   `pkg/messaging/` and `pkg/store/`.
+
+2. **Added Makefile target** `check-conversation-upsert-guard` and wired it into
+   both `ci` and `ci-full` dependency lists.
+
+3. **Added CI workflow step** in `.github/workflows/ci.yml`.
+
+## Modifications from em9's original
+
+| Change | Rationale |
+|--------|-----------|
+| Extended Check 1 grep to include `AddParticipant` | AddParticipant modifies the participant listing index; unguarded calls outside the resolve flow corrupt conversation visibility |
+| Removed `webchannel_store` exemption from Check 3 | That exemption is for dual-write paths that don't exist on main yet — they arrive with tranche C |
+| Updated severity framing from "authorization"/"auth bypass" to "listing-index integrity" | The participant table is a derived listing index, not the access authority. Exception noted for unknown conversation kinds where requireParticipant acts as ACL |
+
+## Verification results
+
+| Step | Expected | Actual |
+|------|----------|--------|
+| Guard on clean branch | exit 0 | exit 0 |
+| Positive control: `AddParticipant` probe in `pkg/hub/` | exit 1 | exit 1 |
+| Positive control: `UpsertConversationByExternalRef` probe in `pkg/hub/` | exit 1 | exit 1 |
+| `make compat-literals check-authz-guards check-conversation-upsert-guard` | exit 0 | exit 0 |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
           esac
           exit "$rc"
 
+      - name: Check Conversation Upsert Guard
+        run: ./hack/check-conversation-upsert-guard.sh
+
       - name: Run Tests
         run: make test-fast
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GOLANGCI_LINT := $(shell command -v golangci-lint 2>/dev/null || echo $(shell go
 
 .DEFAULT_GOAL := help
 
-.PHONY: all build build-a2a-bridge install test test-fast vet lint compat-literals check-authz-guards golangci-lint web web-typecheck web-test fmt fmt-check ci ci-full clean help container-sciontool container-scion container-binaries proto proto-check
+.PHONY: all build build-a2a-bridge install test test-fast vet lint compat-literals check-authz-guards check-conversation-upsert-guard golangci-lint web web-typecheck web-test fmt fmt-check ci ci-full clean help container-sciontool container-scion container-binaries proto proto-check
 
 ## all: Build the web frontend and compile the Go binary (run 'make install' separately to install)
 all: web build
@@ -88,6 +88,10 @@ compat-literals:
 # apart must invoke ./hack/check-authz-guards.sh directly, as CI does.
 check-authz-guards:
 	@./hack/check-authz-guards.sh
+
+## check-conversation-upsert-guard: Verify UpsertConversationByExternalRef is only called from pkg/messaging and pkg/store
+check-conversation-upsert-guard:
+	@./hack/check-conversation-upsert-guard.sh
 
 ## golangci-lint: Run golangci-lint on new issues only (install via: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest)
 golangci-lint:
@@ -161,12 +165,12 @@ fmt-check:
 	@echo "Go formatting OK."
 
 ## ci: Run fast CI checks (format check, vet, compatibility guardrails, authz guards, tests, build)
-ci: fmt-check lint compat-literals check-authz-guards test-fast build
+ci: fmt-check lint compat-literals check-authz-guards check-conversation-upsert-guard test-fast build
 	@echo ""
 	@echo "CI passed."
 
 ## ci-full: Run the full CI pipeline locally (mirrors GitHub Actions, includes web + golangci-lint)
-ci-full: fmt-check web web-typecheck web-test lint compat-literals check-authz-guards golangci-lint test-fast build
+ci-full: fmt-check web web-typecheck web-test lint compat-literals check-authz-guards check-conversation-upsert-guard golangci-lint test-fast build
 	@echo ""
 	@echo "CI (full) passed."
 

--- a/hack/check-conversation-upsert-guard.sh
+++ b/hack/check-conversation-upsert-guard.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Guard: no conversation row may be minted outside the messaging layer
+# (pkg/messaging/) and the store layer (pkg/store/).
+#
+# The property this guard enforces is: "no conversation is minted outside the
+# messaging layer." It is NOT a function-name check — it is an enumeration of
+# every code path that can INSERT a row into the conversations table or modify
+# the participant listing index.
+#
+# Conversation-minting surface (enumerated 2026-08-27):
+#
+#   Go method calls (must only appear in pkg/messaging/ and pkg/store/):
+#     1.  UpsertConversationByExternalRef — the primary resolve-or-create path
+#     2a. CreateConversation              — direct INSERT (no production callers
+#                                           today, but the method is public)
+#     2b. AddParticipant                  — modifies the participant listing
+#                                           index; an unguarded call outside
+#                                           the resolve flow corrupts
+#                                           conversation visibility
+#
+#   Ent builder (must only appear in pkg/store/):
+#     3. .Conversation.Create()         — raw ent builder; only used inside
+#                                         pkg/store/entadapter/conversation_store.go
+#
+#   Raw SQL INSERT INTO conversations (must only appear in pkg/store/):
+#     4. INSERT [OR IGNORE|OR REPLACE] INTO ["]conversations["]
+#                                       — case-insensitive match for the full
+#                                         INSERT family. SQLite uses OR IGNORE
+#                                         for idempotent inserts; Postgres uses
+#                                         ON CONFLICT ... DO NOTHING (same line).
+#
+# Test files (*_test.go) are excluded: test fixtures legitimately call store
+# methods to set up state. The guard protects production code paths.
+#
+# Enumeration method: grep -rn for each pattern across all .go files, then
+# subtract the allowed packages. If a new minting surface is added to the
+# store interface, it must be added to this guard.
+#
+# LIMITATIONS
+# This guard is textual and line-oriented. It does NOT detect:
+#   - SQL split across lines (e.g., "INSERT INTO\n    conversations ...")
+#   - A table name supplied through a format verb or variable
+#     (e.g., fmt.Sprintf("INSERT INTO %s ...", tbl))
+# Both are low-risk in practice: every existing INSERT site in this codebase
+# puts "INSERT INTO conversations" on a single line (house style), and no
+# site constructs the table name dynamically. But a green gate from this
+# script guarantees only that the enumerated textual patterns are absent
+# outside the allowed packages — it is not a proof that no mint path exists.
+#
+# Note: the default fallback for unknown conversation kinds uses
+# requireParticipant, making the participant table an ACL for any future
+# kind someone forgets to case. The guard therefore protects both
+# listing-index integrity and, indirectly, access control for unhandled kinds.
+#
+# EXIT CODES
+#   0  no violations found
+#   1  violations found
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+rc=0
+
+# --- Check 1: Go method calls that mint conversations ---
+# UpsertConversationByExternalRef, CreateConversation, and AddParticipant
+# must only be called from pkg/messaging/ and pkg/store/.
+grep -rn 'UpsertConversationByExternalRef\|\.CreateConversation(\|\.AddParticipant(' \
+  --include='*.go' \
+  --exclude='*_test.go' \
+  . \
+  | grep -v '^./pkg/messaging/' \
+  | grep -v '^./pkg/store/' \
+  | grep -v '^./vendor/' \
+  >"$tmp" || true
+
+if [[ -s "$tmp" ]]; then
+  echo "Conversation-minting method called outside pkg/messaging/ and pkg/store/:" >&2
+  cat "$tmp" >&2
+  echo >&2
+  echo "Direct calls to UpsertConversationByExternalRef, CreateConversation," >&2
+  echo "and AddParticipant are not allowed outside pkg/messaging/ and pkg/store/." >&2
+  echo "Use the messaging package's resolution helpers" >&2
+  echo "(ResolveOrCreateConversationByKey, etc.)." >&2
+  rc=1
+fi
+
+# --- Check 2: Ent builder conversation creation ---
+# .Conversation.Create() and .Conversation.CreateBulk() must only appear
+# inside pkg/store/ (where the ent adapter lives). pkg/ent/ is excluded
+# because it contains auto-generated code from the ent framework.
+: >"$tmp"
+grep -rn '\.Conversation\.Create\b\|\.Conversation\.CreateBulk\b' \
+  --include='*.go' \
+  --exclude='*_test.go' \
+  . \
+  | grep -v '^./pkg/store/' \
+  | grep -v '^./pkg/ent/' \
+  | grep -v '^./vendor/' \
+  >"$tmp" || true
+
+if [[ -s "$tmp" ]]; then
+  echo "Ent conversation builder used outside pkg/store/:" >&2
+  cat "$tmp" >&2
+  echo >&2
+  echo ".Conversation.Create() must only be used inside pkg/store/entadapter/." >&2
+  rc=1
+fi
+
+# --- Check 3: Raw SQL INSERT INTO conversations ---
+# Matches the full INSERT family: INSERT INTO, INSERT OR IGNORE INTO,
+# INSERT OR REPLACE INTO, with optional quoting on the table name, and
+# case-insensitive to catch any casing variant.
+# Allowed only in pkg/store/.
+: >"$tmp"
+grep -rni 'INSERT[[:space:]]\+\(OR[[:space:]]\+[A-Z]\+[[:space:]]\+\)\?INTO[[:space:]]\+[\"]\?conversations[\"]\?' \
+  --include='*.go' \
+  --exclude='*_test.go' \
+  . \
+  | grep -v '^./pkg/store/' \
+  | grep -v '^./vendor/' \
+  >"$tmp" || true
+
+if [[ -s "$tmp" ]]; then
+  echo "Raw SQL INSERT INTO conversations outside allowed packages:" >&2
+  cat "$tmp" >&2
+  echo >&2
+  echo "Raw SQL conversation inserts are only allowed in pkg/store/." >&2
+  rc=1
+fi
+
+if [[ "$rc" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "check-conversation-upsert-guard: no violations"

--- a/hack/check-conversation-upsert-guard.sh
+++ b/hack/check-conversation-upsert-guard.sh
@@ -67,7 +67,10 @@ rc=0
 # --- Check 1: Go method calls that mint conversations ---
 # UpsertConversationByExternalRef, CreateConversation, and AddParticipant
 # must only be called from pkg/messaging/ and pkg/store/.
-grep -rn 'UpsertConversationByExternalRef\|\.CreateConversation(\|\.AddParticipant(' \
+# Pattern uses POSIX ERE (-E flag). Do not rewrite with BRE alternation (\|)
+# or word-boundary (\b) — those are GNU extensions that silently match nothing
+# on BSD/macOS grep, causing the guard to report false-clean.
+grep -rEn 'UpsertConversationByExternalRef|\.CreateConversation\(|\.AddParticipant\(' \
   --include='*.go' \
   --exclude='*_test.go' \
   . \
@@ -91,8 +94,11 @@ fi
 # .Conversation.Create() and .Conversation.CreateBulk() must only appear
 # inside pkg/store/ (where the ent adapter lives). pkg/ent/ is excluded
 # because it contains auto-generated code from the ent framework.
+# Pattern uses POSIX ERE (-E flag). Do not rewrite with BRE alternation (\|)
+# or word-boundary (\b) — those are GNU extensions that silently match nothing
+# on BSD/macOS grep, causing the guard to report false-clean.
 : >"$tmp"
-grep -rn '\.Conversation\.Create\b\|\.Conversation\.CreateBulk\b' \
+grep -rEn '\.Conversation\.Create(Bulk)?([^a-zA-Z]|$)' \
   --include='*.go' \
   --exclude='*_test.go' \
   . \
@@ -114,8 +120,11 @@ fi
 # INSERT OR REPLACE INTO, with optional quoting on the table name, and
 # case-insensitive to catch any casing variant.
 # Allowed only in pkg/store/.
+# Pattern uses POSIX ERE (-E flag). Do not rewrite with BRE alternation (\|)
+# or word-boundary (\b) — those are GNU extensions that silently match nothing
+# on BSD/macOS grep, causing the guard to report false-clean.
 : >"$tmp"
-grep -rni 'INSERT[[:space:]]\+\(OR[[:space:]]\+[A-Z]\+[[:space:]]\+\)\?INTO[[:space:]]\+[\"]\?conversations[\"]\?' \
+grep -rEni 'INSERT[[:space:]]+(OR[[:space:]]+[A-Z]+[[:space:]]+)?INTO[[:space:]]+"?conversations"?' \
   --include='*.go' \
   --exclude='*_test.go' \
   . \


### PR DESCRIPTION
Adds hack/check-conversation-upsert-guard.sh and wires it into both make ci and make ci-full.

Why this is worth a CI fence: authorization for direct conversations is key-derived, and for group it is project membership -- the participant table is a listing index, not the authority. But the default fallback for unknown conversation kinds uses requireParticipant, which turns the participant table into an ACL for any future kind someone forgets to case. Uncontrolled writes to it become an authorization bypass rather than a cosmetic listing bug.

The guard restricts AddParticipant and UpsertConversationByExternalRef to the packages that own the invariant, and blocks raw INSERT INTO conversations. The prior webchannel_store.go exemption is removed.

Verified by planting four probes rather than by reading it:
- AddParticipant outside allowed packages: exit 1
- UpsertConversationByExternalRef outside: exit 1
- raw INSERT INTO conversations in webchannel_store.go: exit 1, exemption genuinely gone
- paired positive, legal calls inside pkg/messaging: exit 0

The script header documents its own limits: it is textual and line-oriented, so it misses multi-line SQL and dynamic table names. It is a regression fence, not a proof.

Scoped by em9, implemented by em6