### PR TITLE
test(messaging): rename misleading convergence test (DEF-26)

### DIFF
--- a/pkg/messaging/resolve_test.go
+++ b/pkg/messaging/resolve_test.go
@@ -1096,17 +1096,11 @@ func TestGuardB_EveryDMRowHasTwoParticipants(t *testing.T) {
 // AC tests (DEF-8, DEF-10)
 // ---------------------------------------------------------------------------
 
-// TestAC_DEF8_1_ConvergenceTwoPathsSameConversation verifies that two sends
-// to the same agent — one via resolveAgentDM (Resolve with @agent syntax) and
-// one through the legacy ResolveOrCreateDMConversation path — resolve to the
-// SAME conversation. This is the single most important convergence test.
-//
-// NOTE: The legacy path (ResolveOrCreateDMConversation) uses a different key
-// format (dm:{sorted(idA,idB)} without kind prefixes). Full convergence onto
-// a single key format requires the migration (steps 2+3, separate task).
-// This test verifies convergence within the new code path: two calls to
-// Resolve with the same (sender, agent) pair yield ONE conversation row.
-func TestAC_DEF8_1_ConvergenceTwoPathsSameConversation(t *testing.T) {
+// TestResolve_SamePathIdempotency_AgentDM verifies that calling Resolve twice
+// with the same (sender, agent) pair via the @agent syntax produces exactly
+// one conversation row — i.e. the resolver path is idempotent. The first call
+// creates the conversation; the second call must find and return it.
+func TestResolve_SamePathIdempotency_AgentDM(t *testing.T) {
 	ms := newMockStore()
 	ctx := context.Background()
 	projectID := uuid.NewString()
@@ -1165,7 +1159,7 @@ func TestAC_DEF8_1_ConvergenceTwoPathsSameConversation(t *testing.T) {
 // dual-write path (ResolveOrCreateDMConversation) and the resolver path
 // (Resolve with @agent syntax) produce the SAME conversation for the same
 // principal pair. This is the true cross-path convergence test — unlike the
-// original TestAC_DEF8_1 which only exercised the resolver path twice.
+// original TestResolve_SamePathIdempotency_AgentDM which only exercised the resolver path twice.
 //
 // Steps:
 //  1. Call ResolveOrCreateDMConversation (dual-write/legacy path)


### PR DESCRIPTION
Renames TestAC_DEF8_1_ConvergenceTwoPathsSameConversation to TestResolve_SamePathIdempotency_AgentDM and rewrites its doc comment.

The old name claimed the test covered convergence of two paths. It did not: it calls Resolve twice with the same pair and asserts one conversation row. The old comment admitted as much in a NOTE four lines below, so the name and the assertion disagreed -- and the name is what wins when someone scans the file for coverage. The genuine cross-path test already exists separately as TestAC_DEF8_1_CrossPath_DualWriteAndResolverConverge.

No semantic change. 1 file, +6/-12, test body untouched.

Verified independently of the author: the old name has zero hits tree-wide, the AC-DEF8-1 badge has zero, and the two remaining AC_DEF8_1 references both belong to the real cross-path test. Both tests pass.

A rename's failure mode is a dangling reference in a comment, which no compiler catches -- hence the grep sweep rather than relying on a green build.

CI will be red on TestTemplateResource_UATConfinement, a pre-existing failure on main