### PR TITLE
fix: restore messaging UI visibility after permission refactor

### DIFF
--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -1071,7 +1071,7 @@ export class ScionPageAgentDetail extends LitElement {
         <scion-agent-message-viewer
           agentId=${this.agentId}
           agentName=${agent.name || ''}
-          ?canSend=${can(agent._capabilities, 'message')}
+          ?canSend=${can(agent._capabilities, 'attach')}
           ?cloudLogging=${agent.cloudLogging || false}
         ></scion-agent-message-viewer>
       `;
@@ -1101,14 +1101,14 @@ export class ScionPageAgentDetail extends LitElement {
       <scion-chat-thread
         agentId=${this.agentId}
         agentName=${agent.name || ''}
-        ?canSend=${can(agent._capabilities, 'message')}
+        ?canSend=${can(agent._capabilities, 'attach')}
         ?showVisibilityToggle=${true}
         style="display: ${this.chatViewActive ? '' : 'none'}"
       ></scion-chat-thread>
       <scion-agent-message-viewer
         agentId=${this.agentId}
         agentName=${agent.name || ''}
-        ?canSend=${can(agent._capabilities, 'message')}
+        ?canSend=${can(agent._capabilities, 'attach')}
         ?cloudLogging=${agent.cloudLogging || false}
         style="display: ${this.chatViewActive ? 'none' : ''}"
       ></scion-agent-message-viewer>
@@ -1156,7 +1156,7 @@ export class ScionPageAgentDetail extends LitElement {
           </div>
         </div>
         <div class="header-actions">
-          ${can(agent._capabilities, 'message')
+          ${can(agent._capabilities, 'attach')
             ? html`
                 <sl-button
                   variant="default"

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -1017,7 +1017,7 @@ export class ScionPageAgents extends LitElement {
     const isLoading = this.actionLoading[agent.id] || false;
 
     return html`
-      ${can(agent._capabilities, 'message')
+      ${can(agent._capabilities, 'attach')
         ? html`
             <sl-tooltip content="Message">
               <span style="display: inline-flex">

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -825,7 +825,7 @@ export class ScionPageChat extends LitElement {
 
   private async fetchAgentCapabilities(agentId: string): Promise<void> {
     if (this.agentCapabilities.has(agentId)) {
-      this.selectedAgentCanSend = can(this.agentCapabilities.get(agentId), 'message');
+      this.selectedAgentCanSend = can(this.agentCapabilities.get(agentId), 'attach');
       return;
     }
 

--- a/web/src/components/pages/chat.ts
+++ b/web/src/components/pages/chat.ts
@@ -834,7 +834,7 @@ export class ScionPageChat extends LitElement {
       if (res.ok) {
         const agent = (await res.json()) as { _capabilities?: Capabilities };
         this.agentCapabilities.set(agentId, agent._capabilities);
-        this.selectedAgentCanSend = can(agent._capabilities, 'message');
+        this.selectedAgentCanSend = can(agent._capabilities, 'attach');
       }
     } catch {
       this.selectedAgentCanSend = false;

--- a/web/src/components/shared/agent-tree-view.ts
+++ b/web/src/components/shared/agent-tree-view.ts
@@ -966,7 +966,7 @@ export class ScionAgentTreeView extends LitElement {
           ></scion-status-badge>
           ${agent.template ? html`<span class="meta">${agent.template}</span>` : nothing}
         </a>
-        ${can(agent._capabilities, 'message')
+        ${can(agent._capabilities, 'attach')
           ? html`
               <sl-icon-button
                 class="message-btn"


### PR DESCRIPTION
## Summary
- Fixes messaging UI regression introduced by A1-A6 permission refactor
- Backend uses ActionAttach for messaging authorization, but frontend checked 'message' capability (always false after refactor)
- Replaces can(agent._capabilities, 'message') with can(agent._capabilities, 'attach') in 7 call-sites across 4 files

## Test plan
- TypeScript typecheck passes
- Verified all 7 call-sites updated via grep
- No backend changes needed