### PR TITLE
Remove reset auth button from agent detail page

### DIFF
--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -813,7 +813,7 @@ export class ScionPageAgentDetail extends LitElement {
   }
 
   private async handleAction(
-    action: 'start' | 'stop' | 'suspend' | 'resume' | 'delete' | 'reset-auth',
+    action: 'start' | 'stop' | 'suspend' | 'resume' | 'delete',
     event?: MouseEvent
   ): Promise<void> {
     if (!this.agent) return;
@@ -839,25 +839,6 @@ export class ScionPageAgentDetail extends LitElement {
         showToast(err instanceof Error ? err.message : 'Failed to delete agent');
       } finally {
         this.actionLoading = { ...this.actionLoading, delete: false };
-      }
-      return;
-    }
-
-    if (action === 'reset-auth') {
-      this.actionLoading = { ...this.actionLoading, 'reset-auth': true };
-      try {
-        const response = await apiFetch(`/api/v1/agents/${this.agentId}/reset-auth`, {
-          method: 'POST',
-        });
-        if (!response.ok) {
-          throw new Error(await extractApiError(response, 'Failed to reset auth'));
-        }
-        this.backgroundRefresh();
-      } catch (err) {
-        console.error('Failed to reset auth:', err);
-        showToast(err instanceof Error ? err.message : 'Failed to reset auth');
-      } finally {
-        this.actionLoading = { ...this.actionLoading, 'reset-auth': false };
       }
       return;
     }
@@ -1255,23 +1236,6 @@ export class ScionPageAgentDetail extends LitElement {
                     Configure
                   </sl-button>
                 </a>
-              `
-            : nothing}
-          ${isAgentRunning(agent)
-            ? html`
-                <sl-tooltip content="Inject a fresh auth token without restarting">
-                  <sl-button
-                    variant="default"
-                    size="small"
-                    outline
-                    ?loading=${this.actionLoading['reset-auth']}
-                    ?disabled=${this.actionLoading['reset-auth']}
-                    @click=${() => this.handleAction('reset-auth')}
-                  >
-                    <sl-icon slot="prefix" name="key"></sl-icon>
-                    Reset Auth
-                  </sl-button>
-                </sl-tooltip>
               `
             : nothing}
           <sl-tooltip content="See this agent in graph">


### PR DESCRIPTION
Fixes #1320 - remove reset auth button

- Remove button template, click handler, and type reference
- PR #1321, CI green, reviewer APPROVE