### PR TITLE
fix(hub): messaging tranche B - DM conversation dual-write + broadcast ingress hardening

### DIFF
--- a/.design/project-log/2026-08-27-def8-dualwrite.md
+++ b/.design/project-log/2026-08-27-def8-dualwrite.md
@@ -1,0 +1,80 @@
+# DEF-8 Dual-Write Path Convergence
+
+**Date:** 2026-08-27
+**Agent:** dev-def8-dualwrite
+**Branch:** scion/ca-msg-em6
+
+## Summary
+
+Updated the dual-write path (`ResolveOrCreateDMConversation`, `ResolveDMConversationForRead`)
+to use `messages.DMConversationKey` instead of the old `DirectMessageExternalRef`. This
+converges both write paths (resolver and dual-write) onto the same kind-encoded DM key
+format (`dm:<kind>:<uuid>:<kind>:<uuid>`), fixing the core DEF-8 defect where both paths
+created different rows for the same principal pair.
+
+## Changes
+
+### Core function updates (pkg/messaging/conversation.go)
+- `ResolveOrCreateDMConversation` signature changed: now accepts `senderKind, senderID,
+  recipientKind, recipientID` instead of just `senderID, recipientID`.
+- `ResolveDMConversationForRead` signature changed: now accepts `idAKind, idA, idBKind, idB`
+  instead of just `idA, idB`.
+- Both now use `messages.DMConversationKey()` to build the external_ref, producing
+  kind-encoded keys that match the production regex.
+
+### New helper (pkg/messages/dm_key.go)
+- `PrincipalKindFromAddress()` — extracts "user" or "agent" from an address string like
+  `"user:alice"` or `"agent:my-bot"`. Used by hub call sites where the kind must be
+  derived from the Sender/Recipient field.
+
+### Hub call site updates (10 total)
+- **7 ResolveOrCreateDMConversation** call sites updated across:
+  - `handlers_agent_messaging.go` (4 sites)
+  - `handlers_broker_inbound.go` (1 site)
+  - `messagebroker.go` (2 sites)
+- **3 ResolveDMConversationForRead** call sites updated across:
+  - `handlers_messages.go` (2 sites)
+  - `handlers_chat_v2.go` (1 site)
+
+### Tests
+- **Conformance test** (`TestDMConversationKey_MatchesProductionRegex`): verifies all keys
+  match the production regex from `handlers_chat_v2.go:391`.
+- **Golden test vectors** (`TestDMConversationKey_GoldenVectors`): 5 hardcoded deterministic
+  vectors for cross-language conformance (Go + TS).
+- **True cross-path AC-DEF8-1 test** (`TestAC_DEF8_1_CrossPath_DualWriteAndResolverConverge`):
+  exercises BOTH `ResolveOrCreateDMConversation` and `Resolve(@agent)`, asserts same
+  conversation ID and exactly one row.
+- Updated existing `conversation_test.go` and `handlers_read_switch_test.go` for new signatures.
+
+### What was NOT changed (per instructions)
+- `DirectMessageExternalRef` in `divergence.go` — still used by divergence comparison.
+- Divergence comparison logic — untouched.
+- Hub helper functions (`validDMKey`, `parseAgentDMKey`, etc.) — assessed but not refactored.
+
+## Hub Helper Refactoring Size Assessment (Deliverable 5)
+
+Five hub helpers independently string-split DM keys instead of using `messages.ParseDMKey`:
+
+| Helper                  | Production call sites | Files                          |
+|-------------------------|-----------------------|--------------------------------|
+| `validDMKey`            | 6                     | handlers_chat_v2.go            |
+| `parseAgentDMKey`       | 3                     | handlers_chat_v2.go            |
+| `dmUserParticipants`    | 6                     | handlers_chat_v2.go, events.go |
+| `resolveDMPeer`         | 1                     | handlers_chat_v2.go            |
+| `resolveProjectFromDMKey` | 2                   | handlers_chat_v2.go            |
+| **Total**               | **18**                |                                |
+
+**Assessment:** Medium-sized refactoring. Each helper would call `messages.ParseDMKey` instead
+of `strings.Split`, then use the returned `kindA, idA, kindB, idB` fields. The 18 call sites
+are mechanical — no logic changes needed at the call sites themselves. The main risk is
+that `ParseDMKey` validates strictly (rejects malformed keys), while the current helpers
+are lenient. Callers that pass pre-validated keys (via `validDMKey` guard) are safe; callers
+that skip validation need error handling added. Estimated ~100 lines changed, ~3 test files
+updated.
+
+## Verification
+
+- `go build ./...` — passes
+- `go test ./pkg/messages/...` — passes
+- `go test ./pkg/messaging/...` — passes
+- `go test ./pkg/hub/... -run TestUpsert|TestReadSwitch|TestBrokerInbound` — passes

--- a/.design/project-log/2026-08-27-def8-migration.md
+++ b/.design/project-log/2026-08-27-def8-migration.md
@@ -1,0 +1,49 @@
+# DEF-8: DM Migration — Listing Rebuild + Merge/Re-key
+
+**Date:** 2026-08-27  
+**Task:** WS-2  
+**Branch:** `scion/ca-msg-em6`
+
+## What was migrated and why
+
+Direct message conversations historically used three different external_ref
+formats. The new kind-encoded format (`dm:<kind>:<uuid>:<kind>:<uuid>`) was
+introduced as part of DEF-8 to support key-based auth and immutable participant
+guards. This migration normalizes all historical rows to the new format.
+
+## Three categories of old rows
+
+1. **Kind-encoded rows missing participants:** Created by the new code path but
+   lacking entries in the participants table (listing-index). The migration
+   verifies each principal exists in its claimed table (user or agent), then
+   adds both as participants (all-or-nothing per row).
+
+2. **Empty external_ref rows:** Created by the old resolver path (now deleted).
+   The migration reads participants to compute the kind-encoded key. If a row
+   with that key already exists, messages are re-stamped to the target and the
+   old row is soft-deleted (merge). Otherwise, the external_ref is set in place
+   and ProjectID is cleared (DMs are global, fixing DEF-10).
+
+3. **Old-format `dm:{sorted(id1,id2)}` rows:** Created by the old dual-write
+   path. The migration extracts the two UUIDs, resolves each to a kind by
+   looking up both user and agent tables. Ambiguous IDs (found in both or
+   neither) are skipped. Unambiguous pairs get re-keyed or merged with an
+   existing kind-encoded row.
+
+## Files modified
+
+- `pkg/messaging/dm_migration.go` — Migration service with DMMigrationStore
+  interface, DMMigrationConfig, DMMigrationResult, and three-step migration
+  logic (listing rebuild, empty-ref merge/re-key, old-format re-key).
+- `pkg/messaging/dm_migration_test.go` — Unit tests covering all migration
+  steps, dry-run mode, ambiguous IDs, merge scenarios, and three permanent
+  guard tests (A: no empty-ref direct rows, B: every dm: row has 2
+  participants, C: all dm: keys are parseable by ParseDMKey).
+
+## Guard tests (permanent)
+
+- **Guard A:** Zero non-deleted direct conversations with empty external_ref
+- **Guard B:** Every non-deleted dm: row has exactly 2 participants
+- **Guard C:** Every non-deleted dm: row with participants has a ParseDMKey-valid key
+
+All guards enforce rule 14 floors (minimum rows examined to prevent vacuous passes).

--- a/.design/project-log/s2-fix-backfill-extref.md
+++ b/.design/project-log/s2-fix-backfill-extref.md
@@ -1,0 +1,50 @@
+# Fix: Unify DM external_ref and Require ProjectID in Backfill
+
+**Date:** 2026-08-27
+**Author:** dev-fix-backfill
+**Branch:** `scion/dev-fix-backfill`
+**Commit:** `fix(messaging): unify DM external_ref and require ProjectID in backfill`
+
+## Problem
+
+Two defects in the backfill service:
+
+1. **Duplicate DM conversations:** The backfill and dual-write paths produced
+   different `external_ref` values for the same logical DM conversation. Backfill
+   used `direct:{projectID}:{kindA}:{idA}:{kindB}:{idB}` while dual-write used
+   `dm:{sorted(idA,idB)}`. Since conversations have a UNIQUE constraint on
+   `(surface, external_ref)`, the same DM would get two rows.
+
+2. **Missing project isolation:** `BackfillService.Run()` accepted an empty
+   `ProjectID`, which could group messages across project boundaries into a
+   single thread conversation, violating the project isolation invariant.
+
+## Changes
+
+### `pkg/messaging/backfill.go`
+
+- **`groupForMessage`**: Replaced the project-scoped `direct:...` key
+  construction with a call to `DirectMessageExternalRef(senderID, recipientID)`.
+  This produces `dm:{sorted(idA,idB)}` — the same format the dual-write path
+  uses — so both paths resolve to the same conversation row. Thread keys
+  (`thread:{projectID}:{threadID}`) are unchanged since threads are
+  project-scoped.
+
+- **`Run`**: Added early validation that `cfg.ProjectID != ""`, returning an
+  error if empty. This prevents cross-project thread grouping.
+
+### `pkg/messaging/backfill_test.go`
+
+- Updated `TestBackfill_ConversationExternalRef` to assert the exact
+  `DirectMessageExternalRef` output instead of checking for the old `direct:`
+  prefix.
+
+- Added `TestBackfill_EmptyProjectID` to verify that `Run()` returns an error
+  when `ProjectID` is empty.
+
+## Verification
+
+- `go build -buildvcs=false ./...` — passes
+- `go test ./pkg/messaging/...` — all tests pass (21 backfill + messaging tests)
+- `go vet ./pkg/messaging/...` — clean
+- `gofmt` — clean

--- a/.design/project-log/s2-fix-divergence.md
+++ b/.design/project-log/s2-fix-divergence.md
@@ -1,0 +1,41 @@
+# Fix: Compute Divergence Match + ResolveOrCreateDMConversation Unit Tests
+
+**Date:** 2026-08-27
+**Branch:** `scion/dev-fix-divergence`
+**Agent:** dev-fix-divergence
+
+## Problem
+
+All 6 dual-write call sites in Phase 5 hardcoded `Match: true` in their divergence logging. This meant `DivergenceMetrics.Mismatches()` always returned 0, making it impossible to detect routing disagreements between the old model (thread/sender-recipient pairs) and the new model (conversation resolution). The divergence logging is the gate for the S4 read-switch — a clean board that cannot be trusted is worse than no board at all.
+
+Additionally, `ResolveOrCreateDMConversation` — the single function both backfill and dual-write depend on — had no dedicated unit tests.
+
+## Changes
+
+### `pkg/messaging/divergence.go`
+- Added `ComputeDivergenceMatch(senderID, recipientID, threadID, convID)` — returns `(match bool, reason string)` based on:
+  1. `convID == ""` → `false, "no-new-routing"`
+  2. `senderID == "" && recipientID == ""` → `false, "unknown/no-old-routing"`
+  3. `threadID != ""` → `false, "old-model-thread vs new-model-dm"`
+  4. Normal DM agreement → `true, "both-models-dm-agreement"`
+- Added `NewRoutingStr(convID)` helper for consistent `"conv:{id}"` / `"none"` formatting.
+
+### `pkg/hub/handlers_agent_messaging.go` (4 sites)
+- Replaced hardcoded `Match: true` with computed match via `ComputeDivergenceMatch`.
+- Moved `LogDivergence` outside the `if convID != ""` guard so failed resolutions are logged as divergence signals.
+
+### `pkg/hub/messagebroker.go` (2 sites)
+- Same pattern as above, keeping the `!msg.Broadcasted` guard but moving divergence logging outside the `convID != ""` check.
+
+### `pkg/messaging/conversation_test.go` (new)
+- 7 unit tests for `ResolveOrCreateDMConversation`: happy path, empty sender, empty recipient, upsert error, external_ref format, ProjectID set, ProjectID nil.
+
+### `pkg/messaging/divergence_test.go` (appended)
+- 4 unit tests for `ComputeDivergenceMatch` covering all branches.
+- 1 test for `NewRoutingStr`.
+
+## Verification
+
+- `go build -buildvcs=false ./...` — passes
+- `go test ./pkg/messaging/...` — all 62 tests pass (0.006s)
+- No remaining hardcoded `Match: true` in any call site (verified via grep)

--- a/.design/project-log/s2-phase5-dualwrite.md
+++ b/.design/project-log/s2-phase5-dualwrite.md
@@ -1,0 +1,76 @@
+# S2 Phase 5: Dual-Write Conversation Resolution and Divergence Logging
+
+**Date:** 2026-08-27
+**Agent:** dev-dualwrite
+**Branch:** scion/ca-msg-em2
+
+## Summary
+
+Implemented Phase 5 of the messaging conversation model refactor (S2). All
+message send paths in the Hub server now resolve-or-create a Conversation
+record and stamp `conversation_id` on the `store.Message` before persisting it.
+Read paths remain unchanged per S2 contract.
+
+## Changes
+
+### New Files
+
+- **`pkg/messaging/divergence.go`** — `DivergenceEntry` struct, `LogDivergence`
+  function (INFO for matches, WARN for divergences), `DivergenceCounter` with
+  atomic metrics, and helper functions `DirectMessageExternalRef` and
+  `OldRoutingFromMessage` for building deterministic routing keys.
+
+- **`pkg/messaging/divergence_test.go`** — Unit tests for external ref
+  determinism, old-routing computation, divergence logging at correct levels,
+  and concurrent counter safety.
+
+- **`pkg/messaging/conversation.go`** — `ResolveOrCreateDMConversation` helper
+  that calls `UpsertConversationByExternalRef` with a deterministic
+  `dm:{sorted(senderID,recipientID)}` external_ref. Failures are logged and
+  return empty string (non-fatal contract).
+
+### Modified Files
+
+- **`pkg/hub/handlers_agent_messaging.go`**
+  - `handleAgentOutboundMessage` (agent→user): stamps `conversation_id` on
+    `storeMsg` before persist.
+  - `handleAgentMessage` (user/agent→agent): stamps `conversation_id` on
+    `storeMsg` before persist.
+  - `handleGroupMessage` (fan-out): stamps `conversation_id` on each
+    per-recipient `storeMsg` for both agent and user recipients.
+  - Broadcasts (`broadcastDirect`): **skipped** — broadcasts are ephemeral and
+    do not belong to a conversation.
+  - Added `messaging` package import.
+
+- **`pkg/hub/messagebroker.go`**
+  - `deliverToUser` (broker callback): stamps `conversation_id` on user-bound
+    messages (skips broadcasts).
+  - `deliverToAgent` (broker callback): stamps `conversation_id` on
+    agent-bound messages (skips broadcasts).
+  - Added `messaging` package import.
+
+## Design Decisions
+
+1. **Deterministic external_ref** — `dm:{sorted(idA,idB)}` ensures the same
+   conversation is resolved regardless of send direction. This is idempotent
+   via the `UpsertConversationByExternalRef` upsert pattern.
+
+2. **Non-fatal resolution** — All conversation resolution failures log an error
+   and continue without setting `conversation_id`. Message delivery is never
+   broken by a conversation resolution failure.
+
+3. **Broadcasts skipped** — Per the design brief, broadcast messages are
+   ephemeral and do not receive conversation assignment.
+
+4. **Divergence logging** — Every stamped message emits a divergence log entry
+   comparing old-model routing (thread_id or sender/recipient pair) with the
+   new conversation_id. This is the gate for S4 (read-switch). Currently all
+   entries log as `Match: true` since the new model is write-only and there is
+   no read path to compare against yet.
+
+## Verification
+
+- `go build ./...` — passes
+- `go test ./pkg/messaging/... -count=1` — passes (all tests including new divergence tests)
+- `go test ./pkg/hub/... -count=1` — 15 pre-existing failures (verified by
+  running without changes); no new failures introduced

--- a/pkg/hub/chat_notifications_test.go
+++ b/pkg/hub/chat_notifications_test.go
@@ -235,16 +235,22 @@ func TestChatNotifier_DMReceivedCreatesNotification(t *testing.T) {
 
 // B5/F2: After the auth-derivation override, SenderName arrives as a raw UUID
 // (the agent ID) because the Sender field is "agent:"+UUID. NotifyDMReceived
-// must resolve SenderID → agent slug for the notification display text. On
-// lookup failure it falls back to the original label (fail-open, not fail-closed
-// — dropping a notification is worse than showing a UUID).
+// must resolve SenderID → agent display name for the notification text. Name
+// is preferred over Slug, matching handlers_agent_messaging.go:353-357.
+// On lookup failure it falls back to the original label (fail-open, not
+// fail-closed — dropping a notification is worse than showing a UUID).
+//
+// F3: the resolution only fires when SenderName == SenderID (the UUID form).
+// When a caller already passes a proper label (agent.Name, user display name),
+// it must NOT be clobbered.
 func TestChatNotifier_DMReceived_ResolvesAgentSlugFromSenderID(t *testing.T) {
 	env := setupChatNotifTest(t)
 	defer env.unsub()
 
 	ctx := context.Background()
 
-	// Create project and agent so the slug lookup succeeds.
+	// Create project and agent. Name and Slug differ so we can assert
+	// Name is preferred over Slug.
 	project := &store.Project{
 		ID: api.NewUUID(), Name: "f2-notif", Slug: "f2-notif",
 		Visibility: store.VisibilityPrivate,
@@ -252,7 +258,7 @@ func TestChatNotifier_DMReceived_ResolvesAgentSlugFromSenderID(t *testing.T) {
 	require.NoError(t, env.store.CreateProject(ctx, project))
 
 	agent := &store.Agent{
-		ID: api.NewUUID(), Name: "helpful-bot", Slug: "helpful-bot",
+		ID: api.NewUUID(), Name: "Helpful Bot", Slug: "helpful-bot",
 		ProjectID: project.ID, Phase: "running",
 		Visibility: store.VisibilityPrivate,
 	}
@@ -276,16 +282,16 @@ func TestChatNotifier_DMReceived_ResolvesAgentSlugFromSenderID(t *testing.T) {
 	var payload ChatNotificationEvent
 	require.NoError(t, json.Unmarshal(evt.Data, &payload))
 
-	// The notification must display the slug, not the UUID.
-	assert.Equal(t, "helpful-bot", payload.SenderName,
-		"notification SenderName must be the agent slug, not the raw UUID")
+	// The notification must display agent.Name (preferred), not UUID or Slug.
+	assert.Equal(t, "Helpful Bot", payload.SenderName,
+		"notification SenderName must be agent.Name, not the raw UUID or slug")
 
 	// Also check the persisted notification text.
 	notifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeUser, recipientID, false)
 	require.NoError(t, err)
 	require.Len(t, notifs, 1)
-	assert.Contains(t, notifs[0].Message, "helpful-bot",
-		"persisted notification text must use the agent slug")
+	assert.Contains(t, notifs[0].Message, "Helpful Bot",
+		"persisted notification text must use agent.Name")
 	assert.NotContains(t, notifs[0].Message, agent.ID,
 		"persisted notification text must not contain the raw UUID")
 }

--- a/pkg/hub/chat_notifications_test.go
+++ b/pkg/hub/chat_notifications_test.go
@@ -296,6 +296,62 @@ func TestChatNotifier_DMReceived_ResolvesAgentSlugFromSenderID(t *testing.T) {
 		"persisted notification text must not contain the raw UUID")
 }
 
+// B5/F3/F6: When a caller already passes a proper label (e.g.
+// handlers_agent_messaging.go:353-357 passing agent.Name), the F2 slug
+// resolution must NOT overwrite it. The guard SenderName == SenderID
+// ensures the lookup only fires when SenderName is the raw UUID.
+// This test uses a SenderName distinct from both agent.Name and
+// agent.Slug so it fails if the guard is removed (resolution would
+// overwrite with Name) or if the preference order changes.
+func TestChatNotifier_DMReceived_DoesNotClobberCallerLabel(t *testing.T) {
+	env := setupChatNotifTest(t)
+	defer env.unsub()
+
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID: api.NewUUID(), Name: "f6-noclobber", Slug: "f6-noclobber",
+		Visibility: store.VisibilityPrivate,
+	}
+	require.NoError(t, env.store.CreateProject(ctx, project))
+
+	agent := &store.Agent{
+		ID: api.NewUUID(), Name: "Agent Real Name", Slug: "agent-slug",
+		ProjectID: project.ID, Phase: "running",
+		Visibility: store.VisibilityPrivate,
+	}
+	require.NoError(t, env.store.CreateAgent(ctx, agent))
+
+	recipientID := api.NewUUID()
+
+	// Caller supplies a label distinct from both Name and Slug.
+	// This is what handlers_agent_messaging.go:353-357 does (passes
+	// agent.Name), but we use a third string so the test is sensitive
+	// to any overwrite, not just Slug-over-Name.
+	env.notifier.NotifyDMReceived(ctx, recipientID, ChatMessageContext{
+		SenderID:        agent.ID,
+		SenderName:      "Caller Chosen Label",
+		ConversationKey: "dm:agent:" + agent.ID + ":user:" + recipientID,
+		Preview:         "hello",
+		ProjectID:       project.ID,
+	})
+
+	evt := drainNotification(env.notifCh, 2*time.Second)
+	require.NotNil(t, evt, "expected a notification event")
+
+	var payload ChatNotificationEvent
+	require.NoError(t, json.Unmarshal(evt.Data, &payload))
+
+	assert.Equal(t, "Caller Chosen Label", payload.SenderName,
+		"caller-supplied label must not be overwritten by slug resolution")
+
+	notifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeUser, recipientID, false)
+	require.NoError(t, err)
+	require.Len(t, notifs, 1)
+	assert.Contains(t, notifs[0].Message, "Caller Chosen Label",
+		"persisted notification must use the caller-supplied label")
+}
+
 // B5/F2 fallback: when the agent lookup fails (e.g. deleted agent), the
 // notification must still be created with the original label, not dropped.
 func TestChatNotifier_DMReceived_FallsBackOnLookupFailure(t *testing.T) {

--- a/pkg/hub/chat_notifications_test.go
+++ b/pkg/hub/chat_notifications_test.go
@@ -233,6 +233,94 @@ func TestChatNotifier_DMReceivedCreatesNotification(t *testing.T) {
 	assert.Contains(t, n.Message, "Hello there!")
 }
 
+// B5/F2: After the auth-derivation override, SenderName arrives as a raw UUID
+// (the agent ID) because the Sender field is "agent:"+UUID. NotifyDMReceived
+// must resolve SenderID → agent slug for the notification display text. On
+// lookup failure it falls back to the original label (fail-open, not fail-closed
+// — dropping a notification is worse than showing a UUID).
+func TestChatNotifier_DMReceived_ResolvesAgentSlugFromSenderID(t *testing.T) {
+	env := setupChatNotifTest(t)
+	defer env.unsub()
+
+	ctx := context.Background()
+
+	// Create project and agent so the slug lookup succeeds.
+	project := &store.Project{
+		ID: api.NewUUID(), Name: "f2-notif", Slug: "f2-notif",
+		Visibility: store.VisibilityPrivate,
+	}
+	require.NoError(t, env.store.CreateProject(ctx, project))
+
+	agent := &store.Agent{
+		ID: api.NewUUID(), Name: "helpful-bot", Slug: "helpful-bot",
+		ProjectID: project.ID, Phase: "running",
+		Visibility: store.VisibilityPrivate,
+	}
+	require.NoError(t, env.store.CreateAgent(ctx, agent))
+
+	recipientID := api.NewUUID()
+	conversationKey := "dm:agent:" + agent.ID + ":user:" + recipientID
+
+	// SenderName is the UUID form (what TrimPrefix produces after B5 override).
+	env.notifier.NotifyDMReceived(ctx, recipientID, ChatMessageContext{
+		SenderID:        agent.ID,
+		SenderName:      agent.ID, // raw UUID, not slug
+		ConversationKey: conversationKey,
+		Preview:         "Hello from the bot!",
+		ProjectID:       project.ID,
+	})
+
+	evt := drainNotification(env.notifCh, 2*time.Second)
+	require.NotNil(t, evt, "expected a notification event")
+
+	var payload ChatNotificationEvent
+	require.NoError(t, json.Unmarshal(evt.Data, &payload))
+
+	// The notification must display the slug, not the UUID.
+	assert.Equal(t, "helpful-bot", payload.SenderName,
+		"notification SenderName must be the agent slug, not the raw UUID")
+
+	// Also check the persisted notification text.
+	notifs, err := env.store.GetNotifications(ctx, store.SubscriberTypeUser, recipientID, false)
+	require.NoError(t, err)
+	require.Len(t, notifs, 1)
+	assert.Contains(t, notifs[0].Message, "helpful-bot",
+		"persisted notification text must use the agent slug")
+	assert.NotContains(t, notifs[0].Message, agent.ID,
+		"persisted notification text must not contain the raw UUID")
+}
+
+// B5/F2 fallback: when the agent lookup fails (e.g. deleted agent), the
+// notification must still be created with the original label, not dropped.
+func TestChatNotifier_DMReceived_FallsBackOnLookupFailure(t *testing.T) {
+	env := setupChatNotifTest(t)
+	defer env.unsub()
+
+	ctx := context.Background()
+	recipientID := api.NewUUID()
+	nonexistentAgentID := api.NewUUID()
+	conversationKey := "dm:agent:" + nonexistentAgentID + ":user:" + recipientID
+
+	// SenderName is the UUID (agent not in store — lookup will fail).
+	env.notifier.NotifyDMReceived(ctx, recipientID, ChatMessageContext{
+		SenderID:        nonexistentAgentID,
+		SenderName:      nonexistentAgentID,
+		ConversationKey: conversationKey,
+		Preview:         "Ghost message",
+		ProjectID:       "",
+	})
+
+	evt := drainNotification(env.notifCh, 2*time.Second)
+	require.NotNil(t, evt, "notification must still be created on lookup failure (fail-open)")
+
+	var payload ChatNotificationEvent
+	require.NoError(t, json.Unmarshal(evt.Data, &payload))
+
+	// Falls back to the UUID label — not ideal but the notification is not dropped.
+	assert.Equal(t, nonexistentAgentID, payload.SenderName,
+		"on lookup failure, SenderName must fall back to the original label")
+}
+
 // TestChatNotifier_EventPreviewMatchesMessageTruncation pins the two
 // renderings of the same text to one truncation rule. The tray row reads the
 // formatted Message; the browser popup reads Preview. If they truncate

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/hub/githubapp"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/messaging"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
@@ -248,6 +249,33 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 		Visibility:  req.Visibility,
 		CreatedAt:   time.Now(),
 	}
+
+	// Phase 5 dual-write: resolve-or-create conversation, stamp conversation_id.
+	var convResult *messaging.ConversationResult
+	if req.ThreadID != "" {
+		convResult = messaging.ResolveOrCreateThreadConversation(ctx, s.store, s.messageLog, req.ThreadID, agent.ProjectID)
+	} else if agent.ID != "" && recipientID != "" {
+		convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.messageLog, "agent", agent.ID, "user", recipientID)
+	}
+	if convResult != nil {
+		storeMsg.ConversationID = convResult.ConversationID
+	}
+	// Always log divergence — even when convResult is nil, that is a divergence signal.
+	oldRouting := messaging.OldRoutingFromMessage(agent.ID, recipientID, req.ThreadID)
+	convID := ""
+	actualRef := ""
+	if convResult != nil {
+		convID = convResult.ConversationID
+		actualRef = convResult.ExternalRef
+	}
+	match, reason := messaging.ComputeDivergenceMatch(oldRouting, actualRef, convID)
+	messaging.LogDivergence(s.messageLog, messaging.DivergenceEntry{
+		MessageID:  storeMsg.ID,
+		OldRouting: oldRouting,
+		NewRouting: messaging.NewRoutingStr(convID),
+		Match:      match,
+		Reason:     reason,
+	})
 
 	// Build a structured message for external dispatch paths.
 	structuredMsg := &messages.StructuredMessage{
@@ -755,6 +783,37 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 			DispatchState: store.MessageDispatchDispatched,
 			CreatedAt:     time.Now(),
 		}
+		// Phase 5 dual-write: resolve-or-create conversation for user/agent → agent messages.
+		var convResult *messaging.ConversationResult
+		if structuredMsg.ThreadID != "" {
+			convResult = messaging.ResolveOrCreateThreadConversation(ctx, s.store, s.messageLog, structuredMsg.ThreadID, agent.ProjectID)
+		} else if structuredMsg.SenderID != "" && agent.ID != "" {
+			if senderKind, ok := messages.PrincipalKindFromAddress(structuredMsg.Sender); ok {
+				convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.messageLog, senderKind, structuredMsg.SenderID, "agent", agent.ID)
+			} else {
+				s.messageLog.Warn("skipping DM conversation resolution: sender kind undetermined",
+					"sender", structuredMsg.Sender, "sender_id", structuredMsg.SenderID)
+			}
+		}
+		if convResult != nil {
+			storeMsg.ConversationID = convResult.ConversationID
+		}
+		// Always log divergence — even when convResult is nil, that is a divergence signal.
+		oldRouting := messaging.OldRoutingFromMessage(structuredMsg.SenderID, agent.ID, structuredMsg.ThreadID)
+		convID := ""
+		actualRef := ""
+		if convResult != nil {
+			convID = convResult.ConversationID
+			actualRef = convResult.ExternalRef
+		}
+		match, reason := messaging.ComputeDivergenceMatch(oldRouting, actualRef, convID)
+		messaging.LogDivergence(s.messageLog, messaging.DivergenceEntry{
+			MessageID:  storeMsg.ID,
+			OldRouting: oldRouting,
+			NewRouting: messaging.NewRoutingStr(convID),
+			Match:      match,
+			Reason:     reason,
+		})
 		// Propagate GroupID from metadata so CLI-originated group[] messages
 		// preserve correlation in the store.
 		if structuredMsg.Metadata != nil {
@@ -979,6 +1038,35 @@ func (s *Server) handleGroupMessage(w http.ResponseWriter, r *http.Request, anch
 				DispatchState: store.MessageDispatchDispatched,
 				CreatedAt:     time.Now(),
 			}
+			// Phase 5 dual-write: resolve-or-create conversation for group set message.
+			var convResult *messaging.ConversationResult
+			if agentMsg.SenderID != "" && agent.ID != "" {
+				if senderKind, ok := messages.PrincipalKindFromAddress(agentMsg.Sender); ok {
+					convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.messageLog, senderKind, agentMsg.SenderID, "agent", agent.ID)
+				} else {
+					s.messageLog.Warn("skipping DM conversation resolution: sender kind undetermined",
+						"sender", agentMsg.Sender, "sender_id", agentMsg.SenderID)
+				}
+			}
+			if convResult != nil {
+				storeMsg.ConversationID = convResult.ConversationID
+			}
+			// Always log divergence — even when convResult is nil, that is a divergence signal.
+			oldRouting := messaging.OldRoutingFromMessage(agentMsg.SenderID, agent.ID, "")
+			convID := ""
+			actualRef := ""
+			if convResult != nil {
+				convID = convResult.ConversationID
+				actualRef = convResult.ExternalRef
+			}
+			match, reason := messaging.ComputeDivergenceMatch(oldRouting, actualRef, convID)
+			messaging.LogDivergence(s.messageLog, messaging.DivergenceEntry{
+				MessageID:  storeMsg.ID,
+				OldRouting: oldRouting,
+				NewRouting: messaging.NewRoutingStr(convID),
+				Match:      match,
+				Reason:     reason,
+			})
 			if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 				s.messageLog.Error("Failed to persist set message", "recipient", recipStr, "error", err)
 			}
@@ -1073,6 +1161,35 @@ func (s *Server) handleGroupMessage(w http.ResponseWriter, r *http.Request, anch
 				GroupID:     groupID,
 				CreatedAt:   time.Now(),
 			}
+			// Phase 5 dual-write: resolve-or-create conversation for group set message to user.
+			var convResult *messaging.ConversationResult
+			if userMsg.SenderID != "" && userID != "" {
+				if senderKind, ok := messages.PrincipalKindFromAddress(userMsg.Sender); ok {
+					convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.messageLog, senderKind, userMsg.SenderID, "user", userID)
+				} else {
+					s.messageLog.Warn("skipping DM conversation resolution: sender kind undetermined",
+						"sender", userMsg.Sender, "sender_id", userMsg.SenderID)
+				}
+			}
+			if convResult != nil {
+				storeMsg.ConversationID = convResult.ConversationID
+			}
+			// Always log divergence — even when convResult is nil, that is a divergence signal.
+			oldRouting := messaging.OldRoutingFromMessage(userMsg.SenderID, userID, "")
+			convID := ""
+			actualRef := ""
+			if convResult != nil {
+				convID = convResult.ConversationID
+				actualRef = convResult.ExternalRef
+			}
+			match, reason := messaging.ComputeDivergenceMatch(oldRouting, actualRef, convID)
+			messaging.LogDivergence(s.messageLog, messaging.DivergenceEntry{
+				MessageID:  storeMsg.ID,
+				OldRouting: oldRouting,
+				NewRouting: messaging.NewRoutingStr(convID),
+				Match:      match,
+				Reason:     reason,
+			})
 			if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 				s.messageLog.Error("Failed to persist set message", "recipient", recipStr, "error", err)
 			}

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -1253,21 +1253,37 @@ func (s *Server) handleProjectBroadcast(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	// Populate sender from authenticated identity when not provided by the client.
-	if req.StructuredMessage.Sender == "" {
-		req.StructuredMessage.Sender = "user:unknown"
-		if userIdent != nil {
-			req.StructuredMessage.SenderID = userIdent.ID()
-			if name := userIdent.DisplayName(); name != "" {
-				req.StructuredMessage.Sender = "user:" + name
-			} else if email := userIdent.Email(); email != "" {
-				req.StructuredMessage.Sender = "user:" + email
-			}
-		} else if agentIdent != nil {
-			req.StructuredMessage.SenderID = agentIdent.ID()
-			req.StructuredMessage.Sender = "agent:" + agentIdent.ID()
+	// B5 SECURITY FIX: ALWAYS derive sender identity from the
+	// authenticated context, same as handleAgentMessage. Client-supplied
+	// Sender and SenderID are untrusted and must not be used as DM key
+	// inputs or for routing decisions (self-skip).
+	req.StructuredMessage.Sender = "user:unknown"
+	req.StructuredMessage.SenderID = ""
+	if userIdent != nil {
+		req.StructuredMessage.SenderID = userIdent.ID()
+		if name := userIdent.DisplayName(); name != "" {
+			req.StructuredMessage.Sender = "user:" + name
+		} else if email := userIdent.Email(); email != "" {
+			req.StructuredMessage.Sender = "user:" + email
 		}
+	} else if agentIdent != nil {
+		req.StructuredMessage.SenderID = agentIdent.ID()
+		req.StructuredMessage.Sender = "agent:" + agentIdent.ID()
 	}
+
+	// B5 SECURITY FIX: force Broadcasted = true server-side. The client
+	// must not control whether its message is treated as a broadcast —
+	// that is a routing fact the server knows. Without this, a client
+	// setting Broadcasted=false walks the message through the DM
+	// dual-write in deliverToAgent, creating a DM conversation per
+	// running agent.
+	req.StructuredMessage.Broadcasted = true
+
+	// Use authenticated identity for self-skip, not the Sender field.
+	// The Sender field is a display label; the auth identity is the
+	// security-relevant identity. A forged Sender could change which
+	// agents are targeted.
+	authKind, authID := authenticatedSender(ctx)
 
 	// Compute broadcast targeting: list all agents, classify by phase.
 	allResult, err := s.store.ListAgents(ctx, store.AgentFilter{
@@ -1281,7 +1297,8 @@ func (s *Server) handleProjectBroadcast(w http.ResponseWriter, r *http.Request, 
 	var targeted int
 	skippedBreakdown := make(map[string]int)
 	for _, agent := range allResult.Items {
-		if req.StructuredMessage.Sender == "agent:"+agent.Slug {
+		// Skip the sending agent to avoid self-delivery.
+		if authKind == "agent" && agent.ID == authID {
 			continue
 		}
 		if agent.Phase == string(state.PhaseRunning) {
@@ -1298,7 +1315,8 @@ func (s *Server) handleProjectBroadcast(w http.ResponseWriter, r *http.Request, 
 	// Collect running agents from the already-fetched list for direct fan-out.
 	var runningAgents []store.Agent
 	for _, agent := range allResult.Items {
-		if req.StructuredMessage.Sender == "agent:"+agent.Slug {
+		// Skip the sending agent to avoid self-delivery.
+		if authKind == "agent" && agent.ID == authID {
 			continue
 		}
 		if agent.Phase == string(state.PhaseRunning) {

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -255,7 +255,7 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 	if req.ThreadID != "" {
 		convResult = messaging.ResolveOrCreateThreadConversation(ctx, s.store, s.messageLog, req.ThreadID, agent.ProjectID)
 	} else if agent.ID != "" && recipientID != "" {
-		convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.messageLog, "agent", agent.ID, "user", recipientID)
+		convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.store, s.messageLog, "agent", agent.ID, "user", recipientID)
 	}
 	if convResult != nil {
 		storeMsg.ConversationID = convResult.ConversationID
@@ -789,7 +789,7 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 			convResult = messaging.ResolveOrCreateThreadConversation(ctx, s.store, s.messageLog, structuredMsg.ThreadID, agent.ProjectID)
 		} else if structuredMsg.SenderID != "" && agent.ID != "" {
 			if senderKind, ok := messages.PrincipalKindFromAddress(structuredMsg.Sender); ok {
-				convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.messageLog, senderKind, structuredMsg.SenderID, "agent", agent.ID)
+				convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.store, s.messageLog, senderKind, structuredMsg.SenderID, "agent", agent.ID)
 			} else {
 				s.messageLog.Warn("skipping DM conversation resolution: sender kind undetermined",
 					"sender", structuredMsg.Sender, "sender_id", structuredMsg.SenderID)
@@ -1042,7 +1042,7 @@ func (s *Server) handleGroupMessage(w http.ResponseWriter, r *http.Request, anch
 			var convResult *messaging.ConversationResult
 			if agentMsg.SenderID != "" && agent.ID != "" {
 				if senderKind, ok := messages.PrincipalKindFromAddress(agentMsg.Sender); ok {
-					convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.messageLog, senderKind, agentMsg.SenderID, "agent", agent.ID)
+					convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.store, s.messageLog, senderKind, agentMsg.SenderID, "agent", agent.ID)
 				} else {
 					s.messageLog.Warn("skipping DM conversation resolution: sender kind undetermined",
 						"sender", agentMsg.Sender, "sender_id", agentMsg.SenderID)
@@ -1165,7 +1165,7 @@ func (s *Server) handleGroupMessage(w http.ResponseWriter, r *http.Request, anch
 			var convResult *messaging.ConversationResult
 			if userMsg.SenderID != "" && userID != "" {
 				if senderKind, ok := messages.PrincipalKindFromAddress(userMsg.Sender); ok {
-					convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.messageLog, senderKind, userMsg.SenderID, "user", userID)
+					convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.store, s.messageLog, senderKind, userMsg.SenderID, "user", userID)
 				} else {
 					s.messageLog.Warn("skipping DM conversation resolution: sender kind undetermined",
 						"sender", userMsg.Sender, "sender_id", userMsg.SenderID)

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -537,32 +537,26 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 	if req.StructuredMessage != nil {
 		structuredMsg = req.StructuredMessage
 		plainMessage = req.StructuredMessage.Msg
-		// Populate sender from the authenticated identity when the client
-		// didn't provide one (e.g. web UI sends structured_message without sender).
-		if structuredMsg.Sender == "" {
-			structuredMsg.Sender = "user:unknown"
-			if user := GetUserIdentityFromContext(ctx); user != nil {
-				structuredMsg.SenderID = user.ID()
-				if name := user.DisplayName(); name != "" {
-					structuredMsg.Sender = "user:" + name
-				} else if email := user.Email(); email != "" {
-					structuredMsg.Sender = "user:" + email
-				}
-			} else if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
-				structuredMsg.SenderID = agentIdent.ID()
-				structuredMsg.Sender = "agent:" + agentIdent.ID()
+		// B5 SECURITY FIX: ALWAYS derive sender identity from the
+		// authenticated context. Client-supplied Sender and SenderID are
+		// untrusted inputs that must never be used as conversation key
+		// inputs — the DM key IS the access authority for direct
+		// conversations and there is no second check to catch a wrong one.
+		//
+		// This also fixes the downstream broker path: the broker receives
+		// the published message and inherits these (now auth-derived) fields.
+		structuredMsg.Sender = "user:unknown"
+		structuredMsg.SenderID = ""
+		if user := GetUserIdentityFromContext(ctx); user != nil {
+			structuredMsg.SenderID = user.ID()
+			if name := user.DisplayName(); name != "" {
+				structuredMsg.Sender = "user:" + name
+			} else if email := user.Email(); email != "" {
+				structuredMsg.Sender = "user:" + email
 			}
-		}
-		// Backfill SenderID from auth context when the client set Sender
-		// but omitted SenderID (e.g. CLI-originated agent-to-agent messages).
-		// Without this, inter-agent message queries by ParticipantID miss
-		// messages where the agent was the sender.
-		if structuredMsg.SenderID == "" {
-			if user := GetUserIdentityFromContext(ctx); user != nil {
-				structuredMsg.SenderID = user.ID()
-			} else if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
-				structuredMsg.SenderID = agentIdent.ID()
-			}
+		} else if agentIdent := GetAgentIdentityFromContext(ctx); agentIdent != nil {
+			structuredMsg.SenderID = agentIdent.ID()
+			structuredMsg.Sender = "agent:" + agentIdent.ID()
 		}
 		// Default version, timestamp and type when the client omits them
 		// (e.g. the web UI sends a minimal structured_message).
@@ -787,12 +781,11 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		var convResult *messaging.ConversationResult
 		if structuredMsg.ThreadID != "" {
 			convResult = messaging.ResolveOrCreateThreadConversation(ctx, s.store, s.messageLog, structuredMsg.ThreadID, agent.ProjectID)
-		} else if structuredMsg.SenderID != "" && agent.ID != "" {
-			if senderKind, ok := messages.PrincipalKindFromAddress(structuredMsg.Sender); ok {
-				convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.store, s.messageLog, senderKind, structuredMsg.SenderID, "agent", agent.ID)
-			} else {
-				s.messageLog.Warn("skipping DM conversation resolution: sender kind undetermined",
-					"sender", structuredMsg.Sender, "sender_id", structuredMsg.SenderID)
+		} else if agent.ID != "" {
+			// B5 SECURITY: derive sender identity for the DM key from the
+			// authenticated context, never from the message payload.
+			if authKind, authID := authenticatedSender(ctx); authID != "" {
+				convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.store, s.messageLog, authKind, authID, "agent", agent.ID)
 			}
 		}
 		if convResult != nil {
@@ -1039,13 +1032,11 @@ func (s *Server) handleGroupMessage(w http.ResponseWriter, r *http.Request, anch
 				CreatedAt:     time.Now(),
 			}
 			// Phase 5 dual-write: resolve-or-create conversation for group set message.
+			// B5 SECURITY: derive sender from authenticated context, never payload.
 			var convResult *messaging.ConversationResult
-			if agentMsg.SenderID != "" && agent.ID != "" {
-				if senderKind, ok := messages.PrincipalKindFromAddress(agentMsg.Sender); ok {
-					convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.store, s.messageLog, senderKind, agentMsg.SenderID, "agent", agent.ID)
-				} else {
-					s.messageLog.Warn("skipping DM conversation resolution: sender kind undetermined",
-						"sender", agentMsg.Sender, "sender_id", agentMsg.SenderID)
+			if agent.ID != "" {
+				if authKind, authID := authenticatedSender(ctx); authID != "" {
+					convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.store, s.messageLog, authKind, authID, "agent", agent.ID)
 				}
 			}
 			if convResult != nil {
@@ -1162,13 +1153,11 @@ func (s *Server) handleGroupMessage(w http.ResponseWriter, r *http.Request, anch
 				CreatedAt:   time.Now(),
 			}
 			// Phase 5 dual-write: resolve-or-create conversation for group set message to user.
+			// B5 SECURITY: derive sender from authenticated context, never payload.
 			var convResult *messaging.ConversationResult
-			if userMsg.SenderID != "" && userID != "" {
-				if senderKind, ok := messages.PrincipalKindFromAddress(userMsg.Sender); ok {
-					convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.store, s.messageLog, senderKind, userMsg.SenderID, "user", userID)
-				} else {
-					s.messageLog.Warn("skipping DM conversation resolution: sender kind undetermined",
-						"sender", userMsg.Sender, "sender_id", userMsg.SenderID)
+			if userID != "" {
+				if authKind, authID := authenticatedSender(ctx); authID != "" {
+					convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.store, s.messageLog, authKind, authID, "user", userID)
 				}
 			}
 			if convResult != nil {
@@ -1569,4 +1558,22 @@ func (s *Server) processMentions(ctx context.Context, mentionSlugs []string, pri
 	}
 
 	return results
+}
+
+// authenticatedSender returns the principal kind ("user" or "agent") and ID
+// from the request's authenticated context. Returns ("", "") when no
+// authenticated identity is present.
+//
+// B5 SECURITY: DM conversation key inputs MUST come from the authenticated
+// context, never from the client-supplied message payload. The key IS the
+// access control list for direct conversations — any guess on any input to
+// the key derivation is a guess on the ACL.
+func authenticatedSender(ctx context.Context) (kind, id string) {
+	if user := GetUserIdentityFromContext(ctx); user != nil {
+		return "user", user.ID()
+	}
+	if agent := GetAgentIdentityFromContext(ctx); agent != nil {
+		return "agent", agent.ID()
+	}
+	return "", ""
 }

--- a/pkg/hub/handlers_agent_messaging_test.go
+++ b/pkg/hub/handlers_agent_messaging_test.go
@@ -903,7 +903,7 @@ func TestBroadcast_B5F1c_SelfSkipUsesAuthNotSender(t *testing.T) {
 	t.Logf("peer received: %d, sender received: %d", len(peerMsgs.Items), len(senderMsgs.Items))
 
 	if len(peerMsgs.Items) == 0 {
-		t.Errorf("peer-agent received no messages — forged Sender caused it to be "+
+		t.Errorf("peer-agent received no messages — forged Sender caused it to be " +
 			"skipped instead of the real sender. Self-skip must use auth identity.")
 	}
 	if len(senderMsgs.Items) > 0 {

--- a/pkg/hub/handlers_agent_messaging_test.go
+++ b/pkg/hub/handlers_agent_messaging_test.go
@@ -264,3 +264,135 @@ func TestOutboundMessage_TranscriptMirrorDoesNotStarveAgentMessages(t *testing.T
 			rr.Code, rr.Body.String())
 	}
 }
+
+// B5 SECURITY: A client sending a structured_message with a spoofed SenderID
+// must not be able to create (or join) a DM conversation under the spoofed
+// identity. The DM key IS the access control list; if an attacker can choose
+// the sender ID in the key, they can read/write any user's DM.
+//
+// This test sends a message with SenderID set to a different user (the
+// "victim") while the authenticated identity is the attacker. Without the
+// fix, the dual-write path builds a DM key from the spoofed SenderID and
+// creates a conversation that the victim would join on their next message.
+// With the fix, the key is derived from the authenticated caller, so the
+// conversation belongs to the attacker (correct, expected behaviour).
+func TestAgentMessage_B5_SpoofedSenderDoesNotDeriveConversationKey(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "b5-security-project",
+		Slug:       "b5-security-project",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	// The attacker: will authenticate as this user.
+	attacker := &store.User{
+		ID:          api.NewUUID(),
+		Email:       "attacker@example.com",
+		DisplayName: "Attacker",
+	}
+	if err := s.CreateUser(ctx, attacker); err != nil {
+		t.Fatalf("CreateUser (attacker): %v", err)
+	}
+
+	// The victim: attacker will try to spoof this user's ID as SenderID.
+	victim := &store.User{
+		ID:          api.NewUUID(),
+		Email:       "victim@example.com",
+		DisplayName: "Victim",
+	}
+	if err := s.CreateUser(ctx, victim); err != nil {
+		t.Fatalf("CreateUser (victim): %v", err)
+	}
+
+	agent := &store.Agent{
+		ID:         api.NewUUID(),
+		Name:       "target-agent",
+		Slug:       "target-agent",
+		ProjectID:  project.ID,
+		Phase:      "running",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// Build the request with spoofed sender: SenderID and Sender claim to be
+	// the victim, but the authenticated identity is the attacker.
+	spoofedMsg := &messages.StructuredMessage{
+		Sender:    "user:" + victim.Email,
+		SenderID:  victim.ID,
+		Recipient: "agent:" + agent.Slug,
+		Msg:       "spoofed message",
+		Type:      messages.TypeInstruction,
+		Version:   messages.Version,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+	body, _ := json.Marshal(MessageRequest{StructuredMessage: spoofedMsg})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+agent.ID+"/message", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Authenticate as the attacker.
+	req = req.WithContext(contextWithIdentity(req.Context(),
+		NewAuthenticatedUser(attacker.ID, attacker.Email, attacker.DisplayName, "user", "web")))
+
+	rr := httptest.NewRecorder()
+	srv.handleAgentMessage(rr, req, agent.ID)
+
+	// The handler may return 503 (no dispatcher) — that's fine, the
+	// dual-write (conversation creation) happens before delivery.
+	t.Logf("handler response: %d %s", rr.Code, rr.Body.String())
+
+	// Build the expected keys.
+	correctKey, err := messages.DMConversationKey("user", attacker.ID, "agent", agent.ID)
+	if err != nil {
+		t.Fatalf("DMConversationKey (correct): %v", err)
+	}
+	spoofedKey, err := messages.DMConversationKey("user", victim.ID, "agent", agent.ID)
+	if err != nil {
+		t.Fatalf("DMConversationKey (spoofed): %v", err)
+	}
+	t.Logf("correct key (attacker): %s", correctKey)
+	t.Logf("spoofed key (victim):   %s", spoofedKey)
+
+	// The conversation must be keyed to the attacker (the authenticated user),
+	// NOT to the victim (the spoofed sender).
+	correctConv, err := s.GetConversationByExternalRef(ctx, "native", correctKey)
+	if err != nil {
+		t.Fatalf("expected conversation with correct key (attacker) to exist, got: %v", err)
+	}
+	t.Logf("conversation created: id=%s external_ref=%s", correctConv.ID, correctConv.ExternalRef)
+
+	// The spoofed key must NOT have produced a conversation.
+	spoofedConv, spoofedErr := s.GetConversationByExternalRef(ctx, "native", spoofedKey)
+	if spoofedErr == nil && spoofedConv != nil {
+		t.Errorf("SECURITY VIOLATION: conversation created under spoofed victim key %s (conv_id=%s). "+
+			"The DM key must be derived from the authenticated context, never the payload.",
+			spoofedKey, spoofedConv.ID)
+	}
+
+	// Also verify the stored message uses the attacker's sender identity, not
+	// the victim's. This ensures downstream consumers (broker, SSE) inherit
+	// the authenticated identity.
+	msgResult, err := s.ListMessages(ctx, store.MessageFilter{
+		ConversationID: correctConv.ID,
+	}, store.ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	for _, m := range msgResult.Items {
+		if m.SenderID == victim.ID {
+			t.Errorf("stored message %s has SenderID=%s (victim); should be %s (attacker)",
+				m.ID, victim.ID, attacker.ID)
+		}
+		if strings.Contains(m.Sender, victim.Email) || strings.Contains(m.Sender, victim.DisplayName) {
+			t.Errorf("stored message %s has Sender=%q containing victim identity; should use attacker",
+				m.ID, m.Sender)
+		}
+	}
+}

--- a/pkg/hub/handlers_agent_messaging_test.go
+++ b/pkg/hub/handlers_agent_messaging_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -28,6 +29,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/eventbus"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/go-jose/go-jose/v4/jwt"
@@ -393,6 +395,234 @@ func TestAgentMessage_B5_SpoofedSenderDoesNotDeriveConversationKey(t *testing.T)
 		if strings.Contains(m.Sender, victim.Email) || strings.Contains(m.Sender, victim.DisplayName) {
 			t.Errorf("stored message %s has Sender=%q containing victim identity; should use attacker",
 				m.ID, m.Sender)
+		}
+	}
+}
+
+// B5/F1 SECURITY: handleProjectBroadcast is a sibling ingress that fans out
+// to every running agent. Without the fix, a spoofed Sender/SenderID with
+// Broadcasted=false creates a DM conversation per running agent under the
+// victim's identity — wider blast radius than the handleAgentMessage path.
+//
+// This test verifies both halves of the fix:
+//   - (a) unconditional auth-derivation of sender
+//   - (b) Broadcasted forced to true server-side
+func TestBroadcast_B5F1_SpoofedSenderDoesNotDeriveConversationKey(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID: api.NewUUID(), Name: "b5-f1-broadcast", Slug: "b5-f1-broadcast",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	attacker := &store.User{
+		ID: api.NewUUID(), Email: "attacker@example.com",
+		DisplayName: "Attacker", Role: store.UserRoleMember, Status: "active",
+	}
+	victim := &store.User{
+		ID: api.NewUUID(), Email: "victim@example.com",
+		DisplayName: "Victim", Role: store.UserRoleMember, Status: "active",
+	}
+	if err := s.CreateUser(ctx, attacker); err != nil {
+		t.Fatalf("CreateUser attacker: %v", err)
+	}
+	if err := s.CreateUser(ctx, victim); err != nil {
+		t.Fatalf("CreateUser victim: %v", err)
+	}
+
+	agent := &store.Agent{
+		ID: api.NewUUID(), Name: "target-agent", Slug: "target-agent",
+		ProjectID: project.ID, Phase: "running",
+		Visibility:      store.VisibilityPrivate,
+		RuntimeBrokerID: "test-broker",
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// Set up broker infrastructure so the broadcast reaches deliverToAgent.
+	inproc := eventbus.NewInProcessEventBus(slog.Default())
+	fanout := eventbus.NewFanOutEventBus([]eventbus.NamedEventBus{
+		{Name: eventbus.InProcessBusName, Bus: inproc},
+		{Name: "web", Bus: nullSpokeEventBus{}},
+	}, slog.Default())
+	events := NewChannelEventPublisher()
+	defer events.Close()
+	proxy := NewMessageBrokerProxy(fanout, s, events,
+		func() AgentDispatcher { return noopDispatcher{} }, slog.Default())
+	proxy.Start()
+	t.Cleanup(proxy.Stop)
+	srv.SetMessageBrokerProxy(proxy)
+	proxy.subscribeProjectBroadcast(project.ID)
+	proxy.subscribeAgent(project.ID, agent.Slug)
+
+	// Attacker sends broadcast with spoofed sender (victim's identity)
+	// and Broadcasted=false to try to reach the DM dual-write path.
+	spoofed := &messages.StructuredMessage{
+		Version:     messages.Version,
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		Type:        messages.TypeInstruction,
+		Sender:      "user:" + victim.Email,
+		SenderID:    victim.ID,
+		Msg:         "broadcast as the victim",
+		Broadcasted: false, // client attempts to disable broadcast flag
+	}
+	body, _ := json.Marshal(BroadcastMessageRequest{StructuredMessage: spoofed})
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/projects/"+project.ID+"/broadcast", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithIdentity(req.Context(),
+		NewAuthenticatedUser(attacker.ID, attacker.Email, attacker.DisplayName, "user", "web")))
+
+	rr := httptest.NewRecorder()
+	srv.handleProjectBroadcast(rr, req, project.ID)
+	t.Logf("broadcast response: %d %s", rr.Code, rr.Body.String())
+
+	// Give async bus fan-out time to land.
+	spoofedKey, err := messages.DMConversationKey("user", victim.ID, "agent", agent.ID)
+	if err != nil {
+		t.Fatalf("DMConversationKey spoofed: %v", err)
+	}
+	honestKey, err := messages.DMConversationKey("user", attacker.ID, "agent", agent.ID)
+	if err != nil {
+		t.Fatalf("DMConversationKey honest: %v", err)
+	}
+	t.Logf("spoofed key (victim):  %s", spoofedKey)
+	t.Logf("honest key (attacker): %s", honestKey)
+
+	// Wait briefly for async processing.
+	deadline := time.Now().Add(3 * time.Second)
+	var spoofedFound, honestFound bool
+	for time.Now().Before(deadline) {
+		if !spoofedFound {
+			if c, e := s.GetConversationByExternalRef(ctx, "native", spoofedKey); e == nil && c != nil {
+				spoofedFound = true
+				t.Logf("SPOOFED conversation found: id=%s ref=%s", c.ID, c.ExternalRef)
+			}
+		}
+		if !honestFound {
+			if c, e := s.GetConversationByExternalRef(ctx, "native", honestKey); e == nil && c != nil {
+				honestFound = true
+				t.Logf("honest conversation found: id=%s ref=%s", c.ID, c.ExternalRef)
+			}
+		}
+		if spoofedFound || honestFound {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if spoofedFound {
+		t.Errorf("SECURITY VIOLATION (B5/F1): broadcast ingress minted DM conversation "+
+			"under spoofed victim key %s. handleProjectBroadcast must derive sender "+
+			"from auth context and force Broadcasted=true.", spoofedKey)
+	}
+
+	// The broadcast path should NOT create DM conversations at all
+	// (Broadcasted=true skips the dual-write). Neither key should exist.
+	if honestFound {
+		t.Errorf("broadcast created DM conversation under honest key %s — "+
+			"Broadcasted must be forced true server-side to skip the DM dual-write", honestKey)
+	}
+}
+
+// B5/F1b: The Broadcasted flag must be forced to true server-side on the
+// broadcast path. Without this, a client setting Broadcasted=false walks the
+// message through the DM dual-write in deliverToAgent, creating a DM
+// conversation per running agent in the project.
+func TestBroadcast_B5F1b_BroadcastedForcedTrueServerSide(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID: api.NewUUID(), Name: "b5-bcast-flag", Slug: "b5-bcast-flag",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	user := &store.User{
+		ID: api.NewUUID(), Email: "user@example.com",
+		DisplayName: "User", Role: store.UserRoleMember, Status: "active",
+	}
+	if err := s.CreateUser(ctx, user); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	// Create two agents so we can verify broadcast reaches them with
+	// Broadcasted=true (which skips DM dual-write).
+	agent1 := &store.Agent{
+		ID: api.NewUUID(), Name: "a1", Slug: "a1",
+		ProjectID: project.ID, Phase: "running",
+		Visibility:      store.VisibilityPrivate,
+		RuntimeBrokerID: "test-broker",
+	}
+	agent2 := &store.Agent{
+		ID: api.NewUUID(), Name: "a2", Slug: "a2",
+		ProjectID: project.ID, Phase: "running",
+		Visibility:      store.VisibilityPrivate,
+		RuntimeBrokerID: "test-broker",
+	}
+	for _, a := range []*store.Agent{agent1, agent2} {
+		if err := s.CreateAgent(ctx, a); err != nil {
+			t.Fatalf("CreateAgent %s: %v", a.Slug, err)
+		}
+	}
+
+	// Set up broker.
+	inproc := eventbus.NewInProcessEventBus(slog.Default())
+	fanout := eventbus.NewFanOutEventBus([]eventbus.NamedEventBus{
+		{Name: eventbus.InProcessBusName, Bus: inproc},
+		{Name: "web", Bus: nullSpokeEventBus{}},
+	}, slog.Default())
+	events := NewChannelEventPublisher()
+	defer events.Close()
+	proxy := NewMessageBrokerProxy(fanout, s, events,
+		func() AgentDispatcher { return noopDispatcher{} }, slog.Default())
+	proxy.Start()
+	t.Cleanup(proxy.Stop)
+	srv.SetMessageBrokerProxy(proxy)
+	proxy.subscribeProjectBroadcast(project.ID)
+	proxy.subscribeAgent(project.ID, agent1.Slug)
+	proxy.subscribeAgent(project.ID, agent2.Slug)
+
+	// Client explicitly sends Broadcasted=false.
+	msg := &messages.StructuredMessage{
+		Version:     messages.Version,
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		Type:        messages.TypeInstruction,
+		Msg:         "should be broadcast",
+		Broadcasted: false,
+	}
+	body, _ := json.Marshal(BroadcastMessageRequest{StructuredMessage: msg})
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/projects/"+project.ID+"/broadcast", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithIdentity(req.Context(),
+		NewAuthenticatedUser(user.ID, user.Email, user.DisplayName, "user", "web")))
+
+	rr := httptest.NewRecorder()
+	srv.handleProjectBroadcast(rr, req, project.ID)
+	t.Logf("broadcast response: %d %s", rr.Code, rr.Body.String())
+
+	// Wait for async processing.
+	time.Sleep(2 * time.Second)
+
+	// With Broadcasted forced true, NO DM conversations should be created.
+	for _, a := range []*store.Agent{agent1, agent2} {
+		key, err := messages.DMConversationKey("user", user.ID, "agent", a.ID)
+		if err != nil {
+			t.Fatalf("DMConversationKey for %s: %v", a.Slug, err)
+		}
+		conv, convErr := s.GetConversationByExternalRef(ctx, "native", key)
+		if convErr == nil && conv != nil {
+			t.Errorf("DM conversation created for agent %s (key=%s) — "+
+				"Broadcasted flag was not forced to true server-side", a.Slug, key)
 		}
 	}
 }

--- a/pkg/hub/handlers_agent_messaging_test.go
+++ b/pkg/hub/handlers_agent_messaging_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/require"
 )
 
 // postOutbound sends one agent→human message as the given agent.
@@ -998,5 +999,73 @@ func TestBroker_R2_FanOutGlobalSelfSkipBySenderID(t *testing.T) {
 	if selfN > 0 {
 		t.Errorf("SELF-DELIVERY in fanOutGlobal: sender received its own broadcast (%d rows). "+
 			"fanOutGlobal must skip by SenderID, not by the Sender display label.", selfN)
+	}
+}
+
+// R3b/F4: When a broadcast has an agent-prefixed Sender but empty SenderID,
+// the fan-out cannot self-skip and the sender silently receives its own
+// broadcast. The R3b warning makes this visible. This test asserts the
+// warning fires — without it, the safety net can silently disappear.
+func TestBroker_R3b_WarnOnEmptySenderID(t *testing.T) {
+	_, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID: api.NewUUID(), Name: "r3b", Slug: "r3b",
+		Visibility: store.VisibilityPrivate,
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+
+	agent := &store.Agent{
+		ID: api.NewUUID(), Name: "warn-agent", Slug: "warn-agent",
+		ProjectID: project.ID, Phase: "running",
+		Visibility:      store.VisibilityPrivate,
+		RuntimeBrokerID: "test-broker",
+	}
+	require.NoError(t, s.CreateAgent(ctx, agent))
+
+	// Capture log output via a slog handler backed by a bytes.Buffer.
+	var logBuf bytes.Buffer
+	handler := slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	logger := slog.New(handler)
+
+	inproc := eventbus.NewInProcessEventBus(slog.Default())
+	fanout := eventbus.NewFanOutEventBus([]eventbus.NamedEventBus{
+		{Name: eventbus.InProcessBusName, Bus: inproc},
+		{Name: "web", Bus: nullSpokeEventBus{}},
+	}, slog.Default())
+	events := NewChannelEventPublisher()
+	defer events.Close()
+	proxy := NewMessageBrokerProxy(fanout, s, events,
+		func() AgentDispatcher { return noopDispatcher{} }, logger)
+	proxy.Start()
+	t.Cleanup(proxy.Stop)
+	proxy.subscribeAgent(project.ID, agent.Slug)
+
+	// Agent-prefixed Sender, but NO SenderID — the exact scenario R3b warns about.
+	msg := &messages.StructuredMessage{
+		Version:   messages.Version,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Type:      messages.TypeInstruction,
+		Sender:    "agent:warn-agent",
+		SenderID:  "", // deliberately empty
+		Msg:       "self-skip impossible",
+	}
+
+	// Test fanOutToProject warning.
+	proxy.fanOutToProject(ctx, project.ID, msg)
+
+	logged := logBuf.String()
+	if !strings.Contains(logged, "self-skip not possible") {
+		t.Errorf("fanOutToProject: expected R3b warning in log output, got:\n%s", logged)
+	}
+
+	// Reset and test fanOutGlobal warning.
+	logBuf.Reset()
+	proxy.fanOutGlobal(ctx, msg)
+
+	logged = logBuf.String()
+	if !strings.Contains(logged, "self-skip not possible") {
+		t.Errorf("fanOutGlobal: expected R3b warning in log output, got:\n%s", logged)
 	}
 }

--- a/pkg/hub/handlers_agent_messaging_test.go
+++ b/pkg/hub/handlers_agent_messaging_test.go
@@ -911,3 +911,92 @@ func TestBroadcast_B5F1c_SelfSkipUsesAuthNotSender(t *testing.T) {
 			len(senderMsgs.Items))
 	}
 }
+
+// B5/R2: fanOutGlobal self-skip must use SenderID, not Sender slug.
+// fanOutGlobal is currently unreachable from the HTTP surface (PublishBroadcast
+// only receives non-empty projectID), but fixing the class without testing
+// every member leaves a latent bug that returns when a global broadcast
+// endpoint is added.
+//
+// Direct sink test — no HTTP plumbing.
+func TestBroker_R2_FanOutGlobalSelfSkipBySenderID(t *testing.T) {
+	_, s := testServer(t)
+	ctx := context.Background()
+
+	projectA := &store.Project{
+		ID: api.NewUUID(), Name: "r2-pa", Slug: "r2-pa",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, projectA); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	sender := &store.Agent{
+		ID: api.NewUUID(), Name: "global-sender", Slug: "global-sender",
+		ProjectID: projectA.ID, Phase: "running",
+		Visibility:      store.VisibilityPrivate,
+		RuntimeBrokerID: "test-broker",
+	}
+	peer := &store.Agent{
+		ID: api.NewUUID(), Name: "global-peer", Slug: "global-peer",
+		ProjectID: projectA.ID, Phase: "running",
+		Visibility:      store.VisibilityPrivate,
+		RuntimeBrokerID: "test-broker",
+	}
+	if err := s.CreateAgent(ctx, sender); err != nil {
+		t.Fatalf("CreateAgent sender: %v", err)
+	}
+	if err := s.CreateAgent(ctx, peer); err != nil {
+		t.Fatalf("CreateAgent peer: %v", err)
+	}
+
+	inproc := eventbus.NewInProcessEventBus(slog.Default())
+	fanout := eventbus.NewFanOutEventBus([]eventbus.NamedEventBus{
+		{Name: eventbus.InProcessBusName, Bus: inproc},
+		{Name: "web", Bus: nullSpokeEventBus{}},
+	}, slog.Default())
+	events := NewChannelEventPublisher()
+	defer events.Close()
+	proxy := NewMessageBrokerProxy(fanout, s, events,
+		func() AgentDispatcher { return noopDispatcher{} }, slog.Default())
+	proxy.Start()
+	t.Cleanup(proxy.Stop)
+
+	// Subscribe agents so deliverToAgent can find them.
+	proxy.subscribeAgent(projectA.ID, sender.Slug)
+	proxy.subscribeAgent(projectA.ID, peer.Slug)
+
+	// Call fanOutGlobal directly — SenderID is the sender agent's UUID,
+	// Sender is the UUID form (as it would be after the B5 override).
+	msg := &messages.StructuredMessage{
+		Version:     messages.Version,
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		Type:        messages.TypeInstruction,
+		Sender:      "agent:" + sender.ID, // UUID form, not slug
+		SenderID:    sender.ID,
+		Msg:         "global broadcast",
+		Broadcasted: true,
+	}
+	proxy.fanOutGlobal(ctx, msg)
+
+	// Check stored messages.
+	countFor := func(agentID string) int {
+		res, err := s.ListMessages(ctx, store.MessageFilter{AgentID: agentID}, store.ListOptions{})
+		if err != nil {
+			t.Fatalf("ListMessages: %v", err)
+		}
+		return len(res.Items)
+	}
+
+	peerN := countFor(peer.ID)
+	selfN := countFor(sender.ID)
+	t.Logf("fanOutGlobal delivered: peer=%d self=%d", peerN, selfN)
+
+	if peerN == 0 {
+		t.Fatalf("INCONCLUSIVE: peer received nothing — fanOutGlobal did not deliver")
+	}
+	if selfN > 0 {
+		t.Errorf("SELF-DELIVERY in fanOutGlobal: sender received its own broadcast (%d rows). "+
+			"fanOutGlobal must skip by SenderID, not by the Sender display label.", selfN)
+	}
+}

--- a/pkg/hub/handlers_agent_messaging_test.go
+++ b/pkg/hub/handlers_agent_messaging_test.go
@@ -626,3 +626,288 @@ func TestBroadcast_B5F1b_BroadcastedForcedTrueServerSide(t *testing.T) {
 		}
 	}
 }
+
+// B5/R1: An agent broadcasting via the broker must not receive its own
+// broadcast. messagebroker.go fanOutToProject/fanOutGlobal must skip by
+// SenderID (the canonical identity), not by the display-label Sender field
+// (which is now in UUID form after the B5 auth-derivation override).
+func TestBroadcast_R1_BroadcastingAgentDoesNotReceiveOwnMessage(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID: api.NewUUID(), Name: "r1-selfskip", Slug: "r1-selfskip",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	sender := &store.Agent{
+		ID: api.NewUUID(), Name: "sender-agent", Slug: "sender-agent",
+		ProjectID: project.ID, Phase: "running",
+		Visibility:      store.VisibilityPrivate,
+		RuntimeBrokerID: "test-broker",
+	}
+	peer := &store.Agent{
+		ID: api.NewUUID(), Name: "peer-agent", Slug: "peer-agent",
+		ProjectID: project.ID, Phase: "running",
+		Visibility:      store.VisibilityPrivate,
+		RuntimeBrokerID: "test-broker",
+	}
+	if err := s.CreateAgent(ctx, sender); err != nil {
+		t.Fatalf("CreateAgent sender: %v", err)
+	}
+	if err := s.CreateAgent(ctx, peer); err != nil {
+		t.Fatalf("CreateAgent peer: %v", err)
+	}
+
+	// Set up broker.
+	inproc := eventbus.NewInProcessEventBus(slog.Default())
+	fanout := eventbus.NewFanOutEventBus([]eventbus.NamedEventBus{
+		{Name: eventbus.InProcessBusName, Bus: inproc},
+		{Name: "web", Bus: nullSpokeEventBus{}},
+	}, slog.Default())
+	events := NewChannelEventPublisher()
+	defer events.Close()
+	proxy := NewMessageBrokerProxy(fanout, s, events,
+		func() AgentDispatcher { return noopDispatcher{} }, slog.Default())
+	proxy.Start()
+	t.Cleanup(proxy.Stop)
+	srv.SetMessageBrokerProxy(proxy)
+	proxy.subscribeProjectBroadcast(project.ID)
+	proxy.subscribeAgent(project.ID, sender.Slug)
+	proxy.subscribeAgent(project.ID, peer.Slug)
+
+	// Agent broadcasts using its slug-form Sender (what agents actually send).
+	body, _ := json.Marshal(BroadcastMessageRequest{
+		StructuredMessage: &messages.StructuredMessage{
+			Version:   messages.Version,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			Type:      messages.TypeInstruction,
+			Sender:    "agent:" + sender.Slug,
+			Msg:       "hello project",
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/projects/"+project.ID+"/broadcast", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithIdentity(req.Context(),
+		&agentIdentityWrapper{&AgentTokenClaims{
+			Claims:    jwt.Claims{Subject: sender.ID},
+			ProjectID: project.ID,
+			Scopes:    []AgentTokenScope{ScopeAgentLifecycle},
+		}}))
+
+	rr := httptest.NewRecorder()
+	srv.handleProjectBroadcast(rr, req, project.ID)
+	t.Logf("broadcast response: %d %s", rr.Code, rr.Body.String())
+
+	// Wait for async fan-out.
+	countFor := func(agentID string) int {
+		res, err := s.ListMessages(ctx, store.MessageFilter{AgentID: agentID}, store.ListOptions{})
+		if err != nil {
+			t.Fatalf("ListMessages: %v", err)
+		}
+		return len(res.Items)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if countFor(peer.ID) > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	peerN := countFor(peer.ID)
+	selfN := countFor(sender.ID)
+	t.Logf("delivered: peer=%d self=%d", peerN, selfN)
+
+	// Positive control: peer must have received the broadcast.
+	if peerN == 0 {
+		t.Fatalf("PROBE INCONCLUSIVE: peer agent received nothing — fan-out never ran")
+	}
+	if selfN > 0 {
+		t.Errorf("SELF-DELIVERY: broadcasting agent received its own broadcast (%d rows). "+
+			"fanOutToProject must skip by SenderID, not by the Sender display label.", selfN)
+	}
+}
+
+// B5/F1(a) — independent test for unconditional sender override.
+// Pins sub-fix (a) independently of sub-fix (b) (Broadcasted=true).
+// Uses broadcastDirect (no broker) to check stored message rows.
+// Without sub-fix (a), the spoofed SenderID survives into the stored messages.
+func TestBroadcast_B5F1a_SenderOverrideStoresAuthIdentity(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID: api.NewUUID(), Name: "b5-f1a", Slug: "b5-f1a",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	attacker := &store.User{
+		ID: api.NewUUID(), Email: "attacker@example.com",
+		DisplayName: "Attacker", Role: store.UserRoleMember, Status: "active",
+	}
+	victim := &store.User{
+		ID: api.NewUUID(), Email: "victim@example.com",
+		DisplayName: "Victim", Role: store.UserRoleMember, Status: "active",
+	}
+	if err := s.CreateUser(ctx, attacker); err != nil {
+		t.Fatalf("CreateUser attacker: %v", err)
+	}
+	if err := s.CreateUser(ctx, victim); err != nil {
+		t.Fatalf("CreateUser victim: %v", err)
+	}
+
+	agent := &store.Agent{
+		ID: api.NewUUID(), Name: "a1", Slug: "a1",
+		ProjectID: project.ID, Phase: "running",
+		Visibility: store.VisibilityPrivate,
+		// No RuntimeBrokerID — uses broadcastDirect path.
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// Set dispatcher so broadcastDirect doesn't 503.
+	srv.SetDispatcher(noopDispatcher{})
+
+	// Attacker sends broadcast with victim's SenderID.
+	spoofed := &messages.StructuredMessage{
+		Version:   messages.Version,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Type:      messages.TypeInstruction,
+		Sender:    "user:" + victim.Email,
+		SenderID:  victim.ID,
+		Msg:       "spoofed broadcast",
+	}
+	body, _ := json.Marshal(BroadcastMessageRequest{StructuredMessage: spoofed})
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/projects/"+project.ID+"/broadcast", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithIdentity(req.Context(),
+		NewAuthenticatedUser(attacker.ID, attacker.Email, attacker.DisplayName, "user", "web")))
+
+	rr := httptest.NewRecorder()
+	srv.handleProjectBroadcast(rr, req, project.ID)
+	t.Logf("broadcast response: %d %s", rr.Code, rr.Body.String())
+
+	// Check stored messages — SenderID must be the attacker (auth), not victim.
+	res, err := s.ListMessages(ctx, store.MessageFilter{AgentID: agent.ID}, store.ListOptions{})
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	if len(res.Items) == 0 {
+		t.Fatalf("no messages stored for agent — broadcastDirect did not run")
+	}
+	for _, m := range res.Items {
+		if m.SenderID == victim.ID {
+			t.Errorf("stored broadcast message %s has SenderID=%s (victim); "+
+				"must be %s (attacker). The sender override is not working.",
+				m.ID, victim.ID, attacker.ID)
+		}
+		if m.SenderID != attacker.ID {
+			t.Errorf("stored broadcast message %s has SenderID=%s; expected %s (attacker)",
+				m.ID, m.SenderID, attacker.ID)
+		}
+		if strings.Contains(m.Sender, victim.Email) || strings.Contains(m.Sender, victim.DisplayName) {
+			t.Errorf("stored broadcast message %s has Sender=%q containing victim identity",
+				m.ID, m.Sender)
+		}
+	}
+}
+
+// B5/F1(c) — independent test for self-skip via authenticatedSender.
+// Pins sub-fix (c) independently: a forged Sender must not change which
+// agents are targeted. Uses broadcastDirect (no broker) to inspect
+// which agents received messages.
+//
+// Scenario: sender-agent broadcasts with Sender forged to "agent:peer-agent".
+// Without (c): the old slug comparison skips peer-agent and delivers to
+// sender-agent — exactly backwards. With (c): auth identity skips
+// sender-agent correctly.
+func TestBroadcast_B5F1c_SelfSkipUsesAuthNotSender(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID: api.NewUUID(), Name: "b5-f1c", Slug: "b5-f1c",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	senderAgent := &store.Agent{
+		ID: api.NewUUID(), Name: "sender-agent", Slug: "sender-agent",
+		ProjectID: project.ID, Phase: "running",
+		Visibility: store.VisibilityPrivate,
+	}
+	peerAgent := &store.Agent{
+		ID: api.NewUUID(), Name: "peer-agent", Slug: "peer-agent",
+		ProjectID: project.ID, Phase: "running",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, senderAgent); err != nil {
+		t.Fatalf("CreateAgent sender: %v", err)
+	}
+	if err := s.CreateAgent(ctx, peerAgent); err != nil {
+		t.Fatalf("CreateAgent peer: %v", err)
+	}
+
+	srv.SetDispatcher(noopDispatcher{})
+
+	// Sender-agent broadcasts with Sender forged to look like peer-agent.
+	forged := &messages.StructuredMessage{
+		Version:   messages.Version,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Type:      messages.TypeInstruction,
+		Sender:    "agent:" + peerAgent.Slug, // forged!
+		SenderID:  peerAgent.ID,              // forged!
+		Msg:       "forged broadcast targeting",
+	}
+	body, _ := json.Marshal(BroadcastMessageRequest{StructuredMessage: forged})
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/v1/projects/"+project.ID+"/broadcast", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithIdentity(req.Context(),
+		&agentIdentityWrapper{&AgentTokenClaims{
+			Claims:    jwt.Claims{Subject: senderAgent.ID},
+			ProjectID: project.ID,
+			Scopes:    []AgentTokenScope{ScopeAgentLifecycle},
+		}}))
+
+	rr := httptest.NewRecorder()
+	srv.handleProjectBroadcast(rr, req, project.ID)
+	t.Logf("broadcast response: %d %s", rr.Code, rr.Body.String())
+
+	// With correct self-skip: sender-agent is skipped (auth identity),
+	// peer-agent receives the broadcast.
+	// With forged self-skip: peer-agent is skipped (Sender match), sender
+	// receives its own broadcast.
+	peerMsgs, err := s.ListMessages(ctx, store.MessageFilter{AgentID: peerAgent.ID}, store.ListOptions{})
+	if err != nil {
+		t.Fatalf("ListMessages peer: %v", err)
+	}
+	senderMsgs, err := s.ListMessages(ctx, store.MessageFilter{AgentID: senderAgent.ID}, store.ListOptions{})
+	if err != nil {
+		t.Fatalf("ListMessages sender: %v", err)
+	}
+
+	t.Logf("peer received: %d, sender received: %d", len(peerMsgs.Items), len(senderMsgs.Items))
+
+	if len(peerMsgs.Items) == 0 {
+		t.Errorf("peer-agent received no messages — forged Sender caused it to be "+
+			"skipped instead of the real sender. Self-skip must use auth identity.")
+	}
+	if len(senderMsgs.Items) > 0 {
+		t.Errorf("sender-agent received its own broadcast (%d msgs) — "+
+			"self-skip is using the forged Sender instead of auth identity",
+			len(senderMsgs.Items))
+	}
+}

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -708,6 +708,16 @@ func (p *MessageBrokerProxy) fanOutToProject(ctx context.Context, projectID stri
 
 	p.log.Debug("Broadcasting to project agents", "project_id", projectID, "count", len(result.Items))
 
+	// R3b: warn when a broadcast carries an agent-prefixed Sender but no
+	// SenderID. Without SenderID the self-skip cannot fire and the sender
+	// will silently receive its own broadcast. Do not guess from the slug —
+	// that is the bug B5/R1 removed. Just make it loud so it is caught in
+	// logs rather than silently regressing.
+	if msg.Broadcasted && strings.HasPrefix(msg.Sender, "agent:") && msg.SenderID == "" {
+		p.log.Warn("Broadcast has agent Sender but empty SenderID — self-skip not possible",
+			"sender", msg.Sender, "projectID", projectID)
+	}
+
 	for _, agent := range result.Items {
 		// B5/R1: skip the sender by ID, not by the display-label Sender field.
 		// Sender is a display label that may be in UUID form after the B5
@@ -733,6 +743,12 @@ func (p *MessageBrokerProxy) fanOutGlobal(ctx context.Context, msg *messages.Str
 	}
 
 	p.log.Debug("Global broadcast to all agents", "count", len(result.Items))
+
+	// R3b: same warning as fanOutToProject — see comment there.
+	if msg.Broadcasted && strings.HasPrefix(msg.Sender, "agent:") && msg.SenderID == "" {
+		p.log.Warn("Global broadcast has agent Sender but empty SenderID — self-skip not possible",
+			"sender", msg.Sender)
+	}
 
 	for _, agent := range result.Items {
 		// B5/R1: skip the sender by ID, not by the display-label Sender field.

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/eventbus"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/messaging"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
@@ -454,6 +455,42 @@ func (p *MessageBrokerProxy) deliverToUser(ctx context.Context, projectID, topic
 		Visibility:  msg.Visibility,
 		CreatedAt:   time.Now(),
 	}
+	// Phase 5 dual-write: resolve-or-create conversation for broker-delivered user messages.
+	// Skip broadcasts — they are ephemeral and do not belong to a conversation.
+	if !msg.Broadcasted {
+		var convResult *messaging.ConversationResult
+		if msg.ThreadID != "" {
+			convResult = messaging.ResolveOrCreateThreadConversation(ctx, p.store, p.log, msg.ThreadID, projectID)
+		} else if msg.SenderID != "" && msg.RecipientID != "" {
+			senderKind, sOK := messages.PrincipalKindFromAddress(msg.Sender)
+			recipientKind, rOK := messages.PrincipalKindFromAddress(msg.Recipient)
+			if sOK && rOK {
+				convResult = messaging.ResolveOrCreateDMConversation(ctx, p.store, p.log, senderKind, msg.SenderID, recipientKind, msg.RecipientID)
+			} else {
+				p.log.Warn("skipping DM conversation resolution: principal kind undetermined",
+					"sender", msg.Sender, "sender_ok", sOK, "recipient", msg.Recipient, "recipient_ok", rOK)
+			}
+		}
+		if convResult != nil {
+			storeMsg.ConversationID = convResult.ConversationID
+		}
+		// Always log divergence — even when convResult is nil, that is a divergence signal.
+		oldRouting := messaging.OldRoutingFromMessage(msg.SenderID, msg.RecipientID, msg.ThreadID)
+		convID := ""
+		actualRef := ""
+		if convResult != nil {
+			convID = convResult.ConversationID
+			actualRef = convResult.ExternalRef
+		}
+		match, reason := messaging.ComputeDivergenceMatch(oldRouting, actualRef, convID)
+		messaging.LogDivergence(p.log, messaging.DivergenceEntry{
+			MessageID:  storeMsg.ID,
+			OldRouting: oldRouting,
+			NewRouting: messaging.NewRoutingStr(convID),
+			Match:      match,
+			Reason:     reason,
+		})
+	}
 	if err := p.store.CreateMessage(ctx, storeMsg); err != nil {
 		p.log.Error("Failed to persist user message from broker", "topic", topic, "error", err)
 	}
@@ -592,6 +629,40 @@ func (p *MessageBrokerProxy) deliverToAgent(ctx context.Context, projectID, agen
 		AgentID:       agent.ID,
 		DispatchState: store.MessageDispatchDispatched,
 		CreatedAt:     time.Now(),
+	}
+	// Phase 5 dual-write: resolve-or-create conversation for broker-delivered agent messages.
+	// Skip broadcasts — they are ephemeral and do not belong to a conversation.
+	if !msg.Broadcasted {
+		var convResult *messaging.ConversationResult
+		if msg.ThreadID != "" {
+			convResult = messaging.ResolveOrCreateThreadConversation(ctx, p.store, p.log, msg.ThreadID, projectID)
+		} else if msg.SenderID != "" && agent.ID != "" {
+			if senderKind, ok := messages.PrincipalKindFromAddress(msg.Sender); ok {
+				convResult = messaging.ResolveOrCreateDMConversation(ctx, p.store, p.log, senderKind, msg.SenderID, "agent", agent.ID)
+			} else {
+				p.log.Warn("skipping DM conversation resolution: sender kind undetermined",
+					"sender", msg.Sender, "sender_id", msg.SenderID)
+			}
+		}
+		if convResult != nil {
+			storeMsg.ConversationID = convResult.ConversationID
+		}
+		// Always log divergence — even when convResult is nil, that is a divergence signal.
+		oldRouting := messaging.OldRoutingFromMessage(msg.SenderID, agent.ID, msg.ThreadID)
+		convID := ""
+		actualRef := ""
+		if convResult != nil {
+			convID = convResult.ConversationID
+			actualRef = convResult.ExternalRef
+		}
+		match, reason := messaging.ComputeDivergenceMatch(oldRouting, actualRef, convID)
+		messaging.LogDivergence(p.log, messaging.DivergenceEntry{
+			MessageID:  storeMsg.ID,
+			OldRouting: oldRouting,
+			NewRouting: messaging.NewRoutingStr(convID),
+			Match:      match,
+			Reason:     reason,
+		})
 	}
 	if err := p.store.CreateMessage(ctx, storeMsg); err != nil {
 		p.log.Error("Failed to persist broker message to store", "agentSlug", agentSlug, "error", err)

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -465,7 +465,7 @@ func (p *MessageBrokerProxy) deliverToUser(ctx context.Context, projectID, topic
 			senderKind, sOK := messages.PrincipalKindFromAddress(msg.Sender)
 			recipientKind, rOK := messages.PrincipalKindFromAddress(msg.Recipient)
 			if sOK && rOK {
-				convResult = messaging.ResolveOrCreateDMConversation(ctx, p.store, p.log, senderKind, msg.SenderID, recipientKind, msg.RecipientID)
+				convResult = messaging.ResolveOrCreateDMConversation(ctx, p.store, p.store, p.log, senderKind, msg.SenderID, recipientKind, msg.RecipientID)
 			} else {
 				p.log.Warn("skipping DM conversation resolution: principal kind undetermined",
 					"sender", msg.Sender, "sender_ok", sOK, "recipient", msg.Recipient, "recipient_ok", rOK)
@@ -638,7 +638,7 @@ func (p *MessageBrokerProxy) deliverToAgent(ctx context.Context, projectID, agen
 			convResult = messaging.ResolveOrCreateThreadConversation(ctx, p.store, p.log, msg.ThreadID, projectID)
 		} else if msg.SenderID != "" && agent.ID != "" {
 			if senderKind, ok := messages.PrincipalKindFromAddress(msg.Sender); ok {
-				convResult = messaging.ResolveOrCreateDMConversation(ctx, p.store, p.log, senderKind, msg.SenderID, "agent", agent.ID)
+				convResult = messaging.ResolveOrCreateDMConversation(ctx, p.store, p.store, p.log, senderKind, msg.SenderID, "agent", agent.ID)
 			} else {
 				p.log.Warn("skipping DM conversation resolution: sender kind undetermined",
 					"sender", msg.Sender, "sender_id", msg.SenderID)

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -713,7 +713,10 @@ func (p *MessageBrokerProxy) fanOutToProject(ctx context.Context, projectID stri
 	// will silently receive its own broadcast. Do not guess from the slug —
 	// that is the bug B5/R1 removed. Just make it loud so it is caught in
 	// logs rather than silently regressing.
-	if msg.Broadcasted && strings.HasPrefix(msg.Sender, "agent:") && msg.SenderID == "" {
+	// The Broadcasted flag is not checked: these functions are only reached
+	// from broadcast subscriptions, and omitting the flag is exactly the
+	// class of publisher error R3b guards against.
+	if strings.HasPrefix(msg.Sender, "agent:") && msg.SenderID == "" {
 		p.log.Warn("Broadcast has agent Sender but empty SenderID — self-skip not possible",
 			"sender", msg.Sender, "projectID", projectID)
 	}
@@ -745,7 +748,7 @@ func (p *MessageBrokerProxy) fanOutGlobal(ctx context.Context, msg *messages.Str
 	p.log.Debug("Global broadcast to all agents", "count", len(result.Items))
 
 	// R3b: same warning as fanOutToProject — see comment there.
-	if msg.Broadcasted && strings.HasPrefix(msg.Sender, "agent:") && msg.SenderID == "" {
+	if strings.HasPrefix(msg.Sender, "agent:") && msg.SenderID == "" {
 		p.log.Warn("Global broadcast has agent Sender but empty SenderID — self-skip not possible",
 			"sender", msg.Sender)
 	}

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -709,8 +709,10 @@ func (p *MessageBrokerProxy) fanOutToProject(ctx context.Context, projectID stri
 	p.log.Debug("Broadcasting to project agents", "project_id", projectID, "count", len(result.Items))
 
 	for _, agent := range result.Items {
-		// Skip the sender if it's an agent in this project
-		if msg.Sender == "agent:"+agent.Slug {
+		// B5/R1: skip the sender by ID, not by the display-label Sender field.
+		// Sender is a display label that may be in UUID form after the B5
+		// auth-derivation override; SenderID is the canonical identity.
+		if msg.SenderID != "" && msg.SenderID == agent.ID {
 			continue
 		}
 		agentMsg := *msg // copy to set per-agent recipient
@@ -733,7 +735,8 @@ func (p *MessageBrokerProxy) fanOutGlobal(ctx context.Context, msg *messages.Str
 	p.log.Debug("Global broadcast to all agents", "count", len(result.Items))
 
 	for _, agent := range result.Items {
-		if msg.Sender == "agent:"+agent.Slug {
+		// B5/R1: skip the sender by ID, not by the display-label Sender field.
+		if msg.SenderID != "" && msg.SenderID == agent.ID {
 			continue
 		}
 		agentMsg := *msg

--- a/pkg/hub/messagebroker_test.go
+++ b/pkg/hub/messagebroker_test.go
@@ -425,7 +425,7 @@ func TestMessageBrokerProxy_ProjectBroadcast(t *testing.T) {
 func TestMessageBrokerProxy_BroadcastSkipsSender(t *testing.T) {
 	s := newBrokerTestStore(t)
 	projectID := setupBrokerTestProject(t, s)
-	setupBrokerTestAgent(t, s, projectID, "sender-agent", "running")
+	senderAgent := setupBrokerTestAgent(t, s, projectID, "sender-agent", "running")
 	setupBrokerTestAgent(t, s, projectID, tid("other-agent"), "running")
 
 	events := NewChannelEventPublisher()
@@ -444,6 +444,10 @@ func TestMessageBrokerProxy_BroadcastSkipsSender(t *testing.T) {
 
 	msg := messages.NewInstruction("agent:sender-agent", "project:test-project", "any updates?")
 	msg.Broadcasted = true
+	// R3: production now always sets SenderID from auth (B5 override at
+	// handleProjectBroadcast:1261-1270). The fan-out self-skip relies on
+	// SenderID, not the display-label Sender field.
+	msg.SenderID = senderAgent.ID
 	_ = proxy.PublishBroadcast(context.Background(), projectID, msg)
 
 	time.Sleep(100 * time.Millisecond)

--- a/pkg/hub/notifications.go
+++ b/pkg/hub/notifications.go
@@ -650,6 +650,18 @@ func (cn *ChatNotifier) NotifyDMReceived(ctx context.Context, recipientUserID st
 		return
 	}
 
+	// F2: resolve agent slug for display. After the B5 auth-derivation
+	// override, SenderName may be a raw UUID (the agent ID). Resolve it
+	// to the human-readable slug for the notification text. This runs
+	// AFTER the muted and presence gates so the lookup only fires when a
+	// notification will actually be written. On failure, fall back to the
+	// current label — display resolution must never drop a notification.
+	if msg.SenderID != "" {
+		if agent, err := cn.store.GetAgent(ctx, msg.SenderID); err == nil && agent.Slug != "" {
+			senderName = agent.Slug
+		}
+	}
+
 	message := formatChatNotification(ChatNotificationDMReceived, senderName, "", msg.Preview)
 
 	notif := cn.buildChatNotification(recipientUserID, ChatNotificationDMReceived, message, msg.ProjectID)
@@ -661,7 +673,10 @@ func (cn *ChatNotifier) NotifyDMReceived(ctx context.Context, recipientUserID st
 	}
 
 	// A DM has no thread name; make sure a stale one cannot ride along.
+	// Also propagate the resolved slug (if any) so the SSE event payload
+	// carries the human-readable name, not the raw UUID.
 	dmMsg := msg
+	dmMsg.SenderName = senderName
 	dmMsg.ConversationName = ""
 	cn.events.PublishChatNotification(ctx, notif, dmMsg)
 	cn.log.Info("DM notification created",

--- a/pkg/hub/notifications.go
+++ b/pkg/hub/notifications.go
@@ -650,15 +650,23 @@ func (cn *ChatNotifier) NotifyDMReceived(ctx context.Context, recipientUserID st
 		return
 	}
 
-	// F2: resolve agent slug for display. After the B5 auth-derivation
-	// override, SenderName may be a raw UUID (the agent ID). Resolve it
-	// to the human-readable slug for the notification text. This runs
-	// AFTER the muted and presence gates so the lookup only fires when a
-	// notification will actually be written. On failure, fall back to the
-	// current label — display resolution must never drop a notification.
-	if msg.SenderID != "" {
-		if agent, err := cn.store.GetAgent(ctx, msg.SenderID); err == nil && agent.Slug != "" {
-			senderName = agent.Slug
+	// F2: resolve agent display name. After the B5 auth-derivation
+	// override, the broker path sets SenderName to the raw UUID (the
+	// agent ID). Resolve it to the human-readable Name (preferred) or
+	// Slug (fallback) for the notification text. The guard ensures we
+	// only look up when SenderName IS the UUID — other callers
+	// (handlers_agent_messaging.go:353, handlers_chat_v2.go:1293)
+	// already pass a proper label and must not be clobbered. This also
+	// avoids a pointless GetAgent call on the user-to-user DM path.
+	// On lookup failure, fall back to the current label — display
+	// resolution must never drop a notification.
+	if msg.SenderID != "" && msg.SenderName == msg.SenderID {
+		if agent, err := cn.store.GetAgent(ctx, msg.SenderID); err == nil {
+			if agent.Name != "" {
+				senderName = agent.Name
+			} else if agent.Slug != "" {
+				senderName = agent.Slug
+			}
 		}
 	}
 

--- a/pkg/messaging/divergence.go
+++ b/pkg/messaging/divergence.go
@@ -139,10 +139,29 @@ func ComputeDivergenceMatch(oldRouting, actualExternalRef, convID string) (match
 		return false, "unknown/no-old-routing"
 	}
 
-	// DM comparison: old="sender-recipient:{sorted pair}", new="dm:{sorted pair}"
+	// DM comparison: old="sender-recipient:{sortedID}:{sortedID}",
+	// new="dm:{kind}:{id}:{kind}:{id}" (kind-prefixed canonical key from
+	// DMConversationKey). Extract the raw IDs from the kind-prefixed key
+	// and sort them to compare against the old model's raw sorted pair.
+	//
+	// Case (c) ruling: a DM that carries a thread_id enters the thread
+	// branch above via OldRoutingFromMessage, producing "thread:{threadID}".
+	// The new model routes it by DM key, so it hits the routing-type-mismatch
+	// fallback. This is the correct signal — the old model really did route
+	// those by thread while the new model routes by DM key.
+	//
+	// Case (d) note: non-canonical raw IDs (e.g. uppercase UUIDs) in the old
+	// routing will not match canonical IDs in the new key. Treated as latent;
+	// not observed in production.
 	if strings.HasPrefix(oldRouting, "sender-recipient:") && strings.HasPrefix(actualExternalRef, "dm:") {
 		oldPair := strings.TrimPrefix(oldRouting, "sender-recipient:")
+		// New format: "dm:kindA:idA:kindB:idB" → extract raw IDs, sort, join.
 		newPair := strings.TrimPrefix(actualExternalRef, "dm:")
+		if parts := strings.Split(actualExternalRef, ":"); len(parts) == 5 && parts[0] == "dm" {
+			pair := []string{parts[2], parts[4]}
+			sort.Strings(pair)
+			newPair = strings.Join(pair, ":")
+		}
 		if oldPair == newPair {
 			return true, "dm-routing-agreement"
 		}

--- a/pkg/messaging/divergence.go
+++ b/pkg/messaging/divergence.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import (
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"sync/atomic"
+)
+
+// ---------------------------------------------------------------------------
+// Divergence logging (Phase 5 gate for S4 read-switch)
+// ---------------------------------------------------------------------------
+
+// DivergenceEntry records a comparison between old-model routing (thread_id,
+// sender/recipient pairs) and new-model routing (conversation_id resolved via
+// UpsertConversationByExternalRef).
+type DivergenceEntry struct {
+	MessageID  string `json:"message_id"`
+	OldRouting string `json:"old_routing"` // e.g. "thread:dm:abc123" or "sender:X->recipient:Y"
+	NewRouting string `json:"new_routing"` // e.g. "conv:uuid-of-conversation"
+	Match      bool   `json:"match"`       // true when old and new agree
+	Reason     string `json:"reason"`      // human-readable explanation
+}
+
+// DivergenceCounter tracks the total number of divergence entries logged,
+// partitioned into matches and mismatches. Safe for concurrent use.
+type DivergenceCounter struct {
+	matches    atomic.Int64
+	mismatches atomic.Int64
+}
+
+// Inc increments the appropriate counter.
+func (c *DivergenceCounter) Inc(match bool) {
+	if match {
+		c.matches.Add(1)
+	} else {
+		c.mismatches.Add(1)
+	}
+}
+
+// Matches returns the total number of matching entries logged.
+func (c *DivergenceCounter) Matches() int64 { return c.matches.Load() }
+
+// Mismatches returns the total number of mismatching entries logged.
+func (c *DivergenceCounter) Mismatches() int64 { return c.mismatches.Load() }
+
+// Total returns the total number of divergence entries logged.
+func (c *DivergenceCounter) Total() int64 { return c.matches.Load() + c.mismatches.Load() }
+
+// DivergenceMetrics is the package-level counter for divergence events.
+// Exported so that metrics collectors can read it.
+var DivergenceMetrics = &DivergenceCounter{}
+
+// LogDivergence logs a DivergenceEntry to the provided logger and increments
+// the global divergence counter. Matching entries are logged at INFO;
+// mismatches are logged at WARN for easy grep.
+func LogDivergence(log *slog.Logger, entry DivergenceEntry) {
+	DivergenceMetrics.Inc(entry.Match)
+
+	attrs := []any{
+		"message_id", entry.MessageID,
+		"old_routing", entry.OldRouting,
+		"new_routing", entry.NewRouting,
+		"match", entry.Match,
+		"divergence_count", DivergenceMetrics.Total(),
+	}
+	if entry.Reason != "" {
+		attrs = append(attrs, "reason", entry.Reason)
+	}
+
+	if entry.Match {
+		log.Info("conversation routing check: match", attrs...)
+	} else {
+		log.Warn("conversation routing check: DIVERGENCE", attrs...)
+	}
+}
+
+// NewRoutingStr formats a conversation ID for the divergence log's NewRouting
+// field. Returns "conv:{id}" when convID is non-empty, "none" otherwise.
+func NewRoutingStr(convID string) string {
+	if convID == "" {
+		return "none"
+	}
+	return "conv:" + convID
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic external reference helpers
+// ---------------------------------------------------------------------------
+
+// directMessageExternalRef builds a deterministic, order-independent external
+// reference for a direct-message conversation between two principals.
+// Format: dm:{sorted(idA, idB)}
+//
+// UNEXPORTED: This is the legacy format that predates kind-safe convergence
+// (DEF-8). Production code must use DeriveConversationKey / DMConversationKey
+// instead. This function is retained only for divergence tests that need the
+// old shape for comparison.
+//
+// Both IDs are required; an empty ID produces a ref that makes the divergence
+// visible rather than silently swallowing the error.
+func directMessageExternalRef(idA, idB string) string {
+	pair := []string{idA, idB}
+	sort.Strings(pair)
+	return fmt.Sprintf("dm:%s:%s", pair[0], pair[1])
+}
+
+// ComputeDivergenceMatch compares old-model routing against the ACTUAL
+// external_ref of the conversation the new model resolved. The comparison
+// is non-tautological: actualExternalRef comes from the database, not from
+// reconstructing inputs.
+//
+// Parameters:
+//   - oldRouting: the old-model routing key (from OldRoutingFromMessage)
+//   - actualExternalRef: the external_ref read from the DB via ConversationResult
+//   - convID: the conversation ID resolved by the new model (empty if resolution failed)
+func ComputeDivergenceMatch(oldRouting, actualExternalRef, convID string) (match bool, reason string) {
+	// New model failed
+	if convID == "" {
+		return false, "no-new-routing"
+	}
+	// Old model has no routing
+	if oldRouting == "" {
+		return false, "unknown/no-old-routing"
+	}
+
+	// DM comparison: old="sender-recipient:{sorted pair}", new="dm:{sorted pair}"
+	if strings.HasPrefix(oldRouting, "sender-recipient:") && strings.HasPrefix(actualExternalRef, "dm:") {
+		oldPair := strings.TrimPrefix(oldRouting, "sender-recipient:")
+		newPair := strings.TrimPrefix(actualExternalRef, "dm:")
+		if oldPair == newPair {
+			return true, "dm-routing-agreement"
+		}
+		return false, fmt.Sprintf("dm-routing-mismatch: old=%s new=%s", oldPair, newPair)
+	}
+
+	// Thread comparison: old="thread:{threadID}", new="thread:{projectID}:{threadID}"
+	if strings.HasPrefix(oldRouting, "thread:") && strings.HasPrefix(actualExternalRef, "thread:") {
+		oldThreadID := strings.TrimPrefix(oldRouting, "thread:")
+		// New format is "thread:{projectID}:{threadID}" — extract the threadID part
+		newAfterPrefix := strings.TrimPrefix(actualExternalRef, "thread:")
+		// Split on first ":" to separate projectID from threadID
+		if idx := strings.Index(newAfterPrefix, ":"); idx >= 0 {
+			newThreadID := newAfterPrefix[idx+1:]
+			if oldThreadID == newThreadID {
+				return true, "thread-routing-agreement"
+			}
+			return false, fmt.Sprintf("thread-routing-mismatch: old=%s new=%s", oldThreadID, newThreadID)
+		}
+		// Unexpected format — no projectID separator
+		return false, fmt.Sprintf("thread-format-unexpected: %s", actualExternalRef)
+	}
+
+	// Routing type mismatch (e.g., old says DM but new resolved a thread, or vice versa)
+	return false, fmt.Sprintf("routing-type-mismatch: old=%s new=%s", oldRouting, actualExternalRef)
+}
+
+// OldRoutingFromMessage builds the old-model routing key from a message's
+// sender/recipient pair and optional thread_id.
+func OldRoutingFromMessage(senderID, recipientID, threadID string) string {
+	if threadID != "" {
+		return "thread:" + threadID
+	}
+	parts := []string{senderID, recipientID}
+	sort.Strings(parts)
+	return fmt.Sprintf("sender-recipient:%s", strings.Join(parts, ":"))
+}

--- a/pkg/messaging/divergence_test.go
+++ b/pkg/messaging/divergence_test.go
@@ -1,0 +1,295 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestLegacyDirectMessageExternalRef_Deterministic(t *testing.T) {
+	// Order should not matter — the ref is sorted.
+	refAB := directMessageExternalRef("aaa", "bbb")
+	refBA := directMessageExternalRef("bbb", "aaa")
+	if refAB != refBA {
+		t.Errorf("refs should be identical regardless of order: %q vs %q", refAB, refBA)
+	}
+	if refAB != "dm:aaa:bbb" {
+		t.Errorf("unexpected ref format: %q", refAB)
+	}
+}
+
+func TestLegacyDirectMessageExternalRef_EmptyID(t *testing.T) {
+	ref := directMessageExternalRef("", "xyz")
+	if ref != "dm::xyz" {
+		t.Errorf("expected dm::xyz, got %q", ref)
+	}
+}
+
+func TestOldRoutingFromMessage_WithThreadID(t *testing.T) {
+	routing := OldRoutingFromMessage("sender1", "recip1", "dm:abc123")
+	if routing != "thread:dm:abc123" {
+		t.Errorf("expected thread:dm:abc123, got %q", routing)
+	}
+}
+
+func TestOldRoutingFromMessage_WithoutThreadID(t *testing.T) {
+	routing := OldRoutingFromMessage("sender1", "recip1", "")
+	// sender-recipient with sorted IDs
+	expected := "sender-recipient:recip1:sender1"
+	if routing != expected {
+		t.Errorf("expected %q, got %q", expected, routing)
+	}
+
+	// Order-independent
+	routing2 := OldRoutingFromMessage("recip1", "sender1", "")
+	if routing != routing2 {
+		t.Errorf("routing should be order-independent: %q vs %q", routing, routing2)
+	}
+}
+
+func TestLogDivergence_Match(t *testing.T) {
+	// Reset global counter for this test.
+	DivergenceMetrics = &DivergenceCounter{}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	entry := DivergenceEntry{
+		MessageID:  "msg-1",
+		OldRouting: "thread:dm:abc",
+		NewRouting: "conv:uuid-123",
+		Match:      true,
+		Reason:     "both resolve to same pair",
+	}
+	LogDivergence(logger, entry)
+
+	if DivergenceMetrics.Matches() != 1 {
+		t.Errorf("expected 1 match, got %d", DivergenceMetrics.Matches())
+	}
+	if DivergenceMetrics.Mismatches() != 0 {
+		t.Errorf("expected 0 mismatches, got %d", DivergenceMetrics.Mismatches())
+	}
+	if DivergenceMetrics.Total() != 1 {
+		t.Errorf("expected 1 total, got %d", DivergenceMetrics.Total())
+	}
+
+	output := buf.String()
+	if !contains(output, "match") {
+		t.Errorf("expected 'match' in log output, got: %s", output)
+	}
+}
+
+func TestLogDivergence_Mismatch(t *testing.T) {
+	DivergenceMetrics = &DivergenceCounter{}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	entry := DivergenceEntry{
+		MessageID:  "msg-2",
+		OldRouting: "thread:dm:abc",
+		NewRouting: "conv:uuid-456",
+		Match:      false,
+		Reason:     "thread_id maps to different conversation",
+	}
+	LogDivergence(logger, entry)
+
+	if DivergenceMetrics.Mismatches() != 1 {
+		t.Errorf("expected 1 mismatch, got %d", DivergenceMetrics.Mismatches())
+	}
+
+	output := buf.String()
+	if !contains(output, "DIVERGENCE") {
+		t.Errorf("expected 'DIVERGENCE' in log output, got: %s", output)
+	}
+}
+
+func TestDivergenceCounter_Concurrent(t *testing.T) {
+	DivergenceMetrics = &DivergenceCounter{}
+
+	done := make(chan struct{})
+	for i := 0; i < 100; i++ {
+		go func(match bool) {
+			DivergenceMetrics.Inc(match)
+			done <- struct{}{}
+		}(i%2 == 0)
+	}
+	for i := 0; i < 100; i++ {
+		<-done
+	}
+
+	if DivergenceMetrics.Total() != 100 {
+		t.Errorf("expected 100 total, got %d", DivergenceMetrics.Total())
+	}
+	if DivergenceMetrics.Matches() != 50 {
+		t.Errorf("expected 50 matches, got %d", DivergenceMetrics.Matches())
+	}
+	if DivergenceMetrics.Mismatches() != 50 {
+		t.Errorf("expected 50 mismatches, got %d", DivergenceMetrics.Mismatches())
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && bytes.Contains([]byte(s), []byte(substr))
+}
+
+// ---------------------------------------------------------------------------
+// ComputeDivergenceMatch tests
+// ---------------------------------------------------------------------------
+
+func TestComputeDivergenceMatch_EmptyConvID(t *testing.T) {
+	match, reason := ComputeDivergenceMatch("sender-recipient:a:b", "dm:a:b", "")
+	if match {
+		t.Error("expected match=false when convID is empty")
+	}
+	if reason != "no-new-routing" {
+		t.Errorf("expected reason 'no-new-routing', got %q", reason)
+	}
+}
+
+func TestComputeDivergenceMatch_NoOldRouting(t *testing.T) {
+	match, reason := ComputeDivergenceMatch("", "dm:a:b", "conv-abc")
+	if match {
+		t.Error("expected match=false when oldRouting is empty")
+	}
+	if reason != "unknown/no-old-routing" {
+		t.Errorf("expected reason 'unknown/no-old-routing', got %q", reason)
+	}
+}
+
+func TestComputeDivergenceMatch_DMAgreement(t *testing.T) {
+	oldRouting := OldRoutingFromMessage("sender", "recip", "")
+	actualExternalRef := directMessageExternalRef("sender", "recip")
+	match, reason := ComputeDivergenceMatch(oldRouting, actualExternalRef, "conv-abc")
+	if !match {
+		t.Error("expected match=true for DM agreement")
+	}
+	if reason != "dm-routing-agreement" {
+		t.Errorf("expected reason 'dm-routing-agreement', got %q", reason)
+	}
+}
+
+func TestComputeDivergenceMatch_ThreadAgreement(t *testing.T) {
+	oldRouting := OldRoutingFromMessage("", "", "thread-ABC")
+	actualExternalRef := "thread:proj1:thread-ABC"
+	match, reason := ComputeDivergenceMatch(oldRouting, actualExternalRef, "conv-xyz")
+	if !match {
+		t.Error("expected match=true for thread agreement")
+	}
+	if reason != "thread-routing-agreement" {
+		t.Errorf("expected reason 'thread-routing-agreement', got %q", reason)
+	}
+}
+
+func TestComputeDivergenceMatch_RoutingTypeMismatch(t *testing.T) {
+	// Old says DM, new says thread
+	oldRouting := OldRoutingFromMessage("sender", "recip", "")
+	actualExternalRef := "thread:proj1:thread-ABC"
+	match, reason := ComputeDivergenceMatch(oldRouting, actualExternalRef, "conv-xyz")
+	if match {
+		t.Error("expected match=false when routing types differ")
+	}
+	if !strings.Contains(reason, "routing-type-mismatch") {
+		t.Errorf("expected reason to contain 'routing-type-mismatch', got %q", reason)
+	}
+
+	// Old says thread, new says DM
+	oldRouting = OldRoutingFromMessage("", "", "thread-ABC")
+	actualExternalRef = directMessageExternalRef("sender", "recip")
+	match, reason = ComputeDivergenceMatch(oldRouting, actualExternalRef, "conv-xyz")
+	if match {
+		t.Error("expected match=false when routing types differ (thread vs DM)")
+	}
+	if !strings.Contains(reason, "routing-type-mismatch") {
+		t.Errorf("expected reason to contain 'routing-type-mismatch', got %q", reason)
+	}
+}
+
+func TestComputeDivergenceMatch_ThreadFormatUnexpected(t *testing.T) {
+	// Thread without projectID separator
+	oldRouting := "thread:thread-ABC"
+	actualExternalRef := "thread:noProjectSep"
+	match, reason := ComputeDivergenceMatch(oldRouting, actualExternalRef, "conv-xyz")
+	if match {
+		t.Error("expected match=false for unexpected thread format")
+	}
+	if !strings.Contains(reason, "thread-format-unexpected") {
+		t.Errorf("expected reason to contain 'thread-format-unexpected', got %q", reason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MANDATORY: Genuine disagreement tests (architect-required)
+// ---------------------------------------------------------------------------
+
+func TestComputeDivergenceMatch_GenuineDisagreement(t *testing.T) {
+	// Construct a case where old-model and new-model genuinely disagree:
+	// message has sender=A, recipient=B (old routing = sender-recipient:A:B)
+	// but the conversation it was stamped with belongs to a different pair (dm:X:Y)
+	oldRouting := OldRoutingFromMessage("agent-A", "user-B", "")
+	actualExternalRef := directMessageExternalRef("agent-X", "user-Y") // DIFFERENT pair
+
+	match, reason := ComputeDivergenceMatch(oldRouting, actualExternalRef, "some-conv-id")
+	if match {
+		t.Fatal("expected match=false when conversation belongs to a different pair than the message's sender/recipient")
+	}
+	if !strings.Contains(reason, "mismatch") {
+		t.Errorf("expected reason to contain 'mismatch', got %q", reason)
+	}
+
+	// Also verify Mismatches counter increments
+	DivergenceMetrics = &DivergenceCounter{}
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	LogDivergence(logger, DivergenceEntry{
+		MessageID:  "test-msg",
+		OldRouting: oldRouting,
+		NewRouting: "conv:some-conv-id",
+		Match:      match,
+		Reason:     reason,
+	})
+	if DivergenceMetrics.Mismatches() != 1 {
+		t.Fatalf("expected Mismatches()=1, got %d", DivergenceMetrics.Mismatches())
+	}
+}
+
+func TestComputeDivergenceMatch_ThreadDisagreement(t *testing.T) {
+	oldRouting := OldRoutingFromMessage("", "", "thread-ABC")
+	actualExternalRef := "thread:proj1:thread-XYZ" // DIFFERENT thread
+
+	match, reason := ComputeDivergenceMatch(oldRouting, actualExternalRef, "some-conv-id")
+	if match {
+		t.Fatal("expected match=false when thread IDs differ")
+	}
+	if !strings.Contains(reason, "mismatch") {
+		t.Errorf("expected reason to contain 'mismatch', got %q", reason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NewRoutingStr tests
+// ---------------------------------------------------------------------------
+
+func TestNewRoutingStr(t *testing.T) {
+	if got := NewRoutingStr(""); got != "none" {
+		t.Errorf("expected 'none' for empty convID, got %q", got)
+	}
+	if got := NewRoutingStr("conv-abc"); got != "conv:conv-abc" {
+		t.Errorf("expected 'conv:conv-abc', got %q", got)
+	}
+}

--- a/pkg/messaging/divergence_test.go
+++ b/pkg/messaging/divergence_test.go
@@ -19,6 +19,9 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/google/uuid"
 )
 
 func TestLegacyDirectMessageExternalRef_Deterministic(t *testing.T) {
@@ -173,13 +176,23 @@ func TestComputeDivergenceMatch_NoOldRouting(t *testing.T) {
 }
 
 func TestComputeDivergenceMatch_DMAgreement(t *testing.T) {
-	oldRouting := OldRoutingFromMessage("sender", "recip", "")
-	actualExternalRef := directMessageExternalRef("sender", "recip")
+	// Use realistic UUIDs and kind-safe DMConversationKey, matching what
+	// production actually stores. The old model routes by raw sorted IDs;
+	// the new model stores kind-prefixed canonical keys.
+	agentID := uuid.New().String()
+	userID := uuid.New().String()
+
+	oldRouting := OldRoutingFromMessage(agentID, userID, "")
+	actualExternalRef, err := messages.DMConversationKey("agent", agentID, "user", userID)
+	if err != nil {
+		t.Fatalf("DMConversationKey: %v", err)
+	}
 	match, reason := ComputeDivergenceMatch(oldRouting, actualExternalRef, "conv-abc")
 	if !match {
-		t.Error("expected match=true for DM agreement")
+		t.Errorf("expected match=true for DM agreement, got reason=%q (old=%s new=%s)",
+			reason, oldRouting, actualExternalRef)
 	}
-	if reason != "dm-routing-agreement" {
+	if match && reason != "dm-routing-agreement" {
 		t.Errorf("expected reason 'dm-routing-agreement', got %q", reason)
 	}
 }
@@ -209,9 +222,14 @@ func TestComputeDivergenceMatch_RoutingTypeMismatch(t *testing.T) {
 	}
 
 	// Old says thread, new says DM
+	senderID := uuid.New().String()
+	recipID := uuid.New().String()
 	oldRouting = OldRoutingFromMessage("", "", "thread-ABC")
-	actualExternalRef = directMessageExternalRef("sender", "recip")
-	match, reason = ComputeDivergenceMatch(oldRouting, actualExternalRef, "conv-xyz")
+	dmRef, err := messages.DMConversationKey("agent", senderID, "user", recipID)
+	if err != nil {
+		t.Fatalf("DMConversationKey: %v", err)
+	}
+	match, reason = ComputeDivergenceMatch(oldRouting, dmRef, "conv-xyz")
 	if match {
 		t.Error("expected match=false when routing types differ (thread vs DM)")
 	}
@@ -241,8 +259,16 @@ func TestComputeDivergenceMatch_GenuineDisagreement(t *testing.T) {
 	// Construct a case where old-model and new-model genuinely disagree:
 	// message has sender=A, recipient=B (old routing = sender-recipient:A:B)
 	// but the conversation it was stamped with belongs to a different pair (dm:X:Y)
-	oldRouting := OldRoutingFromMessage("agent-A", "user-B", "")
-	actualExternalRef := directMessageExternalRef("agent-X", "user-Y") // DIFFERENT pair
+	agentA := uuid.New().String()
+	userB := uuid.New().String()
+	agentX := uuid.New().String()
+	userY := uuid.New().String()
+
+	oldRouting := OldRoutingFromMessage(agentA, userB, "")
+	actualExternalRef, err := messages.DMConversationKey("agent", agentX, "user", userY) // DIFFERENT pair
+	if err != nil {
+		t.Fatalf("DMConversationKey: %v", err)
+	}
 
 	match, reason := ComputeDivergenceMatch(oldRouting, actualExternalRef, "some-conv-id")
 	if match {

--- a/pkg/messaging/dm_migration.go
+++ b/pkg/messaging/dm_migration.go
@@ -1,0 +1,510 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/google/uuid"
+)
+
+// DMMigrationConfig controls the behaviour of a DM migration run.
+type DMMigrationConfig struct {
+	// DryRun when true computes statistics without making any changes.
+	DryRun bool
+	// BatchSize is the page size for scanning conversations (default 100).
+	BatchSize int
+}
+
+// DMMigrationResult summarises what a DM migration run did (or would do).
+type DMMigrationResult struct {
+	TotalScanned      int      // total direct conversations examined
+	ParticipantsAdded int      // step 2: participants derived from key
+	EmptyRefMerged    int      // step 3a: empty-ref rows merged with existing
+	EmptyRefRekeyed   int      // step 3a: empty-ref rows re-keyed in place
+	OldFormatRekeyed  int      // step 3b: old dm:X:Y rows re-keyed
+	Unparseable       int      // rows that could not be processed
+	Ambiguous         int      // IDs found in neither or both tables
+	Errors            []string // non-fatal errors encountered
+}
+
+// DMMigrationStore is the interface required by the DM migration service.
+// It is satisfied by store.Store which embeds all sub-stores.
+type DMMigrationStore interface {
+	// ConversationStore methods
+	GetConversation(ctx context.Context, id string) (*store.Conversation, error)
+	UpdateConversation(ctx context.Context, conv *store.Conversation) error
+	DeleteConversation(ctx context.Context, id string) error
+	ListConversations(ctx context.Context, filter store.ConversationFilter, opts store.ListOptions) (*store.ListResult[store.Conversation], error)
+	GetConversationByExternalRef(ctx context.Context, surface, externalRef string) (*store.Conversation, error)
+	AddParticipant(ctx context.Context, p *store.ConversationParticipant) error
+	ListParticipants(ctx context.Context, conversationID string) ([]store.ConversationParticipant, error)
+
+	// User/Agent lookup methods
+	GetUser(ctx context.Context, id string) (*store.User, error)
+	GetAgent(ctx context.Context, id string) (*store.Agent, error)
+
+	// Message re-stamping
+	ListMessages(ctx context.Context, filter store.MessageFilter, opts store.ListOptions) (*store.ListResult[store.Message], error)
+	SetMessageConversationID(ctx context.Context, messageID, conversationID string) error
+}
+
+// DMMigrationService migrates historical DM conversation rows to use
+// kind-encoded keys (dm:<kind>:<uuid>:<kind>:<uuid>). It handles three
+// categories of old rows:
+//
+//  1. Kind-encoded rows that may lack participants (listing-index rebuild)
+//  2. Empty external_ref rows (merge with existing or re-key in place)
+//  3. Old-format dm:{sorted(id1,id2)} rows without kind encoding (re-key)
+type DMMigrationService struct {
+	store DMMigrationStore
+}
+
+// NewDMMigrationService creates a new DMMigrationService.
+func NewDMMigrationService(s DMMigrationStore) *DMMigrationService {
+	return &DMMigrationService{store: s}
+}
+
+// Run executes the DM migration. It is safe to call multiple times (idempotent).
+func (s *DMMigrationService) Run(ctx context.Context, cfg DMMigrationConfig) (*DMMigrationResult, error) {
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = defaultBatchSize
+	}
+
+	result := &DMMigrationResult{}
+
+	// Collect all direct conversations first, then process.
+	convs, err := s.collectDirectConversations(ctx, cfg.BatchSize)
+	if err != nil {
+		return nil, fmt.Errorf("collecting direct conversations: %w", err)
+	}
+
+	for i := range convs {
+		conv := &convs[i]
+		result.TotalScanned++
+
+		switch s.classifyConversation(conv) {
+		case convClassKindEncoded:
+			s.stepRebuildParticipants(ctx, conv, cfg.DryRun, result)
+		case convClassEmptyRef:
+			s.stepMergeOrRekeyEmptyRef(ctx, conv, cfg.DryRun, result)
+		case convClassOldFormat:
+			s.stepRekeyOldFormat(ctx, conv, cfg.DryRun, result)
+		default:
+			// Unknown format — record but skip.
+			result.Unparseable++
+		}
+	}
+
+	return result, nil
+}
+
+// convClass represents the classification of a conversation row.
+type convClass int
+
+const (
+	convClassUnknown     convClass = iota
+	convClassKindEncoded           // ParseDMKey succeeds
+	convClassEmptyRef              // external_ref == ""
+	convClassOldFormat             // starts with "dm:" but ParseDMKey fails
+)
+
+// classifyConversation determines which migration step applies.
+func (s *DMMigrationService) classifyConversation(conv *store.Conversation) convClass {
+	if conv.ExternalRef == "" {
+		return convClassEmptyRef
+	}
+
+	if strings.HasPrefix(conv.ExternalRef, "dm:") {
+		_, _, _, _, err := messages.ParseDMKey(conv.ExternalRef)
+		if err == nil {
+			return convClassKindEncoded
+		}
+		return convClassOldFormat
+	}
+
+	return convClassUnknown
+}
+
+// collectDirectConversations paginates through all direct conversations.
+func (s *DMMigrationService) collectDirectConversations(ctx context.Context, batchSize int) ([]store.Conversation, error) {
+	var all []store.Conversation
+	cursor := ""
+
+	for {
+		page, err := s.store.ListConversations(ctx, store.ConversationFilter{
+			Kind: "direct",
+		}, store.ListOptions{
+			Limit:  batchSize,
+			Cursor: cursor,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		all = append(all, page.Items...)
+
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+
+	return all, nil
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: Listing-index rebuild (kind-encoded rows missing participants)
+// ---------------------------------------------------------------------------
+
+func (s *DMMigrationService) stepRebuildParticipants(
+	ctx context.Context,
+	conv *store.Conversation,
+	dryRun bool,
+	result *DMMigrationResult,
+) {
+	kindA, idA, kindB, idB, err := messages.ParseDMKey(conv.ExternalRef)
+	if err != nil {
+		result.Unparseable++
+		result.Errors = append(result.Errors,
+			fmt.Sprintf("step2: parse key %q: %v", conv.ExternalRef, err))
+		return
+	}
+
+	// Verify both principals exist in their claimed tables.
+	if !s.verifyPrincipal(ctx, kindA, idA) || !s.verifyPrincipal(ctx, kindB, idB) {
+		result.Unparseable++
+		return
+	}
+
+	if dryRun {
+		// In dry-run, count what would be added.
+		existing, _ := s.store.ListParticipants(ctx, conv.ID)
+		needed := s.countMissingParticipants(existing, kindA, idA, kindB, idB)
+		result.ParticipantsAdded += needed
+		return
+	}
+
+	// Add participants (idempotent — ErrAlreadyExists is expected for existing).
+	added := 0
+	for _, p := range []struct{ kind, id string }{{kindA, idA}, {kindB, idB}} {
+		err := s.store.AddParticipant(ctx, &store.ConversationParticipant{
+			ID:             uuid.NewString(),
+			ConversationID: conv.ID,
+			PrincipalKind:  p.kind,
+			PrincipalID:    p.id,
+			Role:           "member",
+		})
+		if err == nil {
+			added++
+		} else if !errors.Is(err, store.ErrAlreadyExists) {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("step2: add participant %s:%s to %s: %v", p.kind, p.id, conv.ID, err))
+		}
+	}
+	result.ParticipantsAdded += added
+}
+
+// verifyPrincipal checks that the given ID exists in the table claimed by kind.
+func (s *DMMigrationService) verifyPrincipal(ctx context.Context, kind, id string) bool {
+	switch kind {
+	case "user":
+		_, err := s.store.GetUser(ctx, id)
+		return err == nil
+	case "agent":
+		_, err := s.store.GetAgent(ctx, id)
+		return err == nil
+	default:
+		return false
+	}
+}
+
+// countMissingParticipants returns how many of the two principals are missing.
+func (s *DMMigrationService) countMissingParticipants(
+	existing []store.ConversationParticipant,
+	kindA, idA, kindB, idB string,
+) int {
+	missing := 2
+	for _, p := range existing {
+		if (p.PrincipalKind == kindA && p.PrincipalID == idA) ||
+			(p.PrincipalKind == kindB && p.PrincipalID == idB) {
+			missing--
+		}
+	}
+	if missing < 0 {
+		missing = 0
+	}
+	return missing
+}
+
+// ---------------------------------------------------------------------------
+// Step 3a: Merge or re-key empty-ref rows
+// ---------------------------------------------------------------------------
+
+func (s *DMMigrationService) stepMergeOrRekeyEmptyRef(
+	ctx context.Context,
+	conv *store.Conversation,
+	dryRun bool,
+	result *DMMigrationResult,
+) {
+	// Read participants to determine the two principals.
+	parts, err := s.store.ListParticipants(ctx, conv.ID)
+	if err != nil {
+		result.Unparseable++
+		result.Errors = append(result.Errors,
+			fmt.Sprintf("step3a: list participants for %s: %v", conv.ID, err))
+		return
+	}
+
+	// Filter to active participants (no LeftAt).
+	var active []store.ConversationParticipant
+	for _, p := range parts {
+		if p.LeftAt == nil {
+			active = append(active, p)
+		}
+	}
+
+	if len(active) != 2 {
+		result.Unparseable++
+		return
+	}
+
+	// Validate kinds.
+	if !isValidDMKind(active[0].PrincipalKind) || !isValidDMKind(active[1].PrincipalKind) {
+		result.Unparseable++
+		return
+	}
+
+	// Compute the kind-encoded key.
+	newKey, err := messages.DMConversationKey(
+		active[0].PrincipalKind, active[0].PrincipalID,
+		active[1].PrincipalKind, active[1].PrincipalID,
+	)
+	if err != nil {
+		result.Unparseable++
+		result.Errors = append(result.Errors,
+			fmt.Sprintf("step3a: compute key for %s: %v", conv.ID, err))
+		return
+	}
+
+	// Check if a row with this key already exists.
+	existing, err := s.store.GetConversationByExternalRef(ctx, "native", newKey)
+	if err == nil && existing != nil && existing.ID != conv.ID {
+		// Merge case: re-stamp messages and soft-delete old row.
+		if dryRun {
+			result.EmptyRefMerged++
+			return
+		}
+		if mergeErr := s.mergeConversation(ctx, conv.ID, existing.ID, active, result); mergeErr != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("step3a: merge %s → %s: %v", conv.ID, existing.ID, mergeErr))
+			return
+		}
+		result.EmptyRefMerged++
+	} else {
+		// Re-key in place.
+		if dryRun {
+			result.EmptyRefRekeyed++
+			return
+		}
+		conv.ExternalRef = newKey
+		conv.ProjectID = nil // DMs are global (DEF-10)
+		if err := s.store.UpdateConversation(ctx, conv); err != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("step3a: re-key %s: %v", conv.ID, err))
+			return
+		}
+		result.EmptyRefRekeyed++
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Step 3b: Re-key old-format dm: rows
+// ---------------------------------------------------------------------------
+
+func (s *DMMigrationService) stepRekeyOldFormat(
+	ctx context.Context,
+	conv *store.Conversation,
+	dryRun bool,
+	result *DMMigrationResult,
+) {
+	// Old format: dm:<sorted_id1>:<sorted_id2>
+	// Strip "dm:" prefix, split into exactly 2 IDs.
+	body := conv.ExternalRef[3:] // strip "dm:"
+	parts := strings.SplitN(body, ":", 2)
+	if len(parts) != 2 {
+		result.Unparseable++
+		return
+	}
+
+	id1, id2 := parts[0], parts[1]
+
+	// Validate both are UUIDs.
+	if !isValidUUID(id1) || !isValidUUID(id2) {
+		result.Unparseable++
+		return
+	}
+
+	// Resolve kinds by looking up each ID in both tables.
+	kind1, ok1 := s.resolveKind(ctx, id1)
+	kind2, ok2 := s.resolveKind(ctx, id2)
+
+	if !ok1 || !ok2 {
+		result.Ambiguous++
+		result.Errors = append(result.Errors,
+			fmt.Sprintf("step3b: ambiguous kind resolution for conversation %s — id1=%s id2=%s (found in neither or both tables)", conv.ID, id1, id2))
+		return
+	}
+
+	// Compute the kind-encoded key.
+	newKey, err := messages.DMConversationKey(kind1, id1, kind2, id2)
+	if err != nil {
+		result.Unparseable++
+		result.Errors = append(result.Errors,
+			fmt.Sprintf("step3b: compute key for %s: %v", conv.ID, err))
+		return
+	}
+
+	// Check if a row with this key already exists.
+	existing, err := s.store.GetConversationByExternalRef(ctx, "native", newKey)
+	if err == nil && existing != nil && existing.ID != conv.ID {
+		// Merge case.
+		if dryRun {
+			result.OldFormatRekeyed++
+			return
+		}
+		// Get participants for merge.
+		convParts, _ := s.store.ListParticipants(ctx, conv.ID)
+		if mergeErr := s.mergeConversation(ctx, conv.ID, existing.ID, convParts, result); mergeErr != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("step3b: merge %s → %s: %v", conv.ID, existing.ID, mergeErr))
+			return
+		}
+		result.OldFormatRekeyed++
+	} else {
+		// Re-key in place.
+		if dryRun {
+			result.OldFormatRekeyed++
+			return
+		}
+		conv.ExternalRef = newKey
+		conv.ProjectID = nil // DMs are global (DEF-10)
+		if err := s.store.UpdateConversation(ctx, conv); err != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("step3b: re-key %s: %v", conv.ID, err))
+			return
+		}
+		result.OldFormatRekeyed++
+	}
+}
+
+// resolveKind attempts to determine the kind ("user" or "agent") for a given ID
+// by looking it up in both tables. Returns ("", false) if found in neither or both.
+func (s *DMMigrationService) resolveKind(ctx context.Context, id string) (string, bool) {
+	_, userErr := s.store.GetUser(ctx, id)
+	_, agentErr := s.store.GetAgent(ctx, id)
+
+	isUser := userErr == nil
+	isAgent := agentErr == nil
+
+	if isUser && isAgent {
+		// Found in both — ambiguous.
+		return "", false
+	}
+	if !isUser && !isAgent {
+		// Found in neither — ambiguous.
+		return "", false
+	}
+	if isUser {
+		return "user", true
+	}
+	return "agent", true
+}
+
+// ---------------------------------------------------------------------------
+// Merge helper
+// ---------------------------------------------------------------------------
+
+// mergeConversation moves messages from oldConvID to newConvID, copies missing
+// participants, and soft-deletes the old row.
+func (s *DMMigrationService) mergeConversation(
+	ctx context.Context,
+	oldConvID, newConvID string,
+	oldParticipants []store.ConversationParticipant,
+	result *DMMigrationResult,
+) error {
+	// Re-stamp all messages from old conversation to new.
+	cursor := ""
+	for {
+		page, err := s.store.ListMessages(ctx, store.MessageFilter{
+			ConversationID: oldConvID,
+		}, store.ListOptions{
+			Limit:  defaultBatchSize,
+			Cursor: cursor,
+		})
+		if err != nil {
+			return fmt.Errorf("listing messages for %s: %w", oldConvID, err)
+		}
+
+		for _, msg := range page.Items {
+			if err := s.store.SetMessageConversationID(ctx, msg.ID, newConvID); err != nil {
+				result.Errors = append(result.Errors,
+					fmt.Sprintf("re-stamp message %s: %v", msg.ID, err))
+			}
+		}
+
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+
+	// Copy missing participants to the target conversation.
+	for _, p := range oldParticipants {
+		err := s.store.AddParticipant(ctx, &store.ConversationParticipant{
+			ID:             uuid.NewString(),
+			ConversationID: newConvID,
+			PrincipalKind:  p.PrincipalKind,
+			PrincipalID:    p.PrincipalID,
+			Role:           "member",
+		})
+		if err != nil && !errors.Is(err, store.ErrAlreadyExists) {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("copy participant %s:%s to %s: %v",
+					p.PrincipalKind, p.PrincipalID, newConvID, err))
+		}
+	}
+
+	// Soft-delete the old row.
+	if err := s.store.DeleteConversation(ctx, oldConvID); err != nil {
+		return fmt.Errorf("deleting old conversation %s: %w", oldConvID, err)
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// isValidDMKind returns true if the kind is a valid DM principal kind.
+func isValidDMKind(kind string) bool {
+	return kind == "user" || kind == "agent"
+}

--- a/pkg/messaging/dm_migration_test.go
+++ b/pkg/messaging/dm_migration_test.go
@@ -1,0 +1,935 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Mock DMMigrationStore
+// ---------------------------------------------------------------------------
+
+type mockMigrationStore struct {
+	conversations map[string]*store.Conversation
+	participants  map[string][]store.ConversationParticipant // key: conversationID
+	users         map[string]*store.User                     // key: user ID
+	agents        map[string]*store.Agent                    // key: agent ID
+	messages      map[string]*store.Message                  // key: message ID
+}
+
+func newMockMigrationStore() *mockMigrationStore {
+	return &mockMigrationStore{
+		conversations: make(map[string]*store.Conversation),
+		participants:  make(map[string][]store.ConversationParticipant),
+		users:         make(map[string]*store.User),
+		agents:        make(map[string]*store.Agent),
+		messages:      make(map[string]*store.Message),
+	}
+}
+
+func (m *mockMigrationStore) GetConversation(_ context.Context, id string) (*store.Conversation, error) {
+	conv, ok := m.conversations[id]
+	if !ok {
+		return nil, store.ErrNotFound
+	}
+	return conv, nil
+}
+
+func (m *mockMigrationStore) UpdateConversation(_ context.Context, conv *store.Conversation) error {
+	if _, ok := m.conversations[conv.ID]; !ok {
+		return store.ErrNotFound
+	}
+	m.conversations[conv.ID] = conv
+	return nil
+}
+
+func (m *mockMigrationStore) DeleteConversation(_ context.Context, id string) error {
+	conv, ok := m.conversations[id]
+	if !ok {
+		return store.ErrNotFound
+	}
+	now := time.Now()
+	conv.DeletedAt = &now
+	return nil
+}
+
+func (m *mockMigrationStore) ListConversations(_ context.Context, filter store.ConversationFilter, opts store.ListOptions) (*store.ListResult[store.Conversation], error) {
+	var items []store.Conversation
+	for _, conv := range m.conversations {
+		// Skip soft-deleted conversations.
+		if conv.DeletedAt != nil {
+			continue
+		}
+		if filter.Kind != "" && conv.Kind != filter.Kind {
+			continue
+		}
+		if filter.Surface != "" && conv.Surface != filter.Surface {
+			continue
+		}
+		items = append(items, *conv)
+	}
+
+	// Sort by ID for deterministic pagination.
+	sort.Slice(items, func(i, j int) bool { return items[i].ID < items[j].ID })
+
+	// Apply cursor.
+	if opts.Cursor != "" {
+		idx := 0
+		for i, it := range items {
+			if it.ID == opts.Cursor {
+				idx = i + 1
+				break
+			}
+		}
+		items = items[idx:]
+	}
+
+	if opts.Limit > 0 && len(items) > opts.Limit {
+		nextCursor := items[opts.Limit-1].ID
+		return &store.ListResult[store.Conversation]{
+			Items:      items[:opts.Limit],
+			TotalCount: len(items),
+			NextCursor: nextCursor,
+		}, nil
+	}
+
+	return &store.ListResult[store.Conversation]{Items: items, TotalCount: len(items)}, nil
+}
+
+func (m *mockMigrationStore) GetConversationByExternalRef(_ context.Context, surface, externalRef string) (*store.Conversation, error) {
+	for _, conv := range m.conversations {
+		if conv.DeletedAt != nil {
+			continue
+		}
+		if conv.Surface == surface && conv.ExternalRef == externalRef {
+			return conv, nil
+		}
+	}
+	return nil, store.ErrNotFound
+}
+
+func (m *mockMigrationStore) AddParticipant(_ context.Context, p *store.ConversationParticipant) error {
+	for _, existing := range m.participants[p.ConversationID] {
+		if existing.PrincipalKind == p.PrincipalKind && existing.PrincipalID == p.PrincipalID {
+			return store.ErrAlreadyExists
+		}
+	}
+	m.participants[p.ConversationID] = append(m.participants[p.ConversationID], *p)
+	return nil
+}
+
+func (m *mockMigrationStore) ListParticipants(_ context.Context, conversationID string) ([]store.ConversationParticipant, error) {
+	return m.participants[conversationID], nil
+}
+
+func (m *mockMigrationStore) GetUser(_ context.Context, id string) (*store.User, error) {
+	user, ok := m.users[id]
+	if !ok {
+		return nil, store.ErrNotFound
+	}
+	return user, nil
+}
+
+func (m *mockMigrationStore) GetAgent(_ context.Context, id string) (*store.Agent, error) {
+	agent, ok := m.agents[id]
+	if !ok {
+		return nil, store.ErrNotFound
+	}
+	return agent, nil
+}
+
+func (m *mockMigrationStore) ListMessages(_ context.Context, filter store.MessageFilter, opts store.ListOptions) (*store.ListResult[store.Message], error) {
+	var items []store.Message
+	for _, msg := range m.messages {
+		if filter.ConversationID != "" && msg.ConversationID != filter.ConversationID {
+			continue
+		}
+		items = append(items, *msg)
+	}
+
+	// Sort by ID for deterministic pagination.
+	sort.Slice(items, func(i, j int) bool { return items[i].ID < items[j].ID })
+
+	// Apply cursor.
+	if opts.Cursor != "" {
+		idx := 0
+		for i, it := range items {
+			if it.ID == opts.Cursor {
+				idx = i + 1
+				break
+			}
+		}
+		items = items[idx:]
+	}
+
+	if opts.Limit > 0 && len(items) > opts.Limit {
+		nextCursor := items[opts.Limit-1].ID
+		return &store.ListResult[store.Message]{
+			Items:      items[:opts.Limit],
+			TotalCount: len(items),
+			NextCursor: nextCursor,
+		}, nil
+	}
+
+	return &store.ListResult[store.Message]{Items: items, TotalCount: len(items)}, nil
+}
+
+func (m *mockMigrationStore) SetMessageConversationID(_ context.Context, messageID, conversationID string) error {
+	msg, ok := m.messages[messageID]
+	if !ok {
+		return store.ErrNotFound
+	}
+	msg.ConversationID = conversationID
+	return nil
+}
+
+// addConv is a helper to add a conversation with optional participants.
+func (m *mockMigrationStore) addConv(conv *store.Conversation, participants ...store.ConversationParticipant) {
+	m.conversations[conv.ID] = conv
+	m.participants[conv.ID] = participants
+}
+
+// addMessage is a helper to add a message.
+func (m *mockMigrationStore) addMessage(msg *store.Message) {
+	m.messages[msg.ID] = msg
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: Listing-index rebuild tests
+// ---------------------------------------------------------------------------
+
+// TestStep2_KindEncodedRowAddsParticipants verifies that a kind-encoded row
+// with no participants gets both principals added after migration.
+func TestStep2_KindEncodedRowAddsParticipants(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	userID := uuid.NewString()
+	agentID := uuid.NewString()
+	convID := uuid.NewString()
+
+	// Register both principals in their tables.
+	ms.users[userID] = &store.User{ID: userID, Email: "test@example.com"}
+	ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "test-agent"}
+
+	// Kind-encoded row with NO participants.
+	extRef := mustDMKey("user", userID, "agent", agentID)
+	ms.addConv(&store.Conversation{
+		ID:          convID,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: extRef,
+	})
+
+	svc := NewDMMigrationService(ms)
+	result, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	// Verify participants were added.
+	parts := ms.participants[convID]
+	require.Len(t, parts, 2, "expected 2 participants, got %d", len(parts))
+
+	var hasUser, hasAgent bool
+	for _, p := range parts {
+		if p.PrincipalKind == "user" && p.PrincipalID == userID {
+			hasUser = true
+		}
+		if p.PrincipalKind == "agent" && p.PrincipalID == agentID {
+			hasAgent = true
+		}
+	}
+	assert.True(t, hasUser, "user participant should be added")
+	assert.True(t, hasAgent, "agent participant should be added")
+	assert.Equal(t, 2, result.ParticipantsAdded, "ParticipantsAdded should be 2")
+	assert.Equal(t, 1, result.TotalScanned, "TotalScanned should be 1")
+}
+
+// TestStep2_SkipsWhenPrincipalNotFound verifies that when one principal doesn't
+// exist, the entire row is skipped (all-or-nothing).
+func TestStep2_SkipsWhenPrincipalNotFound(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	userID := uuid.NewString()
+	agentID := uuid.NewString()
+	convID := uuid.NewString()
+
+	// Only register the user — agent does NOT exist.
+	ms.users[userID] = &store.User{ID: userID, Email: "test@example.com"}
+
+	extRef := mustDMKey("user", userID, "agent", agentID)
+	ms.addConv(&store.Conversation{
+		ID:          convID,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: extRef,
+	})
+
+	svc := NewDMMigrationService(ms)
+	result, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	// No participants should be added (all-or-nothing skip).
+	parts := ms.participants[convID]
+	assert.Len(t, parts, 0, "no participants should be added when one principal is missing")
+	assert.Equal(t, 0, result.ParticipantsAdded)
+	assert.Equal(t, 1, result.Unparseable, "should be counted as unparseable")
+}
+
+// TestStep2_IdempotentExistingParticipants verifies that re-running migration
+// on a row that already has participants doesn't error.
+func TestStep2_IdempotentExistingParticipants(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	userID := uuid.NewString()
+	agentID := uuid.NewString()
+	convID := uuid.NewString()
+
+	ms.users[userID] = &store.User{ID: userID, Email: "test@example.com"}
+	ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "test-agent"}
+
+	extRef := mustDMKey("user", userID, "agent", agentID)
+	ms.addConv(&store.Conversation{
+		ID:          convID,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: extRef,
+	},
+		store.ConversationParticipant{ConversationID: convID, PrincipalKind: "user", PrincipalID: userID},
+		store.ConversationParticipant{ConversationID: convID, PrincipalKind: "agent", PrincipalID: agentID},
+	)
+
+	svc := NewDMMigrationService(ms)
+	result, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, result.ParticipantsAdded, "no new participants should be added")
+	assert.Len(t, result.Errors, 0, "no errors on idempotent run")
+}
+
+// ---------------------------------------------------------------------------
+// Step 3a: Empty-ref merge/re-key tests
+// ---------------------------------------------------------------------------
+
+// TestStep3a_MergeEmptyRefWithExisting verifies that an empty-ref row is merged
+// with an existing kind-encoded row — messages re-stamped, old row deleted.
+func TestStep3a_MergeEmptyRefWithExisting(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	userID := uuid.NewString()
+	agentID := uuid.NewString()
+	oldConvID := uuid.NewString()
+	newConvID := uuid.NewString()
+
+	ms.users[userID] = &store.User{ID: userID, Email: "test@example.com"}
+	ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "test-agent"}
+
+	// Old empty-ref row with participants.
+	ms.addConv(&store.Conversation{
+		ID:          oldConvID,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: "",
+	},
+		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "user", PrincipalID: userID},
+		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "agent", PrincipalID: agentID},
+	)
+
+	// Existing kind-encoded row for the same pair.
+	extRef := mustDMKey("user", userID, "agent", agentID)
+	ms.addConv(&store.Conversation{
+		ID:          newConvID,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: extRef,
+	},
+		store.ConversationParticipant{ConversationID: newConvID, PrincipalKind: "user", PrincipalID: userID},
+		store.ConversationParticipant{ConversationID: newConvID, PrincipalKind: "agent", PrincipalID: agentID},
+	)
+
+	// Add a message to the old conversation.
+	msgID := uuid.NewString()
+	ms.addMessage(&store.Message{
+		ID:             msgID,
+		ConversationID: oldConvID,
+		Msg:            "hello",
+	})
+
+	svc := NewDMMigrationService(ms)
+	result, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	// Old row should be soft-deleted.
+	assert.NotNil(t, ms.conversations[oldConvID].DeletedAt, "old row should be soft-deleted")
+
+	// Message should be re-stamped to the new conversation.
+	assert.Equal(t, newConvID, ms.messages[msgID].ConversationID,
+		"message should be re-stamped to new conversation")
+
+	assert.Equal(t, 1, result.EmptyRefMerged, "EmptyRefMerged should be 1")
+}
+
+// TestStep3a_RekeyEmptyRefInPlace verifies that an empty-ref row with no
+// existing kind-encoded counterpart gets re-keyed in place.
+func TestStep3a_RekeyEmptyRefInPlace(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	userID := uuid.NewString()
+	agentID := uuid.NewString()
+	convID := uuid.NewString()
+	projectID := "some-project"
+
+	ms.users[userID] = &store.User{ID: userID, Email: "test@example.com"}
+	ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "test-agent"}
+
+	// Empty-ref row with a ProjectID that should be cleared.
+	ms.addConv(&store.Conversation{
+		ID:          convID,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: "",
+		ProjectID:   &projectID,
+	},
+		store.ConversationParticipant{ConversationID: convID, PrincipalKind: "user", PrincipalID: userID},
+		store.ConversationParticipant{ConversationID: convID, PrincipalKind: "agent", PrincipalID: agentID},
+	)
+
+	svc := NewDMMigrationService(ms)
+	result, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	// External ref should be set to the kind-encoded key.
+	expectedKey := mustDMKey("user", userID, "agent", agentID)
+	conv := ms.conversations[convID]
+	assert.Equal(t, expectedKey, conv.ExternalRef, "ExternalRef should be set to kind-encoded key")
+	assert.Nil(t, conv.ProjectID, "ProjectID should be nil (DMs are global)")
+	assert.Equal(t, 1, result.EmptyRefRekeyed, "EmptyRefRekeyed should be 1")
+}
+
+// TestStep3a_SkipsWhenParticipantsNot2 verifies that empty-ref rows with != 2
+// active participants are skipped.
+func TestStep3a_SkipsWhenParticipantsNot2(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	convID := uuid.NewString()
+	userID := uuid.NewString()
+
+	// Only 1 participant.
+	ms.addConv(&store.Conversation{
+		ID:          convID,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: "",
+	},
+		store.ConversationParticipant{ConversationID: convID, PrincipalKind: "user", PrincipalID: userID},
+	)
+
+	svc := NewDMMigrationService(ms)
+	result, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.Unparseable, "should be unparseable with 1 participant")
+	assert.Equal(t, 0, result.EmptyRefRekeyed)
+	assert.Equal(t, 0, result.EmptyRefMerged)
+}
+
+// ---------------------------------------------------------------------------
+// Step 3b: Old-format re-key tests
+// ---------------------------------------------------------------------------
+
+// TestStep3b_OldFormatRekey verifies that an old dm:id1:id2 row is re-keyed
+// to the kind-encoded format when both IDs resolve unambiguously.
+func TestStep3b_OldFormatRekey(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	userID := uuid.NewString()
+	agentID := uuid.NewString()
+	convID := uuid.NewString()
+	projectID := "old-project"
+
+	ms.users[userID] = &store.User{ID: userID, Email: "test@example.com"}
+	ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "test-agent"}
+
+	// Old format key: dm:{sorted(id1,id2)}.
+	oldKey := directMessageExternalRef(userID, agentID)
+	ms.addConv(&store.Conversation{
+		ID:          convID,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: oldKey,
+		ProjectID:   &projectID,
+	})
+
+	svc := NewDMMigrationService(ms)
+	result, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	// Should be re-keyed to kind-encoded format.
+	expectedKey := mustDMKey("user", userID, "agent", agentID)
+	conv := ms.conversations[convID]
+	assert.Equal(t, expectedKey, conv.ExternalRef, "should be re-keyed to kind-encoded format")
+	assert.Nil(t, conv.ProjectID, "ProjectID should be nil (DMs are global)")
+	assert.Equal(t, 1, result.OldFormatRekeyed, "OldFormatRekeyed should be 1")
+}
+
+// TestStep3b_AmbiguousIDInNeither verifies that when an ID is found in neither
+// the user nor agent table, it's counted as ambiguous and skipped.
+func TestStep3b_AmbiguousIDInNeither(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	id1 := uuid.NewString()
+	id2 := uuid.NewString()
+	convID := uuid.NewString()
+
+	// Neither ID exists in any table.
+	oldKey := directMessageExternalRef(id1, id2)
+	ms.addConv(&store.Conversation{
+		ID:          convID,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: oldKey,
+	})
+
+	svc := NewDMMigrationService(ms)
+	result, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.Ambiguous, "should be counted as ambiguous")
+	assert.Equal(t, 0, result.OldFormatRekeyed)
+}
+
+// TestStep3b_AmbiguousIDInBoth verifies that when an ID exists in both user
+// and agent tables, it's counted as ambiguous.
+func TestStep3b_AmbiguousIDInBoth(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	sharedID := uuid.NewString()
+	otherID := uuid.NewString()
+	convID := uuid.NewString()
+
+	// Same ID in both tables — ambiguous.
+	ms.users[sharedID] = &store.User{ID: sharedID, Email: "ambig@example.com"}
+	ms.agents[sharedID] = &store.Agent{ID: sharedID, Slug: "ambig-agent"}
+	ms.users[otherID] = &store.User{ID: otherID, Email: "other@example.com"}
+
+	oldKey := directMessageExternalRef(sharedID, otherID)
+	ms.addConv(&store.Conversation{
+		ID:          convID,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: oldKey,
+	})
+
+	svc := NewDMMigrationService(ms)
+	result, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.Ambiguous, "should be counted as ambiguous")
+	assert.Equal(t, 0, result.OldFormatRekeyed)
+}
+
+// TestStep3b_OldFormatMerge verifies that an old-format row is merged with
+// an existing kind-encoded row when both exist for the same pair.
+func TestStep3b_OldFormatMerge(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	userID := uuid.NewString()
+	agentID := uuid.NewString()
+	oldConvID := uuid.NewString()
+	newConvID := uuid.NewString()
+
+	ms.users[userID] = &store.User{ID: userID, Email: "test@example.com"}
+	ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "test-agent"}
+
+	// Old-format row.
+	oldKey := directMessageExternalRef(userID, agentID)
+	ms.addConv(&store.Conversation{
+		ID:          oldConvID,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: oldKey,
+	},
+		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "user", PrincipalID: userID},
+		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "agent", PrincipalID: agentID},
+	)
+
+	// Existing kind-encoded row.
+	extRef := mustDMKey("user", userID, "agent", agentID)
+	ms.addConv(&store.Conversation{
+		ID:          newConvID,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: extRef,
+	},
+		store.ConversationParticipant{ConversationID: newConvID, PrincipalKind: "user", PrincipalID: userID},
+		store.ConversationParticipant{ConversationID: newConvID, PrincipalKind: "agent", PrincipalID: agentID},
+	)
+
+	// Add a message to the old conversation.
+	msgID := uuid.NewString()
+	ms.addMessage(&store.Message{
+		ID:             msgID,
+		ConversationID: oldConvID,
+		Msg:            "old message",
+	})
+
+	svc := NewDMMigrationService(ms)
+	result, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	// Old row soft-deleted, message re-stamped.
+	assert.NotNil(t, ms.conversations[oldConvID].DeletedAt, "old row should be soft-deleted")
+	assert.Equal(t, newConvID, ms.messages[msgID].ConversationID, "message re-stamped")
+	assert.Equal(t, 1, result.OldFormatRekeyed)
+}
+
+// ---------------------------------------------------------------------------
+// DryRun test
+// ---------------------------------------------------------------------------
+
+// TestDryRun_NoWrites verifies that DryRun=true computes statistics without
+// making any changes.
+func TestDryRun_NoWrites(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	userID := uuid.NewString()
+	agentID := uuid.NewString()
+
+	ms.users[userID] = &store.User{ID: userID, Email: "test@example.com"}
+	ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "test-agent"}
+
+	// Kind-encoded row with no participants (step 2 candidate).
+	convID1 := uuid.NewString()
+	extRef := mustDMKey("user", userID, "agent", agentID)
+	ms.addConv(&store.Conversation{
+		ID:          convID1,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: extRef,
+	})
+
+	// Empty-ref row (step 3a candidate).
+	user2ID := uuid.NewString()
+	agent2ID := uuid.NewString()
+	ms.users[user2ID] = &store.User{ID: user2ID, Email: "test2@example.com"}
+	ms.agents[agent2ID] = &store.Agent{ID: agent2ID, Slug: "test-agent-2"}
+
+	convID2 := uuid.NewString()
+	ms.addConv(&store.Conversation{
+		ID:          convID2,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: "",
+	},
+		store.ConversationParticipant{ConversationID: convID2, PrincipalKind: "user", PrincipalID: user2ID},
+		store.ConversationParticipant{ConversationID: convID2, PrincipalKind: "agent", PrincipalID: agent2ID},
+	)
+
+	// Old-format row (step 3b candidate).
+	user3ID := uuid.NewString()
+	agent3ID := uuid.NewString()
+	ms.users[user3ID] = &store.User{ID: user3ID, Email: "test3@example.com"}
+	ms.agents[agent3ID] = &store.Agent{ID: agent3ID, Slug: "test-agent-3"}
+
+	convID3 := uuid.NewString()
+	oldKey := directMessageExternalRef(user3ID, agent3ID)
+	ms.addConv(&store.Conversation{
+		ID:          convID3,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: oldKey,
+	})
+
+	svc := NewDMMigrationService(ms)
+	result, err := svc.Run(ctx, DMMigrationConfig{DryRun: true})
+	require.NoError(t, err)
+
+	// Statistics should be computed.
+	assert.Equal(t, 3, result.TotalScanned, "should scan all 3 conversations")
+	assert.Equal(t, 2, result.ParticipantsAdded, "should count 2 missing participants")
+	assert.Equal(t, 1, result.EmptyRefRekeyed, "should count 1 re-key")
+	assert.Equal(t, 1, result.OldFormatRekeyed, "should count 1 old-format re-key")
+
+	// No actual changes should be made.
+	assert.Len(t, ms.participants[convID1], 0, "no participants should be added in dry run")
+	assert.Equal(t, "", ms.conversations[convID2].ExternalRef, "external ref unchanged in dry run")
+	assert.Equal(t, oldKey, ms.conversations[convID3].ExternalRef, "old key unchanged in dry run")
+}
+
+// ---------------------------------------------------------------------------
+// Guard tests (permanent post-migration invariant assertions)
+// ---------------------------------------------------------------------------
+
+// TestGuardA_Migration_NoEmptyRefDirectRows asserts that after migration,
+// zero non-deleted direct conversations have an empty external_ref.
+// Floor: the test creates at least 2 such rows before migration (rule 14).
+func TestGuardA_Migration_NoEmptyRefDirectRows(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	// Create 2 empty-ref direct rows.
+	for i := 0; i < 2; i++ {
+		userID := uuid.NewString()
+		agentID := uuid.NewString()
+		convID := uuid.NewString()
+		ms.users[userID] = &store.User{ID: userID, Email: "guard-a@example.com"}
+		ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "guard-a-agent"}
+
+		ms.addConv(&store.Conversation{
+			ID:          convID,
+			Kind:        "direct",
+			Surface:     "native",
+			ExternalRef: "",
+		},
+			store.ConversationParticipant{ConversationID: convID, PrincipalKind: "user", PrincipalID: userID},
+			store.ConversationParticipant{ConversationID: convID, PrincipalKind: "agent", PrincipalID: agentID},
+		)
+	}
+
+	// Also create a kind-encoded row that's fine already.
+	userOK := uuid.NewString()
+	agentOK := uuid.NewString()
+	ms.users[userOK] = &store.User{ID: userOK, Email: "ok@example.com"}
+	ms.agents[agentOK] = &store.Agent{ID: agentOK, Slug: "ok-agent"}
+	okRef := mustDMKey("user", userOK, "agent", agentOK)
+	ms.addConv(&store.Conversation{
+		ID:          uuid.NewString(),
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: okRef,
+	},
+		store.ConversationParticipant{ConversationID: "", PrincipalKind: "user", PrincipalID: userOK},
+	)
+
+	// Run migration.
+	svc := NewDMMigrationService(ms)
+	_, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	// Guard assertion: zero non-deleted direct conversations with empty ref.
+	var directCount, emptyRefCount int
+	for _, conv := range ms.conversations {
+		if conv.Kind != "direct" || conv.DeletedAt != nil {
+			continue
+		}
+		directCount++
+		if conv.ExternalRef == "" {
+			emptyRefCount++
+		}
+	}
+
+	// Rule 14: floor — at least 3 rows examined.
+	require.GreaterOrEqual(t, directCount, 3,
+		"floor violation: expected at least 3 direct conversations, found %d", directCount)
+	assert.Equal(t, 0, emptyRefCount,
+		"found %d non-deleted direct conversations with empty external_ref", emptyRefCount)
+}
+
+// TestGuardB_Migration_EveryDMRowHasTwoParticipants asserts that after migration,
+// every non-deleted dm: row has exactly two participants.
+// Floor: >= 3 dm: rows examined.
+func TestGuardB_Migration_EveryDMRowHasTwoParticipants(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	// Create 3 kind-encoded rows with no participants.
+	for i := 0; i < 3; i++ {
+		userID := uuid.NewString()
+		agentID := uuid.NewString()
+		ms.users[userID] = &store.User{ID: userID, Email: "guard-b@example.com"}
+		ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "guard-b-agent"}
+
+		extRef := mustDMKey("user", userID, "agent", agentID)
+		ms.addConv(&store.Conversation{
+			ID:          uuid.NewString(),
+			Kind:        "direct",
+			Surface:     "native",
+			ExternalRef: extRef,
+		})
+	}
+
+	// Run migration (should add participants).
+	svc := NewDMMigrationService(ms)
+	_, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	// Guard assertion.
+	var dmCount int
+	for _, conv := range ms.conversations {
+		if conv.DeletedAt != nil {
+			continue
+		}
+		if !strings.HasPrefix(conv.ExternalRef, "dm:") {
+			continue
+		}
+		dmCount++
+		parts := ms.participants[conv.ID]
+		assert.Len(t, parts, 2,
+			"dm: conversation %s has %d participants, expected 2", conv.ID, len(parts))
+	}
+
+	require.GreaterOrEqual(t, dmCount, 3,
+		"floor violation: expected at least 3 dm: conversations, found %d", dmCount)
+}
+
+// TestGuardC_Migration_AllDMKeysAreParseable asserts that after migration,
+// every non-deleted dm: row with participants has a key that ParseDMKey accepts.
+// Floor: >= 3 such rows.
+func TestGuardC_Migration_AllDMKeysAreParseable(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	// Create 3 kind-encoded rows with no participants (step 2 will add them).
+	for i := 0; i < 3; i++ {
+		userID := uuid.NewString()
+		agentID := uuid.NewString()
+		ms.users[userID] = &store.User{ID: userID, Email: "guard-c@example.com"}
+		ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "guard-c-agent"}
+
+		extRef := mustDMKey("user", userID, "agent", agentID)
+		ms.addConv(&store.Conversation{
+			ID:          uuid.NewString(),
+			Kind:        "direct",
+			Surface:     "native",
+			ExternalRef: extRef,
+		})
+	}
+
+	// Also create an old-format row with participants (step 3b will re-key it,
+	// and step 2 won't touch it in this pass — but it already has participants).
+	userOld := uuid.NewString()
+	agentOld := uuid.NewString()
+	ms.users[userOld] = &store.User{ID: userOld, Email: "old@example.com"}
+	ms.agents[agentOld] = &store.Agent{ID: agentOld, Slug: "old-agent"}
+	oldKey := directMessageExternalRef(userOld, agentOld)
+	oldConvID := uuid.NewString()
+	ms.addConv(&store.Conversation{
+		ID:          oldConvID,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: oldKey,
+	},
+		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "user", PrincipalID: userOld},
+		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "agent", PrincipalID: agentOld},
+	)
+
+	// Run migration.
+	svc := NewDMMigrationService(ms)
+	_, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	// Guard assertion.
+	var dmWithPartsCount int
+	for _, conv := range ms.conversations {
+		if conv.DeletedAt != nil {
+			continue
+		}
+		if !strings.HasPrefix(conv.ExternalRef, "dm:") {
+			continue
+		}
+		parts := ms.participants[conv.ID]
+		if len(parts) == 0 {
+			continue
+		}
+		dmWithPartsCount++
+		_, _, _, _, parseErr := messages.ParseDMKey(conv.ExternalRef)
+		assert.NoError(t, parseErr,
+			"dm: conversation %s has unparseable key %q", conv.ID, conv.ExternalRef)
+	}
+
+	require.GreaterOrEqual(t, dmWithPartsCount, 3,
+		"floor violation: expected at least 3 dm: rows with participants, found %d", dmWithPartsCount)
+}
+
+// ---------------------------------------------------------------------------
+// Mixed scenario test
+// ---------------------------------------------------------------------------
+
+// TestMigration_MixedScenarios verifies that all three categories of rows
+// are processed correctly in a single migration run.
+func TestMigration_MixedScenarios(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	// Category 1: Kind-encoded row with no participants.
+	user1 := uuid.NewString()
+	agent1 := uuid.NewString()
+	ms.users[user1] = &store.User{ID: user1}
+	ms.agents[agent1] = &store.Agent{ID: agent1}
+
+	conv1ID := uuid.NewString()
+	ref1 := mustDMKey("user", user1, "agent", agent1)
+	ms.addConv(&store.Conversation{
+		ID: conv1ID, Kind: "direct", Surface: "native", ExternalRef: ref1,
+	})
+
+	// Category 2: Empty-ref row.
+	user2 := uuid.NewString()
+	agent2 := uuid.NewString()
+	ms.users[user2] = &store.User{ID: user2}
+	ms.agents[agent2] = &store.Agent{ID: agent2}
+
+	conv2ID := uuid.NewString()
+	ms.addConv(&store.Conversation{
+		ID: conv2ID, Kind: "direct", Surface: "native", ExternalRef: "",
+	},
+		store.ConversationParticipant{ConversationID: conv2ID, PrincipalKind: "user", PrincipalID: user2},
+		store.ConversationParticipant{ConversationID: conv2ID, PrincipalKind: "agent", PrincipalID: agent2},
+	)
+
+	// Category 3: Old-format row.
+	user3 := uuid.NewString()
+	agent3 := uuid.NewString()
+	ms.users[user3] = &store.User{ID: user3}
+	ms.agents[agent3] = &store.Agent{ID: agent3}
+
+	conv3ID := uuid.NewString()
+	oldKey := directMessageExternalRef(user3, agent3)
+	ms.addConv(&store.Conversation{
+		ID: conv3ID, Kind: "direct", Surface: "native", ExternalRef: oldKey,
+	})
+
+	svc := NewDMMigrationService(ms)
+	result, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, result.TotalScanned)
+	assert.Equal(t, 2, result.ParticipantsAdded, "2 participants from kind-encoded row")
+	assert.Equal(t, 1, result.EmptyRefRekeyed, "1 empty-ref re-keyed")
+	assert.Equal(t, 1, result.OldFormatRekeyed, "1 old-format re-keyed")
+	assert.Equal(t, 0, result.Unparseable)
+	assert.Equal(t, 0, result.Ambiguous)
+	assert.Len(t, result.Errors, 0)
+}

--- a/pkg/messaging/key_consolidation_test.go
+++ b/pkg/messaging/key_consolidation_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAC_DEF15_1_KeyDerivationConsolidation reads the Go source files in
+// pkg/messaging/ and asserts that the legacy key-construction patterns are
+// confined to their expected files.
+//
+// This test prevents regressions where a new call site constructs a thread:
+// or DM key directly instead of going through DeriveConversationKey.
+//
+// Prior art: cmd/doc_syntax_test.go reads source files and validates content.
+func TestAC_DEF15_1_KeyDerivationConsolidation(t *testing.T) {
+	// Read all non-test .go files in this package directory.
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	var threadKeyFiles []string
+	var legacyDMRefFiles []string
+
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		// Skip test files — we only care about production code.
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(".", name))
+		require.NoError(t, err)
+
+		content := string(data)
+
+		// Check for fmt.Sprintf("thread:%s:%s" — the thread key construction pattern.
+		if strings.Contains(content, `fmt.Sprintf("thread:%s:%s"`) {
+			threadKeyFiles = append(threadKeyFiles, name)
+		}
+
+		// Check for directMessageExternalRef (now unexported).
+		// Count production definitions (not just references in comments).
+		for _, line := range strings.Split(content, "\n") {
+			trimmed := strings.TrimSpace(line)
+			// Skip comments.
+			if strings.HasPrefix(trimmed, "//") {
+				continue
+			}
+			if strings.Contains(line, "directMessageExternalRef") {
+				legacyDMRefFiles = append(legacyDMRefFiles, name)
+				break // one match per file is enough
+			}
+		}
+	}
+
+	// AC-DEF15-1: fmt.Sprintf("thread:%s:%s" must appear in exactly ONE
+	// non-test .go file (derive_key.go).
+	assert.Equal(t, []string{"derive_key.go"}, threadKeyFiles,
+		"AC-DEF15-1: thread key construction must be confined to derive_key.go")
+
+	// AC-DEF15-1: directMessageExternalRef (now unexported) must appear in
+	// exactly ONE non-test .go file (divergence.go).
+	assert.Equal(t, []string{"divergence.go"}, legacyDMRefFiles,
+		"AC-DEF15-1: directMessageExternalRef must be confined to divergence.go")
+}


### PR DESCRIPTION
Tranche B of the messaging conversation-model refactor. 8 commits, 16 files, +3566/-44. Rebased on main f4d02461, zero conflicts.

- Phase 5 dual-write of DM/group conversations; non-tautological divergence checks; DEF-8 kind-safety.
- SECURITY: DM conversation keys derive from the authenticated caller, never the payload. A spoofed sender can no longer select another agent's conversation.
- SECURITY: broadcast ingress forces server-side sender identity and the Broadcasted flag.
- Broadcast self-skip compares SenderID (canonical identity), not Sender (display label), in both fan-outs.
- DM notifications resolve agent display names from SenderID without clobbering a caller-supplied label.

Every sub-fix is pinned by a test that fails when that sub-fix alone is reverted: 11/11 mutations killed. Full pkg/hub green except TestTemplateResource_UATConfinement, which also fails on unmodified main and is not compiled by CI