### PR TITLE
docs: nightly doc update Aug 28 (Permissions P2, quota system, DM security)

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -239,6 +239,14 @@ A scoped, revocable bearer token (prefixed with `scion_pat_`) linked to a user a
 _Avoid_: personal access token (PAT), API key, secret token
 _See also_: Hub
 
+
+**Quota System**:
+An advisory-lock-based enforcement system that governs resource consumption at agent and project creation. It uses fail-closed semantics and prevents reservation leaks, operating on schemas including LimitDefinition, EntitlementBinding, and UsageReservation.
+_Avoid_: rate limits, usage caps
+
+**LimitDefinition**:
+A seeded system or custom limit configuration that defines a quota boundary within the Quota System.
+
 ## Messaging
 
 **Native Web Chat**:

--- a/docs-site/src/content/docs/glossary.md
+++ b/docs-site/src/content/docs/glossary.md
@@ -159,6 +159,14 @@ A named collection of Hub users (and nested groups) used by the Hub permissions 
 ### User Access Token (UAT)
 A scoped, revocable bearer token (prefixed with `scion_pat_`) linked to a user account and used for non-interactive Hub authentication (e.g., CLI, CI/CD pipelines, desktop app integration). Every UAT is scoped to a single project and carries a specific list of action permissions (scopes). Formerly known as a *Personal Access Token (PAT)*.
 
+
+**Quota System**:
+An advisory-lock-based enforcement system that governs resource consumption at agent and project creation. It uses fail-closed semantics and prevents reservation leaks, operating on schemas including LimitDefinition, EntitlementBinding, and UsageReservation.
+_Avoid_: rate limits, usage caps
+
+**LimitDefinition**:
+A seeded system or custom limit configuration that defines a quota boundary within the Quota System.
+
 ## Messaging
 
 ### Native Web Chat

--- a/docs-site/src/content/docs/glossary.md
+++ b/docs-site/src/content/docs/glossary.md
@@ -159,12 +159,11 @@ A named collection of Hub users (and nested groups) used by the Hub permissions 
 ### User Access Token (UAT)
 A scoped, revocable bearer token (prefixed with `scion_pat_`) linked to a user account and used for non-interactive Hub authentication (e.g., CLI, CI/CD pipelines, desktop app integration). Every UAT is scoped to a single project and carries a specific list of action permissions (scopes). Formerly known as a *Personal Access Token (PAT)*.
 
-
-**Quota System**:
+### Quota System
 An advisory-lock-based enforcement system that governs resource consumption at agent and project creation. It uses fail-closed semantics and prevents reservation leaks, operating on schemas including LimitDefinition, EntitlementBinding, and UsageReservation.
 _Avoid_: rate limits, usage caps
 
-**LimitDefinition**:
+### LimitDefinition
 A seeded system or custom limit configuration that defines a quota boundary within the Quota System.
 
 ## Messaging

--- a/docs-site/src/content/docs/hosted/ha/permissions.md
+++ b/docs-site/src/content/docs/hosted/ha/permissions.md
@@ -10,7 +10,7 @@ For a detailed technical specification of the policy language and agent identity
 ## Core Concepts
 
 ### Unified Authorization
-Scion uses a `UnifiedAuthMiddleware` to enforce declarative route guards across the Hub. Every request undergoes deterministic policy evaluation before reaching the handler, ensuring no resource can be accessed without explicit permission.
+Scion uses a `UnifiedAuthMiddleware` to enforce declarative route guards across the Hub. Every request undergoes deterministic policy evaluation via a Decide path before reaching the handler, ensuring no resource can be accessed without explicit permission. Engine internals, settings handlers, User Access Token (UAT) endpoints, user management, integrations, and operations have all been converted to explicit permission-based checks, deprecating the legacy `requireAdmin` fallback.
 
 ### Roles and Bindings
 Access is granted through explicit role assignments:
@@ -166,6 +166,14 @@ To make the service account lifecycle transparent and auditable for users and ad
 
 ---
 
+## Quotas and Limits
+
+The Scion Hub enforces resource consumption through a strict **Quota System** (Permissions Phase 2). This system operates at both the project and agent creation layers:
+- **Enforcement Mechanics**: Quotas are evaluated via advisory-lock-based enforcement with fail-closed semantics to ensure hard limits are respected and reservation leaks are prevented.
+- **Data Model**: The quota system uses `LimitDefinition`, `EntitlementBinding`, and `UsageReservation` schemas backed by a dedicated `QuotaStore`.
+- **System Limits**: Several seeded system limit definitions provide out-of-the-box safe bounds on resource usage.
+- **Quota API**: A suite of 13 quota API endpoints is available for inspecting and managing quotas. These endpoints feature strict route guard read/write permission splits and built-in protection against arbitrary system limit modification.
+
 ## Roles
 
 To simplify management, Scion separates roles into **User Roles** (for human operators) and **Agent Roles** (for running agents).
@@ -176,7 +184,7 @@ These built-in roles bundle common permissions for human users:
 
 | Role | Description |
 |------|-------------|
-| `hub:admin` | Full control over the entire Hub. |
+| `hub-admin` | Full control over the entire Hub (System Role). |
 | `hub:member` | Standard user; can create their own projects. |
 | `project:admin` | Full control over a specific project and its agents. |
 | `project:developer` | Can create and manage agents within a project. |
@@ -248,7 +256,7 @@ When an agent creates a child agent (for example, to delegate a sub-task), the s
 The Scion Web Dashboard includes a centralized **Admin Management Suite** (accessible to users with administrative privileges) that provides dedicated views for access control management:
 
 - **Server Configuration Editor**: A full-featured settings editor at `/admin/server-config`. This allows administrators to view and modify the global `settings.yaml` through the Web UI with support for tabbed navigation, sensitive field masking, and hot-reloading of key settings like log levels, telemetry defaults, and admin emails.
-- **Users List**: View all authenticated users, search for specific accounts, track "Last Seen" timestamps, and manage their system-wide roles (e.g., granting `hub:admin` access).
+- **Users List**: View all authenticated users, search for specific accounts, track "Last Seen" timestamps, and manage their system-wide roles (e.g., granting `hub-admin` access).
 - **Groups Management**: Create organizational groups and manage their membership with a human-friendly member editor and user search autocomplete. Group creation is strictly authorized, and the `project:` prefix is a reserved slug. To prevent slug collisions, colliding group identifiers require a system marker combined with the `ProjectID`. Membership lookups rely on canonical identity resolution. This enables policy-based authorization where permissions can be granted to an entire team at once, while strictly enforcing group ownership and authorization rules.
 - **Admin Security**: When verifying administrative privileges across endpoints, the `requireAdmin` guard explicitly rejects scoped user identities (e.g. from limited personal access tokens) prior to evaluating the principal's embedded roles, ensuring that scoped identities cannot inadvertently bypass administrative gates.
 - **Broker Visibility**: Comprehensive broker detail pages provide a grouped view of all active agents by their respective projects, helping administrators understand resource distribution.

--- a/docs-site/src/content/docs/hosted/single-node/metrics.md
+++ b/docs-site/src/content/docs/hosted/single-node/metrics.md
@@ -212,7 +212,7 @@ For every significant lifecycle event (session start/end, tool use, model call),
 
 ## Hub Infrastructure Metrics
 
-The Scion Hub maintains internal operational metrics for infrastructure monitoring. These are available via the `/api/v1/admin/metrics` endpoint (requires `hub:admin` role) and can be exported to standard monitoring tools.
+The Scion Hub maintains internal operational metrics for infrastructure monitoring. These are available via the `/api/v1/admin/metrics` endpoint (requires `hub-admin` role) and can be exported to standard monitoring tools.
 
 ### GCP Token Metrics
 

--- a/docs-site/src/content/docs/hosted/user/messaging.md
+++ b/docs-site/src/content/docs/hosted/user/messaging.md
@@ -216,7 +216,13 @@ When using slug-based query paths or addressing agents via `agent:<name>` (e.g.,
   - **Granular Scopes**: Authorization gates require the agent token to hold the `project:read` scope for reading subscriptions and the `project:agent:notify` scope for writing (creating, updating, or deleting) subscriptions.
   - **Ownership Constraints**: Acknowledging notifications or modifying/deleting existing subscriptions strictly requires ownership validation, meaning an agent can only modify or acknowledge subscriptions that target or belong to itself.
 
-### 4. Sleep Anti-Pattern & Polling
+### 4. Message Security & Thread Validation
+
+Scion employs strict, ingress-level security controls for Direct Messages (DMs) to prevent spoofing and cross-project injection:
+- **Ownership Validation**: At all message ingress points, the system validates the authenticated identity from the request context against the provided DM key. An agent cannot write into another agent's DM conversation by supplying a well-formed but unauthorized DM key.
+- **Thread ID Formatting**: When an agent supplies a `thread_id` (used as the DM key), it is strictly validated against the canonical DM key format at ingress. Malformed or unauthorized thread IDs are rejected with a `400 Bad Request` before any dispatch or persistence occurs.
+
+### 5. Sleep Anti-Pattern & Polling
 
 :::danger[Avoid Sleep]
 **Never use the shell `sleep` command to wait for external processes.** Running a blocking `sleep` loop keeps your agent alive but inactive, triggering the Hub's stall detector and leading to an automatic suspend.
@@ -231,7 +237,7 @@ sciontool status blocked "Waiting for build job 103"
 ```
 The scheduled message delivers the wake-up poke; `status blocked` tells the platform that your silence is intentional, keeping you from being suspended.
 
-### 5. @mention Parsing & Multi-Recipient CC Fan-Out
+### 6. @mention Parsing & Multi-Recipient CC Fan-Out
 
 When a human or an agent sends a message, Scion automatically scans for recipient targeting to fan-out notifications. This enables multi-agent notification and collaboration through two distinct mechanisms:
 

--- a/docs-site/src/content/docs/hosted/user/scheduling.md
+++ b/docs-site/src/content/docs/hosted/user/scheduling.md
@@ -124,6 +124,8 @@ Use these commands to manage schedules and events in your project:
 | **Delete a recurring schedule** | `scion schedule delete <id-or-name>` |
 | **View execution history** | `scion schedule history <id-or-name>` |
 
+*Tip: All 6 schedule subcommands (`get`, `cancel`, `pause`, `resume`, `delete`, `history`) support client-side prefix matching. You can provide a truncated schedule ID (e.g. `scion schedule cancel a1b2`) instead of the full ID.*
+
 ---
 
 ## Gotchas & Best Practices


### PR DESCRIPTION
Nightly documentation update for Aug 27 changelog.

- permissions.md: Permissions Phase 2 admin handler conversion, quota system
- messaging.md: DM security fixes, conversation model foundation
- scheduling.md: truncated schedule ID prefix matching
- glossary: quota/limits terminology
- metrics.md: minor update

Cherry-picked from doc-writer agent du-0827.