### PR TITLE
feat: Role and binding management API with CanDelegate enforcement (P2-C1)

### DIFF
--- a/.design/project-log/pf-p2c-roles.md
+++ b/.design/project-log/pf-p2c-roles.md
@@ -1,0 +1,64 @@
+# PR-C1: Role/Binding Management Endpoints
+
+**Date:** 2026-08-28
+**Agent:** dev-pf-p2c-roles
+**Branch:** scion/pf-p2c-roles
+
+## Summary
+
+Implemented CRUD API endpoints for role definitions, role bindings, and a
+permissions registry endpoint. This enables the scoped admin model by allowing
+hub-admins to manage roles and assign them to users through the API.
+
+## Changes
+
+### 1. Permissions Registry (`pkg/hub/permissions/registry.go`)
+- Added `ResourceRole` and `ResourceRoleBinding` constants
+- Added 7 new permissions: `role.read`, `role.create`, `role.update`,
+  `role.delete`, `role_binding.read`, `role_binding.create`, `role_binding.delete`
+- All use `CapabilityScope` kind
+
+### 2. Hub-Admin Seed (`pkg/hub/seed.go`)
+- Added all 7 role/binding permissions to `hubAdminPermissionIDs()`
+
+### 3. Store Layer (`pkg/store/store.go`, `pkg/store/entadapter/role_store.go`)
+- Added `UpdateRoleDefinition`, `DeleteRoleDefinition`, `ListAllRoleBindings`
+  to the `RoleStore` interface
+- Implemented in ent adapter with proper guards:
+  - System roles cannot be updated or deleted
+  - Roles with active bindings cannot be deleted
+
+### 4. API Handlers (`pkg/hub/handlers_roles.go` — new file)
+- Role definitions: GET/POST `/admin/roles`, GET/PUT/DELETE `/admin/roles/:id`
+- Role bindings: GET/POST `/admin/role-bindings`, DELETE `/admin/role-bindings/:id`,
+  GET `/admin/role-bindings/user/:userID`
+- Permissions: GET `/admin/permissions`
+- CanDelegate enforced on role binding creation (GrantTypeRoleBinding) and
+  custom role creation (GrantTypeCustomRole)
+- D10 super-admin binding guard enforced at store level
+
+### 5. Route Metadata (`pkg/hub/route_metadata.go`)
+- All 5 new route patterns use `RouteHubAdmin` classification (not RoutePolicy)
+
+### 6. Route Registration (`pkg/hub/server.go`)
+- Registered all 5 route handlers via `s.mux.HandleFunc`
+
+### 7. Tests (`pkg/hub/handlers_roles_test.go` — new file)
+- 25+ test cases covering CRUD, system role immutability, invalid permissions,
+  super-admin binding rejection, unauthenticated access, validation
+
+### 8. Route Classification (`pkg/hub/route_classification_test.go`)
+- Added new routes to `routePermissionClassifications` map
+
+## Verification
+
+- `make ci` passes (build, lint, format, all tests)
+
+## Boundaries Respected
+
+- Did NOT modify super-admin bypass in checkAccessForUser
+- Did NOT build PolicyBoundary
+- Did NOT allow scoped credentials to carry super-admin bypass
+- Did NOT modify CanDelegate logic
+- Did NOT touch policy handlers
+- Used RouteHubAdmin (not RoutePolicy) for all new routes

--- a/pkg/hub/handlers_roles.go
+++ b/pkg/hub/handlers_roles.go
@@ -411,9 +411,16 @@ func (s *Server) listRoleBindings(w http.ResponseWriter, r *http.Request) {
 	if bindings == nil {
 		bindings = []*store.RoleBinding{}
 	}
+
+	total, err := s.store.CountAllRoleBindings(r.Context())
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
 	writeJSON(w, http.StatusOK, listRoleBindingsResponse{
 		Items:      bindings,
-		TotalCount: len(bindings),
+		TotalCount: total,
 	})
 }
 
@@ -458,6 +465,10 @@ func (s *Server) createRoleBinding(w http.ResponseWriter, r *http.Request, user 
 	}
 	if req.ScopeType != store.RoleScopeSystem && req.ScopeType != store.RoleScopeProject {
 		BadRequest(w, "scopeType must be \"system\" or \"project\"")
+		return
+	}
+	if req.ScopeType == store.RoleScopeProject && req.ScopeID == "" {
+		BadRequest(w, "scope_id is required when scope_type is 'project'")
 		return
 	}
 

--- a/pkg/hub/handlers_roles.go
+++ b/pkg/hub/handlers_roles.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/hub/permissions"
@@ -326,6 +327,19 @@ func (s *Server) updateRoleDefinition(w http.ResponseWriter, r *http.Request, id
 		return
 	}
 
+	// CanDelegate check: actor must hold all permissions in the updated role.
+	if s.authzService != nil {
+		decision := s.authzService.CanDelegate(r.Context(), user, GrantDescriptor{
+			Type:                  GrantTypeCustomRole,
+			CustomRolePermissions: req.Permissions,
+			ScopeType:             existing.ScopeType,
+		})
+		if !decision.Allowed {
+			writeForbidden(w, "cannot update role: "+decision.Reason)
+			return
+		}
+	}
+
 	existing.Name = req.Name
 	existing.Description = req.Description
 	existing.Permissions = req.Permissions
@@ -387,7 +401,9 @@ func (s *Server) deleteRoleDefinition(w http.ResponseWriter, r *http.Request, id
 // ---------------------------------------------------------------------------
 
 func (s *Server) listRoleBindings(w http.ResponseWriter, r *http.Request) {
-	bindings, err := s.store.ListAllRoleBindings(r.Context())
+	limit, offset := parsePaginationParams(r)
+
+	bindings, err := s.store.ListAllRoleBindings(r.Context(), limit, offset)
 	if err != nil {
 		writeErrorFromErr(w, err, "")
 		return
@@ -399,6 +415,22 @@ func (s *Server) listRoleBindings(w http.ResponseWriter, r *http.Request) {
 		Items:      bindings,
 		TotalCount: len(bindings),
 	})
+}
+
+// parsePaginationParams extracts limit and offset from query parameters.
+// Returns 0 for limit (store uses default) and 0 for offset if not provided.
+func parsePaginationParams(r *http.Request) (limit, offset int) {
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if v := r.URL.Query().Get("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+	return limit, offset
 }
 
 func (s *Server) createRoleBinding(w http.ResponseWriter, r *http.Request, user UserIdentity) {

--- a/pkg/hub/handlers_roles.go
+++ b/pkg/hub/handlers_roles.go
@@ -1,0 +1,616 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/hub/permissions"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// ---------------------------------------------------------------------------
+// Request / Response types
+// ---------------------------------------------------------------------------
+
+// createRoleDefinitionRequest is the payload for POST /api/v1/admin/roles.
+type createRoleDefinitionRequest struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	ScopeType   string   `json:"scopeType"`
+	Permissions []string `json:"permissions"`
+}
+
+// updateRoleDefinitionRequest is the payload for PUT /api/v1/admin/roles/:id.
+type updateRoleDefinitionRequest struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Permissions []string `json:"permissions"`
+}
+
+// createRoleBindingRequest is the payload for POST /api/v1/admin/role-bindings.
+type createRoleBindingRequest struct {
+	RoleDefinitionID string `json:"roleDefinitionId"`
+	PrincipalType    string `json:"principalType"`
+	PrincipalID      string `json:"principalId"`
+	ScopeType        string `json:"scopeType"`
+	ScopeID          string `json:"scopeId"`
+}
+
+// listRoleDefinitionsResponse wraps the list result for the API.
+type listRoleDefinitionsResponse struct {
+	Items      []*store.RoleDefinition `json:"items"`
+	TotalCount int                     `json:"totalCount"`
+}
+
+// listRoleBindingsResponse wraps the list result for the API.
+type listRoleBindingsResponse struct {
+	Items      []*store.RoleBinding `json:"items"`
+	TotalCount int                  `json:"totalCount"`
+}
+
+// listPermissionsResponse wraps the permissions registry for the API.
+type listPermissionsResponse struct {
+	Items      []permissions.Permission `json:"items"`
+	TotalCount int                      `json:"totalCount"`
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers: Role Definitions
+// ---------------------------------------------------------------------------
+
+// handleAdminRoles handles GET (list) and POST (create) on
+// /api/v1/admin/roles.
+// Authorization: route guard checks role.read for GET.
+// POST requires role.create via inline Decide.
+func (s *Server) handleAdminRoles(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listRoleDefinitions(w, r)
+	case http.MethodPost:
+		user, ok := s.requireWritePermissionForRole(w, r, "role.create", "create")
+		if !ok {
+			return
+		}
+		s.createRoleDefinition(w, r, user)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// handleAdminRoleByID handles GET / PUT / DELETE on
+// /api/v1/admin/roles/:id.
+func (s *Server) handleAdminRoleByID(w http.ResponseWriter, r *http.Request) {
+	id := extractID(r, "/api/v1/admin/roles")
+	if id == "" {
+		BadRequest(w, "role definition ID is required")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		s.getRoleDefinition(w, r, id)
+	case http.MethodPut:
+		user, ok := s.requireWritePermissionForRole(w, r, "role.update", "update")
+		if !ok {
+			return
+		}
+		s.updateRoleDefinition(w, r, id, user)
+	case http.MethodDelete:
+		user, ok := s.requireWritePermissionForRole(w, r, "role.delete", "delete")
+		if !ok {
+			return
+		}
+		s.deleteRoleDefinition(w, r, id, user)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Route handlers: Role Bindings
+// ---------------------------------------------------------------------------
+
+// handleAdminRoleBindings handles GET (list) and POST (create) on
+// /api/v1/admin/role-bindings.
+// Authorization: route guard checks role_binding.read for GET.
+// POST requires role_binding.create via inline Decide.
+func (s *Server) handleAdminRoleBindings(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listRoleBindings(w, r)
+	case http.MethodPost:
+		user, ok := s.requireWritePermissionForRoleBinding(w, r, "role_binding.create", "create")
+		if !ok {
+			return
+		}
+		s.createRoleBinding(w, r, user)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// handleAdminRoleBindingByID handles DELETE on /api/v1/admin/role-bindings/:id
+// and GET on /api/v1/admin/role-bindings/user/:userID.
+func (s *Server) handleAdminRoleBindingByID(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/role-bindings/")
+	path = strings.TrimSuffix(path, "/")
+
+	// Handle user-specific binding lookup.
+	if strings.HasPrefix(path, "user/") {
+		userID := strings.TrimPrefix(path, "user/")
+		if userID == "" {
+			BadRequest(w, "user ID is required")
+			return
+		}
+		if r.Method != http.MethodGet {
+			MethodNotAllowed(w)
+			return
+		}
+		s.listBindingsForUser(w, r, userID)
+		return
+	}
+
+	// Otherwise it's a binding ID.
+	id := path
+	if id == "" {
+		BadRequest(w, "role binding ID is required")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodDelete:
+		user, ok := s.requireWritePermissionForRoleBinding(w, r, "role_binding.delete", "delete")
+		if !ok {
+			return
+		}
+		s.deleteRoleBinding(w, r, id, user)
+	default:
+		MethodNotAllowed(w)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Route handler: Permissions Registry
+// ---------------------------------------------------------------------------
+
+// handleAdminPermissions handles GET on /api/v1/admin/permissions.
+func (s *Server) handleAdminPermissions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+	s.listPermissions(w, r)
+}
+
+// ---------------------------------------------------------------------------
+// CRUD: Role Definitions
+// ---------------------------------------------------------------------------
+
+func (s *Server) listRoleDefinitions(w http.ResponseWriter, r *http.Request) {
+	defs, err := s.store.ListRoleDefinitions(r.Context())
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	if defs == nil {
+		defs = []*store.RoleDefinition{}
+	}
+	writeJSON(w, http.StatusOK, listRoleDefinitionsResponse{
+		Items:      defs,
+		TotalCount: len(defs),
+	})
+}
+
+func (s *Server) getRoleDefinition(w http.ResponseWriter, r *http.Request, id string) {
+	def, err := s.store.GetRoleDefinition(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Role Definition")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	writeJSON(w, http.StatusOK, def)
+}
+
+func (s *Server) createRoleDefinition(w http.ResponseWriter, r *http.Request, user UserIdentity) {
+	var req createRoleDefinitionRequest
+	if err := readJSON(r, &req); err != nil {
+		BadRequest(w, "invalid request body: "+err.Error())
+		return
+	}
+
+	req.Name = strings.TrimSpace(req.Name)
+	if req.Name == "" {
+		BadRequest(w, "name is required")
+		return
+	}
+
+	if req.ScopeType != store.RoleScopeSystem && req.ScopeType != store.RoleScopeProject {
+		BadRequest(w, "scopeType must be \"system\" or \"project\"")
+		return
+	}
+
+	// Validate permissions against registry.
+	if err := validatePermissionIDs(req.Permissions); err != nil {
+		BadRequest(w, err.Error())
+		return
+	}
+
+	// CanDelegate check: actor must hold all permissions in the custom role.
+	if s.authzService != nil {
+		decision := s.authzService.CanDelegate(r.Context(), user, GrantDescriptor{
+			Type:                  GrantTypeCustomRole,
+			CustomRolePermissions: req.Permissions,
+			ScopeType:             req.ScopeType,
+		})
+		if !decision.Allowed {
+			writeForbidden(w, "cannot create role: "+decision.Reason)
+			return
+		}
+	}
+
+	rd := &store.RoleDefinition{
+		Name:        req.Name,
+		Description: req.Description,
+		ScopeType:   req.ScopeType,
+		Permissions: req.Permissions,
+		System:      false, // Only seed creates system roles.
+	}
+
+	created, err := s.store.CreateRoleDefinition(r.Context(), rd)
+	if err != nil {
+		if errors.Is(err, store.ErrAlreadyExists) {
+			Conflict(w, "a role definition with this name and scope already exists")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	slog.Info("role definition created",
+		"role_id", created.ID, "name", created.Name, "actor", user.Email())
+
+	writeJSON(w, http.StatusCreated, created)
+}
+
+func (s *Server) updateRoleDefinition(w http.ResponseWriter, r *http.Request, id string, user UserIdentity) {
+	var req updateRoleDefinitionRequest
+	if err := readJSON(r, &req); err != nil {
+		BadRequest(w, "invalid request body: "+err.Error())
+		return
+	}
+
+	req.Name = strings.TrimSpace(req.Name)
+	if req.Name == "" {
+		BadRequest(w, "name is required")
+		return
+	}
+
+	// Fetch existing to check system flag.
+	existing, err := s.store.GetRoleDefinition(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Role Definition")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	if existing.System {
+		writeForbidden(w, "system roles cannot be modified")
+		return
+	}
+
+	// Validate permissions against registry.
+	if err := validatePermissionIDs(req.Permissions); err != nil {
+		BadRequest(w, err.Error())
+		return
+	}
+
+	existing.Name = req.Name
+	existing.Description = req.Description
+	existing.Permissions = req.Permissions
+
+	updated, err := s.store.UpdateRoleDefinition(r.Context(), existing)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Role Definition")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	slog.Info("role definition updated",
+		"role_id", updated.ID, "name", updated.Name, "actor", user.Email())
+
+	writeJSON(w, http.StatusOK, updated)
+}
+
+func (s *Server) deleteRoleDefinition(w http.ResponseWriter, r *http.Request, id string, user UserIdentity) {
+	// Fetch first to check system flag and include name in logs.
+	def, err := s.store.GetRoleDefinition(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Role Definition")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	if def.System {
+		writeForbidden(w, "system roles cannot be deleted")
+		return
+	}
+
+	if err := s.store.DeleteRoleDefinition(r.Context(), id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Role Definition")
+			return
+		}
+		if errors.Is(err, store.ErrInvalidInput) {
+			Conflict(w, err.Error())
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	slog.Info("role definition deleted",
+		"role_id", def.ID, "name", def.Name, "actor", user.Email())
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ---------------------------------------------------------------------------
+// CRUD: Role Bindings
+// ---------------------------------------------------------------------------
+
+func (s *Server) listRoleBindings(w http.ResponseWriter, r *http.Request) {
+	bindings, err := s.store.ListAllRoleBindings(r.Context())
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	if bindings == nil {
+		bindings = []*store.RoleBinding{}
+	}
+	writeJSON(w, http.StatusOK, listRoleBindingsResponse{
+		Items:      bindings,
+		TotalCount: len(bindings),
+	})
+}
+
+func (s *Server) createRoleBinding(w http.ResponseWriter, r *http.Request, user UserIdentity) {
+	var req createRoleBindingRequest
+	if err := readJSON(r, &req); err != nil {
+		BadRequest(w, "invalid request body: "+err.Error())
+		return
+	}
+
+	if req.RoleDefinitionID == "" {
+		BadRequest(w, "roleDefinitionId is required")
+		return
+	}
+	if req.PrincipalType == "" {
+		BadRequest(w, "principalType is required")
+		return
+	}
+	if req.PrincipalType != store.RoleBindingPrincipalUser && req.PrincipalType != store.RoleBindingPrincipalAgent {
+		BadRequest(w, "principalType must be \"user\" or \"agent\"")
+		return
+	}
+	if req.PrincipalID == "" {
+		BadRequest(w, "principalId is required")
+		return
+	}
+	if req.ScopeType != store.RoleScopeSystem && req.ScopeType != store.RoleScopeProject {
+		BadRequest(w, "scopeType must be \"system\" or \"project\"")
+		return
+	}
+
+	// CanDelegate check: security invariant — the actor must hold all
+	// permissions granted by the target role.
+	if s.authzService != nil {
+		decision := s.authzService.CanDelegate(r.Context(), user, GrantDescriptor{
+			Type:             GrantTypeRoleBinding,
+			RoleDefinitionID: req.RoleDefinitionID,
+			ScopeType:        req.ScopeType,
+			ScopeID:          req.ScopeID,
+		})
+		if !decision.Allowed {
+			writeForbidden(w, "cannot create binding: "+decision.Reason)
+			return
+		}
+	}
+
+	rb := &store.RoleBinding{
+		RoleDefinitionID: req.RoleDefinitionID,
+		PrincipalType:    req.PrincipalType,
+		PrincipalID:      req.PrincipalID,
+		ScopeType:        req.ScopeType,
+		ScopeID:          req.ScopeID,
+		CreatedBy:        user.ID(),
+	}
+
+	created, err := s.store.CreateRoleBinding(r.Context(), rb)
+	if err != nil {
+		if errors.Is(err, store.ErrAlreadyExists) {
+			Conflict(w, "this role binding already exists")
+			return
+		}
+		if errors.Is(err, store.ErrSuperAdminBindingRestricted) {
+			writeForbidden(w, "super-admin role bindings can only be created by the system reconciler")
+			return
+		}
+		if errors.Is(err, store.ErrNotFound) {
+			BadRequest(w, "role definition not found")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	slog.Info("role binding created",
+		"binding_id", created.ID, "role_definition_id", req.RoleDefinitionID,
+		"principal", req.PrincipalType+":"+req.PrincipalID, "actor", user.Email())
+
+	writeJSON(w, http.StatusCreated, created)
+}
+
+func (s *Server) deleteRoleBinding(w http.ResponseWriter, r *http.Request, id string, user UserIdentity) {
+	// Verify the binding exists before deleting.
+	_, err := s.store.GetRoleBinding(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Role Binding")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	if err := s.store.DeleteRoleBinding(r.Context(), id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			NotFound(w, "Role Binding")
+			return
+		}
+		writeErrorFromErr(w, err, "")
+		return
+	}
+
+	slog.Info("role binding deleted",
+		"binding_id", id, "actor", user.Email())
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) listBindingsForUser(w http.ResponseWriter, r *http.Request, userID string) {
+	bindings, err := s.store.ListRoleBindingsForPrincipal(r.Context(), store.RoleBindingPrincipalUser, userID)
+	if err != nil {
+		writeErrorFromErr(w, err, "")
+		return
+	}
+	if bindings == nil {
+		bindings = []*store.RoleBinding{}
+	}
+	writeJSON(w, http.StatusOK, listRoleBindingsResponse{
+		Items:      bindings,
+		TotalCount: len(bindings),
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Permissions Registry
+// ---------------------------------------------------------------------------
+
+func (s *Server) listPermissions(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, listPermissionsResponse{
+		Items:      permissions.Registry,
+		TotalCount: len(permissions.Registry),
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Authorization helpers
+// ---------------------------------------------------------------------------
+
+// requireWritePermissionForRole checks that the authenticated user has the
+// specified role permission.
+func (s *Server) requireWritePermissionForRole(w http.ResponseWriter, r *http.Request, permission string, action string) (UserIdentity, bool) {
+	identity := GetIdentityFromContext(r.Context())
+	if identity == nil {
+		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "authentication required", nil)
+		return nil, false
+	}
+	user, ok := identity.(UserIdentity)
+	if !ok {
+		Forbidden(w)
+		return nil, false
+	}
+	if s.authzService == nil {
+		Forbidden(w)
+		return nil, false
+	}
+	decision := s.authzService.Decide(r.Context(), AuthzRequest{
+		Principal:  principalContextForIdentity(user),
+		Credential: credentialContextForIdentity(user),
+		Resource:   Resource{Type: "role", ID: "hub"},
+		Action:     Action(action),
+		Permission: permission,
+	})
+	if !decision.Allowed {
+		Forbidden(w)
+		return nil, false
+	}
+	return user, true
+}
+
+// requireWritePermissionForRoleBinding checks that the authenticated user has
+// the specified role_binding permission.
+func (s *Server) requireWritePermissionForRoleBinding(w http.ResponseWriter, r *http.Request, permission string, action string) (UserIdentity, bool) {
+	identity := GetIdentityFromContext(r.Context())
+	if identity == nil {
+		writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized, "authentication required", nil)
+		return nil, false
+	}
+	user, ok := identity.(UserIdentity)
+	if !ok {
+		Forbidden(w)
+		return nil, false
+	}
+	if s.authzService == nil {
+		Forbidden(w)
+		return nil, false
+	}
+	decision := s.authzService.Decide(r.Context(), AuthzRequest{
+		Principal:  principalContextForIdentity(user),
+		Credential: credentialContextForIdentity(user),
+		Resource:   Resource{Type: "role_binding", ID: "hub"},
+		Action:     Action(action),
+		Permission: permission,
+	})
+	if !decision.Allowed {
+		Forbidden(w)
+		return nil, false
+	}
+	return user, true
+}
+
+// validatePermissionIDs checks that all provided IDs exist in the permissions registry.
+func validatePermissionIDs(ids []string) error {
+	valid := make(map[string]bool, len(permissions.Registry))
+	for _, p := range permissions.Registry {
+		valid[p.ID] = true
+	}
+	var invalid []string
+	for _, id := range ids {
+		if !valid[id] {
+			invalid = append(invalid, id)
+		}
+	}
+	if len(invalid) > 0 {
+		return errors.New("invalid permission IDs: " + strings.Join(invalid, ", "))
+	}
+	return nil
+}

--- a/pkg/hub/handlers_roles_test.go
+++ b/pkg/hub/handlers_roles_test.go
@@ -17,8 +17,10 @@
 package hub
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/hub/permissions"
@@ -577,4 +579,191 @@ func TestRolesAPI_UpdateRoleDefinition_InvalidPermissions(t *testing.T) {
 		Permissions: []string{"nonexistent.permission"},
 	})
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: Non-admin identity
+// ---------------------------------------------------------------------------
+
+const (
+	nonAdminUserID    = "11111111-1111-1111-1111-111111111111"
+	nonAdminUserEmail = "scoped-admin@test.local"
+)
+
+// doRequestAsIdentity performs an HTTP request with a custom identity injected
+// into the context. This bypasses the dev-auth super-admin fast-path by using
+// an AuthenticatedUser whose Role() != "admin", so that CanDelegate and
+// permission-based route guards are actually exercised.
+func doRequestAsIdentity(t *testing.T, srv *Server, identity Identity, method, path string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = json.Marshal(body)
+		if err != nil {
+			t.Fatalf("failed to marshal body: %v", err)
+		}
+	}
+
+	req := httptest.NewRequest(method, path, bytes.NewReader(bodyBytes))
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	// Inject the custom identity directly into the context so the route
+	// guard and handler see a non-admin user instead of the DevUser.
+	ctx := contextWithIdentity(req.Context(), identity)
+	req = req.WithContext(ctx)
+
+	// Serve using the mux directly (bypassing auth middleware) since the
+	// identity is already in the context. The route guards and handlers
+	// call GetIdentityFromContext, which will find our injected identity.
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// setupNonAdminUser creates a non-admin user identity and grants it specific
+// permissions via a custom role binding. Returns the identity.
+//
+// The user gets a role binding granting the specified permissions at system scope.
+func setupNonAdminUser(t *testing.T, st store.Store, perms []string) *AuthenticatedUser {
+	t.Helper()
+	ctx := t.Context()
+
+	user := NewAuthenticatedUser(nonAdminUserID, nonAdminUserEmail, "Scoped Admin", "member", "api")
+
+	// Create a custom role definition with the requested permissions.
+	rd, err := st.CreateRoleDefinition(ctx, &store.RoleDefinition{
+		Name:        "test-scoped-admin-" + t.Name(),
+		Description: "Test scoped admin role",
+		ScopeType:   store.RoleScopeSystem,
+		Permissions: perms,
+		System:      false,
+	})
+	require.NoError(t, err)
+
+	// Bind it to our test user.
+	_, err = st.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: rd.ID,
+		PrincipalType:    store.RoleBindingPrincipalUser,
+		PrincipalID:      nonAdminUserID,
+		ScopeType:        store.RoleScopeSystem,
+		CreatedBy:        "test-setup",
+	})
+	require.NoError(t, err)
+
+	return user
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Non-admin CanDelegate enforcement
+// ---------------------------------------------------------------------------
+
+func TestRolesAPI_NonAdmin_CreateRole_WithHeldPermissions(t *testing.T) {
+	srv, st := testServer(t)
+
+	// Give non-admin user role.create, role.read, and agent.read permissions.
+	user := setupNonAdminUser(t, st, []string{"role.create", "role.read", "agent.read"})
+
+	// Create a role containing only permissions the user holds → should succeed.
+	rec := doRequestAsIdentity(t, srv, user, http.MethodPost, "/api/v1/admin/roles", createRoleDefinitionRequest{
+		Name:        "non-admin-created-role",
+		Description: "Created by non-admin",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+
+	var def store.RoleDefinition
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&def))
+	assert.Equal(t, "non-admin-created-role", def.Name)
+	assert.Equal(t, []string{"agent.read"}, def.Permissions)
+}
+
+func TestRolesAPI_NonAdmin_CreateRole_WithUnheldPermissions(t *testing.T) {
+	srv, st := testServer(t)
+
+	// Give non-admin user role.create and agent.read, but NOT user.suspend.
+	user := setupNonAdminUser(t, st, []string{"role.create", "role.read", "agent.read"})
+
+	// Try to create a role containing user.suspend → should get 403 (CanDelegate denies).
+	rec := doRequestAsIdentity(t, srv, user, http.MethodPost, "/api/v1/admin/roles", createRoleDefinitionRequest{
+		Name:        "escalated-role",
+		Description: "Attempting privilege escalation",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read", "user.suspend"},
+	})
+	assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+}
+
+func TestRolesAPI_NonAdmin_UpdateRole_WithUnheldPermissions(t *testing.T) {
+	srv, st := testServer(t)
+
+	// Give non-admin user role.create, role.update, role.read, and agent.read.
+	user := setupNonAdminUser(t, st, []string{"role.create", "role.update", "role.read", "agent.read"})
+
+	// First, create a role as admin (DevUser) with only agent.read.
+	created := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "update-escalation-test",
+		Description: "Role to be updated by non-admin",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+
+	// Non-admin tries to update the role to add user.suspend → should get 403.
+	rec := doRequestAsIdentity(t, srv, user, http.MethodPut, "/api/v1/admin/roles/"+created.ID, updateRoleDefinitionRequest{
+		Name:        "update-escalation-test",
+		Description: "Escalated",
+		Permissions: []string{"agent.read", "user.suspend"},
+	})
+	assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
+}
+
+func TestRolesAPI_NonAdmin_CreateBinding_WithHeldPermissions(t *testing.T) {
+	srv, st := testServer(t)
+
+	// Give non-admin user role_binding.create, role_binding.read, and agent.read.
+	user := setupNonAdminUser(t, st, []string{"role_binding.create", "role_binding.read", "agent.read"})
+
+	// Create a role as admin with only agent.read (a permission our user holds).
+	role := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "binding-held-test",
+		Description: "Contains only held permissions",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+
+	// Non-admin creates binding for this role → should succeed.
+	rec := doRequestAsIdentity(t, srv, user, http.MethodPost, "/api/v1/admin/role-bindings", createRoleBindingRequest{
+		RoleDefinitionID: role.ID,
+		PrincipalType:    "user",
+		PrincipalID:      "some-other-user",
+		ScopeType:        "system",
+	})
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+}
+
+func TestRolesAPI_NonAdmin_CreateBinding_WithUnheldPermissions(t *testing.T) {
+	srv, st := testServer(t)
+
+	// Give non-admin user role_binding.create, role_binding.read, and agent.read
+	// but NOT user.suspend.
+	user := setupNonAdminUser(t, st, []string{"role_binding.create", "role_binding.read", "agent.read"})
+
+	// Create a role as admin that includes user.suspend (a permission our user does NOT hold).
+	role := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "binding-unheld-test",
+		Description: "Contains unheld permissions",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read", "user.suspend"},
+	})
+
+	// Non-admin tries to create binding for this role → should get 403.
+	rec := doRequestAsIdentity(t, srv, user, http.MethodPost, "/api/v1/admin/role-bindings", createRoleBindingRequest{
+		RoleDefinitionID: role.ID,
+		PrincipalType:    "user",
+		PrincipalID:      "some-other-user",
+		ScopeType:        "system",
+	})
+	assert.Equal(t, http.StatusForbidden, rec.Code, "body: %s", rec.Body.String())
 }

--- a/pkg/hub/handlers_roles_test.go
+++ b/pkg/hub/handlers_roles_test.go
@@ -1,0 +1,580 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/hub/permissions"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// createRoleViaAPI creates a role definition through the handler and returns it.
+func createRoleViaAPI(t *testing.T, srv *Server, req createRoleDefinitionRequest) *store.RoleDefinition {
+	t.Helper()
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/roles", req)
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+	var def store.RoleDefinition
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&def))
+	return &def
+}
+
+// createBindingViaAPI creates a role binding through the handler and returns it.
+func createBindingViaAPI(t *testing.T, srv *Server, req createRoleBindingRequest) *store.RoleBinding {
+	t.Helper()
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/role-bindings", req)
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+	var rb store.RoleBinding
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&rb))
+	return &rb
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Role Definition CRUD
+// ---------------------------------------------------------------------------
+
+func TestRolesAPI_CreateRoleDefinition(t *testing.T) {
+	srv, _ := testServer(t)
+
+	def := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "custom-viewer",
+		Description: "Custom viewer role",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read", "project.read"},
+	})
+
+	assert.NotEmpty(t, def.ID)
+	assert.Equal(t, "custom-viewer", def.Name)
+	assert.Equal(t, "system", def.ScopeType)
+	assert.Equal(t, []string{"agent.read", "project.read"}, def.Permissions)
+	assert.False(t, def.System)
+}
+
+func TestRolesAPI_CreateRoleDefinition_MissingName(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/roles", createRoleDefinitionRequest{
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRolesAPI_CreateRoleDefinition_InvalidScopeType(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/roles", createRoleDefinitionRequest{
+		Name:        "bad-scope",
+		ScopeType:   "invalid",
+		Permissions: []string{"agent.read"},
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRolesAPI_CreateRoleDefinition_InvalidPermissions(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/roles", createRoleDefinitionRequest{
+		Name:        "bad-perms",
+		ScopeType:   "system",
+		Permissions: []string{"nonexistent.permission"},
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRolesAPI_CreateRoleDefinition_ProjectScope(t *testing.T) {
+	srv, _ := testServer(t)
+
+	def := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "project-viewer",
+		Description: "Project viewer role",
+		ScopeType:   "project",
+		Permissions: []string{"agent.read", "agent.list"},
+	})
+
+	assert.Equal(t, "project", def.ScopeType)
+	assert.False(t, def.System)
+}
+
+func TestRolesAPI_GetRoleDefinition(t *testing.T) {
+	srv, _ := testServer(t)
+
+	created := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "get-test-role",
+		Description: "Get test",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/roles/"+created.ID, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var def store.RoleDefinition
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&def))
+	assert.Equal(t, created.ID, def.ID)
+	assert.Equal(t, "get-test-role", def.Name)
+}
+
+func TestRolesAPI_GetRoleDefinition_NotFound(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/roles/00000000-0000-0000-0000-000000000000", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestRolesAPI_ListRoleDefinitions(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// System roles are seeded, so the list should already be non-empty.
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/roles", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp listRoleDefinitionsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Greater(t, resp.TotalCount, 0)
+}
+
+func TestRolesAPI_UpdateRoleDefinition(t *testing.T) {
+	srv, _ := testServer(t)
+
+	created := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "update-test-role",
+		Description: "Before update",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/admin/roles/"+created.ID, updateRoleDefinitionRequest{
+		Name:        "updated-role",
+		Description: "After update",
+		Permissions: []string{"agent.read", "project.read"},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var updated store.RoleDefinition
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&updated))
+	assert.Equal(t, "updated-role", updated.Name)
+	assert.Equal(t, "After update", updated.Description)
+	assert.Equal(t, []string{"agent.read", "project.read"}, updated.Permissions)
+}
+
+func TestRolesAPI_UpdateRoleDefinition_SystemRole(t *testing.T) {
+	srv, st := testServer(t)
+
+	// Find a system role.
+	defs, err := st.ListRoleDefinitions(t.Context())
+	require.NoError(t, err)
+
+	var systemRole *store.RoleDefinition
+	for _, d := range defs {
+		if d.System {
+			systemRole = d
+			break
+		}
+	}
+	require.NotNil(t, systemRole, "expected at least one system role")
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/admin/roles/"+systemRole.ID, updateRoleDefinitionRequest{
+		Name:        "hacked-name",
+		Description: "hacked",
+		Permissions: []string{"agent.read"},
+	})
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestRolesAPI_DeleteRoleDefinition(t *testing.T) {
+	srv, _ := testServer(t)
+
+	created := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "delete-test-role",
+		Description: "To be deleted",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+
+	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/admin/roles/"+created.ID, nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Verify it's gone.
+	rec = doRequest(t, srv, http.MethodGet, "/api/v1/admin/roles/"+created.ID, nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestRolesAPI_DeleteRoleDefinition_SystemRole(t *testing.T) {
+	srv, st := testServer(t)
+
+	defs, err := st.ListRoleDefinitions(t.Context())
+	require.NoError(t, err)
+
+	var systemRole *store.RoleDefinition
+	for _, d := range defs {
+		if d.System {
+			systemRole = d
+			break
+		}
+	}
+	require.NotNil(t, systemRole)
+
+	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/admin/roles/"+systemRole.ID, nil)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestRolesAPI_DeleteRoleDefinition_WithBindings(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Create a custom role.
+	role := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "bound-role",
+		Description: "Has bindings",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+
+	// Create a binding to it.
+	createBindingViaAPI(t, srv, createRoleBindingRequest{
+		RoleDefinitionID: role.ID,
+		PrincipalType:    "user",
+		PrincipalID:      DevUserID,
+		ScopeType:        "system",
+	})
+
+	// Try to delete — should fail because of active bindings.
+	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/admin/roles/"+role.ID, nil)
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+func TestRolesAPI_MethodNotAllowed_Roles(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPatch, "/api/v1/admin/roles", nil)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Role Binding CRUD
+// ---------------------------------------------------------------------------
+
+func TestRolesAPI_CreateRoleBinding(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Create a custom role first.
+	role := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "binding-test-role",
+		Description: "For binding tests",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+
+	binding := createBindingViaAPI(t, srv, createRoleBindingRequest{
+		RoleDefinitionID: role.ID,
+		PrincipalType:    "user",
+		PrincipalID:      "some-user-id",
+		ScopeType:        "system",
+	})
+
+	assert.NotEmpty(t, binding.ID)
+	assert.Equal(t, role.ID, binding.RoleDefinitionID)
+	assert.Equal(t, "user", binding.PrincipalType)
+	assert.Equal(t, "some-user-id", binding.PrincipalID)
+	assert.Equal(t, "system", binding.ScopeType)
+}
+
+func TestRolesAPI_CreateRoleBinding_MissingFields(t *testing.T) {
+	srv, _ := testServer(t)
+
+	tests := []struct {
+		name string
+		req  createRoleBindingRequest
+	}{
+		{"missing roleDefinitionId", createRoleBindingRequest{PrincipalType: "user", PrincipalID: "u1", ScopeType: "system"}},
+		{"missing principalType", createRoleBindingRequest{RoleDefinitionID: "some-id", PrincipalID: "u1", ScopeType: "system"}},
+		{"missing principalId", createRoleBindingRequest{RoleDefinitionID: "some-id", PrincipalType: "user", ScopeType: "system"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/role-bindings", tt.req)
+			assert.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+		})
+	}
+}
+
+func TestRolesAPI_CreateRoleBinding_InvalidPrincipalType(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/role-bindings", createRoleBindingRequest{
+		RoleDefinitionID: "some-id",
+		PrincipalType:    "group",
+		PrincipalID:      "g1",
+		ScopeType:        "system",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRolesAPI_CreateRoleBinding_InvalidScopeType(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/role-bindings", createRoleBindingRequest{
+		RoleDefinitionID: "some-id",
+		PrincipalType:    "user",
+		PrincipalID:      "u1",
+		ScopeType:        "invalid",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRolesAPI_CreateRoleBinding_SuperAdmin_Blocked(t *testing.T) {
+	srv, st := testServer(t)
+
+	// Find the super-admin role definition.
+	rd, err := st.GetRoleDefinitionByName(t.Context(), store.SystemRoleSuperAdmin, store.RoleScopeSystem)
+	require.NoError(t, err)
+
+	// Try to create a super-admin binding — should be blocked by the D10 store guard.
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/role-bindings", createRoleBindingRequest{
+		RoleDefinitionID: rd.ID,
+		PrincipalType:    "user",
+		PrincipalID:      "some-user",
+		ScopeType:        "system",
+	})
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestRolesAPI_ListRoleBindings(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Create a binding so the list is non-empty.
+	role := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "list-bindings-role",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+	createBindingViaAPI(t, srv, createRoleBindingRequest{
+		RoleDefinitionID: role.ID,
+		PrincipalType:    "user",
+		PrincipalID:      "list-user",
+		ScopeType:        "system",
+	})
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/role-bindings", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp listRoleBindingsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.GreaterOrEqual(t, resp.TotalCount, 1)
+}
+
+func TestRolesAPI_DeleteRoleBinding(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Create a custom role and binding.
+	role := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "del-binding-role",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+	binding := createBindingViaAPI(t, srv, createRoleBindingRequest{
+		RoleDefinitionID: role.ID,
+		PrincipalType:    "user",
+		PrincipalID:      "del-user",
+		ScopeType:        "system",
+	})
+
+	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/admin/role-bindings/"+binding.ID, nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestRolesAPI_DeleteRoleBinding_NotFound(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodDelete, "/api/v1/admin/role-bindings/00000000-0000-0000-0000-000000000000", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestRolesAPI_ListBindingsForUser(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// Create a custom role and bind it to a specific user.
+	role := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "user-binding-role",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+	createBindingViaAPI(t, srv, createRoleBindingRequest{
+		RoleDefinitionID: role.ID,
+		PrincipalType:    "user",
+		PrincipalID:      "target-user-123",
+		ScopeType:        "system",
+	})
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/role-bindings/user/target-user-123", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp listRoleBindingsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.GreaterOrEqual(t, resp.TotalCount, 1)
+}
+
+func TestRolesAPI_ListBindingsForUser_Empty(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/role-bindings/user/nonexistent-user", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp listRoleBindingsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, 0, resp.TotalCount)
+}
+
+func TestRolesAPI_MethodNotAllowed_Bindings(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPatch, "/api/v1/admin/role-bindings", nil)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Permissions Registry Endpoint
+// ---------------------------------------------------------------------------
+
+func TestRolesAPI_ListPermissions(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/admin/permissions", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp listPermissionsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, len(permissions.Registry), resp.TotalCount)
+	assert.Greater(t, resp.TotalCount, 0)
+
+	// Verify role permissions are in the registry.
+	found := make(map[string]bool)
+	for _, p := range resp.Items {
+		found[p.ID] = true
+	}
+	assert.True(t, found["role.read"], "role.read should be in registry")
+	assert.True(t, found["role.create"], "role.create should be in registry")
+	assert.True(t, found["role_binding.read"], "role_binding.read should be in registry")
+	assert.True(t, found["role_binding.create"], "role_binding.create should be in registry")
+}
+
+func TestRolesAPI_ListPermissions_MethodNotAllowed(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/permissions", nil)
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Unauthenticated access
+// ---------------------------------------------------------------------------
+
+func TestRolesAPI_Unauthenticated_Roles(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequestNoAuth(t, srv, http.MethodGet, "/api/v1/admin/roles", nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestRolesAPI_Unauthenticated_Bindings(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequestNoAuth(t, srv, http.MethodGet, "/api/v1/admin/role-bindings", nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestRolesAPI_Unauthenticated_Permissions(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequestNoAuth(t, srv, http.MethodGet, "/api/v1/admin/permissions", nil)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Validate Permission IDs
+// ---------------------------------------------------------------------------
+
+func TestValidatePermissionIDs_Valid(t *testing.T) {
+	err := validatePermissionIDs([]string{"agent.read", "project.read"})
+	assert.NoError(t, err)
+}
+
+func TestValidatePermissionIDs_Invalid(t *testing.T) {
+	err := validatePermissionIDs([]string{"agent.read", "fake.perm"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "fake.perm")
+}
+
+func TestValidatePermissionIDs_Empty(t *testing.T) {
+	err := validatePermissionIDs(nil)
+	assert.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Role Binding with agent principal type
+// ---------------------------------------------------------------------------
+
+func TestRolesAPI_CreateRoleBinding_AgentPrincipal(t *testing.T) {
+	srv, _ := testServer(t)
+
+	role := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "agent-binding-role",
+		ScopeType:   "project",
+		Permissions: []string{"agent.read"},
+	})
+
+	binding := createBindingViaAPI(t, srv, createRoleBindingRequest{
+		RoleDefinitionID: role.ID,
+		PrincipalType:    "agent",
+		PrincipalID:      "some-agent-id",
+		ScopeType:        "project",
+		ScopeID:          "some-project-id",
+	})
+
+	assert.Equal(t, "agent", binding.PrincipalType)
+	assert.Equal(t, "some-agent-id", binding.PrincipalID)
+	assert.Equal(t, "project", binding.ScopeType)
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Update role definition with invalid permissions
+// ---------------------------------------------------------------------------
+
+func TestRolesAPI_UpdateRoleDefinition_InvalidPermissions(t *testing.T) {
+	srv, _ := testServer(t)
+
+	created := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "update-invalid-perms",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+
+	rec := doRequest(t, srv, http.MethodPut, "/api/v1/admin/roles/"+created.ID, updateRoleDefinitionRequest{
+		Name:        "updated-name",
+		Permissions: []string{"nonexistent.permission"},
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/pkg/hub/handlers_roles_test.go
+++ b/pkg/hub/handlers_roles_test.go
@@ -335,6 +335,27 @@ func TestRolesAPI_CreateRoleBinding_InvalidPrincipalType(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestRolesAPI_CreateRoleBinding_ProjectScopeMissingScopeID(t *testing.T) {
+	srv, _ := testServer(t)
+
+	role := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "project-scope-no-id-role",
+		ScopeType:   "project",
+		Permissions: []string{"agent.read"},
+	})
+
+	// project-scoped binding with empty scope_id → 400
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/role-bindings", createRoleBindingRequest{
+		RoleDefinitionID: role.ID,
+		PrincipalType:    "user",
+		PrincipalID:      "u1",
+		ScopeType:        "project",
+		ScopeID:          "",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "scope_id is required")
+}
+
 func TestRolesAPI_CreateRoleBinding_InvalidScopeType(t *testing.T) {
 	srv, _ := testServer(t)
 

--- a/pkg/hub/permissions/registry.go
+++ b/pkg/hub/permissions/registry.go
@@ -33,6 +33,8 @@ const (
 	ResourceGCPServiceAccount = "gcp_service_account"
 	ResourceHub               = "hub"
 	ResourceQuota             = "quota"
+	ResourceRole              = "role"
+	ResourceRoleBinding       = "role_binding"
 
 	ActionCreate       = "create"
 	ActionRead         = "read"
@@ -191,6 +193,15 @@ var Registry = []Permission{
 	{ID: "quota.create", Resource: ResourceQuota, Action: ActionCreate, CapabilityKind: CapabilityScope, Description: "Create limit definitions and entitlement bindings", Enforcement: []string{"pkg/hub/handlers_quota.go"}},
 	{ID: "quota.update", Resource: ResourceQuota, Action: ActionUpdate, CapabilityKind: CapabilityScope, Description: "Update limit definitions and entitlement bindings", Enforcement: []string{"pkg/hub/handlers_quota.go"}},
 	{ID: "quota.delete", Resource: ResourceQuota, Action: ActionDelete, CapabilityKind: CapabilityScope, Description: "Delete limit definitions and entitlement bindings", Enforcement: []string{"pkg/hub/handlers_quota.go"}},
+
+	// Role management (Phase 2 PR-C1)
+	{ID: "role.read", Resource: ResourceRole, Action: ActionRead, CapabilityKind: CapabilityScope, Description: "Read role definitions", Enforcement: []string{"pkg/hub/handlers_roles.go"}},
+	{ID: "role.create", Resource: ResourceRole, Action: ActionCreate, CapabilityKind: CapabilityScope, Description: "Create custom role definitions", Enforcement: []string{"pkg/hub/handlers_roles.go"}},
+	{ID: "role.update", Resource: ResourceRole, Action: ActionUpdate, CapabilityKind: CapabilityScope, Description: "Update custom role definitions", Enforcement: []string{"pkg/hub/handlers_roles.go"}},
+	{ID: "role.delete", Resource: ResourceRole, Action: ActionDelete, CapabilityKind: CapabilityScope, Description: "Delete custom role definitions", Enforcement: []string{"pkg/hub/handlers_roles.go"}},
+	{ID: "role_binding.read", Resource: ResourceRoleBinding, Action: ActionRead, CapabilityKind: CapabilityScope, Description: "Read role bindings", Enforcement: []string{"pkg/hub/handlers_roles.go"}},
+	{ID: "role_binding.create", Resource: ResourceRoleBinding, Action: ActionCreate, CapabilityKind: CapabilityScope, Description: "Create role bindings", Enforcement: []string{"pkg/hub/handlers_roles.go"}},
+	{ID: "role_binding.delete", Resource: ResourceRoleBinding, Action: ActionDelete, CapabilityKind: CapabilityScope, Description: "Delete role bindings", Enforcement: []string{"pkg/hub/handlers_roles.go"}},
 
 	// Extensions to existing resource types (Phase 2 D4 resolution)
 	{ID: "user.invite", Resource: ResourceUser, Action: ActionInvite, CapabilityKind: CapabilityScope, UATScope: "user:invite", Description: "Invite users", NonRouteUse: []string{"Phase 2 D4 route guard conversion"}},

--- a/pkg/hub/route_classification_test.go
+++ b/pkg/hub/route_classification_test.go
@@ -186,6 +186,12 @@ var routePermissionClassifications = map[string]string{
 	"/api/v1/admin/usage":                       "hub-admin:quota",
 	"/api/v1/admin/usage/":                      "hub-admin:quota",
 	"/api/v1/usage/me":                          "authenticated:quota-usage",
+	// Role management (PR-C1)
+	"/api/v1/admin/roles":          "hub-admin:role",
+	"/api/v1/admin/roles/":         "hub-admin:role",
+	"/api/v1/admin/role-bindings":  "hub-admin:role_binding",
+	"/api/v1/admin/role-bindings/": "hub-admin:role_binding",
+	"/api/v1/admin/permissions":    "hub-admin:role",
 }
 
 func TestRegisteredRoutesHavePermissionClassification(t *testing.T) {

--- a/pkg/hub/route_metadata.go
+++ b/pkg/hub/route_metadata.go
@@ -751,6 +751,35 @@ var routeMetadataTable = map[string]RouteMetadata{
 	},
 
 	// -------------------------------------------------------------------------
+	// Hub admin: Role management (PR-C1)
+	// -------------------------------------------------------------------------
+	"/api/v1/admin/roles": {
+		Pattern: "/api/v1/admin/roles", RouteID: "admin.roles",
+		Classification: RouteHubAdmin,
+		Permission:     "role.read", Resource: "role", Action: "read",
+	},
+	"/api/v1/admin/roles/": {
+		Pattern: "/api/v1/admin/roles/", RouteID: "admin.roles.byId",
+		Classification: RouteHubAdmin,
+		Permission:     "role.read", Resource: "role", Action: "read",
+	},
+	"/api/v1/admin/role-bindings": {
+		Pattern: "/api/v1/admin/role-bindings", RouteID: "admin.roleBindings",
+		Classification: RouteHubAdmin,
+		Permission:     "role_binding.read", Resource: "role_binding", Action: "read",
+	},
+	"/api/v1/admin/role-bindings/": {
+		Pattern: "/api/v1/admin/role-bindings/", RouteID: "admin.roleBindings.byId",
+		Classification: RouteHubAdmin,
+		Permission:     "role_binding.read", Resource: "role_binding", Action: "read",
+	},
+	"/api/v1/admin/permissions": {
+		Pattern: "/api/v1/admin/permissions", RouteID: "admin.permissions",
+		Classification: RouteHubAdmin,
+		Permission:     "role.read", Resource: "role", Action: "read",
+	},
+
+	// -------------------------------------------------------------------------
 	// Authenticated: Usage self-service
 	// -------------------------------------------------------------------------
 	"/api/v1/usage/me": {

--- a/pkg/hub/seed.go
+++ b/pkg/hub/seed.go
@@ -542,6 +542,14 @@ func hubAdminPermissionIDs() []string {
 		"quota.create": true,
 		"quota.update": true,
 		"quota.delete": true,
+		// Role and binding management (PR-C1)
+		"role.read":           true,
+		"role.create":         true,
+		"role.update":         true,
+		"role.delete":         true,
+		"role_binding.read":   true,
+		"role_binding.create": true,
+		"role_binding.delete": true,
 		// Project oversight
 		"project.read":   true,
 		"project.list":   true,

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3846,6 +3846,13 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/admin/usage/", s.guarded("/api/v1/admin/usage/", s.handleAdminUsageByLimit))
 	s.mux.HandleFunc("/api/v1/usage/me", s.guarded("/api/v1/usage/me", s.handleUsageMe))
 
+	// Role management (PR-C1)
+	s.mux.HandleFunc("/api/v1/admin/roles", s.guarded("/api/v1/admin/roles", s.handleAdminRoles))
+	s.mux.HandleFunc("/api/v1/admin/roles/", s.guarded("/api/v1/admin/roles/", s.handleAdminRoleByID))
+	s.mux.HandleFunc("/api/v1/admin/role-bindings", s.guarded("/api/v1/admin/role-bindings", s.handleAdminRoleBindings))
+	s.mux.HandleFunc("/api/v1/admin/role-bindings/", s.guarded("/api/v1/admin/role-bindings/", s.handleAdminRoleBindingByID))
+	s.mux.HandleFunc("/api/v1/admin/permissions", s.guarded("/api/v1/admin/permissions", s.handleAdminPermissions))
+
 	// Notification endpoints (user-facing)
 	s.mux.HandleFunc("/api/v1/notifications", s.guarded("/api/v1/notifications", s.handleNotifications))
 	s.mux.HandleFunc("/api/v1/notifications/", s.guarded("/api/v1/notifications/", s.handleNotificationRoutes))

--- a/pkg/store/entadapter/role_store.go
+++ b/pkg/store/entadapter/role_store.go
@@ -228,6 +228,11 @@ func (r *RoleStore) ListAllRoleBindings(ctx context.Context, limit, offset int) 
 	return result, nil
 }
 
+// CountAllRoleBindings returns the total number of role bindings.
+func (r *RoleStore) CountAllRoleBindings(ctx context.Context) (int, error) {
+	return r.client.RoleBinding.Query().Count(ctx)
+}
+
 // GetRoleBinding retrieves a role binding by ID.
 func (r *RoleStore) GetRoleBinding(ctx context.Context, id string) (*store.RoleBinding, error) {
 	uid, err := parseGetID(id)

--- a/pkg/store/entadapter/role_store.go
+++ b/pkg/store/entadapter/role_store.go
@@ -200,10 +200,23 @@ func (r *RoleStore) DeleteRoleDefinition(ctx context.Context, id string) error {
 	return nil
 }
 
-// ListAllRoleBindings returns all role bindings (admin view).
-func (r *RoleStore) ListAllRoleBindings(ctx context.Context) ([]*store.RoleBinding, error) {
+// ListAllRoleBindings returns all role bindings (admin view) with pagination.
+// A limit of 0 defaults to 100. The maximum allowed limit is 1000.
+func (r *RoleStore) ListAllRoleBindings(ctx context.Context, limit, offset int) ([]*store.RoleBinding, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
 	rbs, err := r.client.RoleBinding.Query().
 		Order(ent.Desc(rolebinding.FieldCreated)).
+		Limit(limit).
+		Offset(offset).
 		All(ctx)
 	if err != nil {
 		return nil, mapError(err)

--- a/pkg/store/entadapter/role_store.go
+++ b/pkg/store/entadapter/role_store.go
@@ -135,6 +135,86 @@ func (r *RoleStore) CreateRoleDefinition(ctx context.Context, rd *store.RoleDefi
 	return entRoleDefinitionToStore(created), nil
 }
 
+// UpdateRoleDefinition updates an existing role definition.
+// System roles (System == true) cannot be updated.
+func (r *RoleStore) UpdateRoleDefinition(ctx context.Context, rd *store.RoleDefinition) (*store.RoleDefinition, error) {
+	uid, err := parseGetID(rd.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch existing to check system flag.
+	existing, err := r.client.RoleDefinition.Get(ctx, uid)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	if existing.System {
+		return nil, fmt.Errorf("%w: system roles cannot be modified", store.ErrInvalidInput)
+	}
+
+	builder := r.client.RoleDefinition.UpdateOneID(uid).
+		SetName(rd.Name).
+		SetDescription(rd.Description).
+		SetPermissions(rd.Permissions)
+	// ScopeType is intentionally not updatable.
+
+	updated, err := builder.Save(ctx)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	return entRoleDefinitionToStore(updated), nil
+}
+
+// DeleteRoleDefinition deletes a role definition by ID.
+// System roles (System == true) cannot be deleted.
+// Returns an error if any bindings reference the role.
+func (r *RoleStore) DeleteRoleDefinition(ctx context.Context, id string) error {
+	uid, err := parseGetID(id)
+	if err != nil {
+		return err
+	}
+
+	// Fetch existing to check system flag.
+	existing, err := r.client.RoleDefinition.Get(ctx, uid)
+	if err != nil {
+		return mapError(err)
+	}
+	if existing.System {
+		return fmt.Errorf("%w: system roles cannot be deleted", store.ErrInvalidInput)
+	}
+
+	// Check for active bindings referencing this role.
+	count, err := r.client.RoleBinding.Query().
+		Where(rolebinding.RoleDefinitionIDEQ(uid)).
+		Count(ctx)
+	if err != nil {
+		return mapError(err)
+	}
+	if count > 0 {
+		return fmt.Errorf("%w: role has %d active binding(s)", store.ErrInvalidInput, count)
+	}
+
+	if err := r.client.RoleDefinition.DeleteOneID(uid).Exec(ctx); err != nil {
+		return mapError(err)
+	}
+	return nil
+}
+
+// ListAllRoleBindings returns all role bindings (admin view).
+func (r *RoleStore) ListAllRoleBindings(ctx context.Context) ([]*store.RoleBinding, error) {
+	rbs, err := r.client.RoleBinding.Query().
+		Order(ent.Desc(rolebinding.FieldCreated)).
+		All(ctx)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	result := make([]*store.RoleBinding, len(rbs))
+	for i, rb := range rbs {
+		result[i] = entRoleBindingToStore(rb)
+	}
+	return result, nil
+}
+
 // GetRoleBinding retrieves a role binding by ID.
 func (r *RoleStore) GetRoleBinding(ctx context.Context, id string) (*store.RoleBinding, error) {
 	uid, err := parseGetID(id)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1708,7 +1708,9 @@ type RoleStore interface {
 	DeleteRoleDefinition(ctx context.Context, id string) error
 
 	// ListAllRoleBindings returns all role bindings (admin view).
-	ListAllRoleBindings(ctx context.Context) ([]*RoleBinding, error)
+	// limit and offset control pagination. A limit of 0 defaults to 100.
+	// The maximum allowed limit is 1000.
+	ListAllRoleBindings(ctx context.Context, limit, offset int) ([]*RoleBinding, error)
 
 	// GetProjectMembership returns the project membership for a user in a project.
 	// Returns ErrNotFound if the user is not a member of the project.

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1712,6 +1712,9 @@ type RoleStore interface {
 	// The maximum allowed limit is 1000.
 	ListAllRoleBindings(ctx context.Context, limit, offset int) ([]*RoleBinding, error)
 
+	// CountAllRoleBindings returns the total number of role bindings.
+	CountAllRoleBindings(ctx context.Context) (int, error)
+
 	// GetProjectMembership returns the project membership for a user in a project.
 	// Returns ErrNotFound if the user is not a member of the project.
 	GetProjectMembership(ctx context.Context, projectID, userID string) (*ProjectMembership, error)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1699,6 +1699,17 @@ type RoleStore interface {
 	// Returns ErrNotFound if the role binding doesn't exist.
 	DeleteRoleBinding(ctx context.Context, id string) error
 
+	// UpdateRoleDefinition updates an existing role definition.
+	// Returns ErrNotFound if the role definition doesn't exist.
+	UpdateRoleDefinition(ctx context.Context, rd *RoleDefinition) (*RoleDefinition, error)
+
+	// DeleteRoleDefinition deletes a role definition by ID.
+	// Returns ErrNotFound if the role definition doesn't exist.
+	DeleteRoleDefinition(ctx context.Context, id string) error
+
+	// ListAllRoleBindings returns all role bindings (admin view).
+	ListAllRoleBindings(ctx context.Context) ([]*RoleBinding, error)
+
 	// GetProjectMembership returns the project membership for a user in a project.
 	// Returns ErrNotFound if the user is not a member of the project.
 	GetProjectMembership(ctx context.Context, projectID, userID string) (*ProjectMembership, error)


### PR DESCRIPTION
## Summary
- Role definition CRUD (create/read/update/delete) with system role immutability
- Role binding CRUD with CanDelegate enforcement on create and update
- ListAllRoleBindings with pagination (limit/offset, default 100, max 1000)
- D10 guard: role definitions cannot reference nonexistent permissions
- 25+ CRUD tests + 5 non-admin CanDelegate delegation tests
- CRITICAL fix: CanDelegate added to updateRoleDefinition (closes privilege escalation vector)

## Test plan
- make ci passes
- Code review: APPROVE (after 3 findings fixed)
- Security audit: PASS (CanDelegate on update verified)