### PR TITLE
fix(messaging): B6/B7/B9 - extract D-1 guard, add EnsureParticipant, nil-pe guard

### DIFF
--- a/.design/project-log/b6b7b9-d1-guard-ensure-participant.md
+++ b/.design/project-log/b6b7b9-d1-guard-ensure-participant.md
@@ -1,0 +1,83 @@
+# B6+B7+B9: D-1 Guard Extraction, EnsureParticipant, nil-pe Guard
+
+**Date:** 2026-08-28
+**Branch:** ca-msg-em6-b6b7b9
+
+## Summary
+
+Three coupled fixes addressing the interaction between conversation resolution,
+participant registration, and the DM immutability guard.
+
+## Changes
+
+### Deliverable 1: Shared D-1 guard predicate
+
+Extracted the direct-conversation immutability guard from `AddParticipant` into
+a shared function `checkDMParticipantKey(conv, principalKind, principalID)`.
+Both `AddParticipant` and `EnsureParticipant` now route through this single
+predicate, eliminating the risk of guard divergence (the exact defect class
+that DEF-31 demonstrated).
+
+**File:** `pkg/store/entadapter/conversation_store.go`
+
+### Deliverable 2: EnsureParticipant (B6 un-leaving + B9 self-repair)
+
+**Problem:** `ResolveOrCreateDMConversation` called `AddParticipant` on every
+resolve. `AddParticipant` queries for `LeftAtNotNil()` rows and clears
+`left_at`, silently overwriting a user's listing preference when they had
+left/hidden a DM conversation (B6). The self-repair contract (retry on next
+message) is what causes B6 (B9).
+
+**Solution:** Split the intent:
+
+- **AddParticipant** keeps its `ClearLeftAt` behavior for explicit re-join.
+- **EnsureParticipant** (new) does insert-if-absent. If any row exists (active
+  or soft-removed), it is left completely untouched including `left_at`.
+
+`ResolveOrCreateDMConversation` now takes `ParticipantEnsurer` instead of
+`ParticipantAdder` and calls `EnsureParticipant`.
+
+**Files:**
+- `pkg/store/entadapter/conversation_store.go` — `EnsureParticipant` implementation
+- `pkg/store/store.go` — interface addition
+- `pkg/messaging/conversation.go` — `ParticipantEnsurer` interface, signature change
+
+### Deliverable 3: nil-pe guard (B7)
+
+Added a nil check on the `ParticipantEnsurer` parameter before the participant
+registration loop. A nil `pe` logs a warning and returns the `ConversationResult`
+normally, honouring the function's non-fatal contract for participant registration.
+
+**File:** `pkg/messaging/conversation.go`
+
+## Test Coverage
+
+1. **B7 nil-pe test** — `TestResolveOrCreateDMConversation_NilParticipantEnsurer`:
+   Passes nil pe, asserts non-nil ConversationResult and no panic.
+
+2. **B6 resolve-after-leave** — `TestEnsureParticipant_ResolveAfterLeave`:
+   Full scenario: create DM, add both, soft-remove one, EnsureParticipant,
+   assert left_at timestamp is exactly preserved.
+
+3. **EnsureParticipant does not clear left_at** — `TestEnsureParticipant_DoesNotClearLeftAt`:
+   Focused: pins the exact left_at timestamp before and after EnsureParticipant.
+
+4. **D-1 guard shared predicate** — `TestEnsureParticipant_DM_ThirdPartyRejection`:
+   Exercises BOTH AddParticipant and EnsureParticipant with a third party not
+   named in the DM key. Both must reject with the same error.
+
+5. **EnsureParticipant insert-if-absent** — `TestEnsureParticipant_InsertIfAbsent`:
+   Creates row via EnsureParticipant, verifies it exists, calls again to verify
+   idempotency.
+
+6. **Mock updates** — Added `EnsureParticipant` to all three test mocks
+   (`mockConversationUpserter`, `mockConversationStore`, `mockResolutionStore`).
+   Updated existing tests that call `ResolveOrCreateDMConversation`.
+
+## Design Rationale
+
+The key insight is that `AddParticipant` conflates two intents: "join this
+conversation" (explicit, should clear left_at) and "ensure the row exists for
+listing" (implicit, must not touch existing state). Splitting these into
+separate methods makes each intent explicit and prevents one from breaking the
+other.

--- a/pkg/messaging/backfill_test.go
+++ b/pkg/messaging/backfill_test.go
@@ -289,6 +289,21 @@ func (m *mockConversationStore) AddParticipant(_ context.Context, p *store.Conve
 	return nil
 }
 
+func (m *mockConversationStore) EnsureParticipant(_ context.Context, p *store.ConversationParticipant) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// If any row exists (active or soft-removed), leave it untouched.
+	for _, existing := range m.participants {
+		if existing.ConversationID == p.ConversationID &&
+			existing.PrincipalKind == p.PrincipalKind &&
+			existing.PrincipalID == p.PrincipalID {
+			return nil
+		}
+	}
+	m.participants = append(m.participants, *p)
+	return nil
+}
+
 func (m *mockConversationStore) RemoveParticipant(_ context.Context, conversationID, principalKind, principalID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/messaging/conversation.go
+++ b/pkg/messaging/conversation.go
@@ -16,7 +16,6 @@ package messaging
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
@@ -43,6 +42,14 @@ type ParticipantAdder interface {
 	AddParticipant(ctx context.Context, p *store.ConversationParticipant) error
 }
 
+// ParticipantEnsurer is the minimal interface for idempotent participant
+// registration that preserves existing row state (including left_at).
+// Separated from ParticipantAdder because EnsureParticipant has different
+// semantics: insert-if-absent vs upsert-and-revive.
+type ParticipantEnsurer interface {
+	EnsureParticipant(ctx context.Context, p *store.ConversationParticipant) error
+}
+
 // ConversationResult carries the outcome of a resolve-or-create operation,
 // including the actual ExternalRef read back from the database.
 type ConversationResult struct {
@@ -61,7 +68,7 @@ type ConversationResult struct {
 func ResolveOrCreateDMConversation(
 	ctx context.Context,
 	cs ConversationUpserter,
-	pa ParticipantAdder,
+	pe ParticipantEnsurer,
 	log *slog.Logger,
 	senderKind, senderID, recipientKind, recipientID string,
 ) *ConversationResult {
@@ -99,38 +106,50 @@ func ResolveOrCreateDMConversation(
 		return nil
 	}
 
+	// B7 nil-pe guard: a nil ParticipantEnsurer must not panic. The function
+	// advertises non-fatal semantics for participant registration; a nil pe
+	// that panics would violate that contract. Log and skip.
+	if pe == nil {
+		log.Warn("skipping participant registration: nil ParticipantEnsurer (non-fatal)",
+			"external_ref", extRef)
+		return &ConversationResult{
+			ConversationID: result.ID,
+			ExternalRef:    result.ExternalRef,
+		}
+	}
+
 	// Register both participants so the DM appears in each party's sidebar.
 	// Errors are logged but not returned — participant registration is a listing
 	// concern, not an access concern (the DM key IS the access authority).
 	//
-	// This registration runs on EVERY resolve, not only on first create, and
-	// ErrAlreadyExists is swallowed. Registration is therefore idempotent and
-	// self-repairing: if one of the two AddParticipant calls fails transiently,
-	// the next message in the same DM retries it. Do not "fix" the swallowed
-	// error by returning it — that would make participant failure kill delivery,
-	// which is exactly backwards.
+	// This registration runs on EVERY resolve, not only on first create.
+	// EnsureParticipant is insert-if-absent: if the row already exists (active
+	// or soft-removed), it is left untouched — including left_at. This prevents
+	// resolve-driven calls from silently overwriting a user's listing preference
+	// (B6 un-leaving fix).
+	//
+	// Registration is self-repairing: if one of the two EnsureParticipant calls
+	// fails transiently, the next message in the same DM retries it.
 	//
 	// Race note: concurrent ResolveOrCreateDMConversation calls may both
-	// attempt AddParticipant. This is benign: AddParticipant's immutability
-	// guard reads Kind and ExternalRef, which are immutable for a conversation's
-	// lifetime (set at creation, never updated by UpsertConversationByExternalRef).
-	// Worst case is ErrAlreadyExists, which is swallowed below.
+	// attempt EnsureParticipant. This is benign: EnsureParticipant is
+	// idempotent and race-safe (unique constraint violations are mapped to nil).
 	for _, pp := range []struct{ kind, id string }{
 		{senderKind, senderID},
 		{recipientKind, recipientID},
 	} {
-		addErr := pa.AddParticipant(ctx, &store.ConversationParticipant{
+		ensureErr := pe.EnsureParticipant(ctx, &store.ConversationParticipant{
 			ConversationID: result.ID,
 			PrincipalKind:  pp.kind,
 			PrincipalID:    pp.id,
 			Role:           "member",
 		})
-		if addErr != nil && !errors.Is(addErr, store.ErrAlreadyExists) {
+		if ensureErr != nil {
 			log.Warn("participant registration failed (listing gap, not access)",
 				"conversation_id", result.ID,
 				"principal_kind", pp.kind,
 				"principal_id", pp.id,
-				"error", addErr)
+				"error", ensureErr)
 		}
 	}
 

--- a/pkg/messaging/conversation_test.go
+++ b/pkg/messaging/conversation_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
-// mockConversationUpserter is a test double for ConversationUpserter and
-// ParticipantAdder.
+// mockConversationUpserter is a test double for ConversationUpserter,
+// ParticipantAdder, and ParticipantEnsurer.
 type mockConversationUpserter struct {
 	// lastConv captures the most recent conversation passed to Upsert.
 	lastConv *store.Conversation
@@ -38,6 +38,10 @@ type mockConversationUpserter struct {
 	participants []store.ConversationParticipant
 	// addPartErr is the injected error for AddParticipant.
 	addPartErr error
+	// ensuredParticipants captures EnsureParticipant calls (tracked separately).
+	ensuredParticipants []store.ConversationParticipant
+	// ensurePartErr is the injected error for EnsureParticipant.
+	ensurePartErr error
 }
 
 func (m *mockConversationUpserter) UpsertConversationByExternalRef(
@@ -61,6 +65,14 @@ func (m *mockConversationUpserter) AddParticipant(_ context.Context, p *store.Co
 		return m.addPartErr
 	}
 	m.participants = append(m.participants, *p)
+	return nil
+}
+
+func (m *mockConversationUpserter) EnsureParticipant(_ context.Context, p *store.ConversationParticipant) error {
+	if m.ensurePartErr != nil {
+		return m.ensurePartErr
+	}
+	m.ensuredParticipants = append(m.ensuredParticipants, *p)
 	return nil
 }
 
@@ -242,33 +254,33 @@ func TestResolveOrCreateDMConversation_RegistersBothParticipants(t *testing.T) {
 	if got == nil {
 		t.Fatal("expected non-nil result")
 	}
-	if len(mock.participants) != 2 {
-		t.Fatalf("expected 2 participants, got %d", len(mock.participants))
+	if len(mock.ensuredParticipants) != 2 {
+		t.Fatalf("expected 2 ensured participants, got %d", len(mock.ensuredParticipants))
 	}
 	// Sender is registered first.
-	if mock.participants[0].PrincipalKind != "agent" || mock.participants[0].PrincipalID != "6ba7b810-9dad-11d1-80b4-00c04fd430c8" {
-		t.Errorf("unexpected sender participant: %+v", mock.participants[0])
+	if mock.ensuredParticipants[0].PrincipalKind != "agent" || mock.ensuredParticipants[0].PrincipalID != "6ba7b810-9dad-11d1-80b4-00c04fd430c8" {
+		t.Errorf("unexpected sender participant: %+v", mock.ensuredParticipants[0])
 	}
-	if mock.participants[0].Role != "member" {
-		t.Errorf("expected role 'member', got %q", mock.participants[0].Role)
+	if mock.ensuredParticipants[0].Role != "member" {
+		t.Errorf("expected role 'member', got %q", mock.ensuredParticipants[0].Role)
 	}
 	// Recipient is registered second.
-	if mock.participants[1].PrincipalKind != "user" || mock.participants[1].PrincipalID != "550e8400-e29b-41d4-a716-446655440000" {
-		t.Errorf("unexpected recipient participant: %+v", mock.participants[1])
+	if mock.ensuredParticipants[1].PrincipalKind != "user" || mock.ensuredParticipants[1].PrincipalID != "550e8400-e29b-41d4-a716-446655440000" {
+		t.Errorf("unexpected recipient participant: %+v", mock.ensuredParticipants[1])
 	}
-	if mock.participants[1].Role != "member" {
-		t.Errorf("expected role 'member', got %q", mock.participants[1].Role)
+	if mock.ensuredParticipants[1].Role != "member" {
+		t.Errorf("expected role 'member', got %q", mock.ensuredParticipants[1].Role)
 	}
 	// Both point at the same conversation.
-	if mock.participants[0].ConversationID != "conv-part-test" || mock.participants[1].ConversationID != "conv-part-test" {
+	if mock.ensuredParticipants[0].ConversationID != "conv-part-test" || mock.ensuredParticipants[1].ConversationID != "conv-part-test" {
 		t.Error("participant conversation IDs should match the resolved conversation")
 	}
 }
 
 func TestResolveOrCreateDMConversation_ParticipantErrorIsNonFatal(t *testing.T) {
 	mock := &mockConversationUpserter{
-		returnConv: &store.Conversation{ID: "conv-err", ExternalRef: "dm:agent:6ba7b810-9dad-11d1-80b4-00c04fd430c8:user:550e8400-e29b-41d4-a716-446655440000"},
-		addPartErr: errors.New("db error"),
+		returnConv:    &store.Conversation{ID: "conv-err", ExternalRef: "dm:agent:6ba7b810-9dad-11d1-80b4-00c04fd430c8:user:550e8400-e29b-41d4-a716-446655440000"},
+		ensurePartErr: errors.New("db error"),
 	}
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
@@ -303,14 +315,14 @@ func TestResolveOrCreateDMConversation_ThirdPartyGuardDocumented(t *testing.T) {
 		"agent", "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
 		"user", "550e8400-e29b-41d4-a716-446655440000")
 
-	if len(mock.participants) != 2 {
-		t.Fatalf("expected exactly 2 participants from ResolveOrCreateDMConversation, got %d", len(mock.participants))
+	if len(mock.ensuredParticipants) != 2 {
+		t.Fatalf("expected exactly 2 ensured participants from ResolveOrCreateDMConversation, got %d", len(mock.ensuredParticipants))
 	}
 
 	// Verify the two principals match the key inputs.
 	kinds := map[string]string{
-		mock.participants[0].PrincipalID: mock.participants[0].PrincipalKind,
-		mock.participants[1].PrincipalID: mock.participants[1].PrincipalKind,
+		mock.ensuredParticipants[0].PrincipalID: mock.ensuredParticipants[0].PrincipalKind,
+		mock.ensuredParticipants[1].PrincipalID: mock.ensuredParticipants[1].PrincipalKind,
 	}
 	if kinds["6ba7b810-9dad-11d1-80b4-00c04fd430c8"] != "agent" {
 		t.Error("expected agent participant")
@@ -320,13 +332,12 @@ func TestResolveOrCreateDMConversation_ThirdPartyGuardDocumented(t *testing.T) {
 	}
 }
 
-func TestResolveOrCreateDMConversation_AlreadyExistsSwallowed(t *testing.T) {
-	// When AddParticipant returns ErrAlreadyExists (upsert found an existing
-	// conversation whose participants are already registered), the function
-	// must succeed silently — no warning log.
+func TestResolveOrCreateDMConversation_IdempotentEnsure(t *testing.T) {
+	// EnsureParticipant returns nil for already-existing rows (no
+	// ErrAlreadyExists to swallow). The function must succeed silently.
 	mock := &mockConversationUpserter{
 		returnConv: &store.Conversation{ID: "conv-idem", ExternalRef: "dm:agent:6ba7b810-9dad-11d1-80b4-00c04fd430c8:user:550e8400-e29b-41d4-a716-446655440000"},
-		addPartErr: store.ErrAlreadyExists,
+		// ensurePartErr is nil — simulating the "row already exists" case.
 	}
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
@@ -335,14 +346,14 @@ func TestResolveOrCreateDMConversation_AlreadyExistsSwallowed(t *testing.T) {
 		"agent", "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
 		"user", "550e8400-e29b-41d4-a716-446655440000")
 	if got == nil {
-		t.Fatal("expected non-nil result when AddParticipant returns ErrAlreadyExists")
+		t.Fatal("expected non-nil result when EnsureParticipant returns nil")
 	}
 	if got.ConversationID != "conv-idem" {
 		t.Errorf("expected conv-idem, got %q", got.ConversationID)
 	}
 	output := buf.String()
 	if strings.Contains(output, "participant registration failed") {
-		t.Errorf("ErrAlreadyExists should be swallowed silently, but got warning log: %s", output)
+		t.Errorf("nil return from EnsureParticipant should produce no warning log, got: %s", output)
 	}
 }
 
@@ -552,6 +563,43 @@ func TestResolveOrCreateThreadConversation_DMKeyRefusalLogsDistinctly(t *testing
 	}
 	if strings.Contains(output, "thread conversation resolution failed") {
 		t.Errorf("refusal log should NOT contain the old resolution-failed text, got: %s", output)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// B7 nil-pe guard test
+// ---------------------------------------------------------------------------
+
+func TestResolveOrCreateDMConversation_NilParticipantEnsurer(t *testing.T) {
+	// B7: a nil ParticipantEnsurer must not panic. The function advertises
+	// non-fatal semantics for participant registration, and a nil pe that
+	// panics violates that contract. Assert: returns non-nil ConversationResult
+	// AND no panic.
+	mock := &mockConversationUpserter{
+		returnConv: &store.Conversation{
+			ID:          "conv-nil-pe",
+			ExternalRef: "dm:agent:6ba7b810-9dad-11d1-80b4-00c04fd430c8:user:550e8400-e29b-41d4-a716-446655440000",
+		},
+	}
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Pass nil as pe — must not panic.
+	got := ResolveOrCreateDMConversation(context.Background(), mock, nil, logger,
+		"agent", "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+		"user", "550e8400-e29b-41d4-a716-446655440000")
+	if got == nil {
+		t.Fatal("expected non-nil ConversationResult with nil pe — conversation itself resolved")
+	}
+	if got.ConversationID != "conv-nil-pe" {
+		t.Errorf("expected ConversationID conv-nil-pe, got %q", got.ConversationID)
+	}
+	if got.ExternalRef != "dm:agent:6ba7b810-9dad-11d1-80b4-00c04fd430c8:user:550e8400-e29b-41d4-a716-446655440000" {
+		t.Errorf("expected ExternalRef from mock, got %q", got.ExternalRef)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "nil ParticipantEnsurer") {
+		t.Errorf("expected warning log about nil ParticipantEnsurer, got: %s", output)
 	}
 }
 

--- a/pkg/messaging/resolve_test.go
+++ b/pkg/messaging/resolve_test.go
@@ -135,6 +135,17 @@ func (m *mockResolutionStore) AddParticipant(_ context.Context, p *store.Convers
 	return nil
 }
 
+func (m *mockResolutionStore) EnsureParticipant(_ context.Context, p *store.ConversationParticipant) error {
+	// If any row exists, leave it untouched.
+	for _, existing := range m.participants[p.ConversationID] {
+		if existing.PrincipalKind == p.PrincipalKind && existing.PrincipalID == p.PrincipalID {
+			return nil
+		}
+	}
+	m.participants[p.ConversationID] = append(m.participants[p.ConversationID], *p)
+	return nil
+}
+
 func (m *mockResolutionStore) ListParticipants(_ context.Context, conversationID string) ([]store.ConversationParticipant, error) {
 	return m.participants[conversationID], nil
 }

--- a/pkg/store/entadapter/conversation_store.go
+++ b/pkg/store/entadapter/conversation_store.go
@@ -663,6 +663,10 @@ func (s *ConversationStore) EnsureParticipant(ctx context.Context, p *store.Conv
 	}
 	if existing != nil {
 		// Row exists — leave it untouched (including left_at).
+		// Read back ID and JoinedAt so the caller's struct matches
+		// AddParticipant's post-condition on both paths.
+		p.ID = existing.ID.String()
+		p.JoinedAt = existing.JoinedAt
 		return nil
 	}
 

--- a/pkg/store/entadapter/conversation_store.go
+++ b/pkg/store/entadapter/conversation_store.go
@@ -516,6 +516,27 @@ func isUniqueConstraintError(err error) bool {
 // Participant operations
 // ---------------------------------------------------------------------------
 
+// checkDMParticipantKey is the shared immutability guard for direct
+// conversations. Only principals named in the kind-encoded DM key may be
+// added or ensured. Both AddParticipant and EnsureParticipant route through
+// this predicate so the guard cannot diverge across call sites.
+//
+// For non-direct conversations the function is a no-op (returns nil).
+func checkDMParticipantKey(conv *ent.Conversation, principalKind, principalID string) error {
+	if string(conv.Kind) != "direct" {
+		return nil
+	}
+	kindA, idA, kindB, idB, parseErr := messages.ParseDMKey(conv.ExternalRef)
+	if parseErr != nil {
+		return fmt.Errorf("direct conversation has unparseable external_ref: %w", store.ErrInvalidInput)
+	}
+	if (principalKind != kindA || principalID != idA) &&
+		(principalKind != kindB || principalID != idB) {
+		return fmt.Errorf("participant (%s, %s) not named in direct conversation key: %w", principalKind, principalID, store.ErrInvalidInput)
+	}
+	return nil
+}
+
 // AddParticipant adds a principal to a conversation.
 // If a soft-removed participant with the same (conversation_id, principal_kind,
 // principal_id) exists (left_at IS NOT NULL), the row is re-activated instead
@@ -538,15 +559,8 @@ func (s *ConversationStore) AddParticipant(ctx context.Context, p *store.Convers
 	if err != nil {
 		return fmt.Errorf("loading conversation for participant guard: %w", err)
 	}
-	if string(conv.Kind) == "direct" {
-		kindA, idA, kindB, idB, parseErr := messages.ParseDMKey(conv.ExternalRef)
-		if parseErr != nil {
-			return fmt.Errorf("direct conversation has unparseable external_ref: %w", store.ErrInvalidInput)
-		}
-		if (p.PrincipalKind != kindA || p.PrincipalID != idA) &&
-			(p.PrincipalKind != kindB || p.PrincipalID != idB) {
-			return fmt.Errorf("participant (%s, %s) not named in direct conversation key: %w", p.PrincipalKind, p.PrincipalID, store.ErrInvalidInput)
-		}
+	if err := checkDMParticipantKey(conv, p.PrincipalKind, p.PrincipalID); err != nil {
+		return err
 	}
 
 	// Check for a soft-removed participant that can be re-joined.
@@ -603,6 +617,83 @@ func (s *ConversationStore) AddParticipant(ctx context.Context, p *store.Convers
 
 	created, err := create.Save(ctx)
 	if err != nil {
+		return mapError(err)
+	}
+	p.ID = created.ID.String()
+	p.JoinedAt = created.JoinedAt
+	return nil
+}
+
+// EnsureParticipant ensures a participant row exists for the given principal.
+// If the participant already exists (active or soft-removed), the row is left
+// completely untouched — including left_at. Unlike AddParticipant, this does
+// NOT clear left_at on existing rows.
+//
+// Semantics: after a successful call the participant row exists. Already-existing
+// rows (whether active or soft-removed) are not modified and return nil, not an
+// error. A race-induced unique-constraint violation on insert also returns nil.
+func (s *ConversationStore) EnsureParticipant(ctx context.Context, p *store.ConversationParticipant) error {
+	if p.ConversationID == "" || p.PrincipalID == "" {
+		return fmt.Errorf("conversationID and principalID are required: %w", store.ErrInvalidInput)
+	}
+	convUID, err := parseUUID(p.ConversationID)
+	if err != nil {
+		return err
+	}
+
+	// D-1 guard: shared predicate with AddParticipant.
+	conv, err := s.client.Conversation.Get(ctx, convUID)
+	if err != nil {
+		return fmt.Errorf("loading conversation for participant guard: %w", err)
+	}
+	if err := checkDMParticipantKey(conv, p.PrincipalKind, p.PrincipalID); err != nil {
+		return err
+	}
+
+	// Check for ANY existing row (active or soft-removed).
+	existing, err := s.client.ConversationParticipant.Query().
+		Where(
+			conversationparticipant.ConversationIDEQ(convUID),
+			conversationparticipant.PrincipalKindEQ(conversationparticipant.PrincipalKind(p.PrincipalKind)),
+			conversationparticipant.PrincipalIDEQ(p.PrincipalID),
+		).
+		Only(ctx)
+	if err != nil && !ent.IsNotFound(err) {
+		return err
+	}
+	if existing != nil {
+		// Row exists — leave it untouched (including left_at).
+		return nil
+	}
+
+	// No row exists — create it.
+	create := s.client.ConversationParticipant.Create().
+		SetConversationID(convUID).
+		SetPrincipalKind(conversationparticipant.PrincipalKind(p.PrincipalKind)).
+		SetPrincipalID(p.PrincipalID).
+		SetRole(conversationparticipant.Role(p.Role))
+
+	if p.ID != "" {
+		uid, pErr := parseUUID(p.ID)
+		if pErr != nil {
+			return pErr
+		}
+		create.SetID(uid)
+	}
+	if !p.JoinedAt.IsZero() {
+		create.SetJoinedAt(p.JoinedAt)
+	}
+	if p.Role == "" {
+		create.SetRole(conversationparticipant.RoleMember)
+	}
+
+	created, err := create.Save(ctx)
+	if err != nil {
+		// Race-safe: a concurrent insert may have created the row between
+		// our query and this insert. Treat that as success.
+		if isUniqueConstraintError(err) {
+			return nil
+		}
 		return mapError(err)
 	}
 	p.ID = created.ID.String()

--- a/pkg/store/entadapter/conversation_store_test.go
+++ b/pkg/store/entadapter/conversation_store_test.go
@@ -1509,3 +1509,67 @@ func TestEnsureParticipant_DM_ThirdPartyRejection(t *testing.T) {
 	assert.Contains(t, addErr.Error(), "not named in direct conversation key")
 	assert.Contains(t, ensureErr.Error(), "not named in direct conversation key")
 }
+
+// TestEnsureParticipant_PopulatesCallerStruct verifies that EnsureParticipant
+// populates p.ID and p.JoinedAt from the existing row, matching AddParticipant's
+// post-condition. This is a READ-BACK, not a write — the DB row is untouched.
+func TestEnsureParticipant_PopulatesCallerStruct(t *testing.T) {
+	s := newTestConversationStore(t)
+	ctx := context.Background()
+
+	userA := uuid.NewString()
+	userB := uuid.NewString()
+
+	conv := newTestDMConversation("user", userA, "user", userB)
+	require.NoError(t, s.CreateConversation(ctx, conv))
+
+	// Add userB via AddParticipant, then soft-remove.
+	addP := &store.ConversationParticipant{
+		ConversationID: conv.ID, PrincipalKind: "user", PrincipalID: userB, Role: "member",
+	}
+	require.NoError(t, s.AddParticipant(ctx, addP))
+	require.NoError(t, s.RemoveParticipant(ctx, conv.ID, "user", userB))
+
+	// Record DB state for the soft-removed row.
+	convUID, err := parseUUID(conv.ID)
+	require.NoError(t, err)
+	dbRow, err := s.client.ConversationParticipant.Query().
+		Where(
+			conversationparticipant.ConversationIDEQ(convUID),
+			conversationparticipant.PrincipalIDEQ(userB),
+		).
+		Only(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, dbRow.LeftAt, "precondition: left_at must be set")
+	originalLeftAt := *dbRow.LeftAt
+
+	// Call EnsureParticipant with a fresh struct (zero ID, zero JoinedAt).
+	ensureP := &store.ConversationParticipant{
+		ConversationID: conv.ID, PrincipalKind: "user", PrincipalID: userB, Role: "member",
+	}
+	require.Empty(t, ensureP.ID, "precondition: p.ID must be zero before call")
+	require.True(t, ensureP.JoinedAt.IsZero(), "precondition: p.JoinedAt must be zero before call")
+
+	// (a) returns nil
+	err = s.EnsureParticipant(ctx, ensureP)
+	require.NoError(t, err)
+
+	// (b) left_at unchanged in DB
+	afterRow, err := s.client.ConversationParticipant.Query().
+		Where(
+			conversationparticipant.ConversationIDEQ(convUID),
+			conversationparticipant.PrincipalIDEQ(userB),
+		).
+		Only(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, afterRow.LeftAt, "left_at must remain set")
+	assert.True(t, originalLeftAt.Equal(*afterRow.LeftAt),
+		"left_at must be unchanged: original=%v, after=%v", originalLeftAt, *afterRow.LeftAt)
+
+	// (c) p.ID and p.JoinedAt now match the existing row
+	assert.Equal(t, dbRow.ID.String(), ensureP.ID,
+		"p.ID must be populated from existing row")
+	assert.True(t, dbRow.JoinedAt.Equal(ensureP.JoinedAt),
+		"p.JoinedAt must be populated from existing row: expected=%v, got=%v",
+		dbRow.JoinedAt, ensureP.JoinedAt)
+}

--- a/pkg/store/entadapter/conversation_store_test.go
+++ b/pkg/store/entadapter/conversation_store_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/ent/conversation"
+	"github.com/GoogleCloudPlatform/scion/pkg/ent/conversationparticipant"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/GoogleCloudPlatform/scion/pkg/store/enttest"
@@ -1317,4 +1318,194 @@ func TestAddParticipant_DM_ReAddAfterSoftRemove(t *testing.T) {
 	// Rule 14: Assert non-zero floor — at least 2 participants examined.
 	require.GreaterOrEqual(t, len(participants), 2,
 		"floor violation: expected at least 2 participants")
+}
+
+// ---------------------------------------------------------------------------
+// EnsureParticipant tests (B6, B9 fixes)
+// ---------------------------------------------------------------------------
+
+// TestEnsureParticipant_InsertIfAbsent verifies that EnsureParticipant creates
+// a new participant row when none exists, and is idempotent on repeat calls.
+func TestEnsureParticipant_InsertIfAbsent(t *testing.T) {
+	s := newTestConversationStore(t)
+	ctx := context.Background()
+
+	userA := uuid.NewString()
+	userB := uuid.NewString()
+
+	conv := newTestDMConversation("user", userA, "user", userB)
+	require.NoError(t, s.CreateConversation(ctx, conv))
+
+	// Ensure participant A — no prior row.
+	err := s.EnsureParticipant(ctx, &store.ConversationParticipant{
+		ConversationID: conv.ID, PrincipalKind: "user", PrincipalID: userA, Role: "member",
+	})
+	require.NoError(t, err)
+
+	// Verify participant was created.
+	participants, err := s.ListParticipants(ctx, conv.ID)
+	require.NoError(t, err)
+	require.Len(t, participants, 1)
+	assert.Equal(t, userA, participants[0].PrincipalID)
+
+	// Call EnsureParticipant again — must be idempotent (no error).
+	err = s.EnsureParticipant(ctx, &store.ConversationParticipant{
+		ConversationID: conv.ID, PrincipalKind: "user", PrincipalID: userA, Role: "member",
+	})
+	require.NoError(t, err, "second EnsureParticipant call must be idempotent")
+
+	// Still exactly one active participant.
+	participants, err = s.ListParticipants(ctx, conv.ID)
+	require.NoError(t, err)
+	assert.Len(t, participants, 1)
+}
+
+// TestEnsureParticipant_DoesNotClearLeftAt (B6) verifies that EnsureParticipant
+// on a soft-removed row leaves left_at UNCHANGED — pinning the exact timestamp.
+func TestEnsureParticipant_DoesNotClearLeftAt(t *testing.T) {
+	s := newTestConversationStore(t)
+	ctx := context.Background()
+
+	userA := uuid.NewString()
+	userB := uuid.NewString()
+
+	conv := newTestDMConversation("user", userA, "user", userB)
+	require.NoError(t, s.CreateConversation(ctx, conv))
+
+	// Add both participants via AddParticipant.
+	require.NoError(t, s.AddParticipant(ctx, &store.ConversationParticipant{
+		ConversationID: conv.ID, PrincipalKind: "user", PrincipalID: userA, Role: "member",
+	}))
+	require.NoError(t, s.AddParticipant(ctx, &store.ConversationParticipant{
+		ConversationID: conv.ID, PrincipalKind: "user", PrincipalID: userB, Role: "member",
+	}))
+
+	// Soft-remove userB.
+	require.NoError(t, s.RemoveParticipant(ctx, conv.ID, "user", userB))
+
+	// Record the exact left_at timestamp.
+	convUID, err := parseUUID(conv.ID)
+	require.NoError(t, err)
+	softRemoved, err := s.client.ConversationParticipant.Query().
+		Where(
+			conversationparticipant.ConversationIDEQ(convUID),
+			conversationparticipant.PrincipalIDEQ(userB),
+		).
+		Only(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, softRemoved.LeftAt, "left_at must be set after RemoveParticipant")
+	originalLeftAt := *softRemoved.LeftAt
+
+	// Call EnsureParticipant for the soft-removed participant.
+	err = s.EnsureParticipant(ctx, &store.ConversationParticipant{
+		ConversationID: conv.ID, PrincipalKind: "user", PrincipalID: userB, Role: "member",
+	})
+	require.NoError(t, err)
+
+	// Assert left_at is UNCHANGED — pin the exact timestamp.
+	afterEnsure, err := s.client.ConversationParticipant.Query().
+		Where(
+			conversationparticipant.ConversationIDEQ(convUID),
+			conversationparticipant.PrincipalIDEQ(userB),
+		).
+		Only(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, afterEnsure.LeftAt, "left_at must still be set after EnsureParticipant")
+	assert.True(t, originalLeftAt.Equal(*afterEnsure.LeftAt),
+		"left_at must be unchanged: original=%v, after=%v", originalLeftAt, *afterEnsure.LeftAt)
+}
+
+// TestEnsureParticipant_ResolveAfterLeave (B6) is the full scenario test:
+// create DM, add both participants, soft-remove one, then call EnsureParticipant.
+// The left_at timestamp must be preserved exactly.
+func TestEnsureParticipant_ResolveAfterLeave(t *testing.T) {
+	s := newTestConversationStore(t)
+	ctx := context.Background()
+
+	userA := uuid.NewString()
+	userB := uuid.NewString()
+
+	conv := newTestDMConversation("user", userA, "user", userB)
+	require.NoError(t, s.CreateConversation(ctx, conv))
+
+	// Add both participants.
+	require.NoError(t, s.AddParticipant(ctx, &store.ConversationParticipant{
+		ConversationID: conv.ID, PrincipalKind: "user", PrincipalID: userA, Role: "member",
+	}))
+	require.NoError(t, s.AddParticipant(ctx, &store.ConversationParticipant{
+		ConversationID: conv.ID, PrincipalKind: "user", PrincipalID: userB, Role: "member",
+	}))
+
+	// Soft-remove userB (user "leaves" / hides the DM).
+	require.NoError(t, s.RemoveParticipant(ctx, conv.ID, "user", userB))
+
+	// Record exact left_at.
+	convUID, err := parseUUID(conv.ID)
+	require.NoError(t, err)
+	before, err := s.client.ConversationParticipant.Query().
+		Where(
+			conversationparticipant.ConversationIDEQ(convUID),
+			conversationparticipant.PrincipalIDEQ(userB),
+		).
+		Only(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, before.LeftAt)
+	pinnedLeftAt := *before.LeftAt
+
+	// Simulate resolve-driven EnsureParticipant (what ResolveOrCreateDMConversation does).
+	err = s.EnsureParticipant(ctx, &store.ConversationParticipant{
+		ConversationID: conv.ID, PrincipalKind: "user", PrincipalID: userB, Role: "member",
+	})
+	require.NoError(t, err)
+
+	// Assert left_at is unchanged.
+	after, err := s.client.ConversationParticipant.Query().
+		Where(
+			conversationparticipant.ConversationIDEQ(convUID),
+			conversationparticipant.PrincipalIDEQ(userB),
+		).
+		Only(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, after.LeftAt, "left_at must remain set after EnsureParticipant")
+	assert.True(t, pinnedLeftAt.Equal(*after.LeftAt),
+		"left_at must be exactly preserved: pinned=%v, actual=%v", pinnedLeftAt, *after.LeftAt)
+
+	// userB should NOT appear in active participant list (left_at is still set).
+	activeParticipants, err := s.ListParticipants(ctx, conv.ID)
+	require.NoError(t, err)
+	assert.Len(t, activeParticipants, 1, "only userA should be active")
+	assert.Equal(t, userA, activeParticipants[0].PrincipalID)
+}
+
+// TestEnsureParticipant_DM_ThirdPartyRejection verifies that the D-1 guard
+// shared predicate rejects third parties via EnsureParticipant, same as
+// AddParticipant. Testing BOTH methods proves the guard cannot diverge.
+func TestEnsureParticipant_DM_ThirdPartyRejection(t *testing.T) {
+	s := newTestConversationStore(t)
+	ctx := context.Background()
+
+	userA := uuid.NewString()
+	userB := uuid.NewString()
+	userC := uuid.NewString() // intruder — NOT named in key
+
+	conv := newTestDMConversation("user", userA, "user", userB)
+	require.NoError(t, s.CreateConversation(ctx, conv))
+
+	// AddParticipant rejects third party.
+	addErr := s.AddParticipant(ctx, &store.ConversationParticipant{
+		ConversationID: conv.ID, PrincipalKind: "user", PrincipalID: userC, Role: "member",
+	})
+	require.Error(t, addErr, "AddParticipant must reject third party")
+	assert.ErrorIs(t, addErr, store.ErrInvalidInput)
+
+	// EnsureParticipant rejects the same third party.
+	ensureErr := s.EnsureParticipant(ctx, &store.ConversationParticipant{
+		ConversationID: conv.ID, PrincipalKind: "user", PrincipalID: userC, Role: "member",
+	})
+	require.Error(t, ensureErr, "EnsureParticipant must reject third party")
+	assert.ErrorIs(t, ensureErr, store.ErrInvalidInput)
+
+	// Both errors should contain the same diagnostic message pattern.
+	assert.Contains(t, addErr.Error(), "not named in direct conversation key")
+	assert.Contains(t, ensureErr.Error(), "not named in direct conversation key")
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1638,6 +1638,11 @@ type ConversationStore interface {
 	// Returns ErrAlreadyExists if the participant already exists.
 	AddParticipant(ctx context.Context, p *ConversationParticipant) error
 
+	// EnsureParticipant ensures a participant row exists. If the participant
+	// already exists (active or soft-removed), the row is left untouched.
+	// Unlike AddParticipant, this does not clear left_at on existing rows.
+	EnsureParticipant(ctx context.Context, p *ConversationParticipant) error
+
 	// RemoveParticipant soft-removes a participant by setting LeftAt.
 	// Returns ErrNotFound if the participant doesn't exist.
 	RemoveParticipant(ctx context.Context, conversationID, principalKind, principalID string) error


### PR DESCRIPTION
Three coupled fixes to DM participant registration.

B6+B9 (one commit, one owner): registration ran on every resolve and cleared left_at, so leaving a DM was undone by the next message. Fixed by splitting intent rather than changing shared behaviour: AddParticipant keeps ClearLeftAt as the explicit re-join path; a new EnsureParticipant does insert-if-absent and leaves existing rows untouched including left_at. B9 self-repair survives, B6 is fixed, neither re-opens the other.

D-1 guard extracted: checkDMParticipantKey is now a single shared predicate. AddParticipant and EnsureParticipant both route through it, so the DM immutability guard cannot diverge across ingresses. Parse failure denies.

B7: nil ParticipantEnsurer no longer panics in an eventbus goroutine.

Verified by mutation, all killed against a clean baseline:
- nil-pe guard removed -> test panics, caught
- EnsureParticipant revives left_at -> 3 tests fail
- guard disabled in EnsureParticipant only -> caught
- guard disabled in AddParticipant only -> 4 tests fail

The last one proves the extraction is genuinely shared, not two copies.

Gates: gofmt, authz-guards, compat-literals, conversation-upsert-guard, build, test-fast all clean.

One test deleted (AlreadyExistsSwallowed); rationale and residual are in the commit message