### PR TITLE
fix(hub): tranche B - conversation stamping, publish guards, AST enumeration

### DIFF
--- a/pkg/hub/create_message_enumeration_test.go
+++ b/pkg/hub/create_message_enumeration_test.go
@@ -69,6 +69,9 @@ func TestCreateMessageEnumeration(t *testing.T) {
 
 		// messagebroker deliverToAgent: broker-delivered agent messages.
 		"messagebroker.go:deliverToAgent": "Phase 5 dual-write: broker-delivered agent message",
+
+		// createInboxMessage: agent → user inbox notification (e.g. WAITING_FOR_INPUT).
+		"notifications.go:createInboxMessage": "Phase 5 dual-write: agent→user inbox notification DM conversation",
 	}
 
 	// -------------------------------------------------------------------
@@ -78,12 +81,7 @@ func TestCreateMessageEnumeration(t *testing.T) {
 		// broadcastDirect: Broadcast messages are ephemeral fan-outs.
 		// Both broker paths also skip conversation resolution for broadcasts.
 		// No conversation ownership applies.
-		"handlers_agent_messaging.go:broadcastDirect": "Broadcast messages are ephemeral; no conversation ownership",
-
-		// createInboxMessage: System notification creating a synthetic inbox
-		// message (e.g. WAITING_FOR_INPUT). Not a real conversation participant
-		// message; it is a one-way notification.
-		"notifications.go:createInboxMessage": "System notification; synthetic inbox message, not a conversation participant message",
+		"handlers_agent_messaging.go:broadcastDirect": "Deferred pending group-conversation model; broadcast is one-to-many with no two-party key to derive",
 	}
 
 	// Build combined set for lookup.

--- a/pkg/hub/create_message_enumeration_test.go
+++ b/pkg/hub/create_message_enumeration_test.go
@@ -1,0 +1,324 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCreateMessageEnumeration uses go/ast to find every CreateMessage call
+// site in non-test .go files under pkg/hub. Each site must appear in either
+// the "stamped" set (verified to set ConversationID) or the "exempt" set
+// (intentionally omits ConversationID, with a documented reason). Any
+// unaccounted site causes a hard failure — this is the durable guard that
+// prevents a new CreateMessage from silently missing conversation stamping
+// when the S4 read-switch activates.
+func TestCreateMessageEnumeration(t *testing.T) {
+	// -------------------------------------------------------------------
+	// Stamped sites: each of these sets ConversationID before calling
+	// CreateMessage.
+	// -------------------------------------------------------------------
+	stamped := map[string]string{
+		// handleAgentOutboundMessage: agent → user outbound message.
+		"handlers_agent_messaging.go:handleAgentOutboundMessage": "Phase 5 dual-write: agent outbound DM or thread conversation",
+
+		// handleAgentMessage direct-persist path: user/agent → agent.
+		"handlers_agent_messaging.go:handleAgentMessage": "Phase 5 dual-write: user/agent → agent (authenticated sender)",
+
+		// handleGroupMessage agent fan-out: authenticated sender → agent.
+		"handlers_agent_messaging.go:handleGroupMessage:agent": "Phase 5 dual-write: group set message to agent",
+
+		// handleGroupMessage user fan-out: authenticated sender → user.
+		"handlers_agent_messaging.go:handleGroupMessage:user": "Phase 5 dual-write: group set message to user",
+
+		// processMentions: agent mention dispatch (B15).
+		"handlers_agent_messaging.go:processMentions": "B15 dual-write: agent mention dispatch conversation stamping",
+
+		// handleBrokerInbound: external channel inbound (B15).
+		"handlers_broker_inbound.go:handleBrokerInbound": "B15 dual-write: broker inbound conversation stamping",
+
+		// sendAgentRouted primary: web chat user → agent.
+		"handlers_chat_v2.go:sendAgentRouted:primary": "B15 dual-write: web chat user→agent primary message",
+
+		// sendAgentRouted mention fan-out: web chat user → mentioned agent.
+		"handlers_chat_v2.go:sendAgentRouted:mention": "B15 dual-write: web chat mention fan-out",
+
+		// sendHumanToHuman: web chat user → user DM or thread.
+		"handlers_chat_v2.go:sendHumanToHuman": "B15 dual-write: human-to-human DM/thread conversation stamping",
+
+		// messagebroker deliverToUser: broker-delivered user messages.
+		"messagebroker.go:deliverToUser": "Phase 5 dual-write: broker-delivered user message",
+
+		// messagebroker deliverToAgent: broker-delivered agent messages.
+		"messagebroker.go:deliverToAgent": "Phase 5 dual-write: broker-delivered agent message",
+	}
+
+	// -------------------------------------------------------------------
+	// Exempt sites: intentionally do NOT set ConversationID, with reasons.
+	// -------------------------------------------------------------------
+	exempt := map[string]string{
+		// broadcastDirect: Broadcast messages are ephemeral fan-outs.
+		// Both broker paths also skip conversation resolution for broadcasts.
+		// No conversation ownership applies.
+		"handlers_agent_messaging.go:broadcastDirect": "Broadcast messages are ephemeral; no conversation ownership",
+
+		// createInboxMessage: System notification creating a synthetic inbox
+		// message (e.g. WAITING_FOR_INPUT). Not a real conversation participant
+		// message; it is a one-way notification.
+		"notifications.go:createInboxMessage": "System notification; synthetic inbox message, not a conversation participant message",
+	}
+
+	// Build combined set for lookup.
+	accounted := make(map[string]bool, len(stamped)+len(exempt))
+	for k := range stamped {
+		accounted[k] = true
+	}
+	for k := range exempt {
+		accounted[k] = true
+	}
+
+	// -------------------------------------------------------------------
+	// Parse all non-test .go files under pkg/hub and find CreateMessage
+	// call sites.
+	// -------------------------------------------------------------------
+	hubDir := findHubDir(t)
+	fset := token.NewFileSet()
+
+	entries, err := os.ReadDir(hubDir)
+	if err != nil {
+		t.Fatalf("failed to read hub directory: %v", err)
+	}
+
+	type callSite struct {
+		file     string // base filename
+		line     int
+		funcName string // enclosing function name
+	}
+	var sites []callSite
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		fullPath := filepath.Join(hubDir, name)
+		f, err := parser.ParseFile(fset, fullPath, nil, 0)
+		if err != nil {
+			t.Fatalf("failed to parse %s: %v", name, err)
+		}
+
+		// Walk the AST and find every CallExpr ending in CreateMessage.
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if !isCreateMessageCall(call) {
+				return true
+			}
+			pos := fset.Position(call.Pos())
+			funcName := enclosingFuncName(fset, f, pos.Offset)
+			sites = append(sites, callSite{
+				file:     name,
+				line:     pos.Line,
+				funcName: funcName,
+			})
+			return true
+		})
+	}
+
+	if len(sites) == 0 {
+		t.Fatal("found zero CreateMessage call sites — the scanner is broken")
+	}
+
+	// -------------------------------------------------------------------
+	// Match each site to the accounted set. We match on file:enclosingFunc.
+	// When a function contains multiple CreateMessage calls, they are
+	// disambiguated by a suffix heuristic.
+	// -------------------------------------------------------------------
+
+	// Group sites by file:func to detect duplicates.
+	type groupKey struct{ file, fn string }
+	grouped := make(map[groupKey][]callSite)
+	for _, s := range sites {
+		k := groupKey{s.file, s.funcName}
+		grouped[k] = append(grouped[k], s)
+	}
+
+	// For each site, build a lookup key and check membership.
+	var unaccounted []string
+	matched := make(map[string]bool)
+
+	for gk, groupSites := range grouped {
+		if len(groupSites) == 1 {
+			key := gk.file + ":" + gk.fn
+			if accounted[key] {
+				matched[key] = true
+			} else {
+				unaccounted = append(unaccounted, key+
+					" (line "+itoa(groupSites[0].line)+")")
+			}
+		} else {
+			// Multiple CreateMessage calls in the same function.
+			// Try disambiguation using known suffix patterns.
+			for i, s := range groupSites {
+				key := gk.file + ":" + gk.fn
+				if accounted[key] && len(groupSites) == 1 {
+					matched[key] = true
+					continue
+				}
+				// Try suffixed keys.
+				found := false
+				for _, suffix := range disambiguationSuffixes(gk.file, gk.fn, i, len(groupSites)) {
+					candidate := gk.file + ":" + gk.fn + ":" + suffix
+					if accounted[candidate] {
+						matched[candidate] = true
+						found = true
+						break
+					}
+				}
+				if !found {
+					// Try bare key (for single-entry funcs that happened to be grouped).
+					if accounted[key] && !matched[key] {
+						matched[key] = true
+					} else {
+						unaccounted = append(unaccounted,
+							gk.file+":"+gk.fn+
+								" (line "+itoa(s.line)+", call #"+itoa(i+1)+")")
+					}
+				}
+			}
+		}
+	}
+
+	if len(unaccounted) > 0 {
+		t.Errorf("Found %d CreateMessage call site(s) not in stamped or exempt list:\n", len(unaccounted))
+		for _, u := range unaccounted {
+			t.Errorf("  - %s", u)
+		}
+		t.Error("\nEvery CreateMessage site must be in the stamped set (sets ConversationID) " +
+			"or the exempt set (documented reason for omission). " +
+			"Add the new site to the appropriate list in this test.")
+	}
+
+	// Verify all expected entries were actually found.
+	for key := range accounted {
+		if !matched[key] {
+			t.Errorf("Expected call site %q is listed but was not found in source. "+
+				"The function may have been renamed, moved, or deleted.", key)
+		}
+	}
+
+	t.Logf("Verified %d CreateMessage call sites: %d stamped, %d exempt",
+		len(sites), len(stamped), len(exempt))
+}
+
+// isCreateMessageCall returns true if the call expression is a call to a
+// function or method named CreateMessage.
+func isCreateMessageCall(call *ast.CallExpr) bool {
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		return fn.Sel.Name == "CreateMessage"
+	case *ast.Ident:
+		return fn.Name == "CreateMessage"
+	}
+	return false
+}
+
+// enclosingFuncName returns the name of the function or method that contains
+// the given byte offset.
+func enclosingFuncName(fset *token.FileSet, f *ast.File, offset int) string {
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		start := fset.Position(fn.Body.Pos()).Offset
+		end := fset.Position(fn.Body.End()).Offset
+		if offset >= start && offset <= end {
+			return fn.Name.Name
+		}
+	}
+	return "<unknown>"
+}
+
+// disambiguationSuffixes returns candidate suffixes for multi-call functions.
+// The mapping is hard-coded for known cases.
+func disambiguationSuffixes(file, fn string, idx, total int) []string {
+	switch {
+	case file == "handlers_chat_v2.go" && fn == "sendAgentRouted" && total == 2:
+		if idx == 0 {
+			return []string{"primary"}
+		}
+		return []string{"mention"}
+	case file == "handlers_agent_messaging.go" && fn == "handleGroupMessage" && total == 2:
+		if idx == 0 {
+			return []string{"agent"}
+		}
+		return []string{"user"}
+	case file == "messagebroker.go" && total == 2:
+		if idx == 0 {
+			return []string{"deliverToUser"}
+		}
+		return []string{"deliverToAgent"}
+	}
+	return nil
+}
+
+// findHubDir locates the pkg/hub directory relative to the test file.
+func findHubDir(t *testing.T) string {
+	t.Helper()
+	// The test runs from pkg/hub, so "." should work, but use an absolute path
+	// for robustness.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	// Verify this looks like the hub package.
+	if _, err := os.Stat(filepath.Join(wd, "server.go")); err != nil {
+		t.Fatalf("working directory %q does not look like pkg/hub (server.go not found)", wd)
+	}
+	return wd
+}
+
+// itoa is a minimal int-to-string without importing strconv.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -1569,6 +1569,21 @@ func (s *Server) processMentions(ctx context.Context, mentionSlugs []string, pri
 		if mentionMsg.Metadata != nil {
 			storeMsg.GroupID = mentionMsg.Metadata["group_id"]
 		}
+		// B15 dual-write: resolve-or-create conversation for agent mention dispatch.
+		{
+			var convResult *messaging.ConversationResult
+			if mentionMsg.ThreadID != "" {
+				convResult = messaging.ResolveOrCreateThreadConversation(ctx, s.store, s.messageLog, mentionMsg.ThreadID, primaryAgent.ProjectID)
+			} else if mentionMsg.SenderID != "" && mentionAgent.ID != "" {
+				senderKind, sOK := messages.PrincipalKindFromAddress(mentionMsg.Sender)
+				if sOK {
+					convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.store, s.messageLog, senderKind, mentionMsg.SenderID, "agent", mentionAgent.ID)
+				}
+			}
+			if convResult != nil {
+				storeMsg.ConversationID = convResult.ConversationID
+			}
+		}
 		var persisted bool
 		if createErr := s.store.CreateMessage(ctx, storeMsg); createErr != nil {
 			s.messageLog.Error("Failed to persist mention message", "slug", r.Slug, "error", createErr)

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -819,10 +819,14 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		} else {
 			persistedMsgID = storeMsg.ID
 		}
-		// Publish SSE event so connected browser clients can update the
-		// per-agent conversation view in real time — mirrors the agent→user
-		// publish path in handleAgentOutboundMessage.
-		s.events.PublishUserMessage(ctx, storeMsg)
+		// B11/B13: only publish when persistence succeeded — publishing an
+		// unpersisted message is not legal.
+		if persistedMsgID != "" {
+			// Publish SSE event so connected browser clients can update the
+			// per-agent conversation view in real time — mirrors the agent→user
+			// publish path in handleAgentOutboundMessage.
+			s.events.PublishUserMessage(ctx, storeMsg)
+		}
 	}
 
 	// Managed agent path: deliver message directly via backend, bypass broker.
@@ -851,11 +855,18 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 			managedMentionResults = s.processMentions(ctx, req.Mentions, agent, structuredMsg)
 		}
 
+		// B11/B13: reflect persistence failure in the response status.
+		// The request still succeeds (dispatch worked), but the caller
+		// should know the message was not persisted.
+		managedStatus := "delivered"
+		if persistedMsgID == "" {
+			managedStatus = "delivered_not_persisted"
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode(MessageDeliveryResponse{
 			MessageID:      persistedMsgID,
-			Status:         "delivered",
+			Status:         managedStatus,
 			Agent:          agent.Slug,
 			AgentPhase:     agent.Phase,
 			MentionResults: managedMentionResults,
@@ -932,11 +943,16 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		mentionResults = s.processMentions(ctx, req.Mentions, agent, structuredMsg)
 	}
 
+	// B11/B13: reflect persistence failure in the response status.
+	deliveryStatus := "delivered"
+	if persistedMsgID == "" {
+		deliveryStatus = "delivered_not_persisted"
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(MessageDeliveryResponse{
 		MessageID:      persistedMsgID,
-		Status:         "delivered",
+		Status:         deliveryStatus,
 		Agent:          agent.Slug,
 		AgentPhase:     agent.Phase,
 		MentionResults: mentionResults,
@@ -1060,8 +1076,10 @@ func (s *Server) handleGroupMessage(w http.ResponseWriter, r *http.Request, anch
 			})
 			if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 				s.messageLog.Error("Failed to persist set message", "recipient", recipStr, "error", err)
+			} else {
+				// B11/B13: only publish when persistence succeeded.
+				s.events.PublishUserMessage(ctx, storeMsg)
 			}
-			s.events.PublishUserMessage(ctx, storeMsg)
 
 			if dispatcher == nil {
 				results[i] = GroupMessageRecipientResult{Recipient: recipStr, Status: "failed", Error: "dispatcher not available"}
@@ -1181,8 +1199,10 @@ func (s *Server) handleGroupMessage(w http.ResponseWriter, r *http.Request, anch
 			})
 			if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 				s.messageLog.Error("Failed to persist set message", "recipient", recipStr, "error", err)
+			} else {
+				// B11/B13: only publish when persistence succeeded.
+				s.events.PublishUserMessage(ctx, storeMsg)
 			}
-			s.events.PublishUserMessage(ctx, storeMsg)
 
 			results[i] = GroupMessageRecipientResult{Recipient: recipStr, Status: "delivered"}
 			delivered++
@@ -1555,7 +1575,10 @@ func (s *Server) processMentions(ctx context.Context, mentionSlugs []string, pri
 		} else {
 			persisted = true
 		}
-		s.events.PublishUserMessage(ctx, storeMsg)
+		// B11/B13: only publish when persistence succeeded.
+		if persisted {
+			s.events.PublishUserMessage(ctx, storeMsg)
+		}
 
 		// Dispatch to the mentioned agent's runtime.
 		dispatcher := s.GetDispatcher()

--- a/pkg/hub/handlers_broker_inbound.go
+++ b/pkg/hub/handlers_broker_inbound.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/messaging"
 	"github.com/GoogleCloudPlatform/scion/pkg/projectcompat"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
@@ -264,6 +265,21 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 	if req.Message.Metadata != nil {
 		if gid, ok := req.Message.Metadata["group_id"]; ok {
 			storeMsg.GroupID = gid
+		}
+	}
+	// B15 dual-write: resolve-or-create conversation for broker inbound messages.
+	{
+		var convResult *messaging.ConversationResult
+		if req.Message.ThreadID != "" {
+			convResult = messaging.ResolveOrCreateThreadConversation(r.Context(), s.store, log, req.Message.ThreadID, agent.ProjectID)
+		} else if senderUserID != "" && agent.ID != "" {
+			senderKind, sOK := messages.PrincipalKindFromAddress(req.Message.Sender)
+			if sOK {
+				convResult = messaging.ResolveOrCreateDMConversation(r.Context(), s.store, s.store, log, senderKind, senderUserID, "agent", agent.ID)
+			}
+		}
+		if convResult != nil {
+			storeMsg.ConversationID = convResult.ConversationID
 		}
 	}
 	if err := s.store.CreateMessage(r.Context(), storeMsg); err != nil {

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -63,6 +63,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/messaging"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/google/uuid"
 )
@@ -1136,6 +1137,18 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 		DispatchState: store.MessageDispatchDispatched,
 		CreatedAt:     now,
 	}
+	// B15 dual-write: resolve-or-create conversation for web chat user→agent messages.
+	{
+		var convResult *messaging.ConversationResult
+		if key != "" {
+			convResult = messaging.ResolveOrCreateThreadConversation(ctx, s.store, s.messageLog, key, projectID)
+		} else if user.ID() != "" && primaryAgent.ID != "" {
+			convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.store, s.messageLog, "user", user.ID(), "agent", primaryAgent.ID)
+		}
+		if convResult != nil {
+			storeMsg.ConversationID = convResult.ConversationID
+		}
+	}
 	if err := s.store.CreateMessage(ctx, storeMsg); err != nil {
 		s.messageLog.Error("Failed to persist agent-routed message", "error", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to persist message", nil)
@@ -1237,6 +1250,18 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 				DispatchState: store.MessageDispatchDispatched,
 				CreatedAt:     now,
 			}
+			// B15 dual-write: resolve-or-create conversation for web chat mention fan-out.
+			{
+				var convResult *messaging.ConversationResult
+				if key != "" {
+					convResult = messaging.ResolveOrCreateThreadConversation(ctx, s.store, s.messageLog, key, projectID)
+				} else if user.ID() != "" && mentionAgent.ID != "" {
+					convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.store, s.messageLog, "user", user.ID(), "agent", mentionAgent.ID)
+				}
+				if convResult != nil {
+					mentionStoreMsg.ConversationID = convResult.ConversationID
+				}
+			}
 			if err := s.store.CreateMessage(ctx, mentionStoreMsg); err != nil {
 				s.messageLog.Error("Failed to persist mention message", "slug", mentionAgent.Slug, "error", err)
 			} else {
@@ -1328,6 +1353,18 @@ func (s *Server) sendHumanToHuman(w http.ResponseWriter, r *http.Request, key, p
 		ThreadID:      key,
 		DispatchState: store.MessageDispatchDispatched,
 		CreatedAt:     now,
+	}
+	// B15 dual-write: resolve-or-create conversation for human-to-human messages.
+	{
+		var convResult *messaging.ConversationResult
+		if key != "" {
+			convResult = messaging.ResolveOrCreateThreadConversation(ctx, s.store, s.messageLog, key, msgProjectID)
+		} else if user.ID() != "" && recipientID != "" {
+			convResult = messaging.ResolveOrCreateDMConversation(ctx, s.store, s.store, s.messageLog, "user", user.ID(), "user", recipientID)
+		}
+		if convResult != nil {
+			storeMsg.ConversationID = convResult.ConversationID
+		}
 	}
 
 	if err := s.store.CreateMessage(ctx, storeMsg); err != nil {

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -461,14 +461,12 @@ func (p *MessageBrokerProxy) deliverToUser(ctx context.Context, projectID, topic
 		var convResult *messaging.ConversationResult
 		if msg.ThreadID != "" {
 			convResult = messaging.ResolveOrCreateThreadConversation(ctx, p.store, p.log, msg.ThreadID, projectID)
-		} else if msg.SenderID != "" && msg.RecipientID != "" {
-			senderKind, sOK := messages.PrincipalKindFromAddress(msg.Sender)
-			recipientKind, rOK := messages.PrincipalKindFromAddress(msg.Recipient)
-			if sOK && rOK {
-				convResult = messaging.ResolveOrCreateDMConversation(ctx, p.store, p.store, p.log, senderKind, msg.SenderID, recipientKind, msg.RecipientID)
+		} else if msg.RecipientID != "" {
+			if recipientKind, rOK := messages.PrincipalKindFromAddress(msg.Recipient); rOK {
+				convResult = p.resolveDMConversation(ctx, msg, recipientKind, msg.RecipientID)
 			} else {
-				p.log.Warn("skipping DM conversation resolution: principal kind undetermined",
-					"sender", msg.Sender, "sender_ok", sOK, "recipient", msg.Recipient, "recipient_ok", rOK)
+				p.log.Warn("skipping DM conversation resolution: recipient kind undetermined",
+					"recipient", msg.Recipient, "recipient_id", msg.RecipientID)
 			}
 		}
 		if convResult != nil {
@@ -636,13 +634,8 @@ func (p *MessageBrokerProxy) deliverToAgent(ctx context.Context, projectID, agen
 		var convResult *messaging.ConversationResult
 		if msg.ThreadID != "" {
 			convResult = messaging.ResolveOrCreateThreadConversation(ctx, p.store, p.log, msg.ThreadID, projectID)
-		} else if msg.SenderID != "" && agent.ID != "" {
-			if senderKind, ok := messages.PrincipalKindFromAddress(msg.Sender); ok {
-				convResult = messaging.ResolveOrCreateDMConversation(ctx, p.store, p.store, p.log, senderKind, msg.SenderID, "agent", agent.ID)
-			} else {
-				p.log.Warn("skipping DM conversation resolution: sender kind undetermined",
-					"sender", msg.Sender, "sender_id", msg.SenderID)
-			}
+		} else if agent.ID != "" {
+			convResult = p.resolveDMConversation(ctx, msg, "agent", agent.ID)
 		}
 		if convResult != nil {
 			storeMsg.ConversationID = convResult.ConversationID
@@ -825,6 +818,27 @@ func (p *MessageBrokerProxy) publishDeliveryFailed(ctx context.Context, projectI
 		p.log.Warn("Failed to dispatch DELIVERY_FAILED notification",
 			"senderID", msg.SenderID, "error", err)
 	}
+}
+
+// resolveDMConversation derives the sender kind from msg.Sender and delegates
+// to messaging.ResolveOrCreateDMConversation. recipientKind and recipientID
+// are caller-supplied because the two call sites obtain them differently:
+// deliverToUser derives both from the message, deliverToAgent hardcodes "agent".
+// Returns nil (and logs) when the sender address is unparseable or SenderID is
+// empty — callers treat nil as "no conversation resolved" (Phase 5 non-fatal).
+func (p *MessageBrokerProxy) resolveDMConversation(ctx context.Context, msg *messages.StructuredMessage, recipientKind, recipientID string) *messaging.ConversationResult {
+	if msg.SenderID == "" {
+		p.log.Warn("skipping DM conversation resolution: empty SenderID",
+			"sender", msg.Sender)
+		return nil
+	}
+	senderKind, ok := messages.PrincipalKindFromAddress(msg.Sender)
+	if !ok {
+		p.log.Warn("skipping DM conversation resolution: sender kind undetermined",
+			"sender", msg.Sender, "sender_id", msg.SenderID)
+		return nil
+	}
+	return messaging.ResolveOrCreateDMConversation(ctx, p.store, p.store, p.log, senderKind, msg.SenderID, recipientKind, recipientID)
 }
 
 // containsSuffix checks if a dot-separated subject string ends with the given suffix.

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -489,48 +489,45 @@ func (p *MessageBrokerProxy) deliverToUser(ctx context.Context, projectID, topic
 			Reason:     reason,
 		})
 	}
-	persistOK := true
 	if err := p.store.CreateMessage(ctx, storeMsg); err != nil {
 		p.log.Error("Failed to persist user message from broker", "topic", topic, "error", err)
-		persistOK = false
+		return
 	}
 
-	// B11/B13: everything below requires the message row to exist in the store.
-	// Skip attachment links, watermarks, and SSE publish when persistence
-	// failed — publishing an unpersisted message is not legal.
-	if persistOK {
-		// W7: Link the sender's attachments, recorded before publish, to the message
-		// row created here — the ID they need exists nowhere else. Done before the
-		// SSE event so a client refetching on it already sees them.
-		linkAttachmentRefs(ctx, p.webChatStore, storeMsg.ID, parseAttachmentRefs(msg.Metadata), p.log)
+	// Everything below requires the message row to exist in the store.
+	// CreateMessage failure returns above, matching deliverToAgent's pattern.
 
-		// Stamp the DM watermark with the store-assigned message ID. The web
-		// channel spoke already registered the participant rows and bumped
-		// last_activity_at, but it runs before the ID exists — without this the
-		// unread indicator (last_message_id != last_read_message_id) never fires
-		// for agent replies.
-		if p.webChatStore != nil && storeMsg.ThreadID != "" {
-			switch {
-			case strings.HasPrefix(storeMsg.ThreadID, "dm:"):
-				registerDMParticipants(ctx, p.webChatStore, storeMsg.ThreadID)
-				if err := p.webChatStore.TouchDMActivity(ctx, storeMsg.ThreadID, storeMsg.ID); err != nil {
-					p.log.Error("Failed to stamp DM watermark",
-						"thread_id", storeMsg.ThreadID, "error", err)
-				}
-			case !strings.HasPrefix(storeMsg.ThreadID, "agent:"):
-				// Space topic. Same reasoning as DMs: the topic's unread dot is
-				// driven by last_message_id, and the spoke stamped only the
-				// activity timestamp.
-				if err := p.webChatStore.TouchTopicActivity(ctx, storeMsg.ThreadID, storeMsg.ID); err != nil {
-					p.log.Error("Failed to stamp topic watermark",
-						"thread_id", storeMsg.ThreadID, "error", err)
-				}
+	// W7: Link the sender's attachments, recorded before publish, to the message
+	// row created here — the ID they need exists nowhere else. Done before the
+	// SSE event so a client refetching on it already sees them.
+	linkAttachmentRefs(ctx, p.webChatStore, storeMsg.ID, parseAttachmentRefs(msg.Metadata), p.log)
+
+	// Stamp the DM watermark with the store-assigned message ID. The web
+	// channel spoke already registered the participant rows and bumped
+	// last_activity_at, but it runs before the ID exists — without this the
+	// unread indicator (last_message_id != last_read_message_id) never fires
+	// for agent replies.
+	if p.webChatStore != nil && storeMsg.ThreadID != "" {
+		switch {
+		case strings.HasPrefix(storeMsg.ThreadID, "dm:"):
+			registerDMParticipants(ctx, p.webChatStore, storeMsg.ThreadID)
+			if err := p.webChatStore.TouchDMActivity(ctx, storeMsg.ThreadID, storeMsg.ID); err != nil {
+				p.log.Error("Failed to stamp DM watermark",
+					"thread_id", storeMsg.ThreadID, "error", err)
+			}
+		case !strings.HasPrefix(storeMsg.ThreadID, "agent:"):
+			// Space topic. Same reasoning as DMs: the topic's unread dot is
+			// driven by last_message_id, and the spoke stamped only the
+			// activity timestamp.
+			if err := p.webChatStore.TouchTopicActivity(ctx, storeMsg.ThreadID, storeMsg.ID); err != nil {
+				p.log.Error("Failed to stamp topic watermark",
+					"thread_id", storeMsg.ThreadID, "error", err)
 			}
 		}
-
-		// Publish SSE event so connected browser clients receive real-time inbox updates.
-		p.events.PublishUserMessage(ctx, storeMsg)
 	}
+
+	// Publish SSE event so connected browser clients receive real-time inbox updates.
+	p.events.PublishUserMessage(ctx, storeMsg)
 
 	// W6: DM notification for agent → human replies via broker path.
 	if p.chatNotifier != nil && storeMsg.ThreadID != "" &&

--- a/pkg/hub/messagebroker.go
+++ b/pkg/hub/messagebroker.go
@@ -489,41 +489,48 @@ func (p *MessageBrokerProxy) deliverToUser(ctx context.Context, projectID, topic
 			Reason:     reason,
 		})
 	}
+	persistOK := true
 	if err := p.store.CreateMessage(ctx, storeMsg); err != nil {
 		p.log.Error("Failed to persist user message from broker", "topic", topic, "error", err)
+		persistOK = false
 	}
 
-	// W7: Link the sender's attachments, recorded before publish, to the message
-	// row created here — the ID they need exists nowhere else. Done before the
-	// SSE event so a client refetching on it already sees them.
-	linkAttachmentRefs(ctx, p.webChatStore, storeMsg.ID, parseAttachmentRefs(msg.Metadata), p.log)
+	// B11/B13: everything below requires the message row to exist in the store.
+	// Skip attachment links, watermarks, and SSE publish when persistence
+	// failed — publishing an unpersisted message is not legal.
+	if persistOK {
+		// W7: Link the sender's attachments, recorded before publish, to the message
+		// row created here — the ID they need exists nowhere else. Done before the
+		// SSE event so a client refetching on it already sees them.
+		linkAttachmentRefs(ctx, p.webChatStore, storeMsg.ID, parseAttachmentRefs(msg.Metadata), p.log)
 
-	// Stamp the DM watermark with the store-assigned message ID. The web
-	// channel spoke already registered the participant rows and bumped
-	// last_activity_at, but it runs before the ID exists — without this the
-	// unread indicator (last_message_id != last_read_message_id) never fires
-	// for agent replies.
-	if p.webChatStore != nil && storeMsg.ThreadID != "" {
-		switch {
-		case strings.HasPrefix(storeMsg.ThreadID, "dm:"):
-			registerDMParticipants(ctx, p.webChatStore, storeMsg.ThreadID)
-			if err := p.webChatStore.TouchDMActivity(ctx, storeMsg.ThreadID, storeMsg.ID); err != nil {
-				p.log.Error("Failed to stamp DM watermark",
-					"thread_id", storeMsg.ThreadID, "error", err)
-			}
-		case !strings.HasPrefix(storeMsg.ThreadID, "agent:"):
-			// Space topic. Same reasoning as DMs: the topic's unread dot is
-			// driven by last_message_id, and the spoke stamped only the
-			// activity timestamp.
-			if err := p.webChatStore.TouchTopicActivity(ctx, storeMsg.ThreadID, storeMsg.ID); err != nil {
-				p.log.Error("Failed to stamp topic watermark",
-					"thread_id", storeMsg.ThreadID, "error", err)
+		// Stamp the DM watermark with the store-assigned message ID. The web
+		// channel spoke already registered the participant rows and bumped
+		// last_activity_at, but it runs before the ID exists — without this the
+		// unread indicator (last_message_id != last_read_message_id) never fires
+		// for agent replies.
+		if p.webChatStore != nil && storeMsg.ThreadID != "" {
+			switch {
+			case strings.HasPrefix(storeMsg.ThreadID, "dm:"):
+				registerDMParticipants(ctx, p.webChatStore, storeMsg.ThreadID)
+				if err := p.webChatStore.TouchDMActivity(ctx, storeMsg.ThreadID, storeMsg.ID); err != nil {
+					p.log.Error("Failed to stamp DM watermark",
+						"thread_id", storeMsg.ThreadID, "error", err)
+				}
+			case !strings.HasPrefix(storeMsg.ThreadID, "agent:"):
+				// Space topic. Same reasoning as DMs: the topic's unread dot is
+				// driven by last_message_id, and the spoke stamped only the
+				// activity timestamp.
+				if err := p.webChatStore.TouchTopicActivity(ctx, storeMsg.ThreadID, storeMsg.ID); err != nil {
+					p.log.Error("Failed to stamp topic watermark",
+						"thread_id", storeMsg.ThreadID, "error", err)
+				}
 			}
 		}
-	}
 
-	// Publish SSE event so connected browser clients receive real-time inbox updates.
-	p.events.PublishUserMessage(ctx, storeMsg)
+		// Publish SSE event so connected browser clients receive real-time inbox updates.
+		p.events.PublishUserMessage(ctx, storeMsg)
+	}
 
 	// W6: DM notification for agent → human replies via broker path.
 	if p.chatNotifier != nil && storeMsg.ThreadID != "" &&

--- a/pkg/hub/messagebroker_test.go
+++ b/pkg/hub/messagebroker_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/eventbus"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/messaging"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 )
 
@@ -1046,3 +1047,116 @@ func TestMessageBrokerProxy_UserMessageLinksAttachments(t *testing.T) {
 		t.Fatalf("expected the attachment to be linked to the delivered message, got %+v", linked)
 	}
 }
+
+// TestResolveDMConversation_BothPathsAgree verifies that the user path
+// (PrincipalKindFromAddress for the recipient) and the agent path
+// (hardcoded "agent" kind) produce the same conversation ID when given
+// the same principal pair.
+func TestResolveDMConversation_BothPathsAgree(t *testing.T) {
+	s := newBrokerTestStore(t)
+	log := slog.Default()
+	ctx := context.Background()
+
+	proxy := &MessageBrokerProxy{
+		store: s,
+		log:   log,
+	}
+
+	agentID := api.NewUUID()
+	userID := api.NewUUID()
+
+	msg := messages.NewInstruction("agent:test-bot", "user:alice", "hello")
+	msg.SenderID = agentID
+	msg.RecipientID = userID
+
+	// User path: derive recipientKind from msg.Recipient
+	recipientKind, rOK := messages.PrincipalKindFromAddress(msg.Recipient)
+	if !rOK {
+		t.Fatal("expected recipient kind to resolve")
+	}
+	resultUser := proxy.resolveDMConversation(ctx, msg, recipientKind, msg.RecipientID)
+	if resultUser == nil {
+		t.Fatal("expected non-nil conversation result from user path")
+	}
+
+	// Agent path: caller knows recipient is an agent, hardcode kind
+	// Build the reciprocal message: user sends to agent
+	msgAgent := messages.NewInstruction("user:alice", "agent:test-bot", "hi back")
+	msgAgent.SenderID = userID
+	msgAgent.RecipientID = agentID
+
+	resultAgent := proxy.resolveDMConversation(ctx, msgAgent, "agent", agentID)
+	if resultAgent == nil {
+		t.Fatal("expected non-nil conversation result from agent path")
+	}
+
+	if resultUser.ConversationID != resultAgent.ConversationID {
+		t.Fatalf("conversation IDs differ: user-path=%q agent-path=%q",
+			resultUser.ConversationID, resultAgent.ConversationID)
+	}
+}
+
+// TestResolveDMConversation_BroadcastSkipped verifies that the helper returns
+// nil and does not create a conversation when msg.Broadcasted is true. The
+// helper itself does not check Broadcasted — the guard lives in the callers —
+// so this test checks the callers' guards indirectly by exercising deliverToUser
+// and verifying no conversation_id is set on the persisted message.
+func TestResolveDMConversation_BroadcastSkipped(t *testing.T) {
+	s := newBrokerTestStore(t)
+	projectID := setupBrokerTestProject(t, s)
+	log := slog.Default()
+	ctx := context.Background()
+
+	events := NewChannelEventPublisher()
+	defer events.Close()
+
+	b := eventbus.NewInProcessEventBus(log)
+	defer func() { _ = b.Close() }()
+
+	proxy := NewMessageBrokerProxy(b, s, events, func() AgentDispatcher { return &brokerMockDispatcher{} }, log)
+
+	msg := messages.NewInstruction("agent:sender-bot", "user:bob", "broadcast hello")
+	msg.SenderID = api.NewUUID()
+	msg.RecipientID = api.NewUUID()
+	msg.Broadcasted = true
+
+	proxy.deliverToUser(ctx, projectID, "project."+projectID+".user.message", msg)
+
+	result, err := s.ListMessages(ctx, store.MessageFilter{RecipientID: msg.RecipientID}, store.ListOptions{})
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	if len(result.Items) != 1 {
+		t.Fatalf("expected 1 persisted message, got %d", len(result.Items))
+	}
+	if result.Items[0].ConversationID != "" {
+		t.Fatalf("expected empty ConversationID for broadcast, got %q", result.Items[0].ConversationID)
+	}
+}
+
+// TestResolveDMConversation_EmptySenderID verifies the helper returns nil when
+// SenderID is empty, without panicking.
+func TestResolveDMConversation_EmptySenderID(t *testing.T) {
+	s := newBrokerTestStore(t)
+	log := slog.Default()
+	ctx := context.Background()
+
+	proxy := &MessageBrokerProxy{
+		store: s,
+		log:   log,
+	}
+
+	msg := messages.NewInstruction("agent:test-bot", "user:alice", "hello")
+	// Deliberately leave SenderID empty.
+	msg.SenderID = ""
+	msg.RecipientID = api.NewUUID()
+
+	result := proxy.resolveDMConversation(ctx, msg, "user", msg.RecipientID)
+	if result != nil {
+		t.Fatalf("expected nil result when SenderID is empty, got %+v", result)
+	}
+}
+
+// Compile-time check: ensure messaging import is used by verifying the type
+// is accessible. This prevents "imported and not used" errors.
+var _ *messaging.ConversationResult

--- a/pkg/hub/notifications.go
+++ b/pkg/hub/notifications.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/messaging"
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
@@ -490,6 +491,13 @@ func (nd *NotificationDispatcher) createInboxMessage(ctx context.Context, sub *s
 		Type:        msgType,
 		AgentID:     agent.ID,
 		CreatedAt:   time.Now(),
+	}
+
+	// Phase 5 dual-write: resolve-or-create DM conversation for inbox notification messages.
+	convResult := messaging.ResolveOrCreateDMConversation(ctx, nd.store, nd.store, nd.log,
+		"agent", agent.ID, "user", sub.SubscriberID)
+	if convResult != nil {
+		storeMsg.ConversationID = convResult.ConversationID
 	}
 
 	if err := nd.store.CreateMessage(ctx, storeMsg); err != nil {

--- a/pkg/hub/notifications.go
+++ b/pkg/hub/notifications.go
@@ -494,10 +494,17 @@ func (nd *NotificationDispatcher) createInboxMessage(ctx context.Context, sub *s
 	}
 
 	// Phase 5 dual-write: resolve-or-create DM conversation for inbox notification messages.
-	convResult := messaging.ResolveOrCreateDMConversation(ctx, nd.store, nd.store, nd.log,
-		"agent", agent.ID, "user", sub.SubscriberID)
-	if convResult != nil {
-		storeMsg.ConversationID = convResult.ConversationID
+	// SubscriberID may be a slug or federated identity rather than a UUID;
+	// DMConversationKey requires valid UUIDs for both parties.
+	if _, parseErr := uuid.Parse(sub.SubscriberID); parseErr != nil {
+		nd.log.Warn("skipping DM conversation resolution for inbox message: subscriber ID not a UUID",
+			"subscriber_id", sub.SubscriberID, "notification_id", notif.ID)
+	} else {
+		convResult := messaging.ResolveOrCreateDMConversation(ctx, nd.store, nd.store, nd.log,
+			"agent", agent.ID, "user", sub.SubscriberID)
+		if convResult != nil {
+			storeMsg.ConversationID = convResult.ConversationID
+		}
 	}
 
 	if err := nd.store.CreateMessage(ctx, storeMsg); err != nil {

--- a/pkg/hub/notifications_conversation_test.go
+++ b/pkg/hub/notifications_conversation_test.go
@@ -105,6 +105,10 @@ func TestCreateInboxMessage_StampsConversationID(t *testing.T) {
 // the subscriber has a non-UUID SubscriberID (e.g. a slug or federated identity),
 // createInboxMessage does not panic and the persisted message has an empty
 // ConversationID.
+//
+// DEF-32: when federated-identity → user UUID resolution is added to the store,
+// this expectation inverts — a non-UUID subscriber SHOULD resolve to a canonical
+// UUID and receive a ConversationID. Update this assertion when DEF-32 lands.
 func TestCreateInboxMessage_NonUUIDSubscriber_NoStampNoPanic(t *testing.T) {
 	_, s := testServer(t)
 	ctx := context.Background()
@@ -164,6 +168,7 @@ func TestCreateInboxMessage_NonUUIDSubscriber_NoStampNoPanic(t *testing.T) {
 	}
 
 	last := msgs[len(msgs)-1]
+	// DEF-32: this assertion inverts when federated-identity resolution lands.
 	if last.ConversationID != "" {
 		t.Errorf("expected empty ConversationID for non-UUID subscriber, got %q", last.ConversationID)
 	}

--- a/pkg/hub/notifications_conversation_test.go
+++ b/pkg/hub/notifications_conversation_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// TestCreateInboxMessage_StampsConversationID verifies that when the subscriber
+// has a valid UUID SubscriberID, the persisted inbox message gets a non-empty
+// ConversationID stamped via DM conversation resolution.
+func TestCreateInboxMessage_StampsConversationID(t *testing.T) {
+	_, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "conv-stamp-project",
+		Slug:       "conv-stamp-project",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	agent := &store.Agent{
+		ID:         api.NewUUID(),
+		Name:       "conv-agent",
+		Slug:       "conv-agent",
+		ProjectID:  project.ID,
+		Phase:      "running",
+		Runtime:    "managed",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	user := &store.User{
+		ID:          api.NewUUID(),
+		Email:       "convuser@example.com",
+		DisplayName: "ConvUser",
+	}
+	if err := s.CreateUser(ctx, user); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	spy := &spyEventPublisher{}
+	nd := NewNotificationDispatcher(s, spy, func() AgentDispatcher { return nil }, slog.Default())
+
+	sub := &store.NotificationSubscription{
+		ID:             api.NewUUID(),
+		Scope:          store.SubscriptionScopeAgent,
+		AgentID:        agent.ID,
+		SubscriberType: store.SubscriberTypeUser,
+		SubscriberID:   user.ID, // valid UUID
+		ProjectID:      project.ID,
+	}
+
+	notif := &store.Notification{
+		ID:             api.NewUUID(),
+		SubscriptionID: sub.ID,
+		AgentID:        agent.ID,
+		ProjectID:      project.ID,
+		SubscriberType: store.SubscriberTypeUser,
+		SubscriberID:   user.ID,
+		Status:         "WAITING_FOR_INPUT",
+		Message:        "Agent needs input",
+	}
+
+	nd.createInboxMessage(ctx, sub, notif, agent)
+
+	// Retrieve the persisted message via the spy (which records PublishUserMessage calls).
+	msgs := spy.getUserMessages()
+	if len(msgs) == 0 {
+		t.Fatal("expected at least one published user message, got none")
+	}
+
+	last := msgs[len(msgs)-1]
+	if last.ConversationID == "" {
+		t.Errorf("expected non-empty ConversationID for UUID subscriber, got empty")
+	}
+}
+
+// TestCreateInboxMessage_NonUUIDSubscriber_NoStampNoPanic verifies that when
+// the subscriber has a non-UUID SubscriberID (e.g. a slug or federated identity),
+// createInboxMessage does not panic and the persisted message has an empty
+// ConversationID.
+func TestCreateInboxMessage_NonUUIDSubscriber_NoStampNoPanic(t *testing.T) {
+	_, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "conv-noid-project",
+		Slug:       "conv-noid-project",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	agent := &store.Agent{
+		ID:         api.NewUUID(),
+		Name:       "conv-noid-agent",
+		Slug:       "conv-noid-agent",
+		ProjectID:  project.ID,
+		Phase:      "running",
+		Runtime:    "managed",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	spy := &spyEventPublisher{}
+	nd := NewNotificationDispatcher(s, spy, func() AgentDispatcher { return nil }, slog.Default())
+
+	sub := &store.NotificationSubscription{
+		ID:             api.NewUUID(),
+		Scope:          store.SubscriptionScopeAgent,
+		AgentID:        agent.ID,
+		SubscriberType: store.SubscriberTypeUser,
+		SubscriberID:   "some-user-slug", // NOT a UUID
+		ProjectID:      project.ID,
+	}
+
+	notif := &store.Notification{
+		ID:             api.NewUUID(),
+		SubscriptionID: sub.ID,
+		AgentID:        agent.ID,
+		ProjectID:      project.ID,
+		SubscriberType: store.SubscriberTypeUser,
+		SubscriberID:   "some-user-slug",
+		Status:         "WAITING_FOR_INPUT",
+		Message:        "Agent needs input",
+	}
+
+	// Must not panic.
+	nd.createInboxMessage(ctx, sub, notif, agent)
+
+	msgs := spy.getUserMessages()
+	if len(msgs) == 0 {
+		t.Fatal("expected at least one published user message, got none")
+	}
+
+	last := msgs[len(msgs)-1]
+	if last.ConversationID != "" {
+		t.Errorf("expected empty ConversationID for non-UUID subscriber, got %q", last.ConversationID)
+	}
+}

--- a/pkg/hub/publish_guard_test.go
+++ b/pkg/hub/publish_guard_test.go
@@ -38,11 +38,13 @@ import (
 // Test doubles
 // ---------------------------------------------------------------------------
 
-// spyEventPublisher embeds noopEventPublisher and records PublishUserMessage calls.
+// spyEventPublisher embeds noopEventPublisher and records PublishUserMessage
+// and PublishChatNotification calls.
 type spyEventPublisher struct {
 	noopEventPublisher
-	mu       sync.Mutex
-	userMsgs []*store.Message
+	mu          sync.Mutex
+	userMsgs    []*store.Message
+	chatNotifCh chan struct{} // optional; signalled on PublishChatNotification
 }
 
 func (s *spyEventPublisher) PublishUserMessage(_ context.Context, msg *store.Message) {
@@ -57,6 +59,47 @@ func (s *spyEventPublisher) getUserMessages() []*store.Message {
 	out := make([]*store.Message, len(s.userMsgs))
 	copy(out, s.userMsgs)
 	return out
+}
+
+func (s *spyEventPublisher) PublishChatNotification(_ context.Context, _ *store.Notification, _ ChatMessageContext) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.chatNotifCh != nil {
+		select {
+		case s.chatNotifCh <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// chatNotifFired reports whether PublishChatNotification was invoked.
+// Safe to call only when no concurrent goroutine can still call
+// PublishChatNotification (e.g. after the goroutine has been joined
+// or was never spawned).
+func (s *spyEventPublisher) chatNotifFired() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.chatNotifCh == nil {
+		return false
+	}
+	select {
+	case <-s.chatNotifCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// stubWebChatStore embeds the WebChatStore interface so that only the
+// methods actually exercised need a real implementation. Unimplemented
+// methods panic with a nil-receiver dereference, which is the desired
+// signal in a test.
+type stubWebChatStore struct {
+	WebChatStore
+}
+
+func (s *stubWebChatStore) IsConversationMuted(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
 }
 
 // createMessageFailStore wraps a real store and makes CreateMessage return an error.
@@ -594,5 +637,90 @@ func TestProcessMentions_PublishesOnPersistSuccess(t *testing.T) {
 	// The publish MUST have fired because CreateMessage succeeded.
 	if msgs := spy.getUserMessages(); len(msgs) != 1 {
 		t.Errorf("expected 1 PublishUserMessage call when persistence succeeds for mention, got %d", len(msgs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Site 6: deliverToUser — W6 DM notification (NotifyDMReceived)
+// ---------------------------------------------------------------------------
+
+// TestDeliverToUser_SkipsNotifyOnPersistFailure verifies that when
+// CreateMessage fails, the W6 NotifyDMReceived goroutine is never
+// spawned — and therefore PublishChatNotification is never called.
+//
+// Determinism: with the early-return fix, deliverToUser returns before
+// reaching the "go p.chatNotifier.NotifyDMReceived(...)" line. No
+// goroutine is launched, so there is no race to synchronise on; the
+// observation (zero PublishChatNotification calls) is checked after
+// deliverToUser returns synchronously.
+func TestDeliverToUser_SkipsNotifyOnPersistFailure(t *testing.T) {
+	realStore := newBrokerTestStore(t)
+	projectID := setupBrokerTestProject(t, realStore)
+	setupBrokerTestAgent(t, realStore, projectID, "agent-a", "running")
+
+	spy := &spyEventPublisher{chatNotifCh: make(chan struct{}, 1)}
+	b := eventbus.NewInProcessEventBus(slog.Default())
+	defer func() { _ = b.Close() }()
+
+	failStore := &createMessageFailStore{Store: realStore}
+	proxy := NewMessageBrokerProxy(b, failStore, spy, func() AgentDispatcher { return nil }, slog.Default())
+
+	// Wire a ChatNotifier so the guard (p.chatNotifier != nil) would pass
+	// if execution ever reached it. The notifier uses the real store and a
+	// stub WebChatStore — but neither is exercised because the function
+	// returns before the notification path.
+	cn := NewChatNotifier(realStore, spy, &stubWebChatStore{}, nil, slog.Default())
+	proxy.chatNotifier = cn
+
+	// Craft a message that satisfies all four W6 guard conditions:
+	//   ThreadID starts with "dm:", RecipientID non-empty,
+	//   Sender starts with "agent:".
+	msg := messages.NewInstruction("agent:agent-a", "user:bob", "hello")
+	msg.SenderID = "agent-uuid"
+	msg.RecipientID = "user-bob-id"
+	msg.ThreadID = "dm:user:user-bob-id:agent:agent-uuid"
+
+	proxy.deliverToUser(context.Background(), projectID, "user.user-bob-id.message", msg)
+
+	// The goroutine was never spawned, so the channel must be empty.
+	if spy.chatNotifFired() {
+		t.Error("PublishChatNotification must not be called when CreateMessage fails")
+	}
+}
+
+// TestDeliverToUser_NotifiesOnPersistSuccess is a positive control:
+// when CreateMessage succeeds and the W6 conditions are met,
+// PublishChatNotification IS called (via the NotifyDMReceived goroutine).
+//
+// Determinism: NotifyDMReceived runs in a goroutine. We wait on a
+// buffered channel that the spy signals from PublishChatNotification,
+// with a generous timeout so CI is not flaky.
+func TestDeliverToUser_NotifiesOnPersistSuccess(t *testing.T) {
+	realStore := newBrokerTestStore(t)
+	projectID := setupBrokerTestProject(t, realStore)
+	setupBrokerTestAgent(t, realStore, projectID, "agent-a", "running")
+
+	spy := &spyEventPublisher{chatNotifCh: make(chan struct{}, 1)}
+	b := eventbus.NewInProcessEventBus(slog.Default())
+	defer func() { _ = b.Close() }()
+
+	proxy := NewMessageBrokerProxy(b, realStore, spy, func() AgentDispatcher { return nil }, slog.Default())
+
+	cn := NewChatNotifier(realStore, spy, &stubWebChatStore{}, nil, slog.Default())
+	proxy.chatNotifier = cn
+
+	msg := messages.NewInstruction("agent:agent-a", "user:bob", "hello")
+	msg.SenderID = "agent-uuid"
+	msg.RecipientID = "user-bob-id"
+	msg.ThreadID = "dm:user:user-bob-id:agent:agent-uuid"
+
+	proxy.deliverToUser(context.Background(), projectID, "user.user-bob-id.message", msg)
+
+	// Wait for the goroutine to signal PublishChatNotification.
+	select {
+	case <-spy.chatNotifCh:
+		// success — notification was delivered
+	case <-time.After(5 * time.Second):
+		t.Error("PublishChatNotification was not called within timeout; expected W6 DM notification on persist success")
 	}
 }

--- a/pkg/hub/publish_guard_test.go
+++ b/pkg/hub/publish_guard_test.go
@@ -1,0 +1,598 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/api"
+	"github.com/GoogleCloudPlatform/scion/pkg/eventbus"
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+// spyEventPublisher embeds noopEventPublisher and records PublishUserMessage calls.
+type spyEventPublisher struct {
+	noopEventPublisher
+	mu       sync.Mutex
+	userMsgs []*store.Message
+}
+
+func (s *spyEventPublisher) PublishUserMessage(_ context.Context, msg *store.Message) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.userMsgs = append(s.userMsgs, msg)
+}
+
+func (s *spyEventPublisher) getUserMessages() []*store.Message {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*store.Message, len(s.userMsgs))
+	copy(out, s.userMsgs)
+	return out
+}
+
+// createMessageFailStore wraps a real store and makes CreateMessage return an error.
+type createMessageFailStore struct {
+	store.Store
+}
+
+func (s *createMessageFailStore) CreateMessage(_ context.Context, _ *store.Message) error {
+	return errors.New("injected CreateMessage failure")
+}
+
+// ---------------------------------------------------------------------------
+// Site 1: messagebroker.go  deliverToUser
+// ---------------------------------------------------------------------------
+
+func TestDeliverToUser_SkipsPublishOnPersistFailure(t *testing.T) {
+	realStore := newBrokerTestStore(t)
+	projectID := setupBrokerTestProject(t, realStore)
+	setupBrokerTestAgent(t, realStore, projectID, "agent-a", "running")
+
+	spy := &spyEventPublisher{}
+	b := eventbus.NewInProcessEventBus(slog.Default())
+	defer func() { _ = b.Close() }()
+
+	failStore := &createMessageFailStore{Store: realStore}
+	proxy := NewMessageBrokerProxy(b, failStore, spy, func() AgentDispatcher { return nil }, slog.Default())
+
+	msg := messages.NewInstruction("agent:agent-a", "user:bob", "hello")
+	msg.SenderID = "agent-uuid"
+	msg.RecipientID = "user-bob-id"
+
+	proxy.deliverToUser(context.Background(), projectID, "user.user-bob-id.message", msg)
+
+	if msgs := spy.getUserMessages(); len(msgs) != 0 {
+		t.Errorf("expected no PublishUserMessage calls when persistence fails, got %d", len(msgs))
+	}
+}
+
+func TestDeliverToUser_PublishesOnPersistSuccess(t *testing.T) {
+	realStore := newBrokerTestStore(t)
+	projectID := setupBrokerTestProject(t, realStore)
+	setupBrokerTestAgent(t, realStore, projectID, "agent-a", "running")
+
+	spy := &spyEventPublisher{}
+	b := eventbus.NewInProcessEventBus(slog.Default())
+	defer func() { _ = b.Close() }()
+
+	proxy := NewMessageBrokerProxy(b, realStore, spy, func() AgentDispatcher { return nil }, slog.Default())
+
+	msg := messages.NewInstruction("agent:agent-a", "user:bob", "hello")
+	msg.SenderID = "agent-uuid"
+	msg.RecipientID = "user-bob-id"
+
+	proxy.deliverToUser(context.Background(), projectID, "user.user-bob-id.message", msg)
+
+	if msgs := spy.getUserMessages(); len(msgs) != 1 {
+		t.Errorf("expected 1 PublishUserMessage call when persistence succeeds, got %d", len(msgs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Site 2: handleAgentMessage
+// ---------------------------------------------------------------------------
+
+func TestHandleAgentMessage_SkipsPublishOnPersistFailure(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "guard-project",
+		Slug:       "guard-project",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	agent := &store.Agent{
+		ID:         api.NewUUID(),
+		Name:       "guard-agent",
+		Slug:       "guard-agent",
+		ProjectID:  project.ID,
+		Phase:      "running",
+		Runtime:    "managed",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	spy := &spyEventPublisher{}
+	srv.events = spy
+	srv.store = &createMessageFailStore{Store: s}
+
+	structuredMsg := &messages.StructuredMessage{
+		Sender:    "user:tester",
+		SenderID:  "user-id-1",
+		Recipient: "agent:" + agent.Slug,
+		Msg:       "test message",
+		Type:      messages.TypeInstruction,
+		Version:   messages.Version,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+	body, _ := json.Marshal(MessageRequest{StructuredMessage: structuredMsg})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+agent.ID+"/message", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithIdentity(req.Context(),
+		NewAuthenticatedUser("user-id-1", "tester@example.com", "Tester", "user", "web")))
+
+	rr := httptest.NewRecorder()
+	srv.handleAgentMessage(rr, req, agent.ID)
+
+	// The handler should still return 200 (B10: non-fatal) but publish must not fire.
+	if msgs := spy.getUserMessages(); len(msgs) != 0 {
+		t.Errorf("expected no PublishUserMessage calls when persistence fails, got %d", len(msgs))
+	}
+}
+
+func TestHandleAgentMessage_ResponseStatusNotDeliveredOnPersistFailure(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "status-project",
+		Slug:       "status-project",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	agent := &store.Agent{
+		ID:         api.NewUUID(),
+		Name:       "status-agent",
+		Slug:       "status-agent",
+		ProjectID:  project.ID,
+		Phase:      "running",
+		Runtime:    "managed",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	spy := &spyEventPublisher{}
+	srv.events = spy
+	srv.store = &createMessageFailStore{Store: s}
+
+	structuredMsg := &messages.StructuredMessage{
+		Sender:    "user:tester",
+		SenderID:  "user-id-1",
+		Recipient: "agent:" + agent.Slug,
+		Msg:       "test message",
+		Type:      messages.TypeInstruction,
+		Version:   messages.Version,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+	body, _ := json.Marshal(MessageRequest{StructuredMessage: structuredMsg})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+agent.ID+"/message", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithIdentity(req.Context(),
+		NewAuthenticatedUser("user-id-1", "tester@example.com", "Tester", "user", "web")))
+
+	rr := httptest.NewRecorder()
+	srv.handleAgentMessage(rr, req, agent.ID)
+
+	// The handler should return 200 but the status must NOT be "delivered".
+	if rr.Code != http.StatusOK {
+		t.Logf("response: %d %s", rr.Code, rr.Body.String())
+		// 503 (no dispatcher) or other infrastructure errors are acceptable,
+		// but if we got here with a managed runtime, it should be 200.
+	}
+	if rr.Code == http.StatusOK {
+		var resp MessageDeliveryResponse
+		if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+		if resp.Status == "delivered" {
+			t.Errorf("response Status should not be 'delivered' when persistence fails, got %q", resp.Status)
+		}
+		if resp.MessageID != "" {
+			t.Errorf("response MessageID should be empty when persistence fails, got %q", resp.MessageID)
+		}
+	}
+}
+
+func TestHandleAgentMessage_PublishesOnPersistSuccess(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "ok-project",
+		Slug:       "ok-project",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	agent := &store.Agent{
+		ID:         api.NewUUID(),
+		Name:       "ok-agent",
+		Slug:       "ok-agent",
+		ProjectID:  project.ID,
+		Phase:      "running",
+		Runtime:    "managed",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, agent); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	spy := &spyEventPublisher{}
+	srv.events = spy
+	// Keep using real store so persistence succeeds.
+
+	structuredMsg := &messages.StructuredMessage{
+		Sender:    "user:tester",
+		SenderID:  "user-id-1",
+		Recipient: "agent:" + agent.Slug,
+		Msg:       "test message",
+		Type:      messages.TypeInstruction,
+		Version:   messages.Version,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+	body, _ := json.Marshal(MessageRequest{StructuredMessage: structuredMsg})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+agent.ID+"/message", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithIdentity(req.Context(),
+		NewAuthenticatedUser("user-id-1", "tester@example.com", "Tester", "user", "web")))
+
+	rr := httptest.NewRecorder()
+	srv.handleAgentMessage(rr, req, agent.ID)
+
+	if msgs := spy.getUserMessages(); len(msgs) != 1 {
+		t.Errorf("expected 1 PublishUserMessage call when persistence succeeds, got %d", len(msgs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sites 3 & 4: handleGroupMessage (agent + user recipients)
+// ---------------------------------------------------------------------------
+
+func TestHandleGroupMessage_SkipsPublishOnPersistFailure(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "group-project",
+		Slug:       "group-project",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	// Create a user recipient.
+	user := &store.User{
+		ID:          api.NewUUID(),
+		Email:       "groupuser@example.com",
+		DisplayName: "GroupUser",
+	}
+	if err := s.CreateUser(ctx, user); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	// Create an anchor agent and a target agent.
+	anchor := &store.Agent{
+		ID:              api.NewUUID(),
+		Name:            "anchor",
+		Slug:            "anchor",
+		ProjectID:       project.ID,
+		Phase:           "running",
+		RuntimeBrokerID: "broker-1",
+		Visibility:      store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, anchor); err != nil {
+		t.Fatalf("CreateAgent (anchor): %v", err)
+	}
+	target := &store.Agent{
+		ID:              api.NewUUID(),
+		Name:            "target",
+		Slug:            "target",
+		ProjectID:       project.ID,
+		Phase:           "running",
+		RuntimeBrokerID: "broker-1",
+		Visibility:      store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, target); err != nil {
+		t.Fatalf("CreateAgent (target): %v", err)
+	}
+
+	spy := &spyEventPublisher{}
+	srv.events = spy
+	srv.store = &createMessageFailStore{Store: s}
+
+	// Message to group[agent:target,user:groupuser@example.com]
+	structuredMsg := &messages.StructuredMessage{
+		Sender:    "user:tester",
+		SenderID:  "user-id-1",
+		Recipient: "group[agent:target,user:groupuser@example.com]",
+		Msg:       "group message",
+		Type:      messages.TypeInstruction,
+		Version:   messages.Version,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	body, _ := json.Marshal(MessageRequest{StructuredMessage: structuredMsg})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+anchor.ID+"/message", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithIdentity(req.Context(),
+		NewAuthenticatedUser("user-id-1", "tester@example.com", "Tester", "user", "web")))
+
+	rr := httptest.NewRecorder()
+	srv.handleAgentMessage(rr, req, anchor.ID)
+
+	t.Logf("group response: %d %s", rr.Code, rr.Body.String())
+
+	// Neither agent nor user recipient should have had PublishUserMessage called.
+	if msgs := spy.getUserMessages(); len(msgs) != 0 {
+		t.Errorf("expected no PublishUserMessage calls when persistence fails for group message, got %d", len(msgs))
+	}
+}
+
+func TestHandleGroupMessage_PublishesOnPersistSuccess(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "group-ok-project",
+		Slug:       "group-ok-project",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	// Create a user recipient.
+	user := &store.User{
+		ID:          api.NewUUID(),
+		Email:       "groupuser2@example.com",
+		DisplayName: "GroupUser2",
+	}
+	if err := s.CreateUser(ctx, user); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	anchor := &store.Agent{
+		ID:              api.NewUUID(),
+		Name:            "anchor2",
+		Slug:            "anchor2",
+		ProjectID:       project.ID,
+		Phase:           "running",
+		RuntimeBrokerID: "broker-1",
+		Visibility:      store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, anchor); err != nil {
+		t.Fatalf("CreateAgent (anchor2): %v", err)
+	}
+	target := &store.Agent{
+		ID:              api.NewUUID(),
+		Name:            "target2",
+		Slug:            "target2",
+		ProjectID:       project.ID,
+		Phase:           "running",
+		RuntimeBrokerID: "broker-1",
+		Visibility:      store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, target); err != nil {
+		t.Fatalf("CreateAgent (target2): %v", err)
+	}
+
+	spy := &spyEventPublisher{}
+	srv.events = spy
+	// Keep real store for success path.
+
+	structuredMsg := &messages.StructuredMessage{
+		Sender:    "user:tester",
+		SenderID:  "user-id-1",
+		Recipient: "group[agent:target2,user:groupuser2@example.com]",
+		Msg:       "group message ok",
+		Type:      messages.TypeInstruction,
+		Version:   messages.Version,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	body, _ := json.Marshal(MessageRequest{StructuredMessage: structuredMsg})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/"+anchor.ID+"/message", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(contextWithIdentity(req.Context(),
+		NewAuthenticatedUser("user-id-1", "tester@example.com", "Tester", "user", "web")))
+
+	rr := httptest.NewRecorder()
+	srv.handleAgentMessage(rr, req, anchor.ID)
+
+	t.Logf("group ok response: %d %s", rr.Code, rr.Body.String())
+
+	// Both agent and user recipient should have PublishUserMessage called (2 total).
+	if msgs := spy.getUserMessages(); len(msgs) != 2 {
+		t.Errorf("expected 2 PublishUserMessage calls when persistence succeeds for group message, got %d", len(msgs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Site 5: processMentions
+// ---------------------------------------------------------------------------
+
+func TestProcessMentions_SkipsPublishOnPersistFailure(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "mention-project",
+		Slug:       "mention-project",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	primary := &store.Agent{
+		ID:              api.NewUUID(),
+		Name:            "primary",
+		Slug:            "primary",
+		ProjectID:       project.ID,
+		Phase:           "running",
+		RuntimeBrokerID: "broker-1",
+		Visibility:      store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, primary); err != nil {
+		t.Fatalf("CreateAgent (primary): %v", err)
+	}
+
+	mentioned := &store.Agent{
+		ID:              api.NewUUID(),
+		Name:            "mentioned",
+		Slug:            "mentioned",
+		ProjectID:       project.ID,
+		Phase:           "running",
+		RuntimeBrokerID: "broker-1",
+		Visibility:      store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, mentioned); err != nil {
+		t.Fatalf("CreateAgent (mentioned): %v", err)
+	}
+
+	spy := &spyEventPublisher{}
+	srv.events = spy
+	srv.store = &createMessageFailStore{Store: s}
+
+	originalMsg := &messages.StructuredMessage{
+		Sender:    "user:tester",
+		SenderID:  "user-id-1",
+		Recipient: "agent:" + primary.Slug,
+		Msg:       "hello @mentioned",
+		Type:      messages.TypeInstruction,
+		Version:   messages.Version,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	results := srv.processMentions(ctx, []string{"mentioned"}, primary, originalMsg)
+
+	// The mention should still produce a result (dispatch may fail, but that's OK).
+	t.Logf("mention results: %+v", results)
+
+	// The publish must NOT have fired because CreateMessage failed.
+	if msgs := spy.getUserMessages(); len(msgs) != 0 {
+		t.Errorf("expected no PublishUserMessage calls when persistence fails for mention, got %d", len(msgs))
+	}
+}
+
+func TestProcessMentions_PublishesOnPersistSuccess(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	project := &store.Project{
+		ID:         api.NewUUID(),
+		Name:       "mention-ok-project",
+		Slug:       "mention-ok-project",
+		Visibility: store.VisibilityPrivate,
+	}
+	if err := s.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	primary := &store.Agent{
+		ID:              api.NewUUID(),
+		Name:            "primary2",
+		Slug:            "primary2",
+		ProjectID:       project.ID,
+		Phase:           "running",
+		RuntimeBrokerID: "broker-1",
+		Visibility:      store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, primary); err != nil {
+		t.Fatalf("CreateAgent (primary2): %v", err)
+	}
+
+	mentioned := &store.Agent{
+		ID:              api.NewUUID(),
+		Name:            "mentioned2",
+		Slug:            "mentioned2",
+		ProjectID:       project.ID,
+		Phase:           "running",
+		RuntimeBrokerID: "broker-1",
+		Visibility:      store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, mentioned); err != nil {
+		t.Fatalf("CreateAgent (mentioned2): %v", err)
+	}
+
+	spy := &spyEventPublisher{}
+	srv.events = spy
+	// Real store => persistence succeeds.
+
+	originalMsg := &messages.StructuredMessage{
+		Sender:    "user:tester",
+		SenderID:  "user-id-1",
+		Recipient: "agent:" + primary.Slug,
+		Msg:       "hello @mentioned2",
+		Type:      messages.TypeInstruction,
+		Version:   messages.Version,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	results := srv.processMentions(ctx, []string{"mentioned2"}, primary, originalMsg)
+	t.Logf("mention ok results: %+v", results)
+
+	// The publish MUST have fired because CreateMessage succeeded.
+	if msgs := spy.getUserMessages(); len(msgs) != 1 {
+		t.Errorf("expected 1 PublishUserMessage call when persistence succeeds for mention, got %d", len(msgs))
+	}
+}

--- a/pkg/hub/publish_site_enumeration_test.go
+++ b/pkg/hub/publish_site_enumeration_test.go
@@ -24,15 +24,33 @@ import (
 	"testing"
 )
 
-// TestPublishUserMessageEnumeration uses go/ast to find every
-// PublishUserMessage call site (arity 2 — the event publish signature) in
-// non-test .go files under pkg/hub. Each site must appear in the "guarded"
-// set (the call only executes when CreateMessage has already succeeded).
-// Broker proxy calls (arity 4) are excluded from the population entirely —
-// persistence is handled by the deliverToUser callback, not by the caller.
-// Any unaccounted site causes a hard failure — this is the durable guard for
-// contract B11/B13: publishing an unpersisted message is not legal.
-func TestPublishUserMessageEnumeration(t *testing.T) {
+// TestPersistedRowEffectEnumeration uses go/ast to find every call site of
+// externally visible effects that require a persisted message row in non-test
+// .go files under pkg/hub. Each site must appear in the "guarded" set (the
+// call only executes when CreateMessage has already succeeded). Any unaccounted
+// site causes a hard failure.
+//
+// Effect categories in scope:
+//   - SSE publish: PublishUserMessage (arity 2 — the event publish signature).
+//     Broker proxy calls (arity 4) are excluded — persistence is handled by
+//     the deliverToUser callback, not by the caller.
+//   - DM notification dispatch: NotifyDMReceived.
+//
+// Effect categories deliberately NOT enumerated:
+//   - Watermark updates (TouchDMActivity, TouchTopicActivity): currently
+//     structurally guarded by early return or conditional scope in all
+//     existing call sites.
+//   - Attachment links (linkAttachmentRefs, LinkAttachmentToMessage):
+//     currently structurally guarded by early return or conditional scope
+//     in all existing call sites.
+//   - Audit log entries (messageLog.Info): currently structurally guarded
+//     by early return or conditional scope in all existing call sites.
+//
+// The latter three categories are omitted because adding them would require
+// receiver-type resolution beyond go/ast's capability. The two enumerated
+// categories are the ones with externally visible user impact (SSE event
+// delivery and push notifications).
+func TestPersistedRowEffectEnumeration(t *testing.T) {
 	// -------------------------------------------------------------------
 	// Guarded sites: each of these only executes after CreateMessage has
 	// succeeded (error return, else-branch, or conditional block).
@@ -52,10 +70,16 @@ func TestPublishUserMessageEnumeration(t *testing.T) {
 
 		// sendHumanToHuman: CreateMessage error triggers early return
 		// before publish.
-		"handlers_chat_v2.go:sendHumanToHuman": "CreateMessage error triggers early return before publish",
+		"handlers_chat_v2.go:sendHumanToHuman:publish": "CreateMessage error triggers early return before publish",
 
-		// deliverToUser: publish inside if persistOK block.
-		"messagebroker.go:deliverToUser": "Publish inside if persistOK block",
+		// sendHumanToHuman: DM notification after successful persist.
+		"handlers_chat_v2.go:sendHumanToHuman:notify": "CreateMessage error triggers early return before notification dispatch",
+
+		// deliverToUser: CreateMessage error triggers early return.
+		"messagebroker.go:deliverToUser:publish": "CreateMessage error triggers early return before all effects",
+
+		// deliverToUser: DM notification after successful persist.
+		"messagebroker.go:deliverToUser:notify": "CreateMessage error triggers early return before notification dispatch",
 
 		// handleBrokerInbound: publish in else branch of CreateMessage
 		// error check.
@@ -63,7 +87,11 @@ func TestPublishUserMessageEnumeration(t *testing.T) {
 
 		// handleAgentOutboundMessage: CreateMessage error triggers early
 		// return before publish.
-		"handlers_agent_messaging.go:handleAgentOutboundMessage": "CreateMessage error triggers early return before publish",
+		"handlers_agent_messaging.go:handleAgentOutboundMessage:publish": "CreateMessage error triggers early return before publish",
+
+		// handleAgentOutboundMessage: DM notification after successful
+		// persist (non-broker path only).
+		"handlers_agent_messaging.go:handleAgentOutboundMessage:notify": "CreateMessage error triggers early return before notification dispatch",
 
 		// handleAgentMessage: publish inside if persistedMsgID != empty
 		// block.
@@ -89,7 +117,7 @@ func TestPublishUserMessageEnumeration(t *testing.T) {
 
 	// -------------------------------------------------------------------
 	// Parse all non-test .go files under pkg/hub and find
-	// PublishUserMessage call sites.
+	// PublishUserMessage and NotifyDMReceived call sites.
 	// -------------------------------------------------------------------
 	hubDir := findHubDir(t)
 	fset := token.NewFileSet()
@@ -103,6 +131,7 @@ func TestPublishUserMessageEnumeration(t *testing.T) {
 		file     string // base filename
 		line     int
 		funcName string // enclosing function name
+		target   string // "publish" or "notify"
 	}
 	var sites []callSite
 
@@ -118,14 +147,20 @@ func TestPublishUserMessageEnumeration(t *testing.T) {
 			t.Fatalf("failed to parse %s: %v", name, err)
 		}
 
-		// Walk the AST and find every CallExpr ending in
-		// PublishUserMessage.
+		// Walk the AST and find every CallExpr matching either
+		// PublishUserMessage (arity 2) or NotifyDMReceived.
 		ast.Inspect(f, func(n ast.Node) bool {
 			call, ok := n.(*ast.CallExpr)
 			if !ok {
 				return true
 			}
-			if !isPublishUserMessageCall(call) {
+			var target string
+			switch {
+			case isPublishUserMessageCall(call):
+				target = "publish"
+			case isNotifyDMReceivedCall(call):
+				target = "notify"
+			default:
 				return true
 			}
 			pos := fset.Position(call.Pos())
@@ -134,19 +169,21 @@ func TestPublishUserMessageEnumeration(t *testing.T) {
 				file:     name,
 				line:     pos.Line,
 				funcName: funcName,
+				target:   target,
 			})
 			return true
 		})
 	}
 
 	if len(sites) == 0 {
-		t.Fatal("found zero PublishUserMessage call sites — the scanner is broken")
+		t.Fatal("found zero persisted-row effect call sites — the scanner is broken")
 	}
 
 	// -------------------------------------------------------------------
 	// Match each site to the accounted set. We match on file:enclosingFunc.
-	// When a function contains multiple PublishUserMessage calls, they are
-	// disambiguated by a suffix heuristic.
+	// When a function contains multiple enumerated calls, they are
+	// disambiguated by target kind ("publish" vs "notify") and, within the
+	// same target kind, by a suffix heuristic.
 	// -------------------------------------------------------------------
 
 	// Group sites by file:func to detect duplicates.
@@ -163,6 +200,7 @@ func TestPublishUserMessageEnumeration(t *testing.T) {
 
 	for gk, groupSites := range grouped {
 		if len(groupSites) == 1 {
+			// Single call in this function — try bare key first.
 			key := gk.file + ":" + gk.fn
 			if accounted[key] {
 				matched[key] = true
@@ -171,33 +209,71 @@ func TestPublishUserMessageEnumeration(t *testing.T) {
 					" (line "+itoa(groupSites[0].line)+")")
 			}
 		} else {
-			// Multiple PublishUserMessage calls in the same function.
-			// Try disambiguation using known suffix patterns.
-			for i, s := range groupSites {
-				key := gk.file + ":" + gk.fn
-				if accounted[key] && len(groupSites) == 1 {
-					matched[key] = true
-					continue
+			// Multiple enumerated calls in the same function.
+			// Check if they have mixed targets (publish + notify).
+			hasPublish := false
+			hasNotify := false
+			for _, s := range groupSites {
+				switch s.target {
+				case "publish":
+					hasPublish = true
+				case "notify":
+					hasNotify = true
 				}
-				// Try suffixed keys.
-				found := false
-				for _, suffix := range publishDisambiguationSuffixes(gk.file, gk.fn, i, len(groupSites)) {
-					candidate := gk.file + ":" + gk.fn + ":" + suffix
-					if accounted[candidate] {
-						matched[candidate] = true
-						found = true
-						break
-					}
-				}
-				if !found {
-					// Try bare key (for single-entry funcs that
-					// happened to be grouped).
-					if accounted[key] && !matched[key] {
+			}
+			mixedTargets := hasPublish && hasNotify
+
+			// Sub-group by target kind for disambiguation within each kind.
+			targetGroups := make(map[string][]callSite)
+			for _, s := range groupSites {
+				targetGroups[s.target] = append(targetGroups[s.target], s)
+			}
+
+			for target, tgSites := range targetGroups {
+				if len(tgSites) == 1 && mixedTargets {
+					// Single call of this target kind in a mixed-target
+					// function — use target as suffix.
+					key := gk.file + ":" + gk.fn + ":" + target
+					if accounted[key] {
 						matched[key] = true
 					} else {
-						unaccounted = append(unaccounted,
-							gk.file+":"+gk.fn+
-								" (line "+itoa(s.line)+", call #"+itoa(i+1)+")")
+						unaccounted = append(unaccounted, key+
+							" (line "+itoa(tgSites[0].line)+")")
+					}
+				} else if len(tgSites) == 1 && !mixedTargets {
+					// Two calls of the same target? Should not happen
+					// with len(tgSites)==1, but handle bare key.
+					key := gk.file + ":" + gk.fn
+					if accounted[key] {
+						matched[key] = true
+					} else {
+						unaccounted = append(unaccounted, key+
+							" (line "+itoa(tgSites[0].line)+")")
+					}
+				} else {
+					// Multiple calls of the same target kind — use
+					// target-specific disambiguation suffixes.
+					for i, s := range tgSites {
+						found := false
+						for _, suffix := range persistedRowDisambiguationSuffixes(gk.file, gk.fn, target, i, len(tgSites)) {
+							candidate := gk.file + ":" + gk.fn + ":" + suffix
+							if accounted[candidate] {
+								matched[candidate] = true
+								found = true
+								break
+							}
+						}
+						if !found {
+							// Try bare key (fallback).
+							key := gk.file + ":" + gk.fn
+							if accounted[key] && !matched[key] {
+								matched[key] = true
+							} else {
+								unaccounted = append(unaccounted,
+									gk.file+":"+gk.fn+
+										" (line "+itoa(s.line)+", "+target+" call #"+itoa(i+1)+")")
+							}
+						}
 					}
 				}
 			}
@@ -205,12 +281,13 @@ func TestPublishUserMessageEnumeration(t *testing.T) {
 	}
 
 	if len(unaccounted) > 0 {
-		t.Errorf("Found %d PublishUserMessage call site(s) not in guarded list:\n", len(unaccounted))
+		t.Errorf("Found %d persisted-row effect call site(s) not in guarded list:\n", len(unaccounted))
 		for _, u := range unaccounted {
 			t.Errorf("  - %s", u)
 		}
-		t.Error("\nEvery PublishUserMessage site (event publish, arity 2) must be " +
-			"in the guarded set (preceded by a successful CreateMessage). " +
+		t.Error("\nEvery PublishUserMessage site (event publish, arity 2) and " +
+			"NotifyDMReceived site must be in the guarded set " +
+			"(preceded by a successful CreateMessage). " +
 			"Add the new site to the guarded list in this test.")
 	}
 
@@ -222,7 +299,7 @@ func TestPublishUserMessageEnumeration(t *testing.T) {
 		}
 	}
 
-	t.Logf("Verified %d PublishUserMessage call sites (event publish, arity 2): %d guarded",
+	t.Logf("Verified %d persisted-row effect call sites: %d guarded",
 		len(sites), len(guarded))
 }
 
@@ -240,17 +317,28 @@ func isPublishUserMessageCall(call *ast.CallExpr) bool {
 	return false
 }
 
-// publishDisambiguationSuffixes returns candidate suffixes for multi-call
-// functions containing PublishUserMessage. The mapping is hard-coded for known
-// cases.
-func publishDisambiguationSuffixes(file, fn string, idx, total int) []string {
+// isNotifyDMReceivedCall returns true if the call expression is a call to
+// NotifyDMReceived (any arity).
+func isNotifyDMReceivedCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	return sel.Sel.Name == "NotifyDMReceived"
+}
+
+// persistedRowDisambiguationSuffixes returns candidate suffixes for multi-call
+// functions containing enumerated persisted-row effect calls. The target
+// parameter indicates whether this is a "publish" or "notify" call. The
+// mapping is hard-coded for known cases.
+func persistedRowDisambiguationSuffixes(file, fn, target string, idx, total int) []string {
 	switch {
-	case file == "handlers_chat_v2.go" && fn == "sendAgentRouted" && total == 2:
+	case file == "handlers_chat_v2.go" && fn == "sendAgentRouted" && target == "publish" && total == 2:
 		if idx == 0 {
 			return []string{"primary"}
 		}
 		return []string{"mention"}
-	case file == "handlers_agent_messaging.go" && fn == "handleGroupMessage" && total == 2:
+	case file == "handlers_agent_messaging.go" && fn == "handleGroupMessage" && target == "publish" && total == 2:
 		if idx == 0 {
 			return []string{"agent"}
 		}

--- a/pkg/hub/publish_site_enumeration_test.go
+++ b/pkg/hub/publish_site_enumeration_test.go
@@ -25,11 +25,12 @@ import (
 )
 
 // TestPublishUserMessageEnumeration uses go/ast to find every
-// PublishUserMessage call site in non-test .go files under pkg/hub. Each site
-// must appear in either the "guarded" set (the call only executes when
-// CreateMessage has already succeeded) or the "exempt" set (broker proxy
-// routing where persistence is handled by the deliverToUser callback). Any
-// unaccounted site causes a hard failure — this is the durable guard for
+// PublishUserMessage call site (arity 2 — the event publish signature) in
+// non-test .go files under pkg/hub. Each site must appear in the "guarded"
+// set (the call only executes when CreateMessage has already succeeded).
+// Broker proxy calls (arity 4) are excluded from the population entirely —
+// persistence is handled by the deliverToUser callback, not by the caller.
+// Any unaccounted site causes a hard failure — this is the durable guard for
 // contract B11/B13: publishing an unpersisted message is not legal.
 func TestPublishUserMessageEnumeration(t *testing.T) {
 	// -------------------------------------------------------------------
@@ -60,9 +61,9 @@ func TestPublishUserMessageEnumeration(t *testing.T) {
 		// error check.
 		"handlers_broker_inbound.go:handleBrokerInbound": "Publish in else branch of CreateMessage error check",
 
-		// handleAgentOutboundMessage direct path: CreateMessage error
-		// triggers early return before publish.
-		"handlers_agent_messaging.go:handleAgentOutboundMessage:direct": "CreateMessage error triggers early return before publish",
+		// handleAgentOutboundMessage: CreateMessage error triggers early
+		// return before publish.
+		"handlers_agent_messaging.go:handleAgentOutboundMessage": "CreateMessage error triggers early return before publish",
 
 		// handleAgentMessage: publish inside if persistedMsgID != empty
 		// block.
@@ -80,30 +81,9 @@ func TestPublishUserMessageEnumeration(t *testing.T) {
 		"handlers_agent_messaging.go:processMentions": "Publish inside if persisted block",
 	}
 
-	// -------------------------------------------------------------------
-	// Exempt sites: broker proxy routing — persistence and guard handled
-	// by the deliverToUser callback in messagebroker.go.
-	// -------------------------------------------------------------------
-	exempt := map[string]string{
-		// dispatchToBroker: broker proxy routing method; persistence and
-		// guard handled by deliverToUser callback in messagebroker.go.
-		"notifications.go:dispatchToBroker": "Broker proxy routing; persistence and guard handled by deliverToUser callback",
-
-		// PublishToGroup: broker proxy fan-out routing; delegates to
-		// deliverToUser for persistence.
-		"messagebroker.go:PublishToGroup": "Broker proxy fan-out routing; delegates to deliverToUser for persistence",
-
-		// handleAgentOutboundMessage broker path: broker proxy routing;
-		// persistence handled by deliverToUser callback.
-		"handlers_agent_messaging.go:handleAgentOutboundMessage:broker": "Broker proxy routing; persistence handled by deliverToUser callback",
-	}
-
-	// Build combined set for lookup.
-	accounted := make(map[string]bool, len(guarded)+len(exempt))
+	// Build accounted set from guarded entries.
+	accounted := make(map[string]bool, len(guarded))
 	for k := range guarded {
-		accounted[k] = true
-	}
-	for k := range exempt {
 		accounted[k] = true
 	}
 
@@ -225,14 +205,13 @@ func TestPublishUserMessageEnumeration(t *testing.T) {
 	}
 
 	if len(unaccounted) > 0 {
-		t.Errorf("Found %d PublishUserMessage call site(s) not in guarded or exempt list:\n", len(unaccounted))
+		t.Errorf("Found %d PublishUserMessage call site(s) not in guarded list:\n", len(unaccounted))
 		for _, u := range unaccounted {
 			t.Errorf("  - %s", u)
 		}
-		t.Error("\nEvery PublishUserMessage site must be in the guarded set " +
-			"(preceded by a successful CreateMessage) or the exempt set " +
-			"(documented reason for omission). " +
-			"Add the new site to the appropriate list in this test.")
+		t.Error("\nEvery PublishUserMessage site (event publish, arity 2) must be " +
+			"in the guarded set (preceded by a successful CreateMessage). " +
+			"Add the new site to the guarded list in this test.")
 	}
 
 	// Verify all expected entries were actually found.
@@ -243,18 +222,20 @@ func TestPublishUserMessageEnumeration(t *testing.T) {
 		}
 	}
 
-	t.Logf("Verified %d PublishUserMessage call sites: %d guarded, %d exempt",
-		len(sites), len(guarded), len(exempt))
+	t.Logf("Verified %d PublishUserMessage call sites (event publish, arity 2): %d guarded",
+		len(sites), len(guarded))
 }
 
-// isPublishUserMessageCall returns true if the call expression is a call to a
-// function or method named PublishUserMessage.
+// isPublishUserMessageCall returns true if the call expression is a call to
+// PublishUserMessage with exactly 2 arguments (the event publish signature).
+// The broker proxy's PublishUserMessage takes 4 arguments and is excluded —
+// persistence is handled by its deliverToUser callback, not by the caller.
 func isPublishUserMessageCall(call *ast.CallExpr) bool {
 	switch fn := call.Fun.(type) {
 	case *ast.SelectorExpr:
-		return fn.Sel.Name == "PublishUserMessage"
+		return fn.Sel.Name == "PublishUserMessage" && len(call.Args) == 2
 	case *ast.Ident:
-		return fn.Name == "PublishUserMessage"
+		return fn.Name == "PublishUserMessage" && len(call.Args) == 2
 	}
 	return false
 }
@@ -274,11 +255,6 @@ func publishDisambiguationSuffixes(file, fn string, idx, total int) []string {
 			return []string{"agent"}
 		}
 		return []string{"user"}
-	case file == "handlers_agent_messaging.go" && fn == "handleAgentOutboundMessage" && total == 2:
-		if idx == 0 {
-			return []string{"broker"}
-		}
-		return []string{"direct"}
 	}
 	return nil
 }

--- a/pkg/hub/publish_site_enumeration_test.go
+++ b/pkg/hub/publish_site_enumeration_test.go
@@ -1,0 +1,284 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPublishUserMessageEnumeration uses go/ast to find every
+// PublishUserMessage call site in non-test .go files under pkg/hub. Each site
+// must appear in either the "guarded" set (the call only executes when
+// CreateMessage has already succeeded) or the "exempt" set (broker proxy
+// routing where persistence is handled by the deliverToUser callback). Any
+// unaccounted site causes a hard failure — this is the durable guard for
+// contract B11/B13: publishing an unpersisted message is not legal.
+func TestPublishUserMessageEnumeration(t *testing.T) {
+	// -------------------------------------------------------------------
+	// Guarded sites: each of these only executes after CreateMessage has
+	// succeeded (error return, else-branch, or conditional block).
+	// -------------------------------------------------------------------
+	guarded := map[string]string{
+		// createInboxMessage: CreateMessage error triggers early return
+		// before publish.
+		"notifications.go:createInboxMessage": "CreateMessage error triggers early return before publish",
+
+		// sendAgentRouted primary: CreateMessage error triggers early return
+		// before publish.
+		"handlers_chat_v2.go:sendAgentRouted:primary": "CreateMessage error triggers early return before publish",
+
+		// sendAgentRouted mention fan-out: publish in else branch of
+		// CreateMessage error check.
+		"handlers_chat_v2.go:sendAgentRouted:mention": "Publish in else branch of CreateMessage error check",
+
+		// sendHumanToHuman: CreateMessage error triggers early return
+		// before publish.
+		"handlers_chat_v2.go:sendHumanToHuman": "CreateMessage error triggers early return before publish",
+
+		// deliverToUser: publish inside if persistOK block.
+		"messagebroker.go:deliverToUser": "Publish inside if persistOK block",
+
+		// handleBrokerInbound: publish in else branch of CreateMessage
+		// error check.
+		"handlers_broker_inbound.go:handleBrokerInbound": "Publish in else branch of CreateMessage error check",
+
+		// handleAgentOutboundMessage direct path: CreateMessage error
+		// triggers early return before publish.
+		"handlers_agent_messaging.go:handleAgentOutboundMessage:direct": "CreateMessage error triggers early return before publish",
+
+		// handleAgentMessage: publish inside if persistedMsgID != empty
+		// block.
+		"handlers_agent_messaging.go:handleAgentMessage": "Publish inside if persistedMsgID != empty block",
+
+		// handleGroupMessage agent fan-out: publish in else branch of
+		// CreateMessage error check.
+		"handlers_agent_messaging.go:handleGroupMessage:agent": "Publish in else branch of CreateMessage error check",
+
+		// handleGroupMessage user fan-out: publish in else branch of
+		// CreateMessage error check.
+		"handlers_agent_messaging.go:handleGroupMessage:user": "Publish in else branch of CreateMessage error check",
+
+		// processMentions: publish inside if persisted block.
+		"handlers_agent_messaging.go:processMentions": "Publish inside if persisted block",
+	}
+
+	// -------------------------------------------------------------------
+	// Exempt sites: broker proxy routing — persistence and guard handled
+	// by the deliverToUser callback in messagebroker.go.
+	// -------------------------------------------------------------------
+	exempt := map[string]string{
+		// dispatchToBroker: broker proxy routing method; persistence and
+		// guard handled by deliverToUser callback in messagebroker.go.
+		"notifications.go:dispatchToBroker": "Broker proxy routing; persistence and guard handled by deliverToUser callback",
+
+		// PublishToGroup: broker proxy fan-out routing; delegates to
+		// deliverToUser for persistence.
+		"messagebroker.go:PublishToGroup": "Broker proxy fan-out routing; delegates to deliverToUser for persistence",
+
+		// handleAgentOutboundMessage broker path: broker proxy routing;
+		// persistence handled by deliverToUser callback.
+		"handlers_agent_messaging.go:handleAgentOutboundMessage:broker": "Broker proxy routing; persistence handled by deliverToUser callback",
+	}
+
+	// Build combined set for lookup.
+	accounted := make(map[string]bool, len(guarded)+len(exempt))
+	for k := range guarded {
+		accounted[k] = true
+	}
+	for k := range exempt {
+		accounted[k] = true
+	}
+
+	// -------------------------------------------------------------------
+	// Parse all non-test .go files under pkg/hub and find
+	// PublishUserMessage call sites.
+	// -------------------------------------------------------------------
+	hubDir := findHubDir(t)
+	fset := token.NewFileSet()
+
+	entries, err := os.ReadDir(hubDir)
+	if err != nil {
+		t.Fatalf("failed to read hub directory: %v", err)
+	}
+
+	type callSite struct {
+		file     string // base filename
+		line     int
+		funcName string // enclosing function name
+	}
+	var sites []callSite
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		fullPath := filepath.Join(hubDir, name)
+		f, err := parser.ParseFile(fset, fullPath, nil, 0)
+		if err != nil {
+			t.Fatalf("failed to parse %s: %v", name, err)
+		}
+
+		// Walk the AST and find every CallExpr ending in
+		// PublishUserMessage.
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if !isPublishUserMessageCall(call) {
+				return true
+			}
+			pos := fset.Position(call.Pos())
+			funcName := enclosingFuncName(fset, f, pos.Offset)
+			sites = append(sites, callSite{
+				file:     name,
+				line:     pos.Line,
+				funcName: funcName,
+			})
+			return true
+		})
+	}
+
+	if len(sites) == 0 {
+		t.Fatal("found zero PublishUserMessage call sites — the scanner is broken")
+	}
+
+	// -------------------------------------------------------------------
+	// Match each site to the accounted set. We match on file:enclosingFunc.
+	// When a function contains multiple PublishUserMessage calls, they are
+	// disambiguated by a suffix heuristic.
+	// -------------------------------------------------------------------
+
+	// Group sites by file:func to detect duplicates.
+	type groupKey struct{ file, fn string }
+	grouped := make(map[groupKey][]callSite)
+	for _, s := range sites {
+		k := groupKey{s.file, s.funcName}
+		grouped[k] = append(grouped[k], s)
+	}
+
+	// For each site, build a lookup key and check membership.
+	var unaccounted []string
+	matched := make(map[string]bool)
+
+	for gk, groupSites := range grouped {
+		if len(groupSites) == 1 {
+			key := gk.file + ":" + gk.fn
+			if accounted[key] {
+				matched[key] = true
+			} else {
+				unaccounted = append(unaccounted, key+
+					" (line "+itoa(groupSites[0].line)+")")
+			}
+		} else {
+			// Multiple PublishUserMessage calls in the same function.
+			// Try disambiguation using known suffix patterns.
+			for i, s := range groupSites {
+				key := gk.file + ":" + gk.fn
+				if accounted[key] && len(groupSites) == 1 {
+					matched[key] = true
+					continue
+				}
+				// Try suffixed keys.
+				found := false
+				for _, suffix := range publishDisambiguationSuffixes(gk.file, gk.fn, i, len(groupSites)) {
+					candidate := gk.file + ":" + gk.fn + ":" + suffix
+					if accounted[candidate] {
+						matched[candidate] = true
+						found = true
+						break
+					}
+				}
+				if !found {
+					// Try bare key (for single-entry funcs that
+					// happened to be grouped).
+					if accounted[key] && !matched[key] {
+						matched[key] = true
+					} else {
+						unaccounted = append(unaccounted,
+							gk.file+":"+gk.fn+
+								" (line "+itoa(s.line)+", call #"+itoa(i+1)+")")
+					}
+				}
+			}
+		}
+	}
+
+	if len(unaccounted) > 0 {
+		t.Errorf("Found %d PublishUserMessage call site(s) not in guarded or exempt list:\n", len(unaccounted))
+		for _, u := range unaccounted {
+			t.Errorf("  - %s", u)
+		}
+		t.Error("\nEvery PublishUserMessage site must be in the guarded set " +
+			"(preceded by a successful CreateMessage) or the exempt set " +
+			"(documented reason for omission). " +
+			"Add the new site to the appropriate list in this test.")
+	}
+
+	// Verify all expected entries were actually found.
+	for key := range accounted {
+		if !matched[key] {
+			t.Errorf("Expected call site %q is listed but was not found in source. "+
+				"The function may have been renamed, moved, or deleted.", key)
+		}
+	}
+
+	t.Logf("Verified %d PublishUserMessage call sites: %d guarded, %d exempt",
+		len(sites), len(guarded), len(exempt))
+}
+
+// isPublishUserMessageCall returns true if the call expression is a call to a
+// function or method named PublishUserMessage.
+func isPublishUserMessageCall(call *ast.CallExpr) bool {
+	switch fn := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		return fn.Sel.Name == "PublishUserMessage"
+	case *ast.Ident:
+		return fn.Name == "PublishUserMessage"
+	}
+	return false
+}
+
+// publishDisambiguationSuffixes returns candidate suffixes for multi-call
+// functions containing PublishUserMessage. The mapping is hard-coded for known
+// cases.
+func publishDisambiguationSuffixes(file, fn string, idx, total int) []string {
+	switch {
+	case file == "handlers_chat_v2.go" && fn == "sendAgentRouted" && total == 2:
+		if idx == 0 {
+			return []string{"primary"}
+		}
+		return []string{"mention"}
+	case file == "handlers_agent_messaging.go" && fn == "handleGroupMessage" && total == 2:
+		if idx == 0 {
+			return []string{"agent"}
+		}
+		return []string{"user"}
+	case file == "handlers_agent_messaging.go" && fn == "handleAgentOutboundMessage" && total == 2:
+		if idx == 0 {
+			return []string{"broker"}
+		}
+		return []string{"direct"}
+	}
+	return nil
+}


### PR DESCRIPTION
Adds Phase 5 dual-write conversation stamping to the remaining pkg/hub CreateMessage sites, guards every SSE publish on a successful persist, and locks both invariants with AST enumeration tests so a new call site cannot silently miss them.

- CreateMessage enumeration: 12 stamped, 1 exempt (broadcastDirect, deferred pending a group-conversation model).
- PublishUserMessage enumeration: discriminated by arity so broker-proxy calls leave the population entirely. 11 event-publish sites, all guarded, zero exemptions.
- createInboxMessage now stamps notification inbox messages, so WAITING_FOR_INPUT notifications survive the S4 read-switch.

Known gap, marked in the tests: DMConversationKey is UUID-strict, and NotificationSubscription.SubscriberID may be a slug or a federated identity. Those subscribers are logged and left unstamped rather than mis-keyed. Tracked as DEF-32; the affected test carries a marker noting its expectation inverts when federated-identity resolution lands.

Verified: mutation testing on the stamping and both enumerations. pkg/hub has one pre-existing failure (TestTemplateResource_UATConfinement) that reproduces on upstream/main and is excluded from CI by the no_sqlite tag