### PR TITLE
fix(messaging): B2/B1/B14 - route DM participant guard through one shared predicate

### DIFF
--- a/.design/project-log/b2b1b14-dm-migration-fixes.md
+++ b/.design/project-log/b2b1b14-dm-migration-fixes.md
@@ -1,0 +1,63 @@
+# B2+B1+B14: DM Migration Atomicity, D-1 Guard Routing, Empty-Ref Ruling
+
+**Date:** 2026-08-28
+**Branch:** `scion/ca-msg-em6-b2b1b14`
+**Base:** `ea35abfdd` (origin/main)
+
+## Summary
+
+Four commits addressing three bugs in the DM migration system:
+
+### Commit 1: Shared predicate extraction
+
+Extracted `messages.CheckDMParticipantKey(convKind, externalRef, principalKind, principalID)` into `pkg/messages/dm_key.go` — the canonical D-1 immutability guard implementation. Refactored `checkDMParticipantKey` in `pkg/store/entadapter/conversation_store.go` to delegate to it, wrapping errors with `store.ErrInvalidInput` to preserve existing `ErrorIs` behaviour.
+
+### Commit 2: B2 — Atomicity fix in mergeConversation
+
+**Bug:** The re-stamp loop in `mergeConversation` recorded errors in `result.Errors` but continued to soft-delete the old row. If re-stamping failed, messages were left pointing at a soft-deleted row — data loss.
+
+**Fix:** Track re-stamp failures; abort before participant copy or soft-delete. Under-migrating is recoverable; deleting the source is not.
+
+### Commit 3: B1 — D-1 guard routing in mergeConversation
+
+**Bug:** `mergeConversation` blindly copied ALL old-row participants to the target via `AddParticipant`. A stranger in the old row's participant table would be copied. The D-1 guard in `AddParticipant` would reject the stranger, but the error was swallowed.
+
+**Fix:** Before the participant copy loop, look up the target conversation's kind and external_ref. Filter each participant through `messages.CheckDMParticipantKey` before calling `AddParticipant`. Strangers are logged and skipped.
+
+### Commit 4: B14 — Empty-ref ruling
+
+**Bug:** `stepMergeOrRekeyEmptyRef` read participants from an empty-ref row and synthesized a key from them, fabricating an ACL from the listing index.
+
+**Ruling:** An empty-ref direct row must be left keyless for operator review. Deriving a key from the participant index inverts the direction of authority. This does NOT contradict re-keying malformed-but-parseable keys (step 3b), where principals are already named in the data — that is normalization, not fabrication.
+
+**Fix:** `stepMergeOrRekeyEmptyRef` now unconditionally skips, incrementing a new `EmptyRefSkipped` counter on `DMMigrationResult`.
+
+## Mutation verification
+
+| Fix | Test | Mutation (revert fix alone) | Result |
+|-----|------|---------------------------|--------|
+| B2 | `TestB2_MergeAbortsOnRestampFailure` | Remove `restampFailed` abort → old row soft-deleted | ✅ FAIL as expected |
+| B1 | `TestB1_MergeRejectsStrangerParticipant`, `TestB1_SharedPredicate_MergeConversationDirectly` | Remove `CheckDMParticipantKey` filter → stranger copied | ✅ FAIL as expected |
+| B14 | `TestB14_EmptyRefRowLeftKeyless` | Restore old fabrication logic → row re-keyed | ✅ FAIL as expected |
+
+All three mutations confirmed: each test fails only when its specific fix is reverted, with positive controls confirming the selector selects.
+
+## Gate results
+
+- `gofmt -l .` — clean
+- `make check-authz-guards` — no violations
+- `make compat-literals` — clean
+- `./hack/check-conversation-upsert-guard.sh` — no violations
+- `make test-fast` — all pass
+- `make build` — success
+- `go test ./pkg/messaging/... -count=1` — all pass
+- `go test ./pkg/messages/... -count=1` — all pass
+- `go test -tags '!no_sqlite' ./pkg/store/entadapter/... -count=1` — all pass
+
+## Files changed
+
+- `pkg/messages/dm_key.go` — added `CheckDMParticipantKey`
+- `pkg/messages/dm_key_test.go` — tests for shared predicate
+- `pkg/store/entadapter/conversation_store.go` — refactored `checkDMParticipantKey` to delegate
+- `pkg/messaging/dm_migration.go` — B2 atomicity, B1 guard routing, B14 skip, `EmptyRefSkipped` counter
+- `pkg/messaging/dm_migration_test.go` — tests for B2, B1, B14 with mutation contracts

--- a/.design/project-log/b2b1b14-fixes.md
+++ b/.design/project-log/b2b1b14-fixes.md
@@ -1,0 +1,77 @@
+# B2/B1/B14 Architect Review Fixes
+
+**Date:** 2026-08-28
+**Branch:** scion/ca-msg-em6-b2b1b14
+**Author:** dev-b2b1b14-fixes
+
+## Summary
+
+Three fixes requested by the architect after reviewing the B2/B1/B14 DM migration
+changes. All are non-functional (tests and comments only); no production code changed.
+
+## Fix 1: AST Enumeration Test for D-1 Guard Call Sites
+
+**File:** `pkg/store/entadapter/dm_guard_enumeration_test.go`
+
+Created a new AST-based enumeration test with no build tag, so it runs under
+`-tags no_sqlite` (CI mode). The test parses `conversation_store.go` and verifies:
+
+1. `AddParticipant` calls `checkDMParticipantKey`
+2. `EnsureParticipant` calls `checkDMParticipantKey`
+3. `checkDMParticipantKey` delegates to `messages.CheckDMParticipantKey`
+
+### Mutation m4 Results
+
+**m4 under `-tags no_sqlite` (CI mode) — KILLED:**
+```
+--- FAIL: TestDMGuardCallSites_Enumeration (0.00s)
+    --- FAIL: TestDMGuardCallSites_Enumeration/checkDMParticipantKey_delegates_to_messages (0.00s)
+        dm_guard_enumeration_test.go:158: checkDMParticipantKey does not call messages.CheckDMParticipantKey — the delegation to the shared predicate in pkg/messages has been severed. See conversation_store_test.go for the behavioural tests.
+FAIL
+FAIL	github.com/GoogleCloudPlatform/scion/pkg/store/entadapter	0.010s
+FAIL
+```
+
+**m4 without tag (full mode) — KILLED:**
+```
+--- FAIL: TestDMGuardCallSites_Enumeration (0.00s)
+    --- FAIL: TestDMGuardCallSites_Enumeration/checkDMParticipantKey_delegates_to_messages (0.00s)
+        dm_guard_enumeration_test.go:158: checkDMParticipantKey does not call messages.CheckDMParticipantKey — the delegation to the shared predicate in pkg/messages has been severed. See conversation_store_test.go for the behavioural tests.
+FAIL
+FAIL	github.com/GoogleCloudPlatform/scion/pkg/store/entadapter	0.011s
+FAIL
+```
+
+## Fix 2: Tautology Explanation at stepRebuildParticipants
+
+**File:** `pkg/messaging/dm_migration.go` (~line 206)
+
+Added a comment explaining why `AddParticipant` in `stepRebuildParticipants` has
+no explicit `CheckDMParticipantKey` guard: the principals `{kindA, idA}` and
+`{kindB, idB}` are derived from `ParseDMKey` on the row's own `external_ref`,
+so the check would re-parse the same string and compare its output to itself
+(a tautology). Points to `mergeConversation` (~line 439) as the site where
+principals are foreign and the guard is load-bearing.
+
+## Fix 3: DEF-29 in B14 Pinning Tests
+
+**File:** `pkg/messaging/dm_migration_test.go`
+
+Updated doc comments for all five B14 pinning tests to reference DEF-29 and
+explain that they pin current-but-wrong behaviour:
+
+1. `TestGuardA_Migration_EmptyRefDirectRowsSkipped`
+2. `TestStep3a_EmptyRefRowSkipped`
+3. `TestStep3a_EmptyRefNotRekeyed`
+4. `TestStep3a_EmptyRefSkippedRegardlessOfParticipantCount`
+5. `TestB14_EmptyRefRowLeftKeyless`
+
+### DEF-29 Naming Rationale
+
+A direct conversation's `external_ref` IS its access-control basis — the DM key
+names who is entitled to see the messages. A keyless row has no ACL at all. The
+migration currently leaves these rows keyless because deriving a key from the
+listing index would fabricate an ACL (B14 ruling). This is correct behaviour
+given the constraint, but the underlying problem (keyless rows exist) is tracked
+as DEF-29. When DEF-29 closes, the test expectations will invert; the correct
+resolution is operator review, not automated migration.

--- a/pkg/messages/dm_key.go
+++ b/pkg/messages/dm_key.go
@@ -84,6 +84,26 @@ func PrincipalKindFromAddress(address string) (string, bool) {
 	return "", false
 }
 
+// CheckDMParticipantKey validates that the given principal is named in a direct
+// conversation's kind-encoded DM key. For non-direct conversations the function
+// is a no-op (returns nil). This is the canonical shared implementation of the
+// D-1 immutability guard, used by both the store layer (AddParticipant /
+// EnsureParticipant) and the migration layer (mergeConversation).
+func CheckDMParticipantKey(convKind, externalRef, principalKind, principalID string) error {
+	if convKind != "direct" {
+		return nil
+	}
+	kindA, idA, kindB, idB, parseErr := ParseDMKey(externalRef)
+	if parseErr != nil {
+		return fmt.Errorf("direct conversation has unparseable external_ref: %w", parseErr)
+	}
+	if (principalKind != kindA || principalID != idA) &&
+		(principalKind != kindB || principalID != idB) {
+		return fmt.Errorf("participant (%s, %s) not named in direct conversation key", principalKind, principalID)
+	}
+	return nil
+}
+
 // ParseDMKey parses a key produced by DMConversationKey back into its
 // constituent parts. The returned kinds and IDs are in sorted token order
 // (the same order they appear in the key).

--- a/pkg/messages/dm_key_test.go
+++ b/pkg/messages/dm_key_test.go
@@ -268,3 +268,40 @@ func TestDMConversationKey_GoldenVectors(t *testing.T) {
 	key2, _ := DMConversationKey(vectors[1].kindA, vectors[1].idA, vectors[1].kindB, vectors[1].idB)
 	assert.Equal(t, key1, key2, "reversed argument order must produce the same key")
 }
+
+// ---------------------------------------------------------------------------
+// CheckDMParticipantKey tests
+// ---------------------------------------------------------------------------
+
+func TestCheckDMParticipantKey_NonDirectIsNoop(t *testing.T) {
+	err := CheckDMParticipantKey("group", "anything", "user", uuid.NewString())
+	assert.NoError(t, err, "non-direct conversations should pass unconditionally")
+}
+
+func TestCheckDMParticipantKey_AcceptsNamedParticipant(t *testing.T) {
+	userID := uuid.NewString()
+	agentID := uuid.NewString()
+	key, err := DMConversationKey("user", userID, "agent", agentID)
+	require.NoError(t, err)
+
+	assert.NoError(t, CheckDMParticipantKey("direct", key, "user", userID))
+	assert.NoError(t, CheckDMParticipantKey("direct", key, "agent", agentID))
+}
+
+func TestCheckDMParticipantKey_RejectsStranger(t *testing.T) {
+	userID := uuid.NewString()
+	agentID := uuid.NewString()
+	strangerID := uuid.NewString()
+	key, err := DMConversationKey("user", userID, "agent", agentID)
+	require.NoError(t, err)
+
+	err = CheckDMParticipantKey("direct", key, "user", strangerID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not named in direct conversation key")
+}
+
+func TestCheckDMParticipantKey_UnparseableRef(t *testing.T) {
+	err := CheckDMParticipantKey("direct", "garbage-key", "user", uuid.NewString())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unparseable external_ref")
+}

--- a/pkg/messaging/dm_migration.go
+++ b/pkg/messaging/dm_migration.go
@@ -39,6 +39,7 @@ type DMMigrationResult struct {
 	ParticipantsAdded int      // step 2: participants derived from key
 	EmptyRefMerged    int      // step 3a: empty-ref rows merged with existing
 	EmptyRefRekeyed   int      // step 3a: empty-ref rows re-keyed in place
+	EmptyRefSkipped   int      // step 3a: empty-ref rows left keyless (B14 ruling)
 	OldFormatRekeyed  int      // step 3b: old dm:X:Y rows re-keyed
 	Unparseable       int      // rows that could not be processed
 	Ambiguous         int      // IDs found in neither or both tables
@@ -259,80 +260,19 @@ func (s *DMMigrationService) countMissingParticipants(
 // ---------------------------------------------------------------------------
 
 func (s *DMMigrationService) stepMergeOrRekeyEmptyRef(
-	ctx context.Context,
-	conv *store.Conversation,
-	dryRun bool,
+	_ context.Context,
+	_ *store.Conversation,
+	_ bool,
 	result *DMMigrationResult,
 ) {
-	// Read participants to determine the two principals.
-	parts, err := s.store.ListParticipants(ctx, conv.ID)
-	if err != nil {
-		result.Unparseable++
-		result.Errors = append(result.Errors,
-			fmt.Sprintf("step3a: list participants for %s: %v", conv.ID, err))
-		return
-	}
-
-	// Filter to active participants (no LeftAt).
-	var active []store.ConversationParticipant
-	for _, p := range parts {
-		if p.LeftAt == nil {
-			active = append(active, p)
-		}
-	}
-
-	if len(active) != 2 {
-		result.Unparseable++
-		return
-	}
-
-	// Validate kinds.
-	if !isValidDMKind(active[0].PrincipalKind) || !isValidDMKind(active[1].PrincipalKind) {
-		result.Unparseable++
-		return
-	}
-
-	// Compute the kind-encoded key.
-	newKey, err := messages.DMConversationKey(
-		active[0].PrincipalKind, active[0].PrincipalID,
-		active[1].PrincipalKind, active[1].PrincipalID,
-	)
-	if err != nil {
-		result.Unparseable++
-		result.Errors = append(result.Errors,
-			fmt.Sprintf("step3a: compute key for %s: %v", conv.ID, err))
-		return
-	}
-
-	// Check if a row with this key already exists.
-	existing, err := s.store.GetConversationByExternalRef(ctx, "native", newKey)
-	if err == nil && existing != nil && existing.ID != conv.ID {
-		// Merge case: re-stamp messages and soft-delete old row.
-		if dryRun {
-			result.EmptyRefMerged++
-			return
-		}
-		if mergeErr := s.mergeConversation(ctx, conv.ID, existing.ID, active, result); mergeErr != nil {
-			result.Errors = append(result.Errors,
-				fmt.Sprintf("step3a: merge %s → %s: %v", conv.ID, existing.ID, mergeErr))
-			return
-		}
-		result.EmptyRefMerged++
-	} else {
-		// Re-key in place.
-		if dryRun {
-			result.EmptyRefRekeyed++
-			return
-		}
-		conv.ExternalRef = newKey
-		conv.ProjectID = nil // DMs are global (DEF-10)
-		if err := s.store.UpdateConversation(ctx, conv); err != nil {
-			result.Errors = append(result.Errors,
-				fmt.Sprintf("step3a: re-key %s: %v", conv.ID, err))
-			return
-		}
-		result.EmptyRefRekeyed++
-	}
+	// B14 RULING: an empty-ref direct row has no ACL. Deriving a key from the
+	// participant index would fabricate an ACL from the listing index, inverting
+	// the direction of authority. Left keyless for operator review.
+	//
+	// Distinction: re-keying a malformed-but-parseable key (where principals
+	// are already named in the data) is normalization. Inventing a key from
+	// the index is fabrication. This row has no key data at all.
+	result.EmptyRefSkipped++
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/messaging/dm_migration.go
+++ b/pkg/messaging/dm_migration.go
@@ -485,8 +485,23 @@ func (s *DMMigrationService) mergeConversation(
 		return fmt.Errorf("aborting merge %s → %s: re-stamp failed, old row left intact", oldConvID, newConvID)
 	}
 
+	// B1 D-1 GUARD ROUTING: look up the target conversation to get its kind
+	// and external_ref, then filter each old participant through
+	// CheckDMParticipantKey before copying. This prevents a stranger in the
+	// old row's participant table from being injected into the target DM.
+	targetConv, err := s.store.GetConversation(ctx, newConvID)
+	if err != nil {
+		return fmt.Errorf("loading target conversation %s for participant guard: %w", newConvID, err)
+	}
+
 	// Copy missing participants to the target conversation.
 	for _, p := range oldParticipants {
+		if guardErr := messages.CheckDMParticipantKey(targetConv.Kind, targetConv.ExternalRef, p.PrincipalKind, p.PrincipalID); guardErr != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("skip participant %s:%s (not named in target DM key): %v",
+					p.PrincipalKind, p.PrincipalID, guardErr))
+			continue
+		}
 		err := s.store.AddParticipant(ctx, &store.ConversationParticipant{
 			ID:             uuid.NewString(),
 			ConversationID: newConvID,

--- a/pkg/messaging/dm_migration.go
+++ b/pkg/messaging/dm_migration.go
@@ -203,7 +203,11 @@ func (s *DMMigrationService) stepRebuildParticipants(
 		return
 	}
 
-	// Add participants (idempotent — ErrAlreadyExists is expected for existing).
+	// No CheckDMParticipantKey guard here: {kindA, idA} and {kindB, idB} are
+	// derived from ParseDMKey on this row's own external_ref (line 184), so the
+	// check would re-parse the same string and compare its output to itself — a
+	// tautology. See mergeConversation (~line 439) for the site where principals
+	// are foreign and the guard is load-bearing.
 	added := 0
 	for _, p := range []struct{ kind, id string }{{kindA, idA}, {kindB, idB}} {
 		err := s.store.AddParticipant(ctx, &store.ConversationParticipant{

--- a/pkg/messaging/dm_migration.go
+++ b/pkg/messaging/dm_migration.go
@@ -437,6 +437,9 @@ func (s *DMMigrationService) mergeConversation(
 	if err != nil {
 		return fmt.Errorf("loading target conversation %s for participant guard: %w", newConvID, err)
 	}
+	if targetConv == nil {
+		return fmt.Errorf("target conversation %s not found (nil without error)", newConvID)
+	}
 
 	// Copy missing participants to the target conversation.
 	for _, p := range oldParticipants {

--- a/pkg/messaging/dm_migration.go
+++ b/pkg/messaging/dm_migration.go
@@ -451,6 +451,7 @@ func (s *DMMigrationService) mergeConversation(
 	result *DMMigrationResult,
 ) error {
 	// Re-stamp all messages from old conversation to new.
+	var restampFailed bool
 	cursor := ""
 	for {
 		page, err := s.store.ListMessages(ctx, store.MessageFilter{
@@ -465,6 +466,7 @@ func (s *DMMigrationService) mergeConversation(
 
 		for _, msg := range page.Items {
 			if err := s.store.SetMessageConversationID(ctx, msg.ID, newConvID); err != nil {
+				restampFailed = true
 				result.Errors = append(result.Errors,
 					fmt.Sprintf("re-stamp message %s: %v", msg.ID, err))
 			}
@@ -474,6 +476,13 @@ func (s *DMMigrationService) mergeConversation(
 			break
 		}
 		cursor = page.NextCursor
+	}
+
+	// B2 ATOMICITY: if any re-stamp failed, abort the merge. Under-migrating
+	// is recoverable; deleting the source row while messages still reference
+	// it is data loss.
+	if restampFailed {
+		return fmt.Errorf("aborting merge %s → %s: re-stamp failed, old row left intact", oldConvID, newConvID)
 	}
 
 	// Copy missing participants to the target conversation.

--- a/pkg/messaging/dm_migration_test.go
+++ b/pkg/messaging/dm_migration_test.go
@@ -338,6 +338,12 @@ func TestStep2_IdempotentExistingParticipants(t *testing.T) {
 
 // TestStep3a_EmptyRefRowSkipped verifies that an empty-ref row is left
 // keyless per the B14 ruling — it is NOT merged or re-keyed.
+//
+// DEF-29 (open): a direct conversation's external_ref IS its access-control
+// basis; a keyless row has no ACL. This test pins current-but-wrong behaviour —
+// the migration skips empty-ref rows rather than resolving them. Expectations
+// will invert when DEF-29 closes; correct resolution is operator review, not
+// migration.
 func TestStep3a_EmptyRefRowSkipped(t *testing.T) {
 	ms := newMockMigrationStore()
 	ctx := context.Background()
@@ -403,6 +409,12 @@ func TestStep3a_EmptyRefRowSkipped(t *testing.T) {
 
 // TestStep3a_EmptyRefNotRekeyed verifies that an empty-ref row with no
 // existing kind-encoded counterpart is NOT re-keyed in place (B14 ruling).
+//
+// DEF-29 (open): a direct conversation's external_ref IS its access-control
+// basis; a keyless row has no ACL. This test pins current-but-wrong behaviour —
+// the migration does not fabricate a key from the participant index. Expectations
+// will invert when DEF-29 closes; correct resolution is operator review, not
+// migration.
 func TestStep3a_EmptyRefNotRekeyed(t *testing.T) {
 	ms := newMockMigrationStore()
 	ctx := context.Background()
@@ -441,6 +453,12 @@ func TestStep3a_EmptyRefNotRekeyed(t *testing.T) {
 
 // TestStep3a_EmptyRefSkippedRegardlessOfParticipantCount verifies that
 // empty-ref rows are skipped regardless of participant count (B14 ruling).
+//
+// DEF-29 (open): a direct conversation's external_ref IS its access-control
+// basis; a keyless row has no ACL. This test pins current-but-wrong behaviour —
+// the migration skips empty-ref rows even when only one participant exists.
+// Expectations will invert when DEF-29 closes; correct resolution is operator
+// review, not migration.
 func TestStep3a_EmptyRefSkippedRegardlessOfParticipantCount(t *testing.T) {
 	ms := newMockMigrationStore()
 	ctx := context.Background()
@@ -704,6 +722,11 @@ func TestDryRun_NoWrites(t *testing.T) {
 // empty-ref direct conversations are left keyless (B14 ruling) and counted
 // as EmptyRefSkipped for operator visibility.
 // Floor: the test creates at least 2 such rows before migration (rule 14).
+//
+// DEF-29 (open): a keyless direct row has no ACL. This test pins current-but-wrong
+// behaviour — the migration leaves these rows keyless because deriving a key from
+// the listing index would fabricate an ACL (B14 ruling). Expectations will invert
+// when DEF-29 closes; correct resolution is operator review, not migration.
 func TestGuardA_Migration_EmptyRefDirectRowsSkipped(t *testing.T) {
 	ms := newMockMigrationStore()
 	ctx := context.Background()
@@ -1139,6 +1162,11 @@ func TestB1_SharedPredicate_MergeConversationDirectly(t *testing.T) {
 //
 // Mutation contract: reverting the skip (restoring the old stepMergeOrRekeyEmptyRef
 // logic) causes this test to fail because the row gets re-keyed.
+//
+// DEF-29 (open): a keyless direct row has no ACL. This test pins current-but-wrong
+// behaviour — the migration leaves these rows keyless because deriving a key from
+// the listing index would fabricate an ACL (B14 ruling). Expectations will invert
+// when DEF-29 closes; correct resolution is operator review, not migration.
 func TestB14_EmptyRefRowLeftKeyless(t *testing.T) {
 	ms := newMockMigrationStore()
 	ctx := context.Background()

--- a/pkg/messaging/dm_migration_test.go
+++ b/pkg/messaging/dm_migration_test.go
@@ -16,6 +16,7 @@ package messaging
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"strings"
 	"testing"
@@ -932,4 +933,59 @@ func TestMigration_MixedScenarios(t *testing.T) {
 	assert.Equal(t, 0, result.Unparseable)
 	assert.Equal(t, 0, result.Ambiguous)
 	assert.Len(t, result.Errors, 0)
+}
+
+// ---------------------------------------------------------------------------
+// B2: Atomicity — re-stamp failure must not delete the old row
+// ---------------------------------------------------------------------------
+
+// failingRestamp wraps the mock and makes message re-stamping always fail.
+type failingRestamp struct{ *mockMigrationStore }
+
+func (f *failingRestamp) SetMessageConversationID(_ context.Context, _, _ string) error {
+	return errors.New("simulated DB failure during re-stamp")
+}
+
+// TestB2_MergeAbortsOnRestampFailure verifies that mergeConversation does NOT
+// soft-delete the old conversation row when re-stamping messages fails.
+//
+// Mutation contract: removing the restampFailed abort check causes this test
+// to fail because the old row gets soft-deleted despite re-stamp failure.
+func TestB2_MergeAbortsOnRestampFailure(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+	userID, agentID := uuid.NewString(), uuid.NewString()
+	oldConvID, newConvID := uuid.NewString(), uuid.NewString()
+
+	ms.users[userID] = &store.User{ID: userID, Email: "t@e.com"}
+	ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "a"}
+
+	// Old empty-ref row with a message.
+	ms.addConv(&store.Conversation{ID: oldConvID, Kind: "direct", Surface: "native", ExternalRef: ""},
+		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "user", PrincipalID: userID},
+		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "agent", PrincipalID: agentID})
+
+	// Target kind-encoded row.
+	ms.addConv(&store.Conversation{ID: newConvID, Kind: "direct", Surface: "native",
+		ExternalRef: mustDMKey("user", userID, "agent", agentID)},
+		store.ConversationParticipant{ConversationID: newConvID, PrincipalKind: "user", PrincipalID: userID},
+		store.ConversationParticipant{ConversationID: newConvID, PrincipalKind: "agent", PrincipalID: agentID})
+
+	msgID := uuid.NewString()
+	ms.addMessage(&store.Message{ID: msgID, ConversationID: oldConvID, Msg: "important history"})
+
+	svc := NewDMMigrationService(&failingRestamp{ms})
+	result, _ := svc.Run(ctx, DMMigrationConfig{})
+
+	// (a) Old row must NOT be soft-deleted.
+	assert.Nil(t, ms.conversations[oldConvID].DeletedAt,
+		"old row must not be soft-deleted when re-stamp fails")
+
+	// (b) Message must still point at old conversation.
+	assert.Equal(t, oldConvID, ms.messages[msgID].ConversationID,
+		"message must still reference old conversation after re-stamp failure")
+
+	// (c) Errors must be reported.
+	assert.NotEmpty(t, result.Errors,
+		"result.Errors must be non-empty after re-stamp failure")
 }

--- a/pkg/messaging/dm_migration_test.go
+++ b/pkg/messaging/dm_migration_test.go
@@ -989,3 +989,129 @@ func TestB2_MergeAbortsOnRestampFailure(t *testing.T) {
 	assert.NotEmpty(t, result.Errors,
 		"result.Errors must be non-empty after re-stamp failure")
 }
+
+// ---------------------------------------------------------------------------
+// B1: D-1 guard routing — mergeConversation must filter participants
+// ---------------------------------------------------------------------------
+
+// TestB1_MergeRejectsStrangerParticipant verifies that mergeConversation does
+// NOT copy a participant that is not named in the target DM key. The two
+// legitimate participants are still copied (positive control).
+//
+// Mutation contract: removing the CheckDMParticipantKey filter causes this
+// test to fail because the stranger gets copied to the target conversation.
+func TestB1_MergeRejectsStrangerParticipant(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+	userID, agentID := uuid.NewString(), uuid.NewString()
+	strangerID := uuid.NewString()
+	oldConvID, newConvID := uuid.NewString(), uuid.NewString()
+
+	ms.users[userID] = &store.User{ID: userID, Email: "t@e.com"}
+	ms.users[strangerID] = &store.User{ID: strangerID, Email: "stranger@e.com"}
+	ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "a"}
+
+	// Old-format row with stranger in participant list.
+	ms.addConv(&store.Conversation{ID: oldConvID, Kind: "direct", Surface: "native",
+		ExternalRef: "dm:" + userID + ":" + agentID},
+		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "user", PrincipalID: userID},
+		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "agent", PrincipalID: agentID},
+		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "user", PrincipalID: strangerID})
+
+	// Target kind-encoded row.
+	targetKey := mustDMKey("user", userID, "agent", agentID)
+	ms.addConv(&store.Conversation{ID: newConvID, Kind: "direct", Surface: "native",
+		ExternalRef: targetKey},
+		store.ConversationParticipant{ConversationID: newConvID, PrincipalKind: "user", PrincipalID: userID},
+		store.ConversationParticipant{ConversationID: newConvID, PrincipalKind: "agent", PrincipalID: agentID})
+
+	svc := NewDMMigrationService(ms)
+	_, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	// Stranger must NOT be in target's participant list.
+	for _, p := range ms.participants[newConvID] {
+		if p.PrincipalID == strangerID {
+			t.Errorf("stranger %s was injected into DM keyed %s", strangerID, targetKey)
+		}
+	}
+
+	// Positive control: named participants ARE present.
+	var hasUser, hasAgent bool
+	for _, p := range ms.participants[newConvID] {
+		if p.PrincipalKind == "user" && p.PrincipalID == userID {
+			hasUser = true
+		}
+		if p.PrincipalKind == "agent" && p.PrincipalID == agentID {
+			hasAgent = true
+		}
+	}
+	assert.True(t, hasUser, "named user must be present in target")
+	assert.True(t, hasAgent, "named agent must be present in target")
+}
+
+// TestB1_SharedPredicate_MergeConversationDirectly calls mergeConversation
+// directly (not through Run) with a stranger participant and asserts rejection.
+// This proves that the shared messages.CheckDMParticipantKey predicate is the
+// enforcement point for mergeConversation — a test that only exercises Run
+// would pass against two divergent copies of the guard logic.
+func TestB1_SharedPredicate_MergeConversationDirectly(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+	userID, agentID := uuid.NewString(), uuid.NewString()
+	strangerID := uuid.NewString()
+	oldConvID, newConvID := uuid.NewString(), uuid.NewString()
+
+	ms.users[userID] = &store.User{ID: userID, Email: "t@e.com"}
+	ms.users[strangerID] = &store.User{ID: strangerID, Email: "stranger@e.com"}
+	ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "a"}
+
+	targetKey := mustDMKey("user", userID, "agent", agentID)
+
+	ms.addConv(&store.Conversation{ID: oldConvID, Kind: "direct", Surface: "native",
+		ExternalRef: ""},
+		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "user", PrincipalID: userID},
+		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "agent", PrincipalID: agentID},
+		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "user", PrincipalID: strangerID})
+
+	ms.addConv(&store.Conversation{ID: newConvID, Kind: "direct", Surface: "native",
+		ExternalRef: targetKey},
+		store.ConversationParticipant{ConversationID: newConvID, PrincipalKind: "user", PrincipalID: userID},
+		store.ConversationParticipant{ConversationID: newConvID, PrincipalKind: "agent", PrincipalID: agentID})
+
+	svc := NewDMMigrationService(ms)
+	result := &DMMigrationResult{}
+	oldParts := ms.participants[oldConvID]
+
+	mergeErr := svc.mergeConversation(ctx, oldConvID, newConvID, oldParts, result)
+	require.NoError(t, mergeErr)
+
+	// Stranger must NOT be in target.
+	for _, p := range ms.participants[newConvID] {
+		if p.PrincipalID == strangerID {
+			t.Errorf("stranger %s was injected into DM via direct mergeConversation call", strangerID)
+		}
+	}
+
+	// Positive control: named participants are present.
+	var hasUser, hasAgent bool
+	for _, p := range ms.participants[newConvID] {
+		if p.PrincipalKind == "user" && p.PrincipalID == userID {
+			hasUser = true
+		}
+		if p.PrincipalKind == "agent" && p.PrincipalID == agentID {
+			hasAgent = true
+		}
+	}
+	assert.True(t, hasUser, "named user must be present via direct mergeConversation call")
+	assert.True(t, hasAgent, "named agent must be present via direct mergeConversation call")
+
+	// At least one error about skipping the stranger.
+	var foundSkipError bool
+	for _, e := range result.Errors {
+		if strings.Contains(e, "skip participant") && strings.Contains(e, strangerID) {
+			foundSkipError = true
+		}
+	}
+	assert.True(t, foundSkipError, "expected error about skipping stranger participant")
+}

--- a/pkg/messaging/dm_migration_test.go
+++ b/pkg/messaging/dm_migration_test.go
@@ -336,9 +336,9 @@ func TestStep2_IdempotentExistingParticipants(t *testing.T) {
 // Step 3a: Empty-ref merge/re-key tests
 // ---------------------------------------------------------------------------
 
-// TestStep3a_MergeEmptyRefWithExisting verifies that an empty-ref row is merged
-// with an existing kind-encoded row — messages re-stamped, old row deleted.
-func TestStep3a_MergeEmptyRefWithExisting(t *testing.T) {
+// TestStep3a_EmptyRefRowSkipped verifies that an empty-ref row is left
+// keyless per the B14 ruling — it is NOT merged or re-keyed.
+func TestStep3a_EmptyRefRowSkipped(t *testing.T) {
 	ms := newMockMigrationStore()
 	ctx := context.Background()
 
@@ -361,7 +361,7 @@ func TestStep3a_MergeEmptyRefWithExisting(t *testing.T) {
 		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "agent", PrincipalID: agentID},
 	)
 
-	// Existing kind-encoded row for the same pair.
+	// Existing kind-encoded row for the same pair (merge target would be this).
 	extRef := mustDMKey("user", userID, "agent", agentID)
 	ms.addConv(&store.Conversation{
 		ID:          newConvID,
@@ -385,19 +385,25 @@ func TestStep3a_MergeEmptyRefWithExisting(t *testing.T) {
 	result, err := svc.Run(ctx, DMMigrationConfig{})
 	require.NoError(t, err)
 
-	// Old row should be soft-deleted.
-	assert.NotNil(t, ms.conversations[oldConvID].DeletedAt, "old row should be soft-deleted")
+	// B14: old row must NOT be soft-deleted — left for operator review.
+	assert.Nil(t, ms.conversations[oldConvID].DeletedAt, "empty-ref row must not be soft-deleted")
 
-	// Message should be re-stamped to the new conversation.
-	assert.Equal(t, newConvID, ms.messages[msgID].ConversationID,
-		"message should be re-stamped to new conversation")
+	// Message must still point at old conversation.
+	assert.Equal(t, oldConvID, ms.messages[msgID].ConversationID,
+		"message must still reference old conversation (no merge)")
 
-	assert.Equal(t, 1, result.EmptyRefMerged, "EmptyRefMerged should be 1")
+	// External ref must still be empty.
+	assert.Equal(t, "", ms.conversations[oldConvID].ExternalRef,
+		"external_ref must remain empty")
+
+	assert.Equal(t, 1, result.EmptyRefSkipped, "EmptyRefSkipped should be 1")
+	assert.Equal(t, 0, result.EmptyRefMerged, "EmptyRefMerged should be 0")
+	assert.Equal(t, 0, result.EmptyRefRekeyed, "EmptyRefRekeyed should be 0")
 }
 
-// TestStep3a_RekeyEmptyRefInPlace verifies that an empty-ref row with no
-// existing kind-encoded counterpart gets re-keyed in place.
-func TestStep3a_RekeyEmptyRefInPlace(t *testing.T) {
+// TestStep3a_EmptyRefNotRekeyed verifies that an empty-ref row with no
+// existing kind-encoded counterpart is NOT re-keyed in place (B14 ruling).
+func TestStep3a_EmptyRefNotRekeyed(t *testing.T) {
 	ms := newMockMigrationStore()
 	ctx := context.Background()
 
@@ -409,7 +415,7 @@ func TestStep3a_RekeyEmptyRefInPlace(t *testing.T) {
 	ms.users[userID] = &store.User{ID: userID, Email: "test@example.com"}
 	ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "test-agent"}
 
-	// Empty-ref row with a ProjectID that should be cleared.
+	// Empty-ref row with a ProjectID.
 	ms.addConv(&store.Conversation{
 		ID:          convID,
 		Kind:        "direct",
@@ -425,24 +431,24 @@ func TestStep3a_RekeyEmptyRefInPlace(t *testing.T) {
 	result, err := svc.Run(ctx, DMMigrationConfig{})
 	require.NoError(t, err)
 
-	// External ref should be set to the kind-encoded key.
-	expectedKey := mustDMKey("user", userID, "agent", agentID)
+	// B14: external ref must remain empty — no fabrication from index.
 	conv := ms.conversations[convID]
-	assert.Equal(t, expectedKey, conv.ExternalRef, "ExternalRef should be set to kind-encoded key")
-	assert.Nil(t, conv.ProjectID, "ProjectID should be nil (DMs are global)")
-	assert.Equal(t, 1, result.EmptyRefRekeyed, "EmptyRefRekeyed should be 1")
+	assert.Equal(t, "", conv.ExternalRef, "ExternalRef must remain empty (B14)")
+	assert.Equal(t, &projectID, conv.ProjectID, "ProjectID must be unchanged")
+	assert.Equal(t, 1, result.EmptyRefSkipped, "EmptyRefSkipped should be 1")
+	assert.Equal(t, 0, result.EmptyRefRekeyed, "EmptyRefRekeyed should be 0")
 }
 
-// TestStep3a_SkipsWhenParticipantsNot2 verifies that empty-ref rows with != 2
-// active participants are skipped.
-func TestStep3a_SkipsWhenParticipantsNot2(t *testing.T) {
+// TestStep3a_EmptyRefSkippedRegardlessOfParticipantCount verifies that
+// empty-ref rows are skipped regardless of participant count (B14 ruling).
+func TestStep3a_EmptyRefSkippedRegardlessOfParticipantCount(t *testing.T) {
 	ms := newMockMigrationStore()
 	ctx := context.Background()
 
 	convID := uuid.NewString()
 	userID := uuid.NewString()
 
-	// Only 1 participant.
+	// Only 1 participant — previously this was Unparseable, now it's EmptyRefSkipped.
 	ms.addConv(&store.Conversation{
 		ID:          convID,
 		Kind:        "direct",
@@ -456,7 +462,7 @@ func TestStep3a_SkipsWhenParticipantsNot2(t *testing.T) {
 	result, err := svc.Run(ctx, DMMigrationConfig{})
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, result.Unparseable, "should be unparseable with 1 participant")
+	assert.Equal(t, 1, result.EmptyRefSkipped, "empty-ref row should be skipped (B14)")
 	assert.Equal(t, 0, result.EmptyRefRekeyed)
 	assert.Equal(t, 0, result.EmptyRefMerged)
 }
@@ -680,7 +686,8 @@ func TestDryRun_NoWrites(t *testing.T) {
 	// Statistics should be computed.
 	assert.Equal(t, 3, result.TotalScanned, "should scan all 3 conversations")
 	assert.Equal(t, 2, result.ParticipantsAdded, "should count 2 missing participants")
-	assert.Equal(t, 1, result.EmptyRefRekeyed, "should count 1 re-key")
+	assert.Equal(t, 1, result.EmptyRefSkipped, "should count 1 empty-ref skipped (B14)")
+	assert.Equal(t, 0, result.EmptyRefRekeyed, "should count 0 re-key (B14 ruling)")
 	assert.Equal(t, 1, result.OldFormatRekeyed, "should count 1 old-format re-key")
 
 	// No actual changes should be made.
@@ -693,10 +700,11 @@ func TestDryRun_NoWrites(t *testing.T) {
 // Guard tests (permanent post-migration invariant assertions)
 // ---------------------------------------------------------------------------
 
-// TestGuardA_Migration_NoEmptyRefDirectRows asserts that after migration,
-// zero non-deleted direct conversations have an empty external_ref.
+// TestGuardA_Migration_EmptyRefDirectRowsSkipped asserts that after migration,
+// empty-ref direct conversations are left keyless (B14 ruling) and counted
+// as EmptyRefSkipped for operator visibility.
 // Floor: the test creates at least 2 such rows before migration (rule 14).
-func TestGuardA_Migration_NoEmptyRefDirectRows(t *testing.T) {
+func TestGuardA_Migration_EmptyRefDirectRowsSkipped(t *testing.T) {
 	ms := newMockMigrationStore()
 	ctx := context.Background()
 
@@ -736,10 +744,10 @@ func TestGuardA_Migration_NoEmptyRefDirectRows(t *testing.T) {
 
 	// Run migration.
 	svc := NewDMMigrationService(ms)
-	_, err := svc.Run(ctx, DMMigrationConfig{})
+	result, err := svc.Run(ctx, DMMigrationConfig{})
 	require.NoError(t, err)
 
-	// Guard assertion: zero non-deleted direct conversations with empty ref.
+	// Guard assertion: empty-ref rows are left in place (B14), counted as skipped.
 	var directCount, emptyRefCount int
 	for _, conv := range ms.conversations {
 		if conv.Kind != "direct" || conv.DeletedAt != nil {
@@ -754,8 +762,11 @@ func TestGuardA_Migration_NoEmptyRefDirectRows(t *testing.T) {
 	// Rule 14: floor — at least 3 rows examined.
 	require.GreaterOrEqual(t, directCount, 3,
 		"floor violation: expected at least 3 direct conversations, found %d", directCount)
-	assert.Equal(t, 0, emptyRefCount,
-		"found %d non-deleted direct conversations with empty external_ref", emptyRefCount)
+	// B14: empty-ref rows are left keyless, so they persist.
+	assert.Equal(t, 2, emptyRefCount,
+		"empty-ref rows must be left keyless per B14 ruling")
+	assert.Equal(t, 2, result.EmptyRefSkipped,
+		"EmptyRefSkipped should count the left-behind rows")
 }
 
 // TestGuardB_Migration_EveryDMRowHasTwoParticipants asserts that after migration,
@@ -928,7 +939,8 @@ func TestMigration_MixedScenarios(t *testing.T) {
 
 	assert.Equal(t, 3, result.TotalScanned)
 	assert.Equal(t, 2, result.ParticipantsAdded, "2 participants from kind-encoded row")
-	assert.Equal(t, 1, result.EmptyRefRekeyed, "1 empty-ref re-keyed")
+	assert.Equal(t, 1, result.EmptyRefSkipped, "1 empty-ref skipped (B14)")
+	assert.Equal(t, 0, result.EmptyRefRekeyed, "0 empty-ref re-keyed (B14)")
 	assert.Equal(t, 1, result.OldFormatRekeyed, "1 old-format re-keyed")
 	assert.Equal(t, 0, result.Unparseable)
 	assert.Equal(t, 0, result.Ambiguous)
@@ -960,8 +972,9 @@ func TestB2_MergeAbortsOnRestampFailure(t *testing.T) {
 	ms.users[userID] = &store.User{ID: userID, Email: "t@e.com"}
 	ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "a"}
 
-	// Old empty-ref row with a message.
-	ms.addConv(&store.Conversation{ID: oldConvID, Kind: "direct", Surface: "native", ExternalRef: ""},
+	// Old-format row (triggers step3b merge path) with a message.
+	ms.addConv(&store.Conversation{ID: oldConvID, Kind: "direct", Surface: "native",
+		ExternalRef: directMessageExternalRef(userID, agentID)},
 		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "user", PrincipalID: userID},
 		store.ConversationParticipant{ConversationID: oldConvID, PrincipalKind: "agent", PrincipalID: agentID})
 
@@ -1114,4 +1127,61 @@ func TestB1_SharedPredicate_MergeConversationDirectly(t *testing.T) {
 		}
 	}
 	assert.True(t, foundSkipError, "expected error about skipping stranger participant")
+}
+
+// ---------------------------------------------------------------------------
+// B14: Empty-ref ruling — empty-ref rows left keyless
+// ---------------------------------------------------------------------------
+
+// TestB14_EmptyRefRowLeftKeyless verifies that an empty-ref direct row is left
+// keyless and participant-less after migration. The migration must NOT derive
+// a key from the participant index (that would be fabrication of an ACL).
+//
+// Mutation contract: reverting the skip (restoring the old stepMergeOrRekeyEmptyRef
+// logic) causes this test to fail because the row gets re-keyed.
+func TestB14_EmptyRefRowLeftKeyless(t *testing.T) {
+	ms := newMockMigrationStore()
+	ctx := context.Background()
+
+	userID := uuid.NewString()
+	agentID := uuid.NewString()
+	convID := uuid.NewString()
+
+	ms.users[userID] = &store.User{ID: userID, Email: "t@e.com"}
+	ms.agents[agentID] = &store.Agent{ID: agentID, Slug: "a"}
+
+	// Empty-ref direct row with 2 active participants.
+	ms.addConv(&store.Conversation{
+		ID:          convID,
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: "",
+	},
+		store.ConversationParticipant{ConversationID: convID, PrincipalKind: "user", PrincipalID: userID},
+		store.ConversationParticipant{ConversationID: convID, PrincipalKind: "agent", PrincipalID: agentID},
+	)
+
+	svc := NewDMMigrationService(ms)
+	result, err := svc.Run(ctx, DMMigrationConfig{})
+	require.NoError(t, err)
+
+	conv := ms.conversations[convID]
+
+	// (a) External ref must still be empty.
+	assert.Equal(t, "", conv.ExternalRef,
+		"external_ref must remain empty — deriving a key from the index is fabrication")
+
+	// (b) Row must NOT be soft-deleted.
+	assert.Nil(t, conv.DeletedAt,
+		"empty-ref row must not be soft-deleted")
+
+	// (c) EmptyRefSkipped counter must be 1.
+	assert.Equal(t, 1, result.EmptyRefSkipped,
+		"EmptyRefSkipped should be 1")
+
+	// (d) EmptyRefMerged and EmptyRefRekeyed must both be 0.
+	assert.Equal(t, 0, result.EmptyRefMerged,
+		"EmptyRefMerged should be 0")
+	assert.Equal(t, 0, result.EmptyRefRekeyed,
+		"EmptyRefRekeyed should be 0")
 }

--- a/pkg/store/entadapter/conversation_store.go
+++ b/pkg/store/entadapter/conversation_store.go
@@ -523,16 +523,8 @@ func isUniqueConstraintError(err error) bool {
 //
 // For non-direct conversations the function is a no-op (returns nil).
 func checkDMParticipantKey(conv *ent.Conversation, principalKind, principalID string) error {
-	if string(conv.Kind) != "direct" {
-		return nil
-	}
-	kindA, idA, kindB, idB, parseErr := messages.ParseDMKey(conv.ExternalRef)
-	if parseErr != nil {
-		return fmt.Errorf("direct conversation has unparseable external_ref: %w", store.ErrInvalidInput)
-	}
-	if (principalKind != kindA || principalID != idA) &&
-		(principalKind != kindB || principalID != idB) {
-		return fmt.Errorf("participant (%s, %s) not named in direct conversation key: %w", principalKind, principalID, store.ErrInvalidInput)
+	if err := messages.CheckDMParticipantKey(string(conv.Kind), conv.ExternalRef, principalKind, principalID); err != nil {
+		return fmt.Errorf("%w: %w", store.ErrInvalidInput, err)
 	}
 	return nil
 }

--- a/pkg/store/entadapter/conversation_store.go
+++ b/pkg/store/entadapter/conversation_store.go
@@ -523,6 +523,9 @@ func isUniqueConstraintError(err error) bool {
 //
 // For non-direct conversations the function is a no-op (returns nil).
 func checkDMParticipantKey(conv *ent.Conversation, principalKind, principalID string) error {
+	if conv == nil {
+		return fmt.Errorf("%w: conversation is nil", store.ErrInvalidInput)
+	}
 	if err := messages.CheckDMParticipantKey(string(conv.Kind), conv.ExternalRef, principalKind, principalID); err != nil {
 		return fmt.Errorf("%w: %w", store.ErrInvalidInput, err)
 	}

--- a/pkg/store/entadapter/dm_guard_enumeration_test.go
+++ b/pkg/store/entadapter/dm_guard_enumeration_test.go
@@ -163,8 +163,8 @@ func TestDMGuardCallSites_Enumeration(t *testing.T) {
 			t.Fatalf("function AddParticipant not found in %s", conversationStoreSource)
 		}
 		if !bodyCallsIdent(body, "checkDMParticipantKey") {
-			t.Fatalf("AddParticipant does not call checkDMParticipantKey — "+
-				"the D-1 immutability guard has been severed. "+
+			t.Fatalf("AddParticipant does not call checkDMParticipantKey — " +
+				"the D-1 immutability guard has been severed. " +
 				"See conversation_store_test.go for the behavioural tests.")
 		}
 	})
@@ -176,8 +176,8 @@ func TestDMGuardCallSites_Enumeration(t *testing.T) {
 			t.Fatalf("function EnsureParticipant not found in %s", conversationStoreSource)
 		}
 		if !bodyCallsIdent(body, "checkDMParticipantKey") {
-			t.Fatalf("EnsureParticipant does not call checkDMParticipantKey — "+
-				"the D-1 immutability guard has been severed. "+
+			t.Fatalf("EnsureParticipant does not call checkDMParticipantKey — " +
+				"the D-1 immutability guard has been severed. " +
 				"See conversation_store_test.go for the behavioural tests.")
 		}
 	})
@@ -189,8 +189,8 @@ func TestDMGuardCallSites_Enumeration(t *testing.T) {
 			t.Fatalf("function checkDMParticipantKey not found in %s", conversationStoreSource)
 		}
 		if !bodyCallsSelector(body, "messages", "CheckDMParticipantKey") {
-			t.Fatalf("checkDMParticipantKey does not call messages.CheckDMParticipantKey — "+
-				"the delegation to the shared predicate in pkg/messages has been severed. "+
+			t.Fatalf("checkDMParticipantKey does not call messages.CheckDMParticipantKey — " +
+				"the delegation to the shared predicate in pkg/messages has been severed. " +
 				"See conversation_store_test.go for the behavioural tests.")
 		}
 	})

--- a/pkg/store/entadapter/dm_guard_enumeration_test.go
+++ b/pkg/store/entadapter/dm_guard_enumeration_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NO BUILD TAG — this file must run under -tags no_sqlite (CI mode).
+//
+// This is an AST enumeration test, not a correctness test.
+//
+// It proves that the D-1 immutability guard call sites are wired up:
+//   - AddParticipant calls checkDMParticipantKey
+//   - EnsureParticipant calls checkDMParticipantKey
+//   - checkDMParticipantKey delegates to messages.CheckDMParticipantKey
+//
+// This makes mutation m4 (sever the delegation entirely — replace the
+// guard body with "return nil") impossible to land while the behavioural
+// tests are dark in CI.
+//
+// What this test is NOT: a correctness test. It would not catch subtle
+// bugs in the guard logic (wrong field order, inverted condition, etc.).
+// It does not prove the guard is correct — only that the call sites
+// exist.
+//
+// The real behavioural coverage lives in conversation_store_test.go
+// behind //go:build !no_sqlite. This file exists because CI runs with
+// -tags no_sqlite, so the entadapter package contributes zero
+// behavioural tests to the pipeline.
+
+package entadapter
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+const conversationStoreSource = "conversation_store.go"
+
+// funcBody finds the function declaration with the given name and returns its
+// body. Returns nil if the function is not found.
+func funcBody(file *ast.File, name string) *ast.BlockStmt {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fn.Name.Name == name {
+			return fn.Body
+		}
+	}
+	return nil
+}
+
+// bodyCallsIdent reports whether the function body contains a call expression
+// whose callee is a plain identifier matching name (e.g. checkDMParticipantKey).
+func bodyCallsIdent(body *ast.BlockStmt, name string) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == name {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// bodyCallsSelector reports whether the function body contains a call expression
+// whose callee is a selector expression X.Sel matching pkg.sel
+// (e.g. messages.CheckDMParticipantKey).
+func bodyCallsSelector(body *ast.BlockStmt, pkg, sel string) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selExpr, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		x, ok := selExpr.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if x.Name == pkg && selExpr.Sel.Name == sel {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// TestDMGuardCallSites_Enumeration is an AST enumeration test that verifies
+// the D-1 immutability guard wiring in conversation_store.go. See the file-
+// level comment for scope and limitations.
+func TestDMGuardCallSites_Enumeration(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, conversationStoreSource, nil, 0)
+	if err != nil {
+		t.Fatalf("failed to parse %s: %v", conversationStoreSource, err)
+	}
+
+	// 1. AddParticipant must call checkDMParticipantKey.
+	t.Run("AddParticipant_calls_checkDMParticipantKey", func(t *testing.T) {
+		body := funcBody(file, "AddParticipant")
+		if body == nil {
+			t.Fatalf("function AddParticipant not found in %s", conversationStoreSource)
+		}
+		if !bodyCallsIdent(body, "checkDMParticipantKey") {
+			t.Fatalf("AddParticipant does not call checkDMParticipantKey — "+
+				"the D-1 immutability guard has been severed. "+
+				"See conversation_store_test.go for the behavioural tests.")
+		}
+	})
+
+	// 2. EnsureParticipant must call checkDMParticipantKey.
+	t.Run("EnsureParticipant_calls_checkDMParticipantKey", func(t *testing.T) {
+		body := funcBody(file, "EnsureParticipant")
+		if body == nil {
+			t.Fatalf("function EnsureParticipant not found in %s", conversationStoreSource)
+		}
+		if !bodyCallsIdent(body, "checkDMParticipantKey") {
+			t.Fatalf("EnsureParticipant does not call checkDMParticipantKey — "+
+				"the D-1 immutability guard has been severed. "+
+				"See conversation_store_test.go for the behavioural tests.")
+		}
+	})
+
+	// 3. checkDMParticipantKey must delegate to messages.CheckDMParticipantKey.
+	t.Run("checkDMParticipantKey_delegates_to_messages", func(t *testing.T) {
+		body := funcBody(file, "checkDMParticipantKey")
+		if body == nil {
+			t.Fatalf("function checkDMParticipantKey not found in %s", conversationStoreSource)
+		}
+		if !bodyCallsSelector(body, "messages", "CheckDMParticipantKey") {
+			t.Fatalf("checkDMParticipantKey does not call messages.CheckDMParticipantKey — "+
+				"the delegation to the shared predicate in pkg/messages has been severed. "+
+				"See conversation_store_test.go for the behavioural tests.")
+		}
+	})
+}

--- a/pkg/store/entadapter/dm_guard_enumeration_test.go
+++ b/pkg/store/entadapter/dm_guard_enumeration_test.go
@@ -21,19 +21,18 @@
 //   - EnsureParticipant calls checkDMParticipantKey
 //   - checkDMParticipantKey delegates to messages.CheckDMParticipantKey
 //
-// This makes mutation m4 (sever the delegation entirely — replace the
-// guard body with "return nil") impossible to land while the behavioural
-// tests are dark in CI.
+// It catches the two most likely accidental breaks:
+//   - m4: total removal — guard body replaced with "return nil"
+//   - m5: result discard — call present but assigned to _ instead of checked
 //
-// What this test is NOT: a correctness test. It would not catch subtle
-// bugs in the guard logic (wrong field order, inverted condition, etc.).
-// It does not prove the guard is correct — only that the call sites
-// exist.
-//
-// The real behavioural coverage lives in conversation_store_test.go
-// behind //go:build !no_sqlite. This file exists because CI runs with
-// -tags no_sqlite, so the entadapter package contributes zero
-// behavioural tests to the pipeline.
+// Remaining limitation: an "if err := checkDMParticipantKey(...); err != nil { }"
+// with an empty body would still slip past, as would many other deliberate
+// evasion patterns. The tightening targets the accidental case (refactor
+// at 5pm on a Friday), not the adversarial case (attacker editing the
+// store layer). The only real fix is getting the behavioural tests
+// (conversation_store_test.go, behind //go:build !no_sqlite) into CI.
+// That fix is tracked and is not this team's work. This file should be
+// deleted the day the behavioural tests run in CI.
 
 package entadapter
 
@@ -112,6 +111,41 @@ func bodyCallsSelector(body *ast.BlockStmt, pkg, sel string) bool {
 	return found
 }
 
+// bodyDiscardsCallResult reports whether any call to the named function has
+// its result assigned to the blank identifier (_).
+func bodyDiscardsCallResult(body *ast.BlockStmt, fnName string) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		// Check if RHS contains a call to fnName.
+		for _, rhs := range assign.Rhs {
+			call, ok := rhs.(*ast.CallExpr)
+			if !ok {
+				continue
+			}
+			ident, ok := call.Fun.(*ast.Ident)
+			if !ok || ident.Name != fnName {
+				continue
+			}
+			// RHS calls fnName — check if any LHS is the blank identifier.
+			for _, lhs := range assign.Lhs {
+				if id, ok := lhs.(*ast.Ident); ok && id.Name == "_" {
+					found = true
+					return false
+				}
+			}
+		}
+		return true
+	})
+	return found
+}
+
 // TestDMGuardCallSites_Enumeration is an AST enumeration test that verifies
 // the D-1 immutability guard wiring in conversation_store.go. See the file-
 // level comment for scope and limitations.
@@ -158,6 +192,21 @@ func TestDMGuardCallSites_Enumeration(t *testing.T) {
 			t.Fatalf("checkDMParticipantKey does not call messages.CheckDMParticipantKey — "+
 				"the delegation to the shared predicate in pkg/messages has been severed. "+
 				"See conversation_store_test.go for the behavioural tests.")
+		}
+	})
+
+	// 4. Guard result must be consumed, not discarded (catches mutation m5).
+	t.Run("guard_result_consumed_not_discarded", func(t *testing.T) {
+		for _, fn := range []string{"AddParticipant", "EnsureParticipant"} {
+			body := funcBody(file, fn)
+			if body == nil {
+				t.Fatalf("function %s not found in %s", fn, conversationStoreSource)
+			}
+			if bodyDiscardsCallResult(body, "checkDMParticipantKey") {
+				t.Fatalf("%s calls checkDMParticipantKey but discards its result (assigns to _). "+
+					"The guard is present but dead — its error is never checked. "+
+					"See conversation_store_test.go for the behavioural tests.", fn)
+			}
 		}
 	})
 }


### PR DESCRIPTION
Invariant D-1: a direct conversation's participant set is immutable for its lifetime.

**B1** extracts the participant-key check to `messages.CheckDMParticipantKey` and routes all
three ingresses through it - `AddParticipant`, `EnsureParticipant`, `mergeConversation`.
**B2** aborts the migration on restamp failure instead of continuing.
**B14** leaves empty-ref direct rows keyless rather than fabricating a key; inventing an ACL
from the listing index would invert the direction of authority.

**CI gap.** `conversation_store_test.go` sits behind `//go:build !no_sqlite` while `make ci`
runs `go test -tags no_sqlite ./...`, so the four tests catching removal of D-1 have never run
in the pipeline. This adds an untagged AST tripwire that fires if the guard call sites are
removed or their result discarded. Its doc comment says what it misses and that it should be
deleted once the behavioural tests reach CI. A smoke alarm, not coverage.

**Verification.** Under `-tags no_sqlite`: m4 (sever delegation) KILLED, m5 (discard result)
KILLED, control PASS. Both authored independently of the implementing agent; m5 initially
survived and this PR closes it.

The five B14 tests pinning current-but-wrong behaviour each name DEF-29 as open