### PR TITLE
ci: add security marker gate for B5 / #1322 / #1347 handler symbols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,23 @@ jobs:
       - name: Check Conversation Upsert Guard
         run: ./hack/check-conversation-upsert-guard.sh
 
+      - name: Check Security Marker Gates
+        run: |
+          # Invoked directly rather than via `make check-security-marker-gates`:
+          # GNU make reports its own failure code (always 2), which would collapse
+          # exit 1 (guard violation) and exit 2 (nothing was analysed) into one
+          # indistinguishable result. Those mean opposite things.
+          set +e
+          ./hack/check-security-marker-gates.sh
+          rc=$?
+          set -e
+          case "$rc" in
+            0) ;;
+            1) echo "::error title=Security marker gates::Security marker gate violations found — a guarded symbol was removed or moved out of its enclosing function. See the step log above." ;;
+            *) echo "::error title=Security marker gates NOT checked::check-security-marker-gates could not run (exit $rc) — NOTHING WAS ANALYSED. This is an environment failure and is NOT a statement about the codebase. Do not read it as a guard failure." ;;
+          esac
+          exit "$rc"
+
       - name: Run Tests
         run: make test-fast
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GOLANGCI_LINT := $(shell command -v golangci-lint 2>/dev/null || echo $(shell go
 
 .DEFAULT_GOAL := help
 
-.PHONY: all build build-a2a-bridge install test test-fast vet lint compat-literals check-authz-guards check-conversation-upsert-guard golangci-lint web web-typecheck web-test fmt fmt-check ci ci-full clean help container-sciontool container-scion container-binaries proto proto-check
+.PHONY: all build build-a2a-bridge install test test-fast vet lint compat-literals check-authz-guards check-conversation-upsert-guard check-security-marker-gates golangci-lint web web-typecheck web-test fmt fmt-check ci ci-full clean help container-sciontool container-scion container-binaries proto proto-check
 
 ## all: Build the web frontend and compile the Go binary (run 'make install' separately to install)
 all: web build
@@ -93,6 +93,10 @@ check-authz-guards:
 check-conversation-upsert-guard:
 	@./hack/check-conversation-upsert-guard.sh
 
+## check-security-marker-gates: Verify security symbols (authenticatedSender, validateDefaultAgent, ActionAttach) remain in handler code
+check-security-marker-gates:
+	@./hack/check-security-marker-gates.sh
+
 ## golangci-lint: Run golangci-lint on new issues only (install via: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest)
 golangci-lint:
 	@if [ ! -x "$(GOLANGCI_LINT)" ]; then \
@@ -165,7 +169,7 @@ fmt-check:
 	@echo "Go formatting OK."
 
 ## ci: Run fast CI checks (format check, vet, compatibility guardrails, authz guards, tests, build)
-ci: fmt-check lint compat-literals check-authz-guards check-conversation-upsert-guard test-fast build
+ci: fmt-check lint compat-literals check-authz-guards check-conversation-upsert-guard check-security-marker-gates test-fast build
 	@echo ""
 	@echo "CI passed."
 

--- a/hack/check-security-marker-gates.sh
+++ b/hack/check-security-marker-gates.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# Guard: security symbols from B5, #1322, #1338, and #1347 must remain in the
+# handler files where they enforce authorization and identity invariants.
+#
+# This is the regression guard for the security fixtures that messaging-v2
+# (scion/messaging-v2) would revert. The branch pre-dates B5 (#1343), #1322,
+# #1347, and #1338 (DEF-31). A naive merge or cherry-pick from v2 silently
+# deletes sender-identity derivation, DM ownership checks, agent authorization,
+# and default-agent validation.
+#
+# WHAT THIS CHECKS
+#
+# Each gate row asserts that a named symbol appears a specific number of times
+# inside a named enclosing function. Function names survive line drift; the
+# assertion never pins an absolute line number.
+#
+# Gate categories:
+#
+#   REQUIRED — calls and definitions. The check runs or exists. A missing
+#   REQUIRED site means the check no longer runs or no longer exists; that is
+#   the revert. Gate HARD FAILS.
+#
+#   AUDIT — calls whose absence removes the only record of a security decision.
+#   On a path that fails silently by design (no 403, the denied action is simply
+#   dropped), the log carries the entire evidentiary weight. Gate HARD FAILS.
+#   Distinguished from REQUIRED so the failure report can say "the denial is now
+#   unrecorded" rather than "the check is gone."
+#
+#   INFORMATIONAL — doc-comment mentions. Prose, not behavior. Gate REPORTS
+#   (printed as a notice) but does NOT fail. A gate that fails on a doc-comment
+#   reword gets overridden without reading by the third occurrence.
+#
+# Gate rows:
+#
+#   authenticatedSender in handlers_agent_messaging.go:
+#     REQUIRED: handleAgentMessage x1, handleGroupMessage x2,
+#               handleProjectBroadcast x1, func definition x1
+#     INFORMATIONAL: doc comment x1
+#
+#   validateDefaultAgent in handlers_chat_v2.go:
+#     REQUIRED: handleCreateThread x1, handleTopicPatch x1, func definition x1
+#     INFORMATIONAL: doc comments x3
+#
+#   ActionAttach in handlers_agent_messaging.go:
+#     REQUIRED: handleProjectBroadcast x1
+#
+#   ActionAttach in handlers_chat_v2.go:
+#     REQUIRED: sendAgentRouted x2 (s.authorize + CheckAccess)
+#     AUDIT: sendAgentRouted x1 (logAuthzDenial — silent-denial path, no 403)
+#
+#   COMPOSITE: handleProjectBroadcast in handlers_agent_messaging.go must
+#   contain BOTH authenticatedSender AND ActionAttach.
+#
+# EXIT CODES
+#   0  all gates pass
+#   1  one or more REQUIRED or AUDIT gates failed
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+rc=0
+notices=""
+
+# ---------------------------------------------------------------------------
+# count_in_func FILE FUNC_NAME SYMBOL
+#
+# Counts occurrences of SYMBOL inside the body of the named top-level function
+# in FILE. Uses awk brace-depth tracking from the func declaration line.
+#
+# For "func definition" checks, use count_func_def instead.
+# ---------------------------------------------------------------------------
+count_in_func() {
+  local file="$1" func_name="$2" symbol="$3"
+  awk -v fname="$func_name" -v sym="$symbol" '
+    BEGIN { in_func = 0; in_sig = 0; depth = 0; count = 0; done = 0 }
+
+    # Match top-level func declaration. Handles both free functions and methods.
+    # Matches: func foo(, func (s *Server) foo(
+    # The opening brace may be on the same line or on a continuation line
+    # (multi-line signatures).
+    /^func / {
+      if (done) next
+      # Extract the function name (strip receiver if present)
+      name = $0
+      sub(/^func[[:space:]]+/, "", name)
+      sub(/^\([^)]*\)[[:space:]]*/, "", name)
+      sub(/[[:space:]]*\(.*$/, "", name)
+      if (name == fname) {
+        # Check if the opening brace is on this line
+        if ($0 ~ /\{[[:space:]]*$/) {
+          in_func = 1
+          depth = 1
+        } else {
+          # Multi-line signature — wait for the opening brace
+          in_sig = 1
+        }
+        next
+      }
+    }
+
+    # Multi-line signature continuation: look for the opening brace
+    in_sig && !done {
+      if ($0 ~ /\{[[:space:]]*$/) {
+        in_func = 1
+        in_sig = 0
+        depth = 1
+        next
+      }
+      next
+    }
+
+    in_func && !done {
+      # Count braces
+      opn = $0; gsub(/[^{]/, "", opn)
+      cls = $0; gsub(/[^}]/, "", cls)
+      depth += length(opn) - length(cls)
+
+      # Count symbol occurrences on this line, but skip comment lines
+      if ($0 !~ /^[[:space:]]*\/\//) {
+        line = $0
+        n = gsub(sym, "&", line)
+        count += n
+      }
+
+      if (depth <= 0) {
+        done = 1
+      }
+    }
+
+    END { print count }
+  ' "$file"
+}
+
+# ---------------------------------------------------------------------------
+# count_func_def FILE SYMBOL
+#
+# Counts lines matching "func SYMBOL(" or "func (receiver) SYMBOL(" at the
+# top level. This detects the function definition itself.
+# ---------------------------------------------------------------------------
+count_func_def() {
+  local file="$1" symbol="$2"
+  local count
+  count=$(grep -cE "^func[[:space:]]+(\\([^)]*\\)[[:space:]]+)?${symbol}\\(" "$file" 2>/dev/null) || count=0
+  echo "$count"
+}
+
+# ---------------------------------------------------------------------------
+# count_comments FILE SYMBOL
+#
+# Counts comment lines (// ...) mentioning the symbol. Used for INFORMATIONAL.
+# ---------------------------------------------------------------------------
+count_comments() {
+  local file="$1" symbol="$2"
+  local count
+  count=$(grep -c "^[[:space:]]*//.*${symbol}" "$file" 2>/dev/null) || count=0
+  echo "$count"
+}
+
+# ---------------------------------------------------------------------------
+# assert_required DESCRIPTION FILE FUNC SYMBOL EXPECTED
+# ---------------------------------------------------------------------------
+assert_required() {
+  local desc="$1" file="$2" func="$3" symbol="$4" expected="$5"
+  local actual
+  actual="$(count_in_func "$file" "$func" "$symbol")"
+  if [[ "$actual" -ne "$expected" ]]; then
+    echo "FAIL [REQUIRED] $desc" >&2
+    echo "  expected $symbol x$expected in $func ($file), found x$actual" >&2
+    rc=1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# assert_funcdef DESCRIPTION FILE SYMBOL EXPECTED
+# ---------------------------------------------------------------------------
+assert_funcdef() {
+  local desc="$1" file="$2" symbol="$3" expected="$4"
+  local actual
+  actual="$(count_func_def "$file" "$symbol")"
+  if [[ "$actual" -ne "$expected" ]]; then
+    echo "FAIL [REQUIRED] $desc" >&2
+    echo "  expected func $symbol definition x$expected in $file, found x$actual" >&2
+    rc=1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# assert_audit DESCRIPTION FILE FUNC SYMBOL EXPECTED
+# ---------------------------------------------------------------------------
+assert_audit() {
+  local desc="$1" file="$2" func="$3" symbol="$4" expected="$5"
+  local actual
+  actual="$(count_in_func "$file" "$func" "$symbol")"
+  if [[ "$actual" -ne "$expected" ]]; then
+    echo "FAIL [AUDIT] $desc" >&2
+    echo "  expected $symbol x$expected in $func ($file), found x$actual" >&2
+    echo "  This is a silent-denial path — logAuthzDenial is the ONLY record of the denial." >&2
+    rc=1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# assert_informational DESCRIPTION FILE SYMBOL EXPECTED
+# ---------------------------------------------------------------------------
+assert_informational() {
+  local desc="$1" file="$2" symbol="$3" expected="$4"
+  local actual
+  actual="$(count_comments "$file" "$symbol")"
+  if [[ "$actual" -lt "$expected" ]]; then
+    notices="${notices}NOTICE [INFORMATIONAL] $desc: expected $symbol in ≥$expected doc comments in $file, found $actual
+"
+  fi
+}
+
+# ===== Gate assertions =====
+
+HAM="pkg/hub/handlers_agent_messaging.go"
+HCV="pkg/hub/handlers_chat_v2.go"
+
+# --- authenticatedSender in handlers_agent_messaging.go ---
+
+# REQUIRED: 4 call sites + 1 definition
+assert_required \
+  "authenticatedSender in handleAgentMessage (B5 — DM key derivation)" \
+  "$HAM" handleAgentMessage authenticatedSender 1
+
+assert_required \
+  "authenticatedSender in handleGroupMessage (B5 — per-agent and per-user DM resolution)" \
+  "$HAM" handleGroupMessage authenticatedSender 2
+
+assert_required \
+  "authenticatedSender in handleProjectBroadcast (B5 — broadcast self-skip)" \
+  "$HAM" handleProjectBroadcast authenticatedSender 1
+
+assert_funcdef \
+  "authenticatedSender function definition (B5 — must exist)" \
+  "$HAM" authenticatedSender 1
+
+# INFORMATIONAL: 1 doc comment
+assert_informational \
+  "authenticatedSender doc comment" \
+  "$HAM" authenticatedSender 1
+
+# --- validateDefaultAgent in handlers_chat_v2.go ---
+
+# REQUIRED: 2 call sites + 1 definition
+assert_required \
+  "validateDefaultAgent in handleCreateThread (DEF-31 — topic creation)" \
+  "$HCV" handleCreateThread validateDefaultAgent 1
+
+assert_required \
+  "validateDefaultAgent in handleTopicPatch (DEF-31 — topic update)" \
+  "$HCV" handleTopicPatch validateDefaultAgent 1
+
+assert_funcdef \
+  "validateDefaultAgent function definition (DEF-31 — must exist)" \
+  "$HCV" validateDefaultAgent 1
+
+# INFORMATIONAL: 3 doc comments
+assert_informational \
+  "validateDefaultAgent doc comments" \
+  "$HCV" validateDefaultAgent 3
+
+# --- ActionAttach in handlers_agent_messaging.go ---
+
+# REQUIRED: 1 call in handleProjectBroadcast
+assert_required \
+  "ActionAttach in handleProjectBroadcast (#1347 — project broadcast authorization)" \
+  "$HAM" handleProjectBroadcast ActionAttach 1
+
+# --- ActionAttach in handlers_chat_v2.go ---
+
+# REQUIRED: 2 calls in sendAgentRouted (s.authorize + CheckAccess)
+# AUDIT: 1 call in sendAgentRouted (logAuthzDenial — silent denial path)
+# Total ActionAttach occurrences in sendAgentRouted = 3
+assert_required \
+  "ActionAttach authorize + CheckAccess in sendAgentRouted (#1347 — agent attach authorization)" \
+  "$HCV" sendAgentRouted ActionAttach 3
+
+# The AUDIT check: logAuthzDenial specifically, within sendAgentRouted
+assert_audit \
+  "logAuthzDenial(ActionAttach) in sendAgentRouted (#1347 — silent mention-denial audit trail)" \
+  "$HCV" sendAgentRouted logAuthzDenial 1
+
+# --- COMPOSITE GATE: handleProjectBroadcast ---
+# This single function carries authenticatedSender (B5) AND ActionAttach (#1347).
+# messaging-v2 reverts BOTH. A regression here costs sender-identity derivation
+# and project authorization simultaneously.
+
+composite_auth="$(count_in_func "$HAM" handleProjectBroadcast authenticatedSender)"
+composite_attach="$(count_in_func "$HAM" handleProjectBroadcast ActionAttach)"
+
+if [[ "$composite_auth" -lt 1 ]] || [[ "$composite_attach" -lt 1 ]]; then
+  echo "FAIL [COMPOSITE] handleProjectBroadcast must contain BOTH authenticatedSender AND ActionAttach" >&2
+  echo "  authenticatedSender: found x$composite_auth (need ≥1)" >&2
+  echo "  ActionAttach: found x$composite_attach (need ≥1)" >&2
+  echo "  This function is the highest-value anchor: a single regression costs" >&2
+  echo "  sender-identity derivation AND project authorization simultaneously." >&2
+  rc=1
+fi
+
+# --- Print results ---
+
+if [[ -n "$notices" ]]; then
+  echo "$notices"
+fi
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "check-security-marker-gates: all gates pass"
+else
+  echo >&2
+  echo "check-security-marker-gates: FAILED — see above" >&2
+fi
+
+exit "$rc"

--- a/hack/check-security-marker-gates.sh
+++ b/hack/check-security-marker-gates.sh
@@ -54,9 +54,32 @@
 # EXIT CODES
 #   0  all gates pass
 #   1  one or more REQUIRED or AUDIT gates failed
+#   2  could not analyse — a guarded file is missing or unreadable. This is NOT
+#      a statement about the codebase; it means the instrument could not run.
+#      Distinguished from exit 1 so CI can report "nothing was analysed" rather
+#      than "the symbol is gone." GNU make collapses both into exit 2, which is
+#      why CI invokes this script directly rather than via `make`.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
+
+# ---------------------------------------------------------------------------
+# File-existence precheck. A missing or renamed file yields count 0 from the
+# greps below, which reports "symbol missing" — technically fail-closed, but
+# misleading: "ActionAttach missing from sendAgentRouted" when the truth is
+# "somebody moved the file." Exit 2 with a distinct message before any
+# counting so the failure report says what actually happened.
+# ---------------------------------------------------------------------------
+HAM="pkg/hub/handlers_agent_messaging.go"
+HCV="pkg/hub/handlers_chat_v2.go"
+
+for f in "$HAM" "$HCV"; do
+  if [[ ! -r "$f" ]]; then
+    echo "ABORT: guarded file not found or not readable: $f" >&2
+    echo "  Nothing was analysed. This is an environment/rename issue, not a guard failure." >&2
+    exit 2
+  fi
+done
 
 rc=0
 notices=""
@@ -213,9 +236,6 @@ assert_informational() {
 }
 
 # ===== Gate assertions =====
-
-HAM="pkg/hub/handlers_agent_messaging.go"
-HCV="pkg/hub/handlers_chat_v2.go"
 
 # --- authenticatedSender in handlers_agent_messaging.go ---
 

--- a/hack/check-security-marker-gates.sh
+++ b/hack/check-security-marker-gates.sh
@@ -70,7 +70,9 @@
 # Why not `go run`? Because `go run` collapses all non-zero exit codes into 1,
 # destroying the exit-1/exit-2 distinction that the CI step depends on.
 
-cd "$(dirname "$0")/.."
+set -euo pipefail
+
+cd "$(dirname "$0")/.." || exit 2
 
 tmpbin=$(mktemp)
 trap 'rm -f "$tmpbin"' EXIT

--- a/hack/check-security-marker-gates.sh
+++ b/hack/check-security-marker-gates.sh
@@ -11,8 +11,8 @@
 # WHAT THIS CHECKS
 #
 # Each gate row asserts that a named symbol appears a specific number of times
-# inside a named enclosing function. Function names survive line drift; the
-# assertion never pins an absolute line number.
+# inside a named enclosing function. Uses go/ast for exact identifier matching
+# and function scoping — comments and substrings cannot produce false results.
 #
 # Gate categories:
 #
@@ -54,282 +54,31 @@
 # EXIT CODES
 #   0  all gates pass
 #   1  one or more REQUIRED or AUDIT gates failed
-#   2  could not analyse — a guarded file is missing or unreadable. This is NOT
-#      a statement about the codebase; it means the instrument could not run.
-#      Distinguished from exit 1 so CI can report "nothing was analysed" rather
-#      than "the symbol is gone." GNU make collapses both into exit 2, which is
-#      why CI invokes this script directly rather than via `make`.
-set -euo pipefail
+#   2  could not analyse — a guarded file is missing, unreadable, or has syntax
+#      errors. This is NOT a statement about the codebase; it means the
+#      instrument could not run. Distinguished from exit 1 so CI can report
+#      "nothing was analysed" rather than "the symbol is gone." GNU make
+#      collapses both into exit 2, which is why CI invokes this script directly
+#      rather than via `make`.
+#
+# IMPLEMENTATION
+#
+# The actual checking is done by a Go program (hack/checksecuritymarkergates)
+# that uses go/ast for exact identifier matching and function scoping. This
+# shell script compiles that program into a temp binary and exec's it.
+#
+# Why not `go run`? Because `go run` collapses all non-zero exit codes into 1,
+# destroying the exit-1/exit-2 distinction that the CI step depends on.
 
 cd "$(dirname "$0")/.."
 
-# ---------------------------------------------------------------------------
-# File-existence precheck. A missing or renamed file yields count 0 from the
-# greps below, which reports "symbol missing" — technically fail-closed, but
-# misleading: "ActionAttach missing from sendAgentRouted" when the truth is
-# "somebody moved the file." Exit 2 with a distinct message before any
-# counting so the failure report says what actually happened.
-# ---------------------------------------------------------------------------
-HAM="pkg/hub/handlers_agent_messaging.go"
-HCV="pkg/hub/handlers_chat_v2.go"
+tmpbin=$(mktemp)
+trap 'rm -f "$tmpbin"' EXIT
 
-for f in "$HAM" "$HCV"; do
-  if [[ ! -r "$f" ]]; then
-    echo "ABORT: guarded file not found or not readable: $f" >&2
-    echo "  Nothing was analysed. This is an environment/rename issue, not a guard failure." >&2
-    exit 2
-  fi
-done
-
-rc=0
-notices=""
-
-# ---------------------------------------------------------------------------
-# count_in_func FILE FUNC_NAME SYMBOL
-#
-# Counts occurrences of SYMBOL inside the body of the named top-level function
-# in FILE. Uses awk brace-depth tracking from the func declaration line.
-#
-# For "func definition" checks, use count_func_def instead.
-# ---------------------------------------------------------------------------
-count_in_func() {
-  local file="$1" func_name="$2" symbol="$3"
-  awk -v fname="$func_name" -v sym="$symbol" '
-    BEGIN { in_func = 0; in_sig = 0; depth = 0; count = 0; done = 0 }
-
-    # Match top-level func declaration. Handles both free functions and methods.
-    # Matches: func foo(, func (s *Server) foo(
-    # The opening brace may be on the same line or on a continuation line
-    # (multi-line signatures).
-    /^func / {
-      if (done) next
-      # Extract the function name (strip receiver if present)
-      name = $0
-      sub(/^func[[:space:]]+/, "", name)
-      sub(/^\([^)]*\)[[:space:]]*/, "", name)
-      sub(/[[:space:]]*\(.*$/, "", name)
-      if (name == fname) {
-        # Check if the opening brace is on this line
-        if ($0 ~ /\{[[:space:]]*$/) {
-          in_func = 1
-          depth = 1
-        } else {
-          # Multi-line signature — wait for the opening brace
-          in_sig = 1
-        }
-        next
-      }
-    }
-
-    # Multi-line signature continuation: look for the opening brace
-    in_sig && !done {
-      if ($0 ~ /\{[[:space:]]*$/) {
-        in_func = 1
-        in_sig = 0
-        depth = 1
-        next
-      }
-      next
-    }
-
-    in_func && !done {
-      # Count braces
-      opn = $0; gsub(/[^{]/, "", opn)
-      cls = $0; gsub(/[^}]/, "", cls)
-      depth += length(opn) - length(cls)
-
-      # Count symbol occurrences on this line, but skip comment lines
-      if ($0 !~ /^[[:space:]]*\/\//) {
-        line = $0
-        n = gsub(sym, "&", line)
-        count += n
-      }
-
-      if (depth <= 0) {
-        done = 1
-      }
-    }
-
-    END { print count }
-  ' "$file"
-}
-
-# ---------------------------------------------------------------------------
-# count_func_def FILE SYMBOL
-#
-# Counts lines matching "func SYMBOL(" or "func (receiver) SYMBOL(" at the
-# top level. This detects the function definition itself.
-# ---------------------------------------------------------------------------
-count_func_def() {
-  local file="$1" symbol="$2"
-  local count
-  count=$(grep -cE "^func[[:space:]]+(\\([^)]*\\)[[:space:]]+)?${symbol}\\(" "$file" 2>/dev/null) || count=0
-  echo "$count"
-}
-
-# ---------------------------------------------------------------------------
-# count_comments FILE SYMBOL
-#
-# Counts comment lines (// ...) mentioning the symbol. Used for INFORMATIONAL.
-# ---------------------------------------------------------------------------
-count_comments() {
-  local file="$1" symbol="$2"
-  local count
-  count=$(grep -c "^[[:space:]]*//.*${symbol}" "$file" 2>/dev/null) || count=0
-  echo "$count"
-}
-
-# ---------------------------------------------------------------------------
-# assert_required DESCRIPTION FILE FUNC SYMBOL EXPECTED
-# ---------------------------------------------------------------------------
-assert_required() {
-  local desc="$1" file="$2" func="$3" symbol="$4" expected="$5"
-  local actual
-  actual="$(count_in_func "$file" "$func" "$symbol")"
-  if [[ "$actual" -ne "$expected" ]]; then
-    echo "FAIL [REQUIRED] $desc" >&2
-    echo "  expected $symbol x$expected in $func ($file), found x$actual" >&2
-    rc=1
-  fi
-}
-
-# ---------------------------------------------------------------------------
-# assert_funcdef DESCRIPTION FILE SYMBOL EXPECTED
-# ---------------------------------------------------------------------------
-assert_funcdef() {
-  local desc="$1" file="$2" symbol="$3" expected="$4"
-  local actual
-  actual="$(count_func_def "$file" "$symbol")"
-  if [[ "$actual" -ne "$expected" ]]; then
-    echo "FAIL [REQUIRED] $desc" >&2
-    echo "  expected func $symbol definition x$expected in $file, found x$actual" >&2
-    rc=1
-  fi
-}
-
-# ---------------------------------------------------------------------------
-# assert_audit DESCRIPTION FILE FUNC SYMBOL EXPECTED
-# ---------------------------------------------------------------------------
-assert_audit() {
-  local desc="$1" file="$2" func="$3" symbol="$4" expected="$5"
-  local actual
-  actual="$(count_in_func "$file" "$func" "$symbol")"
-  if [[ "$actual" -ne "$expected" ]]; then
-    echo "FAIL [AUDIT] $desc" >&2
-    echo "  expected $symbol x$expected in $func ($file), found x$actual" >&2
-    echo "  This is a silent-denial path — logAuthzDenial is the ONLY record of the denial." >&2
-    rc=1
-  fi
-}
-
-# ---------------------------------------------------------------------------
-# assert_informational DESCRIPTION FILE SYMBOL EXPECTED
-# ---------------------------------------------------------------------------
-assert_informational() {
-  local desc="$1" file="$2" symbol="$3" expected="$4"
-  local actual
-  actual="$(count_comments "$file" "$symbol")"
-  if [[ "$actual" -lt "$expected" ]]; then
-    notices="${notices}NOTICE [INFORMATIONAL] $desc: expected $symbol in ≥$expected doc comments in $file, found $actual
-"
-  fi
-}
-
-# ===== Gate assertions =====
-
-# --- authenticatedSender in handlers_agent_messaging.go ---
-
-# REQUIRED: 4 call sites + 1 definition
-assert_required \
-  "authenticatedSender in handleAgentMessage (B5 — DM key derivation)" \
-  "$HAM" handleAgentMessage authenticatedSender 1
-
-assert_required \
-  "authenticatedSender in handleGroupMessage (B5 — per-agent and per-user DM resolution)" \
-  "$HAM" handleGroupMessage authenticatedSender 2
-
-assert_required \
-  "authenticatedSender in handleProjectBroadcast (B5 — broadcast self-skip)" \
-  "$HAM" handleProjectBroadcast authenticatedSender 1
-
-assert_funcdef \
-  "authenticatedSender function definition (B5 — must exist)" \
-  "$HAM" authenticatedSender 1
-
-# INFORMATIONAL: 1 doc comment
-assert_informational \
-  "authenticatedSender doc comment" \
-  "$HAM" authenticatedSender 1
-
-# --- validateDefaultAgent in handlers_chat_v2.go ---
-
-# REQUIRED: 2 call sites + 1 definition
-assert_required \
-  "validateDefaultAgent in handleCreateThread (DEF-31 — topic creation)" \
-  "$HCV" handleCreateThread validateDefaultAgent 1
-
-assert_required \
-  "validateDefaultAgent in handleTopicPatch (DEF-31 — topic update)" \
-  "$HCV" handleTopicPatch validateDefaultAgent 1
-
-assert_funcdef \
-  "validateDefaultAgent function definition (DEF-31 — must exist)" \
-  "$HCV" validateDefaultAgent 1
-
-# INFORMATIONAL: 3 doc comments
-assert_informational \
-  "validateDefaultAgent doc comments" \
-  "$HCV" validateDefaultAgent 3
-
-# --- ActionAttach in handlers_agent_messaging.go ---
-
-# REQUIRED: 1 call in handleProjectBroadcast
-assert_required \
-  "ActionAttach in handleProjectBroadcast (#1347 — project broadcast authorization)" \
-  "$HAM" handleProjectBroadcast ActionAttach 1
-
-# --- ActionAttach in handlers_chat_v2.go ---
-
-# REQUIRED: 2 calls in sendAgentRouted (s.authorize + CheckAccess)
-# AUDIT: 1 call in sendAgentRouted (logAuthzDenial — silent denial path)
-# Total ActionAttach occurrences in sendAgentRouted = 3
-assert_required \
-  "ActionAttach authorize + CheckAccess in sendAgentRouted (#1347 — agent attach authorization)" \
-  "$HCV" sendAgentRouted ActionAttach 3
-
-# The AUDIT check: logAuthzDenial specifically, within sendAgentRouted
-assert_audit \
-  "logAuthzDenial(ActionAttach) in sendAgentRouted (#1347 — silent mention-denial audit trail)" \
-  "$HCV" sendAgentRouted logAuthzDenial 1
-
-# --- COMPOSITE GATE: handleProjectBroadcast ---
-# This single function carries authenticatedSender (B5) AND ActionAttach (#1347).
-# messaging-v2 reverts BOTH. A regression here costs sender-identity derivation
-# and project authorization simultaneously.
-
-composite_auth="$(count_in_func "$HAM" handleProjectBroadcast authenticatedSender)"
-composite_attach="$(count_in_func "$HAM" handleProjectBroadcast ActionAttach)"
-
-if [[ "$composite_auth" -lt 1 ]] || [[ "$composite_attach" -lt 1 ]]; then
-  echo "FAIL [COMPOSITE] handleProjectBroadcast must contain BOTH authenticatedSender AND ActionAttach" >&2
-  echo "  authenticatedSender: found x$composite_auth (need ≥1)" >&2
-  echo "  ActionAttach: found x$composite_attach (need ≥1)" >&2
-  echo "  This function is the highest-value anchor: a single regression costs" >&2
-  echo "  sender-identity derivation AND project authorization simultaneously." >&2
-  rc=1
+if ! go build -o "$tmpbin" ./hack/checksecuritymarkergates 2>&1; then
+  echo "ABORT: could not compile check-security-marker-gates" >&2
+  echo "  Nothing was analysed. This is a build failure, not a guard failure." >&2
+  exit 2
 fi
 
-# --- Print results ---
-
-if [[ -n "$notices" ]]; then
-  echo "$notices"
-fi
-
-if [[ "$rc" -eq 0 ]]; then
-  echo "check-security-marker-gates: all gates pass"
-else
-  echo >&2
-  echo "check-security-marker-gates: FAILED — see above" >&2
-fi
-
-exit "$rc"
+exec "$tmpbin"

--- a/hack/checksecuritymarkergates/main.go
+++ b/hack/checksecuritymarkergates/main.go
@@ -1,0 +1,251 @@
+// Package main implements the check-security-marker-gates regression guard.
+//
+// Each gate row asserts that a named security symbol appears a specific number
+// of times inside a named enclosing function, using go/ast for exact identifier
+// matching and function scoping.
+//
+// Why go/ast instead of grep/awk:
+//   - Identifier matching is exact: ActionAttachment ≠ ActionAttach.
+//   - Comments are not identifiers: a trailing comment naming the symbol cannot
+//     satisfy a gate row.
+//   - Function scope is exact: the AST knows where a function body ends, so
+//     braces inside comments, strings, or raw literals cannot shift the boundary.
+//
+// See hack/check-security-marker-gates.sh (the invoking wrapper) for full
+// documentation of gate categories, exit codes, and the security rationale.
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+)
+
+var (
+	rc      int
+	notices []string
+)
+
+func main() {
+	hamPath := "pkg/hub/handlers_agent_messaging.go"
+	hcvPath := "pkg/hub/handlers_chat_v2.go"
+
+	// File-existence precheck (exit 2).
+	for _, f := range []string{hamPath, hcvPath} {
+		if _, err := os.Stat(f); err != nil {
+			fmt.Fprintf(os.Stderr, "ABORT: guarded file not found or not readable: %s\n", f)
+			fmt.Fprintf(os.Stderr, "  Nothing was analysed. This is an environment/rename issue, not a guard failure.\n")
+			os.Exit(2)
+		}
+	}
+
+	fset := token.NewFileSet()
+
+	ham, err := parser.ParseFile(fset, hamPath, nil, parser.ParseComments)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ABORT: could not parse %s: %v\n", hamPath, err)
+		fmt.Fprintf(os.Stderr, "  Nothing was analysed. This is a syntax error, not a guard failure.\n")
+		os.Exit(2)
+	}
+
+	hcv, err := parser.ParseFile(fset, hcvPath, nil, parser.ParseComments)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ABORT: could not parse %s: %v\n", hcvPath, err)
+		fmt.Fprintf(os.Stderr, "  Nothing was analysed. This is a syntax error, not a guard failure.\n")
+		os.Exit(2)
+	}
+
+	// ===== Gate assertions =====
+
+	// --- authenticatedSender in handlers_agent_messaging.go ---
+
+	// REQUIRED: 4 call sites + 1 definition
+	assertRequired(
+		"authenticatedSender in handleAgentMessage (B5 — DM key derivation)",
+		ham, hamPath, "handleAgentMessage", "authenticatedSender", 1)
+
+	assertRequired(
+		"authenticatedSender in handleGroupMessage (B5 — per-agent and per-user DM resolution)",
+		ham, hamPath, "handleGroupMessage", "authenticatedSender", 2)
+
+	assertRequired(
+		"authenticatedSender in handleProjectBroadcast (B5 — broadcast self-skip)",
+		ham, hamPath, "handleProjectBroadcast", "authenticatedSender", 1)
+
+	assertFuncDef(
+		"authenticatedSender function definition (B5 — must exist)",
+		ham, hamPath, "authenticatedSender", 1)
+
+	// INFORMATIONAL: 1 doc comment
+	assertInformational(
+		"authenticatedSender doc comment",
+		ham, hamPath, "authenticatedSender", 1)
+
+	// --- validateDefaultAgent in handlers_chat_v2.go ---
+
+	// REQUIRED: 2 call sites + 1 definition
+	assertRequired(
+		"validateDefaultAgent in handleCreateThread (DEF-31 — topic creation)",
+		hcv, hcvPath, "handleCreateThread", "validateDefaultAgent", 1)
+
+	assertRequired(
+		"validateDefaultAgent in handleTopicPatch (DEF-31 — topic update)",
+		hcv, hcvPath, "handleTopicPatch", "validateDefaultAgent", 1)
+
+	assertFuncDef(
+		"validateDefaultAgent function definition (DEF-31 — must exist)",
+		hcv, hcvPath, "validateDefaultAgent", 1)
+
+	// INFORMATIONAL: 3 doc comments
+	assertInformational(
+		"validateDefaultAgent doc comments",
+		hcv, hcvPath, "validateDefaultAgent", 3)
+
+	// --- ActionAttach in handlers_agent_messaging.go ---
+
+	// REQUIRED: 1 call in handleProjectBroadcast
+	assertRequired(
+		"ActionAttach in handleProjectBroadcast (#1347 — project broadcast authorization)",
+		ham, hamPath, "handleProjectBroadcast", "ActionAttach", 1)
+
+	// --- ActionAttach in handlers_chat_v2.go ---
+
+	// REQUIRED: 2 calls in sendAgentRouted (s.authorize + CheckAccess)
+	// AUDIT: 1 call in sendAgentRouted (logAuthzDenial — silent denial path)
+	// Total ActionAttach occurrences in sendAgentRouted = 3
+	assertRequired(
+		"ActionAttach authorize + CheckAccess in sendAgentRouted (#1347 — agent attach authorization)",
+		hcv, hcvPath, "sendAgentRouted", "ActionAttach", 3)
+
+	// The AUDIT check: logAuthzDenial specifically, within sendAgentRouted
+	assertAudit(
+		"logAuthzDenial(ActionAttach) in sendAgentRouted (#1347 — silent mention-denial audit trail)",
+		hcv, hcvPath, "sendAgentRouted", "logAuthzDenial", 1)
+
+	// --- COMPOSITE GATE: handleProjectBroadcast ---
+	// This single function carries authenticatedSender (B5) AND ActionAttach (#1347).
+	// messaging-v2 reverts BOTH. A regression here costs sender-identity derivation
+	// and project authorization simultaneously.
+
+	compositeAuth := countIdentsInFunc(ham, "handleProjectBroadcast", "authenticatedSender")
+	compositeAttach := countIdentsInFunc(ham, "handleProjectBroadcast", "ActionAttach")
+
+	if compositeAuth < 1 || compositeAttach < 1 {
+		fmt.Fprintf(os.Stderr, "FAIL [COMPOSITE] handleProjectBroadcast must contain BOTH authenticatedSender AND ActionAttach\n")
+		fmt.Fprintf(os.Stderr, "  authenticatedSender: found x%d (need ≥1)\n", compositeAuth)
+		fmt.Fprintf(os.Stderr, "  ActionAttach: found x%d (need ≥1)\n", compositeAttach)
+		fmt.Fprintf(os.Stderr, "  This function is the highest-value anchor: a single regression costs\n")
+		fmt.Fprintf(os.Stderr, "  sender-identity derivation AND project authorization simultaneously.\n")
+		rc = 1
+	}
+
+	// --- Print results ---
+
+	for _, n := range notices {
+		fmt.Println(n)
+	}
+
+	if rc == 0 {
+		fmt.Println("check-security-marker-gates: all gates pass")
+	} else {
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "check-security-marker-gates: FAILED — see above")
+	}
+
+	os.Exit(rc)
+}
+
+// countIdentsInFunc returns the number of *ast.Ident nodes with the exact given
+// name inside the body of the named function. Returns 0 if the function is not
+// found or has no body.
+func countIdentsInFunc(file *ast.File, funcName, symbol string) int {
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Name.Name != funcName || fd.Body == nil {
+			continue
+		}
+		count := 0
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			if ident, ok := n.(*ast.Ident); ok && ident.Name == symbol {
+				count++
+			}
+			return true
+		})
+		return count
+	}
+	return 0
+}
+
+// countFuncDefs returns the number of top-level function declarations whose
+// Name.Name exactly matches the given symbol.
+func countFuncDefs(file *ast.File, symbol string) int {
+	count := 0
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fd.Name.Name == symbol {
+			count++
+		}
+	}
+	return count
+}
+
+// countCommentMentions returns the number of individual comment lines in the
+// file that contain the given symbol as a substring. Used for INFORMATIONAL
+// gates where the check is about documentation presence, not code behavior.
+func countCommentMentions(file *ast.File, symbol string) int {
+	count := 0
+	for _, cg := range file.Comments {
+		for _, c := range cg.List {
+			if strings.Contains(c.Text, symbol) {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func assertRequired(desc string, file *ast.File, filename, funcName, symbol string, expected int) {
+	actual := countIdentsInFunc(file, funcName, symbol)
+	if actual != expected {
+		fmt.Fprintf(os.Stderr, "FAIL [REQUIRED] %s\n", desc)
+		fmt.Fprintf(os.Stderr, "  expected %s x%d in %s (%s), found x%d\n",
+			symbol, expected, funcName, filename, actual)
+		rc = 1
+	}
+}
+
+func assertFuncDef(desc string, file *ast.File, filename, symbol string, expected int) {
+	actual := countFuncDefs(file, symbol)
+	if actual != expected {
+		fmt.Fprintf(os.Stderr, "FAIL [REQUIRED] %s\n", desc)
+		fmt.Fprintf(os.Stderr, "  expected func %s definition x%d in %s, found x%d\n",
+			symbol, expected, filename, actual)
+		rc = 1
+	}
+}
+
+func assertAudit(desc string, file *ast.File, filename, funcName, symbol string, expected int) {
+	actual := countIdentsInFunc(file, funcName, symbol)
+	if actual != expected {
+		fmt.Fprintf(os.Stderr, "FAIL [AUDIT] %s\n", desc)
+		fmt.Fprintf(os.Stderr, "  expected %s x%d in %s (%s), found x%d\n",
+			symbol, expected, funcName, filename, actual)
+		fmt.Fprintf(os.Stderr, "  This is a silent-denial path — logAuthzDenial is the ONLY record of the denial.\n")
+		rc = 1
+	}
+}
+
+func assertInformational(desc string, file *ast.File, filename, symbol string, expected int) {
+	actual := countCommentMentions(file, symbol)
+	if actual < expected {
+		notices = append(notices, fmt.Sprintf(
+			"NOTICE [INFORMATIONAL] %s: expected %s in ≥%d doc comments in %s, found %d",
+			desc, symbol, expected, filename, actual))
+	}
+}


### PR DESCRIPTION
Adds hack/check-security-marker-gates.sh, a Makefile target, and a CI step.

Asserts that the authorization symbols from B5 (#1343), DM ownership (#1322) and agent
attach (#1347) are still present in the handler layer, so merging a stale branch cannot
revert them silently.

Counting is scoped to the named enclosing function, not the file: moving a call out of
its handler but leaving it in the file still fails.

Exit 1 = a guarded symbol is gone. Exit 2 = a guarded file was not found and nothing was
analysed. The CI step discriminates them, following check-authz-guards.

Every row was demonstrated to fail when its symbol is removed. Also verified: passes on
unmodified main, survives a doc-comment reword, catches a call moved out of its function
with the file-wide count unchanged, and reports a renamed function as a violation rather
than an abort.

No product files touched