### PR TITLE
fix(messages): reject non-canonical kind and UUID in DMConversationKey

### DIFF
--- a/pkg/messages/dm_key.go
+++ b/pkg/messages/dm_key.go
@@ -16,7 +16,6 @@ package messages
 
 import (
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"github.com/google/uuid"
@@ -45,11 +44,9 @@ var validDMKinds = map[string]bool{
 func DMConversationKey(kindA, idA, kindB, idB string) (string, error) {
 	// No normalisation — reject non-canonical input.
 	if !validDMKinds[kindA] {
-		slog.Warn("DMConversationKey: rejected non-canonical kind", "received", kindA)
 		return "", fmt.Errorf("dm key: unknown kind %q (must be user or agent)", kindA)
 	}
 	if !validDMKinds[kindB] {
-		slog.Warn("DMConversationKey: rejected non-canonical kind", "received", kindB)
 		return "", fmt.Errorf("dm key: unknown kind %q (must be user or agent)", kindB)
 	}
 
@@ -58,8 +55,7 @@ func DMConversationKey(kindA, idA, kindB, idB string) (string, error) {
 		return "", fmt.Errorf("dm key: invalid UUID for %s: %w", kindA, err)
 	}
 	if uA.String() != idA {
-		slog.Warn("DMConversationKey: rejected non-canonical UUID", "kind", kindA, "shape", describeNonCanonicalUUID(idA))
-		return "", fmt.Errorf("dm key: non-canonical UUID %q for %s (expected %s)", idA, kindA, uA.String())
+		return "", fmt.Errorf("dm key: non-canonical UUID for %s (shape: %s)", kindA, describeNonCanonicalUUID(idA))
 	}
 
 	uB, err := uuid.Parse(idB)
@@ -67,8 +63,7 @@ func DMConversationKey(kindA, idA, kindB, idB string) (string, error) {
 		return "", fmt.Errorf("dm key: invalid UUID for %s: %w", kindB, err)
 	}
 	if uB.String() != idB {
-		slog.Warn("DMConversationKey: rejected non-canonical UUID", "kind", kindB, "shape", describeNonCanonicalUUID(idB))
-		return "", fmt.Errorf("dm key: non-canonical UUID %q for %s (expected %s)", idB, kindB, uB.String())
+		return "", fmt.Errorf("dm key: non-canonical UUID for %s (shape: %s)", kindB, describeNonCanonicalUUID(idB))
 	}
 
 	tokenA := kindA + ":" + idA

--- a/pkg/messages/dm_key.go
+++ b/pkg/messages/dm_key.go
@@ -16,6 +16,7 @@ package messages
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/google/uuid"
@@ -31,35 +32,47 @@ var validDMKinds = map[string]bool{
 // reference key for a direct-message conversation between two principals.
 //
 // Format: dm:<token1>:<token2> where each token is <kind>:<uuid>.
-//   - kind must be "user" or "agent" (lowercase).
-//   - UUID is normalised to canonical lowercase hex-with-hyphens.
+//   - kind must be exactly "user" or "agent" (case-sensitive, no normalisation).
+//   - UUID must be canonical lowercase hex-with-hyphens (no normalisation; non-canonical forms are rejected).
 //   - The two tokens are sorted byte-wise lexicographically.
 //
 // Because "agent:" < "user:" lexically, mixed pairs always render as
 // dm:agent:<aid>:user:<uid>. Same-kind pairs sort by UUID.
+//
+// Note: PrincipalKindFromAddress (used by messagebroker.go) folds kind to
+// lowercase before calling this function, so the kind rejection below does
+// not fire on that path. That upstream fold is tracked as a separate defect.
 func DMConversationKey(kindA, idA, kindB, idB string) (string, error) {
-	kindA = strings.ToLower(kindA)
-	kindB = strings.ToLower(kindB)
-
+	// No normalisation — reject non-canonical input.
 	if !validDMKinds[kindA] {
+		slog.Warn("DMConversationKey: rejected non-canonical kind", "received", kindA)
 		return "", fmt.Errorf("dm key: unknown kind %q (must be user or agent)", kindA)
 	}
 	if !validDMKinds[kindB] {
+		slog.Warn("DMConversationKey: rejected non-canonical kind", "received", kindB)
 		return "", fmt.Errorf("dm key: unknown kind %q (must be user or agent)", kindB)
 	}
 
-	// Parse and re-format UUIDs to canonical lowercase.
 	uA, err := uuid.Parse(idA)
 	if err != nil {
 		return "", fmt.Errorf("dm key: invalid UUID for %s: %w", kindA, err)
 	}
+	if uA.String() != idA {
+		slog.Warn("DMConversationKey: rejected non-canonical UUID", "kind", kindA, "shape", describeNonCanonicalUUID(idA))
+		return "", fmt.Errorf("dm key: non-canonical UUID %q for %s (expected %s)", idA, kindA, uA.String())
+	}
+
 	uB, err := uuid.Parse(idB)
 	if err != nil {
 		return "", fmt.Errorf("dm key: invalid UUID for %s: %w", kindB, err)
 	}
+	if uB.String() != idB {
+		slog.Warn("DMConversationKey: rejected non-canonical UUID", "kind", kindB, "shape", describeNonCanonicalUUID(idB))
+		return "", fmt.Errorf("dm key: non-canonical UUID %q for %s (expected %s)", idB, kindB, uB.String())
+	}
 
-	tokenA := kindA + ":" + uA.String()
-	tokenB := kindB + ":" + uB.String()
+	tokenA := kindA + ":" + idA
+	tokenB := kindB + ":" + idB
 
 	// Sort tokens lexicographically.
 	if tokenA > tokenB {
@@ -67,6 +80,26 @@ func DMConversationKey(kindA, idA, kindB, idB string) (string, error) {
 	}
 
 	return "dm:" + tokenA + ":" + tokenB, nil
+}
+
+// describeNonCanonicalUUID returns a shape description of a non-canonical UUID
+// string for logging purposes. It does not log the value itself.
+func describeNonCanonicalUUID(id string) string {
+	if strings.HasPrefix(id, "urn:uuid:") {
+		return "urn-prefixed"
+	}
+	if len(id) > 0 && id[0] == '{' {
+		return "braced"
+	}
+	if len(id) == 32 && !strings.Contains(id, "-") {
+		return "unhyphenated"
+	}
+	for _, c := range id {
+		if c >= 'A' && c <= 'F' {
+			return "uppercase-hex"
+		}
+	}
+	return "other"
 }
 
 // PrincipalKindFromAddress extracts the kind prefix ("user" or "agent") from

--- a/pkg/messages/dm_key_test.go
+++ b/pkg/messages/dm_key_test.go
@@ -69,19 +69,22 @@ func TestDMConversationKey_Ordering_SameKind(t *testing.T) {
 	assert.Equal(t, "dm:user:"+id1+":user:"+id2, key1)
 }
 
-func TestDMConversationKey_CaseNormalisation(t *testing.T) {
-	id := "AABBCCDD-0011-2233-4455-667788990011"
-	lower := strings.ToLower(id)
+// TestDMConversationKey_RejectsNonCanonicalKind verifies that non-lowercase
+// kind strings are rejected outright.
+//
+// Previous behaviour was normalisation (strings.ToLower). That was wrong: the
+// key IS the ACL. Normalising silently rewrites the ACL, creating a key the
+// caller did not ask for. Rejection ensures the deriver and checker agree.
+func TestDMConversationKey_RejectsNonCanonicalKind(t *testing.T) {
+	id := "aabbccdd-0011-2233-4455-667788990011"
 
-	key, err := DMConversationKey("USER", id, "AGENT", lower)
-	require.NoError(t, err)
+	_, err := DMConversationKey("USER", id, "agent", id)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown kind")
 
-	// Kind normalised to lowercase, UUID normalised to lowercase.
-	assert.Contains(t, key, "agent:")
-	assert.Contains(t, key, "user:")
-	assert.NotContains(t, key, "AABBCCDD")
-	assert.NotContains(t, key, "USER")
-	assert.NotContains(t, key, "AGENT")
+	_, err = DMConversationKey("user", id, "AGENT", id)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown kind")
 }
 
 func TestDMConversationKey_RejectBadUUID(t *testing.T) {
@@ -171,7 +174,6 @@ func TestDMConversationKey_MatchesProductionRegex(t *testing.T) {
 		{"user+agent", "user", uuid.NewString(), "agent", uuid.NewString()},
 		{"user+user", "user", uuid.NewString(), "user", uuid.NewString()},
 		{"agent+agent", "agent", uuid.NewString(), "agent", uuid.NewString()},
-		{"uppercase UUID", "user", "AABBCCDD-0011-2233-4455-667788990011", "agent", uuid.NewString()},
 	}
 
 	require.Greater(t, len(cases), 0, "conformance test must have at least one case (rule 14)")
@@ -184,6 +186,13 @@ func TestDMConversationKey_MatchesProductionRegex(t *testing.T) {
 				"DMConversationKey output must match production regex from handlers_chat_v2.go:391")
 		})
 	}
+
+	// Uppercase UUID must now be rejected (previously it was normalised).
+	t.Run("uppercase UUID rejected", func(t *testing.T) {
+		_, err := DMConversationKey("user", "AABBCCDD-0011-2233-4455-667788990011", "agent", uuid.NewString())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-canonical UUID")
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -239,14 +248,6 @@ func TestDMConversationKey_GoldenVectors(t *testing.T) {
 			idB:      "12345678-1234-5678-1234-567812345678",
 			expected: "dm:agent:12345678-1234-5678-1234-567812345678:agent:a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
 		},
-		{
-			name:     "uppercase UUID requires lowercase normalisation",
-			kindA:    "user",
-			idA:      "AABBCCDD-0011-2233-4455-667788990011",
-			kindB:    "agent",
-			idB:      "6BA7B810-9DAD-11D1-80B4-00C04FD430C8",
-			expected: "dm:agent:6ba7b810-9dad-11d1-80b4-00c04fd430c8:user:aabbccdd-0011-2233-4455-667788990011",
-		},
 	}
 
 	require.Greater(t, len(vectors), 0, "golden vectors must have at least one case (rule 14)")
@@ -267,6 +268,44 @@ func TestDMConversationKey_GoldenVectors(t *testing.T) {
 	key1, _ := DMConversationKey(vectors[0].kindA, vectors[0].idA, vectors[0].kindB, vectors[0].idB)
 	key2, _ := DMConversationKey(vectors[1].kindA, vectors[1].idA, vectors[1].kindB, vectors[1].idB)
 	assert.Equal(t, key1, key2, "reversed argument order must produce the same key")
+
+	// Rejection golden vectors: non-canonical inputs that used to be normalised.
+	rejections := []struct {
+		name  string
+		kindA string
+		idA   string
+		kindB string
+		idB   string
+	}{
+		{
+			name:  "uppercase kind",
+			kindA: "USER",
+			idA:   "550e8400-e29b-41d4-a716-446655440000",
+			kindB: "agent",
+			idB:   "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+		},
+		{
+			name:  "uppercase UUID",
+			kindA: "user",
+			idA:   "AABBCCDD-0011-2233-4455-667788990011",
+			kindB: "agent",
+			idB:   "6BA7B810-9DAD-11D1-80B4-00C04FD430C8",
+		},
+		{
+			name:  "mixed-case UUID",
+			kindA: "user",
+			idA:   "6ba7b810-9dad-11d1-80b4-00C04FD430C8",
+			kindB: "agent",
+			idB:   "550e8400-e29b-41d4-a716-446655440000",
+		},
+	}
+
+	for _, tc := range rejections {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			_, err := DMConversationKey(tc.kindA, tc.idA, tc.kindB, tc.idB)
+			require.Error(t, err, "non-canonical input must be rejected")
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/messages/dm_key_test.go
+++ b/pkg/messages/dm_key_test.go
@@ -344,3 +344,59 @@ func TestCheckDMParticipantKey_UnparseableRef(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unparseable external_ref")
 }
+
+// ---------------------------------------------------------------------------
+// Cross-writer agreement test
+// ---------------------------------------------------------------------------
+
+// TestDMConversationKey_CrossWriterAgreement verifies that DMConversationKey
+// produces byte-identical keys to the SQL concatenation pattern used by four
+// SQL writers in webchannel_store that construct DM keys by concatenation
+// ('dm:agent:' + agentID + ':user:' + userID) without calling
+// DMConversationKey. This test pins that the two construction methods agree.
+// If the sort order or format ever changes, this test will catch the
+// divergence.
+func TestDMConversationKey_CrossWriterAgreement(t *testing.T) {
+	agentID := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	userID := "550e8400-e29b-41d4-a716-446655440000"
+
+	// agent+user pair: SQL writers use "dm:agent:" + agentID + ":user:" + userID
+	// because "agent:" < "user:" lexically.
+	goKey, err := DMConversationKey("agent", agentID, "user", userID)
+	require.NoError(t, err)
+
+	sqlKey := "dm:agent:" + agentID + ":user:" + userID
+	assert.Equal(t, sqlKey, goKey,
+		"DMConversationKey must produce byte-identical output to SQL concatenation pattern")
+}
+
+// ---------------------------------------------------------------------------
+// Rejection golden vectors for non-canonical UUID forms
+// ---------------------------------------------------------------------------
+
+// TestDMConversationKey_RejectsNonCanonicalUUID exercises every non-canonical
+// UUID form that uuid.Parse accepts but that does not match canonical
+// lowercase-hyphenated output.
+func TestDMConversationKey_RejectsNonCanonicalUUID(t *testing.T) {
+	canonical := "550e8400-e29b-41d4-a716-446655440000"
+
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{"uppercase", "6BA7B810-9DAD-11D1-80B4-00C04FD430C8"},
+		{"mixed case", "6ba7b810-9dad-11d1-80b4-00C04FD430C8"},
+		{"braced", "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}"},
+		{"unhyphenated", "6ba7b8109dad11d180b400c04fd430c8"},
+		{"urn:uuid: form", "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DMConversationKey("user", tc.id, "agent", canonical)
+			require.Error(t, err, "non-canonical UUID %q must be rejected", tc.id)
+			assert.Contains(t, err.Error(), "non-canonical UUID",
+				"error message must mention non-canonical UUID")
+		})
+	}
+}


### PR DESCRIPTION
The DM key IS the access-control basis for a direct conversation, so a wrong key is worse than no key.

- `DMConversationKey` rejects non-canonical kinds and non-canonical UUIDs instead of accepting them.
- No normalisation on the derivation path: a differing round-trip is an error, never a rewrite.
- Adds golden vectors, rejection vectors, cross-writer agreement tests.
- Drops `slog` from derivation; shape description moves into the error.

2 files, +151/-28, rebased onto b14c4141.

**Verification.** `make test-fast` green; 12 key tests pass; no `ToLower`/`TrimSpace` on the derivation path. Positive controls confirm the tests cover the fix rather than merely passing beside it: disabling the canonicality rejection fails the suite, and so does disabling kind validation.

**Stack.** Previously stacked on #1360 (squash-merged). Rebased via `git rebase --onto` so it replays only its own 3 commits; all 8 files from #1360 verified byte-identical in main first.

`cla/google` fails on agent-authored branches and is not required