### PR TITLE
ci: extend security marker gate to messagebroker and broker-inbound (B5/R1, #1347)

### DIFF
--- a/hack/check-security-marker-gates.sh
+++ b/hack/check-security-marker-gates.sh
@@ -52,6 +52,13 @@
 #     REQUIRED: fanOutToProject x3 (B5/R1 — broadcast self-skip by canonical ID)
 #     REQUIRED: fanOutGlobal x3 (B5/R1 — global broadcast self-skip by canonical ID)
 #
+#   handlers_broker_inbound.go (parallel entry point to handlers_agent_messaging):
+#     REQUIRED: ActionAttach x1 in handleBrokerInbound (#1347 — broker inbound authz)
+#     REQUIRED: CheckAccess x1 in handleBrokerInbound (#1347 — policy check)
+#     REQUIRED: SenderID x4 in handleBrokerInbound (B5 — canonical sender identity)
+#     REQUIRED: NewAuthenticatedUser x1 in handleBrokerInbound (B5 — server-derived identity)
+#     REQUIRED: parseDMKeyIDs x1 in handleBrokerInbound (B5 — DM key ownership)
+#
 #   COMPOSITE: handleProjectBroadcast in handlers_agent_messaging.go must
 #   contain BOTH authenticatedSender AND ActionAttach.
 #

--- a/hack/check-security-marker-gates.sh
+++ b/hack/check-security-marker-gates.sh
@@ -48,6 +48,10 @@
 #     REQUIRED: sendAgentRouted x2 (s.authorize + CheckAccess)
 #     AUDIT: sendAgentRouted x1 (logAuthzDenial — silent-denial path, no 403)
 #
+#   SenderID in messagebroker.go:
+#     REQUIRED: fanOutToProject x3 (B5/R1 — broadcast self-skip by canonical ID)
+#     REQUIRED: fanOutGlobal x3 (B5/R1 — global broadcast self-skip by canonical ID)
+#
 #   COMPOSITE: handleProjectBroadcast in handlers_agent_messaging.go must
 #   contain BOTH authenticatedSender AND ActionAttach.
 #

--- a/hack/checksecuritymarkergates/main.go
+++ b/hack/checksecuritymarkergates/main.go
@@ -32,9 +32,10 @@ var (
 func main() {
 	hamPath := "pkg/hub/handlers_agent_messaging.go"
 	hcvPath := "pkg/hub/handlers_chat_v2.go"
+	mbPath := "pkg/hub/messagebroker.go"
 
 	// File-existence precheck (exit 2).
-	for _, f := range []string{hamPath, hcvPath} {
+	for _, f := range []string{hamPath, hcvPath, mbPath} {
 		if _, err := os.Stat(f); err != nil {
 			fmt.Fprintf(os.Stderr, "ABORT: guarded file not found or not readable: %s\n", f)
 			fmt.Fprintf(os.Stderr, "  Nothing was analysed. This is an environment/rename issue, not a guard failure.\n")
@@ -54,6 +55,13 @@ func main() {
 	hcv, err := parser.ParseFile(fset, hcvPath, nil, parser.ParseComments)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ABORT: could not parse %s: %v\n", hcvPath, err)
+		fmt.Fprintf(os.Stderr, "  Nothing was analysed. This is a syntax error, not a guard failure.\n")
+		os.Exit(2)
+	}
+
+	mb, err := parser.ParseFile(fset, mbPath, nil, parser.ParseComments)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ABORT: could not parse %s: %v\n", mbPath, err)
 		fmt.Fprintf(os.Stderr, "  Nothing was analysed. This is a syntax error, not a guard failure.\n")
 		os.Exit(2)
 	}
@@ -141,6 +149,18 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  sender-identity derivation AND project authorization simultaneously.\n")
 		rc = 1
 	}
+
+	// --- SenderID in messagebroker.go ---
+
+	// REQUIRED: 3 uses in fanOutToProject (B5/R1 — broadcast self-skip by ID)
+	assertRequired(
+		"SenderID in fanOutToProject (B5/R1 — broadcast self-skip by canonical ID)",
+		mb, mbPath, "fanOutToProject", "SenderID", 3)
+
+	// REQUIRED: 3 uses in fanOutGlobal (B5/R1 — global self-skip by ID)
+	assertRequired(
+		"SenderID in fanOutGlobal (B5/R1 — global broadcast self-skip by canonical ID)",
+		mb, mbPath, "fanOutGlobal", "SenderID", 3)
 
 	// --- Print results ---
 

--- a/hack/checksecuritymarkergates/main.go
+++ b/hack/checksecuritymarkergates/main.go
@@ -33,9 +33,10 @@ func main() {
 	hamPath := "pkg/hub/handlers_agent_messaging.go"
 	hcvPath := "pkg/hub/handlers_chat_v2.go"
 	mbPath := "pkg/hub/messagebroker.go"
+	hbiPath := "pkg/hub/handlers_broker_inbound.go"
 
 	// File-existence precheck (exit 2).
-	for _, f := range []string{hamPath, hcvPath, mbPath} {
+	for _, f := range []string{hamPath, hcvPath, mbPath, hbiPath} {
 		if _, err := os.Stat(f); err != nil {
 			fmt.Fprintf(os.Stderr, "ABORT: guarded file not found or not readable: %s\n", f)
 			fmt.Fprintf(os.Stderr, "  Nothing was analysed. This is an environment/rename issue, not a guard failure.\n")
@@ -62,6 +63,13 @@ func main() {
 	mb, err := parser.ParseFile(fset, mbPath, nil, parser.ParseComments)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ABORT: could not parse %s: %v\n", mbPath, err)
+		fmt.Fprintf(os.Stderr, "  Nothing was analysed. This is a syntax error, not a guard failure.\n")
+		os.Exit(2)
+	}
+
+	hbi, err := parser.ParseFile(fset, hbiPath, nil, parser.ParseComments)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ABORT: could not parse %s: %v\n", hbiPath, err)
 		fmt.Fprintf(os.Stderr, "  Nothing was analysed. This is a syntax error, not a guard failure.\n")
 		os.Exit(2)
 	}
@@ -162,6 +170,40 @@ func main() {
 		"SenderID in fanOutGlobal (B5/R1 — global broadcast self-skip by canonical ID)",
 		mb, mbPath, "fanOutGlobal", "SenderID", 3)
 
+	// --- handlers_broker_inbound.go ---
+	// Parallel entry point to handlers_agent_messaging.go. Same B5 and #1347
+	// security patterns: server-derived sender identity, ActionAttach
+	// enforcement, DM key ownership verification.
+
+	// REQUIRED: ActionAttach x1 in handleBrokerInbound (CheckAccess call)
+	assertRequired(
+		"ActionAttach in handleBrokerInbound (#1347 — broker inbound authorization)",
+		hbi, hbiPath, "handleBrokerInbound", "ActionAttach", 1)
+
+	// REQUIRED: CheckAccess x1 in handleBrokerInbound (policy enforcement)
+	assertRequired(
+		"CheckAccess in handleBrokerInbound (#1347 — broker inbound policy check)",
+		hbi, hbiPath, "handleBrokerInbound", "CheckAccess", 1)
+
+	// REQUIRED: SenderID x4 in handleBrokerInbound (B5 — canonical sender identity)
+	// The 4 idents are: assignment from senderUser.ID, DM ownership check,
+	// message persistence, and conversation resolution.
+	assertRequired(
+		"SenderID in handleBrokerInbound (B5 — canonical sender identity propagation)",
+		hbi, hbiPath, "handleBrokerInbound", "SenderID", 4)
+
+	// REQUIRED: NewAuthenticatedUser x1 in handleBrokerInbound
+	// Identity constructed from DB-resolved senderUser, not request payload.
+	assertRequired(
+		"NewAuthenticatedUser in handleBrokerInbound (B5 — server-derived identity construction)",
+		hbi, hbiPath, "handleBrokerInbound", "NewAuthenticatedUser", 1)
+
+	// REQUIRED: parseDMKeyIDs x1 in handleBrokerInbound
+	// Validates DM thread_id matches the resolved sender and agent.
+	assertRequired(
+		"parseDMKeyIDs in handleBrokerInbound (B5 — DM key ownership verification)",
+		hbi, hbiPath, "handleBrokerInbound", "parseDMKeyIDs", 1)
+
 	// --- Print results ---
 
 	for _, n := range notices {
@@ -232,9 +274,9 @@ func countCommentMentions(file *ast.File, symbol string) int {
 
 func assertRequired(desc string, file *ast.File, filename, funcName, symbol string, expected int) {
 	actual := countIdentsInFunc(file, funcName, symbol)
-	if actual != expected {
+	if actual < expected {
 		fmt.Fprintf(os.Stderr, "FAIL [REQUIRED] %s\n", desc)
-		fmt.Fprintf(os.Stderr, "  expected %s x%d in %s (%s), found x%d\n",
+		fmt.Fprintf(os.Stderr, "  expected %s at least x%d in %s (%s), found x%d\n",
 			symbol, expected, funcName, filename, actual)
 		rc = 1
 	}
@@ -242,9 +284,9 @@ func assertRequired(desc string, file *ast.File, filename, funcName, symbol stri
 
 func assertFuncDef(desc string, file *ast.File, filename, symbol string, expected int) {
 	actual := countFuncDefs(file, symbol)
-	if actual != expected {
+	if actual < expected {
 		fmt.Fprintf(os.Stderr, "FAIL [REQUIRED] %s\n", desc)
-		fmt.Fprintf(os.Stderr, "  expected func %s definition x%d in %s, found x%d\n",
+		fmt.Fprintf(os.Stderr, "  expected func %s definition at least x%d in %s, found x%d\n",
 			symbol, expected, filename, actual)
 		rc = 1
 	}
@@ -252,9 +294,9 @@ func assertFuncDef(desc string, file *ast.File, filename, symbol string, expecte
 
 func assertAudit(desc string, file *ast.File, filename, funcName, symbol string, expected int) {
 	actual := countIdentsInFunc(file, funcName, symbol)
-	if actual != expected {
+	if actual < expected {
 		fmt.Fprintf(os.Stderr, "FAIL [AUDIT] %s\n", desc)
-		fmt.Fprintf(os.Stderr, "  expected %s x%d in %s (%s), found x%d\n",
+		fmt.Fprintf(os.Stderr, "  expected %s at least x%d in %s (%s), found x%d\n",
 			symbol, expected, funcName, filename, actual)
 		fmt.Fprintf(os.Stderr, "  This is a silent-denial path — logAuthzDenial is the ONLY record of the denial.\n")
 		rc = 1


### PR DESCRIPTION
Stacked on #1361. Adds gate rows for the B5/R1 canonical-ID self-skip (fanOutToProject, fanOutGlobal) and for the broker-inbound entry point.

Relaxes REQUIRED/AUDIT counts from exact to at-least: adding call sites no longer fails the gate, removals still do.

Verified against a scion/messaging-v2 overlay: fanOut rows fire (found x0 of 3), broker-inbound SenderID (x2 of 4) and parseDMKeyIDs (x0 of 1). Missing file exits 2. make test-fast passes