### PR TITLE
security: stop credential leak in runtime error and debug paths (#127 P5)

### DIFF
--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -552,22 +552,26 @@ func isImageNotFoundOutput(output string) bool {
 }
 
 func runSimpleCommand(ctx context.Context, command string, args ...string) (string, error) {
-	cmdStr := command + " " + strings.Join(args, " ")
-	runtimeLog.Debug("Executing command", "cmd", cmdStr)
+	// Log the command name and argument count only — never the argument values.
+	// On this tier, secrets travel in argv (--env KEY=VALUE), so logging the
+	// full command string would write credentials to logs.  See #127 / P5.
+	runtimeLog.Debug("Executing command", "cmd", command, "argc", len(args))
 	start := time.Now()
 	cmd := exec.CommandContext(ctx, command, args...)
 	out, err := cmd.CombinedOutput()
 	elapsed := time.Since(start)
 	if err != nil {
-		runtimeLog.Debug("Command failed", "cmd", cmdStr, "duration", elapsed, "output", strings.TrimSpace(string(out)))
-		return string(out), fmt.Errorf("%s %s failed: %w", command, strings.Join(args, " "), err)
+		runtimeLog.Debug("Command failed", "cmd", command, "argc", len(args), "duration", elapsed, "output", strings.TrimSpace(string(out)))
+		return string(out), fmt.Errorf("%s failed: %w", command, err)
 	}
-	runtimeLog.Debug("Command completed", "cmd", cmdStr, "duration", elapsed)
+	runtimeLog.Debug("Command completed", "cmd", command, "argc", len(args), "duration", elapsed)
 	return strings.TrimSpace(string(out)), nil
 }
 
 func runInteractiveCommand(command string, args ...string) error {
-	runtimeLog.Debug("Executing interactive command", "cmd", command+" "+strings.Join(args, " "))
+	// Log command name and argument count only — see runSimpleCommand comment
+	// and #127 / P5 for rationale.
+	runtimeLog.Debug("Executing interactive command", "cmd", command, "argc", len(args))
 	cmd := exec.Command(command, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -611,10 +615,13 @@ func insertVolumeFlags(args []string, image string, mountSpecs []string) []strin
 	return result
 }
 
-// WriteRuntimeDebugFile writes the full runtime execution command to a debug
-// file inside the agent directory for diagnostic purposes. The command is
-// formatted with one argument per line using backslash continuation characters
-// for readability. The file is written to <agentDir>/runtime-exec-debug.
+// WriteRuntimeDebugFile writes a redacted summary of the runtime execution
+// command to a debug file inside the agent directory. The file records the
+// command name and argument count but NOT the argument values, because on the
+// sandbox tier secrets travel in argv (--env KEY=VALUE) and writing them to a
+// host-filesystem file creates an uncontrolled secret-at-rest.  See #127 / P5.
+//
+// The file is written to <agentDir>/runtime-exec-debug.
 // This is a no-op if config.Debug is false or HomeDir is empty.
 func WriteRuntimeDebugFile(config RunConfig, command string, args []string) {
 	if !config.Debug || config.HomeDir == "" {
@@ -625,11 +632,7 @@ func WriteRuntimeDebugFile(config RunConfig, command string, args []string) {
 
 	var buf strings.Builder
 	buf.WriteString(command)
-	for _, arg := range args {
-		buf.WriteString(" \\\n  ")
-		buf.WriteString(arg)
-	}
-	buf.WriteString("\n")
+	buf.WriteString(fmt.Sprintf(" [%d args redacted — may contain credentials, see #127]\n", len(args)))
 
 	if err := os.WriteFile(debugPath, []byte(buf.String()), 0644); err != nil {
 		runtimeLog.Debug("Failed to write runtime debug file", "path", debugPath, "error", err)

--- a/pkg/runtime/common.go
+++ b/pkg/runtime/common.go
@@ -632,7 +632,7 @@ func WriteRuntimeDebugFile(config RunConfig, command string, args []string) {
 
 	var buf strings.Builder
 	buf.WriteString(command)
-	buf.WriteString(fmt.Sprintf(" [%d args redacted — may contain credentials, see #127]\n", len(args)))
+	fmt.Fprintf(&buf, " [%d args redacted — may contain credentials, see #127]\n", len(args))
 
 	if err := os.WriteFile(debugPath, []byte(buf.String()), 0644); err != nil {
 		runtimeLog.Debug("Failed to write runtime debug file", "path", debugPath, "error", err)

--- a/pkg/runtime/common_test.go
+++ b/pkg/runtime/common_test.go
@@ -15,8 +15,11 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -824,7 +827,7 @@ func TestGcloudMountPreCreatesDirectory(t *testing.T) {
 }
 
 func TestWriteRuntimeDebugFile(t *testing.T) {
-	t.Run("writes file when debug is true", func(t *testing.T) {
+	t.Run("writes redacted file when debug is true", func(t *testing.T) {
 		agentDir := t.TempDir()
 		homeDir := filepath.Join(agentDir, "home")
 		_ = os.MkdirAll(homeDir, 0755)
@@ -834,13 +837,14 @@ func TestWriteRuntimeDebugFile(t *testing.T) {
 			HomeDir: homeDir,
 		}
 
-		WriteRuntimeDebugFile(config, "docker", []string{
+		args := []string{
 			"run", "-t", "--name", "my-agent",
-			"-e", "FOO=bar",
+			"--env", "FOO=bar",
 			"-v", "/host:/container",
 			"my-image:latest",
 			"tmux", "new-session", "-s", "scion",
-		})
+		}
+		WriteRuntimeDebugFile(config, "docker", args)
 
 		debugPath := filepath.Join(agentDir, "runtime-exec-debug")
 		content, err := os.ReadFile(debugPath)
@@ -850,29 +854,25 @@ func TestWriteRuntimeDebugFile(t *testing.T) {
 
 		text := string(content)
 
-		// Should start with the command
+		// Should start with the command name.
 		if !strings.HasPrefix(text, "docker") {
 			t.Errorf("expected file to start with 'docker', got: %s", text)
 		}
 
-		// Should have continuation characters
-		if !strings.Contains(text, " \\\n  ") {
-			t.Errorf("expected backslash continuation characters, got: %s", text)
+		// Should contain the arg count.
+		if !strings.Contains(text, fmt.Sprintf("%d args", len(args))) {
+			t.Errorf("expected file to mention arg count %d, got: %s", len(args), text)
 		}
 
-		// Should contain each arg on its own line
-		lines := strings.Split(text, "\n")
-		// First line is "docker \", remaining are "  arg \" (last arg has no \)
-		if len(lines) < 10 {
-			t.Errorf("expected at least 10 lines (one per arg), got %d: %s", len(lines), text)
+		// Must NOT contain actual argument values — they may carry secrets.
+		if strings.Contains(text, "--name") {
+			t.Errorf("file contains arg values that should be redacted: %s", text)
 		}
-
-		// Should contain specific args
-		if !strings.Contains(text, "--name") {
-			t.Errorf("expected --name in debug file, got: %s", text)
+		if strings.Contains(text, "my-image:latest") {
+			t.Errorf("file contains arg values that should be redacted: %s", text)
 		}
-		if !strings.Contains(text, "my-image:latest") {
-			t.Errorf("expected image in debug file, got: %s", text)
+		if strings.Contains(text, "FOO=bar") {
+			t.Errorf("file contains env value that should be redacted: %s", text)
 		}
 	})
 
@@ -903,6 +903,134 @@ func TestWriteRuntimeDebugFile(t *testing.T) {
 		// Should not panic
 		WriteRuntimeDebugFile(config, "docker", []string{"run", "test"})
 	})
+}
+
+// TestRunSimpleCommand_NoSecretsInDebugLog is the mutation test for Site 1
+// of #127/P5. It verifies that secret values carried in command arguments do
+// NOT appear in debug log output.
+//
+// Mutation proof: reverting the fix in runSimpleCommand (logging the full
+// cmdStr instead of command+argc) causes this test to fail, because the
+// sentinel value then appears in the captured log output.
+func TestRunSimpleCommand_NoSecretsInDebugLog(t *testing.T) {
+	const sentinel = "FAKE-KEY-SENTINEL-not-a-real-credential"
+
+	// runtimeLog captured slog.Default() at package init, before any custom
+	// handler was installed (#1339). Its handler bridges to the stdlib log
+	// package. We capture that output here and lower the level gate so Debug
+	// lines reach the buffer.
+	var buf bytes.Buffer
+	origWriter := log.Writer()
+	origFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0) // drop date/time prefix for simpler assertions
+	t.Cleanup(func() {
+		log.SetOutput(origWriter)
+		log.SetFlags(origFlags)
+	})
+	origLevel := slog.SetLogLoggerLevel(slog.LevelDebug)
+	t.Cleanup(func() { slog.SetLogLoggerLevel(origLevel) })
+
+	// --- Success path ---
+	// "echo" succeeds; its args include the sentinel via --env.
+	buf.Reset()
+	_, _ = runSimpleCommand(context.Background(), "echo", "--env", "SECRET_KEY="+sentinel)
+
+	logOutput := buf.String()
+	if strings.Contains(logOutput, sentinel) {
+		t.Errorf("SECURITY: debug log (success path) contains secret sentinel %q\nLog: %s",
+			sentinel, logOutput)
+	}
+	// The command name must still be logged — we redacted args, not everything.
+	if !strings.Contains(logOutput, "echo") {
+		t.Errorf("debug log should contain the command name 'echo'\nLog: %s", logOutput)
+	}
+
+	// --- Failure path ---
+	// Use "false" so the command fails with no output (the sentinel can only
+	// appear if it leaks from the argument list, not from command stdout).
+	buf.Reset()
+	_, err := runSimpleCommand(context.Background(), "false", "--env", "SECRET_KEY="+sentinel)
+	if err == nil {
+		t.Fatal("expected error from 'false', got nil")
+	}
+
+	logOutput = buf.String()
+	if strings.Contains(logOutput, sentinel) {
+		t.Errorf("SECURITY: debug log (failure path) contains secret sentinel %q\nLog: %s",
+			sentinel, logOutput)
+	}
+
+	// The error message returned to callers must also not contain the sentinel,
+	// because callers may log it at non-debug levels.
+	if strings.Contains(err.Error(), sentinel) {
+		t.Errorf("SECURITY: error message contains secret sentinel %q\nError: %s",
+			sentinel, err.Error())
+	}
+}
+
+// TestWriteRuntimeDebugFile_NoSecretsInFile is the mutation test for Site 2
+// of #127/P5. It verifies that secret values carried in command arguments do
+// NOT appear in the debug file written by WriteRuntimeDebugFile.
+//
+// Mutation proof: reverting the fix in WriteRuntimeDebugFile (writing the full
+// args instead of the redacted summary) causes this test to fail, because the
+// sentinel value then appears in the file contents.
+func TestWriteRuntimeDebugFile_NoSecretsInFile(t *testing.T) {
+	const sentinel = "FAKE-AUTH-SENTINEL-not-a-real-credential"
+
+	agentDir := t.TempDir()
+	homeDir := filepath.Join(agentDir, "home")
+	if err := os.MkdirAll(homeDir, 0755); err != nil {
+		t.Fatalf("failed to create home dir: %v", err)
+	}
+
+	config := RunConfig{
+		Debug:   true,
+		HomeDir: homeDir,
+	}
+
+	// Build an arg list that mimics a sandbox start command with secrets in
+	// --env flags — the exact shape that leaks on this tier.
+	args := []string{
+		"run", "--detach", "--rootfs", "/",
+		"--env", "SAFE_VAR=safe-value",
+		"--env", "GEMINI_API_KEY=" + sentinel,
+		"--env", "SCION_AUTH_TOKEN=" + sentinel,
+		"--", "/usr/bin/sciontool", "init",
+	}
+	WriteRuntimeDebugFile(config, "/usr/local/gcp/bin/sandbox", args)
+
+	debugPath := filepath.Join(agentDir, "runtime-exec-debug")
+	content, err := os.ReadFile(debugPath)
+	if err != nil {
+		t.Fatalf("expected debug file to exist: %v", err)
+	}
+
+	text := string(content)
+
+	// The sentinel must NOT appear in the file.
+	if strings.Contains(text, sentinel) {
+		t.Errorf("SECURITY: debug file contains secret sentinel %q\nFile contents:\n%s",
+			sentinel, text)
+	}
+
+	// The command name must still appear — we redacted args, not the command.
+	if !strings.Contains(text, "sandbox") {
+		t.Errorf("debug file should contain the command name\nFile contents:\n%s", text)
+	}
+
+	// The arg count must appear for diagnostic value.
+	if !strings.Contains(text, fmt.Sprintf("%d args", len(args))) {
+		t.Errorf("debug file should mention arg count %d\nFile contents:\n%s",
+			len(args), text)
+	}
+
+	// Env values must not appear even for "safe" values — we redact all args,
+	// because classification is exactly what #127 showed we get wrong.
+	if strings.Contains(text, "safe-value") {
+		t.Errorf("debug file contains non-secret arg value — all args should be redacted\nFile contents:\n%s", text)
+	}
 }
 
 func TestScionDirShadowedWhenFullRepoMounted(t *testing.T) {


### PR DESCRIPTION
Fixes an active credential leak on the sandbox agent-start failure path.

pkg/runtime/common.go:563 built every --env KEY=VALUE pair, including API keys, into a returned error. It was gated on nothing. On any container start failure that error reached three sinks unredacted: Cloud Logging, an OpenTelemetry span, and the HTTP response body (pkg/runtimebroker/handlers.go:882-904; same at :1421 and :1663).

Three adjacent runtimeLog.Debug calls carried the same data. Those were --debug gated, so lesser, but are cleaned here too.

Verified: two new tests fail against main and pass with the fix. go test ./pkg/runtime/ green, 24 tests.

This does not close #127. Secrets still travel in argv until the classification phase lands