### PR TITLE
docs: port messaging design logs from em9-unify and messaging-v2 (re-derivation phase 1)

### DIFF
--- a/.design/project-log/2026-08-27-def11-preresolved-externalref.md
+++ b/.design/project-log/2026-08-27-def11-preresolved-externalref.md
@@ -1,0 +1,65 @@
+# DEF-11: Pre-resolved ConversationID leaves ExternalRef empty
+
+**Date:** 2026-08-27
+**Author:** dev-def11
+**Branch:** `scion/ca-msg-em7` (from `scion/messaging-v2`)
+
+## Problem
+
+When the CLI pre-resolves a `ConversationID` on a `StructuredMessage`, the
+handler in `handleAgentMessage` (pkg/hub/handlers_agent_messaging.go) constructed
+a `ConversationResult` with only `ConversationID` set, leaving `ExternalRef` as
+an empty string. This empty ref was then fed into `ComputeDivergenceMatch`, which
+compared e.g. `oldRouting="sender-recipient:A:B"` against `actualExternalRef=""`
+and produced a false `routing-type-mismatch: old=sender-recipient:A:B new=` error.
+
+The two routing models actually agreed; the comparison was being fed a blank.
+
+## Fix
+
+Three changes across `pkg/messaging/divergence.go` and `pkg/hub/handlers_agent_messaging.go`:
+
+1. **Populate ExternalRef from the store:** After building the `ConversationResult`
+   for a pre-resolved `ConversationID`, call
+   `s.store.GetConversation(ctx, structuredMsg.ConversationID)` and set
+   `convResult.ExternalRef = conv.ExternalRef` on success. On failure, set an
+   explicit `lookupFailed` boolean (scoped to the pre-resolved branch only —
+   empty ExternalRefs from thread conversations or unmigrated rows still flow
+   through `ComputeDivergenceMatch` as intended).
+
+2. **Fallback field on DivergenceEntry:** Added `Fallback bool` to
+   `DivergenceEntry`. When set, `LogDivergence` routes the event to
+   `IncFallback()` instead of `Inc(match)`, ensuring one event increments
+   exactly one counter. This prevents lookup failures from blocking the
+   read-switch gate that requires zero mismatches.
+
+3. **Fallback handling for lookup failures:** When `lookupFailed` is true,
+   log a `DivergenceEntry` with `Reason: "conv-lookup-failed"` and
+   `Fallback: true` through the standard `LogDivergence` path. This skips
+   `ComputeDivergenceMatch` entirely, avoids the ambiguous empty-ref artifact,
+   and produces the same parseable record shape as all other divergence entries.
+
+## Tests Added
+
+Four new tests in `pkg/hub/handlers_agent_messaging_test.go`, all using the
+existing `testServer(t)` / `doRequest()` harness with delta-based assertions on
+the process-global `DivergenceMetrics` singleton:
+
+| Test | Verifies |
+|------|----------|
+| `TestDEF11_PreResolvedConversation_PopulatesExternalRef` | ExternalRef is populated from store; dm-routing-agreement match occurs |
+| `TestDEF11_PreResolvedConversation_DivergenceMatch` | Pre-resolved send produces Matches delta >= 1, Mismatches delta == 0 |
+| `TestDEF11_PreResolvedConversation_LookupFailure` | Non-existent ConversationID records Fallbacks delta >= 1, Mismatches delta == 0 |
+| `TestDEF11_PreResolvedConversation_GenuineDisagreement` | Wrong ExternalRef produces Mismatches delta >= 1 (comparison is active) |
+
+**Mutation proof:** Removing the `GetConversation` call causes
+`TestDEF11_PreResolvedConversation_DivergenceMatch` to fail because ExternalRef
+reverts to empty, producing `routing-type-mismatch` instead of
+`dm-routing-agreement`.
+
+## Files Changed
+
+- `pkg/messaging/divergence.go` -- added `Fallback` field to `DivergenceEntry`, updated `LogDivergence`
+- `pkg/messaging/divergence_test.go` -- added `TestLogDivergence_Fallback`
+- `pkg/hub/handlers_agent_messaging.go` -- the fix + fallback handling with `lookupFailed` flag
+- `pkg/hub/handlers_agent_messaging_test.go` -- four new tests

--- a/.design/project-log/2026-08-27-def13-help-text.md
+++ b/.design/project-log/2026-08-27-def13-help-text.md
@@ -1,0 +1,58 @@
+# DEF-13: Document conversation-reference grammar in `scion message --help`
+
+**Date:** 2026-08-27
+**Agent:** dev-def13
+**Branch:** scion/ca-msg-em8
+**Commit:** 2e6178ee
+
+## Problem
+
+The `scion message` deprecation warnings for `--channel` and `--thread-id`
+directed users to "use @<agent-name>" but the `--help` text never defined
+that form, nor any of the other conversation-reference forms accepted by
+`messaging.ParseReference` (`@<email>`, `conv:<uuid>`, `#<thread>`).
+
+## Changes
+
+### cmd/message.go
+
+1. **Help text**: Added four new recipient forms to the Recipients section
+   of `messageCmd.Long`:
+   - `@<agent-name>` — preferred form for sending to agents
+   - `@<email>` — global DM by email
+   - `conv:<uuid>` — annotated as "not yet supported — errors"
+   - `#<thread>` — annotated as "not yet supported — errors"
+
+2. **Example**: Added `scion message @my-agent "Please review the PR"` to
+   the Examples section. No `conv:` or `#` examples (deny-listed by policy).
+
+3. **Deprecation table refactor**: Extracted hardcoded
+   `emitDeprecationWarning` calls into a package-level
+   `deprecationReplacements` table. `emitDeprecationWarnings` now iterates
+   the table. This enables tests to assert that deprecation messages
+   referencing conversation forms point to documented help text.
+
+### cmd/message_help_test.go (new)
+
+- `TestMessageHelpCoversAllRefForms`: table-driven test with 4 entries
+  validated against `messaging.ParseReference`.
+- Tripwire assertion: `require.Equal(t, 4, int(messaging.RefThread))` fails
+  if a new `ReferenceKind` is added without updating the table.
+- `catches_missing_form` subtest proves the assertion mechanism is
+  load-bearing.
+- `deprecation_warnings_reference_documented_forms` subtest iterates
+  `deprecationReplacements` and asserts every message referencing a
+  conversation form (`@<`, `conv:`, `#<`) has that form in `Long`.
+
+### cmd/doc_syntax_test.go
+
+- Added `cobra_help_deny_list` subtest: walks the entire cobra command tree,
+  extracts `scion ...` lines from `Long` and `Example` fields, and runs
+  `findDenyListProblems` against them. Catches anyone adding `conv:` or `#`
+  to help-text examples.
+
+## Verification
+
+- `go test ./cmd/ -run TestMessageHelpCoversAllRefForms -v` — PASS (6/6 subtests)
+- `go test ./cmd/ -run TestDocSyntax -v` — PASS (4/4 subtests)
+- `go build ./cmd/scion/` — clean

--- a/.design/project-log/2026-08-27-def15-derive-key-foundation.md
+++ b/.design/project-log/2026-08-27-def15-derive-key-foundation.md
@@ -1,0 +1,58 @@
+# DEF-15 Phase 1+2: DeriveConversationKey Foundation
+
+**Date:** 2026-08-27
+**Branch:** scion/ca-msg-em6
+**Scope:** pkg/messaging
+
+## Summary
+
+Implemented the canonical `DeriveConversationKey` function that collapses five
+separate conversation key derivation paths into one. This is the foundation for
+the DEF-15 security fix that prevents a malformed dm: key from falling through
+to the thread-key path and creating a defective row.
+
+## Changes
+
+### New: `pkg/messaging/derive_key.go`
+
+- `KeyInputs` struct holding all derivation inputs
+- `DeriveConversationKey(KeyInputs)` — single canonical function for all
+  external_ref construction, with three branches:
+  - Case 1: `dm:`-prefixed ThreadID — parse, re-derive, verify canonicality,
+    return verbatim (never normalize)
+  - Case 2: Non-dm ThreadID — validate ProjectID, return `thread:<proj>:<tid>`
+  - Case 3: Empty ThreadID — derive from principal pair via DMConversationKey
+- `ResolveOrCreateConversationByKey` — shared upsert step used by delegating
+  conversation.go functions
+
+### New: `pkg/messaging/derive_key_test.go`
+
+Golden vector table test covering all 3 success branches and 10 error branches:
+- Malformed dm key, unknown kind, invalid UUID, non-canonical UUID (uppercase),
+  non-canonical token order, unhyphenated UUID, empty projectID, empty senderID,
+  unknown senderKind, invalid senderID UUID
+- Verbatim return assertion for case 1
+
+### Modified: `pkg/messaging/conversation.go`
+
+- `ResolveOrCreateThreadConversation` now delegates to `DeriveConversationKey`
+  with distinct refusal log text ("conversation key derivation refused") per
+  Change 5
+- `ResolveThreadConversationForRead` delegates to `DeriveConversationKey`;
+  removed `projectID == ""` from early return so dm:-prefixed ThreadIDs work
+  without a projectID
+
+### Modified: `pkg/messaging/conversation_test.go`
+
+- AC-DEF15-5 write-then-read tests for both dm: and non-dm ThreadIDs
+- Distinct log text assertion for Change 5
+- DM key with empty projectID read-path test
+
+## Acceptance Criteria Met
+
+- AC-DEF15-2: Golden vector table covers all 3 success + all error branches
+- AC-DEF15-5: Write-then-read test passes (same inputs produce same row)
+- All existing tests pass (`go test ./pkg/messaging/... ./pkg/hub/... -count=1`)
+- Canonicality comment present in derive_key.go
+- Both thread functions delegate to DeriveConversationKey
+- Distinct log text for refusal vs resolution failure

--- a/.design/project-log/2026-08-27-def15-thread-dm-shape.md
+++ b/.design/project-log/2026-08-27-def15-thread-dm-shape.md
@@ -1,0 +1,35 @@
+# DEF-15: dm:-prefixed ThreadID produces third DM shape
+
+## Date
+2026-08-27
+
+## Discovery
+During merge verification of origin/main into scion/messaging-v2, the architect
+identified that a dm:-prefixed ThreadID (e.g. "dm:agent:X:user:Y") takes the
+thread resolution path instead of the DM resolution path.
+
+## Root cause
+handlers_agent_messaging.go line 244 (outbound) and line 848 (inbound):
+```
+if req.ThreadID != "" {
+    convResult = ResolveOrCreateThreadConversation(...)
+} else if ... {
+    convResult = ResolveOrCreateDMConversation(...)
+}
+```
+ThreadID is PRIORITISED over pair-based DM resolution. A dm:-prefixed ThreadID
+never reaches DMConversationKey. Instead, ResolveOrCreateThreadConversation
+(conversation.go:158) builds:
+- external_ref = "thread:<projectID>:dm:agent:X:user:Y"
+- kind = "group"
+- project-scoped
+
+## Impact
+- Third DM shape: DEF-8 again, in the code that was supposed to cure DEF-8
+- Bypasses key-based authorization (kind != "direct")
+- Project-scoped instead of global (contradicts DEF-10)
+- Two affected sites: outbound handler (:244) and inbound handler (:848)
+
+## Status
+Logged as DEF-15. Skipped test committed. Architect will spec the fix.
+Acceptance criterion: delete the t.Skip line and the test passes.

--- a/.design/project-log/2026-08-27-def16-dualwrite-validation-order.md
+++ b/.design/project-log/2026-08-27-def16-dualwrite-validation-order.md
@@ -1,0 +1,23 @@
+# DEF-16: dual-write runs before validation in outbound handler
+
+## Date
+2026-08-27
+
+## Discovery
+During DEF-15 investigation, the EM observed that the dual-write conversation
+creation at line 244 runs BEFORE ValidateLegacyMessage at line 288 in
+handleAgentOutboundMessage. The inbound handler (handleAgentMessage) orders
+these correctly: validation at line 615, dual-write at line 848.
+
+## Impact
+When ValidateLegacyMessage rejects a message (e.g., "thread_id requires channel
+to be set"), the conversation row created by the dual-write persists as an
+orphan — no message is attached to it, but the row exists in the database.
+
+## Ordering comparison
+- handleAgentOutboundMessage: dual-write (:245) -> validate (:288) — WRONG
+- handleAgentMessage: validate (:615) -> dual-write (:848) — CORRECT
+
+## Status
+Logged as DEF-16. Not assigned. Fix is to move the dual-write after validation
+in the outbound handler, matching the inbound handler's order.

--- a/.design/project-log/2026-08-27-def26-rename-placeholder-test.md
+++ b/.design/project-log/2026-08-27-def26-rename-placeholder-test.md
@@ -1,0 +1,25 @@
+# DEF-26: Rename AC-DEF8-1 placeholder test
+
+**Date:** 2026-08-27
+**Author:** dev-def26-rename
+**Branch:** scion/ca-msg-em6
+
+## Summary
+
+Renamed `TestAC_DEF8_1_ConvergenceTwoPathsSameConversation` to
+`TestResolve_SamePathIdempotency_AgentDM` in `pkg/messaging/resolve_test.go`.
+
+The test was carrying the AC-DEF8-1 badge but did not test cross-path
+convergence — it only exercised the resolver path twice (same-path
+idempotency). The real cross-path convergence test is
+`TestAC_DEF8_1_CrossPath_DualWriteAndResolverConverge`, which calls both
+`ResolveOrCreateDMConversation` and `Resolve`.
+
+## Changes
+
+- Renamed the function from `TestAC_DEF8_1_ConvergenceTwoPathsSameConversation`
+  to `TestResolve_SamePathIdempotency_AgentDM`.
+- Replaced the doc comment: removed the AC-DEF8-1 claim and described what the
+  test actually asserts (same-path idempotency, not cross-path convergence).
+- Updated the cross-path test's comment to reference the new name.
+- Both tests pass: `go test ./pkg/messaging/ -run 'TestResolve_SamePathIdempotency_AgentDM|TestAC_DEF8_1' -v -count=1`.

--- a/.design/project-log/2026-08-27-def4-hub-test-fix.md
+++ b/.design/project-log/2026-08-27-def4-hub-test-fix.md
@@ -1,0 +1,82 @@
+# DEF-4: Fix pkg/hub test suite SQLite OOM failures
+
+**Date:** 2026-08-27
+**Branch:** scion/ca-msg-em4
+
+## Problem
+
+The `pkg/hub` test suite suffered progressive SQLite "out of memory (7)" failures
+when running the full suite (`go test -count=1 ./pkg/hub/`). Individual test files
+passed in isolation, but the full package run failed with 17–20 non-deterministic
+test failures whose membership changed between runs.
+
+## Root Cause
+
+There were 66+ calls to `newTestStore(":memory:")` across pkg/hub test files. The
+function created a fresh in-memory SQLite database with full Ent migration (49+
+schemas/tables) for each call. Only ~19 call sites had any `Close()` or
+`t.Cleanup()` call. Because unclosed stores kept their in-memory databases alive
+for the entire package test run, every leaked database accumulated memory. As the
+messaging-v2 branch added new tables (conversations, conversation_participants,
+message_addressees), per-database memory cost rose past the point where SQLite
+triggered internal OOM errors (error code 7).
+
+## Fix
+
+1. **Refactored `newTestStore`** in `pkg/hub/teststore_test.go` to accept
+   `*testing.T` as the first parameter and register `t.Cleanup(func() { _ = s.Close() })`
+   internally. This ensures every test store is automatically closed when the
+   test completes, preventing future regressions.
+
+2. **Updated all 66 call sites** across 31 test files to pass `t` as the first
+   argument: `newTestStore(t, ":memory:")`.
+
+3. **Removed redundant close calls** in files that already had explicit
+   `defer db.Close()` or `t.Cleanup(func() { _ = s.Close() })` after
+   `newTestStore`, since the function now handles cleanup internally. Affected
+   files: `brokerclient_test.go` (6), `stalled_detection_test.go` (4),
+   `signing_key_shared_test.go` (2), `chat_notifications_test.go` (1),
+   `handlers_policies_test.go` (1), `harness_config_handlers_image_test.go` (1),
+   `heartbeat_timeout_test.go` (1), `notifications_test.go` (1),
+   `skill_federation_test.go` (1), `skill_registry_handlers_test.go` (1).
+
+## Scope
+
+Test-only change. No production code was modified.
+
+## Verification
+
+All verification runs were green after the fix:
+
+| Run | Command | Result | Duration |
+|-----|---------|--------|----------|
+| 1 | `go test -count=1 ./pkg/hub/` | PASS | 212.9s |
+| 2 | `go test -count=1 -v ./pkg/hub/` | PASS | 213.4s |
+| 3 | `go test -count=3 -timeout 30m ./pkg/hub/` | PASS | 655.0s |
+| 4 | `go test -count=1 -timeout 15m ./pkg/hub/` | PASS | 213.1s |
+
+### Causal Evidence
+
+After verifying the fix, the `t.Cleanup` was temporarily reverted (removed) from
+`newTestStore`. The full suite immediately failed with 20 tests hitting SQLite
+`out of memory (7)` errors, confirming the fix is load-bearing:
+
+```
+--- FAIL: TestRepairStorage_FixesMissingObjects (0.02s)
+--- FAIL: TestSAAudit_AgentCreate_RecordsTheDeny (0.01s)
+--- FAIL: TestServer_UserTokenSurvivesRestart (0.01s)
+--- FAIL: TestServer_GenerateAgentToken_NoDevAuthDoesNotAutoGrant (0.00s)
+--- FAIL: TestServer_GenerateAgentToken_RoleReadOnly (0.01s)
+--- FAIL: TestServer_GCPBackendFailureIsFatal (0.01s)
+--- FAIL: TestSkillsResolve_GHCacheHitOnSecondResolve (0.00s)
+--- FAIL: TestMultipartPublish_HappyPath (0.01s)
+--- FAIL: TestBootstrapTemplatesFromDir_MultipleTemplates (0.01s)
+... (20 failures total, all with "out of memory (7)")
+```
+
+The fix was then restored, and the suite passed again on subsequent runs.
+
+## Files Changed (32 files)
+
+- `pkg/hub/teststore_test.go` — core fix: added `*testing.T` param and `t.Cleanup`
+- 31 test files — updated call sites and removed redundant close calls

--- a/.design/project-log/2026-08-27-def8-auth.md
+++ b/.design/project-log/2026-08-27-def8-auth.md
@@ -1,0 +1,54 @@
+# DEF-8 Auth: Key-Based DM Auth + AddParticipant Immutability Guard
+
+**Date:** 2026-08-27
+**Task:** WS-1c
+**Branch:** `scion/ca-msg-em6`
+
+## Summary
+
+Implemented two security-critical changes for the DEF-8/DEF-10 DM convergence:
+
+1. **Key-based DM auth in `checkPostResolutionAuth`** — For `kind=direct` conversations, auth is now derived from the kind-encoded DM key (`conv.ExternalRef`) instead of querying the `conversation_participants` table. This is strictly tighter than the shipped `isDMParticipant` which only checked UUID positions without verifying kind.
+
+2. **AddParticipant immutability guard** — `AddParticipant` now rejects any principal not named in the DM key for `kind=direct` conversations. This prevents participant substitution attacks.
+
+## Design: Key-Derived Guard vs Count-Based
+
+A count-based guard (`count >= 2`) is **wrong** because:
+
+1. Create DM with participants {A, B} (key says `dm:user:A:user:B`)
+2. Soft-remove B → active count drops to 1
+3. `AddParticipant(C)` — count is 1, so count-based guard passes
+4. Conversation now has {A, C} while key still says {A, B}
+
+The key-derived guard prevents this: C is not named in the key, so it's rejected regardless of current participant count. The test `TestAddParticipant_DM_SoftRemoveThenSubstitute` specifically validates this scenario.
+
+## Files Modified
+
+- **`pkg/messaging/resolve.go`** — `checkPostResolutionAuth`: replaced `requireParticipant` call with `ParseDMKey`-based auth for `case "direct"`. Checks both kind AND ID against both positions in the key. Fails closed on parse error.
+
+- **`pkg/store/entadapter/conversation_store.go`** — `AddParticipant`: added immutability guard that loads the conversation, and for `kind=direct`, parses the `ExternalRef` as a DM key and verifies the participant is named in it.
+
+- **`pkg/messaging/resolve_test.go`** — Added 4 new test functions (7 test cases total):
+  - `TestKeyBasedAuth_AuthorizedCaller` — both key positions authorized
+  - `TestKeyBasedAuth_UnauthorizedCaller_WrongID` — different UUID rejected
+  - `TestKeyBasedAuth_UnauthorizedCaller_WrongKind` — same UUID, wrong kind rejected (kind-check tightening)
+  - `TestKeyBasedAuth_UnparseableExternalRef` — 4 subtests for empty/old-format/garbage/partial refs, all fail closed
+  - Fixed 3 existing tests to include valid `ExternalRef` for DM conversations
+
+- **`pkg/store/entadapter/conversation_store_test.go`** — Added 5 new integration tests:
+  - `TestAddParticipant_DM_SoftRemoveThenSubstitute` — the critical discriminating test
+  - `TestAddParticipant_DM_ThirdPartyRejection` — third party with 2 active participants
+  - `TestAddParticipant_DM_EmptyExternalRefRejection` — unparseable ref
+  - `TestAddParticipant_DM_NamedParticipantAllowed` — happy path
+  - `TestAddParticipant_DM_ReAddAfterSoftRemove` — legitimate re-add after soft-remove
+  - Changed `newTestConversation()` to use `kind=group` (avoids triggering DM guard for unrelated tests)
+  - Added `newTestDMConversation()` helper for DM-specific tests
+
+## Test Coverage
+
+| Area | Tests | Key Scenarios |
+|------|-------|---------------|
+| Key-based auth (resolve) | 4 functions, 7 cases | Authorized, wrong ID, wrong kind, 4 unparseable formats |
+| Immutability guard (store) | 5 functions | Substitution attack, third-party, empty ref, named allowed, re-add |
+| Existing tests fixed | 3 | Updated to include valid ExternalRef |

--- a/.design/project-log/2026-08-27-def8-convergence.md
+++ b/.design/project-log/2026-08-27-def8-convergence.md
@@ -1,0 +1,58 @@
+# DEF-8/DEF-10 Code Convergence
+
+**Date:** 2026-08-27
+**Author:** dev-def8-convergence
+**Branch:** scion/ca-msg-em6
+**Base:** scion/messaging-v2 (ebf8cc27)
+
+## Problem
+
+Two code paths created direct conversations using incompatible identity keys:
+
+- **Path A** (dual-write, `ResolveOrCreateDMConversation`): Used `dm:{sorted(idA,idB)}` (kind-free), nil ProjectID, zero participants.
+- **Path B** (resolver, `resolveAgentDM`/`resolveEmailDM`): Used participant-scan with N+1 queries, empty external_ref, ProjectID = sender's project.
+
+The two paths could never find each other's rows. Same pair could produce two conversation IDs.
+
+## Changes
+
+### 1. DMConversationKey (pkg/messages/dm_key.go) — NEW
+
+Canonical key derivation for DM conversations:
+- Format: `dm:<kind>:<uuid>:<kind>:<uuid>` with tokens sorted lexicographically
+- kind ∈ {user, agent}, lowercase
+- UUID normalised to canonical lowercase hex-with-hyphens before sorting
+- Rejects malformed UUIDs and unknown kinds
+- `ParseDMKey` for roundtrip parsing
+
+### 2. SetDisplayName clobber fix (pkg/store/entadapter/conversation_store.go)
+
+`UpsertConversationByExternalRef` previously set `SetDisplayName(conv.DisplayName)` unconditionally on the update branch, clobbering existing display names when upserting with an empty name. Fixed to skip when `conv.DisplayName` is empty.
+
+### 3. resolve.go convergence
+
+- `resolveAgentDM`: Now uses `DMConversationKey` + `UpsertConversationByExternalRef` + `ensureParticipant`. Project context used only for slug resolution — the DM itself has nil ProjectID (global).
+- `resolveEmailDM`: Same pattern. Already global, now uses upsert instead of participant scan.
+- Added `UpsertConversationByExternalRef` to `ResolutionStore` interface.
+- Added `ensureParticipant` helper (handles `ErrAlreadyExists` gracefully).
+- Deleted `findDirectConversation` (replaced by indexed upsert lookup).
+- Deleted `createDirectConversation` (folded into upsert + ensure pattern).
+
+### 4. Tests
+
+- **Guard A:** Zero direct conversations with empty external_ref (floor ≥ 3 rows).
+- **Guard B:** Every `dm:` row has exactly 2 active participants (floor ≥ 3 rows).
+- **AC-DEF8-1:** Two sends to the same agent via @agent resolve to ONE conversation row.
+- **AC-DEF8-2:** All direct conversations have nil ProjectID (closes DEF-10).
+- **SetDisplayName test:** Upsert with empty display name preserves existing name.
+- **DMConversationKey tests:** Roundtrip, ordering, rejection, case normalisation.
+
+## What was NOT changed
+
+- `DirectMessageExternalRef` in divergence.go — stays as-is for the legacy path.
+- `ResolveOrCreateDMConversation` in conversation.go — continues with old format.
+- No files outside scope (resolve.go, resolve_test.go, conversation_store.go, pkg/messages/).
+
+## DEF-10 resolution
+
+All direct conversations created through the resolve paths now have nil ProjectID (global DMs). The old code set `ProjectID = sender's project`, which was incorrect.

--- a/.design/project-log/2026-08-27-g1-g2-fix.md
+++ b/.design/project-log/2026-08-27-g1-g2-fix.md
@@ -1,0 +1,110 @@
+# G-1 / G-2 Fix — Round 3 (S4)
+
+**Date:** 2026-08-27
+**Branch:** scion/ca-msg-em4
+**Base:** origin/scion/messaging-v2
+
+## G-1: Identity Spoofing in Resolve Endpoint (SECURITY)
+
+**Vulnerability:** The `POST /api/v1/conversations/resolve` endpoint read
+`SenderPrincipalKind` and `SenderPrincipalID` from the JSON request body and
+only fell back to the authenticated identity when those fields were empty. Any
+authenticated user could claim to be another principal and bypass participant
+authorization checks.
+
+**Fix:** Removed `SenderPrincipalKind` and `SenderPrincipalID` from all request
+structs:
+
+- `conversationResolveRequest` (hub handler)
+- `ConversationResolveRequest` (hubclient)
+- `resolveRequest` (test struct)
+
+Sender identity is now **always** derived from the authenticated context
+(`agentIdent.ID()` or `user.ID()`). The field removal is a compile-time
+guarantee: reintroducing body-supplied sender fields would require visible code
+changes that would be caught in review. A security comment documents why the
+fields were deliberately removed.
+
+**Regression guard:** `TestHandleConversationsResolve_SenderFromAuthContext`
+verifies the handler proceeds without error when no sender fields are in the
+request body, confirming sender is derived from auth context.
+
+## G-2: Silent Message Drop for conv: and # (AC-15a)
+
+**Bug:** When `sendMessageViaConversation` received a `RefConversation` or
+`RefThread` reference, it resolved the conversation, printed "resolved
+successfully", returned nil (exit 0), but **never sent the message**. Two of
+three replacement syntaxes named in deprecation warnings silently ate the user's
+message.
+
+**Fix (option b — ship only what works):**
+
+1. Added a gate in the CLI `RunE` block: after `ParseReference` succeeds, if the
+   reference is `RefConversation` or `RefThread`, the CLI returns a clear error:
+   `"conversation reference %q is not yet supported in the CLI; use @<agent-name>
+   to message an agent"`.
+
+2. Updated deprecation warnings for `--channel` and `--thread-id` to say
+   `"use @<agent-name> to message an agent directly"` — only naming the
+   replacement that actually works from the CLI.
+
+3. Removed the dead code tail of `sendMessageViaConversation` (the conv:/#
+   print-and-return-nil block). Since the CLI now gates those refs before calling
+   the function, this code was unreachable.
+
+## @<email> Path
+
+The `@<email>` path in `sendMessageViaConversation` (RefEmail → outbound
+message) is proven to work when `SCION_AGENT_NAME` is set:
+
+- `TestSendMessageViaConversation_EmailRef_AgentContext`: sets
+  `SCION_AGENT_NAME="test-sender-agent"`, sends to `@user@example.com`, asserts
+  delivery via the outbound message recorder (recipient, message text, agent name).
+
+- `TestSendMessageViaConversation_EmailRef_NoAgentContext`: no agent context,
+  asserts error containing "only supported from within an agent container" and
+  zero sends.
+
+`@<email>` is NOT named in the deprecation warning strings because it does not
+work from a human CLI context (hard-errors without SCION_AGENT_NAME). The
+warning says only `"use @<agent-name> to message an agent directly"`.
+
+## Design Gap
+
+**conv: and # delivery routing:** The resolve step works correctly for conv: and
+# references. What is missing is the delivery routing policy — once a
+conversation is resolved, the system needs to determine which agent(s) to deliver
+to. This is an architectural decision (wake default agent, fan-out to
+participants, etc.) and is deferred to the architect. The gate ensures users get
+a clear error instead of silent message loss until this is implemented.
+
+## Empty-ID Guard Note
+
+Removing `SenderPrincipalKind`/`SenderPrincipalID` from the request struct also
+removed the explicit validation guard that rejected requests when both fields
+were empty. If an authenticated identity ever produces an empty ID (e.g. a
+misconfigured auth middleware), the handler now passes an empty sender to
+`messaging.Resolve()` instead of returning a validation error. This fails closed
+today — `requireParticipant()` will not match an empty principal against any
+participant list — so it is not a security hole. But the explicit guard was
+providing a clearer error path. Worth noting for future auth middleware changes.
+
+## DEF-5: conv: and # CLI Delivery (Design Gap for S5)
+
+`conv:<id>` and `#<thread>` conversation references are **resolved correctly** by
+`POST /api/v1/conversations/resolve` — the endpoint handles all four grammar
+forms. However, the CLI has **no delivery routing for these forms**: once a
+conversation is resolved, the system does not know which agent(s) to deliver the
+message to (wake default agent? fan-out to all participants? require explicit
+target?).
+
+These forms are **gated in the CLI** with a clear error:
+`"conversation reference %q is not yet supported in the CLI; use @<agent-name>
+to message an agent"` (non-zero exit, zero sends). The gate is mutation-verified:
+`TestConvRef_ThreadRefGated` and `TestConvRef_ConvIDGated` both fail when the
+gate is removed.
+
+**S5 must document conv: and # as unavailable, not as available.** The routing
+policy must be specified by the architect before the gate is removed. Removing
+the gate without implementing delivery would silently drop messages (the original
+G-2 defect).

--- a/.design/project-log/2026-08-27-i1-warning-fixes.md
+++ b/.design/project-log/2026-08-27-i1-warning-fixes.md
@@ -1,0 +1,37 @@
+# I-1: Fix Broken Deprecation Warning Replacements
+
+**Date:** 2026-08-27
+**Branch:** scion/dev-i1-warnings (based on scion/ca-msg-em5)
+**Issue:** Three deprecation warnings in `cmd/message.go` name replacements that do not exist in the shipped binary (violates AC-15a).
+
+## Problem
+
+1. `--in` warning said "use 'scion schedule message'" — `schedule` has no `message` subcommand
+2. `--at` warning said "use 'scion schedule message'" — same
+3. `--cc` warning said "use --to instead" — `--to` is not a registered flag
+
+## Changes
+
+### cmd/message.go
+- Line 81: `"use 'scion schedule message' instead"` → `"use 'scion schedule create --in' instead"`
+- Line 84: `"use 'scion schedule message' instead"` → `"use 'scion schedule create --at' instead"`
+- Line 93: `"use --to instead"` → `"--cc is deprecated and will be removed"`
+- Line 1199: flag help text updated to match (`scion schedule create --in`)
+- Line 1200: flag help text updated to match (`scion schedule create --at`)
+- Line 1206: flag help text updated to match (deprecated, will be removed)
+
+### cmd/message_deprecation_test.go
+- `TestDeprecatedFlag_In`: assertion updated from `"scion schedule message"` to `"scion schedule create"`
+- `TestDeprecatedFlag_At`: same
+- `TestDeprecatedFlag_CC`: assertion updated from `"use --to instead"` to `"deprecated and will be removed"`
+- Added `TestDeprecationWarnings_ReplacementsExist`: validates every `'scion ...'` reference in deprecation warnings resolves via `rootCmd.Find()`
+- Added `catches_nonexistent_replacement` mutation subtest (Rule 10)
+
+### Documentation
+- `docs-site/src/content/docs/reference/cli.md`: updated `--in`, `--at`, `--cc` entries
+- `docs-site/src/content/docs/hosted/user/messaging.md`: updated deprecation table
+- `resources/platform_skills/scion-messaging/SKILL.md`: updated deprecation table and self-callback tip
+
+## Verification
+- `go test -count=1 ./cmd/ -v -run 'TestDeprecation|TestDeprecatedFlag'` — all 18 tests pass
+- `go test -count=1 ./cmd/` — full suite passes

--- a/.design/project-log/2026-08-27-i2i3-parsecheck-fixes.md
+++ b/.design/project-log/2026-08-27-i2i3-parsecheck-fixes.md
@@ -1,0 +1,46 @@
+# I-2 / I-3: Doc Syntax Parse-Check Fixes
+
+**Date:** 2026-08-27
+**Branch:** scion/ca-msg-em5
+**Files changed:** `cmd/doc_syntax_test.go`
+
+## Problem
+
+The architect's review of S5 (Docs) found two issues in `TestDocSyntax`:
+
+### I-2: rootCmd.Find blind spot
+Cobra's `Find` returns the deepest match and leaves the remainder as args — it
+does NOT error on unknown subcommands. For example, `scion schedule message`
+(which doesn't exist) passes the parse check silently because Find returns
+`cmd=schedule, rest=["message"], err=nil`.
+
+### I-3: Rule 10 subtests re-implement instead of calling
+The `catches_bad_command` and `catches_deny_listed_pattern` subtests
+re-implemented the checking logic independently. Deleting the main-body check
+wouldn't cause the subtests to fail.
+
+## Solution
+
+### I-3: Extract checking logic into callable functions
+Extracted two functions that return problem lists:
+- `findCommandProblems(lines, source) []string` — command-find + subcommand + flag validation
+- `findDenyListProblems(lines, denyPatterns, source) []string` — deny-list pattern matching
+
+Both the main body and Rule 10 subtests call the same functions. The main body
+asserts problems are empty; the subtests assert problems are non-empty for
+known-bad inputs.
+
+### I-2: Detect unconsumed subcommand-like tokens
+After `rootCmd.Find(args)`, if the resolved command is a **pure group**
+(`HasSubCommands() && !Runnable()`) and the first unconsumed token is not a
+flag, verify it matches a registered subcommand name. The `!Runnable()` guard
+prevents false positives on commands like `message` that have both subcommands
+and their own `RunE` (accepting positional args like recipient names).
+
+Added `catches_unconsumed_subcommand` subtest that proves the fix is
+load-bearing: `scion schedule message --in 5m` is correctly caught because
+`schedule` is a pure group and `message` is not one of its subcommands.
+
+## Verification
+- `go test -count=1 ./cmd/ -v -run TestDocSyntax` — all 3 subtests pass
+- `go test -count=1 ./cmd/` — full suite passes

--- a/.design/project-log/2026-08-27-j1j2-test-floors.md
+++ b/.design/project-log/2026-08-27-j1j2-test-floors.md
@@ -1,0 +1,80 @@
+# J-1 & J-2: Test Floor Assertions
+
+**Date:** 2026-08-27
+**Branch:** scion/ca-msg-em5
+**Defects:** J-1 (message_deprecation_test.go), J-2 (doc_syntax_test.go)
+
+## Problem
+
+Both tests proved their mechanisms worked on synthetic fixtures but never
+asserted the mechanism actually ran on real artifacts. Zero extractions or
+zero files scanned was indistinguishable from all-correct.
+
+## Changes
+
+### J-2: cmd/doc_syntax_test.go — TestDocSyntax
+
+- **Replaced `os.IsNotExist` skip with `require.NoError` hard fail** — renamed
+  or moved doc files now cause an immediate test failure instead of silently
+  vanishing from coverage.
+- **Added `totalLines` accumulator and floor assertion** — after scanning all
+  doc files, the test requires at least 9 extracted scion command lines. A drop
+  means either the extractor broke or examples were deleted.
+
+### J-1: cmd/message_deprecation_test.go — TestDeprecationWarnings_ReplacementsExist
+
+- **Extracted standalone `findReplacementProblems` function** — quote-agnostic
+  scanner that finds `scion <subcommand>` references in deprecation warning
+  output and validates each resolves against rootCmd. Handles single-quoted,
+  backtick-quoted, and unquoted references.
+- **Rewrote main test body** to call `findReplacementProblems` and assert a
+  floor of 6 replacement references (the actual count of `scion ...` commands
+  in the 10 deprecation warnings).
+- **Replaced `catches_nonexistent_replacement` subtest** with four targeted
+  subtests exercising the extracted function: `catches_deepest_match_blind_spot`,
+  `catches_backtick_quoted_unknown`, `catches_unquoted_unknown`, and
+  `accepts_valid_replacement`.
+
+### Floor value note
+
+The architect specified a floor of 7 replacement references, but the actual
+`emitDeprecationWarnings` function contains exactly 6 warnings with `scion`
+command references (broadcast, all→broadcast, raw→keys, notify→notifications
+subscribe, in→schedule create, at→schedule create). The remaining 4 warnings
+(plain, channel, thread-id, cc) do not reference scion commands. Floor set to 6.
+
+## Mutation Verification
+
+### MUT-B: emitDeprecationWarning no-op
+Made `emitDeprecationWarning` an empty function body.
+**Result: FAIL (as expected)**
+```
+Error: "0" is not greater than or equal to "6"
+Messages: expected at least 6 replacement references in deprecation warnings;
+got 0 — the extractor may be broken or warnings were removed
+```
+
+### MUT-D: Backtick-quoted nonexistent command
+Added `if cmd.Flags().Changed("wake")` branch emitting
+`` use `scion agent poke` instead `` and set wake as Changed in the test.
+**Result: FAIL (as expected)**
+```
+replacement command not found: scion agent poke
+(from: Warning: --wake is deprecated: use `scion agent poke` instead)
+```
+
+### MUT-E: Nonexistent doc file paths
+Renamed all four `docFiles` entries to nonexistent paths.
+**Result: FAIL (as expected)**
+```
+Error: Received unexpected error:
+  stat .../NONEXISTENT.md: no such file or directory
+Messages: doc file missing: ../resources/platform_skills/scion-messaging/NONEXISTENT.md
+  — update docFiles or restore the file
+```
+
+## Verification
+
+- `go test -count=1 ./cmd/ -v -run 'TestDocSyntax|TestDeprecationWarnings'` — PASS
+- `go test -count=1 ./cmd/` — PASS (full suite, 5.98s)
+- All three mutation tests fail as expected and were reverted.

--- a/.design/project-log/2026-08-27-mutation1-test-rewrite.md
+++ b/.design/project-log/2026-08-27-mutation1-test-rewrite.md
@@ -1,0 +1,47 @@
+# Mutation 1 Test Rewrite: Call the Real Handler
+
+**Date:** 2026-08-27
+**Author:** dev-def8-hubtest2
+**Scope:** `pkg/hub/handlers_read_switch_test.go`
+
+## Problem
+
+`TestDualWrite_UnparseableSenderAddress_NoConversationCreated` replicated
+the kind-safe guard logic from `handlers_agent_messaging.go:836` inline
+instead of calling `srv.handleAgentMessage`. This made mutation 1 a false
+positive: replacing the guard with `senderKind := "user"` in the handler
+did not cause the test to fail because the test never invoked the handler.
+
+## Change
+
+Deleted the old test body and wrote a replacement that:
+
+1. Uses `readSwitchWorld(t)` for setup.
+2. Creates a dedicated "bob" user to avoid collision with the alice+agent
+   DM that `readSwitchWorld` creates.
+3. Builds a `MessageRequest` with a `StructuredMessage` whose `Sender` is
+   `"bare-name-no-prefix"` (no kind prefix, so `PrincipalKindFromAddress`
+   returns false).
+4. Calls `srv.handleAgentMessage(rr, req, agent.ID)` directly, with user
+   auth context set on the request.
+5. Does NOT check the HTTP response status (handler returns 503 because no
+   dispatcher is configured, but the dual-write code has already run).
+6. Asserts that no conversation row exists for bob+agent (matchCount == 0).
+7. Includes a floor assertion (Rule 14): at least 1 direct conversation
+   must exist (the alice+agent DM from `readSwitchWorld`).
+
+The test contains zero copies of the code under test: no
+`PrincipalKindFromAddress`, no `ResolveOrCreateDMConversation`. It sends
+a request and checks the DB.
+
+## Mutation 1 Verification
+
+- **Original code:** test passes.
+- **Mutation** (replace guard with `senderKind := "user"`): test fails with
+  `expected: 0, actual: 1` on the "unparseable sender address must NOT
+  create a conversation row" assertion.
+- **Revert:** test passes again.
+
+## All Existing Tests
+
+`go test ./pkg/hub/ -tags sqlite -count=1` passes (213s).

--- a/.design/project-log/2026-08-27-s5-closeout.md
+++ b/.design/project-log/2026-08-27-s5-closeout.md
@@ -1,0 +1,70 @@
+# S5 — Docs: CLOSEOUT
+
+**Accepted:** 2026-08-27, round 3, at `55dd6e16`. Fast-forward from `19681bc1`.
+**Manager:** `ca-msg-em5`. **Scope:** phase row 12 (skill, messaging page, CLI reference,
+glossary) plus the parse-check that keeps them honest.
+
+## What landed
+
+Documentation of the build **as it ships**, not the design's end state: read switch
+default-off, `conv:<id>` and `#<thread>` unavailable in the CLI, `@<email>` agent-container
+only, `@<agent>` the one form a user can rely on today. Plus two standing regression guards
+in `cmd/`: `TestDocSyntax` (parse-check over four doc files) and
+`TestDeprecationWarnings_ReplacementsExist` (AC-15a).
+
+One production change was authorised inside a docs section: three deprecation warnings on the
+**already-accepted** integration branch named replacements that do not exist
+(`--cc → --to`, and `--in`/`--at` → `scion schedule message`). Fixed at `6269972d`.
+
+## Three rounds, two defect families
+
+**Round 1 (I-1..I-4)** — a broken replacement string in shipped code; a `Find` blind spot in
+the new parse-check that would have hidden the same bug; Rule 10 subtests re-implementing the
+check instead of invoking it; and a divergence recommendation ("clean board — zero
+mismatches") satisfied by `matches: 0, mismatches: 0, fallbacks: 50000`, i.e. by the new model
+never running.
+
+**Round 2 (J-1, J-2)** — both new tests passed while examining **zero real input**. The
+AC-15a extractor keyed on `'scion ` (single quotes only) and asserted no floor: a no-op
+warning emitter passed, and a *new* deprecated flag naming the nonexistent
+`` `scion agent poke` `` took the whole `cmd` suite green. `TestDocSyntax` skipped missing
+files with `t.Logf`: renaming all four sources left every subtest passing.
+
+This produced **rule 14**, rule 13's dual: *a test must assert it had something to observe.*
+Rule 10 subtests over `t.TempDir()` fixtures prove the function is correct and say nothing
+about whether it was ever fed. A check whose input can silently become empty is not a check.
+
+## Verification of the accepted round
+
+Independently reproduced, all now red where they were green:
+
+| Mutation | Result |
+|---|---|
+| MUT-A — revert warning to `scion schedule message` | FAIL: *resolves to wrong command: wanted message, got schedule* |
+| MUT-B — `emitDeprecationWarning` given an empty body | FAIL: *"0" is not greater than or equal to "6"* |
+| MUT-D — new flag naming backtick-quoted `scion agent poke` | FAIL (full suite): *replacement command not found* |
+| MUT-E — one `docFiles` entry renamed | FAIL: *doc file missing … update docFiles or restore the file* |
+| MUT-F — `denyPatterns` emptied | FAIL: `catches_deny_listed_pattern` |
+| Positive control — `scion schedule message --in 5m` appended to real `glossary.md` | FAIL: *unknown subcommand "message" for "schedule"* |
+
+`go test ./cmd/ ./pkg/messaging/` green; tree clean.
+
+## Known residual limits (accepted, not defects)
+
+1. **MUT-G is not caught.** Deleting the main-body *call* to `findDenyListProblems` (or
+   `findCommandProblems`, or `findReplacementProblems`) leaves every subtest passing, because
+   the subtests invoke those functions directly. Floors guard against starved input, not
+   against a deleted invocation. Judged acceptable: unlike a docs rename, this requires
+   deliberately removing a visible `t.Error` loop.
+2. **D6's original limit stands.** The parse-check proves a documented command *parses*, never
+   that it does what the prose says.
+3. Only the first `scion ` reference per warning line is examined; `checked` undercounts if a
+   future warning names two commands. Harmless today.
+
+## Correction to the architect
+
+I specified the AC-15a floor as `>= 7`. em5 pushed back with 6 and was right: of ten warnings,
+four (`--plain`, `--channel`, `--thread-id`, `--cc`) name no `scion` command. Recounted and
+confirmed. **The pushback was correct and is the behaviour I want** — a floor accepted on my
+authority rather than on a count would have been a number nobody had verified, which is the
+same failure mode as the rest of this section.

--- a/.design/project-log/2026-08-27-ws1-phase8-foundation.md
+++ b/.design/project-log/2026-08-27-ws1-phase8-foundation.md
@@ -1,0 +1,78 @@
+# WS-1: Phase 8 Foundation (S4 Messaging Refactor)
+
+**Date**: 2026-08-27  
+**Agent**: ca-msg-em4  
+**Branch**: scion/ca-msg-em4  
+**Base**: scion/messaging-v2  
+
+## Summary
+
+Implemented three foundation deliverables required before the Phase 8 read-switch can be built.
+
+## Deliverables
+
+### DEF-1: Participant-level auth on conversation resolution
+
+**Problem**: `resolveConvByID` checked project isolation (AC-30) but did NOT check whether the sender was a participant. Any principal in the same project could resolve any conversation — a HIGH finding from S1's security audit.
+
+**Solution**: Added post-resolution authorisation in the `Resolve()` function that runs after every resolution branch returns. Rules vary by conversation kind:
+
+- **Direct conversations** (`Kind == "direct"`): sender MUST be a participant. This applies regardless of grammar (conv:<id>, @<agent>, @<email>).
+- **Group conversations** (`Kind == "group"`): project membership authorises access (already enforced). No participant check — agents must be able to post in rooms they've never spoken in.
+- **Global DMs** (nil ProjectID): participant check is the ONLY auth gate.
+
+**Files**: `pkg/messaging/resolve.go` — added `checkPostResolutionAuth()`, `requireParticipant()` functions.
+
+**Rule 10 Tests** (3 tests in `resolve_test.go`):
+1. `TestResolveConvByID_RejectsNonParticipant` — non-participant rejected on direct conv via conv:<id>
+2. `TestResolve_GroupConv_AcceptsNonParticipantProjectMember` — project member accepted on group conv without participation
+3. `TestResolve_DirectConv_RejectionGrammarIndependent` — proves auth check is grammar-independent (conv:<id> vs @<agent>)
+
+All three fail when the participant check is removed (mutation verified).
+
+### DEF-3: Independent divergence source of truth
+
+**Problem**: `ComputeDivergenceMatch` compared old-model routing keys against the conversation's external_ref, but both were derived from the same input fields. They CANNOT disagree — a clean report meant "resolution did not fail", not "the new model routes where the old model routed".
+
+**Solution**: Added `CheckConversationConsistency()` — an independent check that queries prior persisted messages and compares their `conversation_id` against the newly resolved one.
+
+**Files**:
+- `pkg/store/models.go` — added `ConversationID` field to `MessageFilter`
+- `pkg/store/entadapter/message_store.go` — wired `ConversationID` into ent query builder
+- `pkg/messaging/divergence.go` — added `MessageQueryStore` interface and `CheckConversationConsistency()` function
+- `pkg/hub/handlers_agent_messaging.go` — added calls at 4 dual-write sites
+- `pkg/hub/messagebroker.go` — added calls at 2 dual-write sites
+
+**Rule 10 Test**: `TestCheckConversationConsistency_DetectsMismatch` — stores a prior message with conv-A, checks a new message with conv-B for the same thread, asserts mismatch. Removing the comparison makes the function return true → test fails.
+
+### D3: Runtime flag + live divergence endpoint
+
+**Part A — MessagingSettings opsettings section**:
+- Added `MessagingSettings` struct with `ConversationReadSwitch *bool` field
+- Registered as DB-only section (no KoanfPaths, like maintenance)
+- Added hand-written JSON schema
+- Added `ConversationReadSwitch()` accessor on `OperationalSettings` — hot-reloadable via DB-backed cache
+
+**Part B — Divergence HTTP endpoint**:
+- `GET /api/v1/admin/messaging/divergence` — admin-authenticated
+- Returns `{ matches, mismatches, total, read_switch_enabled }`
+- Reads from `messaging.DivergenceMetrics` and `MessagingSettings`
+
+**Files**:
+- `pkg/config/opsettings/sections.go` — `MessagingSettings` struct
+- `pkg/config/opsettings/registry.go` — section + schema registration
+- `pkg/config/opsettings/opsettings_test.go` — updated section expectations
+- `pkg/hub/operational_settings.go` — `ConversationReadSwitch()` accessor
+- `pkg/hub/admin_messaging_divergence.go` — new handler file
+- `pkg/hub/server.go` — route registration
+
+## Test Results
+
+- `go test ./pkg/messaging/...` — all green
+- `go test ./pkg/store/...` — all green
+- `go test ./pkg/config/opsettings/...` — all green
+- `go test ./pkg/hub/` — all green (full suite)
+
+## Rule 10 Mutation Verification
+
+All Rule 10 tests verified: removing the guarded check causes each test to fail as expected.

--- a/.design/project-log/2026-08-27-ws1-skill-update.md
+++ b/.design/project-log/2026-08-27-ws1-skill-update.md
@@ -1,0 +1,37 @@
+# WS-1: scion-messaging Skill Update for S4
+
+**Date:** 2026-08-27  
+**Scope:** S5 WS-1 — Docs  
+**Branch:** `scion/ca-msg-em5`  
+**File:** `resources/platform_skills/scion-messaging/SKILL.md`
+
+## Summary
+
+Updated the `scion-messaging` platform skill to reflect the S4 messaging refactor changes. This skill teaches agents how to use `scion message` and related commands.
+
+## Changes Made
+
+### Recipient Types
+- Added `@<agent-name>` as a fully supported conversation reference form
+- Documented `@<email>` with its agent-container-only limitation
+- Added explicit warning that `conv:<id>` and `#<thread>` are reserved but not available in the CLI (DEF-5)
+- Updated broadcast anti-pattern to reference `scion broadcast` subcommand
+
+### Channel and Thread Targeting
+- Marked `--channel` and `--thread-id` as deprecated, pointing to `@<agent-name>` instead
+
+### Special Message Flags
+- Reorganized into active flags (`--wake`, `--interrupt`, `--attach`, `--visibility`) and a deprecated flags table
+- `--raw` → `scion keys`
+- `--broadcast`/`--all` → `scion broadcast`
+- `--notify` → `scion notifications subscribe`
+- `--in`/`--at` → `scion schedule message`
+- `--plain`, `--channel`, `--thread-id`, `--cc` noted as deprecated
+
+### New Subcommands Section
+- Documented `scion broadcast` with flags and usage guidance
+- Documented `scion keys` for raw keystroke injection
+
+### Other
+- Updated self-callback heartbeat pattern to prefer `scion schedule message`
+- Updated verification checklist to include new recipient forms and subcommand usage

--- a/.design/project-log/2026-08-27-ws2-docs-messaging.md
+++ b/.design/project-log/2026-08-27-ws2-docs-messaging.md
@@ -1,0 +1,49 @@
+# WS-2 Docs: Messaging Page Update for S4 Conversation Model
+
+**Date:** 2026-08-27
+**Task:** S5 WS-2 — Update docs site messaging page for conversation model changes
+**File:** `docs-site/src/content/docs/hosted/user/messaging.md`
+
+## Summary
+
+Updated the Messaging & Notifications documentation page to reflect the conversation model changes shipped in S4 of the messaging-v2 refactor.
+
+## Changes Made
+
+### 1. New Section: Conversation Model
+Added after "Real-Time Delivery", before "Developer Guide". Covers:
+- What the conversation model is (thread tracking, participant-aware routing, Conversation records)
+- Current status: read switch (`ConversationReadSwitch`) is default OFF
+- How to enable: `messaging.conversation_read_switch: true` in `scion-settings.yaml` (runtime flag)
+- Divergence monitoring via `GET /api/v1/admin/messaging/divergence` with field descriptions
+- Recommendation to enable only after zero mismatches over sustained traffic
+
+### 2. Updated CLI Message Management Section
+- Added "Sending Messages" subsection showing `@<agent-name>` conversation reference usage
+- Added availability caveat note: `conv:<id>` and `#<thread>` are gated (DEF-5), `@<email>` is agent-only
+- Added "Additional Subcommands" table: `scion broadcast` and `scion keys`
+
+### 3. New Developer Guide Subsection: Conversation References (§6)
+- Table documenting all four conversation reference forms with availability status
+- `@<agent-name>`: Available
+- `@<email>`: Agent-only (requires SCION_AGENT_NAME)
+- `conv:<uuid>`: Not available (CLI-gated)
+- `#<thread-name>`: Not available (CLI-gated)
+- Caution admonition reinforcing availability constraints
+
+### 4. New Developer Guide Subsection: Deprecated Flags (§7)
+- Table of all deprecated flags with their replacements:
+  - `--broadcast`/`--all` → `scion broadcast`
+  - `--raw` → `scion keys`
+  - `--in`/`--at` → `scion schedule message`
+  - `--notify` → `scion notifications subscribe`
+  - `--channel`/`--thread-id` → `@<agent-name>`
+  - `--cc` → `--to`
+  - `--plain` → no replacement, will be removed
+- Note that all deprecated flags still work with stderr warnings
+
+## Availability Caveats Enforced
+- Conversation read switch documented as default-OFF with explicit enable instructions
+- `conv:<id>` and `#<thread>` documented as NOT available in the CLI
+- `@<email>` documented as agent-container-only
+- `@<agent-name>` documented as the only fully available conversation reference form

--- a/.design/project-log/2026-08-27-ws2-phase8-readswitch.md
+++ b/.design/project-log/2026-08-27-ws2-phase8-readswitch.md
@@ -1,0 +1,120 @@
+# WS-2 Phase 8: Read Switch
+
+**Date:** 2026-08-27
+**Agent:** dev-phase8-readswitch
+**Branch:** scion/ca-msg-em4
+
+## Summary
+
+Implemented Phase 8 of the S4 messaging refactor: the read-switch that gates
+message read/query paths on the `ConversationReadSwitch` runtime flag. When the
+flag is ON, read paths use `ConversationID` instead of `ThreadID/Channel`. Also
+closed the 7th dual-write gap in broker inbound.
+
+## Changes
+
+### 1. Read paths gated on ConversationReadSwitch
+
+Three read paths modified to branch on the runtime flag:
+
+- **handleMessages (user inbox)** — When flag ON and an `agent` query param is
+  provided, resolves the DM conversation between user and agent and adds
+  `ConversationID` to the filter.
+
+- **handleAgentMessages** — When flag ON, resolves either a thread conversation
+  (if `thread_id` param present) or a DM conversation (agent + user), then
+  adds `ConversationID` to the filter.
+
+- **handleConversationHistory** — When flag ON, resolves the conversation from
+  the thread key (DM keys parse participant IDs; thread keys look up the topic
+  for projectID), then queries by `ConversationID` instead of
+  `Channel="web" + ThreadID=key`. Falls back to old path if the conversation
+  doesn't exist yet (pre-dual-write data).
+
+### 2. Read-only conversation lookup
+
+Added `GetConversationByExternalRef` to the store interface and entadapter
+implementation — a read-only lookup by `(surface, external_ref)` that returns
+`ErrNotFound` when no matching active conversation exists. This avoids creating
+conversations as a side-effect of reads.
+
+Added two helpers to `pkg/messaging/conversation.go`:
+- `ResolveThreadConversationForRead` — read-only thread lookup
+- `ResolveDMConversationForRead` — read-only DM lookup
+
+Both return nil on miss, matching the non-fatal contract of the write-path
+counterparts.
+
+### 3. Broker inbound dual-write (7th call site)
+
+`handleBrokerInbound` now stamps `conversation_id` on inbound messages using
+the same resolve-or-create + divergence logging pattern as the other 6 sites:
+- Resolves thread or DM conversation (skips broadcasts)
+- Stamps `storeMsg.ConversationID`
+- Computes and logs divergence
+- Runs DEF-3 independent consistency check
+
+### 4. Tests
+
+Eight tests covering all required scenarios:
+
+| Test | Scenario |
+|------|----------|
+| `TestReadSwitch_FlagOFF_AgentMessages_UsesOldPath` | Flag OFF backward compat — all messages returned |
+| `TestReadSwitch_FlagOFF_UserInbox_UsesOldPath` | Flag OFF inbox — old RecipientID path |
+| `TestReadSwitch_FlagON_AgentMessages_UsesConversationID` | Flag ON — only conv_id messages returned |
+| `TestReadSwitch_FlagON_UserInbox_UsesConversationID` | Flag ON — inbox filters by conv_id |
+| `TestReadSwitch_HotReloadToggle` | OFF→ON→OFF toggle without restart |
+| `TestReadSwitch_ConversationHistory_FlagOFF` | Thread history — old Channel+ThreadID path |
+| `TestReadSwitch_ConversationHistory_FlagON` | Thread history — ConversationID path |
+| `TestBrokerInbound_DualWrite_StampsConversationID` | Broker inbound stamps conv_id |
+
+## Test Results
+
+Full suite (`go test -count=1 ./pkg/hub/`) passed twice:
+- Run 1: ok (216.620s)
+- Run 2: ok (214.511s)
+
+Messaging package tests: ok (0.008s)
+Store package tests: ok
+
+## Flag-Flip Question
+
+> What happens to messages written while flag ON if operator flips it OFF
+> mid-exercise? Is snapshot restore needed or is the switch clean?
+
+**The switch is clean — no snapshot restore needed.**
+
+When the flag is toggled OFF after being ON:
+
+1. **Write path is unaffected.** Dual-write always runs regardless of the flag.
+   Every message gets `conversation_id` stamped whether the read switch is ON
+   or OFF. The flag only controls the _read_ path.
+
+2. **Read path reverts instantly.** The old read path (Channel + ThreadID /
+   RecipientID + AgentID) still works because the old fields are still populated
+   on every message. The conversation model is additive — it adds
+   `conversation_id` without removing any existing routing fields.
+
+3. **No data inconsistency.** Messages written while the flag was ON have both
+   old-model fields (Channel, ThreadID, Sender, Recipient) AND `conversation_id`.
+   When the flag goes OFF, queries use the old fields and these messages are
+   still found. The only messages that would be "invisible" in the ON state are
+   legacy messages written before dual-write began (they lack `conversation_id`).
+   When the flag goes OFF, those messages reappear immediately.
+
+4. **Hot-reload verified.** The `TestReadSwitch_HotReloadToggle` test
+   demonstrates OFF→ON→OFF toggle on the same server instance, confirming the
+   switch is instantaneous and reversible with no restart.
+
+## Files Modified
+
+- `pkg/store/store.go` — Added `GetConversationByExternalRef` to interface
+- `pkg/store/entadapter/conversation_store.go` — Implemented `GetConversationByExternalRef`
+- `pkg/messaging/conversation.go` — Added `ConversationReader` interface,
+  `ResolveDMConversationForRead`, `ResolveThreadConversationForRead`
+- `pkg/messaging/backfill_test.go` — Added `GetConversationByExternalRef` to mock
+- `pkg/hub/handlers_messages.go` — Read-switch for `handleMessages` and `handleAgentMessages`
+- `pkg/hub/handlers_chat_v2.go` — Read-switch for `handleConversationHistory`
+- `pkg/hub/handlers_broker_inbound.go` — 7th dual-write call site
+- `pkg/hub/handlers_read_switch_test.go` — New test file (8 tests)

--- a/.design/project-log/2026-08-27-ws3-cli-reference.md
+++ b/.design/project-log/2026-08-27-ws3-cli-reference.md
@@ -1,0 +1,48 @@
+# WS-3: CLI Reference Updated for Messaging Refactor
+
+**Agent:** dev-ws3-cli
+**Branch:** `scion/ca-msg-em5`
+**Date:** 2026-08-27
+
+## Summary
+
+Updated `docs-site/src/content/docs/reference/cli.md` to document the S4 messaging-model
+refactor: new `scion broadcast` and `scion keys` subcommands, updated `scion message` with
+conversation-reference recipients, and deprecated-flag migration paths.
+
+## Changes
+
+### Section restructure
+
+The previous flat "Agent Lifecycle" section covered everything from `scion start` through
+`scion reset-auth`. This update splits it into three `##`-level groups:
+
+- **Agent Lifecycle** — `start`, `stop`, `suspend`, `resume`, `attach`
+- **Messaging** — `message`, `broadcast`, `keys`, `messages`
+- **Agent Management** — `logs`, `list`, `delete`, `sync`, `reset-auth`
+
+### `scion message` — updated
+
+- **Recipients** now document five forms: bare `<agent-name>`, `agent:<name>`, `user:<name>`,
+  `group[a,b,...]`, and `@<agent-name>` (conversation reference).
+- **Retained flags** reduced to `-i`, `-w`, `-a/--attach`, `--visibility`.
+- **Deprecated flags** listed with migration targets (e.g. `--broadcast` → `scion broadcast`,
+  `--raw` → `scion keys`, `--in`/`--at` → `scion schedule message`).
+- **Caveat block** added: `@<agent-name>` is fully available; `@<email>` is agent-container-only;
+  `conv:<uuid>` and `#<thread-name>` are CLI-gated (parse but do not deliver).
+
+### `scion broadcast` — new
+
+Documents the replacement for `scion message --broadcast` with flags `--all`, `--interrupt`,
+`--wake`, and `--visibility`.
+
+### `scion keys` — new
+
+Documents the replacement for `scion message --raw`: sends raw keystrokes via tmux send-keys.
+Includes examples for `Escape`, `C-c`, and arrow-key sequences.
+
+## Caveats applied
+
+- No fenced code examples use `conv:<id>` or `#<thread>` as working recipients — these appear
+  only in the gated-caveat admonition block.
+- All fenced `scion ...` examples use valid cobra command syntax for parse-checking.

--- a/.design/project-log/2026-08-27-ws3-fix-f1-f2.md
+++ b/.design/project-log/2026-08-27-ws3-fix-f1-f2.md
@@ -1,0 +1,74 @@
+# WS3 Fix: F-1 and F-2 — Conversation Reference Wiring
+
+**Date:** 2026-08-27  
+**Branch:** scion/ca-msg-em4  
+**Agent:** dev-ws3-fix  
+
+## Summary
+
+Fixed two blockers (F-1 and F-2) in the S4 messaging refactor that caused the section to be rejected, plus one non-blocking improvement.
+
+## F-1: Wire conversation reference parsing in CLI
+
+**Problem:** The CLI's `scion message` command had deprecation warnings telling users to use conversation references (`conv:<uuid>`, `@<agent>`, `@<email>`, `#<thread>`), but the recipient parsing at lines 137-153 of `cmd/message.go` never called `ParseReference`. References were misrouted:
+- `conv:<uuid>` → slugified as agent name
+- `@<agent>` → treated as user email (silently misroutes — critical bug)
+- `#<thread>` → slugified as agent name
+
+**Fix:** Modified the recipient parsing block to try `ParseReference()` first. If it succeeds, the conversation is resolved via a new Hub endpoint, and the message is sent with the resolved `conversation_id`. If `ParseReference()` fails, the code falls through to the existing recipient parsing (backward compat).
+
+**Key changes:**
+- `cmd/message.go`: Added `convRef` variable, conversation reference detection, and `sendMessageViaConversation()` function
+- `pkg/hub/handlers_conversations_resolve.go`: New `POST /api/v1/conversations/resolve` endpoint that calls `messaging.Resolve()` with the store
+- `pkg/hubclient/messages.go`: Added `ResolveConversation()` method to `MessageService`
+- `pkg/messages/types.go`: Added `ConversationID` field to `StructuredMessage`
+- `pkg/hub/handlers_agent_messaging.go`: Hub handler now respects `ConversationID` from structured message when already set (skips re-resolution)
+
+## F-2: Participant auth reachable from production
+
+**Problem:** `checkPostResolutionAuth` in `Resolve()` had no production caller — only unit tests exercised it.
+
+**Resolution:** F-1 wires the CLI to call `Resolve()` through the Hub's new `/api/v1/conversations/resolve` endpoint. This makes `checkPostResolutionAuth` reachable from production code. No additional work needed beyond F-1.
+
+## Non-blocking: Fallback counter on divergence endpoint
+
+**Problem:** The read-switch fails open: when `ResolveDMConversationForRead` returns nil, the old read path is used silently. The operator could see clean divergence numbers without the new model ever running.
+
+**Fix:**
+- `pkg/messaging/divergence.go`: Added `fallbacks` counter to `DivergenceCounter` (atomic.Int64) with `IncFallback()` and `Fallbacks()` methods
+- `pkg/hub/handlers_messages.go`: Incremented fallback counter in two read-switch fallback paths
+- `pkg/hub/handlers_chat_v2.go`: Incremented fallback counter in chat v2 read-switch fallback
+- `pkg/hub/admin_messaging_divergence.go`: Added `fallbacks` to the `/api/v1/admin/messaging/divergence` JSON response
+
+## Tests
+
+All tests pass:
+- `go test -count=1 ./cmd/...` — ✅ green
+- `go test -count=1 ./pkg/hub/` — ✅ green (215s full suite)
+- `go test -count=1 ./pkg/messaging/...` — ✅ green
+
+New test files:
+- `cmd/message_convref_test.go`: Conversation reference parsing, resolve flow, backward compat
+- `pkg/hub/admin_messaging_divergence_test.go`: Fallback counter in divergence endpoint
+- `pkg/hub/handlers_conversations_resolve_test.go`: Resolve endpoint handler validation
+- `pkg/messaging/divergence_test.go`: Fallback counter unit tests (added to existing file)
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| cmd/message.go | Wire conversation ref detection + sendMessageViaConversation |
+| cmd/message_convref_test.go | New: CLI conversation ref tests |
+| pkg/hub/admin_messaging_divergence.go | Add fallbacks to endpoint response |
+| pkg/hub/admin_messaging_divergence_test.go | New: divergence endpoint tests |
+| pkg/hub/handlers_agent_messaging.go | Respect CLI-set ConversationID |
+| pkg/hub/handlers_chat_v2.go | Increment fallback counter |
+| pkg/hub/handlers_conversations_resolve.go | New: resolve endpoint handler |
+| pkg/hub/handlers_conversations_resolve_test.go | New: resolve handler tests |
+| pkg/hub/handlers_messages.go | Increment fallback counter |
+| pkg/hub/route_classification_test.go | Add resolve route classification |
+| pkg/hub/server.go | Register resolve endpoint |
+| pkg/hubclient/messages.go | Add ResolveConversation method |
+| pkg/messages/types.go | Add ConversationID to StructuredMessage |
+| pkg/messaging/divergence.go | Add fallback counter to DivergenceCounter |
+| pkg/messaging/divergence_test.go | Add fallback counter tests |

--- a/.design/project-log/2026-08-27-ws3-phase10-cli.md
+++ b/.design/project-log/2026-08-27-ws3-phase10-cli.md
@@ -1,0 +1,75 @@
+# WS-3: Phase 10 CLI Split — scion message refactor
+
+**Date:** 2026-08-27
+**Branch:** scion/ca-msg-em4
+**Author:** dev-phase10-cli agent
+
+## Summary
+
+Split the monolithic `scion message` command (1178 lines, 13 flags, 34 pairwise
+exclusion rules) into focused subcommands, reducing `scion message` to 6 primary
+flags while maintaining full backward compatibility through deprecation mappings.
+
+## Changes
+
+### New subcommands
+
+1. **`scion broadcast`** (`cmd/broadcast.go`)
+   - Project-scoped broadcast via Hub's BroadcastMessage endpoint (default)
+   - Global broadcast via `--all` with client-side fan-out
+   - Flags: `--all`, `--interrupt`, `--wake`, `--visibility`
+   - Local mode fallback for non-Hub environments
+
+2. **`scion keys`** (`cmd/keys.go`)
+   - Raw keystroke injection via `MessageRaw`
+   - Positional args: `<agent-name> <keystrokes>`
+   - Replaces `scion message --raw`
+
+### Reduced `scion message`
+
+Retained flags (6 total):
+- `--interrupt`, `--wake`, `--attach`, `--visibility` (core messaging)
+- Positional: `<recipient> <message>`
+
+### Deprecation mappings (AC-15)
+
+Every deprecated flag emits a warning to stderr AND still succeeds identically:
+
+| Deprecated Flag | Warning Message | Replacement |
+|---|---|---|
+| `--broadcast` | "use 'scion broadcast' instead" | `scion broadcast` |
+| `--all` | "use 'scion broadcast --all' instead" | `scion broadcast --all` |
+| `--raw` | "use 'scion keys' instead" | `scion keys` |
+| `--plain` | "--plain is deprecated and will be removed" | (none) |
+| `--notify` | "use 'scion notifications subscribe' instead" | `scion notifications subscribe` |
+| `--in` | "use 'scion schedule message' instead" | `scion schedule message` |
+| `--at` | "use 'scion schedule message' instead" | `scion schedule message` |
+| `--channel` | "use conversation references instead" | `conv:<id>`, `@<agent>`, `#<thread>` |
+| `--thread-id` | "use conversation references instead" | `conv:<id>`, `@<agent>`, `#<thread>` |
+| `--cc` | "use --to instead" | `--to` |
+
+All deprecated flags are hidden from `--help` output but remain functional.
+
+## Test Results
+
+```
+go test -count=1 ./cmd/...           → ok (5.8s)
+go test -count=1 ./pkg/hub/          → ok (216s)
+```
+
+### New tests added
+
+- `cmd/broadcast_test.go`: Project-scoped, global, no-agents, interrupt, build-message
+- `cmd/keys_test.go`: Arg validation, use string, registration
+- `cmd/message_deprecation_test.go`: Per-flag deprecation warning emission,
+  still-succeeds behavior for broadcast/notify/plain/channel, hidden flag verification,
+  retained flag non-warning verification, multi-warning emission
+
+## Files Changed
+
+- `cmd/broadcast.go` — new: broadcast subcommand
+- `cmd/broadcast_test.go` — new: broadcast tests
+- `cmd/keys.go` — new: keys subcommand
+- `cmd/keys_test.go` — new: keys tests
+- `cmd/message.go` — modified: deprecation warnings, hidden flags, --visibility
+- `cmd/message_deprecation_test.go` — new: deprecation tests

--- a/.design/project-log/2026-08-27-ws4-broker-edge.md
+++ b/.design/project-log/2026-08-27-ws4-broker-edge.md
@@ -1,0 +1,101 @@
+# WS-4: Broker Edge Conversation Resolution (Phase 11)
+
+**Date**: 2026-08-27
+**Agent**: dev-phase11-broker
+**Branch**: scion/ca-msg-em4 (based on scion/messaging-v2)
+
+## Summary
+
+Implemented conversation resolution at the broker edge for all 5 broker
+plugins. Each plugin now sends `surface`, `external_ref`, and `parent_ref`
+with its inbound messages so the hub can resolve (or create) a conversation
+before dispatching.
+
+## Changes
+
+### Hub (first commit)
+
+- Extended `inboundMessageRequest` in `pkg/hub/handlers_broker_inbound.go`
+  with `Surface`, `ExternalRef`, `ParentRef` fields.
+- After message validation, the handler calls
+  `store.UpsertConversationByExternalRef` when both Surface and ExternalRef
+  are present. ExternalRef without Surface is rejected (AC-8 regression
+  guard).
+- Extended `MessageRequest` in `pkg/hub/handlers_agent_messaging.go` with
+  the same fields for the Google Chat SDK path
+  (`POST /api/v1/agents/{id}/message`).
+- Added `SendStructuredMessageWithConv` to `hubclient.AgentService`
+  interface and implementation.
+- Updated `mockAgentService` in the A2A bridge test to satisfy the new
+  interface method.
+
+### Discord
+
+- Populated conversation fields in `deliverInbound`: Surface = `"discord"`,
+  ExternalRef = channel/thread snowflake, ParentRef = guild ID.
+- Tests: payload verification + AC-8 regression (non-discord channel skips
+  fields).
+
+### Slack
+
+- Populated conversation fields in `deliverInbound`: Surface = `"slack"`,
+  ExternalRef = `"channelID:threadTS"` (or bare channelID for top-level),
+  ParentRef = channel ID.
+- Tests: threaded message, top-level message, and AC-8 regression.
+
+### Telegram
+
+- Added `telegramConvFields` helper shared by V1 and V2 brokers.
+  Surface = `"telegram"`, ExternalRef = forum topic ID (or chat ID),
+  ParentRef = chat ID.
+- Updated all three payload construction sites (V1 `deliverInbound`, V2
+  `deliverInbound`, V2 `deliverInboundWithFeedback`).
+- Tests: forum topic, non-forum, nil cases, V1 delivery, AC-8 regression.
+
+### Google Chat
+
+- Added `gchatConvFields` helper. Surface = `"gchat"`,
+  ExternalRef = thread path (`spaces/X/threads/Y`), ParentRef = space path.
+- Updated all three `SendStructuredMessage` call sites to use
+  `SendStructuredMessageWithConv`.
+- Added `SendStructuredMessageWithConv` to test stub.
+- Fixed pre-existing `UploadMedia` mock in `sendqueue_test.go`.
+- Tests: threaded event, space-only, empty/nil events.
+
+### Teams
+
+- Added `teamsConvFields` helper. Surface = `"teams"`,
+  ExternalRef = reply-to activity ID (or conversation ID),
+  ParentRef = conversation ID.
+- Updated `DeliverInbound` to populate conversation fields.
+- Tests: thread reply, top-level, non-teams channel, nil cases.
+- **AC-8 regression test**: explicitly verifies that `channel=""` with
+  `thread_id` set does NOT produce conversation fields.
+
+## Test Results
+
+- `go test -count=1 ./pkg/hub/` (with -tags sqlite): PASS
+- Discord plugin tests: PASS
+- Slack plugin tests: PASS
+- Telegram plugin tests: PASS
+- Google Chat plugin tests: PASS
+- Teams plugin tests: PASS
+
+## Design Decisions
+
+1. **Hub-side resolution over plugin-side**: Plugins send platform
+   identifiers; the hub calls `UpsertConversationByExternalRef`. This keeps
+   the store dependency in the hub and makes plugins simpler.
+
+2. **Two handler paths**: The broker/inbound handler reads conversation
+   fields from `inboundMessageRequest`. The agent/message handler (used by
+   Google Chat) reads from `MessageRequest`. Both call the same store
+   method.
+
+3. **AC-8 guard**: ExternalRef without Surface is rejected at the hub
+   boundary. Each plugin also guards against producing bare ExternalRef
+   (e.g. Teams checks `msg.Channel == "teams"` before deriving fields).
+
+4. **Non-fatal resolution**: If `UpsertConversationByExternalRef` fails,
+   the hub logs the error and proceeds with dispatch. Message delivery is
+   not blocked by conversation resolution failures.

--- a/.design/project-log/2026-08-27-ws4-glossary.md
+++ b/.design/project-log/2026-08-27-ws4-glossary.md
@@ -1,0 +1,23 @@
+# WS-4: Add conversation model terms to glossary
+
+**Date:** 2026-08-27
+**Branch:** `scion/ca-msg-em5`
+**Scope:** S5 Docs — WS-4
+
+## What changed
+
+Added six conversation-model terms to the Messaging section of the docs-site glossary (`docs-site/src/content/docs/glossary.md`):
+
+1. **Backfill** — the one-time process that stamps historical messages with `conversation_id`.
+2. **Conversation** — the core record grouping related messages between participants.
+3. **Conversation Read Switch** — the runtime flag gating read-path routing.
+4. **Conversation Reference** — the recipient identifier addressing via the conversation model.
+5. **Divergence** — the metric tracking agreement between legacy and conversation routing.
+6. **Dual-Write** — the transitional pattern populating both routing models simultaneously.
+
+All entries were placed in alphabetical order within the existing Messaging section, alongside the pre-existing Native Web Chat, Message Group, and Notification entries (which remain unchanged).
+
+## Observations
+
+- The existing `### Notification` entry is accurate and required no changes.
+- The root `GLOSSARY.md` referenced in the page header is maintained separately. The new terms should be added there as part of a separate task to keep the two glossaries in sync.

--- a/.design/project-log/2026-08-27-ws5-doc-parsecheck.md
+++ b/.design/project-log/2026-08-27-ws5-doc-parsecheck.md
@@ -1,0 +1,51 @@
+# WS-5: Doc Syntax Parse-Check Test
+
+**Date:** 2026-08-27
+**Agent:** dev-ws5-parsecheck
+**Task:** S5 WS-5 — Parse-check fenced `scion` examples against cobra tree
+
+## What was done
+
+Created `cmd/doc_syntax_test.go` (~90 lines) that:
+
+1. **Extracts** every `scion ...` command line from fenced code blocks in four
+   documentation files (messaging skill, messaging user docs, CLI reference,
+   glossary).
+2. **Parse-checks** each extracted line against the real cobra command tree using
+   `rootCmd.Find()` + `cmd.ParseFlags()`, ensuring documented commands and flags
+   exist in the shipped binary.
+3. **Deny-list** checks that no fenced code block contains gated forms
+   (`conv:` thread references, `#` thread references) that are not yet
+   implemented (DEF-5).
+4. **Rule 10 compliance** — two subtests prove the test catches errors:
+   - `catches_bad_command`: a temp file with `scion nonexistent-command` is
+     correctly rejected.
+   - `catches_deny_listed_pattern`: a temp file with `scion message conv:abc123`
+     is correctly flagged.
+
+## Skip rules applied
+
+Lines are skipped when they contain:
+- `<` / `>` (documentation placeholders)
+- `$` (shell interpolations)
+- `[flags]` or `...` (usage patterns)
+- `scion help` (cobra built-in, not discoverable via `Find`)
+- Comment lines starting with `#`
+
+## Known limitation
+
+Parse-checking validates that commands and flags exist. It does NOT verify that
+a command does what the prose says it does. This is documented in a comment at
+the top of the test file.
+
+## Test result
+
+```
+=== RUN   TestDocSyntax
+=== RUN   TestDocSyntax/catches_bad_command
+=== RUN   TestDocSyntax/catches_deny_listed_pattern
+--- PASS: TestDocSyntax (0.00s)
+    --- PASS: TestDocSyntax/catches_bad_command (0.00s)
+    --- PASS: TestDocSyntax/catches_deny_listed_pattern (0.00s)
+PASS
+```

--- a/.design/project-log/def12-cli-command.md
+++ b/.design/project-log/def12-cli-command.md
@@ -1,0 +1,58 @@
+# DEF-12: CLI Command — scion server backfill
+
+**Date:** 2026-08-27
+**Author:** dev-backfill-cmd
+**Branch:** scion/ca-msg-em6-def12
+
+## Summary
+
+Implemented the `scion server backfill` CLI subcommand that retroactively
+assigns historical messages to conversations based on thread, sender, and
+recipient metadata.
+
+## Deliverables
+
+### cmd/server_backfill.go
+
+- **Command:** `scion server backfill` added as a subcommand of `serverCmd`
+- **Flags:**
+  - `--execute` — apply changes (default: dry-run mode)
+  - `--project <id>` — scope to a single project (default: all projects)
+  - `--batch-size <n>` — messages per batch (default: 100)
+  - `--checkpoint <msg-id>` — resume from a previous run
+  - `--db <dsn>` — database DSN override (auto-detects sqlite vs postgres)
+- **Database resolution:** `--db` flag > config file (via `LoadGlobalConfig`)
+- **Multi-project support:** when `--project` is omitted, iterates all projects
+  via `ListProjects` and aggregates results
+- **Report:** human-readable summary printed to stdout showing mode, project
+  scope, messages processed/attributed/inferred/skipped, conversations created,
+  hazard counts, errors, and last checkpoint
+
+### cmd/server_backfill_test.go
+
+| Test | AC | Verifies |
+|------|-----|----------|
+| `TestBackfillDryRunMutatesNothing` | AC-12-2 | Dry-run processes messages but leaves conversation_id empty |
+| `TestBackfillExecuteAndIdempotent` | AC-12-3 | Execute stamps messages; second run skips all (idempotent) |
+| `TestBackfillResumeViaCheckpoint` | AC-12-4 | Checkpoint-based resume processes only new messages |
+| `TestBackfillMalformedThreadID` | AC-12-5 | Malformed `dm:invalid:bad:format` ThreadID produces errors |
+| `TestBackfillMergeResult` | — | Result aggregation helper correctness |
+
+All tests use in-memory SQLite via the existing `newTestStore(t)` pattern.
+
+## Design Decisions
+
+1. **Dry-run default:** the command defaults to dry-run mode (no `--execute`)
+   to prevent accidental data modification, matching the safety-first approach
+   of the existing backfill service.
+
+2. **Store opening:** follows the same pattern as `server_foreground.go`'s
+   `initStore()` — opens via `entc.OpenSQLite`/`OpenPostgres`, runs
+   `AutoMigrate`, wraps in `entadapter.NewCompositeStore`. The `--db` flag
+   auto-detects driver from DSN prefix.
+
+3. **Testable core:** extracted `runBackfillWithStore(ctx, store, config)` as
+   the testable entry point, bypassing cobra command/flag parsing.
+
+4. **Result aggregation:** `mergeBackfillResult` accumulates counts across
+   multiple projects for the multi-project case.

--- a/.design/project-log/def12-store-detection.md
+++ b/.design/project-log/def12-store-detection.md
@@ -1,0 +1,52 @@
+# DEF-12: Store Layer + Startup Detection
+
+**Date:** 2026-08-27
+**Branch:** `scion/ca-msg-em6-def12`
+**Base:** `scion/messaging-v2` at `14b3ba7c`
+
+## Summary
+
+Added `CountUnbackfilledMessages` to the `MessageStore` interface and implemented
+the startup detection warning that alerts operators when unbackfilled messages
+exist.
+
+## Changes
+
+### Store interface (`pkg/store/store.go`)
+- Added `CountUnbackfilledMessages(ctx, projectID) (int, error)` to `MessageStore`
+
+### Entadapter implementation (`pkg/store/entadapter/message_store.go`)
+- Implemented using `message.ConversationIDIsNil()` predicate (since
+  `conversation_id` is `Optional().Nillable()` in the ent schema, NULL means
+  unbackfilled)
+- Optional `projectID` scoping via `message.ProjectIDEQ(pid)`
+
+### Mock store (`pkg/messaging/backfill_test.go`)
+- Added `CountUnbackfilledMessages` to `mockMessageStore` — filters in-memory
+  messages with empty `ConversationID`, with optional project scoping
+
+### Startup detection (`cmd/server_foreground.go`)
+- Added `maybeWarnUnbackfilledMessages(ctx, store.Store)` — calls
+  `CountUnbackfilledMessages("" /* all projects */)` and logs a `slog.Warn`
+  with count and remediation guidance when count > 0
+- Errors are non-fatal (logged but don't block boot)
+- Call site: after `migrateStore` succeeds, before `Ping`, inside `initStore`
+
+### Tests (`cmd/server_foreground_backfill_test.go`)
+- **AC-12-1 positive:** count=42 → warning logged with count and command
+- **AC-12-1 negative:** count=0 → no warning logged
+- **AC-12-7 mutation guard:** proves count=0 produces no warning, so a
+  mutation forcing `CountUnbackfilledMessages` to return 0 causes the positive
+  test to fail
+- **Error handling:** store error → graceful warning, no panic
+
+## Design Decisions
+
+- Used `ConversationIDIsNil()` rather than `ConversationIDEQ(uuid.Nil)` because
+  the ent schema declares `conversation_id` as `Optional().Nillable()` — NULL
+  is the sentinel for "not yet backfilled"
+- Placed the warning after migration but before Ping — migration must succeed
+  first (schema might not exist yet), and Ping is the last gate before returning
+  the store
+- Used a stub store (embedding nil `store.Store`) rather than a full mock since
+  `maybeWarnUnbackfilledMessages` only touches `CountUnbackfilledMessages`

--- a/.design/project-log/def12-volume-exercise.md
+++ b/.design/project-log/def12-volume-exercise.md
@@ -1,0 +1,53 @@
+# DEF-12 Volume Exercise (AC-12-6-LOCAL)
+
+**Date:** 2026-08-27
+**Author:** dev-def12-volume
+**Branch:** `scion/ca-msg-em6-def12`
+
+## Summary
+
+Ran the conversation backfill pipeline against 50,000 in-memory SQLite messages
+to validate correctness and measure wall-clock performance at realistic scale.
+
+## Message Distribution
+
+| Category | Count | Pct | Description |
+|---|---|---|---|
+| DM ThreadID | 30,000 | 60% | Canonical `dm:<kind>:<uuid>:<kind>:<uuid>` |
+| Non-DM ThreadID | 7,500 | 15% | Topic/thread style (`topic-N`) |
+| Malformed ThreadID | 5,000 | 10% | Parse failures (`dm:invalid:bad:format`, etc.) |
+| Empty ThreadID | 5,000 | 10% | Legacy — key derived from sender/recipient |
+| Pre-backfilled | 2,500 | 5% | ConversationID already set |
+| **Total** | **50,000** | | 20 distinct sender/recipient pairs |
+
+## Timing Results
+
+| Phase | Wall Time | Detail |
+|---|---|---|
+| Seed | 2.98s | 50,000 message inserts |
+| Phase 1 (dry-run) | 46.67s | 50,000 processed, 70 conversations would be created |
+| Phase 2 (execute) | 48.24s | 70 conversations created, 42,500 attributed |
+| Phase 3 (re-execute) | 47.75s | 45,000 skipped, 5,000 errors (malformed) |
+| **Total backfill** | **2m 22.7s** | |
+
+## Key Observations
+
+1. **Correctness verified** — all three phases pass assertions:
+   - Dry-run produces no mutations (verified by sampling)
+   - Execute correctly stamps 42,500 messages and creates 70 conversations
+   - Re-execute is fully idempotent: 0 attributed, 0 new conversations
+2. **Error handling** — all 5,000 malformed messages produce errors without crashing;
+   they are excluded from the attribution count and skipped on re-run
+3. **Idempotency invariant** — `Attributed + Inferred + Skipped + len(Errors) == TotalProcessed`
+   holds across all phases
+4. **Performance** — ~47s per phase at batch size 1000 on in-memory SQLite.
+   Each phase scans all 50k messages; the dominant cost is ListMessages pagination.
+
+## Test File
+
+`cmd/server_backfill_volume_test.go` — guarded by `//go:build volume_test && !no_sqlite`.
+
+Run with:
+```bash
+go test ./cmd/... -run TestBackfillVolume -tags volume_test -v -count=1 -timeout 300s
+```

--- a/.design/project-log/def15-phase6-migration-sweep.md
+++ b/.design/project-log/def15-phase6-migration-sweep.md
@@ -1,0 +1,52 @@
+# DEF-15 Phase 6: Migration Sweep for thread:%:dm:% Rows
+
+**Date:** 2026-08-27
+**Agent:** dev-migration-sweep
+**Branch:** scion/ca-msg-em6
+**Commit:** 05b37e89
+
+## Summary
+
+Extended `pkg/messaging/dm_migration.go` with `RepairDEF15Artifacts`, a new
+migration function that finds and repairs DEF-15 artifact conversation rows —
+rows whose `external_ref` matches `thread:<projectID>:dm:<rest>` due to a
+dm:-prefixed ThreadID being incorrectly wrapped in a `thread:` key prefix.
+
+## What Was Built
+
+### New classification: `convClassDEF15Artifact`
+
+Added to the existing `convClass` enum for rows matching the
+`thread:<projectID>:dm:<rest>` pattern.
+
+### `RepairDEF15Artifacts` method
+
+Scans all conversations (no kind filter) for the DEF-15 pattern, then for each:
+
+1. **Extracts** the dm: key suffix via `SplitN(":", 3)`
+2. **Validates** with `messages.ParseDMKey` — invalid keys are unrepairable
+3. **Checks canonicality** by re-deriving with `messages.DMConversationKey` — non-canonical keys are unrepairable
+4. **Repairs repairable rows:**
+   - If a correct row already exists: merges (messages re-stamped, DEF-15 row soft-deleted)
+   - If no correct row: updates in place (external_ref → dm: key, kind → "direct", project_id → NULL)
+   - Rebuilds participants from the key (key wins)
+5. **Reports** structured `DEF15RepairResult` with per-row detail
+
+### Tests (AC-MIGRATE-1)
+
+- **Three-row fixture test**: repairable, unrepairable, and merge-conflict scenarios
+- **Non-canonical key test**: verifies uppercase-UUID keys are left byte-identical
+- **Idempotency test**: second run finds zero artifacts
+- **`isDEF15Artifact` unit test**: pattern matcher edge cases
+
+## Files Modified
+
+- `pkg/messaging/dm_migration.go` — new types + methods (~240 lines)
+- `pkg/messaging/dm_migration_test.go` — 4 new test functions (~240 lines)
+
+## Verification
+
+```
+go test ./pkg/messaging/... -count=1  → PASS
+go test ./pkg/messages/... -count=1   → PASS
+```

--- a/.design/project-log/def15-phases3-5-key-consolidation.md
+++ b/.design/project-log/def15-phases3-5-key-consolidation.md
@@ -1,0 +1,64 @@
+# DEF-15 Phases 3-5: Key Derivation Consolidation
+
+**Date**: 2026-08-27
+**Branch**: scion/ca-msg-em6
+**Author**: dev-handler-fixes
+
+## Summary
+
+Completed Phases 3, 4, and 5 of §2.15 "One key derivation, not five". This
+consolidates all conversation key construction to flow through
+`DeriveConversationKey`, eliminating five separate key-construction paths in
+favor of one canonical function.
+
+## Changes
+
+### Phase 3: Handler Repoints
+
+- **Outbound handler** (`handleAgentOutboundMessage`): Replaced the two-branch
+  ThreadID/DM conversation resolution with a single `DeriveConversationKey` call.
+- **Inbound handler** (`handleAgentMessage`): Replaced the ThreadID and DM
+  branches with a single `DeriveConversationKey` call. The `ConversationID`
+  pre-resolved branch (DEF-11) is unchanged.
+- Broker delegation path confirmed working: dm:-keyed ThreadID through
+  `ResolveOrCreateThreadConversation` correctly produces `kind=direct`.
+
+### Phase 4: Backfill Repoint
+
+- **`groupForMessage`** in `backfill.go`: Now uses `DeriveConversationKey`
+  instead of `fmt.Sprintf("thread:...")` and `DirectMessageExternalRef`.
+  Returns nil on key derivation failure; caller skips with error record.
+- **`DirectMessageExternalRef`** unexported → `directMessageExternalRef`.
+  Confined to divergence tests that need the legacy shape.
+- Updated backfill test assertions: DM external_ref now matches
+  `DMConversationKey` format (kind-prefixed). Hazard-A email tests updated
+  to expect derivation failure (email IDs fail UUID validation).
+
+### Phase 5: DEF-16 Ordering Fix
+
+- Moved `ValidateLegacyMessage` BEFORE conversation resolution in the outbound
+  handler. A rejected request now never creates a conversation row.
+- The inbound handler already had correct ordering (validate at :615,
+  dual-write at :857).
+
+## Tests Added
+
+| Test | File | Assertion |
+|------|------|-----------|
+| AC-DEF15-4 | handlers_read_switch_test.go | Invalid dm: key as ThreadID → 0 conversation rows |
+| AC-DEF15-6 | backfill_test.go | dm:-prefixed ThreadID backfill → kind=direct |
+| AC-DEF15-1 | key_consolidation_test.go | Source-reading: thread key and legacy DM ref confined to expected files |
+| AC-DEF16-1 (outbound) | handlers_read_switch_test.go | thread_id without channel → 400 + 0 conversations |
+| AC-DEF16-1 (inbound) | handlers_read_switch_test.go | thread_id without channel → 400 + 0 conversations |
+| Broker delegation | handlers_read_switch_test.go | dm: ThreadID through thread delegation → kind=direct |
+
+## Mutation Test Result
+
+Moving `ValidateLegacyMessage` below dual-write causes
+`TestDEF16_ValidationRejectsBeforeConversationCreated_Outbound` to fail
+(conversation row count goes from 0 to 1). Restoring the fix makes it pass.
+
+## Known Issues
+
+- `TestHandleAdminServerConfig_Get` fails on the base branch (pre-existing,
+  unrelated to this work).

--- a/.design/project-log/def25-grove-fixture-rename.md
+++ b/.design/project-log/def25-grove-fixture-rename.md
@@ -1,0 +1,41 @@
+# DEF-25: Rename grove-* fixture project IDs in test files
+
+**Date:** 2026-08-27
+**Agent:** dev-def25-compat
+**Branch:** scion/ca-msg-em6
+
+## Summary
+
+Renamed 11 test fixture project IDs across two test files from legacy `grove-*`
+vocabulary to `proj-*` vocabulary, making the `compat-literals` CI gate pass
+(exit 0) on this branch.
+
+## Changes
+
+### `cmd/message_deprecation_test.go` (7 renames)
+
+| Before | After |
+|---|---|
+| grove-depr-bcast | proj-depr-bcast |
+| grove-depr-in | proj-depr-in |
+| grove-depr-at | proj-depr-at |
+| grove-depr-bcast-works | proj-depr-bcast-works |
+| grove-depr-notify-works | proj-depr-notify-works |
+| grove-depr-plain-works | proj-depr-plain-works |
+| grove-depr-channel-works | proj-depr-channel-works |
+
+### `cmd/broadcast_test.go` (4 renames)
+
+| Before | After |
+|---|---|
+| grove-bcast-project | proj-bcast-project |
+| grove-bcast-all | proj-bcast-all |
+| grove-bcast-empty | proj-bcast-empty |
+| grove-bcast-interrupt | proj-bcast-interrupt |
+
+## Verification
+
+- `bash hack/check-project-compat-literals.sh` exits 0
+- `go test ./cmd/ -run 'TestBroadcastCmd|TestDeprecation' -count=1` — all tests pass
+- No `grove` literals remain in either file
+- These were internal test fixture IDs with no external dependencies

--- a/.design/project-log/defect-principalkindFromAddress-fold.md
+++ b/.design/project-log/defect-principalkindFromAddress-fold.md
@@ -1,0 +1,646 @@
+# Defect: PrincipalKindFromAddress case-fold masks kind-prefix validation
+
+**Filed by:** ca-msg-em9  
+**Date:** 2026-08-28  
+**Updated:** 2026-08-28 (v4 — false premise corrected, SSE impact added, :1653 sharpened)  
+**Origin:** em6 finding during DMConversationKey tightening audit  
+**Status:** Audit complete — live authorization bypass confirmed — no code changes made  
+
+---
+
+## Summary
+
+`PrincipalKindFromAddress` (pkg/messages/dm_key.go:75-85) applies
+`strings.ToLower` to the kind prefix before validating against
+`validDMKinds`. This means non-canonical prefixes like `"User:"` or
+`"Agent:"` are silently accepted and mapped to their canonical forms.
+
+At call site 2 (handlers_broker_inbound.go:276), the fold is a necessary
+link in a **live authorization bypass chain** on upstream/main. A broker
+plugin sending `"User:alice"` as Sender bypasses the case-sensitive
+`HasPrefix("user:")` gate that performs ActionAttach authorization and
+SenderID resolution. The fold then repairs the prefix downstream,
+allowing DM conversation resolution to proceed with an
+attacker-controlled SenderID. The bypass is not latent — it is
+exploitable now.
+
+**v1 error corrected:** The original audit incorrectly concluded the
+bypass was "inert in practice, gated by a SenderID nil-guard." That
+guard is at messagebroker.go:835 (call site 4) — a different function on
+a different call path. It does not run at call site 2. Furthermore,
+SenderID is decoded from the request JSON body
+(`json:"sender_id,omitempty"`) and is attacker-controlled; the nil-guard
+would not have helped even if it ran on this path.
+
+## Function under audit
+
+```go
+func PrincipalKindFromAddress(address string) (string, bool) {
+    idx := strings.IndexByte(address, ':')
+    if idx < 0 { return "", false }
+    kind := strings.ToLower(address[:idx])   // ← the fold
+    if validDMKinds[kind] { return kind, true }
+    return "", false
+}
+```
+
+`validDMKinds` contains only `"user"` and `"agent"`.
+
+---
+
+## Call-site provenance audit (upstream/main)
+
+### Site 1 — handlers_agent_messaging.go:1578
+
+```go
+senderKind, sOK := messages.PrincipalKindFromAddress(mentionMsg.Sender)
+```
+
+**Provenance:** `mentionMsg.Sender` ← `originalMsg.Sender` ←
+`structuredMsg.Sender` ← B5 auth override (lines 540-559).
+
+B5 override constructs Sender from authenticated context:
+- `"user:" + user.DisplayName()` or `"user:" + user.Email()`
+- `"agent:" + agentIdent.ID()`
+- fallback: `"user:unknown"`
+
+All prefixes are string literals in lowercase.
+
+**Classification: INTERNAL.** Server-constructed, always canonical. The
+fold is identity-preserving. No non-canonical prefix can reach this site.
+
+### Site 2 — handlers_broker_inbound.go:276
+
+```go
+senderKind, sOK := messages.PrincipalKindFromAddress(req.Message.Sender)
+```
+
+**Provenance:** `req.Message.Sender` comes from the JSON body of a
+broker plugin HTTP POST. Transport is HMAC-authenticated (line 58), but
+the Sender field content is controlled by the broker plugin.
+
+**Upstream gate (lines 126-146):** A case-sensitive
+`strings.HasPrefix(req.Message.Sender, "user:")` check controls:
+1. User lookup via `store.GetUserByEmail`
+2. `SenderID` caching on the message
+3. `ActionAttach` permission check for the resolved user
+
+If Sender is `"User:alice"` (capital U):
+- `HasPrefix("user:")` → **false** — skips user lookup, SenderID cache,
+  and ActionAttach permission check
+- `PrincipalKindFromAddress` at line 276 → folds `"User"` to `"user"`,
+  returns `("user", true)` — proceeds into DM conversation resolution
+
+This creates a path where DM conversation resolution proceeds with
+`senderKind = "user"` but without the ActionAttach authorization that
+normally gates user-originated messages.
+
+**Classification: EXTERNAL.** Broker plugin controls Sender content. The
+fold repairs a non-canonical prefix that the upstream case-sensitive gate
+correctly rejected, enabling an authorization bypass.
+
+**This bypass is live, not latent.** The full chain:
+
+**Step 1 — Gate bypass (handlers_broker_inbound.go:126-146).** The
+case-sensitive `HasPrefix("user:")` gate does three things: (a) resolves
+the sender via `store.GetUserByEmail`, (b) runs the ActionAttach
+permission check, and (c) overwrites `req.Message.SenderID` with the
+resolved user's ID. Sender `"User:alice"` (capital U) causes HasPrefix
+to return false. All three operations are skipped.
+
+**Step 2 — Attacker-controlled SenderID survives.** `SenderID` is a
+JSON-decoded field (`json:"sender_id,omitempty"` in
+pkg/messages/types.go:131). Because the gate at :126 was skipped, the
+body-supplied `sender_id` is not overwritten with a server-resolved
+value. The attacker controls it.
+
+**Step 3 — DM ownership check passes (#1322, line 165-170).** The
+ownership check compares `dmUserID` (parsed from the attacker-supplied
+`thread_id`) against `senderID` (the attacker-supplied `sender_id`).
+Both values are attacker-controlled. They trivially match.
+
+**Step 4 — SenderID used under false invariant (line 241).** The
+assignment `senderUserID := req.Message.SenderID` carries a comment:
+*"The sender user ID was resolved and cached in req.Message.SenderID
+during the upstream permission check for 'user:' senders."* This comment
+asserts exactly the invariant that the case-sensitive gate fails to
+guarantee. The attacker's body-supplied value is used as if it were
+server-resolved.
+
+**Step 5 — Fold enables DM resolution (line 276).** At this point,
+`PrincipalKindFromAddress("User:alice")` folds `"User"` to `"user"` and
+returns `("user", true)`. Without the fold, it would return `("", false)`
+and the forged message would never reach `ResolveOrCreateDMConversation`.
+The fold is not the root cause, but it is a necessary link in the chain.
+Removing it shrinks blast radius; it does not close the bypass.
+
+**Step 6 — DM resolution proceeds (line 279).** The call to
+`ResolveOrCreateDMConversation` runs with `senderKind = "user"` and an
+attacker-controlled `senderUserID`. Note that this is a direct call to
+`messaging.ResolveOrCreateDMConversation`, NOT through
+`resolveDMConversation` in messagebroker.go. The nil-guard at
+messagebroker.go:835 (call site 4) is on a completely different call path
+and does not run here.
+
+**Root cause:** The case-sensitive `HasPrefix("user:")` gate at line 126.
+The fold in `PrincipalKindFromAddress` is a contributing factor that
+enables the worst outcome (DM resolution with forged identity).
+
+**Aggravating factor — live-push via EventPublisher.** The forged message
+is not merely persisted. After `CreateMessage` succeeds,
+`s.events.PublishUserMessage` at line 291 publishes it to the
+EventPublisher bus (`p.events`), which carries hub Event structs to
+web/SSE consumers and other subscribers. Because
+`storeMsg.AgentID = agent.ID` (line 258), the forged message is sinked
+to `agent.<agentID>.message` — live-pushed to every subscriber on the
+target agent's stream, carrying the victim's (attacker-chosen) SenderID.
+The forgery is visible in real-time to all connected clients watching
+that agent's conversation feed.
+
+**Existing broker plugins:** The Slack broker plugin constructs Sender as
+`"agent:" + slug` using lowercase string literals with case-sensitive
+HasPrefix checks. No known first-party plugin sends non-canonical
+prefixes. Third-party plugins are unconstrained.
+
+### Site 3 — messagebroker.go:465
+
+```go
+if recipientKind, rOK := messages.PrincipalKindFromAddress(msg.Recipient); rOK {
+```
+
+**Provenance:** `msg.Recipient` arrives via eventbus subscription
+(`subscribeProjectUserMessages`). Published by hub handlers:
+- `handleAgentOutboundMessage` sets Recipient = `"user:" + name`
+  (server-constructed, lines 150/158/164)
+- `handleBrokerInbound` does not publish through this path
+
+All publishers use lowercase string literal prefixes.
+
+**Classification: INTERNAL.** Server-constructed, always canonical. The
+fold is identity-preserving.
+
+### Site 4 — messagebroker.go:839
+
+```go
+senderKind, ok := messages.PrincipalKindFromAddress(msg.Sender)
+```
+
+**Provenance:** Called from `resolveDMConversation`, which is invoked by
+`deliverToUser` and `deliverToAgent`. Messages arrive via eventbus,
+published by hub handlers where Sender is always B5-forced (`"user:" +
+name/email`) or agent-constructed (`"agent:" + slug`). All lowercase
+string literal prefixes.
+
+**Classification: INTERNAL.** Server-constructed, always canonical. The
+fold is identity-preserving.
+
+---
+
+## Answers to architect's questions
+
+### Q1: Can a non-canonical kind prefix originate outside the trust boundary?
+
+**Yes, at exactly one call site.** Site 2 (handlers_broker_inbound.go:276)
+receives Sender from a broker plugin's JSON body. The broker plugin is
+HMAC-authenticated at transport level but the Sender field content is not
+canonicalized or validated before reaching `PrincipalKindFromAddress`.
+
+Sites 1, 3, and 4 are all server-constructed with lowercase string
+literal prefixes. No non-canonical prefix can reach them.
+
+### Q2: Is the fold-induced aliasing semantically inert, or does it matter?
+
+**The aliasing on the DM key is semantically inert in isolation.** There
+is no distinct `"User"` or `"Agent"` principal kind in the system.
+`"User:x"` and `"user:x"` name the same principal. The fold maps to the
+only valid canonical form, and `DMConversationKey` itself also applies
+`ToLower` (line 41-42), so the key derivation is doubly normalized.
+
+**But the fold matters because it is a necessary link in a live
+authorization bypass at site 2.** Without the fold,
+`PrincipalKindFromAddress("User:alice")` would return `("", false)` and
+the B15 dual-write block would not reach `ResolveOrCreateDMConversation`.
+The fold repairs the prefix that the case-sensitive gate correctly
+rejected, enabling the forged message to complete DM resolution with an
+attacker-controlled SenderID.
+
+The full chain at site 2:
+
+- `"user:alice"` → HasPrefix passes → authorized, SenderID resolved →
+  fold → DM resolution with server-verified identity
+- `"User:alice"` → HasPrefix fails → **not authorized, SenderID
+  attacker-supplied** → fold repairs to `"user"` → DM resolution with
+  attacker-controlled identity
+
+The aliasing on the key is inert. The fold's role in enabling the bypass
+is not.
+
+---
+
+## Reasoning error in v1 (corrected)
+
+The v1 audit carried a safety argument across call sites: the nil-guard
+at messagebroker.go:835 (call site 4, `resolveDMConversation`) was cited
+as protecting call site 2 (handlers_broker_inbound.go:276). These are
+different functions on different call paths. Site 2 calls
+`messaging.ResolveOrCreateDMConversation` directly at line 279 — it does
+not go through the `resolveDMConversation` wrapper in messagebroker.go.
+
+Even if the nil-guard ran on this path, it checks
+`msg.SenderID == ""`. SenderID is decoded from the request JSON body
+(`json:"sender_id,omitempty"` in pkg/messages/types.go:131). An attacker
+exercising this bypass controls the body and would not leave SenderID
+empty.
+
+The lesson: when carrying a safety argument across call sites, the guard
+must be on the path being cleared. Write the guard's file and line next
+to the site it protects — the mismatch becomes immediately visible.
+
+---
+
+## Recommendation (no code changes in this audit)
+
+Routing is with the user. Architect has recommended a standalone hotfix
+ahead of the refactor.
+
+1. **Root cause — fix the gate at site 2:** Make the `HasPrefix("user:")`
+   check at handlers_broker_inbound.go:126 case-insensitive, or
+   canonicalize the kind prefix before the gate runs. This closes the
+   bypass regardless of the fold.
+2. **Contributing factor — remove the fold from PrincipalKindFromAddress:**
+   Make it case-sensitive to match the upstream gates. This does not close
+   the bypass on its own (the gate is still the root cause) but removes a
+   necessary link in the worst version of the chain, shrinking blast
+   radius.
+3. **Do not rely on the SenderID nil-guard at site 4** as defense for
+   site 2. It is on a different call path and tests a condition the
+   attacker controls.
+
+---
+
+## DEF-32 class audit: all 24 case-sensitive prefix tests in pkg/hub
+
+DEF-32 is a class, not an instance. There are 24 case-sensitive prefix
+tests on principal addresses in pkg/hub non-test code. This section
+triages each into one of three buckets:
+
+- **AUTHZ** — the comparison gates a permission check, identity
+  resolution, or a field the security layer later trusts. A miss grants
+  something.
+- **ROUTING** — the comparison picks a delivery path or display form. A
+  miss misroutes or mislabels, but grants nothing.
+- **INERT** — operand is provably server-constructed canonical; no
+  external path can supply a non-canonical prefix.
+
+### Bucket counts
+
+| Bucket  | Count | Sites |
+|---------|-------|-------|
+| AUTHZ   | 3     | handlers_broker_inbound.go:126, :127; handlers_chat_v2.go:1653 |
+| ROUTING | 5     | events.go:761; handlers_agent_messaging.go:139; handlers_broker_inbound.go:297; handlers_chat_v2.go:1966, :1974 |
+| INERT   | 16    | events.go:744; handlers_agent_messaging.go:911, :912, :1105, :1466; messagebroker.go:437, :518, :535, :536, :716, :748, :791; webchannel.go:103, :185, :188, :201 |
+| **Total** | **24** | |
+
+### AUTHZ sites (3)
+
+**handlers_broker_inbound.go:126** — `HasPrefix(req.Message.Sender, "user:")`
+Gate for ActionAttach permission check, user resolution, SenderID
+overwrite. EXTERNAL: Sender from broker plugin JSON body.
+*Miss consequence:* ActionAttach check skipped; body-supplied sender_id
+survives as if server-resolved. This is the DEF-32 root cause.
+
+**handlers_broker_inbound.go:127** — `TrimPrefix(req.Message.Sender, "user:")`
+Inside the :126 if-block. Extracts email from Sender for user lookup.
+Dependent on :126 — only reachable when :126 passes, so not independently
+exploitable. However, any fix that makes :126 case-insensitive must also
+address :127 or canonicalize before both.
+*Miss consequence:* Part of the :126 gate; email extraction fails if
+prefix casing mismatches.
+
+**handlers_chat_v2.go:1653** — `HasPrefix(msg.Sender, "agent:")`
+In `hasAgentReplyAfter` (:1635). Reads stored messages from DB to
+determine if an agent has replied in the conversation after a given
+timestamp. Called from the edit handler (:1491) and delete handler
+(:1591). Gates edit/delete permission on user's own message (immutability
+after agent reply).
+
+The function's author explicitly reasoned about failure and chose
+fail-closed on the error path:
+
+    if err != nil || result == nil {
+        return true // fail-closed: deny edit/delete when we can't verify
+    }
+
+But the casing miss is not an error. The query succeeds, returns rows,
+and `HasPrefix(msg.Sender, "agent:")` simply does not match `"Agent:bot"`.
+The loop completes normally and the function returns `false` — fail-OPEN.
+An explicit fail-closed comment sits eight lines above a fail-open path
+in the same function. The comment creates confidence that the function
+fails closed, when it only covers the error branch.
+
+**Casing exploit — latent fail-open, exploitability unproven.**
+handleBrokerInbound persists `req.Message.Sender` verbatim. The :126
+gate only inspects for `"user:"` prefix — `"Agent:bot"` (capital A)
+passes through :126 unexamined, and the message is persisted with
+`Sender = "Agent:bot"`. When a user later calls edit/delete,
+`HasPrefix("agent:")` misses, and the function returns false.
+
+However, adding a non-canonical message does not remove a canonical one.
+`hasAgentReplyAfter` returns true as soon as it finds ANY message
+matching `HasPrefix("agent:")`. Canonical agent replies are server-
+constructed (handlers_agent_messaging.go:239 `"agent:" + agent.Slug`,
+notifications.go:486 same pattern) — never caller-supplied. A genuine
+agent reply through the normal path is canonical and matches. The casing
+exploit requires a thread in which ALL agent replies were persisted via
+the verbatim-Sender broker inbound path and none through the canonical
+server-constructed path. No such thread has been demonstrated.
+
+**DEF-34: Asymmetric Channel invariant (independent of DEF-32, confirmed).**
+
+The function's filter pins `Channel: "web"` (line 1636):
+
+    filter := store.MessageFilter{
+        Channel:  "web",
+        ThreadID: threadID,
+        After:    after,
+    }
+
+The hub enforces Channel on one side of the conversation and the guard
+filters on it as though both sides were enforced:
+
+- **User → agent (handlers_agent_messaging.go:736):** Channel is
+  defaulted to `"web"` when the authenticated user's client type is
+  `"web"`:
+
+      if structuredMsg.Channel == "" {
+          if user := GetUserIdentityFromContext(ctx); user != nil {
+              if au, ok := user.(*AuthenticatedUser); ok && au.ClientType() == "web" {
+                  structuredMsg.Channel = "web"
+              }
+          }
+      }
+
+- **Agent → user (handlers_agent_messaging.go:188-202, 207, 247):**
+  Channel goes through a conditional inference, not a default. When the
+  runtime omits Channel (req.Channel == ""), reply affinity runs:
+
+      if req.Channel == "" && recipientID != "" && s.webChatStore != nil && s.GetMessageBrokerProxy() != nil {
+          if lastCh, err := s.webChatStore.GetLastChannel(ctx, recipientID, agent.ProjectID, agent.ID); err != nil {
+              // Non-fatal: fall through to fan-out-to-all behavior.
+          } else if lastCh != "" {
+              req.Channel = lastCh
+          }
+      }
+
+  `GetLastChannel` is keyed `(userID, projectID, agentID)` — it is
+  **thread-agnostic** (webchannel_store.go:62). But the guard's
+  MessageFilter is keyed `(channel, threadID)` — **per-thread**. Producer
+  key and consumer key disagree.
+
+  If no affinity row exists, lastCh = "" → req.Channel stays "" →
+  Channel validation at :207 is skipped (gates on `req.Channel != ""`)
+  → reply persisted with Channel = "". Empty Channel is documented
+  intended behaviour: "leave channel empty so the message fans out to
+  all spokes" (:193 comment). An intended sentinel value that the guard
+  cannot see.
+
+  **Rule 206.** When one site writes a field and another reads it as a
+  precondition, the two must agree on the field's key. Producer keyed
+  (user, project, agent) and consumer keyed (channel, thread) disagree
+  the first time a user is active on two channels, and the disagreement
+  presents as a guard that passes.
+
+  **Rule 207.** An intended sentinel is still a blind spot. That a value
+  is supported is an argument for handling it, not evidence that it is
+  handled.
+
+**Affinity writers** (two, both confirmed):
+
+1. webchannel.go:139 — inside `webChannelBus.Publish`, writes `"web"`:
+
+       b.store.RecordChannel(ctx, userID, projectID, agentID, "web", ...)
+
+2. handlers_broker_inbound.go:299 — writes the inbound spoke's channel:
+
+       s.webChatStore.RecordChannel(r.Context(), senderUserID, agent.ProjectID, agent.ID, req.Message.Channel, now)
+
+handlers_chat_v2.go calls neither.
+
+**Three routes to bypass, ranked by strength:**
+
+**(b) Cross-channel affinity — strongest, ordinary multi-channel use.**
+No attacker, no misbehaving runtime:
+
+1. User posts in web thread W → affinity = "web"
+   (webchannel.go:139, keyed (user, project, agent))
+2. Same user says anything to the same agent from Discord →
+   affinity = "discord" (handlers_broker_inbound.go:299, same key,
+   overwrites)
+3. Agent sends untagged reply in W → :195 `GetLastChannel` returns
+   "discord" → :200 stamps req.Channel = "discord" → persisted
+4. User edits/deletes their message in W → guard filters
+   Channel="web", misses the "discord" reply, **permits the edit**
+
+**(a) No affinity row — documented intended behaviour.**
+Agent sends first untagged reply before user has spoken on any channel
+(or affinity row expired/absent) → GetLastChannel returns "" → lastCh
+= "" → req.Channel stays "" → Channel = "" persisted. Empty Channel is
+the documented fan-out-to-all-spokes sentinel (:193 comment). Guard
+filters Channel="web", misses it.
+
+**(c) Runtime sets non-web explicitly — weakest, needs cooperating
+client.**
+Agent runtime sets `"channel": "slack"` (or any non-"web" value) in its
+response body → passes channel-registration validation at :207 if
+registered → persisted with that Channel → invisible to guard.
+
+**Fix ruling.** The guard's question is "has the agent replied in this
+thread?" Channel is not part of that question. The correct fix is to
+drop `Channel: "web"` from the MessageFilter in `hasAgentReplyAfter`.
+Defaulting Channel on the agent path is wrong on its own terms — empty
+Channel is load-bearing, it means fan-out-to-all-spokes. Forcing "web"
+would break fan-out to repair a guard. Removing the Channel filter
+widens the match set, so it fails closed: messages that were previously
+invisible become visible, which only causes the guard to return true
+(deny edit/delete) in cases it was incorrectly permitting.
+
+**Adjacent note: pagination termination.** `hasAgentReplyAfter`'s loop
+terminates on `result.NextCursor == "" || len(result.Items) < pageSize`
+(line 1658). A short page that still carries a cursor ends the scan and
+returns false (fail-open). Removing the Channel filter changes page
+occupancy (more messages per page), so this termination condition should
+be reviewed when the filter is removed. Not part of DEF-34, but worth
+recording before anyone modifies this loop.
+
+*Miss consequence (casing):* Latent fail-open on agent-reply immutability.
+*Miss consequence (DEF-34, channel asymmetry):* Agent-reply immutability
+bypassed through ordinary multi-channel use. Confirmed exploitable, no
+malicious actor required.
+
+### ROUTING sites (5)
+
+**events.go:761** — `!HasPrefix(msg.ThreadID, "agent:")`
+In `PublishUserMessage` (EventPublisher). Tests ThreadID to distinguish
+legacy agent-slug keys from UUID topic threads. ThreadID from broker
+inbound path is body-supplied. Miss causes message to be published to
+the shared-space chat event subject when it should not be. No privilege
+granted.
+*Miss consequence:* Message appears in wrong event subject.
+
+**handlers_agent_messaging.go:139** — `TrimPrefix(recipient, "user:")`
+In recipient resolution for handleAgentMessage. If recipient is
+`"User:alice"`, TrimPrefix does not strip, email/name lookup fails,
+resolution fails. No privilege granted — denial, not bypass.
+*Miss consequence:* Recipient resolution failure; message not deliverable.
+
+**handlers_broker_inbound.go:297** — `HasPrefix(req.Message.Sender, "user:")`
+Gates reply-affinity recording (RecordChannel) and thread watermark
+updates. Miss means reply-affinity not recorded for non-canonical sender.
+Agent's next untagged reply may route to wrong channel. No privilege
+granted.
+*Miss consequence:* Routing quality degrades; agent reply may go to wrong
+channel.
+
+**handlers_chat_v2.go:1966** — `HasPrefix(m.Sender, "agent:") && HasPrefix(m.Recipient, "agent:")`
+Inter-agent message filter (first merge loop). Reads from DB. If a non-
+canonical agent Sender/Recipient was stored, message is filtered out of
+inter-agent list. No privilege granted — information hidden, not exposed.
+*Miss consequence:* Inter-agent messages not displayed.
+
+**handlers_chat_v2.go:1974** — same shape as :1966
+Second merge loop, same filter. Same analysis, same consequence.
+
+### INERT sites (16)
+
+All operands are provably server-constructed canonical. No external path
+can supply a non-canonical prefix to any of these sites.
+
+**events.go:744** — `HasPrefix(msg.Recipient, "user:")`
+In PublishUserMessage (EventPublisher). Recipient is always server-
+constructed: "agent:" + slug from handleBrokerInbound, or "user:" + name
+from handleAgentOutboundMessage. No external path sets Recipient.
+
+**handlers_agent_messaging.go:911** — `HasPrefix(structuredMsg.Sender, "agent:")`
+**handlers_agent_messaging.go:912** — `HasPrefix(structuredMsg.Recipient, "agent:")`
+Agent-to-agent observer publishing gate. Both operands B5-forced
+(Sender auth-derived, Recipient from URL path agent resolution).
+
+**handlers_agent_messaging.go:1105** — `HasPrefix(agentMsg.Sender, "agent:")`
+Group message observer publishing gate. Sender B5-forced.
+
+**handlers_agent_messaging.go:1466** — `!HasPrefix(msg.Sender, "agent:") || msg.SenderID == ""`
+`publishBroadcastDeliveryFailed`. Called from handleProjectBroadcast
+(HTTP handler path). Sender and SenderID both B5-forced from auth
+context. SenderID NOT body-settable — B5 override at lines 548-559
+overwrites body value. If prefix missed: DELIVERY_FAILED notification
+not sent (silent failure, no privilege).
+
+**messagebroker.go:437** — `HasPrefix(msg.Sender, "agent:")`
+In deliverToUser, sets AgentID on stored message. msg arrives via
+`p.bus` (the StructuredMessage bus). handleBrokerInbound never publishes
+to `p.bus` — it publishes only to `p.events` (EventPublisher), which
+carries a different type on different subjects. No path from broker
+inbound reaches deliverToUser. All `p.bus` publishers B5-force fields.
+
+**messagebroker.go:518** — `!HasPrefix(storeMsg.ThreadID, "agent:")`
+In deliverToUser, thread watermark routing. msg from `p.bus`
+(StructuredMessage bus); all publishers B5-force fields. No broker
+inbound path.
+
+**messagebroker.go:535** — `HasPrefix(storeMsg.Sender, "agent:")`
+**messagebroker.go:536** — `TrimPrefix(storeMsg.Sender, "agent:")`
+DM notification block in deliverToUser. msg from `p.bus`, B5-forced.
+No broker inbound path.
+
+**messagebroker.go:716** — `HasPrefix(msg.Sender, "agent:") && msg.SenderID == ""`
+R3b diagnostic warning in fanOutToProject. Invoked at :383 inside a
+`p.bus.Subscribe` handler. msg is `*messages.StructuredMessage` from the
+StructuredMessage bus. handleBrokerInbound never publishes to `p.bus`
+(only to `p.events`). All `p.bus` publishers B5-force fields. SenderID
+auth-derived, NOT body-settable. If prefix missed: warning suppressed.
+Self-skip at :726 (ID-based) works independently.
+**B5/R1 self-skip note:** This is broadcast self-skip territory. The R3b
+warning is cosmetic. The actual self-skip logic (`msg.SenderID != "" &&
+msg.SenderID == agent.ID`) does not depend on the prefix test and is
+safe regardless.
+
+**messagebroker.go:748** — `HasPrefix(msg.Sender, "agent:") && msg.SenderID == ""`
+R3b warning in fanOutGlobal. Same analysis as :716. msg from `p.bus`,
+B5-forced. SenderID auth-derived, NOT body-settable.
+
+**messagebroker.go:791** — `!HasPrefix(msg.Sender, "agent:") || msg.SenderID == ""`
+`publishDeliveryFailed` in MessageBrokerProxy. Called from deliverToAgent
+on dispatch failure. msg is `*messages.StructuredMessage` from `p.bus`
+agent topic subscriptions. handleBrokerInbound never publishes to
+`p.bus` — it publishes only to `p.events` (EventPublisher, different
+type, different subjects). All `p.bus` publishers (PublishMessage from
+HTTP handlers, fanOutToProject/Global iteration) B5-force fields.
+SenderID auth-derived, NOT body-settable. If prefix missed:
+DELIVERY_FAILED not sent (silent failure, no privilege).
+
+**webchannel.go:103** — `!HasPrefix(msg.ThreadID, "agent:")`
+Thread watermark routing in web channel spoke. The web spoke is
+registered as an observer on the FanOutEventBus and receives
+`*messages.StructuredMessage` via `p.bus`. handleBrokerInbound never
+publishes to `p.bus`. All `p.bus` publishers B5-force fields.
+
+**webchannel.go:185** — `HasPrefix(msg.Sender, "agent:")`
+**webchannel.go:188** — `TrimPrefix(msg.Sender, "agent:")`
+In identityFromTopic, TopicKindUser case. Sets agentID from agent sender.
+msg from `p.bus`, server-constructed on all publishing paths.
+
+**webchannel.go:201** — `HasPrefix(msg.Sender, "user:")`
+In identityFromTopic, TopicKindAgent case. Sets userID from user sender.
+msg from `p.bus`, server-constructed on all publishing paths.
+
+---
+
+## Why the INERT count is high
+
+16 of 24 sites (67%) are INERT because of a two-bus architecture:
+
+- `MessageBrokerProxy.bus` (`eventbus.EventBus`) carries
+  `*messages.StructuredMessage` — the broker-delivery pipeline.
+  fanOutToProject, deliverToUser, deliverToAgent, and all 16 INERT sites
+  hang off `p.bus` subscribers.
+
+- `MessageBrokerProxy.events` (`EventPublisher`) carries hub Event
+  structs (e.g., `UserMessageEvent`) — in-process fan-out to web/SSE
+  consumers and other subscribers.
+
+The B5 auth-derivation override (handlers_agent_messaging.go:540-559)
+canonicalizes Sender and SenderID at the HTTP handler entry point, and
+these canonical values propagate through `p.bus` to all downstream
+consumers.
+
+handleBrokerInbound is the only HTTP handler that does NOT B5-force
+Sender. It contains zero `p.bus` references and exactly one publish:
+`s.events.PublishUserMessage` at line 291. It publishes to `p.events`
+(EventPublisher), never to `p.bus` (StructuredMessage bus). The two
+buses carry different types on different subjects. No `p.bus` subscriber
+receives messages from handleBrokerInbound.
+
+This is why the forged message reaches EventPublisher subscribers (web
+clients see the forgery live-pushed to `agent.<agentID>.message`) but
+does not reach the 16 INERT sites that consume `*messages.StructuredMessage`
+off `p.bus`.
+
+The 3 AUTHZ + 5 ROUTING sites that are not INERT all either:
+1. Directly process broker inbound request fields (:126, :127, :297), or
+2. Read from the DB where broker inbound may have stored non-canonical
+   values (:1653, :1966, :1974), or
+3. Receive ThreadID from a path that includes broker inbound (:761), or
+4. Process user-supplied recipient strings (:139).
+
+## Fix shape implications
+
+If DEF-32 were a single instance (1 AUTHZ site), patching
+handlers_broker_inbound.go:126 case-insensitively would suffice.
+
+With 3 AUTHZ sites (2 at the gate + 1 second-order via DB), plus 5
+ROUTING sites that degrade on non-canonical input, the correct fix moves
+upstream: **canonicalize Sender (and Recipient if present) once at
+broker inbound ingress** before any downstream comparison can be fooled
+by casing. This closes all 8 non-INERT sites with one normalization
+point, and prevents future case-sensitive comparisons from becoming new
+instances of the class.

--- a/.design/project-log/dev-s3-fixes-review-audit.md
+++ b/.design/project-log/dev-s3-fixes-review-audit.md
@@ -1,0 +1,70 @@
+# S3 Envelope Review/Audit Fix Round
+
+**Date:** 2026-08-27
+**Agent:** dev-s3-fixes
+**Branch:** scion/ca-msg-em3
+
+## Summary
+
+Applied six fixes from code review and security audit of S3 Envelope (phases 6, 7, 9).
+
+## Changes
+
+### Fix 1: Compose validators (Review R1+R2)
+- `ValidateMessage()` now delegates to `msg.Validate()` for structural checks (ID, From, Kind, Visibility, kind/intent/event), then adds domain-level checks (ConversationID, body size, attachments, reply_to_id).
+- Eliminates duplicated switch block between `Message.Validate()` and `ValidateMessage()`.
+- Added `TestValidateMessage_MissingID` test.
+
+### Fix 2: Metadata + channel validation in ValidateLegacyMessage (Audit M1)
+- Added metadata entry count, key size, and value size limits to `ValidateLegacyMessage`.
+- Added channel regex check (`IsValidChannel`) to `ValidateLegacyMessage`.
+- Added `IsValidChannel()` helper to `pkg/messages/types.go` (only change to that file).
+- Added five tests: channel invalid/valid chars, metadata entry count, key size, value size.
+
+### Fix 3: Wire ValidateCrossProjectAddressees (Audit HIGH / AC-33)
+- Added `ValidateMessageAddressees()` composition function in `validate.go`.
+- Wired cross-project check into `handleAgentMessage` for the mentions path: before dispatch, resolved mention agents are checked to ensure they all belong to the same project as the primary recipient.
+- Added tests for `ValidateMessageAddressees` (valid + cross-project rejected).
+
+### Fix 4: Sanitize project IDs from error (Audit M3)
+- Removed project ID values from `ValidateCrossProjectAddressees` error message.
+- Updated test to assert project IDs are NOT disclosed.
+
+### Fix 5: Validation on outbound/broadcast handlers (Audit M2)
+- Added `ValidateLegacyMessage` call in `handleAgentOutboundMessage` after building the StructuredMessage.
+- Added `ValidateLegacyMessage` call in `handleProjectBroadcast` after assembling the request.
+
+### Fix 6: PrincipalRef length limit (Audit L1)
+- Added `MaxPrincipalRefLength = 512` constant and length check to `ValidatePrincipalRef`.
+- Added tests for over-limit and at-limit PrincipalRef values.
+
+### Pre-existing bug fix: buildPrincipalRef raw UUID handling
+- `buildPrincipalRef` in `envelope_compat.go` was using raw UUID SenderIDs directly as PrincipalRefs, which fail validation (no colon prefix). Fixed to derive the kind prefix from the Sender name field when the ID is a raw identifier.
+- This fixed pre-existing test failures in `handleAgentMessage` tests and enables the new outbound validation.
+
+### Test adaptations for new validation
+- `TestOutboundMessage_UnknownTypeIsChargedAsAgentTraffic` — updated to expect 400 rejection (previously unknown types were silently accepted on the outbound path).
+- `TestOutboundMessage_AttachmentsLinkedToMessage` — removed ThreadID from test (not relevant to the attachment linking being tested; thread_id without channel is now caught by validation).
+
+## Files Modified
+
+- `pkg/messaging/validate.go` — composed validators, added ValidateMessageAddressees, sanitized error
+- `pkg/messaging/validate_test.go` — added MissingID, ValidateMessageAddressees, updated project-id assertion
+- `pkg/messaging/validate_compat.go` — added metadata/channel checks
+- `pkg/messaging/validate_compat_test.go` — added metadata/channel tests
+- `pkg/messaging/envelope.go` — added PrincipalRef length limit
+- `pkg/messaging/envelope_test.go` — added PrincipalRef length tests
+- `pkg/messaging/envelope_compat.go` — fixed buildPrincipalRef for raw UUID IDs
+- `pkg/messaging/envelope_compat_test.go` — added buildPrincipalRef tests
+- `pkg/messages/types.go` — added IsValidChannel helper
+- `pkg/hub/handlers_agent_messaging.go` — wired ValidateLegacyMessage into outbound/broadcast, wired cross-project mention check
+- `pkg/hub/handlers_agent_messaging_test.go` — updated unknown type test
+- `pkg/hub/attachments_agent_test.go` — removed ThreadID from attachment test
+
+## Verification
+
+- `go build ./...` — passes
+- `go test ./pkg/messaging/...` — passes
+- `go test ./cmd/...` — passes
+- `go test ./pkg/messages/...` — passes
+- `go test ./pkg/hub/...` — passes

--- a/.design/project-log/e1-native-chat-validation.md
+++ b/.design/project-log/e1-native-chat-validation.md
@@ -1,0 +1,54 @@
+# E-1: Native Chat Validation Bypass Fix
+
+**Date:** 2026-08-27
+**Branch:** scion/ca-msg-em3
+**Task:** Wire ValidateLegacyMessage into native chat inbound path
+
+## Summary
+
+The native chat send path (`handlers_chat_v2.go:sendAgentRouted`) constructed
+and dispatched StructuredMessages without calling `ValidateLegacyMessage`. This
+was a gap in the AC-8 validation choke point — all four inbound surfaces must
+validate through the same choke point.
+
+## Changes
+
+### 1. Validation Wired into sendAgentRouted (`pkg/hub/handlers_chat_v2.go`)
+
+Added `messaging.ValidateLegacyMessage(msg)` call after the StructuredMessage is
+fully constructed (including attachment metadata and mention metadata) but before
+persist and dispatch. Uses `writeError(w, 400, "VALIDATION_ERROR", ...)` error
+pattern consistent with the native chat handler.
+
+### 2. Rule 10 Integration Test (`pkg/hub/handlers_validation_integration_test.go`)
+
+Added `TestNativeChatPath_RejectsInvalidMessage` which proves the validation call
+is load-bearing. The test sends a message with empty content but valid attachment
+through the chat endpoint. The handler allows this (attachments present), but the
+constructed StructuredMessage has Msg="" which ValidateLegacyMessage rejects.
+
+**Rule 10 proof:** When the ValidateLegacyMessage call is removed, the test fails
+(empty body reaches the store which returns 500). With the call present, the test
+passes (400 with "msg field is required").
+
+### 3. Validation Exemptions Doc (`pkg/messaging/VALIDATION_EXEMPTIONS.md`)
+
+Documented three server-generated emitters exempt from ValidateLegacyMessage:
+- Mention fan-out (sendAgentRouted) — derived from already-validated primary message
+- Notification dispatch (notifications.go) — server-internal lifecycle signals
+- Scheduler message (server.go) — previously-validated scheduled event payloads
+
+## Files Changed
+
+- `pkg/hub/handlers_chat_v2.go` — added messaging import + ValidateLegacyMessage call
+- `pkg/hub/handlers_validation_integration_test.go` — added TestNativeChatPath_RejectsInvalidMessage
+- `pkg/messaging/VALIDATION_EXEMPTIONS.md` — new file documenting exemptions
+- `.design/project-log/e1-native-chat-validation.md` — this log entry
+
+## Verification
+
+- `go build ./...` passes
+- `go test ./pkg/messaging/...` passes
+- `go test ./pkg/hub/ -run TestNativeChatPath_RejectsInvalidMessage` passes
+- `go test ./cmd/...` passes
+- Rule 10 verified: test fails when validation call is removed

--- a/.design/project-log/phase1-docs-slice.md
+++ b/.design/project-log/phase1-docs-slice.md
@@ -1,0 +1,45 @@
+# Phase 1 — Docs Slice: Port 45 Design-Log Files
+
+**Date:** 2026-08-29
+
+## What Was Done
+
+Ported 45 `.design/project-log/` markdown files from two source branches onto a
+new branch (`scion/ca-msg-em6-docs-slice`) based on current upstream/main at
+commit `a7ac9c489`.
+
+This is Phase 1 of the em9-unify re-derivation — a docs-only slice with zero
+code changes.
+
+## Source Branches and Commits
+
+| Source branch | Commit | File count |
+|---|---|---|
+| `scion/ca-msg-em9-unify` | `47a7c6736` | 40 |
+| `scion/messaging-v2` | `91c9e3146` | 5 |
+| **Total** | | **45** |
+
+## File Count Breakdown
+
+- **39 shared** — files present on both em9-unify and messaging-v2 (extracted
+  from em9-unify)
+- **1 em9-only** — `defect-principalkindFromAddress-fold.md` (exists only on
+  em9-unify)
+- **5 v2-only** — files that exist only on messaging-v2:
+  - `2026-08-27-def26-rename-placeholder-test.md`
+  - `def12-cli-command.md`
+  - `def12-store-detection.md`
+  - `def12-volume-exercise.md`
+  - `def25-grove-fixture-rename.md`
+
+## Acceptance Checks — Results
+
+| Check | Result |
+|---|---|
+| File count (`git diff --stat`) | ✅ 45 files changed, 3339 insertions(+), 0 deletions |
+| Additive check (zero deletions on main-existing files) | ✅ Empty output — all 45 files are new |
+| `check-security-marker-gates.sh` | ✅ Exit 0 — all gates pass |
+| `check-conversation-upsert-guard.sh` | ✅ Exit 0 — no violations |
+| `check-authz-guards.sh` | ✅ Exit 0 — no violations |
+| `go build ./...` | ✅ Exit 0 |
+| Branch pushed to origin | ✅ `scion/ca-msg-em6-docs-slice` |

--- a/.design/project-log/phase1-schema.md
+++ b/.design/project-log/phase1-schema.md
@@ -1,0 +1,89 @@
+# Phase 1 — Ent Schemas for Messaging Conversation Model
+
+**Date:** 2026-08-27  
+**Branch:** `dev-schema` (based on `origin/scion/messaging-v2`)  
+**Commit:** `feat(messaging): add conversation model ent schemas (Phase 1)`
+
+## Summary
+
+Created three new ent schemas for the messaging conversation model as specified
+in the design doc (§2.2, §2.3). This is purely additive — no existing schemas
+or code paths were modified.
+
+## Schemas Created
+
+### 1. `Conversation` (`pkg/ent/schema/conversation.go`)
+
+Table: `conversations`
+
+Core fields: `id` (UUID), `project_id` (optional UUID), `kind` (enum:
+direct/group), `surface` (enum: native/discord/slack/telegram/gchat/teams),
+`external_ref`, `parent_ref`, `display_name`, `default_agent_id` (UUID, not
+slug), `drift_state` (enum: active/orphaned/unresolvable), timestamps
+(`last_activity_at`, `created_at`, `archived_at`, `deleted_at`).
+
+Indexes:
+- **Partial unique index** on `(surface, external_ref)` WHERE
+  `external_ref <> '' AND deleted_at IS NULL` — implemented using
+  `entsql.IndexWhere()`, which is natively supported in ent v0.14.5.
+  Both SQLite and Postgres support this WHERE clause syntax.
+- Index on `project_id`
+- Index on `kind`
+
+### 2. `ConversationParticipant` (`pkg/ent/schema/conversation_participant.go`)
+
+Table: `conversation_participants`
+
+Fields: `id` (UUID), `conversation_id` (UUID), `principal_kind` (enum:
+user/agent), `principal_id` (string), `role` (enum: member/observer),
+`joined_at`, `left_at` (optional).
+
+Indexes:
+- Unique on `(conversation_id, principal_kind, principal_id)`
+- Index on `principal_id`
+
+### 3. `MessageAddressee` (`pkg/ent/schema/message_addressee.go`)
+
+Table: `message_addressees`
+
+Fields: `id` (UUID), `message_id` (UUID), `principal_kind` (enum: user/agent),
+`principal_id` (string), `via` (enum: explicit/body-mention/default-agent/direct),
+`delivery_state` (enum: pending/delivered/failed), `failure_reason` (optional).
+
+Indexes:
+- Unique on `(message_id, principal_kind, principal_id)`
+- Index on `message_id`
+- Composite index on `(principal_kind, principal_id, delivery_state)`
+
+## Partial Index Approach
+
+The critical partial unique index on `(surface, external_ref)` is expressed
+using ent's built-in `entsql.IndexWhere()` annotation:
+
+```go
+index.Fields("surface", "external_ref").
+    Unique().
+    Annotations(
+        entsql.IndexWhere("external_ref <> '' AND deleted_at IS NULL"),
+    ),
+```
+
+This is fully supported by ent v0.14.5 and generates the correct `WHERE` clause
+in the migration schema for both SQLite and Postgres. No raw SQL migration hooks
+are needed.
+
+## Verification
+
+1. `go generate ./pkg/ent/` — succeeded, generated all ent client code
+2. `go build ./pkg/ent/...` — compiled cleanly
+3. `go build ./...` — full project compiles with no breakage
+4. Partial index WHERE clause confirmed in `pkg/ent/migrate/schema.go`
+
+## Design Decisions
+
+- **No edges**: foreign keys (`project_id`, `default_agent_id`,
+  `conversation_id`, `message_id`) are plain UUID columns, not ent edges.
+  This keeps schemas independent and avoids modifying existing entities.
+- **`default_agent_id` is UUID**: enforces that agent slugs cannot be stored,
+  as required by the design.
+- **Enum fields**: all categorical values use `field.Enum` with `.Values()`.

--- a/.design/project-log/phase2-store.md
+++ b/.design/project-log/phase2-store.md
@@ -1,0 +1,63 @@
+# Phase 2: ConversationStore Interface + Ent Adapter
+
+**Date:** 2026-08-27
+**Branch:** dev-store (based on dev-schema)
+**Agent:** dev-store
+
+## Summary
+
+Implemented the store layer for the messaging refactor (Phase 2), building on
+the ent schemas delivered in Phase 1 (dev-schema).
+
+## Deliverables
+
+### 1. Store Models (`pkg/store/models.go`)
+- `Conversation` — conversation container with project association, kind/surface,
+  external reference, default agent, drift state, and soft-delete timestamps
+- `ConversationParticipant` — through-table linking principals to conversations
+  with role and temporal metadata
+- `MessageAddressee` — per-message addressing record with delivery tracking
+- `ConversationFilter` — query filter for listing conversations
+
+### 2. ConversationStore Interface (`pkg/store/store.go`)
+- Full CRUD: Create, Get, Update, Delete (soft), List with pagination
+- `UpsertConversationByExternalRef` — idempotent create-or-update keyed on
+  (surface, external_ref); race-safe via the partial unique index
+- Participant lifecycle: Add, Remove (soft), List, GetConversationsForPrincipal
+- Addressee management: Add, List, UpdateDeliveryState
+- Embedded in the top-level `Store` interface
+
+### 3. Ent Adapter (`pkg/store/entadapter/conversation_store.go`)
+- Follows message_store.go patterns: dedicated struct, conversion helpers,
+  consistent error mapping
+- DefaultAgentID validation rejects non-UUID values (slugs not accepted)
+- Soft-delete: DeleteConversation sets deleted_at; Get and List exclude
+  soft-deleted rows
+- Cursor-based pagination using the same encoding as message_store
+- UpsertConversationByExternalRef uses query-then-create/update pattern
+  (SQLite does not support ON CONFLICT with partial unique indexes); a
+  constraint violation on insert triggers a retry that updates the existing row
+
+### 4. CompositeStore Wiring (`pkg/store/entadapter/composite.go`)
+- Added `*ConversationStore` field and `NewConversationStore(client)` to
+  `NewCompositeStore`
+
+### 5. Tests (`pkg/store/entadapter/conversation_store_test.go`)
+24 test cases covering:
+- Basic CRUD: create, get, update, soft-delete, list
+- Soft-deleted conversations excluded from Get and List
+- List filters: kind, surface, project_id
+- Cursor-based pagination
+- DefaultAgentID validation (non-UUID rejected)
+- UpsertConversationByExternalRef: create-if-not-exists, update-if-exists
+- Concurrent upsert: 5 goroutines converge on one conversation
+- Different external_refs on same surface produce distinct conversations
+- Partial unique index: soft-deleted row allows external_ref reuse
+- Participant add/remove/list, duplicate rejection, default role
+- GetConversationsForPrincipal (excludes left participants and soft-deleted convs)
+- Addressee add/list/update-delivery-state, duplicate rejection
+- Nil ProjectID (direct conversations)
+
+## Verification
+- `go build ./...` — clean
+- `go test ./pkg/store/entadapter/ -v` — all tests pass (existing + new)

--- a/.design/project-log/phase3-resolution.md
+++ b/.design/project-log/phase3-resolution.md
@@ -1,0 +1,64 @@
+# Phase 3: ResolveConversation Service & DriftState Logic
+
+**Date:** 2026-08-27
+**Branch:** dev-resolution (based on dev-store)
+**Author:** dev-resolution agent
+
+## Summary
+
+Implemented the conversation resolution layer (`pkg/messaging/`) as Phase 3 of
+the messaging refactor. This is pure logic — no HTTP handlers, no CLI wiring.
+
+## Deliverables
+
+| File | Purpose |
+|------|---------|
+| `pkg/messaging/resolve.go` | Reference parser and `Resolve()` function |
+| `pkg/messaging/resolve_test.go` | 26 tests covering all resolution paths |
+| `pkg/messaging/normalize.go` | `NormalizeAgentRef` shared helper |
+| `pkg/messaging/normalize_test.go` | 8 tests for normalization |
+| `pkg/messaging/drift.go` | `TransitionDriftState` pure function |
+| `pkg/messaging/drift_test.go` | 11 tests for drift state machine |
+
+## Key Design Decisions
+
+### Reference Grammar (§2.6)
+
+Four forms accepted: `conv:<uuid>`, `@<agent-slug>`, `@<email>`, `#<thread-name>`.
+The parser rejects `#<space>/<thread>` per AC-31.
+
+### Project Isolation (AC-30)
+
+For `conv:<id>` references pointing to another project:
+- Sender belongs to that project → `boundary-violation` error
+- Sender does NOT belong → `not-found` error (identical to genuinely missing)
+- Conversations with nil ProjectID (global DMs) → always allowed
+
+Project membership is determined by checking if the sender participates in any
+conversation within the target project.
+
+### Resolve-or-Create
+
+`@<agent-slug>` and `@<email>` use resolve-or-create: they find an existing
+direct conversation or create a new one with both parties as participants.
+`@<email>` creates global DMs (nil ProjectID).
+
+### ResolutionStore Interface
+
+A `ResolutionStore` interface defines the minimal subset of store methods needed,
+decoupling the resolution package from the full `store.Store`.
+
+## NormalizeAgentRef Import Path
+
+```
+github.com/GoogleCloudPlatform/scion/pkg/messaging.NormalizeAgentRef
+```
+
+This function is the single source of truth for agent slug/UUID resolution.
+Phase 4 (backfill) should import it from this path.
+
+## Verification
+
+- `go build ./pkg/messaging/...` — clean
+- `go test ./pkg/messaging/... -v` — 45 tests pass
+- `go build ./...` — full project build clean

--- a/.design/project-log/s2-fix-round3.md
+++ b/.design/project-log/s2-fix-round3.md
@@ -1,0 +1,52 @@
+# S2 Fix Round 3: Non-tautological divergence, thread dual-write, global DM ProjectID
+
+**Date**: 2026-08-27
+**Branch**: `scion/dev-fix-round3`
+**Author**: dev-fix-round3
+
+## Summary
+
+Addressed three architect findings from S2 round 2 review:
+
+### C-3: DM conversations must not have ProjectID
+
+- Removed the `if projectID != "" { conv.ProjectID = &projectID }` block from `ResolveOrCreateDMConversation`
+- Removed `projectID` from the function signature entirely
+- DM conversations are now always created with `ProjectID = nil` (global per design 2.4.1)
+- This prevents project-isolation bugs where DMs stamped with project X become inaccessible from project Y
+
+### C-1: Non-tautological ComputeDivergenceMatch
+
+- Added `ConversationResult` type carrying both `ConversationID` and `ExternalRef` from the database
+- Changed `ResolveOrCreateDMConversation` to return `*ConversationResult` (nil on failure) instead of a string
+- Rewrote `ComputeDivergenceMatch` signature to `(oldRouting, actualExternalRef, convID string)` — the comparison now uses the actual `ExternalRef` from the DB, not a value reconstructed from inputs
+- Supports both DM comparison (`sender-recipient:` vs `dm:`) and thread comparison (`thread:{threadID}` vs `thread:{projectID}:{threadID}`)
+- Added mandatory genuine disagreement test that constructs different sender/recipient pairs and asserts `match==false`
+- Added thread disagreement test and routing-type-mismatch test
+
+### C-2: Thread conversation resolution in dual-write
+
+- Added `ResolveOrCreateThreadConversation` function for thread-based conversations with external ref format `thread:{projectID}:{threadID}`
+- Thread conversations are project-scoped (ProjectID is set, unlike DMs)
+- Updated all 6 call sites in `handlers_agent_messaging.go` and `messagebroker.go` to:
+  - Route to `ResolveOrCreateThreadConversation` when `threadID != ""`
+  - Route to `ResolveOrCreateDMConversation` when sender/recipient are present
+  - Use `ConversationResult` for both conversation ID and actual external ref
+  - Pass actual external ref to `ComputeDivergenceMatch`
+- Preserved `!msg.Broadcasted` guards on broker call sites
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `pkg/messaging/conversation.go` | Added `ConversationResult`, `ResolveOrCreateThreadConversation`; removed projectID from DM resolution; changed return type to `*ConversationResult` |
+| `pkg/messaging/divergence.go` | Rewrote `ComputeDivergenceMatch` for non-tautological comparison with DM and thread support |
+| `pkg/hub/handlers_agent_messaging.go` | Updated 4 call sites for new signatures and thread routing |
+| `pkg/hub/messagebroker.go` | Updated 2 call sites for new signatures and thread routing |
+| `pkg/messaging/conversation_test.go` | Updated DM tests for new signature; added thread conversation tests |
+| `pkg/messaging/divergence_test.go` | Updated for new signature; added genuine disagreement, thread disagreement, routing-type-mismatch tests |
+
+## Verification
+
+- `go build ./...` passes
+- `go test ./pkg/messaging/...` passes (55 tests, 0 failures)

--- a/.design/project-log/s2-foundation-schema.md
+++ b/.design/project-log/s2-foundation-schema.md
@@ -1,0 +1,51 @@
+# S2 Foundation: Add conversation_id to Message Schema
+
+**Date:** 2026-08-27
+**Author:** dev-foundation
+**Phase:** S2 – Messaging Conversation Model Refactor
+
+## Summary
+
+Added the `conversation_id` field to the Message ent schema, store model, and
+ent adapter. This is the foundational schema change that links existing messages
+to Conversation records (created in S1). The field is optional and nullable,
+allowing incremental population via backfill (Phase 4) and dual-write (Phase 5).
+
+## Changes
+
+### 1. Ent Schema (`pkg/ent/schema/message.go`)
+- Added `conversation_id` as an optional, nillable UUID field after `thread_id`.
+- Added an index on `conversation_id` for efficient lookups.
+
+### 2. Ent Code Generation
+- Ran `go generate ./pkg/ent/` — all generated files updated to include
+  `ConversationID *uuid.UUID`, setters (`SetConversationID`,
+  `SetNillableConversationID`, `ClearConversationID`), and query predicates.
+
+### 3. Store Model (`pkg/store/models.go`)
+- Added `ConversationID string` field to `Message` struct with
+  `json:"conversationId,omitempty"` tag, placed after `ThreadID`.
+
+### 4. Ent Adapter (`pkg/store/entadapter/message_store.go`)
+- **`entMessageToStore()`**: Maps `*uuid.UUID` → `string` (empty string when nil).
+- **`CreateMessage()`**: Parses and sets `conversation_id` when
+  `msg.ConversationID` is non-empty.
+- **`SetMessageConversationID()`**: New method that updates `conversation_id` on
+  an existing message row. Used by Phase 4 backfill. Returns `ErrNotFound` if
+  the message does not exist.
+
+### 5. Store Interface (`pkg/store/store.go`)
+- Added `SetMessageConversationID(ctx, messageID, conversationID string) error`
+  to `MessageStore` interface.
+
+## Verification
+
+- `go build ./...` — passes
+- `go test ./pkg/store/entadapter/... -count=1` — passes (5.3s)
+
+## Notes
+
+- The field is intentionally optional/nillable: existing rows will have
+  `NULL` until the Phase 4 backfill populates them.
+- No migration file is generated here — ent auto-migration handles schema
+  changes at startup.

--- a/.design/project-log/s2-phase4-backfill.md
+++ b/.design/project-log/s2-phase4-backfill.md
@@ -1,0 +1,75 @@
+# S2 Phase 4: Backfill Service for Conversation Attribution
+
+**Date:** 2026-08-27
+**Author:** dev-backfill
+**Branch:** scion/ca-msg-em2
+
+## Summary
+
+Implemented the Phase 4 backfill service that scans existing messages and groups
+them into Conversation records. The service stamps each message with the
+appropriate `conversation_id`, enabling the transition from legacy flat messages
+to the structured conversation model.
+
+## Files Created
+
+- `pkg/messaging/backfill.go` — BackfillService, BackfillConfig, BackfillResult
+- `pkg/messaging/backfill_test.go` — 19 test cases covering all acceptance criteria
+
+## Design Decisions
+
+### Conversation Key Strategy
+- **Direct conversations:** Canonical key from sorted `(kind:id, kind:id)` pairs
+  within a project. Sorting ensures `(A→B)` and `(B→A)` map to the same conversation.
+- **Thread conversations:** Key from `(projectID, threadID)`. Kind is "group".
+- Keys are stored as `ExternalRef` on the Conversation record, enabling
+  idempotent upserts via `UpsertConversationByExternalRef`.
+
+### Hazard (a): Email-Based DM Keys
+Legacy messages with non-UUID sender/recipient IDs (e.g. `alice@example.com`)
+are flagged as "inferred". A conversation is still created and stamped, but the
+result tracks `HazardAEmailCount` for reporting.
+
+### Hazard (b): DefaultAgent Slug-or-UUID Union
+Agent references are resolved exclusively through `NormalizeAgentRef` (binding
+decision D2). Three outcomes:
+- UUID → used directly as DefaultAgentID
+- Slug resolved → UUID used, hazard-B count incremented
+- Slug not found (deleted agent) → drift state set to "orphaned"
+- Invalid ref (neither UUID nor slug) → treated as inferred
+
+### Three Operating Modes
+1. **Dry-run:** Computes statistics without any writes (no conversations created,
+   no messages stamped).
+2. **Idempotent:** Skips messages that already have a `conversation_id`.
+3. **Resumable:** Accepts a checkpoint message ID; only processes messages created
+   after the checkpoint's `created_at` timestamp.
+
+## Test Coverage
+
+| Test | What it verifies |
+|------|-----------------|
+| NormalDirectMessages | Two-direction pair grouping, separate conversations |
+| ThreadBasedGrouping | Thread ID creates group conversation |
+| BroadcastedMessagesSkipped | Broadcast exclusion |
+| HazardA_EmailBasedDMKeys | Non-UUID sender flagged as inferred |
+| HazardA_BothSidesEmail | Both sides non-UUID |
+| HazardB_SlugResolution | Slug resolved via NormalizeAgentRef |
+| HazardB_DeletedAgent | Deleted agent → orphaned drift state |
+| HazardB_InvalidAgentRef | Invalid ref → inferred |
+| DryRun | No side effects, statistics only |
+| Idempotent | Second run skips already-stamped messages |
+| Resumable | Checkpoint skips earlier messages |
+| ConversationParticipants | Both sender and recipient added |
+| ConversationExternalRef | Upsert key set correctly |
+| MixedDirectAndThread | Same participants, different key types |
+| CheckpointNotFound | Error on invalid checkpoint |
+| LastCheckpointTracked | Result tracks last processed ID |
+| DefaultBatchSize | Empty project handled gracefully |
+| ParsePrincipal | Helper unit tests |
+| IsValidUUID | Helper unit tests |
+
+## Verification
+
+- `go build ./...` — passes
+- `go test ./pkg/messaging/... -count=1` — all tests pass (0.005s)

--- a/.design/project-log/s215-groupmsg-m1-proof.md
+++ b/.design/project-log/s215-groupmsg-m1-proof.md
@@ -1,0 +1,38 @@
+# S215 Group Message M1 Proof Test
+
+**Date:** 2026-08-27
+**Tracking:** AC-S215-M1
+**Author:** dev-groupmsg-m1-test agent
+
+## Summary
+
+Added `TestHandleGroupMessage_ThreadID_NotPropagated` in
+`pkg/hub/handlers_read_switch_test.go` to prove that `handleGroupMessage`
+does not propagate a caller-supplied `ThreadID` into persisted message rows
+and does not use it for conversation key derivation.
+
+## Background
+
+The security auditor flagged M1 (Medium): `handleGroupMessage` bypasses
+`DeriveConversationKey` and uses `ResolveOrCreateDMConversation` directly.
+The architect's response was: "'Not exploitable, no ThreadID in group
+messages' is a claim about code -- prove it with a test."
+
+## What the test proves
+
+1. A `StructuredMessage` with `ThreadID: "thread:proj:some-thread-id"` is
+   sent through the inbound handler (`handleAgentMessage`) with a
+   `group[agent:target-agent,agent:anchor-agent]` recipient.
+2. After the handler persists the messages, **none** of the stored
+   `store.Message` rows carry a non-empty `ThreadID`.
+3. The `GroupID` assigned to the messages is a fresh UUID, not derived
+   from the injected `ThreadID`.
+
+This confirms that `handleGroupMessage` constructs `store.Message` structs
+directly (lines ~967-984 and ~1062-1078) without copying the
+`StructuredMessage.ThreadID` field, making the ThreadID injection path
+inert.
+
+## Files changed
+
+- `pkg/hub/handlers_read_switch_test.go` (new) -- the proof test

--- a/.design/project-log/s215-validDMKey-coexistence-test.md
+++ b/.design/project-log/s215-validDMKey-coexistence-test.md
@@ -1,0 +1,45 @@
+# S215: validDMKey coexistence test
+
+**Date:** 2026-08-27
+**Trace:** AC-S215-COEXISTENCE
+
+## Summary
+
+Added `TestValidDMKey_CoexistenceWithDeriveConversationKey` to
+`pkg/hub/handlers_read_switch_test.go`. The test proves two properties of the
+outbound message handler's DM key guards:
+
+1. **validDMKey rejects malformed `dm:` keys and prevents message persistence.**
+   A ThreadID like `dm:bot:<uuid>:user:<uuid>` (where "bot" is not "user" or
+   "agent") fails the `dmKeyRegexp`, returns HTTP 400, and no message or
+   conversation row is written to the store.
+
+2. **DeriveConversationKey guards only the conversation row, not the message row.**
+   A non-canonical key `dm:user:<userUUID>:agent:<agentUUID>` passes the
+   `validDMKey` regex but fails `DeriveConversationKey`'s canonicality check
+   (the canonical form puts agent first: `dm:agent:...:user:...`). The message
+   IS persisted with the non-canonical ThreadID, but no conversation row is
+   created. This confirms the two guards protect different sinks.
+
+## Side fix
+
+Fixed pre-existing build failure in `handlers_agent_messaging_test.go` where
+three references to `messaging.DirectMessageExternalRef` (unexported after
+DEF-8 refactoring) were replaced with a local `testDirectMessageExternalRef`
+helper that reproduces the legacy external ref format needed for divergence
+tests.
+
+## Files changed
+
+- `pkg/hub/handlers_read_switch_test.go` -- added coexistence test
+- `pkg/hub/handlers_agent_messaging_test.go` -- fixed build (DirectMessageExternalRef)
+
+## Verification
+
+```
+go test ./pkg/hub/... -run TestValidDMKey_CoexistenceWithDeriveConversationKey -v -count=1
+--- PASS (both sub-tests)
+
+go test ./pkg/hub/... -run "TestDEF11_PreResolved|TestDEF11.*Genuine" -v -count=1
+--- PASS (all DEF11 divergence tests still pass)
+```

--- a/.design/project-log/s3-phase6-envelope-types.md
+++ b/.design/project-log/s3-phase6-envelope-types.md
@@ -1,0 +1,112 @@
+# S3 Phase 6: New Envelope Types and Taxonomy Split
+
+**Date:** 2026-08-27
+**Author:** dev-envelope-types
+**Branch:** scion/ca-msg-em3 (based on scion/messaging-v2)
+
+## What was built
+
+### New types (`pkg/messaging/envelope.go`)
+
+Defined the new envelope types that replace the old `StructuredMessage` and its
+8-value type enum. The key design decision is the **split taxonomy**:
+
+| Layer | Type | Values |
+|-------|------|--------|
+| Kind | `MessageKind` | `text`, `event` |
+| Intent (text only) | `TextIntent` | `inform`, `request`, `question` |
+| Event type (event only) | `EventType` | `agent.state-changed`, `agent.input-needed`, `delivery.failed`, `schedule.fired`, `port.exposed` |
+
+Supporting types:
+- `PrincipalRef` — `kind:id` format (user/agent/system) with parsing helpers
+- `AddressedVia` — how an addressee was selected (explicit, body-mention, default-agent, direct)
+- `DeliveryState` — per-addressee tracking (pending, delivered, failed)
+- `Visibility` — consumer filtering (normal, verbose, full)
+- `Message` — the new envelope struct with kind/intent mutual exclusivity validation
+- `Addressee` — per-recipient delivery record
+- `EventBody` — structured event payload (type, subject, status, reason, url)
+- `AttachmentRef` — file reference with path and optional name
+
+All enum types have validation functions and registered value maps.
+
+### Compatibility layer (`pkg/messaging/envelope_compat.go`)
+
+Three mapping functions bridge old and new formats:
+
+1. **`MapLegacyType(oldType, systemCategory, hasAddressee)`** — maps the old 8-value
+   type to the new split taxonomy
+2. **`MapLegacyEnvelope(old)`** — full `StructuredMessage` → `Message` + `[]Addressee`
+3. **`NewEnvelopeToLegacy(msg, addrs)`** — reverse for backward compatibility
+
+Plus `MapLegacyDeliveryArtifact(oldType)` for extracting `AddressedVia` from
+delivery artifact types.
+
+## Mapping table
+
+| Old type | New kind | New intent/event | Notes |
+|----------|----------|-----------------|-------|
+| `instruction` | `text` | `intent: request` | Clean mapping |
+| `chat` | `text` | `intent: inform` | Clean mapping |
+| `assistant-reply` | `text` | `intent: inform` | Provenance now in `from` field |
+| `input-needed` (addressed) | `text` | `intent: question` | Ambiguous — splits on hasAddressee |
+| `input-needed` (broadcast) | `event` | `event.type: agent.input-needed` | Ambiguous — splits on hasAddressee |
+| `state-change` | `event` | `event.type: agent.state-changed` | Clean mapping |
+| `system` (scheduler) | `event` | `event.type: schedule.fired` | Maps system_category metadata |
+| `system` (port-forward) | `event` | `event.type: port.exposed` | Maps system_category metadata |
+| `system` (delivery-failed) | `event` | `event.type: delivery.failed` | Maps system_category metadata |
+| `system` (unknown) | `event` | `event.type: agent.state-changed` | Fallback with log warning |
+| `mention` | `text` | `intent: request` | Delivery artifact → addressee via=body-mention |
+| `group-set` | `text` | `intent: request` | Delivery artifact → addressee via=explicit |
+
+## Ambiguous cases
+
+### `input-needed`
+This old type conflates two concepts: (1) an agent asking a specific person a
+question, and (2) a system notification that an agent needs input. The split
+uses `hasAddressee` (recipient set and not broadcast) to distinguish. When
+addressed → `text/question`; when broadcast → `event/agent.input-needed`.
+
+### `system`
+The old `system` type requires `system_category` metadata to determine the
+specific event. Unknown categories default to `agent.state-changed` with a log
+warning rather than failing, to be resilient to new categories added before the
+mapping is updated.
+
+### `mention` and `group-set`
+These are delivery artifacts, not message kinds. The old format used them as
+message types, but they really describe *how* a recipient was selected. In the
+new format, this information moves to `Addressee.Via`. The mapping returns the
+underlying message kind/intent (`text/request`) and a separate function
+provides the `AddressedVia` value.
+
+## Decisions made
+
+1. **Synthesised message IDs** — The old format has no ID field. Legacy envelope
+   conversion synthesises IDs as `legacy-{timestamp}`. Production callers
+   should assign real IDs before persisting.
+
+2. **Sender heuristic** — When `SenderID` is empty, `buildPrincipalRef` checks
+   if the `Sender` string already has a colon prefix (e.g. `agent:builder`).
+   If not, it defaults to `system:{name}`.
+
+3. **Round-trip fidelity** — The old→new→old round-trip preserves essential
+   semantics (type, body, sender, status) but not all fields. The old format
+   cannot represent multiple addressees, delivery state, or the kind/intent
+   split, so some information is lost in the reverse direction.
+
+4. **Visibility mapping** — Empty visibility in the old format maps to
+   `VisibilityNormal` in the new format, and `VisibilityNormal` maps back to
+   empty (matching old convention of empty = normal).
+
+## Test coverage
+
+- 40+ tests in `envelope_test.go` covering all enum validations, `Message.Validate`
+  mutual exclusivity (text-without-intent, text-with-event, event-without-body,
+  event-with-intent), `Addressee.Validate`, `EventBody.Validate`, `PrincipalRef`
+  parsing.
+- 30+ tests in `envelope_compat_test.go` covering all 8 old type values
+  (table-driven), both `input-needed` scenarios, all `system` category variants,
+  delivery artifact via extraction, full envelope conversion, visibility mapping,
+  attachment mapping, and round-trip tests in both directions.
+
+All tests pass: `go test ./pkg/messaging/... -count=1` and `go build ./...`.

--- a/.design/project-log/s3-phase7-validate.md
+++ b/.design/project-log/s3-phase7-validate.md
@@ -1,0 +1,81 @@
+# Phase 7: Validation Choke Point
+
+**Date:** 2026-08-27
+**Agent:** dev-validate
+**Branch:** scion/ca-msg-em3
+**Status:** Complete
+
+## Summary
+
+Implemented a single validation choke point for the new message envelope types
+and wired it into all three inbound paths. This closes the defect where
+`StructuredMessage.Validate()` was never called on hub inbound paths (findings
+section 6).
+
+## Deliverables
+
+### 1. `pkg/messaging/validate.go`
+- `ValidateMessage(msg *Message) error` — checks ConversationID, From, Kind,
+  intent/event mutual exclusivity, body size limits, attachment count,
+  visibility, and reply_to_id.
+- `ValidateAddressees(addrs []Addressee, msg *Message) error` — checks
+  PrincipalKind, PrincipalID, Via, DeliveryState, and duplicate detection
+  using a deterministic `kind:id` composite key.
+- `ValidateCrossProjectAddressees(ctx, agentStore, addrs) error` (AC-33 / DEF-2)
+  — ensures all agent addressees belong to the same project. User addressees
+  are exempt. Names conflicting projects in the error message per design §2.4.1.
+- `AgentProjectLookup` interface — minimal store dependency for the cross-project
+  check.
+
+### 2. `pkg/messaging/validate_compat.go`
+- `ValidateLegacyMessage(msg *StructuredMessage) error` — the adapter that makes
+  old envelopes go through the new validation choke point. Checks legacy-specific
+  invariants (thread_id requires channel, type enum, channel length) then
+  converts via `MapLegacyEnvelope` and runs `ValidateMessage` and
+  `ValidateAddressees`. Sets a synthetic ConversationID since legacy messages
+  don't have one yet.
+
+### 3. Wiring into inbound paths (AC-8)
+- **Hub handler** (`handlers_agent_messaging.go`): validation after message
+  assembly, before mentions cap.
+- **Broker inbound** (`handlers_broker_inbound.go`): validation after "!"
+  interrupt processing, before dispatch.
+- **CLI** (`cmd/message.go`): validation after `buildStructuredMessage` in the
+  primary send and broadcast paths.
+
+### 4. Tests
+- `validate_test.go`: 30 tests covering every ValidateMessage rule, every
+  ValidateAddressees rule, and AC-33 cross-project check (including the
+  Rule 10 load-bearing test).
+- `validate_compat_test.go`: 12 tests covering the legacy adapter, including the
+  Teams regression (channel="" + thread_id=set).
+- `handlers_validation_integration_test.go`: 3 integration tests proving AC-8
+  (invalid messages rejected at hub handler and broker inbound paths; valid
+  messages pass through).
+
+## Acceptance Criteria Status
+
+| AC | Description | Status |
+|----|-------------|--------|
+| AC-8 | Validate() invoked on all three inbound paths | ✓ |
+| AC-33 | No single message has agent addressees in >1 project | ✓ |
+| Teams regression | channel="" + thread_id=set rejected at hub boundary | ✓ |
+| Rule 10 | Every validation rule has a failing-when-removed test | ✓ |
+| Build | `go build ./...` passes | ✓ |
+| Tests | `go test ./pkg/messaging/... ./cmd/...` passes | ✓ |
+
+## Design Decisions
+
+1. **Synthetic ConversationID for legacy messages**: Legacy StructuredMessages
+   don't carry a ConversationID (that's resolved by Phase 4/5 conversation
+   attribution). The compat adapter sets `"legacy-pending"` to pass the
+   required-field check without weakening the validator.
+
+2. **Duplicate key is `kind:id`**: The addressee deduplication key uses
+   `PrincipalKind + ":" + PrincipalID` — a single constructor, so two code
+   paths cannot produce the same key differently.
+
+3. **Agent sender in broker integration tests**: The broker inbound handler
+   checks user identity (requires store lookup) before reaching validation.
+   Integration tests use `agent:` senders to bypass this, testing validation
+   in isolation from user identity resolution.

--- a/.design/project-log/s3-phase9-delivery-format.md
+++ b/.design/project-log/s3-phase9-delivery-format.md
@@ -1,0 +1,75 @@
+# Phase 9 — New Delivery Format
+
+**Agent:** dev-delivery-format
+**Branch:** `scion/ca-msg-em3` (base: `scion/messaging-v2`)
+**Date:** 2026-08-27
+
+## Summary
+
+Replaced the agent-facing delivery JSON with a new conversation-based format that
+delivers `status` and `visibility` as structured fields, removes the metadata
+allowlist, and gives agents a clean envelope they can act on without parsing prose.
+
+## Problem
+
+The old `deliveryMessage` in `pkg/messages/format.go` dropped critical fields before
+the agent saw them:
+
+- **`status`** — the only machine-readable value on lifecycle events, forcing agents
+  to parse English prose to determine completion state.
+- **`visibility`** — agents had no way to know their message's visibility level.
+- **Addressing** — `broadcasted` was a flat boolean; no structured addressee list.
+- **Metadata allowlist** — 5 keys smuggled through a generic map instead of being
+  first-class fields.
+
+## Changes
+
+### New files
+
+| File | Purpose |
+|---|---|
+| `pkg/messaging/delivery.go` | `ConversationInfo`, `DeliveryEnvelope`, `DeliveryOptions`, `FormatNewDelivery()` |
+| `pkg/messaging/delivery_compat.go` | `FormatLegacyAsNewDelivery()` — adapter from `StructuredMessage` to new format |
+| `pkg/messaging/delivery_test.go` | 13 tests covering all delivery format behaviour |
+| `pkg/messaging/delivery_compat_test.go` | 11 tests covering legacy adapter and round-trip |
+
+### Key design decisions
+
+1. **New format alongside old** — `FormatForDelivery()` in `pkg/messages/format.go`
+   is untouched. The new `FormatNewDelivery()` lives in `pkg/messaging/delivery.go`.
+   Callers switch when ready; no breaking change.
+
+2. **Conversation as first-class context** — `conversation` replaces `channel` +
+   `thread_id`. Agents get `conversation.id` to echo on replies (AC-11).
+
+3. **Kind/intent/event taxonomy** — `kind` + `intent`/`event` replace the overloaded
+   `type` enum. Event messages carry `event.status` as a structured field (AC-10).
+
+4. **Closed field set** — No `metadata` map, no `broadcasted`, no `urgent`. The
+   envelope has exactly the fields agents need (AC-12).
+
+5. **Legacy adapter** — `FormatLegacyAsNewDelivery()` converts `StructuredMessage`
+   via Phase 6's `MapLegacyEnvelope()`, synthesizing `ConversationInfo` when none is
+   available. This enables the new format even before all callers have migrated.
+
+6. **Delimiters unchanged** — `---BEGIN SCION MESSAGE---` / `---END SCION MESSAGE---`
+   remain identical for backward-compatible parsing.
+
+## Acceptance Criteria
+
+- **AC-10** ✅ `status` on lifecycle events is a structured field (`event.status`) in the
+  delivery JSON, verified by `TestFormatNewDelivery_EventWithStatus` and
+  `TestFormatLegacyAsNewDelivery_EventStatusDelivered`.
+- **AC-11** ✅ `conversation.id` is present in every delivery envelope.
+- **AC-12** ✅ Closed, small set of fields — no metadata map, no broadcasted flag.
+- ✅ `visibility` delivered to agents.
+- ✅ Plain/raw delivery returns raw text.
+- ✅ Delimiters identical to existing format.
+- ✅ `go test ./pkg/messaging/...` passes (24 new tests, all existing tests unaffected).
+- ✅ `go build ./...` passes.
+
+## Boundaries
+
+- Did NOT modify `FormatForDelivery()` in `pkg/messages/format.go`.
+- Did NOT modify hub handlers, CLI, or broker code.
+- Did NOT modify envelope types in `pkg/messaging/envelope.go` (Phase 6 owns those).


### PR DESCRIPTION
Phase 1 of re-deriving the messaging work onto current main in slices. Docs only, zero code.

Adds 45 design-log files: the union of scion/ca-msg-em9-unify and scion/messaging-v2 minus main. Neither branch is a superset of the other, so both were needed - 40 from em9, 5 from v2.

Verified: set equality against an independently computed delta set, zero deletions, all 45 are new files, go build exit 0, and all three guard scripts taken from main (not from the branch) exit 0.

This slice deliberately carries no risk. Its purpose is to exercise the slice landing protocol end to end before production code rides on it