### PR TITLE
ci: gate Broadcasted forcing, parseDMKeyIDs ownership, and isDMParticipant (#1322, B5)

### DIFF
--- a/hack/check-security-marker-gates.sh
+++ b/hack/check-security-marker-gates.sh
@@ -52,6 +52,18 @@
 #     REQUIRED: fanOutToProject x3 (B5/R1 — broadcast self-skip by canonical ID)
 #     REQUIRED: fanOutGlobal x3 (B5/R1 — global broadcast self-skip by canonical ID)
 #
+#   Broadcasted in handlers_agent_messaging.go:
+#     REQUIRED: handleProjectBroadcast x1 (B5 — server-side broadcast forcing)
+#
+#   parseDMKeyIDs in handlers_agent_messaging.go:
+#     REQUIRED: handleAgentOutboundMessage x1, handleAgentMessage x1 (#1322 — DM key ownership)
+#
+#   parseDMKeyIDs in handlers_chat_v2.go:
+#     REQUIRED: func definition x1 (#1322 — must exist)
+#
+#   isDMParticipant in handlers_chat_v2.go:
+#     REQUIRED: func definition x1 (#1322 — kind-label tightening, must exist)
+#
 #   handlers_broker_inbound.go (parallel entry point to handlers_agent_messaging):
 #     REQUIRED: ActionAttach x1 in handleBrokerInbound (#1347 — broker inbound authz)
 #     REQUIRED: CheckAccess x1 in handleBrokerInbound (#1347 — policy check)

--- a/hack/checksecuritymarkergates/main.go
+++ b/hack/checksecuritymarkergates/main.go
@@ -158,6 +158,39 @@ func main() {
 		rc = 1
 	}
 
+	// --- Broadcasted forcing in handlers_agent_messaging.go ---
+
+	// REQUIRED: Broadcasted = true server-side forcing in handleProjectBroadcast.
+	// Without this, a client setting Broadcasted=false walks the message through
+	// the DM path with a spoofed sender, bypassing broadcast authorization.
+	assertRequired(
+		"Broadcasted in handleProjectBroadcast (B5 — server-side broadcast forcing)",
+		ham, hamPath, "handleProjectBroadcast", "Broadcasted", 1)
+
+	// --- parseDMKeyIDs in handlers_agent_messaging.go ---
+
+	// REQUIRED: DM key ownership verification (#1322).
+	// parseDMKeyIDs validates that the DM thread_id matches the resolved sender
+	// and agent. Without it, a user can claim a DM key belonging to another
+	// user's conversation.
+	assertRequired(
+		"parseDMKeyIDs in handleAgentOutboundMessage (#1322 — DM key ownership)",
+		ham, hamPath, "handleAgentOutboundMessage", "parseDMKeyIDs", 1)
+
+	assertRequired(
+		"parseDMKeyIDs in handleAgentMessage (#1322 — DM key ownership)",
+		ham, hamPath, "handleAgentMessage", "parseDMKeyIDs", 1)
+
+	// --- parseDMKeyIDs and isDMParticipant definitions in handlers_chat_v2.go ---
+
+	assertFuncDef(
+		"parseDMKeyIDs function definition (#1322 — must exist)",
+		hcv, hcvPath, "parseDMKeyIDs", 1)
+
+	assertFuncDef(
+		"isDMParticipant function definition (#1322 — kind-label tightening, must exist)",
+		hcv, hcvPath, "isDMParticipant", 1)
+
 	// --- SenderID in messagebroker.go ---
 
 	// REQUIRED: 3 uses in fanOutToProject (B5/R1 — broadcast self-skip by ID)


### PR DESCRIPTION
Adds five rows to the security marker gate, closing three gaps found by diffing the prohibition list against what the gate actually enforces. Gate now carries 25 rows.

- Broadcasted in handleProjectBroadcast (B5)
- parseDMKeyIDs in handleAgentOutboundMessage (#1322)
- parseDMKeyIDs in handleAgentMessage (#1322)
- parseDMKeyIDs function definition (#1322)
- isDMParticipant function definition (#1322)

Each row was mutation-tested per function, not by deleting the symbol globally, since a global delete proves only that something fires and not that a row is scoped where it claims. All five exit 1 and fire their own row. Clean tree exits 0.

parseDMKeyIDs occurs in two distinct functions at one call each, not twice in one function; measured by AST.

Not gateable by identifier counting, recorded so their absence is not mistaken for coverage: EnsureParticipant left_at, the direct-conversation external_ref predicate, and the P2 series