### PR TITLE
test(hub): repair two stale tests that keep pkg/hub red

### DIFF
--- a/pkg/hub/authz_agent_baseline_test.go
+++ b/pkg/hub/authz_agent_baseline_test.go
@@ -559,13 +559,16 @@ func TestTemplateResource_UATConfinement(t *testing.T) {
 			"confinement must not fire on the token's own project")
 	})
 
-	// Global templates remain parentless and so remain outside UAT project
-	// confinement. That is unchanged by this commit and is called out here so
-	// the gap is recorded rather than assumed fixed: a project-pinned UAT can
-	// still reach global templates, subject to policy.
-	t.Run("global template is still not confined (unchanged)", func(t *testing.T) {
+	// Global templates are hub-level resources (no project parent). Since
+	// 943241adb (#1327, P2-A2), enforceUATConstraints denies project-scoped
+	// UATs access to hub-level resources. This test asserts the denial is
+	// applied.
+	t.Run("global template is denied as hub-level resource", func(t *testing.T) {
 		r := templateResource(&store.Template{ID: "tmpl-global", Scope: store.TemplateScopeGlobal})
-		assert.Nil(t, authz.enforceUATConstraints(scoped, r, ActionRead))
+		decision := authz.enforceUATConstraints(scoped, r, ActionRead)
+		require.NotNil(t, decision, "project-scoped UAT must be denied access to hub-level global template")
+		assert.False(t, decision.Allowed)
+		assert.Equal(t, "token not scoped for hub-level resources", decision.Reason)
 	})
 }
 

--- a/pkg/hub/scoped_admin_test.go
+++ b/pkg/hub/scoped_admin_test.go
@@ -380,7 +380,7 @@ func TestScopedAdmin_ProjectAdminDeniedUnboundProject(t *testing.T) {
 
 	// A project-admin for X should not have admin access to project Y.
 	// The user can read project Y only if policies allow it (default deny for non-members).
-	rec := doRequestAsUser(t, srv, projectAdmin, http.MethodPut, "/api/v1/projects/"+projectY.ID, map[string]interface{}{
+	rec := doRequestAsUser(t, srv, projectAdmin, http.MethodPatch, "/api/v1/projects/"+projectY.ID, map[string]interface{}{
 		"name": "Renamed",
 	})
 	// Project admin for X should not be able to modify project Y


### PR DESCRIPTION
`go test ./pkg/hub/` is red on main with two failures. Both are stale tests, not product defects. Diff is test files only.

1. **TestTemplateResource_UATConfinement/global_template_is_still_not_confined** (#1034) asserts global templates are not confined. The deny at authz.go:1013-1016 landed 16 days later in 943241adb (#1327) without updating the test. Assertion flipped; it now pins Reason as well as Allowed, so it is stricter than what it replaces.

2. **TestScopedAdmin_ProjectAdminDeniedUnboundProject** sends PUT to /api/v1/projects/{id}, but the router accepts GET/PATCH/DELETE only - so it returned 405 before any auth check ran and had never reached the authz layer it is named for. Method corrected to PATCH; the endpoint returns 403 and the existing assertion is unchanged. That 403 was confirmed independently, since a 2xx would have meant a real authorization gap behind a broken test.

Suite: 0 failures, 334s, no flake. Restores pkg/hub as a gate that can be required again.