### PR TITLE
docs: nightly doc update Aug 29 (Permissions P2 UI, UAT scopes, DM security)

### DIFF
--- a/docs-site/src/content/docs/hosted/ha/permissions.md
+++ b/docs-site/src/content/docs/hosted/ha/permissions.md
@@ -251,14 +251,16 @@ When an agent creates a child agent (for example, to delegate a sub-task), the s
 - **Strict Scoping**: Agent identities are strictly scoped by their project using a specific naming convention (e.g., `project--agent`). This prevents name collisions across different workspaces and ensures that progeny agents cannot impersonate or interfere with agents in other projects.
 - **Granular Secret Access**: Progeny agents inherit granular secret access controls from their parents, ensuring they only have the credentials necessary to perform their specific tasks.
 
-## Managing Users and Groups
+## Managing Access and Infrastructure
 
-The Scion Web Dashboard includes a centralized **Admin Management Suite** (accessible to users with administrative privileges) that provides dedicated views for access control management:
+The Scion Web Dashboard includes a centralized **Admin Management Suite** (accessible to users with appropriate administrative capabilities) that provides dedicated views for access control and infrastructure management:
 
 - **Server Configuration Editor**: A full-featured settings editor at `/admin/server-config`. This allows administrators to view and modify the global `settings.yaml` through the Web UI with support for tabbed navigation, sensitive field masking, and hot-reloading of key settings like log levels, telemetry defaults, and admin emails.
 - **Users List**: View all authenticated users, search for specific accounts, track "Last Seen" timestamps, and manage their system-wide roles (e.g., granting `hub-admin` access).
 - **Groups Management**: Create organizational groups and manage their membership with a human-friendly member editor and user search autocomplete. Group creation is strictly authorized, and the `project:` prefix is a reserved slug. To prevent slug collisions, colliding group identifiers require a system marker combined with the `ProjectID`. Membership lookups rely on canonical identity resolution. This enables policy-based authorization where permissions can be granted to an entire team at once, while strictly enforcing group ownership and authorization rules.
-- **Admin Security**: When verifying administrative privileges across endpoints, the `requireAdmin` guard explicitly rejects scoped user identities (e.g. from limited personal access tokens) prior to evaluating the principal's embedded roles, ensuring that scoped identities cannot inadvertently bypass administrative gates.
+- **Role & Binding Management**: Full CRUD interfaces for Role Definitions and Role Bindings. Administrators can define custom roles, map permissions, and bind them to users, groups, or agents at the Hub or Project scope, while the system enforces `CanDelegate` checks to prevent privilege escalation.
+- **Quota Management**: Dedicated admin view to manage the Quota System. Administrators can view, create, and update `LimitDefinition` thresholds and monitor `EntitlementBinding` status across projects.
+- **Admin Security & Navigation**: The dashboard uses capabilities-based navigation to render the Admin Suite. Instead of a binary `role===admin` check, visibility and access are scoped to specific permissions (e.g., `hub-admin` vs `super-admin`), ensuring users only see the management tools they are authorized to use.
 - **Broker Visibility**: Comprehensive broker detail pages provide a grouped view of all active agents by their respective projects, helping administrators understand resource distribution.
 - **Maintenance Mode**: Administrators can toggle maintenance mode for the Hub and Web servers directly from the UI to facilitate safe infrastructure updates.
 

--- a/docs-site/src/content/docs/hosted/user/messaging.md
+++ b/docs-site/src/content/docs/hosted/user/messaging.md
@@ -7,6 +7,10 @@ Scion provides a robust messaging system that allows for bidirectional communica
 
 ## The Inbox Tray
 
+:::note[Design Record]
+For an in-depth look at the architecture, semantic contract, and design invariants underlying the Scion messaging system, see the [Conversation Model Design](https://github.com/GoogleCloudPlatform/scion/blob/main/.design/messaging-conversation-model.md) and its companion [Defect Inventory](https://github.com/GoogleCloudPlatform/scion/blob/main/.design/messaging-conversation-model-findings.md) in the project repository.
+:::
+
 In the Web Dashboard, the **Inbox Tray** provides a centralized view of all messages sent by your agents.
 - **Unread Badges:** The top navigation bar displays a badge indicating the number of unread messages across all your agents.
 - **Mark as Read:** You can mark individual messages or all messages as read, helping you keep track of what needs your attention.
@@ -216,11 +220,14 @@ When using slug-based query paths or addressing agents via `agent:<name>` (e.g.,
   - **Granular Scopes**: Authorization gates require the agent token to hold the `project:read` scope for reading subscriptions and the `project:agent:notify` scope for writing (creating, updating, or deleting) subscriptions.
   - **Ownership Constraints**: Acknowledging notifications or modifying/deleting existing subscriptions strictly requires ownership validation, meaning an agent can only modify or acknowledge subscriptions that target or belong to itself.
 
-### 4. Message Security & Thread Validation
+### 4. Security Controls for Direct Messages & Broadcasts
 
-Scion employs strict, ingress-level security controls for Direct Messages (DMs) to prevent spoofing and cross-project injection:
-- **Ownership Validation**: At all message ingress points, the system validates the authenticated identity from the request context against the provided DM key. An agent cannot write into another agent's DM conversation by supplying a well-formed but unauthorized DM key.
-- **Thread ID Formatting**: When an agent supplies a `thread_id` (used as the DM key), it is strictly validated against the canonical DM key format at ingress. Malformed or unauthorized thread IDs are rejected with a `400 Bad Request` before any dispatch or persistence occurs.
+Scion employs strict, ingress-level security controls and invariants for Direct Messages (DMs) and Broadcasts to prevent spoofing, cross-project injection, and message divergence:
+- **Server-Side Sender Identity & Derivation**: Sender identity is forced server-side based on the authenticated request context, completely ignoring any sender claims in the payload. Furthermore, DM conversation keys are derived dynamically from the authenticated caller rather than trusting the payload, closing spoofed-sender conversation-selection vectors.
+- **Canonical DM Key Enforcement**: Thread IDs (used as DM keys) undergo strict canonicality enforcement. Non-canonical kinds and UUIDs are rejected immediately at derivation without silent normalization, ensuring precise routing.
+- **Participant Guard Consolidation**: A unified participant guard (`CheckDMParticipantKey`) protects all DM ingresses (adding/ensuring participants or merging conversations). This strict invariant guarantees that participant records cannot diverge from their canonical thread keys.
+- **Broadcast Authorization**: Project membership is strictly required and enforced for all broadcast calls.
+- **Publish Gating & Stamping**: Message publishing to real-time streams (SSE) is securely gated on successful database persistence (dual-write conversation stamping). This ensures that a message is never broadcasted to clients without being safely committed to history.
 
 ### 5. Sleep Anti-Pattern & Polling
 

--- a/docs-site/src/content/docs/hosted/user/personal-access-tokens.md
+++ b/docs-site/src/content/docs/hosted/user/personal-access-tokens.md
@@ -45,6 +45,14 @@ permissions). Available scopes:
 | `agent:dispatch` | Dispatch agents (create + start) |
 | `agent:manage` | All agent scopes (convenience alias) |
 
+In addition to project and agent scopes, Scion supports UAT scopes for 8 other resource types: `skill`, `template`, `harness_config`, `group`, `user`, `broker`, and `gcp_service_account`. 
+
+You can dynamically discover all available scopes and their descriptions by querying the API:
+```bash
+curl -H "Authorization: Bearer $SCION_HUB_TOKEN" \
+     https://scion.example.com/api/v1/auth/scopes
+```
+
 ## Creating a token
 
 Generate a new token with the Scion CLI:

--- a/docs-site/src/content/docs/hosted/user/personal-access-tokens.md
+++ b/docs-site/src/content/docs/hosted/user/personal-access-tokens.md
@@ -45,7 +45,7 @@ permissions). Available scopes:
 | `agent:dispatch` | Dispatch agents (create + start) |
 | `agent:manage` | All agent scopes (convenience alias) |
 
-In addition to project and agent scopes, Scion supports UAT scopes for 8 other resource types: `skill`, `template`, `harness_config`, `group`, `user`, `broker`, and `gcp_service_account`. 
+In addition to project and agent scopes, Scion supports UAT scopes for 7 other resource types: `skill`, `template`, `harness_config`, `group`, `user`, `broker`, and `gcp_service_account`. 
 
 You can dynamically discover all available scopes and their descriptions by querying the API:
 ```bash

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -76,6 +76,16 @@ The stored MIME type is derived from the file's content plus its extension; the 
 - `GET /`: List available agent templates.
 - `POST /`: Upload a new template or version.
 
+#### Auth & Permissions (`/api/v1/auth`)
+- `GET /scopes`: Dynamically discover all available User Access Token (UAT) scopes and their descriptions.
+- `GET /roles`: List Role Definitions.
+- `POST /roles`, `PUT /roles/:id`, `DELETE /roles/:id`: Manage Role Definitions (requires appropriate administrative capabilities). Note that `updateRoleDefinition` includes a `CanDelegate` check to prevent privilege escalation.
+- `GET /role-bindings`: List Role Bindings (paginated).
+- `POST /role-bindings`, `PUT /role-bindings/:id`, `DELETE /role-bindings/:id`: Manage Role Bindings.
+
+#### Quotas (`/api/v1/quotas`)
+The Quota System API provides 13 endpoints for managing limits and reservations, enforcing fail-closed limits. Route guards strictly separate read and write permissions, preventing arbitrary modification of system limits.
+
 ## Runtime Broker API
 
 The Runtime Broker exposes a local API (usually on port 9800) for agent execution and management.

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -76,15 +76,20 @@ The stored MIME type is derived from the file's content plus its extension; the 
 - `GET /`: List available agent templates.
 - `POST /`: Upload a new template or version.
 
-#### Auth & Permissions (`/api/v1/auth`)
+#### Auth (`/api/v1/auth`)
 - `GET /scopes`: Dynamically discover all available User Access Token (UAT) scopes and their descriptions.
+
+#### Admin (`/api/v1/admin`)
 - `GET /roles`: List Role Definitions.
 - `POST /roles`, `PUT /roles/:id`, `DELETE /roles/:id`: Manage Role Definitions (requires appropriate administrative capabilities). Note that `updateRoleDefinition` includes a `CanDelegate` check to prevent privilege escalation.
 - `GET /role-bindings`: List Role Bindings (paginated).
 - `POST /role-bindings`, `PUT /role-bindings/:id`, `DELETE /role-bindings/:id`: Manage Role Bindings.
+- `GET /limits`: List Limit Definitions.
+- `GET /limits/:id`, `PUT /limits/:id`: Inspect or update a Limit Definition.
+- `GET /entitlements/:id`: Inspect an Entitlement Binding.
+- `GET /gcp-quota`: View GCP quota status.
 
-#### Quotas (`/api/v1/quotas`)
-The Quota System API provides 13 endpoints for managing limits and reservations, enforcing fail-closed limits. Route guards strictly separate read and write permissions, preventing arbitrary modification of system limits.
+The Quota System API enforces fail-closed limits. Route guards strictly separate read and write permissions, preventing arbitrary modification of system limits.
 
 ## Runtime Broker API
 


### PR DESCRIPTION
Nightly documentation update based on the 2026-08-28 changelog.

Changes:
- permissions.md: Expanded Admin Management Suite with Role/Binding CRUD pages, Quota management, capabilities-based nav
- personal-access-tokens.md: Documented 30 new UAT scopes across 8 resource types and /api/v1/auth/scopes discovery endpoint
- api.md: Added Auth and Permissions API endpoints reference
- messaging.md: Detailed DM security controls and linked Conversation Model Design records

4 files, 34 insertions, 7 deletions.