### PR TITLE
ci: widen conversation upsert guard for kind='group' topic mints (Option C)

### DIFF
--- a/hack/check-conversation-upsert-guard.sh
+++ b/hack/check-conversation-upsert-guard.sh
@@ -53,12 +53,15 @@
 # site constructs the table name dynamically. But a green gate from this
 # script guarantees only that the enumerated textual patterns are absent
 # outside the allowed packages — it is not a proof that no mint path exists.
-#   - The Option C exemption is textual: it checks for the literal string
-#     'group' in a 3-line window after the INSERT line. A kind value supplied
-#     through a variable (e.g., kindVar instead of 'group') defeats the
-#     exemption check and will be rejected by the guard even if the variable
-#     always holds "group" at runtime. This is deliberate — the guard cannot
-#     verify runtime values, so it requires the literal.
+#   - The Option C exemption is textual: it extracts the SQL statement
+#     (from the INSERT line through the closing backtick of the Go raw
+#     string literal) and requires 'group' to appear in that text while
+#     rejecting any other kind literal ('direct', 'channel', 'support').
+#     A kind value supplied through a variable (e.g., kindVar instead of
+#     'group') defeats the exemption check and will be rejected by the
+#     guard even if the variable always holds "group" at runtime. This is
+#     deliberate — the guard cannot verify runtime values, so it requires
+#     the literal.
 #
 # Note: the default fallback for unknown conversation kinds uses
 # requireParticipant, making the participant table an ACL for any future
@@ -134,8 +137,8 @@ fi
 # case-insensitive to catch any casing variant.
 # Allowed in pkg/store/ unconditionally.
 # Allowed in pkg/hub/webchannel_store{,_postgres}.go ONLY when the INSERT
-# mints kind='group' (Option C). The kind literal is on the VALUES line
-# (the line after the INSERT line), not on the INSERT line itself.
+# mints kind='group' (Option C). The kind literal must appear in the
+# same SQL statement (bounded by the Go raw string backtick delimiter).
 # Pattern uses POSIX ERE (-E flag). Do not rewrite with BRE alternation (\|)
 # or word-boundary (\b) — those are GNU extensions that silently match nothing
 # on BSD/macOS grep, causing the guard to report false-clean.
@@ -150,24 +153,54 @@ grep -rEni 'INSERT[[:space:]]+(OR[[:space:]]+[A-Z]+[[:space:]]+)?INTO[[:space:]]
 
 if [[ -s "$tmp" ]]; then
   # Option C exemption: for matches in the two webchannel_store files,
-  # read a window of 3 lines after the INSERT line and check for 'group'
-  # literal. If found, the site is exempted. If not (e.g., kind='direct'
-  # or a variable), the site is still a violation.
+  # extract the SQL statement that contains the INSERT and verify that
+  # 'group' appears in it (and NO other kind literal such as 'direct').
+  #
+  # Statement extraction: all exempted INSERT sites live inside Go raw
+  # string literals (backtick-delimited). From the INSERT line, we
+  # collect text through the first line that contains a closing backtick,
+  # or up to 20 lines (safety cap). The INSERT line itself is included
+  # so single-line statements are correctly handled.
   violations=""
   while IFS= read -r match; do
     file="${match%%:*}"
     rest="${match#*:}"
     lineno="${rest%%:*}"
 
+    # Normalise the path: strip leading "./" if present, so the
+    # comparison works regardless of how grep formats the prefix.
+    # The normalised value is compared against a fixed allowlist —
+    # any format change causes the exemption to NOT apply (fail-closed).
+    norm_file="${file#./}"
+
     # Exemption applies ONLY to these two files in pkg/hub/
-    if [[ "$file" = ./pkg/hub/webchannel_store.go || "$file" = ./pkg/hub/webchannel_store_postgres.go ]]; then
-      # Read 3 lines after the INSERT line. House style: column list on
-      # the INSERT line, VALUES (including kind) on the next line. A 3-line
-      # window covers multi-line value lists and indentation variants.
-      window=$(sed -n "$((lineno+1)),$((lineno+3))p" "$file")
-      if printf '%s\n' "$window" | grep -q "'group'"; then
-        continue  # Exempted: kind='group' literal found
+    if [[ "$norm_file" = "pkg/hub/webchannel_store.go" || "$norm_file" = "pkg/hub/webchannel_store_postgres.go" ]]; then
+      # Extract the SQL statement: from the INSERT keyword through the
+      # closing backtick (end of Go raw string literal), cap at 20 lines.
+      # On the first line, strip everything before INSERT so the opening
+      # backtick of the Go raw string is removed — otherwise a single-line
+      # INSERT (where both backticks are on the same line) would be
+      # truncated at the opening backtick instead of the closing one.
+      end=$((lineno + 20))
+      stmt=$(sed -n "${lineno},${end}p" "$file")
+      # Strip prefix before INSERT on the first line (removes opening `)
+      stmt=$(printf '%s\n' "$stmt" | sed '1s/^[^Ii]*INSERT/INSERT/I')
+      # Truncate at the first closing backtick (`) to bound the statement.
+      # This prevents text after the statement (comments, next func) from
+      # influencing the kind check.
+      stmt=$(printf '%s\n' "$stmt" | sed '/`/{ s/`.*//; p; d; }' | head -21)
+
+      # Check 1: 'group' must appear in the statement text.
+      if ! printf '%s\n' "$stmt" | grep -q "'group'"; then
+        violations="${violations}${match}"$'\n'
+        continue
       fi
+      # Check 2: no OTHER kind literal (e.g., 'direct') in the statement.
+      if printf '%s\n' "$stmt" | grep -qE "'(direct|channel|support)'"; then
+        violations="${violations}${match}"$'\n'
+        continue
+      fi
+      continue  # Exempted: kind='group' confirmed, no conflicting kinds
     fi
     violations="${violations}${match}"$'\n'
   done <"$tmp"

--- a/hack/check-conversation-upsert-guard.sh
+++ b/hack/check-conversation-upsert-guard.sh
@@ -7,7 +7,7 @@
 # every code path that can INSERT a row into the conversations table or modify
 # the participant listing index.
 #
-# Conversation-minting surface (enumerated 2026-08-27):
+# Conversation-minting surface (enumerated 2026-08-27, Option C added 2026-08-29):
 #
 #   Go method calls (must only appear in pkg/messaging/ and pkg/store/):
 #     1.  UpsertConversationByExternalRef — the primary resolve-or-create path
@@ -29,6 +29,13 @@
 #                                         for idempotent inserts; Postgres uses
 #                                         ON CONFLICT ... DO NOTHING (same line).
 #
+#   EXEMPTION (Option C, tranche C): pkg/hub/webchannel_store.go and
+#   pkg/hub/webchannel_store_postgres.go may contain raw INSERT INTO
+#   conversations when the statement mints kind='group'. These files perform
+#   an atomic topic+conversation dual-write inside an explicit tx; the store
+#   methods take ctx, not tx, so they cannot participate in the webchat
+#   transaction. Surfaces 1, 2a, 2b, and 3 remain fully barred in pkg/hub.
+#
 # Test files (*_test.go) are excluded: test fixtures legitimately call store
 # methods to set up state. The guard protects production code paths.
 #
@@ -46,6 +53,12 @@
 # site constructs the table name dynamically. But a green gate from this
 # script guarantees only that the enumerated textual patterns are absent
 # outside the allowed packages — it is not a proof that no mint path exists.
+#   - The Option C exemption is textual: it checks for the literal string
+#     'group' in a 3-line window after the INSERT line. A kind value supplied
+#     through a variable (e.g., kindVar instead of 'group') defeats the
+#     exemption check and will be rejected by the guard even if the variable
+#     always holds "group" at runtime. This is deliberate — the guard cannot
+#     verify runtime values, so it requires the literal.
 #
 # Note: the default fallback for unknown conversation kinds uses
 # requireParticipant, making the participant table an ACL for any future
@@ -119,7 +132,10 @@ fi
 # Matches the full INSERT family: INSERT INTO, INSERT OR IGNORE INTO,
 # INSERT OR REPLACE INTO, with optional quoting on the table name, and
 # case-insensitive to catch any casing variant.
-# Allowed only in pkg/store/.
+# Allowed in pkg/store/ unconditionally.
+# Allowed in pkg/hub/webchannel_store{,_postgres}.go ONLY when the INSERT
+# mints kind='group' (Option C). The kind literal is on the VALUES line
+# (the line after the INSERT line), not on the INSERT line itself.
 # Pattern uses POSIX ERE (-E flag). Do not rewrite with BRE alternation (\|)
 # or word-boundary (\b) — those are GNU extensions that silently match nothing
 # on BSD/macOS grep, causing the guard to report false-clean.
@@ -133,11 +149,38 @@ grep -rEni 'INSERT[[:space:]]+(OR[[:space:]]+[A-Z]+[[:space:]]+)?INTO[[:space:]]
   >"$tmp" || true
 
 if [[ -s "$tmp" ]]; then
-  echo "Raw SQL INSERT INTO conversations outside allowed packages:" >&2
-  cat "$tmp" >&2
-  echo >&2
-  echo "Raw SQL conversation inserts are only allowed in pkg/store/." >&2
-  rc=1
+  # Option C exemption: for matches in the two webchannel_store files,
+  # read a window of 3 lines after the INSERT line and check for 'group'
+  # literal. If found, the site is exempted. If not (e.g., kind='direct'
+  # or a variable), the site is still a violation.
+  violations=""
+  while IFS= read -r match; do
+    file="${match%%:*}"
+    rest="${match#*:}"
+    lineno="${rest%%:*}"
+
+    # Exemption applies ONLY to these two files in pkg/hub/
+    if [[ "$file" = ./pkg/hub/webchannel_store.go || "$file" = ./pkg/hub/webchannel_store_postgres.go ]]; then
+      # Read 3 lines after the INSERT line. House style: column list on
+      # the INSERT line, VALUES (including kind) on the next line. A 3-line
+      # window covers multi-line value lists and indentation variants.
+      window=$(sed -n "$((lineno+1)),$((lineno+3))p" "$file")
+      if printf '%s\n' "$window" | grep -q "'group'"; then
+        continue  # Exempted: kind='group' literal found
+      fi
+    fi
+    violations="${violations}${match}"$'\n'
+  done <"$tmp"
+
+  if [[ -n "$violations" ]]; then
+    printf 'Raw SQL INSERT INTO conversations outside allowed packages:\n' >&2
+    printf '%s' "$violations" >&2
+    echo >&2
+    printf 'Raw SQL conversation inserts are only allowed in pkg/store/.\n' >&2
+    printf "Exception: pkg/hub/webchannel_store{,_postgres}.go may INSERT\n" >&2
+    printf "with kind='group' (Option C — see script header).\n" >&2
+    rc=1
+  fi
 fi
 
 if [[ "$rc" -ne 0 ]]; then

--- a/hack/test-check-conversation-upsert-guard.sh
+++ b/hack/test-check-conversation-upsert-guard.sh
@@ -8,6 +8,10 @@
 #   4. Rejects AddParticipant calls in webchannel_store.go (fully barred surface)
 #   5. Exempts INSERT INTO conversations with kind='group' in webchannel_store_postgres.go
 #   6. Rejects INSERT INTO conversations with kind='group' in a non-exempted pkg/hub file
+#   7. Exempts single-line kind='group' INSERT (Case A regression)
+#   8. Rejects single-line kind='direct' INSERT
+#   9. Rejects kind='direct' INSERT with decoy 'group' after statement (Case C regression)
+#  10. Rejects decoy 'group' after closing backtick
 #
 # Each test injects a synthetic pattern, runs the guard, and checks the exit code.
 # Originals are always restored via trap.
@@ -46,7 +50,7 @@ run_test() {
   local expected_exit="$2"
 
   set +e
-  "$GUARD" >/dev/null 2>&1
+  guard_output=$("$GUARD" 2>&1)
   actual_exit=$?
   set -e
 
@@ -55,6 +59,10 @@ run_test() {
     ((pass++)) || true
   else
     echo "FAIL: $desc (expected exit $expected_exit, got exit $actual_exit)" >&2
+    if [[ -n "$guard_output" ]]; then
+      echo "  Guard output:" >&2
+      printf '  %s\n' "$guard_output" >&2
+    fi
     ((fail++)) || true
   fi
 
@@ -117,6 +125,56 @@ func c1TestGroupInsertOther() {
 }
 INJECT
 run_test "kind='group' INSERT in non-exempted hub file is rejected" 1
+
+# --- Test 7: Single-line kind='group' INSERT — EXEMPTED (exit 0) ---
+# Regression test for Case A: the INSERT and 'group' are on the same line.
+# The old 3-line-window logic looked only AFTER the INSERT line and missed this.
+cat >>"$SQLITE" <<'INJECT'
+
+// c1-negative-test-inject
+func c1TestSingleLineGroupInsert() {
+	db.Exec(`INSERT INTO conversations (id, project_id, kind) VALUES (?, ?, 'group')`, id, pid)
+}
+INJECT
+run_test "single-line kind='group' INSERT is exempted (Case A fix)" 0
+
+# --- Test 8: Single-line kind='direct' INSERT — NOT EXEMPTED (exit 1) ---
+cat >>"$SQLITE" <<'INJECT'
+
+// c1-negative-test-inject
+func c1TestSingleLineDirectInsert() {
+	db.Exec(`INSERT INTO conversations (id, project_id, kind) VALUES (?, ?, 'direct')`, id, pid)
+}
+INJECT
+run_test "single-line kind='direct' INSERT is rejected" 1
+
+# --- Test 9: Multi-line kind='direct' INSERT with decoy 'group' — NOT EXEMPTED (exit 1) ---
+# Regression test for Case C (SECURITY): a kind='direct' INSERT followed by
+# a comment containing 'group' within the next 3 lines. The old window-based
+# logic would wrongly exempt this because it saw 'group' in the window.
+cat >>"$SQLITE" <<'INJECT'
+
+// c1-negative-test-inject
+func c1TestDirectWithDecoyGroup() {
+	db.Exec(`INSERT INTO conversations (id, project_id, kind, surface)
+		VALUES (?, ?, 'direct', 'native')`, id, pid)
+	// This creates a 'group' sidebar later
+}
+INJECT
+run_test "kind='direct' INSERT with decoy 'group' after statement is rejected (Case C fix)" 1
+
+# --- Test 10: Decoy 'group' after closing backtick — NOT EXEMPTED (exit 1) ---
+# The 'group' literal appears in a Go comment after the raw string ends.
+# The statement itself has kind='direct'.
+cat >>"$SQLITE" <<'INJECT'
+
+// c1-negative-test-inject
+func c1TestDecoyGroupAfterBacktick() {
+	db.Exec(`INSERT INTO conversations (id, project_id, kind, surface)
+		VALUES (?, ?, 'direct', 'native')` + "/* 'group' */", id, pid)
+}
+INJECT
+run_test "decoy 'group' after closing backtick is rejected" 1
 
 # --- Summary ---
 echo

--- a/hack/test-check-conversation-upsert-guard.sh
+++ b/hack/test-check-conversation-upsert-guard.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Negative tests for the conversation-upsert guard (C1 — Option C).
+#
+# Verifies that the guard correctly:
+#   1. Passes with no violations (baseline)
+#   2. Exempts INSERT INTO conversations with kind='group' in webchannel_store.go
+#   3. Rejects INSERT INTO conversations with kind='direct' in webchannel_store.go
+#   4. Rejects AddParticipant calls in webchannel_store.go (fully barred surface)
+#   5. Exempts INSERT INTO conversations with kind='group' in webchannel_store_postgres.go
+#   6. Rejects INSERT INTO conversations with kind='group' in a non-exempted pkg/hub file
+#
+# Each test injects a synthetic pattern, runs the guard, and checks the exit code.
+# Originals are always restored via trap.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+GUARD="./hack/check-conversation-upsert-guard.sh"
+SQLITE="pkg/hub/webchannel_store.go"
+POSTGRES="pkg/hub/webchannel_store_postgres.go"
+INJECT_OTHER="pkg/hub/c1_negative_test_inject.go"
+
+# --- Backup and cleanup ---
+cp "$SQLITE" "${SQLITE}.c1bak"
+cp "$POSTGRES" "${POSTGRES}.c1bak"
+
+cleanup() {
+  mv "${SQLITE}.c1bak" "$SQLITE" 2>/dev/null || true
+  mv "${POSTGRES}.c1bak" "$POSTGRES" 2>/dev/null || true
+  rm -f "$INJECT_OTHER"
+}
+trap cleanup EXIT
+
+restore() {
+  # Restore both files to their backup state before each test
+  cp "${SQLITE}.c1bak" "$SQLITE"
+  cp "${POSTGRES}.c1bak" "$POSTGRES"
+  rm -f "$INJECT_OTHER"
+}
+
+pass=0
+fail=0
+
+run_test() {
+  local desc="$1"
+  local expected_exit="$2"
+
+  set +e
+  "$GUARD" >/dev/null 2>&1
+  actual_exit=$?
+  set -e
+
+  if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+    echo "PASS: $desc (exit $actual_exit)"
+    ((pass++)) || true
+  else
+    echo "FAIL: $desc (expected exit $expected_exit, got exit $actual_exit)" >&2
+    ((fail++)) || true
+  fi
+
+  restore
+}
+
+# --- Test 1: Baseline — guard passes with no injections ---
+run_test "baseline: no violations" 0
+
+# --- Test 2: kind='group' INSERT in webchannel_store.go — EXEMPTED (exit 0) ---
+cat >>"$SQLITE" <<'INJECT'
+
+// c1-negative-test-inject
+func c1TestGroupInsertSqlite() {
+	db.Exec(`INSERT INTO conversations (id, project_id, kind, surface)
+		VALUES (?, ?, 'group', 'native')`, id, pid)
+}
+INJECT
+run_test "kind='group' INSERT in webchannel_store.go is exempted" 0
+
+# --- Test 3: kind='direct' INSERT in webchannel_store.go — NOT EXEMPTED (exit 1) ---
+cat >>"$SQLITE" <<'INJECT'
+
+// c1-negative-test-inject
+func c1TestDirectInsertSqlite() {
+	db.Exec(`INSERT INTO conversations (id, project_id, kind, surface)
+		Values (?, ?, 'direct', 'native')`, id, pid)
+}
+INJECT
+run_test "kind='direct' INSERT in webchannel_store.go is rejected" 1
+
+# --- Test 4: AddParticipant in webchannel_store.go — NOT EXEMPTED (exit 1) ---
+cat >>"$SQLITE" <<'INJECT'
+
+// c1-negative-test-inject
+func c1TestAddParticipant() {
+	s.store.AddParticipant(ctx, conv.ID, userID)
+}
+INJECT
+run_test "AddParticipant in webchannel_store.go is rejected" 1
+
+# --- Test 5: kind='group' INSERT in webchannel_store_postgres.go — EXEMPTED (exit 0) ---
+cat >>"$POSTGRES" <<'INJECT'
+
+// c1-negative-test-inject
+func c1TestGroupInsertPostgres() {
+	db.Exec(`INSERT INTO conversations (id, project_id, kind, surface)
+		VALUES ($1, $2, 'group', 'native')`, id, pid)
+}
+INJECT
+run_test "kind='group' INSERT in webchannel_store_postgres.go is exempted" 0
+
+# --- Test 6: kind='group' INSERT in a NON-exempted hub file — NOT EXEMPTED (exit 1) ---
+cat > "$INJECT_OTHER" <<'INJECT'
+package hub
+
+func c1TestGroupInsertOther() {
+	db.Exec(`INSERT INTO conversations (id, project_id, kind, surface)
+		VALUES (?, ?, 'group', 'native')`, id, pid)
+}
+INJECT
+run_test "kind='group' INSERT in non-exempted hub file is rejected" 1
+
+# --- Summary ---
+echo
+echo "Results: $pass passed, $fail failed out of $((pass + fail)) tests"
+if [[ "$fail" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
Widens the conversation upsert guard to allow raw INSERT INTO conversations in pkg/hub/webchannel_store{,_postgres}.go only when the statement mints kind='group'.

Those 8 sites do an atomic topic+conversation dual-write inside an explicit tx. Store methods take ctx, not tx, so they cannot join it. Routing them through pkg/store needs a tx-carrying store method - that remains the destination; this is the safe intermediate.

UpsertConversationByExternalRef, CreateConversation, AddParticipant and the ent builder stay fully barred in pkg/hub.

Adds a 6-case negative test with three rejection controls: kind='direct' in an exempted file, AddParticipant in an exempted file, and kind='group' in a non-exempted hub file all still fail.

Limitation, recorded in the header: the check is textual, so a kind supplied via a variable is rejected. Deliberate - the guard cannot verify runtime values.

No production code changes. Two files, both under hack/