### PR TITLE
feat(store): add CountUnbackfilledMessages to MessageStore

### DIFF
--- a/pkg/messaging/backfill_test.go
+++ b/pkg/messaging/backfill_test.go
@@ -162,6 +162,20 @@ func (m *mockMessageStore) SetMessageConversationID(_ context.Context, messageID
 	return store.ErrNotFound
 }
 
+func (m *mockMessageStore) CountUnbackfilledMessages(_ context.Context, projectID string) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	count := 0
+	for _, msg := range m.messages {
+		if msg.ConversationID == "" {
+			if projectID == "" || msg.ProjectID == projectID {
+				count++
+			}
+		}
+	}
+	return count, nil
+}
+
 // mockConversationStore is an in-memory ConversationStore used by backfill tests.
 type mockConversationStore struct {
 	mu            sync.Mutex

--- a/pkg/store/entadapter/message_store.go
+++ b/pkg/store/entadapter/message_store.go
@@ -504,3 +504,22 @@ func (s *MessageStore) SetMessageConversationID(ctx context.Context, messageID, 
 	}
 	return nil
 }
+
+// CountUnbackfilledMessages returns the number of messages with a NULL
+// conversation_id. When projectID is non-empty the count is scoped to that
+// project; otherwise it counts across all projects.
+func (s *MessageStore) CountUnbackfilledMessages(ctx context.Context, projectID string) (int, error) {
+	query := s.client.Message.Query().Where(message.ConversationIDIsNil())
+	if projectID != "" {
+		pid, err := parseUUID(projectID)
+		if err != nil {
+			return 0, err
+		}
+		query.Where(message.ProjectIDEQ(pid))
+	}
+	count, err := query.Count(ctx)
+	if err != nil {
+		return 0, mapError(err)
+	}
+	return count, nil
+}

--- a/pkg/store/entadapter/message_store_test.go
+++ b/pkg/store/entadapter/message_store_test.go
@@ -200,3 +200,114 @@ func TestCreateMessagePublishesEvent(t *testing.T) {
 	require.Len(t, pub.published, 1)
 	assert.Equal(t, msg.ID, pub.published[0].ID)
 }
+
+// ---------------------------------------------------------------------------
+// CountUnbackfilledMessages
+// ---------------------------------------------------------------------------
+
+func TestCountUnbackfilledMessages_ZeroWhenAllBackfilled(t *testing.T) {
+	s := newTestMessageStore(t)
+	ctx := context.Background()
+	projectID := uuid.NewString()
+	conversationID := uuid.NewString()
+
+	// Create two messages, then backfill both with a conversation_id.
+	m1 := newTestMessage(projectID, "agent-1")
+	m2 := newTestMessage(projectID, "agent-1")
+	require.NoError(t, s.CreateMessage(ctx, m1))
+	require.NoError(t, s.CreateMessage(ctx, m2))
+	require.NoError(t, s.SetMessageConversationID(ctx, m1.ID, conversationID))
+	require.NoError(t, s.SetMessageConversationID(ctx, m2.ID, conversationID))
+
+	count, err := s.CountUnbackfilledMessages(ctx, projectID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestCountUnbackfilledMessages_SomeUnbackfilled(t *testing.T) {
+	s := newTestMessageStore(t)
+	ctx := context.Background()
+	projectID := uuid.NewString()
+	conversationID := uuid.NewString()
+
+	// Create three messages; backfill only one.
+	m1 := newTestMessage(projectID, "agent-1")
+	m2 := newTestMessage(projectID, "agent-1")
+	m3 := newTestMessage(projectID, "agent-1")
+	require.NoError(t, s.CreateMessage(ctx, m1))
+	require.NoError(t, s.CreateMessage(ctx, m2))
+	require.NoError(t, s.CreateMessage(ctx, m3))
+	require.NoError(t, s.SetMessageConversationID(ctx, m1.ID, conversationID))
+
+	count, err := s.CountUnbackfilledMessages(ctx, projectID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestCountUnbackfilledMessages_ProjectScopingFilters(t *testing.T) {
+	s := newTestMessageStore(t)
+	ctx := context.Background()
+
+	projectA := uuid.NewString()
+	projectB := uuid.NewString()
+	conversationID := uuid.NewString()
+
+	// Project A: 3 messages, backfill 1 → 2 unbackfilled.
+	a1 := newTestMessage(projectA, "agent-1")
+	a2 := newTestMessage(projectA, "agent-1")
+	a3 := newTestMessage(projectA, "agent-1")
+	require.NoError(t, s.CreateMessage(ctx, a1))
+	require.NoError(t, s.CreateMessage(ctx, a2))
+	require.NoError(t, s.CreateMessage(ctx, a3))
+	require.NoError(t, s.SetMessageConversationID(ctx, a1.ID, conversationID))
+
+	// Project B: 2 messages, backfill 0 → 2 unbackfilled.
+	b1 := newTestMessage(projectB, "agent-1")
+	b2 := newTestMessage(projectB, "agent-1")
+	require.NoError(t, s.CreateMessage(ctx, b1))
+	require.NoError(t, s.CreateMessage(ctx, b2))
+
+	// Scoped to project A → must return 2, NOT 4.
+	countA, err := s.CountUnbackfilledMessages(ctx, projectA)
+	require.NoError(t, err)
+	assert.Equal(t, 2, countA, "project A should have exactly 2 unbackfilled messages")
+
+	// Scoped to project B → must return 2, NOT 4.
+	countB, err := s.CountUnbackfilledMessages(ctx, projectB)
+	require.NoError(t, err)
+	assert.Equal(t, 2, countB, "project B should have exactly 2 unbackfilled messages")
+}
+
+func TestCountUnbackfilledMessages_EmptyProjectIDCountsAll(t *testing.T) {
+	s := newTestMessageStore(t)
+	ctx := context.Background()
+
+	projectA := uuid.NewString()
+	projectB := uuid.NewString()
+	conversationID := uuid.NewString()
+
+	// Project A: 2 messages, backfill 1 → 1 unbackfilled.
+	a1 := newTestMessage(projectA, "agent-1")
+	a2 := newTestMessage(projectA, "agent-1")
+	require.NoError(t, s.CreateMessage(ctx, a1))
+	require.NoError(t, s.CreateMessage(ctx, a2))
+	require.NoError(t, s.SetMessageConversationID(ctx, a1.ID, conversationID))
+
+	// Project B: 1 message, no backfill → 1 unbackfilled.
+	b1 := newTestMessage(projectB, "agent-1")
+	require.NoError(t, s.CreateMessage(ctx, b1))
+
+	// Empty projectID → counts all unbackfilled across both projects.
+	count, err := s.CountUnbackfilledMessages(ctx, "")
+	require.NoError(t, err)
+	assert.Equal(t, 2, count, "empty projectID should count unbackfilled messages across all projects")
+}
+
+func TestCountUnbackfilledMessages_InvalidProjectIDReturnsError(t *testing.T) {
+	s := newTestMessageStore(t)
+	ctx := context.Background()
+
+	count, err := s.CountUnbackfilledMessages(ctx, "not-a-uuid")
+	assert.Error(t, err)
+	assert.Equal(t, 0, count)
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1331,6 +1331,11 @@ type MessageStore interface {
 	// message. Used by the Phase 4 backfill to link legacy messages to
 	// Conversation records. Returns ErrNotFound if the message doesn't exist.
 	SetMessageConversationID(ctx context.Context, messageID, conversationID string) error
+
+	// CountUnbackfilledMessages returns the number of messages with an empty
+	// conversation_id for the given project. When projectID is empty, counts
+	// across all projects.
+	CountUnbackfilledMessages(ctx context.Context, projectID string) (int, error)
 }
 
 // =============================================================================


### PR DESCRIPTION
Adds one MessageStore method, CountUnbackfilledMessages(ctx, projectID), counting messages with a NULL conversation_id. Scoped to a project when projectID is non-empty, otherwise counted across all projects. Used by the Phase 4 backfill to measure remaining work.

conversation_id is Optional().Nillable() on the Message schema, so IsNil is the correct unbackfilled test.

3 files, +38 -0. No deletions, no behaviour change, no authorization decision affected - nothing calls the new method yet.

Note on scope: this phase was originally sized at roughly 2000 lines. The conversation entity set (schemas, generated ent, ConversationStore, models) already landed in #1331, so the genuine remaining delta is this single method