### PR TITLE
fix: backfill message action into existing project member policies

### DIFF
--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -862,6 +862,18 @@ func (s *Server) createProjectMembersGroupAndPolicy(ctx context.Context, project
 			policy.Actions = append(policy.Actions, "stop_all")
 			needsUpdate = true
 		}
+		// Backfill: ensure message action is present for existing projects
+		hasMessage := false
+		for _, a := range policy.Actions {
+			if a == "message" {
+				hasMessage = true
+				break
+			}
+		}
+		if !hasMessage {
+			policy.Actions = append(policy.Actions, "message")
+			needsUpdate = true
+		}
 		if needsUpdate {
 			if updateErr := s.store.UpdatePolicy(ctx, policy); updateErr != nil {
 				s.projectsLogger().Warn("failed to update existing project member policy",

--- a/pkg/hub/seed.go
+++ b/pkg/hub/seed.go
@@ -290,6 +290,59 @@ func backfillProjectAssignPolicies(ctx context.Context, s store.Store) {
 	}
 }
 
+// backfillProjectMessageAction ensures every existing project's member-create-agents
+// policy includes the "message" action. Projects created before msg-authz (PR #1371)
+// only had "create" (and possibly "stop_all") — without "message", non-owner/non-admin
+// project members silently lose the ability to message agents. The inline backfill in
+// createProjectMembersGroupAndPolicy covers projects that are touched after the
+// upgrade, but a project nobody touches never runs that path. This startup backfill
+// closes the gap.
+func backfillProjectMessageAction(ctx context.Context, s store.Store) {
+	var cursor string
+	for {
+		res, err := s.ListProjects(ctx, store.ProjectFilter{}, store.ListOptions{
+			Limit:  500,
+			Cursor: cursor,
+		})
+		if err != nil {
+			slog.Warn("failed to list projects for message-action backfill", "error", err)
+			return
+		}
+		for i := range res.Items {
+			project := &res.Items[i]
+			policyName := "project:" + project.Slug + ":member-create-agents"
+			policies, err := s.ListPolicies(ctx, store.PolicyFilter{Name: policyName}, store.ListOptions{Limit: 1})
+			if err != nil || len(policies.Items) == 0 {
+				slog.Debug("skipping message-action backfill, no member policy",
+					"project_id", project.ID, "slug", project.Slug)
+				continue
+			}
+			policy := &policies.Items[0]
+			hasMessage := false
+			for _, a := range policy.Actions {
+				if a == "message" {
+					hasMessage = true
+					break
+				}
+			}
+			if !hasMessage {
+				policy.Actions = append(policy.Actions, "message")
+				if err := s.UpdatePolicy(ctx, policy); err != nil {
+					slog.Warn("failed to backfill message action into project member policy",
+						"project_id", project.ID, "policy", policyName, "error", err)
+				} else {
+					slog.Info("backfilled message action into project member policy",
+						"project_id", project.ID, "policy", policyName)
+				}
+			}
+		}
+		if res.NextCursor == "" {
+			break
+		}
+		cursor = res.NextCursor
+	}
+}
+
 // seedPolicyTombstoneKey returns the hub-setting key used to record that a
 // seeded policy was intentionally deleted by an operator.
 func seedPolicyTombstoneKey(policyName string) string {

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -1350,6 +1350,11 @@ func New(cfg ServerConfig, s store.Store) (*Server, error) {
 	// would silently lose assign when the gate moves to ActionAssign.
 	backfillProjectAssignPolicies(ctx, s)
 
+	// Backfill the "message" action into existing project member-create-agents
+	// policies. Projects created before msg-authz (PR #1371) lack this action,
+	// causing non-owner/non-admin members to be denied agent messaging.
+	backfillProjectMessageAction(ctx, s)
+
 	// Seed role definitions for the role-binding authorization model (Phase 1E).
 	// Must run after seedDefaultPoliciesAndGroups so the hub-members group exists.
 	seedRoleDefinitions(ctx, s)


### PR DESCRIPTION
## Summary
- Projects created before PR #1371 only had create and stop_all in their member-create-agents policy — missing the message action causes non-owner/non-admin members to be silently denied agent messaging
- Adds inline backfill in createProjectMembersGroupAndPolicy (covers projects touched after upgrade)
- Adds startup backfill backfillProjectMessageAction in seed.go (covers untouched projects, paginated, idempotent)

## Test plan
- [x] go build ./... passes
- [x] go vet ./... passes
- [x] Inline backfill follows existing stop_all pattern
- [x] Startup backfill follows existing backfillProjectAssignPolicies pattern