### PR TITLE
fix: remove agent:message from stale UAT scope test

### DIFF
--- a/cmd/hub_token_test.go
+++ b/cmd/hub_token_test.go
@@ -36,7 +36,6 @@ func TestHubTokenCreateHelpUsesRegistryScopes(t *testing.T) {
 	for _, stale := range []string{
 		store.UATScopeAgentStart,
 		store.UATScopeAgentStop,
-		store.UATScopeAgentMessage,
 		store.UATScopeAgentDispatch,
 	} {
 		if strings.Contains(help, stale) {


### PR DESCRIPTION
## Summary
- PR #1371 made agent:message a live enforced permission with UATScope in the registry
- cmd/hub_token_test.go still classified it as stale, causing TestHubTokenCreateHelpUsesRegistryScopes to fail
- Removes store.UATScopeAgentMessage from the stale list (one line)

## Test plan
- [x] TestHubTokenCreateHelpUsesRegistryScopes passes
- [x] go build ./... succeeds