### PR TITLE
fix(messaging): close guard scope and cross-project sentinel defects (DEF-39b, DEF-40)

### DIFF
--- a/hack/check-conversation-upsert-guard.sh
+++ b/hack/check-conversation-upsert-guard.sh
@@ -197,6 +197,7 @@ if [[ -s "$tmp" ]]; then
       # Truncate at the first closing backtick (`) and stop processing
       # (q quits sed). This prevents text after the statement (comments,
       # next func, subsequent lines) from influencing the kind check.
+      # shellcheck disable=SC2016  # backtick is a literal match target (Go raw string delimiter)
       stmt=$(printf '%s\n' "$stmt" | sed '/`/{ s/`.*//; q; }' | head -21)
 
       # Check 1: 'group' must appear in the statement text.

--- a/hack/check-conversation-upsert-guard.sh
+++ b/hack/check-conversation-upsert-guard.sh
@@ -185,10 +185,19 @@ if [[ -s "$tmp" ]]; then
       stmt=$(sed -n "${lineno},${end}p" "$file")
       # Strip prefix before INSERT on the first line (removes opening `)
       stmt=$(printf '%s\n' "$stmt" | sed '1s/^[^Ii]*INSERT/INSERT/I')
-      # Truncate at the first closing backtick (`) to bound the statement.
-      # This prevents text after the statement (comments, next func) from
-      # influencing the kind check.
-      stmt=$(printf '%s\n' "$stmt" | sed '/`/{ s/`.*//; p; d; }' | head -21)
+      # Check for closing backtick — if absent, statement exceeds the
+      # 20-line window and we cannot verify its kind. Refuse to exempt
+      # (fail-closed).
+      # shellcheck disable=SC2016  # backtick is a literal match target (Go raw string delimiter)
+      if ! printf '%s\n' "$stmt" | grep -q '`'; then
+        violations="${violations}${match}"$'\n'
+        continue
+      fi
+
+      # Truncate at the first closing backtick (`) and stop processing
+      # (q quits sed). This prevents text after the statement (comments,
+      # next func, subsequent lines) from influencing the kind check.
+      stmt=$(printf '%s\n' "$stmt" | sed '/`/{ s/`.*//; q; }' | head -21)
 
       # Check 1: 'group' must appear in the statement text.
       if ! printf '%s\n' "$stmt" | grep -q "'group'"; then

--- a/hack/test-check-conversation-upsert-guard.sh
+++ b/hack/test-check-conversation-upsert-guard.sh
@@ -12,6 +12,10 @@
 #   8. Rejects single-line kind='direct' INSERT
 #   9. Rejects kind='direct' INSERT with decoy 'group' after statement (Case C regression)
 #  10. Rejects decoy 'group' after closing backtick
+#  11. Rejects post-backtick content leak (kind via variable, 'group' after backtick)
+#  12. Rejects 20-line cap truncation (unbounded statement with decoy 'group')
+#  13. Exempts long kind='group' statement with closing backtick within window
+#  14. Exempts kind='group' INSERT with 'direct' mentioned only after backtick
 #
 # Each test injects a synthetic pattern, runs the guard, and checks the exit code.
 # Originals are always restored via trap.
@@ -175,6 +179,91 @@ func c1TestDecoyGroupAfterBacktick() {
 }
 INJECT
 run_test "decoy 'group' after closing backtick is rejected" 1
+
+# --- Test 11: Post-backtick content leak — NOT EXEMPTED (exit 1) ---
+# Regression test for Fix 1 (sed d→q): kind is set via a variable (no literal
+# in the SQL). 'group' appears on a line AFTER the closing backtick that has
+# no backtick of its own — the old `p; d` sed logic would leak it into $stmt.
+cat >>"$SQLITE" <<'INJECT'
+
+// c1-negative-test-inject
+func c1TestLeakedGroupAfterStatement() {
+	kind := "group"
+	db.Exec(`INSERT INTO conversations (id, project_id, kind, surface)
+		VALUES (?, ?, ?, 'native')`, id, pid, kind)
+	// Use 'group' conversation for sidebar
+}
+INJECT
+run_test "post-backtick 'group' on non-backtick line does not leak into statement" 1
+
+# --- Test 12: 20-line cap truncation — NOT EXEMPTED (exit 1) ---
+# Regression test for Fix 2: an INSERT statement longer than 20 lines. A decoy
+# 'group' appears inside the statement (within the first 20 lines) and the real
+# 'direct' is in VALUES beyond line 20. Without the fix, the truncated text
+# would show 'group' (pass Check 1) and no 'direct' (pass Check 2), wrongly
+# exempting the INSERT. With the fix, the missing closing backtick within the
+# 20-line window causes fail-closed rejection.
+cat >>"$SQLITE" <<'INJECT'
+
+// c1-negative-test-inject
+func c1TestCapTruncation() {
+	db.Exec(`INSERT INTO conversations (
+		id,
+		project_id,
+		kind,
+		surface,
+		external_ref,
+		created_at,
+		updated_at,
+		col8,
+		col9,
+		col10, -- 'group' placeholder
+		col11,
+		col12,
+		col13,
+		col14,
+		col15,
+		col16,
+		col17,
+		col18,
+		col19,
+		col20
+	) VALUES (
+		?, ?, 'direct', 'native', ?, NOW(), NOW(),
+		?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, args...)
+	// 'group' reference for documentation
+}
+INJECT
+run_test "20-line cap truncation: unbounded statement is rejected (fail-closed)" 1
+
+# --- Test 13: Long kind='group' statement with backtick within window — EXEMPTED (exit 0) ---
+# Control test for Fix 2: a multi-line kind='group' INSERT that IS bounded
+# (closing backtick within 20 lines). Proves the fail-closed path doesn't
+# reject everything.
+cat >>"$SQLITE" <<'INJECT'
+
+// c1-negative-test-inject
+func c1TestLongGroupStatement() {
+	db.Exec(`INSERT INTO conversations (id, project_id, kind, surface, external_ref, created_at, updated_at)
+		VALUES (?, ?, 'group', 'native', ?, NOW(), NOW())`, args...)
+}
+INJECT
+run_test "long kind='group' INSERT with closing backtick within window is exempted" 0
+
+# --- Test 14: kind='group' INSERT with 'direct' only after backtick — EXEMPTED (exit 0) ---
+# Control test for Fix 1: a valid kind='group' INSERT where 'direct' appears
+# only in a comment after the closing backtick. Proves Fix 1 correctly ignores
+# post-backtick content.
+cat >>"$SQLITE" <<'INJECT'
+
+// c1-negative-test-inject
+func c1TestGroupWithPostBacktickDirect() {
+	db.Exec(`INSERT INTO conversations (id, project_id, kind, surface)
+		VALUES (?, ?, 'group', 'native')`, id, pid)
+	// Also handle 'direct' conversations elsewhere
+}
+INJECT
+run_test "kind='group' INSERT with 'direct' only after backtick is exempted" 0
 
 # --- Summary ---
 echo

--- a/pkg/messaging/validate.go
+++ b/pkg/messaging/validate.go
@@ -96,9 +96,19 @@ func ValidateAddressees(addrs []Addressee, msg *Message) error {
 	return nil
 }
 
+// isUnsetProjectID returns true if the project ID represents an agent
+// that cannot be placed in a project — either empty or the zero UUID.
+func isUnsetProjectID(id string) bool {
+	return id == "" || id == "00000000-0000-0000-0000-000000000000"
+}
+
 // ValidateCrossProjectAddressees checks that all agent addressees belong to
 // the same project. This prevents a single message from addressing agents
 // across project boundaries, which would violate project isolation (AC-33 / DEF-2).
+//
+// Agents with an empty or zero-UUID ProjectID are "unplaceable" — they cannot
+// be verified as belonging to any project and are rejected when addressed
+// alongside any other agent. A single unplaceable agent alone is allowed.
 //
 // User addressees are ignored — the rule applies to agent addressees only.
 func ValidateCrossProjectAddressees(
@@ -107,7 +117,8 @@ func ValidateCrossProjectAddressees(
 	addrs []Addressee,
 ) error {
 	var projectID string
-	var projectAgents []string // for error reporting
+	var anchorSet bool
+	var rejectedAddressees []string
 
 	for _, a := range addrs {
 		if a.PrincipalKind != "agent" {
@@ -117,19 +128,37 @@ func ValidateCrossProjectAddressees(
 		if err != nil {
 			return fmt.Errorf("failed to look up agent %q: %w", a.PrincipalID, err)
 		}
-		if projectID == "" {
-			projectID = agent.ProjectID
-			projectAgents = append(projectAgents, a.PrincipalID)
+
+		// An agent without a project identity cannot be placed.
+		// A single unplaceable agent alone is fine, but alongside any
+		// other agent it must be rejected — we cannot verify same-project.
+		if isUnsetProjectID(agent.ProjectID) {
+			rejectedAddressees = append(rejectedAddressees, a.PrincipalID)
 			continue
 		}
-		if agent.ProjectID != projectID {
-			projectAgents = append(projectAgents, a.PrincipalID)
-			return fmt.Errorf(
-				"message addresses agents in multiple projects; " +
-					"a single message may only target agents within one project",
-			)
+
+		if !anchorSet {
+			projectID = agent.ProjectID
+			anchorSet = true
+			continue
 		}
-		projectAgents = append(projectAgents, a.PrincipalID)
+
+		if agent.ProjectID != projectID {
+			rejectedAddressees = append(rejectedAddressees, a.PrincipalID)
+		}
+	}
+
+	// Reject if there are rejected addressees AND either:
+	// - a placed anchor exists (unplaceable/mismatched alongside placed), or
+	// - multiple unplaceable agents with no anchor (cannot verify same-project).
+	// A single unplaceable agent with no anchor is allowed (no cross-project issue).
+	if len(rejectedAddressees) > 0 && (anchorSet || len(rejectedAddressees) > 1) {
+		// AC-33: name the rejected addressee IDs but NEVER the project IDs.
+		// Naming project IDs leaks project existence/membership.
+		return fmt.Errorf(
+			"message addresses agents across project boundaries; "+
+				"rejected addressees: %v", rejectedAddressees,
+		)
 	}
 	return nil
 }

--- a/pkg/messaging/validate.go
+++ b/pkg/messaging/validate.go
@@ -128,6 +128,9 @@ func ValidateCrossProjectAddressees(
 		if err != nil {
 			return fmt.Errorf("failed to look up agent %q: %w", a.PrincipalID, err)
 		}
+		if agent == nil {
+			return fmt.Errorf("failed to look up agent %q: store returned no agent", a.PrincipalID)
+		}
 
 		// An agent without a project identity cannot be placed.
 		// A single unplaceable agent alone is fine, but alongside any

--- a/pkg/messaging/validate_test.go
+++ b/pkg/messaging/validate_test.go
@@ -664,6 +664,31 @@ func TestValidateCrossProjectAddressees_MultipleUnplaceableAgents(t *testing.T) 
 	}
 }
 
+// ---------- Nil agent guard test (DEF-40 adjacent) ----------
+
+// nilAgentStore is a pathological store that returns (nil, nil) — no agent, no
+// error. This models a buggy or incomplete AgentProjectLookup implementation.
+type nilAgentStore struct{}
+
+func (s *nilAgentStore) GetAgent(_ context.Context, _ string) (*store.Agent, error) {
+	return nil, nil // pathological: no agent, no error
+}
+
+func TestValidateCrossProjectAddressees_NilAgentDenied(t *testing.T) {
+	// A store that returns (nil, nil) must produce an error, not a panic.
+	s := &nilAgentStore{}
+	addrs := []Addressee{
+		{PrincipalKind: "agent", PrincipalID: "ghost-agent"},
+	}
+	err := ValidateCrossProjectAddressees(context.Background(), s, addrs)
+	if err == nil {
+		t.Fatal("nil agent with nil error must be denied, not silently passed")
+	}
+	if !strings.Contains(err.Error(), "ghost-agent") {
+		t.Fatalf("error should name the agent, got: %v", err)
+	}
+}
+
 // ---------- ValidateMessageAddressees tests ----------
 
 func TestValidateMessageAddressees_Valid(t *testing.T) {

--- a/pkg/messaging/validate_test.go
+++ b/pkg/messaging/validate_test.go
@@ -478,10 +478,14 @@ func TestValidateCrossProjectAddressees_SpanningProjects(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for agents spanning projects")
 	}
-	if !strings.Contains(err.Error(), "multiple projects") {
-		t.Fatalf("error should mention multiple projects, got: %v", err)
+	if !strings.Contains(err.Error(), "across project boundaries") {
+		t.Fatalf("error should mention project boundaries, got: %v", err)
 	}
-	// Project IDs must NOT be disclosed in the error (security audit M3).
+	// AC-33: error MUST name the rejected addressee IDs.
+	if !strings.Contains(err.Error(), "agent-2") {
+		t.Fatalf("error should name the rejected addressee, got: %v", err)
+	}
+	// AC-33: project IDs must NOT be disclosed in the error.
 	if strings.Contains(err.Error(), "project-a") || strings.Contains(err.Error(), "project-b") {
 		t.Fatalf("error must not disclose project IDs, got: %v", err)
 	}
@@ -521,6 +525,142 @@ func TestValidateCrossProjectAddressees_NoAgents(t *testing.T) {
 	}
 	if err := ValidateCrossProjectAddressees(context.Background(), s, addrs); err != nil {
 		t.Fatalf("no agent addressees should pass: %v", err)
+	}
+}
+
+// ---------- DEF-40: sentinel-collision tests ----------
+
+func TestValidateCrossProjectAddressees_EmptyProjectFirst(t *testing.T) {
+	// Empty-project agent first, then normal agent → must reject (order-independent).
+	s := &mockAgentStore{agents: map[string]*store.Agent{
+		"agent-empty": {ID: "agent-empty", ProjectID: ""},
+		"agent-p1":    {ID: "agent-p1", ProjectID: "project-a"},
+	}}
+	addrs := []Addressee{
+		{PrincipalKind: "agent", PrincipalID: "agent-empty"},
+		{PrincipalKind: "agent", PrincipalID: "agent-p1"},
+	}
+	err := ValidateCrossProjectAddressees(context.Background(), s, addrs)
+	if err == nil {
+		t.Fatal("expected error: empty-project agent alongside placed agent must be rejected")
+	}
+	// AC-33: error names rejected addressees but never project IDs.
+	if !strings.Contains(err.Error(), "agent-empty") {
+		t.Fatalf("error should name the rejected addressee, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "project-a") {
+		t.Fatalf("error must not disclose project IDs, got: %v", err)
+	}
+}
+
+func TestValidateCrossProjectAddressees_EmptyProjectSecond(t *testing.T) {
+	// Normal agent first, then empty-project agent → must also reject.
+	s := &mockAgentStore{agents: map[string]*store.Agent{
+		"agent-p1":    {ID: "agent-p1", ProjectID: "project-a"},
+		"agent-empty": {ID: "agent-empty", ProjectID: ""},
+	}}
+	addrs := []Addressee{
+		{PrincipalKind: "agent", PrincipalID: "agent-p1"},
+		{PrincipalKind: "agent", PrincipalID: "agent-empty"},
+	}
+	err := ValidateCrossProjectAddressees(context.Background(), s, addrs)
+	if err == nil {
+		t.Fatal("expected error: empty-project agent alongside placed agent must be rejected regardless of order")
+	}
+	if !strings.Contains(err.Error(), "agent-empty") {
+		t.Fatalf("error should name the rejected addressee, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "project-a") {
+		t.Fatalf("error must not disclose project IDs, got: %v", err)
+	}
+}
+
+func TestValidateCrossProjectAddressees_ZeroUUIDFirst(t *testing.T) {
+	// Zero-UUID agent first, then normal agent → must reject.
+	s := &mockAgentStore{agents: map[string]*store.Agent{
+		"agent-zero": {ID: "agent-zero", ProjectID: "00000000-0000-0000-0000-000000000000"},
+		"agent-p1":   {ID: "agent-p1", ProjectID: "project-a"},
+	}}
+	addrs := []Addressee{
+		{PrincipalKind: "agent", PrincipalID: "agent-zero"},
+		{PrincipalKind: "agent", PrincipalID: "agent-p1"},
+	}
+	err := ValidateCrossProjectAddressees(context.Background(), s, addrs)
+	if err == nil {
+		t.Fatal("expected error: zero-UUID agent alongside placed agent must be rejected")
+	}
+	if !strings.Contains(err.Error(), "agent-zero") {
+		t.Fatalf("error should name the rejected addressee, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "project-a") {
+		t.Fatalf("error must not disclose project IDs, got: %v", err)
+	}
+}
+
+func TestValidateCrossProjectAddressees_ZeroUUIDSecond(t *testing.T) {
+	// Normal agent first, then zero-UUID agent → must also reject.
+	s := &mockAgentStore{agents: map[string]*store.Agent{
+		"agent-p1":   {ID: "agent-p1", ProjectID: "project-a"},
+		"agent-zero": {ID: "agent-zero", ProjectID: "00000000-0000-0000-0000-000000000000"},
+	}}
+	addrs := []Addressee{
+		{PrincipalKind: "agent", PrincipalID: "agent-p1"},
+		{PrincipalKind: "agent", PrincipalID: "agent-zero"},
+	}
+	err := ValidateCrossProjectAddressees(context.Background(), s, addrs)
+	if err == nil {
+		t.Fatal("expected error: zero-UUID agent alongside placed agent must be rejected regardless of order")
+	}
+	if !strings.Contains(err.Error(), "agent-zero") {
+		t.Fatalf("error should name the rejected addressee, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "project-a") {
+		t.Fatalf("error must not disclose project IDs, got: %v", err)
+	}
+}
+
+func TestValidateCrossProjectAddressees_SingleEmptyProjectAgent(t *testing.T) {
+	// A single unplaceable agent alone has no cross-project issue → must pass.
+	s := &mockAgentStore{agents: map[string]*store.Agent{
+		"agent-empty": {ID: "agent-empty", ProjectID: ""},
+	}}
+	addrs := []Addressee{
+		{PrincipalKind: "agent", PrincipalID: "agent-empty"},
+	}
+	if err := ValidateCrossProjectAddressees(context.Background(), s, addrs); err != nil {
+		t.Fatalf("single unplaceable agent should pass: %v", err)
+	}
+}
+
+func TestValidateCrossProjectAddressees_SingleZeroUUIDAgent(t *testing.T) {
+	// A single zero-UUID agent alone has no cross-project issue → must pass.
+	s := &mockAgentStore{agents: map[string]*store.Agent{
+		"agent-zero": {ID: "agent-zero", ProjectID: "00000000-0000-0000-0000-000000000000"},
+	}}
+	addrs := []Addressee{
+		{PrincipalKind: "agent", PrincipalID: "agent-zero"},
+	}
+	if err := ValidateCrossProjectAddressees(context.Background(), s, addrs); err != nil {
+		t.Fatalf("single zero-UUID agent should pass: %v", err)
+	}
+}
+
+func TestValidateCrossProjectAddressees_MultipleUnplaceableAgents(t *testing.T) {
+	// Multiple unplaceable agents → cannot verify same-project → must reject.
+	s := &mockAgentStore{agents: map[string]*store.Agent{
+		"agent-empty": {ID: "agent-empty", ProjectID: ""},
+		"agent-zero":  {ID: "agent-zero", ProjectID: "00000000-0000-0000-0000-000000000000"},
+	}}
+	addrs := []Addressee{
+		{PrincipalKind: "agent", PrincipalID: "agent-empty"},
+		{PrincipalKind: "agent", PrincipalID: "agent-zero"},
+	}
+	err := ValidateCrossProjectAddressees(context.Background(), s, addrs)
+	if err == nil {
+		t.Fatal("expected error: multiple unplaceable agents must be rejected")
+	}
+	if !strings.Contains(err.Error(), "agent-empty") || !strings.Contains(err.Error(), "agent-zero") {
+		t.Fatalf("error should name all rejected addressees, got: %v", err)
 	}
 }
 
@@ -571,8 +711,8 @@ func TestValidateMessageAddressees_CrossProjectRejected(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for cross-project addressees")
 	}
-	if !strings.Contains(err.Error(), "multiple projects") {
-		t.Fatalf("error should mention multiple projects, got: %v", err)
+	if !strings.Contains(err.Error(), "across project boundaries") {
+		t.Fatalf("error should mention project boundaries, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Two defects found reviewing merged tranche-C work. Both are already on main, so this is follow-up cleanup.

DEF-39b - the conversation-upsert guard could be fooled into exempting a non-group INSERT. Two fail-open routes: extraction leaked lines past the Go raw-string terminator, and a statement longer than the 20-line window was exempted without its kind ever being read. Fixed by requiring a fully bounded statement - no closing backtick in the window now fails closed. The cap was deliberately NOT raised; that moves the hole rather than closing it.

DEF-40 - ValidateCrossProjectAddressees used empty-string projectID as its "no anchor yet" sentinel, so an agent with no project ID failed to anchor and the next agent anchored instead, letting a cross-project pair through. The zero UUID is the same bug in another spelling: being non-empty, it let two orphaned agents mutually validate. Fixed with an explicit anchorSet bool and an isUnsetProjectID helper covering both forms.

Per AC-33 the refusal names rejected addressees but never project IDs, which would leak project existence.

Verified against independent repros that fail on main and pass here. Guard probes for all three bypass routes fail closed. Three CI gates green; gofmt and vet clean. cla/google is expected to fail here