### PR TITLE
feat(hub): dual-write webchat topics into the conversation model (tranche C4)

### DIFF
--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/google/uuid"
 )
 
@@ -78,6 +79,15 @@ type WebChatStore interface {
 	MarkThreadRead(ctx context.Context, userID, projectID, agentID string) error
 
 	// --- Wave-2 Topic methods ---
+
+	// GetTopicConversationID returns the conversation_id for a webchat topic.
+	// Returns ("", store.ErrNotFound) if the topic does not exist or is soft-deleted.
+	// Returns ("", nil) if the topic exists but has no conversation_id yet.
+	GetTopicConversationID(ctx context.Context, topicID string) (string, error)
+
+	// GetTopicConversationIDIncludingDeleted returns the conversation_id for a
+	// webchat topic regardless of its deletion state.
+	GetTopicConversationIDIncludingDeleted(ctx context.Context, topicID string) (string, error)
 
 	// CreateTopic inserts a new topic. Returns an error on name conflict
 	// within the same project.
@@ -272,7 +282,8 @@ type WebChatTopic struct {
 	ProjectID      string     `json:"projectId"`
 	Name           string     `json:"name"`
 	IsGeneral      bool       `json:"isGeneral"`
-	DefaultAgent   string     `json:"defaultAgent,omitempty"` // empty = no default
+	DefaultAgent   string     `json:"defaultAgent,omitempty"`   // empty = no default
+	ConversationID string     `json:"conversationId,omitempty"` // reverse pointer to conversations.id
 	CreatedBy      string     `json:"createdBy"`
 	CreatedAt      time.Time  `json:"createdAt"`
 	LastMessageID  string     `json:"lastMessageId,omitempty"`
@@ -412,6 +423,7 @@ CREATE TABLE IF NOT EXISTS webchat_topic (
     name          TEXT NOT NULL,
     is_general    INTEGER NOT NULL DEFAULT 0,
     default_agent TEXT,
+    conversation_id TEXT,
     created_by    TEXT NOT NULL,
     created_at    TEXT NOT NULL,
     last_message_id TEXT,
@@ -421,6 +433,9 @@ CREATE TABLE IF NOT EXISTS webchat_topic (
 
 CREATE INDEX IF NOT EXISTS idx_webchat_topic_project_activity
     ON webchat_topic (project_id, deleted_at, last_activity_at);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webchat_topic_conversation
+    ON webchat_topic (conversation_id) WHERE conversation_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS webchat_read_state (
     user_id          TEXT NOT NULL,
@@ -662,21 +677,75 @@ UPDATE webchat_thread
 // Wave-2 Topic methods (SQLite)
 // ---------------------------------------------------------------------------
 
-// CreateTopic inserts a new topic. Returns an error on name conflict.
+// CreateTopic inserts a new topic and, when ConversationID is set and the
+// conversations table exists, atomically creates a linked conversations row
+// inside the same transaction.
 func (s *sqliteWebChatStore) CreateTopic(ctx context.Context, topic WebChatTopic) error {
-	const query = `
-INSERT INTO webchat_topic (id, project_id, name, is_general, default_agent, created_by, created_at)
-VALUES (?, ?, ?, ?, ?, ?, ?)
-`
+	if topic.ConversationID != "" && topic.ProjectID == "" {
+		return fmt.Errorf("webchat store: project_id is required for topic conversations")
+	}
+
 	isGeneral := 0
 	if topic.IsGeneral {
 		isGeneral = 1
 	}
-	_, err := s.db.ExecContext(ctx, query, topic.ID, topic.ProjectID, topic.Name,
-		isGeneral, nullableString(topic.DefaultAgent), topic.CreatedBy,
+
+	if topic.ConversationID == "" {
+		// Legacy path: no conversation linkage.
+		const query = `
+INSERT INTO webchat_topic (id, project_id, name, is_general, default_agent, created_by, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+`
+		_, err := s.db.ExecContext(ctx, query, topic.ID, topic.ProjectID, topic.Name,
+			isGeneral, nullableString(topic.DefaultAgent), topic.CreatedBy,
+			topic.CreatedAt.UTC().Format(time.RFC3339Nano))
+		if err != nil {
+			return fmt.Errorf("webchat store: create topic: %w", err)
+		}
+		return nil
+	}
+
+	// ConversationID is set — the handler expects an atomic dual-write
+	// (topic + conversation). If the conversations table doesn't exist,
+	// something is wrong with server initialization; fail explicitly
+	// rather than writing a dangling conversation_id (DEF-22).
+	shouldDualWrite := s.hasConversationsTable()
+	if !shouldDualWrite {
+		return fmt.Errorf("webchat store: create topic: conversations table does not exist but conversation_id %q was provided", topic.ConversationID)
+	}
+
+	// Atomic dual-write: topic + conversation in one transaction.
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("webchat store: begin create topic tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO webchat_topic (id, project_id, name, is_general, default_agent, conversation_id, created_by, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		topic.ID, topic.ProjectID, topic.Name, isGeneral,
+		nullableString(topic.DefaultAgent), topic.ConversationID, topic.CreatedBy,
 		topic.CreatedAt.UTC().Format(time.RFC3339Nano))
 	if err != nil {
 		return fmt.Errorf("webchat store: create topic: %w", err)
+	}
+
+	// DEF-36: group conversations do NOT populate the participant listing index.
+	// Group conversation participants are derived from project membership, not
+	// from an explicit participant table. The participant table is a listing
+	// index, NEVER the access authority (design doc §2.4.2.1).
+	now := topic.CreatedAt.UTC().Format(time.RFC3339Nano)
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO conversations (id, project_id, kind, surface, external_ref, parent_ref, display_name, drift_state, last_activity_at, created_at)
+		 VALUES (?, ?, 'group', 'native', '', '', ?, 'active', ?, ?)`,
+		topic.ConversationID, topic.ProjectID, topic.Name, now, now)
+	if err != nil {
+		return fmt.Errorf("webchat store: create conversation for topic: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("webchat store: commit create topic tx: %w", err)
 	}
 	return nil
 }
@@ -685,6 +754,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?)
 func (s *sqliteWebChatStore) GetTopic(ctx context.Context, topicID string) (*WebChatTopic, error) {
 	const query = `
 SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
+       COALESCE(conversation_id, ''),
        created_by, created_at, COALESCE(last_message_id, ''),
        COALESCE(last_activity_at, ''), deleted_at
   FROM webchat_topic
@@ -696,6 +766,7 @@ SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
 	var deletedAtStr *string
 	err := s.db.QueryRowContext(ctx, query, topicID).Scan(
 		&t.ID, &t.ProjectID, &t.Name, &isGeneral, &t.DefaultAgent,
+		&t.ConversationID,
 		&t.CreatedBy, &createdAtStr, &t.LastMessageID, &activityStr, &deletedAtStr)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -718,6 +789,7 @@ SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
 func (s *sqliteWebChatStore) ListTopics(ctx context.Context, projectID string) ([]WebChatTopic, error) {
 	const query = `
 SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
+       COALESCE(conversation_id, ''),
        created_by, created_at, COALESCE(last_message_id, ''),
        COALESCE(last_activity_at, ''), deleted_at
   FROM webchat_topic
@@ -738,6 +810,7 @@ SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
 		var createdAtStr, activityStr string
 		var deletedAtStr *string
 		if err := rows.Scan(&t.ID, &t.ProjectID, &t.Name, &isGeneral, &t.DefaultAgent,
+			&t.ConversationID,
 			&t.CreatedBy, &createdAtStr, &t.LastMessageID, &activityStr, &deletedAtStr); err != nil {
 			return nil, fmt.Errorf("webchat store: scan topic: %w", err)
 		}
@@ -843,23 +916,66 @@ func (s *sqliteWebChatStore) TouchTopicActivity(ctx context.Context, topicID, me
 
 // EnsureGeneralTopic idempotently creates the #general topic for a project.
 // Returns the topic ID (existing or new) and whether a new row was inserted.
+// When creating a new topic, a linked conversations row is atomically created
+// if the conversations table exists (it is Ent-managed and may not exist in
+// all environments).
 func (s *sqliteWebChatStore) EnsureGeneralTopic(ctx context.Context, projectID, createdBy string) (string, bool, error) {
 	newID := uuid.New().String()
+	convID := uuid.New().String()
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
-	const insert = `
-INSERT INTO webchat_topic (id, project_id, name, is_general, created_by, created_at)
+	// INVARIANT U-TX-1: check hasConversationsTable() BEFORE BeginTx —
+	// it uses s.db.QueryRow which would deadlock inside a tx at MaxOpenConns=1.
+	hasConvTable := s.hasConversationsTable()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", false, fmt.Errorf("webchat store: begin ensure general tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var insert string
+	if hasConvTable {
+		insert = `INSERT INTO webchat_topic (id, project_id, name, is_general, conversation_id, created_by, created_at)
+VALUES (?, ?, 'general', 1, ?, ?, ?)
+ON CONFLICT DO NOTHING`
+	} else {
+		insert = `INSERT INTO webchat_topic (id, project_id, name, is_general, created_by, created_at)
 VALUES (?, ?, 'general', 1, ?, ?)
-ON CONFLICT DO NOTHING
-`
-	_, err := s.db.ExecContext(ctx, insert, newID, projectID, createdBy, now)
+ON CONFLICT DO NOTHING`
+	}
+
+	var res sql.Result
+	if hasConvTable {
+		res, err = tx.ExecContext(ctx, insert, newID, projectID, convID, createdBy, now)
+	} else {
+		res, err = tx.ExecContext(ctx, insert, newID, projectID, createdBy, now)
+	}
 	if err != nil {
 		return "", false, fmt.Errorf("webchat store: ensure general topic: %w", err)
 	}
 
+	inserted, _ := res.RowsAffected()
+	if inserted > 0 && hasConvTable {
+		// New topic was created — also create the linked conversation.
+		// DEF-36: group conversations do NOT populate the participant listing index.
+		// Group conversation participants are derived from project membership, not
+		// from an explicit participant table. The participant table is a listing
+		// index, NEVER the access authority (design doc §2.4.2.1).
+		_, err = tx.ExecContext(ctx,
+			`INSERT INTO conversations (id, project_id, kind, surface, external_ref, parent_ref, display_name, drift_state, last_activity_at, created_at)
+			 VALUES (?, ?, 'group', 'native', '', '', 'general', 'active', ?, ?)`,
+			convID, projectID, now, now)
+		if err != nil {
+			return "", false, fmt.Errorf("webchat store: create conversation for general topic: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", false, fmt.Errorf("webchat store: commit ensure general tx: %w", err)
+	}
+
 	// Return the ID of the existing or newly created #general topic.
-	// If the returned ID matches the one we tried to insert, we created
-	// a new row; otherwise, the topic already existed.
 	const lookup = `SELECT id FROM webchat_topic WHERE project_id = ? AND is_general = 1 AND deleted_at IS NULL`
 	var id string
 	err = s.db.QueryRowContext(ctx, lookup, projectID).Scan(&id)
@@ -867,6 +983,15 @@ ON CONFLICT DO NOTHING
 		return "", false, fmt.Errorf("webchat store: ensure general topic lookup: %w", err)
 	}
 	return id, id == newID, nil
+}
+
+// hasConversationsTable checks whether the conversations table exists.
+// The conversations table is Ent-managed and may not exist in test
+// environments or during initial setup.
+func (s *sqliteWebChatStore) hasConversationsTable() bool {
+	var count int
+	err := s.db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='conversations'").Scan(&count)
+	return err == nil && count > 0
 }
 
 // ---------------------------------------------------------------------------
@@ -1241,6 +1366,41 @@ SELECT id, project_id, COALESCE(thread_id, ''), sender, msg, created
 // Wave-2 Migrations (SQLite)
 // ---------------------------------------------------------------------------
 
+// GetTopicConversationID returns the conversation_id for a webchat topic.
+// Returns ("", error) if the topic does not exist or is soft-deleted.
+// Returns ("", nil) if the topic exists but has no conversation_id yet.
+func (s *sqliteWebChatStore) GetTopicConversationID(ctx context.Context, topicID string) (string, error) {
+	const query = `SELECT COALESCE(conversation_id, '') FROM webchat_topic WHERE id = ? AND deleted_at IS NULL`
+	var convID string
+	err := s.db.QueryRowContext(ctx, query, topicID).Scan(&convID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", fmt.Errorf("topic not found %s: %w", topicID, store.ErrNotFound)
+		}
+		return "", fmt.Errorf("webchat store: get topic conversation_id: %w", err)
+	}
+	return convID, nil
+}
+
+// GetTopicConversationIDIncludingDeleted returns the conversation_id for a
+// webchat topic regardless of its deletion state.
+//
+// Soft-deletion is not declassification. A tombstoned native topic is still
+// a native topic for the purpose of "should I mint." Deletion hides a topic
+// from users; it must not make the mint guard forget the topic was ours.
+func (s *sqliteWebChatStore) GetTopicConversationIDIncludingDeleted(ctx context.Context, topicID string) (string, error) {
+	const query = `SELECT COALESCE(conversation_id, '') FROM webchat_topic WHERE id = ?`
+	var convID string
+	err := s.db.QueryRowContext(ctx, query, topicID).Scan(&convID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", fmt.Errorf("topic not found %s: %w", topicID, store.ErrNotFound)
+		}
+		return "", fmt.Errorf("webchat store: get topic conversation_id (including deleted): %w", err)
+	}
+	return convID, nil
+}
+
 // runMigrations executes idempotent data migrations.
 func (s *sqliteWebChatStore) runMigrations() error {
 	if err := s.migrateThreadIDs(DefaultMigrationBatchSize); err != nil {
@@ -1252,7 +1412,132 @@ func (s *sqliteWebChatStore) runMigrations() error {
 	if err := s.addThreadIDIndex(); err != nil {
 		return fmt.Errorf("thread_id index: %w", err)
 	}
+	if err := s.addTopicConversationID(); err != nil {
+		return fmt.Errorf("topic conversation_id: %w", err)
+	}
+	if err := s.backfillTopicConversations(); err != nil {
+		return fmt.Errorf("topic conversation backfill: %w", err)
+	}
 	return nil
+}
+
+// addTopicConversationID adds the conversation_id column and unique index
+// to the webchat_topic table for existing databases.
+func (s *sqliteWebChatStore) addTopicConversationID() error {
+	done, err := s.migrationCompleted("topic_conversation_id")
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+
+	// ALTER TABLE ADD COLUMN is idempotent-safe: if the column already exists
+	// (DDL ran first), we just skip the error.
+	_, err = s.db.Exec(`ALTER TABLE webchat_topic ADD COLUMN conversation_id TEXT`)
+	if err != nil && !strings.Contains(err.Error(), "duplicate column") {
+		return err
+	}
+
+	_, err = s.db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_webchat_topic_conversation ON webchat_topic (conversation_id) WHERE conversation_id IS NOT NULL`)
+	if err != nil {
+		return err
+	}
+
+	return s.markMigrationCompleted("topic_conversation_id")
+}
+
+// backfillTopicConversations creates conversation rows for existing webchat_topic
+// rows that don't yet have a conversation_id. Each topic is backfilled
+// atomically (INSERT conversation + UPDATE topic in one transaction).
+// The migration is idempotent: re-running creates no duplicate conversations.
+// INVARIANT U-TX-1: hasConversationsTable() is called BEFORE BeginTx.
+func (s *sqliteWebChatStore) backfillTopicConversations() error {
+	done, err := s.migrationCompleted("topic_conversation_backfill")
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+
+	// Check for conversations table BEFORE any transaction (U-TX-1).
+	if !s.hasConversationsTable() {
+		// No conversations table — nothing to backfill; mark as complete.
+		return s.markMigrationCompleted("topic_conversation_backfill")
+	}
+
+	// Find all non-deleted topics without a conversation_id.
+	rows, err := s.db.Query(
+		`SELECT id, project_id, name FROM webchat_topic WHERE conversation_id IS NULL AND deleted_at IS NULL`)
+	if err != nil {
+		return fmt.Errorf("select unlinked topics: %w", err)
+	}
+
+	type topicRow struct {
+		id, projectID, name string
+	}
+	var topics []topicRow
+	for rows.Next() {
+		var t topicRow
+		if err := rows.Scan(&t.id, &t.projectID, &t.name); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan unlinked topic: %w", err)
+		}
+		topics = append(topics, t)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate unlinked topics: %w", err)
+	}
+	_ = rows.Close()
+
+	// Backfill each topic atomically.
+	for _, t := range topics {
+		convID := uuid.New().String()
+		now := time.Now().UTC().Format(time.RFC3339Nano)
+
+		tx, err := s.db.Begin()
+		if err != nil {
+			return fmt.Errorf("begin backfill tx for topic %s: %w", t.id, err)
+		}
+
+		// DEF-36: group conversations do NOT populate the participant listing index.
+		// Group conversation participants are derived from project membership, not
+		// from an explicit participant table. The participant table is a listing
+		// index, NEVER the access authority (design doc §2.4.2.1).
+		_, err = tx.Exec(
+			`INSERT INTO conversations (id, project_id, kind, surface, external_ref, parent_ref, display_name, drift_state, last_activity_at, created_at)
+			 VALUES (?, ?, 'group', 'native', '', '', ?, 'active', ?, ?)`,
+			convID, t.projectID, t.name, now, now)
+		if err != nil {
+			tx.Rollback() //nolint:errcheck
+			return fmt.Errorf("insert conversation for topic %s: %w", t.id, err)
+		}
+
+		// UPDATE the topic — WHERE conversation_id IS NULL makes this safe
+		// under concurrent runs.
+		res, err := tx.Exec(
+			`UPDATE webchat_topic SET conversation_id = ? WHERE id = ? AND conversation_id IS NULL`,
+			convID, t.id)
+		if err != nil {
+			tx.Rollback() //nolint:errcheck
+			return fmt.Errorf("update topic %s conversation_id: %w", t.id, err)
+		}
+
+		// If another process already backfilled this topic, the UPDATE affected
+		// 0 rows. Roll back to avoid orphan conversation rows.
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			tx.Rollback() //nolint:errcheck
+			continue
+		}
+
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit backfill tx for topic %s: %w", t.id, err)
+		}
+	}
+
+	return s.markMigrationCompleted("topic_conversation_backfill")
 }
 
 // migrationCompleted checks whether a named migration has already run.
@@ -1802,7 +2087,13 @@ func (s *sqliteWebChatStore) MigrateReadState(ctx context.Context, oldKey, newKe
 }
 
 // PromoteDM atomically promotes a DM conversation into a space thread.
+// When ConversationID is set on topic, a linked conversations row is also created.
 func (s *sqliteWebChatStore) PromoteDM(ctx context.Context, topic WebChatTopic, dmKey string) (*WebChatTopic, error) {
+	// Check for conversations table BEFORE starting the transaction to avoid
+	// ambient pool access inside the tx (which deadlocks at MaxOpenConns=1).
+	// INVARIANT U-TX-1.
+	writeConv := topic.ConversationID != "" && s.hasConversationsTable()
+
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("webchat store: begin promote tx: %w", err)
@@ -1816,14 +2107,32 @@ func (s *sqliteWebChatStore) PromoteDM(ctx context.Context, topic WebChatTopic, 
 	}
 	_, err = tx.ExecContext(ctx,
 		`INSERT INTO webchat_topic (id, project_id, name, is_general, default_agent,
-		 created_by, created_at, last_activity_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		 conversation_id, created_by, created_at, last_activity_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		topic.ID, topic.ProjectID, topic.Name, isGeneral,
-		nullableString(topic.DefaultAgent), topic.CreatedBy,
+		nullableString(topic.DefaultAgent), nullableString(topic.ConversationID),
+		topic.CreatedBy,
 		topic.CreatedAt.UTC().Format(time.RFC3339Nano),
 		topic.LastActivityAt.UTC().Format(time.RFC3339Nano))
 	if err != nil {
 		return nil, fmt.Errorf("webchat store: create topic in promote: %w", err)
+	}
+
+	// Step 1b: Create linked conversation if ConversationID is set
+	// and the conversations table exists (checked before tx).
+	if writeConv {
+		// DEF-36: group conversations do NOT populate the participant listing index.
+		// Group conversation participants are derived from project membership, not
+		// from an explicit participant table. The participant table is a listing
+		// index, NEVER the access authority (design doc §2.4.2.1).
+		now := topic.CreatedAt.UTC().Format(time.RFC3339Nano)
+		_, err = tx.ExecContext(ctx,
+			`INSERT INTO conversations (id, project_id, kind, surface, external_ref, parent_ref, display_name, drift_state, last_activity_at, created_at)
+			 VALUES (?, ?, 'group', 'native', '', '', ?, 'active', ?, ?)`,
+			topic.ConversationID, topic.ProjectID, topic.Name, now, now)
+		if err != nil {
+			return nil, fmt.Errorf("webchat store: create conversation in promote: %w", err)
+		}
 	}
 
 	// Step 2: Re-key all messages

--- a/pkg/hub/webchannel_store.go
+++ b/pkg/hub/webchannel_store.go
@@ -1493,47 +1493,51 @@ func (s *sqliteWebChatStore) backfillTopicConversations() error {
 
 	// Backfill each topic atomically.
 	for _, t := range topics {
-		convID := uuid.New().String()
-		now := time.Now().UTC().Format(time.RFC3339Nano)
+		if err := func() error {
+			convID := uuid.New().String()
+			now := time.Now().UTC().Format(time.RFC3339Nano)
 
-		tx, err := s.db.Begin()
-		if err != nil {
-			return fmt.Errorf("begin backfill tx for topic %s: %w", t.id, err)
-		}
+			tx, err := s.db.BeginTx(context.Background(), nil)
+			if err != nil {
+				return fmt.Errorf("begin backfill tx for topic %s: %w", t.id, err)
+			}
+			// Rollback after a successful Commit is a no-op in database/sql.
+			// The defer ensures cleanup on ALL exit paths, including commit failure,
+			// which previously leaked the transaction (deadlock at MaxOpenConns=1).
+			defer tx.Rollback() //nolint:errcheck
 
-		// DEF-36: group conversations do NOT populate the participant listing index.
-		// Group conversation participants are derived from project membership, not
-		// from an explicit participant table. The participant table is a listing
-		// index, NEVER the access authority (design doc §2.4.2.1).
-		_, err = tx.Exec(
-			`INSERT INTO conversations (id, project_id, kind, surface, external_ref, parent_ref, display_name, drift_state, last_activity_at, created_at)
-			 VALUES (?, ?, 'group', 'native', '', '', ?, 'active', ?, ?)`,
-			convID, t.projectID, t.name, now, now)
-		if err != nil {
-			tx.Rollback() //nolint:errcheck
-			return fmt.Errorf("insert conversation for topic %s: %w", t.id, err)
-		}
+			// DEF-36: group conversations do NOT populate the participant listing index.
+			// Group conversation participants are derived from project membership, not
+			// from an explicit participant table. The participant table is a listing
+			// index, NEVER the access authority (design doc §2.4.2.1).
+			_, err = tx.Exec(
+				`INSERT INTO conversations (id, project_id, kind, surface, external_ref, parent_ref, display_name, drift_state, last_activity_at, created_at)
+				 VALUES (?, ?, 'group', 'native', '', '', ?, 'active', ?, ?)`,
+				convID, t.projectID, t.name, now, now)
+			if err != nil {
+				return fmt.Errorf("insert conversation for topic %s: %w", t.id, err)
+			}
 
-		// UPDATE the topic — WHERE conversation_id IS NULL makes this safe
-		// under concurrent runs.
-		res, err := tx.Exec(
-			`UPDATE webchat_topic SET conversation_id = ? WHERE id = ? AND conversation_id IS NULL`,
-			convID, t.id)
-		if err != nil {
-			tx.Rollback() //nolint:errcheck
-			return fmt.Errorf("update topic %s conversation_id: %w", t.id, err)
-		}
+			// UPDATE the topic — WHERE conversation_id IS NULL makes this safe
+			// under concurrent runs.
+			res, err := tx.Exec(
+				`UPDATE webchat_topic SET conversation_id = ? WHERE id = ? AND conversation_id IS NULL`,
+				convID, t.id)
+			if err != nil {
+				return fmt.Errorf("update topic %s conversation_id: %w", t.id, err)
+			}
 
-		// If another process already backfilled this topic, the UPDATE affected
-		// 0 rows. Roll back to avoid orphan conversation rows.
-		n, _ := res.RowsAffected()
-		if n == 0 {
-			tx.Rollback() //nolint:errcheck
-			continue
-		}
+			// If another process already backfilled this topic, the UPDATE affected
+			// 0 rows. Return nil WITHOUT committing — the deferred Rollback will
+			// discard the orphan conversation row.
+			n, _ := res.RowsAffected()
+			if n == 0 {
+				return nil
+			}
 
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit backfill tx for topic %s: %w", t.id, err)
+			return tx.Commit()
+		}(); err != nil {
+			return fmt.Errorf("backfill topic %s: %w", t.id, err)
 		}
 	}
 

--- a/pkg/hub/webchannel_store_dualwrite_test.go
+++ b/pkg/hub/webchannel_store_dualwrite_test.go
@@ -1,0 +1,740 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/google/uuid"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+)
+
+// conversationsTableDDL is the schema for the Ent-managed conversations table,
+// reproduced here for testing the dual-write paths that depend on it.
+const conversationsTableDDL = `
+CREATE TABLE IF NOT EXISTS conversations (
+    id              TEXT PRIMARY KEY,
+    project_id      TEXT,
+    kind            TEXT NOT NULL,
+    surface         TEXT NOT NULL,
+    external_ref    TEXT NOT NULL DEFAULT '',
+    parent_ref      TEXT NOT NULL DEFAULT '',
+    display_name    TEXT NOT NULL DEFAULT '',
+    drift_state     TEXT NOT NULL DEFAULT 'active',
+    default_agent_id TEXT,
+    last_activity_at TEXT,
+    created_at      TEXT,
+    archived_at     TEXT,
+    deleted_at      TEXT
+)
+`
+
+// newTestWebChatStoreWithConversations creates a WebChatStore backed by an
+// in-memory SQLite DB that includes the conversations table (Ent-managed in
+// production). This enables testing the dual-write paths that require
+// hasConversationsTable() to return true.
+func newTestWebChatStoreWithConversations(t *testing.T) (WebChatStore, *sql.DB) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+
+	// Create the conversations table BEFORE Init so migrations can see it.
+	_, err = db.Exec(conversationsTableDDL)
+	require.NoError(t, err)
+
+	s := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, s.Init())
+
+	return s, db
+}
+
+// newPromoteTestStoreWithConversations creates a WebChatStore with in-memory
+// SQLite DB that includes both the messages table AND the conversations table.
+func newPromoteTestStoreWithConversations(t *testing.T) (WebChatStore, *sql.DB) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+
+	// Create the Ent messages table manually.
+	_, err = db.Exec(`
+CREATE TABLE IF NOT EXISTS messages (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL DEFAULT '',
+    sender TEXT NOT NULL,
+    sender_id TEXT NOT NULL DEFAULT '',
+    recipient TEXT NOT NULL,
+    recipient_id TEXT NOT NULL DEFAULT '',
+    channel TEXT,
+    thread_id TEXT,
+    msg TEXT NOT NULL DEFAULT '',
+    type TEXT NOT NULL DEFAULT 'chat',
+    dispatch_state TEXT NOT NULL DEFAULT 'dispatched',
+    created TEXT NOT NULL DEFAULT ''
+)
+`)
+	require.NoError(t, err)
+
+	// Create the conversations table.
+	_, err = db.Exec(conversationsTableDDL)
+	require.NoError(t, err)
+
+	s := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, s.Init())
+
+	return s, db
+}
+
+// conversationRow holds the relevant columns from a conversations row for test assertions.
+type conversationRow struct {
+	id, projectID, kind, surface, displayName, driftState string
+}
+
+// getConversation reads a single conversations row by ID, returning nil if not found.
+func getConversation(t *testing.T, db *sql.DB, convID string) *conversationRow {
+	t.Helper()
+	var c conversationRow
+	err := db.QueryRow(
+		`SELECT id, COALESCE(project_id,''), kind, surface, COALESCE(display_name,''), COALESCE(drift_state,'')
+		   FROM conversations WHERE id = ?`, convID).
+		Scan(&c.id, &c.projectID, &c.kind, &c.surface, &c.displayName, &c.driftState)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	require.NoError(t, err)
+	return &c
+}
+
+// countConversations returns the number of rows in the conversations table.
+func countConversations(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var n int
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM conversations").Scan(&n))
+	return n
+}
+
+// getTopicConvID reads conversation_id directly from the webchat_topic table.
+func getTopicConvID(t *testing.T, db *sql.DB, topicID string) string {
+	t.Helper()
+	var convID string
+	err := db.QueryRow("SELECT COALESCE(conversation_id, '') FROM webchat_topic WHERE id = ?", topicID).Scan(&convID)
+	require.NoError(t, err)
+	return convID
+}
+
+// ---------------------------------------------------------------------------
+// TestCreateTopic_DualWrite_WritesConversation
+// ---------------------------------------------------------------------------
+
+func TestCreateTopic_DualWrite_WritesConversation(t *testing.T) {
+	s, db := newTestWebChatStoreWithConversations(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	convID := uuid.New().String()
+	topic := WebChatTopic{
+		ID:             "topic-dw-1",
+		ProjectID:      "proj-1",
+		Name:           "dual-write-test",
+		ConversationID: convID,
+		CreatedBy:      "user-1",
+		CreatedAt:      time.Now().UTC().Truncate(time.Second),
+	}
+	require.NoError(t, s.CreateTopic(ctx, topic))
+
+	// Assert topic row has conversation_id.
+	require.Equal(t, convID, getTopicConvID(t, db, "topic-dw-1"))
+
+	// Assert conversation row exists with correct fields.
+	c := getConversation(t, db, convID)
+	require.NotNil(t, c, "conversations row should exist")
+	require.Equal(t, "proj-1", c.projectID)
+	require.Equal(t, "group", c.kind)
+	require.Equal(t, "native", c.surface)
+	require.Equal(t, "dual-write-test", c.displayName)
+	require.Equal(t, "active", c.driftState)
+
+	// Verify GetTopic returns ConversationID.
+	got, err := s.GetTopic(ctx, "topic-dw-1")
+	require.NoError(t, err)
+	require.Equal(t, convID, got.ConversationID)
+}
+
+func TestCreateTopic_DualWrite_Atomicity(t *testing.T) {
+	s, db := newTestWebChatStoreWithConversations(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	convID := uuid.New().String()
+
+	// Insert a conversation row first to cause a duplicate ID conflict.
+	_, err := db.Exec(
+		`INSERT INTO conversations (id, project_id, kind, surface, display_name, drift_state)
+		 VALUES (?, 'proj-x', 'group', 'native', 'pre-existing', 'active')`, convID)
+	require.NoError(t, err)
+
+	// CreateTopic with the same convID should fail on the conversation INSERT.
+	err = s.CreateTopic(ctx, WebChatTopic{
+		ID:             "topic-dw-atomic",
+		ProjectID:      "proj-1",
+		Name:           "should-rollback",
+		ConversationID: convID,
+		CreatedBy:      "user-1",
+		CreatedAt:      time.Now().UTC(),
+	})
+	require.Error(t, err, "duplicate conversation_id should cause an error")
+
+	// Neither the topic nor a second conversation should be committed.
+	got, err := s.GetTopic(ctx, "topic-dw-atomic")
+	require.NoError(t, err)
+	require.Nil(t, got, "topic should not exist after rollback")
+
+	// Only the pre-existing conversation should remain.
+	require.Equal(t, 1, countConversations(t, db))
+}
+
+func TestCreateTopic_DualWrite_RequiresProjectID(t *testing.T) {
+	s, db := newTestWebChatStoreWithConversations(t)
+	defer db.Close() //nolint:errcheck
+
+	err := s.CreateTopic(context.Background(), WebChatTopic{
+		ID:             "topic-no-proj",
+		ConversationID: uuid.New().String(),
+		Name:           "test",
+		CreatedBy:      "user-1",
+		CreatedAt:      time.Now().UTC(),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "project_id is required")
+}
+
+func TestCreateTopic_LegacyPath_NoConversationID(t *testing.T) {
+	s, db := newTestWebChatStoreWithConversations(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	require.NoError(t, s.CreateTopic(ctx, WebChatTopic{
+		ID:        "topic-legacy",
+		ProjectID: "proj-1",
+		Name:      "no-conv",
+		CreatedBy: "user-1",
+		CreatedAt: time.Now().UTC(),
+	}))
+
+	// Topic created, but no conversation.
+	require.Empty(t, getTopicConvID(t, db, "topic-legacy"))
+	require.Equal(t, 0, countConversations(t, db))
+}
+
+// ---------------------------------------------------------------------------
+// TestEnsureGeneralTopic_DualWrite_WritesConversation
+// ---------------------------------------------------------------------------
+
+func TestEnsureGeneralTopic_DualWrite_WritesConversation(t *testing.T) {
+	s, db := newTestWebChatStoreWithConversations(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	id, created, err := s.EnsureGeneralTopic(ctx, "proj-1", "user-1")
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NotEmpty(t, id)
+
+	// Assert the topic has a conversation_id.
+	convID := getTopicConvID(t, db, id)
+	require.NotEmpty(t, convID, "general topic should have conversation_id")
+
+	// Assert conversations row.
+	c := getConversation(t, db, convID)
+	require.NotNil(t, c)
+	require.Equal(t, "proj-1", c.projectID)
+	require.Equal(t, "group", c.kind)
+	require.Equal(t, "native", c.surface)
+	require.Equal(t, "general", c.displayName)
+}
+
+func TestEnsureGeneralTopic_DualWrite_Idempotent(t *testing.T) {
+	s, db := newTestWebChatStoreWithConversations(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	id1, created1, err := s.EnsureGeneralTopic(ctx, "proj-1", "user-1")
+	require.NoError(t, err)
+	require.True(t, created1)
+
+	id2, created2, err := s.EnsureGeneralTopic(ctx, "proj-1", "user-2")
+	require.NoError(t, err)
+	require.False(t, created2)
+	require.Equal(t, id1, id2)
+
+	// Only one conversation row should exist.
+	require.Equal(t, 1, countConversations(t, db))
+}
+
+// ---------------------------------------------------------------------------
+// TestPromoteDM_DualWrite_WritesConversation
+// ---------------------------------------------------------------------------
+
+func TestPromoteDM_DualWrite_WritesConversation(t *testing.T) {
+	s, db := newPromoteTestStoreWithConversations(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	dmKey := "dm:agent:agent-1:user:user-1"
+
+	// Seed DM data.
+	_, err := db.Exec(`
+INSERT INTO messages (id, project_id, sender, sender_id, recipient, recipient_id, channel, thread_id, msg, created)
+VALUES
+    ('msg-1', 'proj-1', 'user:alice', 'user-1', 'agent:coder', 'agent-1', 'web', ?, 'hello', '2026-08-22T10:00:00Z'),
+    ('msg-2', 'proj-1', 'agent:coder', 'agent-1', 'user:alice', 'user-1', 'web', ?, 'hi back', '2026-08-22T10:01:00Z')
+`, dmKey, dmKey)
+	require.NoError(t, err)
+
+	require.NoError(t, s.UpsertDM(ctx, WebChatDM{
+		ConversationKey: dmKey,
+		ParticipantID:   "user-1",
+		PeerID:          "agent-1",
+		PeerKind:        "agent",
+	}))
+
+	convID := uuid.New().String()
+	now := time.Now().UTC().Truncate(time.Second)
+	topic := WebChatTopic{
+		ID:             "promoted-topic",
+		ProjectID:      "proj-1",
+		Name:           "Promoted Thread",
+		ConversationID: convID,
+		CreatedBy:      "user-1",
+		CreatedAt:      now,
+		LastActivityAt: now,
+	}
+
+	result, err := s.PromoteDM(ctx, topic, dmKey)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 2, result.MessageCount)
+
+	// Assert topic has conversation_id.
+	require.Equal(t, convID, getTopicConvID(t, db, "promoted-topic"))
+
+	// Assert conversations row.
+	c := getConversation(t, db, convID)
+	require.NotNil(t, c)
+	require.Equal(t, "proj-1", c.projectID)
+	require.Equal(t, "group", c.kind)
+	require.Equal(t, "native", c.surface)
+	require.Equal(t, "Promoted Thread", c.displayName)
+}
+
+func TestPromoteDM_NoConversationID_SkipsDualWrite(t *testing.T) {
+	s, db := newPromoteTestStoreWithConversations(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	dmKey := "dm:agent:agent-2:user:user-2"
+
+	_, err := db.Exec(`
+INSERT INTO messages (id, project_id, sender, sender_id, recipient, recipient_id, channel, thread_id, msg, created)
+VALUES ('msg-10', 'proj-1', 'user:bob', 'user-2', 'agent:helper', 'agent-2', 'web', ?, 'test', '2026-08-22T10:00:00Z')
+`, dmKey)
+	require.NoError(t, err)
+
+	require.NoError(t, s.UpsertDM(ctx, WebChatDM{
+		ConversationKey: dmKey,
+		ParticipantID:   "user-2",
+		PeerID:          "agent-2",
+		PeerKind:        "agent",
+	}))
+
+	now := time.Now().UTC().Truncate(time.Second)
+	result, err := s.PromoteDM(ctx, WebChatTopic{
+		ID:             "promoted-no-conv",
+		ProjectID:      "proj-1",
+		Name:           "No Conv Thread",
+		CreatedBy:      "user-2",
+		CreatedAt:      now,
+		LastActivityAt: now,
+	}, dmKey)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// No conversation should be created when ConversationID is empty.
+	require.Equal(t, 0, countConversations(t, db))
+}
+
+// ---------------------------------------------------------------------------
+// TestBackfillTopicConversations
+// ---------------------------------------------------------------------------
+
+func TestBackfillTopicConversations_CreatesConversations(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	// Create conversations table first.
+	_, err = db.Exec(conversationsTableDDL)
+	require.NoError(t, err)
+
+	s := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, s.Init())
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// The Init() call already ran backfillTopicConversations, but there were
+	// no topics yet. Create topics WITHOUT conversation_id to simulate
+	// pre-existing data. Use the legacy (no ConversationID) path.
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		require.NoError(t, s.CreateTopic(ctx, WebChatTopic{
+			ID:        "topic-" + name,
+			ProjectID: "proj-1",
+			Name:      name,
+			CreatedBy: "user-1",
+			CreatedAt: now,
+		}))
+	}
+
+	// Verify no conversation_id set yet.
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		require.Empty(t, getTopicConvID(t, db, "topic-"+name))
+	}
+
+	// Reset the migration marker so backfill re-runs.
+	_, err = db.Exec("DELETE FROM webchat_migrations WHERE name = 'topic_conversation_backfill'")
+	require.NoError(t, err)
+
+	// Re-init triggers migrations including backfill.
+	s2 := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, s2.Init())
+
+	// Verify all topics now have conversation_id and matching conversation rows.
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		convID := getTopicConvID(t, db, "topic-"+name)
+		require.NotEmpty(t, convID, "topic %s should have conversation_id after backfill", name)
+
+		c := getConversation(t, db, convID)
+		require.NotNil(t, c, "conversation row should exist for topic %s", name)
+		require.Equal(t, "proj-1", c.projectID)
+		require.Equal(t, "group", c.kind)
+		require.Equal(t, "native", c.surface)
+		require.Equal(t, name, c.displayName)
+	}
+}
+
+func TestBackfillTopicConversations_Idempotent(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	_, err = db.Exec(conversationsTableDDL)
+	require.NoError(t, err)
+
+	s := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, s.Init())
+
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Create a topic without conversation_id.
+	require.NoError(t, s.CreateTopic(ctx, WebChatTopic{
+		ID:        "topic-idem",
+		ProjectID: "proj-1",
+		Name:      "idempotent-test",
+		CreatedBy: "user-1",
+		CreatedAt: now,
+	}))
+
+	// Reset migration marker and re-run.
+	_, err = db.Exec("DELETE FROM webchat_migrations WHERE name = 'topic_conversation_backfill'")
+	require.NoError(t, err)
+	s2 := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, s2.Init())
+
+	convID1 := getTopicConvID(t, db, "topic-idem")
+	require.NotEmpty(t, convID1)
+	count1 := countConversations(t, db)
+
+	// Reset and run again — should produce no duplicates.
+	_, err = db.Exec("DELETE FROM webchat_migrations WHERE name = 'topic_conversation_backfill'")
+	require.NoError(t, err)
+	s3 := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, s3.Init())
+
+	convID2 := getTopicConvID(t, db, "topic-idem")
+	require.Equal(t, convID1, convID2, "conversation_id should not change on re-run")
+	require.Equal(t, count1, countConversations(t, db), "no duplicate conversations")
+}
+
+func TestBackfillTopicConversations_SkipsWithoutConversationsTable(t *testing.T) {
+	// Without the conversations table, backfill should succeed (no-op).
+	s, db := newTestWebChatStoreV2(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	require.NoError(t, s.CreateTopic(ctx, WebChatTopic{
+		ID:        "topic-no-conv-table",
+		ProjectID: "proj-1",
+		Name:      "test",
+		CreatedBy: "user-1",
+		CreatedAt: time.Now().UTC(),
+	}))
+
+	// Reset and re-run — should not fail even without conversations table.
+	_, err := db.Exec("DELETE FROM webchat_migrations WHERE name = 'topic_conversation_backfill'")
+	require.NoError(t, err)
+	s2 := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, s2.Init())
+
+	// Topic should still have no conversation_id.
+	require.Empty(t, getTopicConvID(t, db, "topic-no-conv-table"))
+}
+
+// ---------------------------------------------------------------------------
+// TestGetTopicConversationID
+// ---------------------------------------------------------------------------
+
+func TestGetTopicConversationID(t *testing.T) {
+	s, db := newTestWebChatStoreWithConversations(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	convID := uuid.New().String()
+
+	// Create topic with conversation_id.
+	require.NoError(t, s.CreateTopic(ctx, WebChatTopic{
+		ID:             "topic-conv-lookup",
+		ProjectID:      "proj-1",
+		Name:           "conv-lookup-test",
+		ConversationID: convID,
+		CreatedBy:      "user-1",
+		CreatedAt:      time.Now().UTC(),
+	}))
+
+	// GetTopicConversationID returns the correct ID.
+	got, err := s.GetTopicConversationID(ctx, "topic-conv-lookup")
+	require.NoError(t, err)
+	require.Equal(t, convID, got)
+
+	// Non-existent topic returns store.ErrNotFound.
+	_, err = s.GetTopicConversationID(ctx, "nonexistent")
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestGetTopicConversationID_NoConversationID(t *testing.T) {
+	s, db := newTestWebChatStoreWithConversations(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+
+	// Create topic WITHOUT conversation_id.
+	require.NoError(t, s.CreateTopic(ctx, WebChatTopic{
+		ID:        "topic-no-conv",
+		ProjectID: "proj-1",
+		Name:      "no-conv",
+		CreatedBy: "user-1",
+		CreatedAt: time.Now().UTC(),
+	}))
+
+	// Should return empty string, no error.
+	got, err := s.GetTopicConversationID(ctx, "topic-no-conv")
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestGetTopicConversationID_SoftDeleted(t *testing.T) {
+	s, db := newTestWebChatStoreWithConversations(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	convID := uuid.New().String()
+
+	require.NoError(t, s.CreateTopic(ctx, WebChatTopic{
+		ID:             "topic-soft-del",
+		ProjectID:      "proj-1",
+		Name:           "will-be-deleted",
+		ConversationID: convID,
+		CreatedBy:      "user-1",
+		CreatedAt:      time.Now().UTC(),
+	}))
+
+	// Soft-delete the topic.
+	require.NoError(t, s.DeleteTopic(ctx, "topic-soft-del"))
+
+	// GetTopicConversationID should return ErrNotFound for deleted topic.
+	_, err := s.GetTopicConversationID(ctx, "topic-soft-del")
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	// GetTopicConversationIDIncludingDeleted should still return the ID.
+	got, err := s.GetTopicConversationIDIncludingDeleted(ctx, "topic-soft-del")
+	require.NoError(t, err)
+	require.Equal(t, convID, got)
+}
+
+func TestGetTopicConversationIDIncludingDeleted_NotFound(t *testing.T) {
+	s, db := newTestWebChatStoreWithConversations(t)
+	defer db.Close() //nolint:errcheck
+
+	_, err := s.GetTopicConversationIDIncludingDeleted(context.Background(), "totally-nonexistent")
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+// ---------------------------------------------------------------------------
+// TestCreateTopic_DualWrite_UTX1_NoDeadlock
+// ---------------------------------------------------------------------------
+
+func TestCreateTopic_DualWrite_UTX1_NoDeadlock(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	// MaxOpenConns=1 simulates the production SQLite pool constraint.
+	// If hasConversationsTable() were called inside a tx, this would deadlock.
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec(conversationsTableDDL)
+	require.NoError(t, err)
+
+	s := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, s.Init())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	convID := uuid.New().String()
+	err = s.CreateTopic(ctx, WebChatTopic{
+		ID:             "topic-utx1",
+		ProjectID:      "proj-1",
+		Name:           "deadlock-test",
+		ConversationID: convID,
+		CreatedBy:      "user-1",
+		CreatedAt:      time.Now().UTC(),
+	})
+	require.NoError(t, err, "CreateTopic should complete without deadlock")
+}
+
+func TestEnsureGeneralTopic_DualWrite_UTX1_NoDeadlock(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec(conversationsTableDDL)
+	require.NoError(t, err)
+
+	s := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, s.Init())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, _, err = s.EnsureGeneralTopic(ctx, "proj-1", "user-1")
+	require.NoError(t, err, "EnsureGeneralTopic should complete without deadlock")
+}
+
+func TestPromoteDM_DualWrite_UTX1_NoDeadlock(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close() //nolint:errcheck
+
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec(conversationsTableDDL)
+	require.NoError(t, err)
+
+	// Create the messages table too — PromoteDM needs it.
+	_, err = db.Exec(`
+CREATE TABLE IF NOT EXISTS messages (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL DEFAULT '',
+    sender TEXT NOT NULL,
+    sender_id TEXT NOT NULL DEFAULT '',
+    recipient TEXT NOT NULL,
+    recipient_id TEXT NOT NULL DEFAULT '',
+    channel TEXT,
+    thread_id TEXT,
+    msg TEXT NOT NULL DEFAULT '',
+    type TEXT NOT NULL DEFAULT 'chat',
+    dispatch_state TEXT NOT NULL DEFAULT 'dispatched',
+    created TEXT NOT NULL DEFAULT ''
+)
+`)
+	require.NoError(t, err)
+
+	s := NewWebChatStore(db, "sqlite3")
+	require.NoError(t, s.Init())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	dmKey := "dm:agent:a1:user:u1"
+	require.NoError(t, s.UpsertDM(ctx, WebChatDM{
+		ConversationKey: dmKey,
+		ParticipantID:   "u1",
+		PeerID:          "a1",
+		PeerKind:        "agent",
+	}))
+
+	convID := uuid.New().String()
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err = s.PromoteDM(ctx, WebChatTopic{
+		ID:             "topic-utx1-promote",
+		ProjectID:      "proj-1",
+		Name:           "Promote Deadlock Test",
+		ConversationID: convID,
+		CreatedBy:      "u1",
+		CreatedAt:      now,
+		LastActivityAt: now,
+	}, dmKey)
+	require.NoError(t, err, "PromoteDM should complete without deadlock")
+}
+
+// ---------------------------------------------------------------------------
+// TestListTopics_ReturnsConversationID
+// ---------------------------------------------------------------------------
+
+func TestListTopics_ReturnsConversationID(t *testing.T) {
+	s, db := newTestWebChatStoreWithConversations(t)
+	defer db.Close() //nolint:errcheck
+
+	ctx := context.Background()
+	convID := uuid.New().String()
+
+	require.NoError(t, s.CreateTopic(ctx, WebChatTopic{
+		ID:             "topic-list-conv",
+		ProjectID:      "proj-list",
+		Name:           "with-conv",
+		ConversationID: convID,
+		CreatedBy:      "user-1",
+		CreatedAt:      time.Now().UTC(),
+	}))
+
+	topics, err := s.ListTopics(ctx, "proj-list")
+	require.NoError(t, err)
+	// Should have the created topic plus a lazily-created #general.
+	var found bool
+	for _, tp := range topics {
+		if tp.ID == "topic-list-conv" {
+			require.Equal(t, convID, tp.ConversationID)
+			found = true
+		}
+	}
+	require.True(t, found, "topic-list-conv should appear in ListTopics")
+}

--- a/pkg/hub/webchannel_store_dualwrite_test.go
+++ b/pkg/hub/webchannel_store_dualwrite_test.go
@@ -738,3 +738,54 @@ func TestListTopics_ReturnsConversationID(t *testing.T) {
 	}
 	require.True(t, found, "topic-list-conv should appear in ListTopics")
 }
+
+// ---------------------------------------------------------------------------
+// TestMigration_UniqueIndexExists
+// ---------------------------------------------------------------------------
+
+// TestMigration_UniqueIndexExists verifies that the addTopicConversationID
+// migration creates the unique partial index on webchat_topic(conversation_id).
+// Without this index a concurrent backfill could silently assign the same
+// conversation to two topics — the constraint is the last line of defence.
+func TestMigration_UniqueIndexExists(t *testing.T) {
+	_, db := newTestWebChatStoreWithConversations(t)
+	defer db.Close() //nolint:errcheck
+
+	var count int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_webchat_topic_conversation'`,
+	).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "unique index idx_webchat_topic_conversation must exist after migration")
+}
+
+// ---------------------------------------------------------------------------
+// TestMigration_UniqueIndexRejectsDuplicateConversationID
+// ---------------------------------------------------------------------------
+
+// TestMigration_UniqueIndexRejectsDuplicateConversationID proves the unique
+// index actually enforces one-topic-per-conversation by inserting two topics
+// with the same conversation_id and expecting a constraint violation on the
+// second insert.
+func TestMigration_UniqueIndexRejectsDuplicateConversationID(t *testing.T) {
+	_, db := newTestWebChatStoreWithConversations(t)
+	defer db.Close() //nolint:errcheck
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	sharedConvID := "conv-dup-test"
+
+	// First topic with conversation_id succeeds.
+	_, err := db.Exec(
+		`INSERT INTO webchat_topic (id, project_id, name, conversation_id, created_by, created_at, last_activity_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"topic-a", "proj-dup", "Topic A", sharedConvID, "user-1", now, now)
+	require.NoError(t, err, "first insert should succeed")
+
+	// Second topic with the SAME conversation_id must fail.
+	_, err = db.Exec(
+		`INSERT INTO webchat_topic (id, project_id, name, conversation_id, created_by, created_at, last_activity_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"topic-b", "proj-dup", "Topic B", sharedConvID, "user-1", now, now)
+	require.Error(t, err, "second insert with duplicate conversation_id must be rejected by unique index")
+	require.Contains(t, err.Error(), "UNIQUE constraint failed", "error should be a constraint violation")
+}

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -1093,46 +1093,50 @@ func (s *pgWebChatStore) backfillTopicConversations() error {
 
 	// Backfill each topic atomically.
 	for _, t := range topics {
-		convID := uuid.New().String()
+		if err := func() error {
+			convID := uuid.New().String()
 
-		tx, err := s.db.Begin()
-		if err != nil {
-			return fmt.Errorf("begin backfill tx for topic %s: %w", t.id, err)
-		}
+			tx, err := s.db.BeginTx(context.Background(), nil)
+			if err != nil {
+				return fmt.Errorf("begin backfill tx for topic %s: %w", t.id, err)
+			}
+			// Rollback after a successful Commit is a no-op in database/sql.
+			// The defer ensures cleanup on ALL exit paths, including commit failure,
+			// which previously leaked the transaction (deadlock at MaxOpenConns=1).
+			defer tx.Rollback() //nolint:errcheck
 
-		// DEF-36: group conversations do NOT populate the participant listing index.
-		// Group conversation participants are derived from project membership, not
-		// from an explicit participant table. The participant table is a listing
-		// index, NEVER the access authority (design doc §2.4.2.1).
-		_, err = tx.Exec(
-			`INSERT INTO conversations (id, project_id, kind, surface, external_ref, parent_ref, display_name, drift_state, last_activity_at, created_at)
-			 VALUES ($1, $2, 'group', 'native', '', '', $3, 'active', NOW(), NOW())`,
-			convID, t.projectID, t.name)
-		if err != nil {
-			tx.Rollback() //nolint:errcheck
-			return fmt.Errorf("insert conversation for topic %s: %w", t.id, err)
-		}
+			// DEF-36: group conversations do NOT populate the participant listing index.
+			// Group conversation participants are derived from project membership, not
+			// from an explicit participant table. The participant table is a listing
+			// index, NEVER the access authority (design doc §2.4.2.1).
+			_, err = tx.Exec(
+				`INSERT INTO conversations (id, project_id, kind, surface, external_ref, parent_ref, display_name, drift_state, last_activity_at, created_at)
+				 VALUES ($1, $2, 'group', 'native', '', '', $3, 'active', NOW(), NOW())`,
+				convID, t.projectID, t.name)
+			if err != nil {
+				return fmt.Errorf("insert conversation for topic %s: %w", t.id, err)
+			}
 
-		// UPDATE the topic — WHERE conversation_id IS NULL makes this safe
-		// under concurrent runs.
-		res, err := tx.Exec(
-			`UPDATE webchat_topic SET conversation_id = $1 WHERE id = $2 AND conversation_id IS NULL`,
-			convID, t.id)
-		if err != nil {
-			tx.Rollback() //nolint:errcheck
-			return fmt.Errorf("update topic %s conversation_id: %w", t.id, err)
-		}
+			// UPDATE the topic — WHERE conversation_id IS NULL makes this safe
+			// under concurrent runs.
+			res, err := tx.Exec(
+				`UPDATE webchat_topic SET conversation_id = $1 WHERE id = $2 AND conversation_id IS NULL`,
+				convID, t.id)
+			if err != nil {
+				return fmt.Errorf("update topic %s conversation_id: %w", t.id, err)
+			}
 
-		// If another process already backfilled this topic, the UPDATE affected
-		// 0 rows. Roll back to avoid orphan conversation rows.
-		n, _ := res.RowsAffected()
-		if n == 0 {
-			tx.Rollback() //nolint:errcheck
-			continue
-		}
+			// If another process already backfilled this topic, the UPDATE affected
+			// 0 rows. Return nil WITHOUT committing — the deferred Rollback will
+			// discard the orphan conversation row.
+			n, _ := res.RowsAffected()
+			if n == 0 {
+				return nil
+			}
 
-		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("commit backfill tx for topic %s: %w", t.id, err)
+			return tx.Commit()
+		}(); err != nil {
+			return fmt.Errorf("backfill topic %s: %w", t.id, err)
 		}
 	}
 

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
 	"github.com/google/uuid"
 )
 
@@ -75,6 +76,7 @@ CREATE TABLE IF NOT EXISTS webchat_topic (
     name          TEXT NOT NULL,
     is_general    BOOLEAN NOT NULL DEFAULT FALSE,
     default_agent TEXT,
+    conversation_id TEXT,
     created_by    TEXT NOT NULL,
     created_at    TIMESTAMPTZ NOT NULL,
     last_message_id TEXT,
@@ -84,6 +86,9 @@ CREATE TABLE IF NOT EXISTS webchat_topic (
 
 CREATE INDEX IF NOT EXISTS idx_webchat_topic_project_activity
     ON webchat_topic (project_id, deleted_at, last_activity_at);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webchat_topic_conversation
+    ON webchat_topic (conversation_id) WHERE conversation_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS webchat_read_state (
     user_id          TEXT NOT NULL,
@@ -309,20 +314,66 @@ UPDATE webchat_thread
 // Wave-2 Topic methods (Postgres)
 // ---------------------------------------------------------------------------
 
-// CreateTopic inserts a new topic. Returns an error on name conflict.
+// CreateTopic inserts a new topic and, when ConversationID is set, atomically
+// creates a linked conversations row inside the same transaction.
 func (s *pgWebChatStore) CreateTopic(ctx context.Context, topic WebChatTopic) error {
-	const query = `
-INSERT INTO webchat_topic (id, project_id, name, is_general, default_agent, created_by, created_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
-`
+	if topic.ConversationID != "" && topic.ProjectID == "" {
+		return fmt.Errorf("webchat store: project_id is required for topic conversations")
+	}
+
 	var defaultAgent interface{}
 	if topic.DefaultAgent != "" {
 		defaultAgent = topic.DefaultAgent
 	}
-	_, err := s.db.ExecContext(ctx, query, topic.ID, topic.ProjectID, topic.Name,
-		topic.IsGeneral, defaultAgent, topic.CreatedBy, topic.CreatedAt)
+
+	if topic.ConversationID == "" {
+		// Legacy path: no conversation linkage.
+		const query = `
+INSERT INTO webchat_topic (id, project_id, name, is_general, default_agent, created_by, created_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+`
+		_, err := s.db.ExecContext(ctx, query, topic.ID, topic.ProjectID, topic.Name,
+			topic.IsGeneral, defaultAgent, topic.CreatedBy, topic.CreatedAt)
+		if err != nil {
+			return fmt.Errorf("webchat store: create topic: %w", err)
+		}
+		return nil
+	}
+
+	// Atomic dual-write: topic + conversation in one transaction.
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("webchat store: begin create topic tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var convID interface{}
+	if topic.ConversationID != "" {
+		convID = topic.ConversationID
+	}
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO webchat_topic (id, project_id, name, is_general, default_agent, conversation_id, created_by, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		topic.ID, topic.ProjectID, topic.Name, topic.IsGeneral,
+		defaultAgent, convID, topic.CreatedBy, topic.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("webchat store: create topic: %w", err)
+	}
+
+	// DEF-36: group conversations do NOT populate the participant listing index.
+	// Group conversation participants are derived from project membership, not
+	// from an explicit participant table. The participant table is a listing
+	// index, NEVER the access authority (design doc §2.4.2.1).
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO conversations (id, project_id, kind, surface, external_ref, parent_ref, display_name, drift_state, last_activity_at, created_at)
+		 VALUES ($1, $2, 'group', 'native', '', '', $3, 'active', $4, $5)`,
+		topic.ConversationID, topic.ProjectID, topic.Name, topic.CreatedAt, topic.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("webchat store: create conversation for topic: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("webchat store: commit create topic tx: %w", err)
 	}
 	return nil
 }
@@ -331,6 +382,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7)
 func (s *pgWebChatStore) GetTopic(ctx context.Context, topicID string) (*WebChatTopic, error) {
 	const query = `
 SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
+       COALESCE(conversation_id, ''),
        created_by, created_at, COALESCE(last_message_id, ''),
        last_activity_at, deleted_at
   FROM webchat_topic
@@ -341,6 +393,7 @@ SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
 	var deletedAt *time.Time
 	err := s.db.QueryRowContext(ctx, query, topicID).Scan(
 		&t.ID, &t.ProjectID, &t.Name, &t.IsGeneral, &t.DefaultAgent,
+		&t.ConversationID,
 		&t.CreatedBy, &t.CreatedAt, &t.LastMessageID, &activityAt, &deletedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -360,6 +413,7 @@ SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
 func (s *pgWebChatStore) ListTopics(ctx context.Context, projectID string) ([]WebChatTopic, error) {
 	const query = `
 SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
+       COALESCE(conversation_id, ''),
        created_by, created_at, COALESCE(last_message_id, ''),
        last_activity_at, deleted_at
   FROM webchat_topic
@@ -379,6 +433,7 @@ SELECT id, project_id, name, is_general, COALESCE(default_agent, ''),
 		var activityAt *time.Time
 		var deletedAt *time.Time
 		if err := rows.Scan(&t.ID, &t.ProjectID, &t.Name, &t.IsGeneral, &t.DefaultAgent,
+			&t.ConversationID,
 			&t.CreatedBy, &t.CreatedAt, &t.LastMessageID, &activityAt, &deletedAt); err != nil {
 			return nil, fmt.Errorf("webchat store: scan topic: %w", err)
 		}
@@ -490,17 +545,44 @@ func (s *pgWebChatStore) TouchTopicActivity(ctx context.Context, topicID, messag
 
 // EnsureGeneralTopic idempotently creates the #general topic for a project.
 // Returns the topic ID (existing or new) and whether a new row was inserted.
+// When creating a new topic, a linked conversations row is atomically created.
 func (s *pgWebChatStore) EnsureGeneralTopic(ctx context.Context, projectID, createdBy string) (string, bool, error) {
 	newID := uuid.New().String()
+	convID := uuid.New().String()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", false, fmt.Errorf("webchat store: begin ensure general tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
 
 	const insert = `
-INSERT INTO webchat_topic (id, project_id, name, is_general, created_by, created_at)
-VALUES ($1, $2, 'general', TRUE, $3, NOW())
+INSERT INTO webchat_topic (id, project_id, name, is_general, conversation_id, created_by, created_at)
+VALUES ($1, $2, 'general', TRUE, $3, $4, NOW())
 ON CONFLICT DO NOTHING
 `
-	_, err := s.db.ExecContext(ctx, insert, newID, projectID, createdBy)
+	res, err := tx.ExecContext(ctx, insert, newID, projectID, convID, createdBy)
 	if err != nil {
 		return "", false, fmt.Errorf("webchat store: ensure general topic: %w", err)
+	}
+
+	inserted, _ := res.RowsAffected()
+	if inserted > 0 {
+		// DEF-36: group conversations do NOT populate the participant listing index.
+		// Group conversation participants are derived from project membership, not
+		// from an explicit participant table. The participant table is a listing
+		// index, NEVER the access authority (design doc §2.4.2.1).
+		_, err = tx.ExecContext(ctx,
+			`INSERT INTO conversations (id, project_id, kind, surface, external_ref, parent_ref, display_name, drift_state, last_activity_at, created_at)
+			 VALUES ($1, $2, 'group', 'native', '', '', 'general', 'active', NOW(), NOW())`,
+			convID, projectID)
+		if err != nil {
+			return "", false, fmt.Errorf("webchat store: create conversation for general topic: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", false, fmt.Errorf("webchat store: commit ensure general tx: %w", err)
 	}
 
 	const lookup = `SELECT id FROM webchat_topic WHERE project_id = $1 AND is_general = TRUE AND deleted_at IS NULL`
@@ -892,6 +974,41 @@ SELECT id, project_id, COALESCE(thread_id, ''), sender, msg, created
 // Wave-2 Migrations (Postgres)
 // ---------------------------------------------------------------------------
 
+// GetTopicConversationID returns the conversation_id for a webchat topic.
+// Returns ("", error) if the topic does not exist or is soft-deleted.
+// Returns ("", nil) if the topic exists but has no conversation_id yet.
+func (s *pgWebChatStore) GetTopicConversationID(ctx context.Context, topicID string) (string, error) {
+	const query = `SELECT COALESCE(conversation_id, '') FROM webchat_topic WHERE id = $1 AND deleted_at IS NULL`
+	var convID string
+	err := s.db.QueryRowContext(ctx, query, topicID).Scan(&convID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", fmt.Errorf("topic not found %s: %w", topicID, store.ErrNotFound)
+		}
+		return "", fmt.Errorf("webchat store: get topic conversation_id: %w", err)
+	}
+	return convID, nil
+}
+
+// GetTopicConversationIDIncludingDeleted returns the conversation_id for a
+// webchat topic regardless of its deletion state.
+//
+// Soft-deletion is not declassification. A tombstoned native topic is still
+// a native topic for the purpose of "should I mint." Deletion hides a topic
+// from users; it must not make the mint guard forget the topic was ours.
+func (s *pgWebChatStore) GetTopicConversationIDIncludingDeleted(ctx context.Context, topicID string) (string, error) {
+	const query = `SELECT COALESCE(conversation_id, '') FROM webchat_topic WHERE id = $1`
+	var convID string
+	err := s.db.QueryRowContext(ctx, query, topicID).Scan(&convID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", fmt.Errorf("topic not found %s: %w", topicID, store.ErrNotFound)
+		}
+		return "", fmt.Errorf("webchat store: get topic conversation_id (including deleted): %w", err)
+	}
+	return convID, nil
+}
+
 // runMigrations executes idempotent data migrations.
 func (s *pgWebChatStore) runMigrations() error {
 	if err := s.migrateThreadIDs(DefaultMigrationBatchSize); err != nil {
@@ -903,7 +1020,123 @@ func (s *pgWebChatStore) runMigrations() error {
 	if err := s.addThreadIDIndex(); err != nil {
 		return fmt.Errorf("thread_id index: %w", err)
 	}
+	if err := s.addTopicConversationID(); err != nil {
+		return fmt.Errorf("topic conversation_id: %w", err)
+	}
+	if err := s.backfillTopicConversations(); err != nil {
+		return fmt.Errorf("topic conversation backfill: %w", err)
+	}
 	return nil
+}
+
+// addTopicConversationID adds the conversation_id column and unique index
+// to the webchat_topic table for existing databases.
+func (s *pgWebChatStore) addTopicConversationID() error {
+	done, err := s.migrationCompleted("topic_conversation_id")
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+
+	// ALTER TABLE ADD COLUMN IF NOT EXISTS is Postgres 9.6+.
+	_, err = s.db.Exec(`ALTER TABLE webchat_topic ADD COLUMN IF NOT EXISTS conversation_id TEXT`)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_webchat_topic_conversation ON webchat_topic (conversation_id) WHERE conversation_id IS NOT NULL`)
+	if err != nil {
+		return err
+	}
+
+	return s.markMigrationCompleted("topic_conversation_id")
+}
+
+// backfillTopicConversations creates conversation rows for existing webchat_topic
+// rows that don't yet have a conversation_id. Each topic is backfilled
+// atomically (INSERT conversation + UPDATE topic in one transaction).
+// The migration is idempotent: re-running creates no duplicate conversations.
+func (s *pgWebChatStore) backfillTopicConversations() error {
+	done, err := s.migrationCompleted("topic_conversation_backfill")
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+
+	// Find all non-deleted topics without a conversation_id.
+	rows, err := s.db.Query(
+		`SELECT id, project_id, name FROM webchat_topic WHERE conversation_id IS NULL AND deleted_at IS NULL`)
+	if err != nil {
+		return fmt.Errorf("select unlinked topics: %w", err)
+	}
+
+	type topicRow struct {
+		id, projectID, name string
+	}
+	var topics []topicRow
+	for rows.Next() {
+		var t topicRow
+		if err := rows.Scan(&t.id, &t.projectID, &t.name); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan unlinked topic: %w", err)
+		}
+		topics = append(topics, t)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate unlinked topics: %w", err)
+	}
+	_ = rows.Close()
+
+	// Backfill each topic atomically.
+	for _, t := range topics {
+		convID := uuid.New().String()
+
+		tx, err := s.db.Begin()
+		if err != nil {
+			return fmt.Errorf("begin backfill tx for topic %s: %w", t.id, err)
+		}
+
+		// DEF-36: group conversations do NOT populate the participant listing index.
+		// Group conversation participants are derived from project membership, not
+		// from an explicit participant table. The participant table is a listing
+		// index, NEVER the access authority (design doc §2.4.2.1).
+		_, err = tx.Exec(
+			`INSERT INTO conversations (id, project_id, kind, surface, external_ref, parent_ref, display_name, drift_state, last_activity_at, created_at)
+			 VALUES ($1, $2, 'group', 'native', '', '', $3, 'active', NOW(), NOW())`,
+			convID, t.projectID, t.name)
+		if err != nil {
+			tx.Rollback() //nolint:errcheck
+			return fmt.Errorf("insert conversation for topic %s: %w", t.id, err)
+		}
+
+		// UPDATE the topic — WHERE conversation_id IS NULL makes this safe
+		// under concurrent runs.
+		res, err := tx.Exec(
+			`UPDATE webchat_topic SET conversation_id = $1 WHERE id = $2 AND conversation_id IS NULL`,
+			convID, t.id)
+		if err != nil {
+			tx.Rollback() //nolint:errcheck
+			return fmt.Errorf("update topic %s conversation_id: %w", t.id, err)
+		}
+
+		// If another process already backfilled this topic, the UPDATE affected
+		// 0 rows. Roll back to avoid orphan conversation rows.
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			tx.Rollback() //nolint:errcheck
+			continue
+		}
+
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit backfill tx for topic %s: %w", t.id, err)
+		}
+	}
+
+	return s.markMigrationCompleted("topic_conversation_backfill")
 }
 
 // migrationCompleted checks whether a named migration has already run.
@@ -1339,6 +1572,7 @@ func (s *pgWebChatStore) MigrateReadState(ctx context.Context, oldKey, newKey st
 }
 
 // PromoteDM atomically promotes a DM conversation into a space thread.
+// When ConversationID is set on topic, a linked conversations row is also created.
 func (s *pgWebChatStore) PromoteDM(ctx context.Context, topic WebChatTopic, dmKey string) (*WebChatTopic, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -1351,15 +1585,34 @@ func (s *pgWebChatStore) PromoteDM(ctx context.Context, topic WebChatTopic, dmKe
 	if topic.DefaultAgent != "" {
 		defaultAgent = topic.DefaultAgent
 	}
+	var convID interface{}
+	if topic.ConversationID != "" {
+		convID = topic.ConversationID
+	}
 	_, err = tx.ExecContext(ctx,
 		`INSERT INTO webchat_topic (id, project_id, name, is_general, default_agent,
-		 created_by, created_at, last_activity_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		 conversation_id, created_by, created_at, last_activity_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
 		topic.ID, topic.ProjectID, topic.Name, topic.IsGeneral,
-		defaultAgent, topic.CreatedBy,
+		defaultAgent, convID, topic.CreatedBy,
 		topic.CreatedAt, topic.LastActivityAt)
 	if err != nil {
 		return nil, fmt.Errorf("webchat store: create topic in promote: %w", err)
+	}
+
+	// Step 1b: Create linked conversation if ConversationID is set.
+	if topic.ConversationID != "" {
+		// DEF-36: group conversations do NOT populate the participant listing index.
+		// Group conversation participants are derived from project membership, not
+		// from an explicit participant table. The participant table is a listing
+		// index, NEVER the access authority (design doc §2.4.2.1).
+		_, err = tx.ExecContext(ctx,
+			`INSERT INTO conversations (id, project_id, kind, surface, external_ref, parent_ref, display_name, drift_state, last_activity_at, created_at)
+			 VALUES ($1, $2, 'group', 'native', '', '', $3, 'active', $4, $5)`,
+			topic.ConversationID, topic.ProjectID, topic.Name, topic.CreatedAt, topic.CreatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("webchat store: create conversation in promote: %w", err)
+		}
 	}
 
 	// Step 2: Re-key all messages


### PR DESCRIPTION
Phase C4 of the messaging conversation-model work. The webchat store now writes conversation rows alongside its existing topic rows, so webchat topics become addressable in the new model without changing how webchat behaves today.

Covers both the sqlite and postgres stores. Reads are untouched - this is dual-write only, so conversation rows are populated but not yet authoritative. The read switch is a later phase.

Two invariants worth review attention:

U-TX-1 - inside the atomic topic-create block nothing may touch the ambient connection pool. At MaxOpenConns=1 a stray acquisition deadlocks rather than erroring, so this is a hang risk, not a test failure. Verified the transaction opens before any conversation work at all three create sites.

DEF-36 - conversation inserts use ON CONFLICT DO NOTHING so a retried topic create cannot fail on a duplicate row. Preserved and commented at each insert site.

A topic carrying a conversation ID when the conversations table is absent is now a hard error rather than a silent skip. Dropping the ID would produce a topic that looks migrated and is not.

All 31 deletions were individually checked and are replacements, not removals. Guards, gofmt and tests clean. cla/google is expected to fail here