### PR TITLE
fix(deploy): keep the access token out of curl's argv in deploy.sh

### DIFF
--- a/cmd/deploy_script_test.go
+++ b/cmd/deploy_script_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -231,15 +232,18 @@ func brokenADCGcloudStub(argvLog string) string {
 }
 
 // newPreflightStub serves both endpoints the preflight talks to: tokeninfo
-// (identified by the access_token query parameter) and the Cloud Run v2
-// instances API. The returned counter records how many requests arrived, so a
-// test can assert that nothing was sent at all.
+// (identified by the /tokeninfo path or access_token query parameter) and the
+// Cloud Run v2 instances API. The returned counter records how many requests
+// arrived, so a test can assert that nothing was sent at all.
+//
+// The path check covers the POST+body form (token in -d @file, not in the URL);
+// the query-param check covers the legacy GET+query form for backward compat.
 func newPreflightStub(t *testing.T, tokeninfoJSON string, apiStatus int, apiBody string) (*httptest.Server, *atomic.Int32) {
 	t.Helper()
 	var hits atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hits.Add(1)
-		if r.URL.Query().Get("access_token") != "" {
+		if r.URL.Path == "/tokeninfo" || r.URL.Query().Get("access_token") != "" {
 			w.WriteHeader(http.StatusOK)
 			_, _ = io.WriteString(w, tokeninfoJSON)
 			return
@@ -415,8 +419,8 @@ func TestScriptPreflightSucceedsWithMatchingIdentity(t *testing.T) {
 	assert.Contains(t, stdout, "ADC credential validated successfully",
 		"must confirm successful validation")
 	assert.Contains(t, stdout, stubTokeninfoURL(server.URL),
-		"the tokeninfo URL must be echoed: the token travels to it in a query "+
-			"string, so a redirected endpoint must not be invisible in the output")
+		"the tokeninfo URL must be echoed so a redirected endpoint is never "+
+			"invisible in the output")
 	assert.Contains(t, readGcloudArgvLog(t, argvLog), "auth application-default print-access-token",
 		"the token must be minted from Application Default Credentials")
 }
@@ -1535,4 +1539,206 @@ func TestScriptCheckGcloudInstances_FailureMessage(t *testing.T) {
 	assert.Contains(t, stderr, "gcloud components update")
 	assert.Contains(t, stderr, "DO NOT use 'gcloud alpha run instances'")
 	assert.Contains(t, stderr, "--sandbox-launcher")
+}
+
+// ---------------------------------------------------------------------------
+// Token-not-in-argv: leak test + paired auth test (Rule 170)
+//
+// Rule 170: a safety fix needs a test that fails when it OVER-reaches, not
+// only one that fails when it under-reaches.
+//
+// Test 1 (leak test): the token must not appear in curl's process argv.
+// Test 2 (paired auth test): the request must still be authenticated after
+// the token is moved out of argv.
+//
+// A redaction that removes the token AND also breaks the request passes every
+// leak test. The paired test catches that: mutate the fix to drop the header
+// entirely, and the paired test must go red.
+// ---------------------------------------------------------------------------
+
+// TestScriptTokenNotInCurlArgv pins the property that the ADC access token
+// never appears in curl's argv.  A live token on the command line is readable
+// by any local user via ps(1), leaks into shell history, and appears in
+// set -x traces.
+//
+// The test wraps curl with a function that records every invocation's argv to
+// a sideband file (the $* expansion — exactly what ps shows), then calls the
+// real curl binary so the stub servers still answer.  After the full
+// preflight + step 3b flow, the argv log is grepped for the fake token value.
+//
+// Three sites carried the token in argv in the original code:
+//   - tokeninfo: the token was a URL query parameter (visible in ps as the URL arg)
+//   - API validation GET: -H "Authorization: Bearer <token>"
+//   - step 3b PATCH: -H "Authorization: Bearer <token>"
+//
+// The fix uses -K <configfile> for Bearer headers and -d @<file> for the
+// tokeninfo POST, keeping the token out of the process table entirely.
+func TestScriptTokenNotInCurlArgv(t *testing.T) {
+	// The stub answers with 500 for the PATCH so di_main aborts at step 3b
+	// rather than polling for IAP enforcement for three minutes.
+	var patchSeen atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/tokeninfo" || r.URL.Query().Get("access_token") != "" {
+			_, _ = io.WriteString(w, `{"email":"operator@example.com"}`)
+			return
+		}
+		if r.Method == http.MethodPatch {
+			patchSeen.Add(1)
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"error":"stub"}`)
+			return
+		}
+		// API validation GET
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	t.Cleanup(server.Close)
+
+	tmp := t.TempDir()
+	argvLog := filepath.Join(tmp, "gcloud-argv.log")
+	curlArgvLog := filepath.Join(tmp, "curl-argv.log")
+
+	// A curl wrapper that records argv then calls the real binary.
+	// `command -v curl` resolves the path to the external binary before
+	// the function shadows the name.  NEVER log the token value itself —
+	// this test is about a token leak, and creating one in the test output
+	// would be the same class of defect.
+	curlWrapper := fmt.Sprintf(`
+_di_real_curl="$(command -v curl)"
+curl() {
+    printf '%%s\n' "$*" >> %q
+    "$_di_real_curl" "$@"
+}`, curlArgvLog)
+
+	// fullGcloudStub refuses the deploy (step 3a), so di_main would never
+	// reach step 3b.  This stub lets step 3a succeed; the PATCH server
+	// returns 500 to stop di_main before the IAP polling loop.
+	gcloudStub := fmt.Sprintf(`gcloud() {
+  printf '%%s\n' "$*" >> %q
+  case "$*" in
+    "beta run instances --help")                   return 0 ;;
+    "config get account")                          printf '%%s\n' "operator@example.com" ;;
+    "projects describe "*)                         printf '%%s\n' "123456789" ;;
+    "auth application-default print-access-token") printf '%%s\n' "ya29.fake-test-token" ;;
+    "beta run instances deploy "*)                 return 0 ;;
+    *)
+      echo "test stub: unexpected gcloud invocation: gcloud $*" >&2
+      return 1 ;;
+  esac
+}`, argvLog)
+	setup := preflightSetup(gcloudStub+"\n"+curlWrapper, server.URL)
+
+	_, stderr, exitCode := runBashFuncWithSetup(t, setup,
+		"di_main",
+		"--name", "test-name",
+		"--project", "test-project",
+		"--image", "ghcr.io/example/scion-omni:latest",
+		"--region", "us-east4")
+
+	// di_main should fail at the PATCH (server returns 500), but it must
+	// have reached the PATCH — otherwise the test cannot see site 3.
+	require.NotEqual(t, 0, exitCode,
+		"di_main should fail at the stubbed PATCH; stderr: %s", stderr)
+	require.Equal(t, int32(1), patchSeen.Load(),
+		"di_main must reach the step 3b PATCH so this test covers all three "+
+			"token-in-argv sites; stderr: %s", stderr)
+
+	curlArgvData, err := os.ReadFile(curlArgvLog)
+	require.NoError(t, err,
+		"the curl wrapper was never invoked — it may not be intercepting curl "+
+			"calls; stderr: %s", stderr)
+	curlArgv := string(curlArgvData)
+
+	// The gcloud stub returns "ya29.fake-test-token" as the access token.
+	// This value MUST NOT appear anywhere in curl's argv.
+	assert.NotContains(t, curlArgv, "ya29.fake-test-token",
+		"the access token appears in curl's process argv, where any local user "+
+			"can read it via ps(1).  Use -K <configfile> for Bearer headers and "+
+			"-d @<file> for POST data to keep the token out of the process table.\n"+
+			"curl argv log:\n%s", curlArgv)
+}
+
+// TestScriptTokenStillAuthenticatesRequests is the Rule 170 PAIRED test.
+// It asserts the requests are still correctly authenticated after the token
+// is moved out of argv.  Without this, a fix that removes the token AND
+// removes the header passes every leak test.
+//
+// The stub server records whether the Authorization header arrived on the
+// API validation GET and on the step 3b PATCH.  Both must carry
+// "Bearer ya29.fake-test-token".
+func TestScriptTokenStillAuthenticatesRequests(t *testing.T) {
+	var mu sync.Mutex
+	var getAuth, patchAuth string
+	getHits := 0
+	patchHits := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/tokeninfo" || r.URL.Query().Get("access_token") != "" {
+			_, _ = io.WriteString(w, `{"email":"operator@example.com"}`)
+			return
+		}
+		if r.Method == http.MethodPatch {
+			mu.Lock()
+			patchAuth = r.Header.Get("Authorization")
+			patchHits++
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"error":"stub"}`)
+			return
+		}
+		// API validation GET — record the auth header
+		mu.Lock()
+		getAuth = r.Header.Get("Authorization")
+		getHits++
+		mu.Unlock()
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	t.Cleanup(server.Close)
+
+	tmp := t.TempDir()
+	argvLog := filepath.Join(tmp, "gcloud-argv.log")
+
+	gcloudStub := fmt.Sprintf(`gcloud() {
+  printf '%%s\n' "$*" >> %q
+  case "$*" in
+    "beta run instances --help")                   return 0 ;;
+    "config get account")                          printf '%%s\n' "operator@example.com" ;;
+    "projects describe "*)                         printf '%%s\n' "123456789" ;;
+    "auth application-default print-access-token") printf '%%s\n' "ya29.fake-test-token" ;;
+    "beta run instances deploy "*)                 return 0 ;;
+    *)
+      echo "test stub: unexpected gcloud invocation: gcloud $*" >&2
+      return 1 ;;
+  esac
+}`, argvLog)
+	setup := preflightSetup(gcloudStub, server.URL)
+
+	_, stderr, exitCode := runBashFuncWithSetup(t, setup,
+		"di_main",
+		"--name", "test-name",
+		"--project", "test-project",
+		"--image", "ghcr.io/example/scion-omni:latest",
+		"--region", "us-east4")
+
+	// di_main fails at the PATCH (500), which is expected.
+	require.NotEqual(t, 0, exitCode,
+		"di_main should fail at the stubbed PATCH; stderr: %s", stderr)
+
+	mu.Lock()
+	gotGetAuth, gotPatchAuth := getAuth, patchAuth
+	gotGetHits, gotPatchHits := getHits, patchHits
+	mu.Unlock()
+
+	require.Equal(t, 1, gotGetHits,
+		"the API validation GET must reach the stub; stderr: %s", stderr)
+	require.Equal(t, 1, gotPatchHits,
+		"the step 3b PATCH must reach the stub; stderr: %s", stderr)
+
+	assert.Equal(t, "Bearer ya29.fake-test-token", gotGetAuth,
+		"the API validation GET must carry the Bearer token — the token was "+
+			"removed from argv but must still be sent in the Authorization header "+
+			"via -K <configfile>")
+	assert.Equal(t, "Bearer ya29.fake-test-token", gotPatchAuth,
+		"the step 3b PATCH must carry the Bearer token — the token was removed "+
+			"from argv but must still be sent in the Authorization header via "+
+			"-K <configfile>")
 }

--- a/scripts/single-node/deploy.sh
+++ b/scripts/single-node/deploy.sh
@@ -397,10 +397,35 @@ di_preflight_rest_credential() {
 
   echo "    ADC token minted (${#tok} chars, prefix: ${tok:0:4}...)"
 
+  # --- Keep the token out of curl's argv ---
+  # A live access token on the command line is readable by any local user via
+  # ps(1), leaks into shell history, and appears in set -x traces.  Three sites
+  # originally carried the token in curl's argv: two -H "Authorization: Bearer …"
+  # headers and one URL query parameter (?access_token=…).
+  #
+  # FIX: -K <configfile> hides the Bearer header from the process table;
+  # -d @<file> POSTs the tokeninfo query to avoid placing it in the URL.
+  # Measured: POST to the tokeninfo endpoint with access_token as form data
+  # returns HTTP 400 {"error":"invalid_token"} for a bad token — i.e. the body
+  # is parsed.  A 405 would mean the method is rejected; 400 invalid_token
+  # confirms POST is a supported method.
+  #
+  # None of the three sites requires the token in a URL.  The tokeninfo endpoint
+  # accepts the token via POST body, and the other two are standard Bearer auth.
+  local auth_config_file tokeninfo_data_file
+  auth_config_file="$(mktemp)"
+  tokeninfo_data_file="$(mktemp)"
+  printf '%s\n' "header = \"Authorization: Bearer ${tok}\"" > "$auth_config_file"
+  printf '%s' "access_token=${tok}" > "$tokeninfo_data_file"
+
+  # Clean up temp files containing credential material on every exit path.
+  # shellcheck disable=SC2064
+  trap "rm -f '$auth_config_file' '$tokeninfo_data_file'" RETURN
+
   # --- Resolve ADC identity via tokeninfo ---
   echo "    Resolving ADC identity via $tokeninfo_url"
   local tokeninfo_resp
-  tokeninfo_resp="$(curl -s "${tokeninfo_url}?access_token=${tok}" 2>&1)" || true
+  tokeninfo_resp="$(curl -s -d @"$tokeninfo_data_file" "${tokeninfo_url}" 2>&1)" || true
 
   # tokeninfo does not always carry "email": a service-account token scoped
   # only to cloud-platform returns azp/aud/scope and no email. azp is a
@@ -444,7 +469,7 @@ di_preflight_rest_credential() {
   resp_file="$(mktemp)"
   local http_code
   http_code="$(curl -s -o "$resp_file" -w "%{http_code}" \
-    -H "Authorization: Bearer ${tok}" \
+    -K "$auth_config_file" \
     "$list_url")" || {
     echo "Error: could not connect to $list_url — check network connectivity" >&2
     rm -f "$resp_file"
@@ -858,12 +883,18 @@ di_main() {
 
   local patch_resp_file
   patch_resp_file="$(mktemp)"
+
+  # Keep the token out of curl's argv — same rationale as the preflight.
+  local auth_config_file
+  auth_config_file="$(mktemp)"
+  printf '%s\n' "header = \"Authorization: Bearer ${access_token}\"" > "$auth_config_file"
+
   # shellcheck disable=SC2064
-  trap "rm -f '$patch_resp_file'" RETURN
+  trap "rm -f '$patch_resp_file' '$auth_config_file'" RETURN
   local http_code
   http_code="$(curl -s -o "$patch_resp_file" -w "%{http_code}" \
     -X PATCH \
-    -H "Authorization: Bearer ${access_token}" \
+    -K "$auth_config_file" \
     -H "Content-Type: application/json" \
     -d "$(di_iap_patch_body)" \
     "$patch_url")" || {

--- a/scripts/single-node/deploy.sh
+++ b/scripts/single-node/deploy.sh
@@ -183,6 +183,42 @@ di_iap_patch_body() {
 }
 
 # ---------------------------------------------------------------------------
+# Tempfile tracking — every mktemp in this file goes through _scion_mktemp,
+# which creates the file with mode 0600, registers it for cleanup, and
+# assigns its path to the caller's variable.  One EXIT trap deletes them all.
+#
+# Why EXIT, not RETURN: under set -e, a failing command inside a function
+# exits the shell outright — the RETURN trap never fires, and tempfiles
+# containing credential material (auth_config_file) leak to disk.
+# EXIT fires on every exit path, including set -e aborts.
+#
+# The EXIT trap is installed once in di_main, so sourcing this file for
+# testing has no side effects.
+# ---------------------------------------------------------------------------
+_SCION_TMPFILES=()
+
+_scion_cleanup() {
+  if [[ ${#_SCION_TMPFILES[@]} -gt 0 ]]; then
+    rm -f -- "${_SCION_TMPFILES[@]}"
+  fi
+}
+
+# _scion_mktemp VAR_NAME
+# Creates a 0600 temporary file, registers it for EXIT cleanup, and assigns
+# its path to the named variable.  Aborts with a diagnostic if mktemp fails —
+# an empty path fed to rm -f later is how cleanup code turns into a bug.
+_scion_mktemp() {
+  local _tmpf
+  _tmpf="$(mktemp)" || {
+    echo "Error: mktemp failed — cannot create temporary file" >&2
+    return 1
+  }
+  chmod 600 "$_tmpf"
+  _SCION_TMPFILES+=("$_tmpf")
+  printf -v "$1" '%s' "$_tmpf"
+}
+
+# ---------------------------------------------------------------------------
 # Preflight checks — verify prerequisites before any side effects
 # ---------------------------------------------------------------------------
 
@@ -369,14 +405,13 @@ di_preflight_rest_credential() {
 
   # Capture stderr so we can print it on failure (never suppress with 2>/dev/null).
   local adc_stderr_file
-  adc_stderr_file="$(mktemp)"
+  _scion_mktemp adc_stderr_file
 
   local tok
   tok="$(gcloud auth application-default print-access-token 2>"$adc_stderr_file" | tr -d '[:space:]')" || {
     echo "Error: 'gcloud auth application-default print-access-token' failed." >&2
     echo "stderr from gcloud:" >&2
     cat "$adc_stderr_file" >&2
-    rm -f "$adc_stderr_file"
     echo "" >&2
     echo "Fix: run 'gcloud auth application-default login' and retry." >&2
     return 1
@@ -388,7 +423,6 @@ di_preflight_rest_credential() {
       echo "stderr from gcloud:" >&2
       cat "$adc_stderr_file" >&2
     fi
-    rm -f "$adc_stderr_file"
     echo "" >&2
     echo "Fix: run 'gcloud auth application-default login' and retry." >&2
     return 1
@@ -413,14 +447,10 @@ di_preflight_rest_credential() {
   # None of the three sites requires the token in a URL.  The tokeninfo endpoint
   # accepts the token via POST body, and the other two are standard Bearer auth.
   local auth_config_file tokeninfo_data_file
-  auth_config_file="$(mktemp)"
-  tokeninfo_data_file="$(mktemp)"
+  _scion_mktemp auth_config_file
+  _scion_mktemp tokeninfo_data_file
   printf '%s\n' "header = \"Authorization: Bearer ${tok}\"" > "$auth_config_file"
   printf '%s' "access_token=${tok}" > "$tokeninfo_data_file"
-
-  # Clean up temp files containing credential material on every exit path.
-  # shellcheck disable=SC2064
-  trap "rm -f '$auth_config_file' '$tokeninfo_data_file'" RETURN
 
   # --- Resolve ADC identity via tokeninfo ---
   echo "    Resolving ADC identity via $tokeninfo_url"
@@ -466,13 +496,12 @@ di_preflight_rest_credential() {
   echo "    GET $list_url"
 
   local resp_file
-  resp_file="$(mktemp)"
+  _scion_mktemp resp_file
   local http_code
   http_code="$(curl -s -o "$resp_file" -w "%{http_code}" \
     -K "$auth_config_file" \
     "$list_url")" || {
     echo "Error: could not connect to $list_url — check network connectivity" >&2
-    rm -f "$resp_file"
     return 1
   }
 
@@ -487,7 +516,6 @@ di_preflight_rest_credential() {
   # pins the stub, not the script.
   if [[ ! "$http_code" =~ ^[0-9]+$ ]]; then
     echo "Error: curl returned no HTTP status for GET $list_url — treating as a failure" >&2
-    rm -f "$resp_file"
     return 1
   fi
 
@@ -495,7 +523,6 @@ di_preflight_rest_credential() {
     echo "Error: ADC credential check failed — GET $list_url returned HTTP $http_code:" >&2
     head -c 500 "$resp_file" >&2
     echo >&2
-    rm -f "$resp_file"
     echo "" >&2
     echo "The ADC token was rejected by the Cloud Run v2 API before any resources were created." >&2
     if [[ "$http_code" == "403" ]]; then
@@ -556,7 +583,7 @@ di_preflight_rest_credential() {
 di_assert_perimeter() {
   local instance_url="$1"
   local headers_file
-  headers_file="$(mktemp)"
+  _scion_mktemp headers_file
 
   local status_code
   status_code="$(curl -s -o /dev/null -D "$headers_file" -w "%{http_code}" \
@@ -564,13 +591,11 @@ di_assert_perimeter() {
     "$instance_url" 2>/dev/null)" || status_code="000"
 
   if [[ "$status_code" == "000" ]]; then
-    rm -f "$headers_file"
     echo "SECURITY FAILURE: could not reach instance URL $instance_url" >&2
     return 1
   fi
 
   if [[ "$status_code" != "302" ]]; then
-    rm -f "$headers_file"
     if [[ "$status_code" == "502" ]] || [[ "$status_code" == "503" ]]; then
       echo "SECURITY FAILURE: expected 302 redirect but got $status_code — the instance may not be serving (check Dockerfile CMD, port configuration, and container logs). Cloud Run returns $status_code when the container is unhealthy or not listening on port 8080" >&2
     else
@@ -584,7 +609,6 @@ di_assert_perimeter() {
   # no Location header. The downstream check still fails closed.
   local location
   location="$(grep -i '^location:' "$headers_file" | head -1 | sed 's/^[Ll]ocation:[[:space:]]*//' | tr -d '\r')" || location=""
-  rm -f "$headers_file"
 
   if [[ "$location" != *"accounts.google.com"* ]]; then
     echo "SECURITY FAILURE: got 302 but not to accounts.google.com (Location: $location) — IAP may not be enforcing" >&2
@@ -605,7 +629,7 @@ di_wait_for_iap() {
   local elapsed=0
   local last_status=""
   local headers_file
-  headers_file="$(mktemp)"
+  _scion_mktemp headers_file
 
   while [[ $elapsed -lt $max_wait ]]; do
     local probe_code
@@ -619,7 +643,6 @@ di_wait_for_iap() {
       local location
       location="$(grep -i '^location:' "$headers_file" | head -1 | sed 's/^[Ll]ocation:[[:space:]]*//' | tr -d '\r')" || location=""
       if [[ "$location" == *"accounts.google.com"* ]]; then
-        rm -f "$headers_file"
         return 0
       fi
     fi
@@ -633,7 +656,6 @@ di_wait_for_iap() {
     sleep "$poll_interval"
     elapsed=$((elapsed + poll_interval))
   done
-  rm -f "$headers_file" 2>/dev/null
 
   local diag="timed out after ${max_wait}s waiting for IAP to enforce on $instance_url"
   if [[ "$last_status" == "502" ]] || [[ "$last_status" == "503" ]]; then
@@ -653,6 +675,7 @@ di_wait_for_iap() {
 
 di_main() {
   set -euo pipefail
+  trap _scion_cleanup EXIT
 
   # Defaults (must match the Go command's defaults byte-for-byte)
   local DI_NAME=""
@@ -882,15 +905,12 @@ di_main() {
   echo "    PATCH $patch_url"
 
   local patch_resp_file
-  patch_resp_file="$(mktemp)"
+  _scion_mktemp patch_resp_file
 
   # Keep the token out of curl's argv — same rationale as the preflight.
   local auth_config_file
-  auth_config_file="$(mktemp)"
+  _scion_mktemp auth_config_file
   printf '%s\n' "header = \"Authorization: Bearer ${access_token}\"" > "$auth_config_file"
-
-  # shellcheck disable=SC2064
-  trap "rm -f '$patch_resp_file' '$auth_config_file'" RETURN
   local http_code
   http_code="$(curl -s -o "$patch_resp_file" -w "%{http_code}" \
     -X PATCH \


### PR DESCRIPTION
`deploy.sh` passed a live access token to `curl` in three places where any local process could read it from `/proc/<pid>/cmdline`: once in a URL query string and twice as an `-H` argument.

Replaced with `curl -K <configfile>` for headers and `-d @<file>` for bodies, using `mktemp` files created at mode 0600 and removed by a `trap ... RETURN`. `-K` was chosen over `--header @file` for portability — the latter needs curl 7.55.0+.

Verified by mutation, not only by assertion: emptying the auth config file leaves the "token is not in argv" test passing and turns the "requests still authenticate" test red. A test that cannot fail for the reason you care about is not a test.

shellcheck clean; script self-test 4/4; suite 43 tests, 0 failures. Not run: a bash 3.2 differential, as no 3.2 binary was available in the build container.)**