### PR TITLE
security(runtime): redact argv and env from sandbox error output

### DIFF
--- a/pkg/runtime/argv_redact.go
+++ b/pkg/runtime/argv_redact.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"sort"
+	"strings"
+)
+
+// Redaction of credential values that the runtime placed in a subprocess argv,
+// for use when that subprocess's failure is reported to a caller. See #1342.
+//
+// The runtime is in the strongest position available here: it KNOWS every value
+// it passed. Nothing below pattern-matches for things that look like secrets,
+// because guessing is both unnecessary and unreliable when the exact values are
+// in hand.
+
+// envValueRedactionFloor is the shortest value that will be redacted.
+//
+// WHY A FLOOR AT ALL. Redaction is substring replacement over the whole error
+// message. A value of "1", "true" or "/tmp" occurs all over an unrelated
+// diagnostic, and replacing every occurrence would destroy the message to
+// protect a string that is not a secret.
+//
+// WHY 8. It sits in a gap whose edges are measured from this repository rather
+// than guessed at:
+//
+//   - BELOW the shortest credential this project handles, with margin. The
+//     shortest credential it MINTS is a dev token: DevTokenPrefix "scion_dev_"
+//     plus hex(DevTokenLength=32) = 74 characters (pkg/apiclient/devauth.go).
+//     The shortest it CONSUMES is bounded by pkg/harness/claude_provision.go,
+//     which fingerprints an API key as its last 20 characters and would panic
+//     on anything shorter -- so 20 is an existing, enforced floor on credential
+//     length elsewhere in the codebase. 8 is under half of that.
+//   - ABOVE the common short non-secret values that reach env in practice:
+//     "1", "true", "scion", "1002", "/tmp", "prod".
+//
+// The gap between 8 and 20 is wide enough that the number is not delicate:
+// anything in 8..16 would behave identically on every value this runtime
+// actually passes. 8 is chosen at the low end because the cost of the two
+// errors is asymmetric -- redacting a short non-secret costs one confusing
+// line, and failing to redact a short secret costs a credential.
+//
+// KNOWN LIMITATION, stated rather than hidden: a credential shorter than 8
+// characters is NOT redacted. No credential format in use here is that short --
+// see the 20-character floor above -- but a future one could be, and this
+// constant is where that assumption lives.
+const envValueRedactionFloor = 8
+
+// externalEnvValues returns the KEY=VALUE env entries that originated OUTSIDE
+// the runtime -- broker-supplied cfg.Env and harness-supplied env -- and that
+// survived into the final env map.
+//
+// WHY NOT SIMPLY EVERY VALUE THE RUNTIME PUT IN ARGV. Because that measurably
+// destroys the diagnostic. envFor synthesises HOME=/home/scion,
+// SCION_WORKSPACE_PATH=/workspace and PATH=..., all of which clear an
+// 8-character floor, and all of which appear in the parts of the message an
+// operator actually needs:
+//
+//	--mount type=bind,source=...,destination=/home/scion
+//	--mount type=bind,source=...,destination=/workspace
+//
+// Redacting by value would rewrite those mount destinations into redaction
+// markers -- and mount failures are exactly the failure this output exists to
+// diagnose. See TestRedactEnvValues_KeepsSynthesisedPathsIntact.
+//
+// This is not a weakening. A runtime-synthesised constant cannot be a
+// credential: it is built here from non-secret configuration. Everything that
+// could carry a secret arrives from outside, and that is precisely the set
+// returned.
+func externalEnvValues(cfg RunConfig, env map[string]string) map[string]string {
+	external := make(map[string]string)
+
+	for _, e := range cfg.Env {
+		if k, v, ok := strings.Cut(e, "="); ok {
+			external[k] = v
+		}
+	}
+	if cfg.Harness != nil {
+		for k, v := range cfg.Harness.GetEnv(cfg.Name, sandboxAgentHome, cfg.UnixUsername) {
+			external[k] = v
+		}
+	}
+
+	// Keep only entries that actually reached argv with that value. envFor
+	// overwrites some keys with synthesised values after parsing cfg.Env, and a
+	// value that was never passed cannot leak -- redacting it would remove a
+	// coincidentally matching string from the message for no benefit.
+	live := make(map[string]string, len(external))
+	for k, v := range external {
+		if env[k] == v {
+			live[k] = v
+		}
+	}
+	return live
+}
+
+// redactEnvValues replaces each secret value in s with a marker naming its key.
+//
+// The marker names the KEY on purpose. A key name is not a credential, and
+// "[value of ANTHROPIC_API_KEY redacted]" tells an operator that a value was
+// removed and which one, where a silently shortened string is a puzzle.
+func redactEnvValues(s string, secrets map[string]string) string {
+	keys := make([]string, 0, len(secrets))
+	for k, v := range secrets {
+		if len(v) >= envValueRedactionFloor {
+			keys = append(keys, k)
+		}
+	}
+
+	// Longest value first. If one secret's value contains another's, replacing
+	// the shorter one first would leave a fragment of the longer one behind.
+	// Ties break on key name so the output is deterministic and diffable.
+	sort.Slice(keys, func(i, j int) bool {
+		li, lj := len(secrets[keys[i]]), len(secrets[keys[j]])
+		if li != lj {
+			return li > lj
+		}
+		return keys[i] < keys[j]
+	})
+
+	for _, k := range keys {
+		s = strings.ReplaceAll(s, secrets[k], "[value of "+k+" redacted]")
+	}
+	return s
+}

--- a/pkg/runtime/argv_redact_test.go
+++ b/pkg/runtime/argv_redact_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactEnvValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		secrets map[string]string
+		want    string
+	}{
+		{
+			name:    "value is replaced with a marker naming its key",
+			in:      "--env API_KEY=" + argvLeakSentinel,
+			secrets: map[string]string{"API_KEY": argvLeakSentinel},
+			want:    "--env API_KEY=[value of API_KEY redacted]",
+		},
+		{
+			name:    "every occurrence is replaced, not just the first",
+			in:      "a " + argvLeakSentinel + " b " + argvLeakSentinel,
+			secrets: map[string]string{"K": argvLeakSentinel},
+			want:    "a [value of K redacted] b [value of K redacted]",
+		},
+		{
+			name:    "values below the floor are left alone",
+			in:      "exit code 1 after 1 attempt, PATH=/tmp",
+			secrets: map[string]string{"RETRIES": "1", "TMPDIR": "/tmp"},
+			want:    "exit code 1 after 1 attempt, PATH=/tmp",
+		},
+		{
+			name:    "a value exactly at the floor is redacted",
+			in:      "token=12345678",
+			secrets: map[string]string{"TOK": "12345678"},
+			want:    "token=[value of TOK redacted]",
+		},
+		{
+			name:    "a value one byte under the floor is not",
+			in:      "token=1234567",
+			secrets: map[string]string{"TOK": "1234567"},
+			want:    "token=1234567",
+		},
+		{
+			// Longest-first ordering. If the shorter value were replaced first,
+			// the longer one would be left as a mangled fragment plus a marker,
+			// and the fragment would still be part of a live credential.
+			name: "a secret containing another secret is redacted whole",
+			in:   "outer=SUPERSECRETVALUE-EXTRA inner=SUPERSECRETVALUE",
+			secrets: map[string]string{
+				"OUTER": "SUPERSECRETVALUE-EXTRA",
+				"INNER": "SUPERSECRETVALUE",
+			},
+			want: "outer=[value of OUTER redacted] inner=[value of INNER redacted]",
+		},
+		{
+			name:    "no secrets is a no-op",
+			in:      "nothing to do here",
+			secrets: map[string]string{},
+			want:    "nothing to do here",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := redactEnvValues(tc.in, tc.secrets); got != tc.want {
+				t.Errorf("redactEnvValues()\n got: %s\nwant: %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// THIS TEST IS THE JUSTIFICATION FOR SCOPING REDACTION BY PROVENANCE, and it is
+// the measurement behind that design choice rather than an argument for it.
+//
+// The obvious reading of "redact the values the runtime put in argv" is: every
+// value. envFor synthesises HOME=/home/scion (11 chars), SCION_WORKSPACE_PATH=
+// /workspace (10) and PATH=... (65). All three clear an 8-character floor, none
+// is a secret, and all three appear inside the mount specifications:
+//
+//	--mount type=bind,source=...,destination=/home/scion
+//
+// Redacting by value would rewrite those destinations into redaction markers.
+// Mount failures are precisely what this output exists to diagnose -- the fake
+// binary in the sibling test says "mount target busy" for that reason. So the
+// naive reading destroys the diagnostic exactly where it is most needed, which
+// is the failure mode #22 and #46 were spent eliminating.
+func TestRedactEnvValues_KeepsSynthesisedPathsIntact(t *testing.T) {
+	out := "sandbox: fatal: mount target busy\n" +
+		"--mount type=bind,source=/scion/agents/a/home,destination=/home/scion\n" +
+		"--mount type=bind,source=/scion/agents/a/workspace,destination=/workspace\n" +
+		"--env ANTHROPIC_API_KEY=" + argvLeakSentinel + "\n"
+
+	env := map[string]string{
+		"HOME":                 sandboxAgentHome,
+		"SCION_WORKSPACE_PATH": sandboxWorkspace,
+		"PATH":                 "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"ANTHROPIC_API_KEY":    argvLeakSentinel,
+	}
+	cfg := RunConfig{Env: []string{"ANTHROPIC_API_KEY=" + argvLeakSentinel}}
+
+	got := redactEnvValues(out, externalEnvValues(cfg, env))
+
+	if strings.Contains(got, argvLeakSentinel) {
+		t.Errorf("secret survived redaction:\n%s", got)
+	}
+	for _, keep := range []string{
+		"destination=/home/scion",
+		"destination=/workspace",
+		"mount target busy",
+	} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("redaction destroyed diagnostic content %q:\n%s", keep, got)
+		}
+	}
+}
+
+func TestExternalEnvValues(t *testing.T) {
+	t.Run("runtime-synthesised values are not treated as secrets", func(t *testing.T) {
+		env := map[string]string{"HOME": sandboxAgentHome, "USER": "scion"}
+		got := externalEnvValues(RunConfig{}, env)
+		if len(got) != 0 {
+			t.Errorf("want no external values, got %v", got)
+		}
+	})
+
+	t.Run("broker-supplied values are", func(t *testing.T) {
+		cfg := RunConfig{Env: []string{"API_KEY=" + argvLeakSentinel}}
+		env := map[string]string{"API_KEY": argvLeakSentinel, "HOME": sandboxAgentHome}
+		got := externalEnvValues(cfg, env)
+		if got["API_KEY"] != argvLeakSentinel {
+			t.Errorf("broker-supplied API_KEY not returned: %v", got)
+		}
+		if _, ok := got["HOME"]; ok {
+			t.Errorf("synthesised HOME should not be returned: %v", got)
+		}
+	})
+
+	t.Run("harness-supplied values are", func(t *testing.T) {
+		cfg := RunConfig{Harness: &mockHarness{env: map[string]string{"H_TOKEN": argvLeakSentinel}}}
+		env := map[string]string{"H_TOKEN": argvLeakSentinel}
+		if got := externalEnvValues(cfg, env); got["H_TOKEN"] != argvLeakSentinel {
+			t.Errorf("harness-supplied H_TOKEN not returned: %v", got)
+		}
+	})
+
+	t.Run("a value overwritten before argv is not redacted", func(t *testing.T) {
+		// envFor parses cfg.Env first, then overwrites some keys with
+		// synthesised values. A value that never reached argv cannot leak, and
+		// redacting it would strip a coincidentally matching string from the
+		// message for no benefit.
+		cfg := RunConfig{Env: []string{"HOME=/somewhere/else"}}
+		env := map[string]string{"HOME": sandboxAgentHome}
+		if got := externalEnvValues(cfg, env); len(got) != 0 {
+			t.Errorf("overwritten value should not be redacted, got %v", got)
+		}
+	})
+
+	t.Run("a malformed env entry without = is ignored", func(t *testing.T) {
+		cfg := RunConfig{Env: []string{"NOT_A_PAIR"}}
+		if got := externalEnvValues(cfg, map[string]string{}); len(got) != 0 {
+			t.Errorf("want no values, got %v", got)
+		}
+	})
+}

--- a/pkg/runtime/argv_redact_test.go
+++ b/pkg/runtime/argv_redact_test.go
@@ -85,8 +85,25 @@ func TestRedactEnvValues(t *testing.T) {
 	}
 }
 
-// THIS TEST IS THE JUSTIFICATION FOR SCOPING REDACTION BY PROVENANCE, and it is
-// the measurement behind that design choice rather than an argument for it.
+// DIAGNOSTIC GUARD -- NOT A LEAK TEST. DO NOT DELETE THIS AS REDUNDANT.
+//
+// It looks like a weaker duplicate of the leak tests and it is the opposite: it
+// is the only test here that fails when redaction OVER-reaches. Mutate the
+// scope to the naive "redact every value the runtime passed" reading and every
+// leak test in this package stays GREEN -- the blind version is perfectly
+// secure -- while this test goes red on both mount destinations. Measured, not
+// predicted.
+//
+// The general form, because it is not specific to #1342: a security fix needs a
+// test that fails when the fix over-reaches, not only one that fails when it
+// under-reaches. Over-redaction is not a milder failure of the same kind; it is
+// invisible to the entire class of test one naturally writes for a security
+// fix, so a suite of leak tests alone would certify the blind version and ship
+// a #22/#46 regression under a security banner.
+//
+// THIS TEST IS ALSO THE JUSTIFICATION FOR SCOPING REDACTION BY PROVENANCE, and
+// it is the measurement behind that design choice rather than an argument for
+// it.
 //
 // The obvious reading of "redact the values the runtime put in argv" is: every
 // value. envFor synthesises HOME=/home/scion (11 chars), SCION_WORKSPACE_PATH=

--- a/pkg/runtime/cloudrun_sandbox_argv_leak_test.go
+++ b/pkg/runtime/cloudrun_sandbox_argv_leak_test.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Tests for ptone/scion#1342: the error returned by CloudRunSandboxRuntime.Run
+// when the sandbox binary fails must not carry the values of the --env pairs
+// the runtime itself placed in argv.
+//
+// WHY THIS EXISTS AS A TEST RATHER THAN AN INVESTIGATION. #1342 records an open
+// question -- "does the sandbox binary echo its own argv when it fails?" -- and
+// says it "cannot be settled from Scion's source; it needs a look at the
+// sandbox binary's error output." It has sat unresolved on the belief that
+// answering it needs a live instance. It does not. A fake sandbox binary that
+// echoes its argv turns "many CLIs might do this" into a measurement, and the
+// measurement is cheap, hermetic and repeatable.
+//
+// THE TWO CASES BELOW ARE A DISCRIMINATING PAIR, NOT A DUPLICATE, AND THEY PIN
+// TWO DIFFERENT THINGS. There are two independent routes by which a value in
+// argv can reach the returned error, and a single test cannot tell you which
+// one fired:
+//
+//	OUT  -- the sandbox binary echoes argv, and that output is spliced in by
+//	        `(output: %s)` at cloudrun_sandbox_runtime.go:780. CONDITIONAL on
+//	        the binary's behaviour. This is the route #1342 asks about and the
+//	        one fixed here.
+//	WRAP -- runSimpleCommand formats the full argv into the error it returns,
+//	        and :780 wraps that error with %w. UNCONDITIONAL -- it does not
+//	        depend on the binary's behaviour at all.
+//
+// WRAP was live on `main` and is closed by #127 P5, which reduced that error to
+// `fmt.Errorf("%s failed: %w", command, err)`. This file is based on P5, so the
+// silent case arrives GREEN and stays that way: it is a REGRESSION GUARD on
+// P5's fix, asserted from the caller's side rather than from common.go's.
+//
+// Keep both cases permanently, and do not merge them. The pair is what makes
+// the failure legible: OUT red with WRAP green says the sandbox binary echoed
+// its argv, while both red would say argv had returned to the error text
+// upstream. Collapsed into one case, those two very different regressions
+// would be indistinguishable.
+//
+// Measured on `main` before the rebase, both cases were RED -- which is how we
+// learned the answer to #1342's open question does not matter: the leak was
+// unconditional there, so whether the binary echoes decided nothing.
+const (
+	// Per the standing constraint: never use a real credential in a test.
+	argvLeakSentinel = "FAKE-KEY-SENTINEL-not-a-real-credential"
+
+	// A distinctive line the fake binary always prints. Asserting this SURVIVES
+	// is as load-bearing as asserting the sentinel does not.
+	//
+	// #22 and #46 were spent making sandbox failures diagnosable, and the
+	// cheapest way to pass a leak test is to stop putting the subprocess output
+	// in the error at all. That is a regression wearing a security fix's
+	// costume, and this constant is what mechanically blocks it: a fix that
+	// drops `out` turns this assertion red. The prohibition is in the test, not
+	// only in the review guidance.
+	argvLeakDiagnostic = "sandbox: fatal: mount target busy"
+)
+
+// writeFakeSandbox creates an executable stand-in for the sandbox binary that
+// always fails. When echoArgv is true it also prints its full argv to stderr,
+// imitating a CLI that reports the offending invocation on an argument error.
+func writeFakeSandbox(t *testing.T, dir string, echoArgv bool) string {
+	t.Helper()
+
+	// Printed to stderr so it lands in CombinedOutput either way. `exit 1` is
+	// what makes runSimpleCommand return an error and take the :779 branch.
+	script := "#!/bin/sh\n" +
+		"echo '" + argvLeakDiagnostic + "' >&2\n"
+	if echoArgv {
+		script += "printf '%s\\n' \"$@\" >&2\n"
+	}
+	script += "exit 1\n"
+
+	path := filepath.Join(dir, "sandbox")
+	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// runWithSentinelEnv drives Run() against a failing fake sandbox with the
+// sentinel supplied the way a real API key arrives: as a broker-provided
+// RunConfig.Env entry, which envFor parses and envArgs turns into --env pairs.
+func runWithSentinelEnv(t *testing.T, echoArgv bool) error {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	mockBin := writeFakeSandbox(t, tmpDir, echoArgv)
+
+	homeDir := filepath.Join(tmpDir, "agent-home")
+	if err := os.MkdirAll(homeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	rt := &CloudRunSandboxRuntime{
+		bin:          mockBin,
+		state:        newSandboxStateStore(filepath.Join(tmpDir, "state.json")),
+		rootDir:      filepath.Join(tmpDir, "scion"),
+		watchCancels: make(map[string]context.CancelFunc),
+	}
+
+	cfg := RunConfig{
+		Name:      "leak-probe",
+		HomeDir:   homeDir,
+		Workspace: filepath.Join(tmpDir, "workspace"),
+		Image:     "omni-image",
+		Env:       []string{"ANTHROPIC_API_KEY=" + argvLeakSentinel},
+		// REQUIRED, and its absence is not a detail. buildEntrypoint returns
+		// "cloudrun-sandbox: no harness provided" and Run() gives up BEFORE it
+		// ever executes the binary, so the first draft of this test went red
+		// without reaching the leak site at all -- a vacuous red that would
+		// have been reported as proof of the leak. The "error stays useful"
+		// assertion is what caught it: the returned error came from Scion, not
+		// from the subprocess.
+		Harness: &mockHarness{command: []string{"/bin/true"}},
+	}
+	if err := os.MkdirAll(cfg.Workspace, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := rt.Run(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("Run() returned nil error, but the fake sandbox binary exits 1; " +
+			"the test cannot say anything about error contents")
+	}
+	return err
+}
+
+func TestCloudRunSandboxRun_ErrorDoesNotLeakEnvValues(t *testing.T) {
+	cases := []struct {
+		name     string
+		echoArgv bool
+		route    string
+	}{
+		{
+			name:     "sandbox binary echoes its argv on failure",
+			echoArgv: true,
+			route: "OUT -- output spliced in by (output: %s). This is the case #1342 " +
+				"asks about and could not answer without a live instance.",
+		},
+		{
+			name:     "sandbox binary is silent",
+			echoArgv: false,
+			route: "WRAP -- runSimpleCommand formats argv into its own error text. " +
+				"The binary echoes NOTHING here, so a failure means the leak does " +
+				"not depend on the sandbox binary's behaviour at all. This case is " +
+				"GREEN on the #127 P5 base; if it is failing, P5's fix to " +
+				"runSimpleCommand has regressed and the problem is NOT at :780.",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := runWithSentinelEnv(t, tc.echoArgv)
+			got := err.Error()
+
+			if strings.Contains(got, argvLeakSentinel) {
+				t.Errorf("CREDENTIAL LEAK: Run() error contains the value of an --env pair.\n"+
+					"route: %s\n"+
+					"This error reaches an HTTP response body via handlers.go RuntimeError().\n"+
+					"error: %s", tc.route, got)
+			}
+
+			// The error must remain diagnosable. See argvLeakDiagnostic.
+			if !strings.Contains(got, argvLeakDiagnostic) {
+				t.Errorf("error is no longer useful: it does not contain the sandbox binary's "+
+					"diagnostic %q.\nRedaction must remove the credential VALUE, not the "+
+					"subprocess output (see #22, #46).\nerror: %s", argvLeakDiagnostic, got)
+			}
+		})
+	}
+}
+
+// The key name is not a secret and must survive redaction: "some value was
+// removed here, and it was ANTHROPIC_API_KEY's" is a diagnostic, while a
+// silently shortened string is a puzzle. Separate from the test above because
+// it asserts a property of the FIX, not the absence of the leak.
+func TestCloudRunSandboxRun_ErrorNamesTheRedactedKey(t *testing.T) {
+	err := runWithSentinelEnv(t, true)
+	got := err.Error()
+
+	if strings.Contains(got, argvLeakSentinel) {
+		t.Skip("leak still present; TestCloudRunSandboxRun_ErrorDoesNotLeakEnvValues owns that failure")
+	}
+	if !strings.Contains(got, "ANTHROPIC_API_KEY") {
+		t.Errorf("redacted error does not name the key whose value was removed.\nerror: %s", got)
+	}
+}

--- a/pkg/runtime/cloudrun_sandbox_runtime.go
+++ b/pkg/runtime/cloudrun_sandbox_runtime.go
@@ -777,7 +777,24 @@ func (r *CloudRunSandboxRuntime) Run(ctx context.Context, cfg RunConfig) (string
 
 	out, err := runSimpleCommand(ctx, r.bin, args...)
 	if err != nil {
-		return "", fmt.Errorf("cloudrun-sandbox: run failed: %w (output: %s)", err, out)
+		// #1342: `out` is the sandbox binary's combined stdout+stderr, and a CLI
+		// that reports the offending invocation on an argument error will echo
+		// its own argv -- which carries every --env KEY=VALUE pair. This error
+		// reaches an HTTP response body via handlers.go RuntimeError(), so the
+		// values are redacted before they are spliced in. Measured, not assumed:
+		// see TestCloudRunSandboxRun_ErrorDoesNotLeakEnvValues.
+		//
+		// `err` itself is safe to wrap as-is on this base: #127 P5 reduced
+		// runSimpleCommand's error to `%s failed: %w` with no argv. The silent
+		// case of that test is the guard on it -- if P5 is ever reverted, the
+		// leak returns through THIS %w and that case goes red.
+		//
+		// %w is deliberately preserved. handlers.go calls errors.Is(err,
+		// agent.ErrContainerNameInUse) at :899 and :1422, and
+		// classifyLaunchRuntimeError calls errors.Is(err, exec.ErrNotFound);
+		// rebuilding this error from a string would sever that chain silently.
+		safeOut := redactEnvValues(out, externalEnvValues(cfg, env))
+		return "", fmt.Errorf("cloudrun-sandbox: run failed: %w (output: %s)", err, safeOut)
 	}
 
 	// Post-run liveness probe: `sandbox run --detach` returns rc=0 even for


### PR DESCRIPTION
## Summary

Closes the remaining unredacted argv/env leak in the Cloud Run sandbox runtime error path.

The error wrap at `pkg/runtime/cloudrun_sandbox_runtime.go:780` can leak environment variables, including credentials, into error messages when a sandbox run fails. #1364 closed the `WriteRuntimeDebugFile` path; this closes the other one.

Four files, all under `pkg/runtime/`: `argv_redact.go` (new helper), `argv_redact_test.go`, `cloudrun_sandbox_argv_leak_test.go`, and 19 changed lines in `cloudrun_sandbox_runtime.go`.

Tracked as ptone/scion#1342. Supersedes fork PR ptone/scion#1347, which was auto-closed when its base branch was deleted, not closed by review. Fork and upstream numbering have diverged, so those two are written in full: `#1342` and `#1347` in this repository are unrelated.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean; `go test ./pkg/runtime/...` green; `./hack/check-security-marker-gates.sh` all gates pass. Fork CI on the identical tree: Build & Test, golangci-lint and shellcheck all SUCCESS