### PR TITLE
ci: add reporting-only full test suite job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,25 @@ jobs:
       - name: Build Binary
         run: make build
 
+  test-full-suite:
+    name: Full Test Suite (reporting only)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Run full test suite (with SQLite)
+        continue-on-error: true
+        run: go test -count=1 -timeout 30m ./...
+
   lint:
     name: golangci-lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
   test-full-suite:
     name: Full Test Suite (reporting only)
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -142,8 +143,15 @@ jobs:
           cache: true
 
       - name: Run full test suite (with SQLite)
-        continue-on-error: true
-        run: go test -count=1 -timeout 30m ./...
+        run: go test -count=1 -timeout 30m ./... 2>&1 | tee test-full-suite-output.txt
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: full-test-suite-results
+          path: test-full-suite-output.txt
+          retention-days: 14
 
   lint:
     name: golangci-lint


### PR DESCRIPTION
## Summary

Add a non-blocking CI job that runs `go test ./...` without `-tags no_sqlite`. Surfaces which tests fail when SQLite is available, establishing a failure inventory.

## Changes

- New test-full-suite job in ci.yml
- continue-on-error at job level
- Test output captured as artifact

Tracking: ptone/scion#1361