### PR TITLE
fix: gofmt formatting in handlers_agent_message_mode.go (#1382)

### DIFF
--- a/pkg/hub/handlers_agent_message_mode.go
+++ b/pkg/hub/handlers_agent_message_mode.go
@@ -52,9 +52,9 @@ type CascadeAgentDetail struct {
 
 // CascadeResult describes which descendants were updated (or would be updated) in a cascade operation.
 type CascadeResult struct {
-	Count    int                  `json:"count"`              // Number of descendants updated
-	AgentIDs []string             `json:"agent_ids"`          // IDs of updated descendants
-	Details  []CascadeAgentDetail `json:"details,omitempty"`  // Per-agent transition details (populated for dryRun and cascade)
+	Count    int                  `json:"count"`             // Number of descendants updated
+	AgentIDs []string             `json:"agent_ids"`         // IDs of updated descendants
+	Details  []CascadeAgentDetail `json:"details,omitempty"` // Per-agent transition details (populated for dryRun and cascade)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes 3 lines of comment-column misalignment in CascadeResult struct from PR #1382 squash merge
- Alignment only — diff -w against main is empty (no semantic changes)
- Unblocks 5 downstream CI gates (Vet, Auth Guards, Conversation Upsert Guard, Security Marker Gates, Tests) that Format Check was short-circuiting