### PR TITLE
ci: use pipefail so full test suite job reports real exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,9 @@ jobs:
           cache: true
 
       - name: Run full test suite (with SQLite)
-        run: go test -count=1 -timeout 30m ./... 2>&1 | tee test-full-suite-output.txt
+        run: |
+          set -o pipefail
+          go test -count=1 -timeout 30m ./... 2>&1 | tee test-full-suite-output.txt
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## Summary

Follow-up to #1388. Add explicit pipefail to the full test suite CI job so go test exit code propagates through the tee pipe.

Tracking: ptone/scion#1361