### PR TITLE
feat(web): role-binding display names + reusable principal picker

### DIFF
--- a/pkg/hub/handlers_roles.go
+++ b/pkg/hub/handlers_roles.go
@@ -489,7 +489,7 @@ func (s *Server) createRoleBinding(w http.ResponseWriter, r *http.Request, user 
 
 	// Resolve email to UUID for user principals (mirrors addGroupMember pattern).
 	if req.PrincipalType == store.RoleBindingPrincipalUser && strings.Contains(req.PrincipalID, "@") {
-		user, err := s.store.GetUserByEmail(r.Context(), req.PrincipalID)
+		resolvedUser, err := s.store.GetUserByEmail(r.Context(), req.PrincipalID)
 		if err != nil {
 			if errors.Is(err, store.ErrNotFound) {
 				BadRequest(w, "user not found with email: "+req.PrincipalID)
@@ -498,7 +498,7 @@ func (s *Server) createRoleBinding(w http.ResponseWriter, r *http.Request, user 
 			writeErrorFromErr(w, err, "")
 			return
 		}
-		req.PrincipalID = user.ID
+		req.PrincipalID = resolvedUser.ID
 	}
 
 	if req.ScopeType != store.RoleScopeSystem && req.ScopeType != store.RoleScopeProject {

--- a/pkg/hub/handlers_roles.go
+++ b/pkg/hub/handlers_roles.go
@@ -59,10 +59,18 @@ type listRoleDefinitionsResponse struct {
 	TotalCount int                     `json:"totalCount"`
 }
 
+// RoleBindingInfo is a role binding enriched with human-friendly display info.
+type RoleBindingInfo struct {
+	store.RoleBinding
+	PrincipalDisplayName string `json:"principalDisplayName,omitempty"`
+	ScopeDisplayName     string `json:"scopeDisplayName,omitempty"`
+	CreatedByDisplayName string `json:"createdByDisplayName,omitempty"`
+}
+
 // listRoleBindingsResponse wraps the list result for the API.
 type listRoleBindingsResponse struct {
-	Items      []*store.RoleBinding `json:"items"`
-	TotalCount int                  `json:"totalCount"`
+	Items      []RoleBindingInfo `json:"items"`
+	TotalCount int               `json:"totalCount"`
 }
 
 // listPermissionsResponse wraps the permissions registry for the API.
@@ -401,9 +409,10 @@ func (s *Server) deleteRoleDefinition(w http.ResponseWriter, r *http.Request, id
 // ---------------------------------------------------------------------------
 
 func (s *Server) listRoleBindings(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	limit, offset := parsePaginationParams(r)
 
-	bindings, err := s.store.ListAllRoleBindings(r.Context(), limit, offset)
+	bindings, err := s.store.ListAllRoleBindings(ctx, limit, offset)
 	if err != nil {
 		writeErrorFromErr(w, err, "")
 		return
@@ -412,14 +421,28 @@ func (s *Server) listRoleBindings(w http.ResponseWriter, r *http.Request) {
 		bindings = []*store.RoleBinding{}
 	}
 
-	total, err := s.store.CountAllRoleBindings(r.Context())
+	total, err := s.store.CountAllRoleBindings(ctx)
 	if err != nil {
 		writeErrorFromErr(w, err, "")
 		return
 	}
 
+	// Enrich bindings with human-friendly display names.
+	enriched := make([]RoleBindingInfo, len(bindings))
+	for i, b := range bindings {
+		enriched[i] = RoleBindingInfo{RoleBinding: *b}
+		enriched[i].PrincipalDisplayName = s.resolveGroupMemberDisplayName(ctx, b.PrincipalType, b.PrincipalID)
+		enriched[i].CreatedByDisplayName = s.resolveGroupMemberDisplayName(ctx, store.GroupMemberTypeUser, b.CreatedBy)
+		if b.ScopeType == store.RoleScopeProject && b.ScopeID != "" {
+			project, err := s.store.GetProject(ctx, b.ScopeID)
+			if err == nil {
+				enriched[i].ScopeDisplayName = project.Name
+			}
+		}
+	}
+
 	writeJSON(w, http.StatusOK, listRoleBindingsResponse{
-		Items:      bindings,
+		Items:      enriched,
 		TotalCount: total,
 	})
 }
@@ -463,6 +486,21 @@ func (s *Server) createRoleBinding(w http.ResponseWriter, r *http.Request, user 
 		BadRequest(w, "principalId is required")
 		return
 	}
+
+	// Resolve email to UUID for user principals (mirrors addGroupMember pattern).
+	if req.PrincipalType == store.RoleBindingPrincipalUser && strings.Contains(req.PrincipalID, "@") {
+		user, err := s.store.GetUserByEmail(r.Context(), req.PrincipalID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				BadRequest(w, "user not found with email: "+req.PrincipalID)
+				return
+			}
+			writeErrorFromErr(w, err, "")
+			return
+		}
+		req.PrincipalID = user.ID
+	}
+
 	if req.ScopeType != store.RoleScopeSystem && req.ScopeType != store.RoleScopeProject {
 		BadRequest(w, "scopeType must be \"system\" or \"project\"")
 		return
@@ -549,7 +587,8 @@ func (s *Server) deleteRoleBinding(w http.ResponseWriter, r *http.Request, id st
 }
 
 func (s *Server) listBindingsForUser(w http.ResponseWriter, r *http.Request, userID string) {
-	bindings, err := s.store.ListRoleBindingsForPrincipal(r.Context(), store.RoleBindingPrincipalUser, userID)
+	ctx := r.Context()
+	bindings, err := s.store.ListRoleBindingsForPrincipal(ctx, store.RoleBindingPrincipalUser, userID)
 	if err != nil {
 		writeErrorFromErr(w, err, "")
 		return
@@ -557,9 +596,24 @@ func (s *Server) listBindingsForUser(w http.ResponseWriter, r *http.Request, use
 	if bindings == nil {
 		bindings = []*store.RoleBinding{}
 	}
+
+	// Enrich bindings with human-friendly display names.
+	enriched := make([]RoleBindingInfo, len(bindings))
+	for i, b := range bindings {
+		enriched[i] = RoleBindingInfo{RoleBinding: *b}
+		enriched[i].PrincipalDisplayName = s.resolveGroupMemberDisplayName(ctx, b.PrincipalType, b.PrincipalID)
+		enriched[i].CreatedByDisplayName = s.resolveGroupMemberDisplayName(ctx, store.GroupMemberTypeUser, b.CreatedBy)
+		if b.ScopeType == store.RoleScopeProject && b.ScopeID != "" {
+			project, err := s.store.GetProject(ctx, b.ScopeID)
+			if err == nil {
+				enriched[i].ScopeDisplayName = project.Name
+			}
+		}
+	}
+
 	writeJSON(w, http.StatusOK, listRoleBindingsResponse{
-		Items:      bindings,
-		TotalCount: len(bindings),
+		Items:      enriched,
+		TotalCount: len(enriched),
 	})
 }
 

--- a/pkg/hub/handlers_roles.go
+++ b/pkg/hub/handlers_roles.go
@@ -428,17 +428,22 @@ func (s *Server) listRoleBindings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Enrich bindings with human-friendly display names.
-	enriched := make([]RoleBindingInfo, len(bindings))
+	enriched := make([]RoleBindingInfo, 0, len(bindings))
 	for i, b := range bindings {
-		enriched[i] = RoleBindingInfo{RoleBinding: *b}
-		enriched[i].PrincipalDisplayName = s.resolveGroupMemberDisplayName(ctx, b.PrincipalType, b.PrincipalID)
-		enriched[i].CreatedByDisplayName = s.resolveGroupMemberDisplayName(ctx, store.GroupMemberTypeUser, b.CreatedBy)
+		if b == nil {
+			slog.Warn("nil role binding in list result, skipping", "index", i)
+			continue
+		}
+		info := RoleBindingInfo{RoleBinding: *b}
+		info.PrincipalDisplayName = s.resolveGroupMemberDisplayName(ctx, b.PrincipalType, b.PrincipalID)
+		info.CreatedByDisplayName = s.resolveGroupMemberDisplayName(ctx, store.GroupMemberTypeUser, b.CreatedBy)
 		if b.ScopeType == store.RoleScopeProject && b.ScopeID != "" {
 			project, err := s.store.GetProject(ctx, b.ScopeID)
-			if err == nil {
-				enriched[i].ScopeDisplayName = project.Name
+			if err == nil && project != nil {
+				info.ScopeDisplayName = project.Name
 			}
 		}
+		enriched = append(enriched, info)
 	}
 
 	writeJSON(w, http.StatusOK, listRoleBindingsResponse{
@@ -496,6 +501,10 @@ func (s *Server) createRoleBinding(w http.ResponseWriter, r *http.Request, user 
 				return
 			}
 			writeErrorFromErr(w, err, "")
+			return
+		}
+		if resolvedUser == nil {
+			BadRequest(w, "user not found with email: "+req.PrincipalID)
 			return
 		}
 		req.PrincipalID = resolvedUser.ID
@@ -598,17 +607,22 @@ func (s *Server) listBindingsForUser(w http.ResponseWriter, r *http.Request, use
 	}
 
 	// Enrich bindings with human-friendly display names.
-	enriched := make([]RoleBindingInfo, len(bindings))
+	enriched := make([]RoleBindingInfo, 0, len(bindings))
 	for i, b := range bindings {
-		enriched[i] = RoleBindingInfo{RoleBinding: *b}
-		enriched[i].PrincipalDisplayName = s.resolveGroupMemberDisplayName(ctx, b.PrincipalType, b.PrincipalID)
-		enriched[i].CreatedByDisplayName = s.resolveGroupMemberDisplayName(ctx, store.GroupMemberTypeUser, b.CreatedBy)
+		if b == nil {
+			slog.Warn("nil role binding in list result, skipping", "index", i)
+			continue
+		}
+		info := RoleBindingInfo{RoleBinding: *b}
+		info.PrincipalDisplayName = s.resolveGroupMemberDisplayName(ctx, b.PrincipalType, b.PrincipalID)
+		info.CreatedByDisplayName = s.resolveGroupMemberDisplayName(ctx, store.GroupMemberTypeUser, b.CreatedBy)
 		if b.ScopeType == store.RoleScopeProject && b.ScopeID != "" {
 			project, err := s.store.GetProject(ctx, b.ScopeID)
-			if err == nil {
-				enriched[i].ScopeDisplayName = project.Name
+			if err == nil && project != nil {
+				info.ScopeDisplayName = project.Name
 			}
 		}
+		enriched = append(enriched, info)
 	}
 
 	writeJSON(w, http.StatusOK, listRoleBindingsResponse{

--- a/web/src/components/pages/admin-role-bindings.ts
+++ b/web/src/components/pages/admin-role-bindings.ts
@@ -25,6 +25,8 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 import { apiFetch, extractApiError } from '../../client/api.js';
+import type { PrincipalChangeDetail } from '../shared/principal-picker.js';
+import '../shared/principal-picker.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -35,9 +37,12 @@ interface RoleBinding {
   roleDefinitionId: string;
   principalType: string;
   principalId: string;
+  principalDisplayName?: string;
   scopeType: string;
   scopeId: string;
+  scopeDisplayName?: string;
   createdBy: string;
+  createdByDisplayName?: string;
   createdAt: string;
 }
 
@@ -612,7 +617,7 @@ export class ScionPageAdminRoleBindings extends LitElement {
       <tr>
         <td>
           <div class="principal-info">
-            <span class="principal-id">${binding.principalId}</span>
+            <span class="principal-id">${binding.principalDisplayName || binding.principalId}</span>
             <span class="principal-type">${binding.principalType}</span>
           </div>
         </td>
@@ -620,7 +625,7 @@ export class ScionPageAdminRoleBindings extends LitElement {
         <td><span class="scope-badge">${binding.scopeType}</span></td>
         <td class="hide-mobile">
           ${binding.scopeId
-            ? html`<span class="scope-id">${binding.scopeId}</span>`
+            ? html`<span class="scope-id">${binding.scopeDisplayName || binding.scopeId}</span>`
             : html`<span class="meta-text">—</span>`}
         </td>
         <td class="hide-mobile">
@@ -685,6 +690,7 @@ export class ScionPageAdminRoleBindings extends LitElement {
             .value=${this.formPrincipalType}
             @sl-change=${(e: Event) => {
               this.formPrincipalType = (e.target as HTMLSelectElement).value;
+              this.formPrincipalId = '';
             }}
           >
             <sl-option value="user">User</sl-option>
@@ -692,15 +698,12 @@ export class ScionPageAdminRoleBindings extends LitElement {
           </sl-select>
         </div>
         <div class="form-group">
-          <sl-input
-            label="Principal ID"
-            placeholder="User or agent ID"
-            .value=${this.formPrincipalId}
-            @sl-input=${(e: Event) => {
-              this.formPrincipalId = (e.target as HTMLInputElement).value;
+          <scion-principal-picker
+            .principalType=${this.formPrincipalType as 'user' | 'agent'}
+            @principal-change=${(e: CustomEvent<PrincipalChangeDetail>) => {
+              this.formPrincipalId = e.detail.principalId;
             }}
-            required
-          ></sl-input>
+          ></scion-principal-picker>
         </div>
         <div class="form-group">
           <sl-select
@@ -779,7 +782,7 @@ export class ScionPageAdminRoleBindings extends LitElement {
       >
         <p>
           Are you sure you want to delete this role binding for
-          <strong>${this.deletingBinding.principalId}</strong>
+          <strong>${this.deletingBinding.principalDisplayName || this.deletingBinding.principalId}</strong>
           (${this.getRoleName(this.deletingBinding.roleDefinitionId)})?
         </p>
         <p class="delete-warning">This action cannot be undone.</p>

--- a/web/src/components/shared/group-member-editor.ts
+++ b/web/src/components/shared/group-member-editor.ts
@@ -28,9 +28,11 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import type { GroupMember, AdminGroup } from '../../shared/types.js';
+import type { PrincipalChangeDetail } from './principal-picker.js';
 import { apiFetch, extractApiError } from '../../client/api.js';
 import { showToast } from '../../utils/toast.js';
 import { showConfirm } from './confirm-dialog.js';
+import './principal-picker.js';
 
 @customElement('scion-group-member-editor')
 export class ScionGroupMemberEditor extends LitElement {
@@ -64,14 +66,6 @@ export class ScionGroupMemberEditor extends LitElement {
   // Available groups for the dropdown
   @state() private availableGroups: AdminGroup[] = [];
   @state() private groupsLoading = false;
-
-  // User search autocomplete state
-  @state() private userSearchQuery = '';
-  @state() private userSearchResults: Array<{ id: string; email: string; displayName: string }> =
-    [];
-  @state() private userSearchLoading = false;
-  @state() private userSearchOpen = false;
-  private userSearchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Removing state
   @state() private removingMember: string | null = null;
@@ -353,62 +347,6 @@ export class ScionGroupMemberEditor extends LitElement {
       border-radius: var(--scion-radius, 0.5rem);
     }
 
-    /* User search autocomplete */
-    .user-search-container {
-      position: relative;
-    }
-
-    .user-search-dropdown {
-      position: absolute;
-      top: 100%;
-      left: 0;
-      right: 0;
-      z-index: 1000;
-      background: var(--scion-surface, #ffffff);
-      border: 1px solid var(--scion-border, #e2e8f0);
-      border-radius: var(--scion-radius, 0.5rem);
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-      max-height: 200px;
-      overflow-y: auto;
-      margin-top: 0.25rem;
-    }
-
-    .user-search-option {
-      display: flex;
-      flex-direction: column;
-      padding: 0.5rem 0.75rem;
-      cursor: pointer;
-      border-bottom: 1px solid var(--scion-border, #e2e8f0);
-    }
-
-    .user-search-option:last-child {
-      border-bottom: none;
-    }
-
-    .user-search-option:hover,
-    .user-search-option.focused {
-      background: var(--scion-bg-subtle, #f1f5f9);
-    }
-
-    .user-search-option .user-name {
-      font-weight: 500;
-      font-size: 0.875rem;
-      color: var(--scion-text, #1e293b);
-    }
-
-    .user-search-option .user-email {
-      font-size: 0.75rem;
-      color: var(--scion-text-muted, #64748b);
-    }
-
-    .user-search-empty,
-    .user-search-loading {
-      padding: 0.75rem;
-      text-align: center;
-      font-size: 0.8125rem;
-      color: var(--scion-text-muted, #64748b);
-    }
-
     @media (max-width: 768px) {
       .hide-mobile {
         display: none;
@@ -469,50 +407,10 @@ export class ScionGroupMemberEditor extends LitElement {
     }
   }
 
-  private handleUserSearchInput(e: Event): void {
-    const value = (e.target as HTMLInputElement).value;
-    this.userSearchQuery = value;
-    this.addMemberInput = value;
-
-    if (this.userSearchDebounceTimer) {
-      clearTimeout(this.userSearchDebounceTimer);
-    }
-
-    if (value.trim().length < 2) {
-      this.userSearchResults = [];
-      this.userSearchOpen = false;
-      return;
-    }
-
-    this.userSearchDebounceTimer = setTimeout(() => {
-      void this.searchUsers(value.trim());
-    }, 250);
-  }
-
-  private async searchUsers(query: string): Promise<void> {
-    this.userSearchLoading = true;
-    this.userSearchOpen = true;
-    try {
-      const response = await apiFetch(`/api/v1/users?search=${encodeURIComponent(query)}&limit=10`);
-      if (response.ok) {
-        const data = (await response.json()) as {
-          users?: Array<{ id: string; email: string; displayName: string }>;
-        };
-        this.userSearchResults = data.users || [];
-      }
-    } catch (err) {
-      console.error('Failed to search users:', err);
-      this.userSearchResults = [];
-    } finally {
-      this.userSearchLoading = false;
-    }
-  }
-
-  private selectUser(user: { id: string; email: string; displayName: string }): void {
-    this.addMemberInput = user.email;
-    this.userSearchQuery = user.displayName ? `${user.displayName} (${user.email})` : user.email;
-    this.userSearchOpen = false;
-    this.userSearchResults = [];
+  private handlePrincipalChange(e: CustomEvent<PrincipalChangeDetail>): void {
+    // The group-member backend (addGroupMember) resolves emails to UUIDs,
+    // so we pass the principalId (UUID) when available.
+    this.addMemberInput = e.detail.principalId;
   }
 
   private openAddDialog(): void {
@@ -520,9 +418,6 @@ export class ScionGroupMemberEditor extends LitElement {
     this.addMemberInput = '';
     this.addMemberRole = 'member';
     this.addMemberError = null;
-    this.userSearchQuery = '';
-    this.userSearchResults = [];
-    this.userSearchOpen = false;
     this.addDialogOpen = true;
     void this.loadAvailableGroups();
   }
@@ -823,9 +718,6 @@ export class ScionGroupMemberEditor extends LitElement {
               this.addMemberType = (e.target as HTMLSelectElement).value;
               this.addMemberInput = '';
               this.addMemberError = null;
-              this.userSearchQuery = '';
-              this.userSearchResults = [];
-              this.userSearchOpen = false;
             }}
           >
             <sl-option value="user">
@@ -867,56 +759,11 @@ export class ScionGroupMemberEditor extends LitElement {
               `
             : this.addMemberType === 'user'
               ? html`
-                  <div class="user-search-container">
-                    <sl-input
-                      label=${inputLabel}
-                      placeholder="Search by name or email..."
-                      value=${this.userSearchQuery}
-                      type="text"
-                      autocomplete="off"
-                      @sl-input=${this.handleUserSearchInput}
-                      @sl-focus=${() => {
-                        if (this.userSearchResults.length > 0) this.userSearchOpen = true;
-                      }}
-                      @sl-blur=${() => {
-                        // Delay to allow click on dropdown
-                        setTimeout(() => {
-                          this.userSearchOpen = false;
-                        }, 200);
-                      }}
-                      required
-                    ></sl-input>
-                    ${this.userSearchOpen
-                      ? html`
-                          <div class="user-search-dropdown">
-                            ${this.userSearchLoading
-                              ? html`<div class="user-search-loading">
-                                  <sl-spinner></sl-spinner> Searching...
-                                </div>`
-                              : this.userSearchResults.length === 0
-                                ? html`<div class="user-search-empty">No users found</div>`
-                                : this.userSearchResults.map(
-                                    (user) => html`
-                                      <div
-                                        class="user-search-option"
-                                        @mousedown=${(e: Event) => {
-                                          e.preventDefault();
-                                          this.selectUser(user);
-                                        }}
-                                      >
-                                        <span class="user-name"
-                                          >${user.displayName || user.email}</span
-                                        >
-                                        ${user.displayName
-                                          ? html`<span class="user-email">${user.email}</span>`
-                                          : nothing}
-                                      </div>
-                                    `
-                                  )}
-                          </div>
-                        `
-                      : nothing}
-                  </div>
+                  <scion-principal-picker
+                    principalType="user"
+                    label=${inputLabel}
+                    @principal-change=${this.handlePrincipalChange}
+                  ></scion-principal-picker>
                 `
               : html`
                   <sl-input

--- a/web/src/components/shared/index.ts
+++ b/web/src/components/shared/index.ts
@@ -57,3 +57,5 @@ export { ScionGitRemoteDisplay } from './git-remote-display.js';
 export { ScionHashDisplay } from './hash-display.js';
 export { ScionPreStartHookList } from './pre-start-hook-list.js';
 export { ScionQuickMessageDialog } from './quick-message-dialog.js';
+export { ScionPrincipalPicker } from './principal-picker.js';
+export type { PrincipalChangeDetail } from './principal-picker.js';

--- a/web/src/components/shared/principal-picker.ts
+++ b/web/src/components/shared/principal-picker.ts
@@ -62,8 +62,16 @@ export class ScionPrincipalPicker extends LitElement {
   @state() private searchLoading = false;
   @state() private searchOpen = false;
   private searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private blurTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private searchRequestId = 0;
   /** True after selectUser(); reset on new typed input. Prevents blur from overwriting a resolved selection. */
   private selectedViaDropdown = false;
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this.searchDebounceTimer) clearTimeout(this.searchDebounceTimer);
+    if (this.blurTimeoutId) clearTimeout(this.blurTimeoutId);
+  }
 
   static override styles = css`
     :host {
@@ -176,10 +184,12 @@ export class ScionPrincipalPicker extends LitElement {
   }
 
   private async searchUsers(query: string): Promise<void> {
+    const requestId = ++this.searchRequestId;
     this.searchLoading = true;
     this.searchOpen = true;
     try {
       const response = await apiFetch(`/api/v1/users?search=${encodeURIComponent(query)}&limit=10`);
+      if (requestId !== this.searchRequestId) return; // stale response, a newer request has superseded this one
       if (response.ok) {
         const data = (await response.json()) as {
           users?: Array<{ id: string; email: string; displayName: string }>;
@@ -187,10 +197,13 @@ export class ScionPrincipalPicker extends LitElement {
         this.searchResults = data.users || [];
       }
     } catch (err) {
+      if (requestId !== this.searchRequestId) return;
       console.error('Failed to search users:', err);
       this.searchResults = [];
     } finally {
-      this.searchLoading = false;
+      if (requestId === this.searchRequestId) {
+        this.searchLoading = false;
+      }
     }
   }
 
@@ -250,7 +263,7 @@ export class ScionPrincipalPicker extends LitElement {
           }}
           @sl-blur=${() => {
             // Delay to allow click on dropdown.
-            setTimeout(() => {
+            this.blurTimeoutId = setTimeout(() => {
               this.searchOpen = false;
               // Emit the raw typed value on blur if no dropdown selection was
               // made, so the parent has the latest value even when the

--- a/web/src/components/shared/principal-picker.ts
+++ b/web/src/components/shared/principal-picker.ts
@@ -1,0 +1,300 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Reusable Principal Picker Component
+ *
+ * Provides a user-search autocomplete for selecting principals (users or agents).
+ * Extracted from the inline user-search in group-member-editor.ts.
+ *
+ * - `user` type: renders a search-autocomplete calling GET /api/v1/users?search=...
+ * - `agent` type: renders a plain text input (no autocomplete API exists yet)
+ *
+ * Emits `principal-change` event with { principalType, principalId, displayLabel }
+ * when a principal is selected.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+import { apiFetch } from '../../client/api.js';
+
+/** Event detail emitted when a principal is selected. */
+export interface PrincipalChangeDetail {
+  principalType: string;
+  principalId: string;
+  displayLabel: string;
+}
+
+@customElement('scion-principal-picker')
+export class ScionPrincipalPicker extends LitElement {
+  /** Controls which input mode to show: 'user' (autocomplete) or 'agent' (plain text). */
+  @property() principalType: 'user' | 'agent' = 'user';
+
+  /** Current selected principal ID. */
+  @property() value = '';
+
+  /** Input label. */
+  @property() label = '';
+
+  /** Placeholder override. */
+  @property() placeholder = '';
+
+  /** Disabled state. */
+  @property({ type: Boolean }) disabled = false;
+
+  // User search autocomplete state
+  @state() private searchQuery = '';
+  @state() private searchResults: Array<{ id: string; email: string; displayName: string }> = [];
+  @state() private searchLoading = false;
+  @state() private searchOpen = false;
+  private searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  static override styles = css`
+    :host {
+      display: block;
+    }
+
+    .user-search-container {
+      position: relative;
+    }
+
+    .user-search-dropdown {
+      position: absolute;
+      top: 100%;
+      left: 0;
+      right: 0;
+      z-index: 1000;
+      background: var(--scion-surface, #ffffff);
+      border: 1px solid var(--scion-border, #e2e8f0);
+      border-radius: var(--scion-radius, 0.5rem);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      max-height: 200px;
+      overflow-y: auto;
+      margin-top: 0.25rem;
+    }
+
+    .user-search-option {
+      display: flex;
+      flex-direction: column;
+      padding: 0.5rem 0.75rem;
+      cursor: pointer;
+      border-bottom: 1px solid var(--scion-border, #e2e8f0);
+    }
+
+    .user-search-option:last-child {
+      border-bottom: none;
+    }
+
+    .user-search-option:hover,
+    .user-search-option.focused {
+      background: var(--scion-bg-subtle, #f1f5f9);
+    }
+
+    .user-search-option .user-name {
+      font-weight: 500;
+      font-size: 0.875rem;
+      color: var(--scion-text, #1e293b);
+    }
+
+    .user-search-option .user-email {
+      font-size: 0.75rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+
+    .user-search-empty,
+    .user-search-loading {
+      padding: 0.75rem;
+      text-align: center;
+      font-size: 0.8125rem;
+      color: var(--scion-text-muted, #64748b);
+    }
+  `;
+
+  override updated(changed: Map<string, unknown>): void {
+    // Reset search state when principal type changes.
+    if (changed.has('principalType')) {
+      this.searchQuery = '';
+      this.searchResults = [];
+      this.searchOpen = false;
+    }
+  }
+
+  private get resolvedLabel(): string {
+    if (this.label) return this.label;
+    return this.principalType === 'user' ? 'User' : 'Agent ID';
+  }
+
+  private get resolvedPlaceholder(): string {
+    if (this.placeholder) return this.placeholder;
+    return this.principalType === 'user' ? 'Search by name or email...' : 'Enter agent ID';
+  }
+
+  // ---------------------------------------------------------------------------
+  // User search logic
+  // ---------------------------------------------------------------------------
+
+  private handleSearchInput(e: Event): void {
+    const value = (e.target as HTMLInputElement).value;
+    this.searchQuery = value;
+
+    if (this.searchDebounceTimer) {
+      clearTimeout(this.searchDebounceTimer);
+    }
+
+    if (value.trim().length < 2) {
+      this.searchResults = [];
+      this.searchOpen = false;
+      // For partial input, emit as-is so form validation works.
+      this.emitChange(value.trim(), value.trim());
+      return;
+    }
+
+    this.searchDebounceTimer = setTimeout(() => {
+      void this.searchUsers(value.trim());
+    }, 250);
+  }
+
+  private async searchUsers(query: string): Promise<void> {
+    this.searchLoading = true;
+    this.searchOpen = true;
+    try {
+      const response = await apiFetch(`/api/v1/users?search=${encodeURIComponent(query)}&limit=10`);
+      if (response.ok) {
+        const data = (await response.json()) as {
+          users?: Array<{ id: string; email: string; displayName: string }>;
+        };
+        this.searchResults = data.users || [];
+      }
+    } catch (err) {
+      console.error('Failed to search users:', err);
+      this.searchResults = [];
+    } finally {
+      this.searchLoading = false;
+    }
+  }
+
+  private selectUser(user: { id: string; email: string; displayName: string }): void {
+    // Show display-friendly label in the input.
+    this.searchQuery = user.displayName ? `${user.displayName} (${user.email})` : user.email;
+    this.searchOpen = false;
+    this.searchResults = [];
+    // Emit the user's UUID as principalId (not email).
+    this.emitChange(user.id, user.displayName || user.email);
+  }
+
+  private handleAgentInput(e: Event): void {
+    const value = (e.target as HTMLInputElement).value;
+    this.emitChange(value.trim(), value.trim());
+  }
+
+  private emitChange(principalId: string, displayLabel: string): void {
+    this.dispatchEvent(
+      new CustomEvent<PrincipalChangeDetail>('principal-change', {
+        detail: {
+          principalType: this.principalType,
+          principalId,
+          displayLabel,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  override render() {
+    if (this.principalType === 'user') {
+      return this.renderUserSearch();
+    }
+    return this.renderAgentInput();
+  }
+
+  private renderUserSearch() {
+    return html`
+      <div class="user-search-container">
+        <sl-input
+          label=${this.resolvedLabel}
+          placeholder=${this.resolvedPlaceholder}
+          value=${this.searchQuery}
+          type="text"
+          autocomplete="off"
+          ?disabled=${this.disabled}
+          @sl-input=${this.handleSearchInput}
+          @sl-focus=${() => {
+            if (this.searchResults.length > 0) this.searchOpen = true;
+          }}
+          @sl-blur=${() => {
+            // Delay to allow click on dropdown.
+            setTimeout(() => {
+              this.searchOpen = false;
+            }, 200);
+          }}
+        ></sl-input>
+        ${this.searchOpen
+          ? html`
+              <div class="user-search-dropdown">
+                ${this.searchLoading
+                  ? html`<div class="user-search-loading">
+                      <sl-spinner></sl-spinner> Searching...
+                    </div>`
+                  : this.searchResults.length === 0
+                    ? html`<div class="user-search-empty">No users found</div>`
+                    : this.searchResults.map(
+                        (user) => html`
+                          <div
+                            class="user-search-option"
+                            @mousedown=${(e: Event) => {
+                              e.preventDefault();
+                              this.selectUser(user);
+                            }}
+                          >
+                            <span class="user-name">${user.displayName || user.email}</span>
+                            ${user.displayName
+                              ? html`<span class="user-email">${user.email}</span>`
+                              : nothing}
+                          </div>
+                        `
+                      )}
+              </div>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderAgentInput() {
+    return html`
+      <sl-input
+        label=${this.resolvedLabel}
+        placeholder=${this.resolvedPlaceholder}
+        value=${this.value}
+        type="text"
+        ?disabled=${this.disabled}
+        @sl-input=${this.handleAgentInput}
+      ></sl-input>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'scion-principal-picker': ScionPrincipalPicker;
+  }
+}

--- a/web/src/components/shared/principal-picker.ts
+++ b/web/src/components/shared/principal-picker.ts
@@ -62,6 +62,8 @@ export class ScionPrincipalPicker extends LitElement {
   @state() private searchLoading = false;
   @state() private searchOpen = false;
   private searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  /** True after selectUser(); reset on new typed input. Prevents blur from overwriting a resolved selection. */
+  private selectedViaDropdown = false;
 
   static override styles = css`
     :host {
@@ -150,6 +152,7 @@ export class ScionPrincipalPicker extends LitElement {
   private handleSearchInput(e: Event): void {
     const value = (e.target as HTMLInputElement).value;
     this.searchQuery = value;
+    this.selectedViaDropdown = false;
 
     if (this.searchDebounceTimer) {
       clearTimeout(this.searchDebounceTimer);
@@ -165,6 +168,10 @@ export class ScionPrincipalPicker extends LitElement {
 
     this.searchDebounceTimer = setTimeout(() => {
       void this.searchUsers(value.trim());
+      // Also emit the raw typed value so the parent's bound value is never stale.
+      // If the user later clicks a dropdown result, selectUser() will overwrite
+      // this with the resolved UUID.
+      this.emitChange(value.trim(), '');
     }, 250);
   }
 
@@ -192,6 +199,7 @@ export class ScionPrincipalPicker extends LitElement {
     this.searchQuery = user.displayName ? `${user.displayName} (${user.email})` : user.email;
     this.searchOpen = false;
     this.searchResults = [];
+    this.selectedViaDropdown = true;
     // Emit the user's UUID as principalId (not email).
     this.emitChange(user.id, user.displayName || user.email);
   }
@@ -244,6 +252,13 @@ export class ScionPrincipalPicker extends LitElement {
             // Delay to allow click on dropdown.
             setTimeout(() => {
               this.searchOpen = false;
+              // Emit the raw typed value on blur if no dropdown selection was
+              // made, so the parent has the latest value even when the
+              // debounce timer hasn't fired yet (e.g. user typed and
+              // immediately tabbed away or clicked submit).
+              if (!this.selectedViaDropdown && this.searchQuery.trim()) {
+                this.emitChange(this.searchQuery.trim(), '');
+              }
             }, 200);
           }}
         ></sl-input>


### PR DESCRIPTION
## Summary
- Role-binding list/delete-dialog now show human-readable names instead of raw UUIDs, via server-side enrichment
- createRoleBinding now resolves email-format principalId to UUID, mirroring the existing addGroupMember pattern
- Extracted a new reusable scion-principal-picker component, wired into role-binding create dialog
- group-member-editor.ts refactored to consume the new component

## Review
Code-reviewed, findings addressed. No security concerns — admin-only, no cross-project leakage, resolution not bypassable