### PR TITLE
fix(web): admin nav visibility for plain members + hub-admin route guard

### DIFF
--- a/pkg/hub/authz.go
+++ b/pkg/hub/authz.go
@@ -1134,6 +1134,34 @@ func (a *AuthzService) IsSystemAdmin(ctx context.Context, userID string) bool {
 	return false
 }
 
+// IsHubAdmin checks whether the given user has a system-scoped hub-admin
+// role binding. A user with the super-admin role binding is NOT implicitly
+// a hub-admin by this check — the caller must combine the results of
+// IsHubAdmin and IsSystemAdmin (or IsUnscopedLocalPlatformAdmin) to get
+// the full picture.
+func (a *AuthzService) IsHubAdmin(ctx context.Context, userID string) bool {
+	if userID == "" {
+		return false
+	}
+	bindings, err := a.store.ListRoleBindingsForPrincipal(ctx, store.RoleBindingPrincipalUser, userID)
+	if err != nil {
+		return false
+	}
+	for _, b := range bindings {
+		if b.ScopeType != store.RoleScopeSystem {
+			continue
+		}
+		rd, err := a.store.GetRoleDefinition(ctx, b.RoleDefinitionID)
+		if err != nil {
+			continue
+		}
+		if rd.Name == store.SystemRoleHubAdmin {
+			return true
+		}
+	}
+	return false
+}
+
 // hubMembersSlug is the slug of the seeded hub-members group. It is the same
 // value seed.go uses when creating the group; kept as a constant so tests and
 // production code agree on the lookup key.

--- a/pkg/hub/authz_test.go
+++ b/pkg/hub/authz_test.go
@@ -18,6 +18,7 @@ package hub
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
@@ -701,4 +702,87 @@ func TestAuthz_AncestryAccess_NotInChain(t *testing.T) {
 
 	decision := authz.CheckAccess(ctx, user, resource, ActionRead)
 	assert.False(t, decision.Allowed)
+}
+
+// =============================================================================
+// IsHubAdmin Tests
+// =============================================================================
+
+func TestIsHubAdmin_SystemScopedHubAdminBinding(t *testing.T) {
+	authz, s := authzTestSetup(t)
+	ctx := context.Background()
+
+	userID := tid("hub-admin-user")
+	createTestUserWithRole(t, s, userID, "hubadmin@test.com", "member", store.SystemRoleHubAdmin)
+
+	result := authz.IsHubAdmin(ctx, userID)
+	assert.True(t, result, "should return true for user with system-scoped hub-admin binding")
+}
+
+func TestIsHubAdmin_ProjectScopedBindingReturnsFalse(t *testing.T) {
+	authz, s := authzTestSetup(t)
+	ctx := context.Background()
+
+	userID := tid("hub-admin-proj-scope")
+	require.NoError(t, s.CreateUser(ctx, &store.User{
+		ID: userID, Email: "projscope@test.com", DisplayName: "ProjScope", Role: "member", Status: "active",
+	}))
+
+	// Create a project-scoped role binding using the hub-admin role definition.
+	// IsHubAdmin must reject non-system-scoped bindings.
+	rd, err := s.GetRoleDefinitionByName(ctx, store.SystemRoleHubAdmin, store.RoleScopeSystem)
+	require.NoError(t, err, "hub-admin role definition must exist")
+
+	_, err = s.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: rd.ID,
+		PrincipalType:    store.RoleBindingPrincipalUser,
+		PrincipalID:      userID,
+		ScopeType:        store.RoleScopeProject,
+		ScopeID:          tid("some-project"),
+		CreatedBy:        "test",
+	})
+	require.NoError(t, err)
+
+	result := authz.IsHubAdmin(ctx, userID)
+	assert.False(t, result, "should return false for project-scoped hub-admin binding (must be system-scoped)")
+}
+
+func TestIsHubAdmin_SuperAdminOnlyReturnsFalse(t *testing.T) {
+	authz, s := authzTestSetup(t)
+	ctx := context.Background()
+
+	userID := tid("super-admin-only")
+	createTestUserWithRole(t, s, userID, "superonly@test.com", "admin", store.SystemRoleSuperAdmin)
+
+	result := authz.IsHubAdmin(ctx, userID)
+	assert.False(t, result, "should return false for user with super-admin only (IsHubAdmin and IsSystemAdmin are independent)")
+}
+
+func TestIsHubAdmin_EmptyUserID(t *testing.T) {
+	authz, _ := authzTestSetup(t)
+	ctx := context.Background()
+
+	result := authz.IsHubAdmin(ctx, "")
+	assert.False(t, result, "should return false for empty userID")
+}
+
+func TestIsHubAdmin_StoreErrorReturnsFalse(t *testing.T) {
+	// IsHubAdmin calls ListRoleBindingsForPrincipal; if the store returns
+	// an error, IsHubAdmin must fail closed (return false).
+	authz := NewAuthzService(&failingRoleBindingStore{}, slog.Default())
+	ctx := context.Background()
+
+	result := authz.IsHubAdmin(ctx, "any-user-id")
+	assert.False(t, result, "should return false when store returns an error (fail closed)")
+}
+
+// failingRoleBindingStore is a minimal store.Store stub that makes
+// ListRoleBindingsForPrincipal return an error. Only the methods called by
+// IsHubAdmin need to be implemented; the rest panic if called.
+type failingRoleBindingStore struct {
+	store.Store
+}
+
+func (f *failingRoleBindingStore) ListRoleBindingsForPrincipal(_ context.Context, _, _ string) ([]*store.RoleBinding, error) {
+	return nil, errors.New("store unavailable")
 }

--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -619,6 +619,7 @@ type AdminStatusResponse struct {
 // and allow access to admin routes.
 func (s *Server) handleAuthAdminStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
 		MethodNotAllowed(w)
 		return
 	}

--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -607,6 +607,40 @@ func (s *Server) handleAuthMe(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// AdminStatusResponse is the response for GET /api/v1/auth/admin-status.
+type AdminStatusResponse struct {
+	IsAdmin      bool `json:"isAdmin"`
+	IsSuperAdmin bool `json:"isSuperAdmin"`
+}
+
+// handleAuthAdminStatus handles GET /api/v1/auth/admin-status.
+// Returns whether the current user has hub-admin or super-admin capabilities.
+// This is used by the frontend to decide whether to show admin navigation
+// and allow access to admin routes.
+func (s *Server) handleAuthAdminStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	user := GetUserIdentityFromContext(r.Context())
+	if user == nil {
+		Unauthorized(w)
+		return
+	}
+
+	isSuperAdmin := IsUnscopedLocalPlatformAdmin(user)
+	isHubAdmin := false
+	if s.authzService != nil {
+		isHubAdmin = s.authzService.IsHubAdmin(r.Context(), user.ID())
+	}
+
+	writeJSON(w, http.StatusOK, AdminStatusResponse{
+		IsAdmin:      isSuperAdmin || isHubAdmin,
+		IsSuperAdmin: isSuperAdmin,
+	})
+}
+
 // handleTokens routes user access token requests.
 func (s *Server) handleTokens(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {

--- a/pkg/hub/handlers_auth_test.go
+++ b/pkg/hub/handlers_auth_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/stretchr/testify/require"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -1205,5 +1206,128 @@ func TestD11Fix2_LoginDemotionDeletesBinding(t *testing.T) {
 	// Key assertion: IsSystemAdmin must be false AFTER login.
 	if srv.authzService.IsSystemAdmin(ctx, userID) {
 		t.Fatal("IsSystemAdmin must return false after login-time demotion (binding should be deleted)")
+	}
+}
+
+// =============================================================================
+// handleAuthAdminStatus Tests
+// =============================================================================
+
+func TestHandleAuthAdminStatus_Unauthenticated(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequestNoAuth(t, srv, http.MethodGet, "/api/v1/auth/admin-status", nil)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("expected status 401 for unauthenticated request, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleAuthAdminStatus_SuperAdmin(t *testing.T) {
+	srv, _ := testServer(t)
+
+	// The dev user is created with Role="admin", so IsUnscopedLocalPlatformAdmin
+	// returns true. Use the dev auth token to authenticate as a super-admin.
+	rec := doRequest(t, srv, http.MethodGet, "/api/v1/auth/admin-status", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp AdminStatusResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if !resp.IsAdmin {
+		t.Error("expected isAdmin=true for super-admin")
+	}
+	if !resp.IsSuperAdmin {
+		t.Error("expected isSuperAdmin=true for super-admin")
+	}
+}
+
+func TestHandleAuthAdminStatus_HubAdmin(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// Create a non-super-admin user with a hub-admin role binding.
+	userID := tid("hub-admin-handler")
+	require.NoError(t, s.CreateUser(ctx, &store.User{
+		ID: userID, Email: "hubadmin-handler@test.com", DisplayName: "HubAdmin", Role: "member", Status: "active",
+	}))
+
+	rd, err := s.GetRoleDefinitionByName(ctx, store.SystemRoleHubAdmin, store.RoleScopeSystem)
+	require.NoError(t, err, "hub-admin role definition must exist")
+	_, err = s.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: rd.ID,
+		PrincipalType:    store.RoleBindingPrincipalUser,
+		PrincipalID:      userID,
+		ScopeType:        store.RoleScopeSystem,
+		ScopeID:          "",
+		CreatedBy:        "test",
+	})
+	require.NoError(t, err)
+
+	token, _, _, err := srv.userTokenService.GenerateTokenPair(
+		userID, "hubadmin-handler@test.com", "HubAdmin", "member", ClientTypeWeb,
+	)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/admin-status", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp AdminStatusResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	if !resp.IsAdmin {
+		t.Error("expected isAdmin=true for hub-admin user")
+	}
+	if resp.IsSuperAdmin {
+		t.Error("expected isSuperAdmin=false for hub-admin (non-super-admin) user")
+	}
+}
+
+func TestHandleAuthAdminStatus_PlainMember(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	userID := tid("plain-member-handler")
+	require.NoError(t, s.CreateUser(ctx, &store.User{
+		ID: userID, Email: "member-handler@test.com", DisplayName: "Member", Role: "member", Status: "active",
+	}))
+
+	token, _, _, err := srv.userTokenService.GenerateTokenPair(
+		userID, "member-handler@test.com", "Member", "member", ClientTypeWeb,
+	)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/admin-status", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp AdminStatusResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	if resp.IsAdmin {
+		t.Error("expected isAdmin=false for plain member")
+	}
+	if resp.IsSuperAdmin {
+		t.Error("expected isSuperAdmin=false for plain member")
+	}
+}
+
+func TestHandleAuthAdminStatus_WrongMethod(t *testing.T) {
+	srv, _ := testServer(t)
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/auth/admin-status", nil)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status 405 for POST, got %d: %s", rec.Code, rec.Body.String())
 	}
 }

--- a/pkg/hub/route_classification_test.go
+++ b/pkg/hub/route_classification_test.go
@@ -37,6 +37,7 @@ var routePermissionClassifications = map[string]string{
 	"/api/v1/auth/token":                        "public:auth",
 	"/api/v1/auth/refresh":                      "public:auth",
 	"/api/v1/auth/validate":                     "public:auth",
+	"/api/v1/auth/admin-status":                  "authenticated:user",
 	"/api/v1/auth/logout":                       "authenticated:user",
 	"/api/v1/auth/me":                           "authenticated:user",
 	"/api/v1/auth/tokens":                       "authenticated:user-token",

--- a/pkg/hub/route_classification_test.go
+++ b/pkg/hub/route_classification_test.go
@@ -37,7 +37,7 @@ var routePermissionClassifications = map[string]string{
 	"/api/v1/auth/token":                        "public:auth",
 	"/api/v1/auth/refresh":                      "public:auth",
 	"/api/v1/auth/validate":                     "public:auth",
-	"/api/v1/auth/admin-status":                  "authenticated:user",
+	"/api/v1/auth/admin-status":                 "authenticated:user",
 	"/api/v1/auth/logout":                       "authenticated:user",
 	"/api/v1/auth/me":                           "authenticated:user",
 	"/api/v1/auth/tokens":                       "authenticated:user-token",

--- a/pkg/hub/route_metadata.go
+++ b/pkg/hub/route_metadata.go
@@ -150,6 +150,10 @@ var routeMetadataTable = map[string]RouteMetadata{
 		Pattern: "/api/v1/auth/me", RouteID: "auth.me",
 		Classification: RouteAuthenticated,
 	},
+	"/api/v1/auth/admin-status": {
+		Pattern: "/api/v1/auth/admin-status", RouteID: "auth.admin-status",
+		Classification: RouteAuthenticated,
+	},
 	"/api/v1/auth/tokens": {
 		Pattern: "/api/v1/auth/tokens", RouteID: "auth.tokens.list",
 		Classification: RouteAuthenticated,

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3706,6 +3706,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/auth/validate", s.guarded("/api/v1/auth/validate", s.handleAuthValidate))
 	s.mux.HandleFunc("/api/v1/auth/logout", s.guarded("/api/v1/auth/logout", s.handleAuthLogout))
 	s.mux.HandleFunc("/api/v1/auth/me", s.guarded("/api/v1/auth/me", s.handleAuthMe))
+	s.mux.HandleFunc("/api/v1/auth/admin-status", s.guarded("/api/v1/auth/admin-status", s.handleAuthAdminStatus))
 	s.mux.HandleFunc("/api/v1/auth/tokens", s.guarded("/api/v1/auth/tokens", s.handleTokens))
 	s.mux.HandleFunc("/api/v1/auth/tokens/", s.guarded("/api/v1/auth/tokens/", s.handleTokenByID))
 	s.mux.HandleFunc("/api/v1/auth/scopes", s.guarded("/api/v1/auth/scopes", s.handleAuthScopes))

--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -801,9 +801,18 @@ async function renderRoute(path: string): Promise<void> {
   // Block non-admin users from admin-only routes.
   // Hub-admin users (who have admin role bindings but not super-admin role)
   // are allowed through, alongside super-admins.
-  if (ADMIN_ROUTES.has(tag) && !(cachedAdminStatus?.isAdmin)) {
-    navigateTo('/');
-    return;
+  //
+  // Re-fetch admin status on every admin-route navigation so that role
+  // grants or revocations made mid-session take effect immediately rather
+  // than being cached for the entire SPA lifetime. The init-time fetch
+  // remains for nav.ts's initial render; this call replaces the cache so
+  // the route guard always uses a fresh result.
+  if (ADMIN_ROUTES.has(tag)) {
+    cachedAdminStatus = await fetchAdminStatus();
+    if (!(cachedAdminStatus?.isAdmin)) {
+      navigateTo('/');
+      return;
+    }
   }
 
   // Block /chat routes when the native_chat feature flag is disabled (O2).

--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -126,6 +126,28 @@ let currentUser: User | null = null;
 let ssrPageData: PageData | null = null;
 
 /**
+ * Cached admin-status flags, fetched once on init from
+ * GET /api/v1/auth/admin-status. Used by the route guard to allow
+ * hub-admin users (not just super-admins) to access admin pages.
+ */
+let cachedAdminStatus: { isAdmin: boolean; isSuperAdmin: boolean } | null = null;
+
+/**
+ * Fetch the current user's admin status from the backend.
+ * Returns null when the user is not authenticated or the fetch fails.
+ */
+async function fetchAdminStatus(): Promise<{ isAdmin: boolean; isSuperAdmin: boolean } | null> {
+  try {
+    const res = await fetch('/api/v1/auth/admin-status', { credentials: 'include' });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return { isAdmin: data.isAdmin === true, isSuperAdmin: data.isSuperAdmin === true };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Fetch the current authenticated user from the backend session.
  * Returns null if not authenticated.
  */
@@ -620,6 +642,12 @@ async function init(): Promise<void> {
     currentUser = await fetchCurrentUser();
   }
 
+  // Fetch admin status early so the route guard can use the cached result
+  // instead of blocking on a network call during navigation.
+  if (currentUser) {
+    cachedAdminStatus = await fetchAdminStatus();
+  }
+
   // Chat notifications are published on user.<id>.notification, so the state
   // manager must know who we are before it opens the first SSE connection.
   if (currentUser?.id) {
@@ -770,8 +798,10 @@ async function renderRoute(path: string): Promise<void> {
     ssrPageData = null;
   }
 
-  // Block non-admin users from admin-only routes
-  if (ADMIN_ROUTES.has(tag) && currentUser?.role !== 'admin') {
+  // Block non-admin users from admin-only routes.
+  // Hub-admin users (who have admin role bindings but not super-admin role)
+  // are allowed through, alongside super-admins.
+  if (ADMIN_ROUTES.has(tag) && !(cachedAdminStatus?.isAdmin)) {
     navigateTo('/');
     return;
   }

--- a/web/src/components/shared/nav.ts
+++ b/web/src/components/shared/nav.ts
@@ -129,13 +129,14 @@ export class ScionNav extends LitElement {
   }
 
   /**
-   * Detect whether the current user has admin capabilities by probing
-   * the admin roles endpoint. A 200 response indicates admin access
-   * (the route guard passes); any other status means no admin access.
+   * Detect whether the current user has admin capabilities by calling
+   * the dedicated admin-status endpoint, which returns explicit boolean
+   * flags for hub-admin and super-admin status.
    *
    * Super-admin users are detected directly via `user.role === 'admin'`
-   * and skip this probe. For hub-admin users (who have admin role bindings
-   * but not the super-admin role), the probe determines nav visibility.
+   * and skip the API call. For hub-admin users (who have admin role
+   * bindings but not the super-admin role), the endpoint determines
+   * nav visibility.
    */
   private async checkAdminCapabilities(): Promise<void> {
     const userId = this.user?.id ?? null;
@@ -156,13 +157,17 @@ export class ScionNav extends LitElement {
       return;
     }
 
-    // Probe an admin-guarded endpoint to detect hub-admin status.
-    // The backend enforces authorization — a 200 means the user is permitted.
+    // Call the dedicated admin-status endpoint to detect hub-admin status.
     try {
-      const res = await apiFetch('/api/v1/admin/roles');
+      const res = await apiFetch('/api/v1/auth/admin-status');
       // Only apply result if user hasn't changed during the fetch
       if (this.adminCheckUserId === userId) {
-        this.hasAdminCapabilities = res.ok;
+        if (res.ok) {
+          const data = await res.json();
+          this.hasAdminCapabilities = data.isAdmin === true;
+        } else {
+          this.hasAdminCapabilities = false;
+        }
       }
     } catch {
       if (this.adminCheckUserId === userId) {


### PR DESCRIPTION
## Summary
- Plain members saw the inoperable Admin sidenav section (probe returns 200 for all members)
- Hub-admins were separately blocked from admin routes by a super-admin-only guard
- New GET /api/v1/auth/admin-status endpoint + IsHubAdmin(), used by both nav and route guard

## Review
10 tests added, fail-closed on all error paths, stale-cache window closed (route guard now re-fetches per admin-route nav)