### PR TITLE
fix(hooks): add data-driven hook response contract for antigravity

### DIFF
--- a/cmd/sciontool/commands/hook.go
+++ b/cmd/sciontool/commands/hook.go
@@ -250,16 +250,7 @@ func processHookData(data []byte) error {
 	// Dialects that don't declare a responses section (e.g. claude) produce
 	// no output, preserving backward compatibility.
 	if mappingDialect != nil {
-		rawEventName := ""
-		for _, field := range mappingDialect.EventNameFields() {
-			if v, ok := rawData[field]; ok {
-				if s, ok := v.(string); ok && s != "" {
-					rawEventName = s
-					break
-				}
-			}
-		}
-		if rawEventName != "" {
+		if rawEventName := mappingDialect.EventName(rawData); rawEventName != "" {
 			if resp := mappingDialect.Response(rawEventName); resp != nil {
 				if err := json.NewEncoder(os.Stdout).Encode(resp); err != nil {
 					return fmt.Errorf("writing hook response: %w", err)

--- a/cmd/sciontool/commands/hook.go
+++ b/cmd/sciontool/commands/hook.go
@@ -175,8 +175,10 @@ func processHookData(data []byte) error {
 	// Register built-in dialects first, then let a harness-bundled dialect.yaml
 	// override the requested dialect by name if one is present.
 	dialects.RegisterBuiltins(processor)
+	var mappingDialect *dialects.MappingDialect
 	if md, err := dialects.DiscoverMappingDialect(hookDialect); err == nil {
 		processor.RegisterDialect(md)
+		mappingDialect = md
 	}
 
 	// Register handlers
@@ -240,7 +242,31 @@ func processHookData(data []byte) error {
 		processor.AddHandler(telemetryHandler.Handle)
 	}
 
-	return processor.ProcessRaw(rawData, hookDialect)
+	if err := processor.ProcessRaw(rawData, hookDialect); err != nil {
+		return err
+	}
+
+	// Emit the response JSON that the harness expects on stdout.
+	// Dialects that don't declare a responses section (e.g. claude) produce
+	// no output, preserving backward compatibility.
+	if mappingDialect != nil {
+		rawEventName := ""
+		for _, field := range mappingDialect.EventNameFields() {
+			if v, ok := rawData[field]; ok {
+				if s, ok := v.(string); ok && s != "" {
+					rawEventName = s
+					break
+				}
+			}
+		}
+		if rawEventName != "" {
+			if resp := mappingDialect.Response(rawEventName); resp != nil {
+				json.NewEncoder(os.Stdout).Encode(resp)
+			}
+		}
+	}
+
+	return nil
 }
 
 // runAskUser updates status to waiting for input.

--- a/cmd/sciontool/commands/hook.go
+++ b/cmd/sciontool/commands/hook.go
@@ -261,7 +261,9 @@ func processHookData(data []byte) error {
 		}
 		if rawEventName != "" {
 			if resp := mappingDialect.Response(rawEventName); resp != nil {
-				json.NewEncoder(os.Stdout).Encode(resp)
+				if err := json.NewEncoder(os.Stdout).Encode(resp); err != nil {
+					return fmt.Errorf("writing hook response: %w", err)
+				}
 			}
 		}
 	}

--- a/harnesses/antigravity/dialect.yaml
+++ b/harnesses/antigravity/dialect.yaml
@@ -14,14 +14,24 @@ mappings:
     fields:
       tool_name: .toolCall.name
       tool_input: .toolCall.args
+      session_id: .conversationId
   PostToolUse:
     event: tool-end
     fields:
       # AGY PostToolUse payload only includes stepIdx and error.
       # toolCall is NOT present — do not map tool_name here.
       error: .error
+      session_id: .conversationId
   Stop:
     event: agent-end
     fields:
       reason: .terminationReason
       error: .error
+      session_id: .conversationId
+responses:
+  PreToolUse:
+    decision: allow
+  PostToolUse: {}
+  PreInvocation: {}
+  PostInvocation: {}
+  Stop: {}

--- a/pkg/sciontool/hooks/dialects/mapping.go
+++ b/pkg/sciontool/hooks/dialects/mapping.go
@@ -19,10 +19,11 @@ import (
 // It maps harness-specific event names to normalized Scion event names and
 // optionally extracts fields from the event payload using dotted paths.
 type MappingDialectSpec struct {
-	Dialect         string                      `yaml:"dialect"`
-	EventNameField  string                      `yaml:"event_name_field"`
-	EventNameFields []string                    `yaml:"event_name_fields"`
-	Mappings        map[string]MappingEntrySpec `yaml:"mappings"`
+	Dialect         string                                `yaml:"dialect"`
+	EventNameField  string                                `yaml:"event_name_field"`
+	EventNameFields []string                              `yaml:"event_name_fields"`
+	Mappings        map[string]MappingEntrySpec            `yaml:"mappings"`
+	Responses       map[string]map[string]interface{}      `yaml:"responses,omitempty"`
 }
 
 // MappingEntrySpec defines how a single harness event maps to a normalized event.
@@ -44,6 +45,22 @@ func NewMappingDialect(spec MappingDialectSpec) *MappingDialect {
 // Name returns the dialect name as declared in the spec.
 func (d *MappingDialect) Name() string {
 	return d.spec.Dialect
+}
+
+// Response returns the response object declared for the given raw event name,
+// or nil if no response is declared for that event.
+func (d *MappingDialect) Response(rawEventName string) map[string]interface{} {
+	if d.spec.Responses == nil {
+		return nil
+	}
+	return d.spec.Responses[rawEventName]
+}
+
+// EventNameFields returns the ordered list of field names used to discover the
+// raw event name in incoming data. Callers that need to extract the event name
+// outside of Parse (e.g. for response lookup) can use this accessor.
+func (d *MappingDialect) EventNameFields() []string {
+	return d.eventNameFields()
 }
 
 // Parse converts a harness event payload into a normalized Event using the

--- a/pkg/sciontool/hooks/dialects/mapping.go
+++ b/pkg/sciontool/hooks/dialects/mapping.go
@@ -56,11 +56,9 @@ func (d *MappingDialect) Response(rawEventName string) map[string]interface{} {
 	return d.spec.Responses[rawEventName]
 }
 
-// EventNameFields returns the ordered list of field names used to discover the
-// raw event name in incoming data. Callers that need to extract the event name
-// outside of Parse (e.g. for response lookup) can use this accessor.
-func (d *MappingDialect) EventNameFields() []string {
-	return d.eventNameFields()
+// EventName extracts the raw event name from the incoming data map.
+func (d *MappingDialect) EventName(data map[string]interface{}) string {
+	return d.eventName(data)
 }
 
 // Parse converts a harness event payload into a normalized Event using the

--- a/pkg/sciontool/hooks/dialects/mapping.go
+++ b/pkg/sciontool/hooks/dialects/mapping.go
@@ -19,11 +19,11 @@ import (
 // It maps harness-specific event names to normalized Scion event names and
 // optionally extracts fields from the event payload using dotted paths.
 type MappingDialectSpec struct {
-	Dialect         string                                `yaml:"dialect"`
-	EventNameField  string                                `yaml:"event_name_field"`
-	EventNameFields []string                              `yaml:"event_name_fields"`
-	Mappings        map[string]MappingEntrySpec            `yaml:"mappings"`
-	Responses       map[string]map[string]interface{}      `yaml:"responses,omitempty"`
+	Dialect         string                            `yaml:"dialect"`
+	EventNameField  string                            `yaml:"event_name_field"`
+	EventNameFields []string                          `yaml:"event_name_fields"`
+	Mappings        map[string]MappingEntrySpec       `yaml:"mappings"`
+	Responses       map[string]map[string]interface{} `yaml:"responses,omitempty"`
 }
 
 // MappingEntrySpec defines how a single harness event maps to a normalized event.

--- a/pkg/sciontool/hooks/dialects/mapping_test.go
+++ b/pkg/sciontool/hooks/dialects/mapping_test.go
@@ -485,6 +485,141 @@ mappings: {}
 	})
 }
 
+func TestMappingDialect_Response(t *testing.T) {
+	t.Run("returns correct response for each event", func(t *testing.T) {
+		spec := MappingDialectSpec{
+			Dialect:        "test-harness",
+			EventNameField: "hook_event_name",
+			Mappings: map[string]MappingEntrySpec{
+				"PreToolUse":     {Event: hooks.EventToolStart},
+				"PostToolUse":    {Event: hooks.EventToolEnd},
+				"PreInvocation":  {Event: hooks.EventModelStart},
+				"PostInvocation": {Event: hooks.EventModelEnd},
+				"Stop":           {Event: hooks.EventAgentEnd},
+			},
+			Responses: map[string]map[string]interface{}{
+				"PreToolUse":     {"decision": "allow"},
+				"PostToolUse":    {},
+				"PreInvocation":  {},
+				"PostInvocation": {},
+				"Stop":           {},
+			},
+		}
+		md := NewMappingDialect(spec)
+
+		resp := md.Response("PreToolUse")
+		require.NotNil(t, resp)
+		assert.Equal(t, "allow", resp["decision"])
+
+		resp = md.Response("PostToolUse")
+		require.NotNil(t, resp)
+		assert.Empty(t, resp)
+
+		resp = md.Response("PreInvocation")
+		require.NotNil(t, resp)
+		assert.Empty(t, resp)
+
+		resp = md.Response("PostInvocation")
+		require.NotNil(t, resp)
+		assert.Empty(t, resp)
+
+		resp = md.Response("Stop")
+		require.NotNil(t, resp)
+		assert.Empty(t, resp)
+	})
+
+	t.Run("returns nil for events without declared responses", func(t *testing.T) {
+		spec := MappingDialectSpec{
+			Dialect:        "test-harness",
+			EventNameField: "hook_event_name",
+			Mappings: map[string]MappingEntrySpec{
+				"PreToolUse": {Event: hooks.EventToolStart},
+				"Stop":       {Event: hooks.EventAgentEnd},
+			},
+			Responses: map[string]map[string]interface{}{
+				"PreToolUse": {"decision": "allow"},
+			},
+		}
+		md := NewMappingDialect(spec)
+
+		assert.NotNil(t, md.Response("PreToolUse"))
+		assert.Nil(t, md.Response("Stop"))
+		assert.Nil(t, md.Response("UnknownEvent"))
+	})
+
+	t.Run("returns nil when no responses section exists", func(t *testing.T) {
+		spec := MappingDialectSpec{
+			Dialect:        "test-harness",
+			EventNameField: "hook_event_name",
+			Mappings: map[string]MappingEntrySpec{
+				"PreToolUse": {Event: hooks.EventToolStart},
+			},
+		}
+		md := NewMappingDialect(spec)
+
+		assert.Nil(t, md.Response("PreToolUse"))
+		assert.Nil(t, md.Response("anything"))
+	})
+}
+
+func TestMappingDialect_EventNameFields(t *testing.T) {
+	t.Run("returns event_name_fields when set", func(t *testing.T) {
+		md := NewMappingDialect(MappingDialectSpec{
+			Dialect:         "test",
+			EventNameFields: []string{"type", "event"},
+		})
+		assert.Equal(t, []string{"type", "event"}, md.EventNameFields())
+	})
+
+	t.Run("returns single event_name_field as slice", func(t *testing.T) {
+		md := NewMappingDialect(MappingDialectSpec{
+			Dialect:        "test",
+			EventNameField: "hook_event_name",
+		})
+		assert.Equal(t, []string{"hook_event_name"}, md.EventNameFields())
+	})
+
+	t.Run("returns nil when neither is set", func(t *testing.T) {
+		md := NewMappingDialect(MappingDialectSpec{
+			Dialect: "test",
+		})
+		assert.Nil(t, md.EventNameFields())
+	})
+}
+
+func TestLoadMappingDialect_WithResponses(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "dialect.yaml")
+	err := os.WriteFile(specPath, []byte(`
+dialect: test-harness
+event_name_field: hook_event_name
+mappings:
+  PreToolUse:
+    event: tool-start
+  PostToolUse:
+    event: tool-end
+responses:
+  PreToolUse:
+    decision: allow
+  PostToolUse: {}
+`), 0644)
+	require.NoError(t, err)
+
+	md, err := LoadMappingDialect(specPath)
+	require.NoError(t, err)
+	assert.Equal(t, "test-harness", md.Name())
+
+	resp := md.Response("PreToolUse")
+	require.NotNil(t, resp)
+	assert.Equal(t, "allow", resp["decision"])
+
+	resp = md.Response("PostToolUse")
+	require.NotNil(t, resp)
+	assert.Empty(t, resp)
+
+	assert.Nil(t, md.Response("UnknownEvent"))
+}
+
 func TestMappingDialect_FullHarnessEvents(t *testing.T) {
 	spec := MappingDialectSpec{
 		Dialect:        "example-harness",

--- a/pkg/sciontool/hooks/dialects/mapping_test.go
+++ b/pkg/sciontool/hooks/dialects/mapping_test.go
@@ -562,28 +562,28 @@ func TestMappingDialect_Response(t *testing.T) {
 	})
 }
 
-func TestMappingDialect_EventNameFields(t *testing.T) {
-	t.Run("returns event_name_fields when set", func(t *testing.T) {
+func TestMappingDialect_EventName(t *testing.T) {
+	t.Run("returns event name when event_name_fields is set", func(t *testing.T) {
 		md := NewMappingDialect(MappingDialectSpec{
 			Dialect:         "test",
 			EventNameFields: []string{"type", "event"},
 		})
-		assert.Equal(t, []string{"type", "event"}, md.EventNameFields())
+		assert.Equal(t, "my-event", md.EventName(map[string]interface{}{"event": "my-event"}))
 	})
 
-	t.Run("returns single event_name_field as slice", func(t *testing.T) {
+	t.Run("returns event name when single event_name_field is set", func(t *testing.T) {
 		md := NewMappingDialect(MappingDialectSpec{
 			Dialect:        "test",
 			EventNameField: "hook_event_name",
 		})
-		assert.Equal(t, []string{"hook_event_name"}, md.EventNameFields())
+		assert.Equal(t, "my-event", md.EventName(map[string]interface{}{"hook_event_name": "my-event"}))
 	})
 
-	t.Run("returns nil when neither is set", func(t *testing.T) {
+	t.Run("returns empty string when neither is set", func(t *testing.T) {
 		md := NewMappingDialect(MappingDialectSpec{
 			Dialect: "test",
 		})
-		assert.Nil(t, md.EventNameFields())
+		assert.Empty(t, md.EventName(map[string]interface{}{"event": "my-event"}))
 	})
 }
 


### PR DESCRIPTION
## Summary

sciontool hook writes nothing to stdout, but AGY hooks are bidirectional - PreToolUse requires {"decision": "allow"} on stdout. This adds a data-driven responses section to the MappingDialect system so each harness can declare its response contract in dialect.yaml.

Changes:
- Add responses section to MappingDialectSpec with Response() method
- processHookData emits dialect-declared response JSON to stdout after handlers run
- Update antigravity dialect.yaml with PreToolUse allow response and empty-object responses for other events
- Fill session_id mapping gaps in PreToolUse, PostToolUse, and Stop events

Backward compatible: dialects without a responses section (claude, codex) produce zero stdout output.

Related to ptone/scion#1370