### PR TITLE
fix(messaging): remove legacy-pending sentinel, split validation choke point (DEF-41)

### DIFF
--- a/hack/check-authz-reachability.sh
+++ b/hack/check-authz-reachability.sh
@@ -82,9 +82,9 @@ check_symbol_in_file \
     "authorizeAgentMessage in handlers_chat_v2.go (sendAgentRouted)"
 
 echo ""
-echo "--- Required gates (ValidateLegacyMessage) ---"
+echo "--- Required gates (ValidateLegacyMessage — shape/content validation) ---"
 
-# V1-V3: ValidateLegacyMessage on all primary send paths
+# V1-V3: ValidateLegacyMessage on all primary send paths (pre-attribution)
 check_symbol_in_file \
     pkg/hub/handlers_agent_messaging.go \
     ValidateLegacyMessage \
@@ -99,6 +99,30 @@ check_symbol_in_file \
     pkg/hub/handlers_chat_v2.go \
     ValidateLegacyMessage \
     "ValidateLegacyMessage in handlers_chat_v2.go"
+
+echo ""
+echo "--- Required gates (ValidateAttributed — post-attribution validation) ---"
+
+# V4-V6: ValidateAttributed on all primary send paths (post-attribution).
+# DEF-41: the legacy validation split. ValidateLegacyMessage checks shape/content
+# before attribution; ValidateAttributed checks ConversationID after attribution
+# has set a real one. Both halves must be present on every path that attributes
+# a conversation — removing either half while the gate watches only the other
+# would let a handler skip validation and stay green.
+check_symbol_in_file \
+    pkg/hub/handlers_agent_messaging.go \
+    ValidateAttributed \
+    "ValidateAttributed in handlers_agent_messaging.go"
+
+check_symbol_in_file \
+    pkg/hub/handlers_broker_inbound.go \
+    ValidateAttributed \
+    "ValidateAttributed in handlers_broker_inbound.go"
+
+check_symbol_in_file \
+    pkg/hub/handlers_chat_v2.go \
+    ValidateAttributed \
+    "ValidateAttributed in handlers_chat_v2.go"
 
 # ---------------------------------------------------------------------------
 # EXEMPT: enumerated bypasses with architect-approved reason and date.

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -303,10 +303,11 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 	}
 	if convResult != nil {
 		storeMsg.ConversationID = convResult.ConversationID
-		// DEF-41: post-attribution validation. The ConversationID check was
-		// previously dead on this path because the legacy adapter fabricated
-		// a sentinel. Now it is live: if attribution produced a result, the
-		// ConversationID must be well-formed.
+		// DEF-41: structural pre-placement. This check is inert while B10
+		// holds: convResult is non-nil only when attribution succeeded, and
+		// ent.Conversation.ID is a uuid.UUID that always renders non-empty.
+		// It becomes load-bearing at Tranche G, when derivation failure
+		// becomes fatal and this call moves outside the nil guard.
 		if err := messaging.ValidateAttributed(storeMsg.ConversationID); err != nil {
 			ValidationError(w, err.Error(), nil)
 			return
@@ -943,15 +944,16 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		if convResult != nil && storeMsg.ConversationID == "" {
 			storeMsg.ConversationID = convResult.ConversationID
 		}
-		// DEF-41: post-attribution validation. Runs after both the
-		// CLI-pre-resolved path (:889) and the server-side resolution path
-		// (:932) have had their chance to set ConversationID.
-		if storeMsg.ConversationID != "" {
-			if err := messaging.ValidateAttributed(storeMsg.ConversationID); err != nil {
-				ValidationError(w, err.Error(), nil)
-				return
-			}
-		}
+		// DEF-41: no ValidateAttributed here. Both paths that set
+		// storeMsg.ConversationID produce a non-empty value by
+		// construction: the CLI-pre-resolved path (:897) copies a
+		// caller-supplied non-empty string, and the server-side
+		// resolution path (:943) copies from convResult which holds a
+		// uuid.UUID. A guard of `if x != "" { reject when x == "" }`
+		// is tautological and would mislead a reader into thinking the
+		// check is live. The file-level gate sees ValidateAttributed
+		// from site 1 (handleAgentOutboundMessage).
+		//
 		// Always log divergence — even when convResult is nil, that is a divergence signal.
 		oldRouting := messaging.OldRoutingFromMessage(structuredMsg.SenderID, agent.ID, structuredMsg.ThreadID)
 		convID := ""

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -944,16 +944,12 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		if convResult != nil && storeMsg.ConversationID == "" {
 			storeMsg.ConversationID = convResult.ConversationID
 		}
-		// DEF-41: no ValidateAttributed here. Both paths that set
-		// storeMsg.ConversationID produce a non-empty value by
-		// construction: the CLI-pre-resolved path (:897) copies a
-		// caller-supplied non-empty string, and the server-side
-		// resolution path (:943) copies from convResult which holds a
-		// uuid.UUID. A guard of `if x != "" { reject when x == "" }`
-		// is tautological and would mislead a reader into thinking the
-		// check is live. The file-level gate sees ValidateAttributed
-		// from site 1 (handleAgentOutboundMessage).
-		//
+		if convResult != nil {
+			if err := messaging.ValidateAttributed(storeMsg.ConversationID); err != nil {
+				ValidationError(w, err.Error(), nil)
+				return
+			}
+		}
 		// Always log divergence — even when convResult is nil, that is a divergence signal.
 		oldRouting := messaging.OldRoutingFromMessage(structuredMsg.SenderID, agent.ID, structuredMsg.ThreadID)
 		convID := ""

--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -303,6 +303,14 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 	}
 	if convResult != nil {
 		storeMsg.ConversationID = convResult.ConversationID
+		// DEF-41: post-attribution validation. The ConversationID check was
+		// previously dead on this path because the legacy adapter fabricated
+		// a sentinel. Now it is live: if attribution produced a result, the
+		// ConversationID must be well-formed.
+		if err := messaging.ValidateAttributed(storeMsg.ConversationID); err != nil {
+			ValidationError(w, err.Error(), nil)
+			return
+		}
 	}
 	// Always log divergence — even when convResult is nil, that is a divergence signal.
 	oldRouting := messaging.OldRoutingFromMessage(agent.ID, recipientID, req.ThreadID)
@@ -934,6 +942,15 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		}
 		if convResult != nil && storeMsg.ConversationID == "" {
 			storeMsg.ConversationID = convResult.ConversationID
+		}
+		// DEF-41: post-attribution validation. Runs after both the
+		// CLI-pre-resolved path (:889) and the server-side resolution path
+		// (:932) have had their chance to set ConversationID.
+		if storeMsg.ConversationID != "" {
+			if err := messaging.ValidateAttributed(storeMsg.ConversationID); err != nil {
+				ValidationError(w, err.Error(), nil)
+				return
+			}
 		}
 		// Always log divergence — even when convResult is nil, that is a divergence signal.
 		oldRouting := messaging.OldRoutingFromMessage(structuredMsg.SenderID, agent.ID, structuredMsg.ThreadID)

--- a/pkg/hub/handlers_broker_inbound.go
+++ b/pkg/hub/handlers_broker_inbound.go
@@ -361,9 +361,12 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 		}
 		if convResult != nil {
 			storeMsg.ConversationID = convResult.ConversationID
-			// DEF-41: post-attribution validation. The ConversationID check
-			// was previously dead on this path because the legacy adapter
-			// fabricated a sentinel. Now it is live.
+			// DEF-41: structural pre-placement. This check is inert
+			// while B10 holds: convResult is non-nil only when
+			// attribution succeeded, and ent.Conversation.ID is a
+			// uuid.UUID that always renders non-empty. It becomes
+			// load-bearing at Tranche G, when derivation failure
+			// becomes fatal and this call moves outside the nil guard.
 			if err := messaging.ValidateAttributed(storeMsg.ConversationID); err != nil {
 				writeError(w, http.StatusBadRequest, ErrCodeValidationError, err.Error(), nil)
 				return

--- a/pkg/hub/handlers_broker_inbound.go
+++ b/pkg/hub/handlers_broker_inbound.go
@@ -361,6 +361,13 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 		}
 		if convResult != nil {
 			storeMsg.ConversationID = convResult.ConversationID
+			// DEF-41: post-attribution validation. The ConversationID check
+			// was previously dead on this path because the legacy adapter
+			// fabricated a sentinel. Now it is live.
+			if err := messaging.ValidateAttributed(storeMsg.ConversationID); err != nil {
+				writeError(w, http.StatusBadRequest, ErrCodeValidationError, err.Error(), nil)
+				return
+			}
 		}
 		// Always log divergence — even when convResult is nil, that is a divergence signal.
 		oldRouting := messaging.OldRoutingFromMessage(senderUserID, agent.ID, storeMsg.ThreadID)

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -1177,9 +1177,12 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 		}
 		if convResult != nil {
 			storeMsg.ConversationID = convResult.ConversationID
-			// DEF-41: post-attribution validation. The ConversationID
-			// check was previously dead on this path because the legacy
-			// adapter fabricated a sentinel. Now it is live.
+			// DEF-41: structural pre-placement. This check is inert
+			// while B10 holds: convResult is non-nil only when
+			// attribution succeeded, and ent.Conversation.ID is a
+			// uuid.UUID that always renders non-empty. It becomes
+			// load-bearing at Tranche G, when derivation failure
+			// becomes fatal and this call moves outside the nil guard.
 			if err := messaging.ValidateAttributed(storeMsg.ConversationID); err != nil {
 				ValidationError(w, err.Error(), nil)
 				return ""

--- a/pkg/hub/handlers_chat_v2.go
+++ b/pkg/hub/handlers_chat_v2.go
@@ -1177,6 +1177,13 @@ func (s *Server) sendAgentRouted(w http.ResponseWriter, r *http.Request, key, pr
 		}
 		if convResult != nil {
 			storeMsg.ConversationID = convResult.ConversationID
+			// DEF-41: post-attribution validation. The ConversationID
+			// check was previously dead on this path because the legacy
+			// adapter fabricated a sentinel. Now it is live.
+			if err := messaging.ValidateAttributed(storeMsg.ConversationID); err != nil {
+				ValidationError(w, err.Error(), nil)
+				return ""
+			}
 		}
 	}
 	if err := s.store.CreateMessage(ctx, storeMsg); err != nil {

--- a/pkg/messaging/validate.go
+++ b/pkg/messaging/validate.go
@@ -85,10 +85,15 @@ func ValidateMessage(msg *Message) error {
 // ValidateAttributed runs after attribution has had the chance to set a real
 // ConversationID.
 //
-// On 7 of 8 legacy call sites, validation historically ran before attribution,
-// so the adapter fabricated a synthetic ConversationID to satisfy
-// ValidateMessage's required-field check. That sentinel made the check dead.
-// The split removes the sentinel and makes this check live (DEF-41).
+// INERTNESS UNDER B10: while derivation failures remain non-fatal (B10),
+// every call site guards this behind `if convResult != nil`, and every
+// non-nil convResult carries a uuid.UUID ConversationID that is never empty.
+// The check is therefore structural pre-placement: it cannot fire today, and
+// it becomes load-bearing at Tranche G when derivation failure becomes fatal
+// and the nil guard is removed.
+//
+// The sentinel that previously masked this check in ValidateLegacyMessage is
+// deleted (DEF-41). The check is correctly positioned; it is not yet reachable.
 func ValidateAttributed(conversationID string) error {
 	if conversationID == "" {
 		return fmt.Errorf("conversation_id is required after attribution")

--- a/pkg/messaging/validate.go
+++ b/pkg/messaging/validate.go
@@ -28,12 +28,11 @@ type AgentProjectLookup interface {
 	GetAgent(ctx context.Context, id string) (*store.Agent, error)
 }
 
-// ValidateMessage checks that a Message is internally consistent.
-// It delegates to msg.Validate() for structural checks (ID, From, Kind,
-// Visibility, kind/intent/event mutual-exclusivity), then adds domain-level
-// checks that only the standalone validator knows about.
-// Every rule has a corresponding test that fails when the rule is removed.
-func ValidateMessage(msg *Message) error {
+// validateMessageContent checks every Message invariant that does not depend
+// on conversation attribution. It is the shared core of both ValidateMessage
+// (native callers that already have a ConversationID) and ValidateLegacyMessage
+// (legacy callers where attribution runs after validation).
+func validateMessageContent(msg *Message) error {
 	if msg == nil {
 		return fmt.Errorf("message must not be nil")
 	}
@@ -41,12 +40,7 @@ func ValidateMessage(msg *Message) error {
 	if err := msg.Validate(); err != nil {
 		return err
 	}
-	// Domain-level checks not on the type itself:
-	// 1. ConversationID is required.
-	if msg.ConversationID == "" {
-		return fmt.Errorf("conversation_id is required")
-	}
-	// 2. Body size limits (reuse constants from messages package).
+	// Body size limits (reuse constants from messages package).
 	if len([]rune(msg.Body)) > messages.MaxMessageLength {
 		return fmt.Errorf("body exceeds %d character limit (current: %d chars)",
 			messages.MaxMessageLength, len([]rune(msg.Body)))
@@ -54,14 +48,50 @@ func ValidateMessage(msg *Message) error {
 	if len(msg.Body) > messages.MaxMsgSize {
 		return fmt.Errorf("body exceeds maximum size of %d bytes", messages.MaxMsgSize)
 	}
-	// 3. Attachment count limit.
+	// Attachment count limit.
 	if len(msg.Attachments) > messages.MaxAttachments {
 		return fmt.Errorf("too many attachments: %d (max %d)",
 			len(msg.Attachments), messages.MaxAttachments)
 	}
-	// 4. ReplyToID, if present, must not be empty string.
+	// ReplyToID, if present, must not be empty string.
 	if msg.ReplyToID != nil && *msg.ReplyToID == "" {
 		return fmt.Errorf("reply_to_id must not be empty when set")
+	}
+	return nil
+}
+
+// ValidateMessage checks that a Message is internally consistent.
+// It delegates to msg.Validate() for structural checks (ID, From, Kind,
+// Visibility, kind/intent/event mutual-exclusivity), then adds domain-level
+// checks that only the standalone validator knows about.
+// Every rule has a corresponding test that fails when the rule is removed.
+func ValidateMessage(msg *Message) error {
+	if err := validateMessageContent(msg); err != nil {
+		return err
+	}
+	// ConversationID is required for native-type callers, which always have
+	// one by construction. Legacy callers use ValidateLegacyMessage (which
+	// skips this check) followed by ValidateAttributed (which performs it
+	// after conversation attribution has set a real ConversationID).
+	if msg.ConversationID == "" {
+		return fmt.Errorf("conversation_id is required")
+	}
+	return nil
+}
+
+// ValidateAttributed checks that a ConversationID was set by the conversation
+// attribution layer. This is the second half of the legacy validation split:
+// ValidateLegacyMessage runs shape/content checks before attribution;
+// ValidateAttributed runs after attribution has had the chance to set a real
+// ConversationID.
+//
+// On 7 of 8 legacy call sites, validation historically ran before attribution,
+// so the adapter fabricated a synthetic ConversationID to satisfy
+// ValidateMessage's required-field check. That sentinel made the check dead.
+// The split removes the sentinel and makes this check live (DEF-41).
+func ValidateAttributed(conversationID string) error {
+	if conversationID == "" {
+		return fmt.Errorf("conversation_id is required after attribution")
 	}
 	return nil
 }

--- a/pkg/messaging/validate_compat.go
+++ b/pkg/messaging/validate_compat.go
@@ -88,15 +88,10 @@ func ValidateLegacyMessage(msg *messages.StructuredMessage) error {
 		return fmt.Errorf("legacy envelope conversion failed: %w", err)
 	}
 
-	// The legacy StructuredMessage does not have a ConversationID; set a
-	// synthetic value so that ValidateMessage's required-field check passes.
-	// The real ConversationID is resolved by the conversation attribution
-	// layer (Phase 4/5), which runs after validation.
-	if newMsg.ConversationID == "" {
-		newMsg.ConversationID = "legacy-pending"
-	}
-
-	if err := ValidateMessage(newMsg); err != nil {
+	// Shape/content validation only — ConversationID is checked later by
+	// ValidateAttributed, after the conversation attribution layer has had
+	// the chance to set a real one. See DEF-41.
+	if err := validateMessageContent(newMsg); err != nil {
 		return err
 	}
 

--- a/pkg/messaging/validate_compat_test.go
+++ b/pkg/messaging/validate_compat_test.go
@@ -454,3 +454,31 @@ func TestValidateLegacyMessage_ChatType(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// ---------- DEF-41: sentinel removal (AC-D-2 dual) ----------
+
+// TestValidateLegacyMessage_AcceptsEmptyConversationID confirms that after
+// the DEF-41 fix, ValidateLegacyMessage no longer checks ConversationID.
+// The check has moved to ValidateAttributed, which runs after attribution.
+//
+// POSITIVE CONTROL EVIDENCE (AC-D-2):
+// On upstream/main before this fix, ValidateLegacyMessage fabricated
+// ConversationID = "legacy-pending" before calling ValidateMessage. The
+// sentinel made the "conversation_id is required" error unreachable. This
+// test proves the sentinel is gone and ValidateLegacyMessage no longer
+// asserts ConversationID — that responsibility belongs to ValidateAttributed.
+//
+// To verify against upstream/main: the equivalent test on main would PASS
+// (because the sentinel masks the check), so this test does not demonstrate
+// a behavioral change. The behavioral change is in
+// TestValidateAttributed_RejectsEmptyConversationID, which demonstrates that
+// the check is now LIVE via ValidateAttributed where it was previously DEAD.
+func TestValidateLegacyMessage_AcceptsEmptyConversationID(t *testing.T) {
+	msg := validLegacyMessage()
+	msg.ConversationID = "" // intentionally empty — attribution hasn't run yet
+	err := ValidateLegacyMessage(msg)
+	if err != nil {
+		t.Fatalf("ValidateLegacyMessage must not check ConversationID "+
+			"(that is ValidateAttributed's job after attribution), got: %v", err)
+	}
+}

--- a/pkg/messaging/validate_compat_test.go
+++ b/pkg/messaging/validate_compat_test.go
@@ -461,18 +461,11 @@ func TestValidateLegacyMessage_ChatType(t *testing.T) {
 // the DEF-41 fix, ValidateLegacyMessage no longer checks ConversationID.
 // The check has moved to ValidateAttributed, which runs after attribution.
 //
-// POSITIVE CONTROL EVIDENCE (AC-D-2):
-// On upstream/main before this fix, ValidateLegacyMessage fabricated
-// ConversationID = "legacy-pending" before calling ValidateMessage. The
-// sentinel made the "conversation_id is required" error unreachable. This
-// test proves the sentinel is gone and ValidateLegacyMessage no longer
-// asserts ConversationID — that responsibility belongs to ValidateAttributed.
-//
-// To verify against upstream/main: the equivalent test on main would PASS
-// (because the sentinel masks the check), so this test does not demonstrate
-// a behavioral change. The behavioral change is in
-// TestValidateAttributed_RejectsEmptyConversationID, which demonstrates that
-// the check is now LIVE via ValidateAttributed where it was previously DEAD.
+// On upstream/main, this test would also pass (the sentinel masked the
+// check, so empty ConversationID was accepted anyway). The behavioral
+// change is in the sentinel removal itself: ValidateLegacyMessage no
+// longer fabricates a synthetic ConversationID, so validateMessageContent
+// runs on the real (empty) value rather than a sentinel.
 func TestValidateLegacyMessage_AcceptsEmptyConversationID(t *testing.T) {
 	msg := validLegacyMessage()
 	msg.ConversationID = "" // intentionally empty — attribution hasn't run yet

--- a/pkg/messaging/validate_test.go
+++ b/pkg/messaging/validate_test.go
@@ -762,28 +762,25 @@ func TestValidateCrossProjectAddressees_CheckIsLoadBearing(t *testing.T) {
 	}
 }
 
-// ---------- ValidateAttributed (DEF-41 positive control — AC-D-2) ----------
+// ---------- ValidateAttributed (DEF-41 — function correctness) ----------
 
-// TestValidateAttributed_RejectsEmptyConversationID is the AC-D-2 positive
-// control. It proves that ValidateAttributed rejects an empty ConversationID.
+// TestValidateAttributed_RejectsEmptyConversationID proves that
+// ValidateAttributed rejects an empty ConversationID.
 //
-// POSITIVE CONTROL EVIDENCE (AC-D-2):
-// On upstream/main before this fix, the equivalent check in ValidateMessage
-// was unreachable on all 7 legacy call sites because ValidateLegacyMessage
-// fabricated ConversationID = "legacy-pending" before calling ValidateMessage.
-// The sentinel made the "conversation_id is required" check dead — it could
-// never fire on a real legacy send. This test exercises the check that was
-// previously unreachable and asserts it now fires.
+// This tests the function body, not production reachability. While B10
+// holds, every production call site guards ValidateAttributed behind
+// `if convResult != nil`, and every non-nil convResult carries a
+// uuid.UUID ConversationID that is never empty. The check is therefore
+// structural pre-placement: it cannot fire today, and it becomes
+// load-bearing at Tranche G when derivation failure becomes fatal and
+// the nil guard is removed.
 //
-// To verify the positive control: run this test against upstream/main (where
-// ValidateAttributed does not exist) and confirm it fails to compile. Then
-// run it on this branch and confirm it passes.
+// See the commit message for the proof-by-enumeration that no
+// production path can deliver "" to ValidateAttributed under B10.
 func TestValidateAttributed_RejectsEmptyConversationID(t *testing.T) {
 	err := ValidateAttributed("")
 	if err == nil {
-		t.Fatal("AC-D-2 VIOLATION: ValidateAttributed must reject an empty " +
-			"conversation_id — this check was previously dead on all legacy " +
-			"paths and must now be live")
+		t.Fatal("ValidateAttributed must reject an empty conversation_id")
 	}
 	if !strings.Contains(err.Error(), "conversation_id") {
 		t.Fatalf("error should mention conversation_id, got: %v", err)
@@ -802,7 +799,8 @@ func TestValidateAttributed_AcceptsNonEmptyConversationID(t *testing.T) {
 // TestValidateAttributed_CheckIsLoadBearing proves that the ValidateAttributed
 // check is load-bearing per Rule 10. If the function body were replaced with
 // `return nil`, this test would fail because an empty ConversationID would
-// incorrectly pass.
+// incorrectly pass. The function is correctly implemented; it is the
+// production call sites that are currently inert (see above).
 func TestValidateAttributed_CheckIsLoadBearing(t *testing.T) {
 	err := ValidateAttributed("")
 	// If the check is removed, err would be nil and this assertion would fail.

--- a/pkg/messaging/validate_test.go
+++ b/pkg/messaging/validate_test.go
@@ -761,3 +761,85 @@ func TestValidateCrossProjectAddressees_CheckIsLoadBearing(t *testing.T) {
 			"agents in different projects must be rejected")
 	}
 }
+
+// ---------- ValidateAttributed (DEF-41 positive control — AC-D-2) ----------
+
+// TestValidateAttributed_RejectsEmptyConversationID is the AC-D-2 positive
+// control. It proves that ValidateAttributed rejects an empty ConversationID.
+//
+// POSITIVE CONTROL EVIDENCE (AC-D-2):
+// On upstream/main before this fix, the equivalent check in ValidateMessage
+// was unreachable on all 7 legacy call sites because ValidateLegacyMessage
+// fabricated ConversationID = "legacy-pending" before calling ValidateMessage.
+// The sentinel made the "conversation_id is required" check dead — it could
+// never fire on a real legacy send. This test exercises the check that was
+// previously unreachable and asserts it now fires.
+//
+// To verify the positive control: run this test against upstream/main (where
+// ValidateAttributed does not exist) and confirm it fails to compile. Then
+// run it on this branch and confirm it passes.
+func TestValidateAttributed_RejectsEmptyConversationID(t *testing.T) {
+	err := ValidateAttributed("")
+	if err == nil {
+		t.Fatal("AC-D-2 VIOLATION: ValidateAttributed must reject an empty " +
+			"conversation_id — this check was previously dead on all legacy " +
+			"paths and must now be live")
+	}
+	if !strings.Contains(err.Error(), "conversation_id") {
+		t.Fatalf("error should mention conversation_id, got: %v", err)
+	}
+}
+
+// TestValidateAttributed_AcceptsNonEmptyConversationID confirms that
+// ValidateAttributed passes when a real ConversationID is present.
+func TestValidateAttributed_AcceptsNonEmptyConversationID(t *testing.T) {
+	err := ValidateAttributed("conv-12345")
+	if err != nil {
+		t.Fatalf("ValidateAttributed should accept a non-empty conversation_id, got: %v", err)
+	}
+}
+
+// TestValidateAttributed_CheckIsLoadBearing proves that the ValidateAttributed
+// check is load-bearing per Rule 10. If the function body were replaced with
+// `return nil`, this test would fail because an empty ConversationID would
+// incorrectly pass.
+func TestValidateAttributed_CheckIsLoadBearing(t *testing.T) {
+	err := ValidateAttributed("")
+	// If the check is removed, err would be nil and this assertion would fail.
+	if err == nil {
+		t.Fatal("RULE 10 VIOLATION: ValidateAttributed check was removed or " +
+			"bypassed — an empty conversation_id after attribution must be rejected")
+	}
+}
+
+// ---------- validateMessageContent (internal, shared core) ----------
+
+// TestValidateMessageContent_SkipsConversationIDCheck confirms that the shared
+// core validator (used by ValidateLegacyMessage) does not check ConversationID.
+// ConversationID is checked by ValidateMessage (native path) or
+// ValidateAttributed (legacy path after attribution).
+func TestValidateMessageContent_SkipsConversationIDCheck(t *testing.T) {
+	msg := validTextMessage()
+	msg.ConversationID = "" // intentionally empty
+	err := validateMessageContent(msg)
+	if err != nil {
+		t.Fatalf("validateMessageContent must not check ConversationID "+
+			"(that is ValidateAttributed's job), got: %v", err)
+	}
+}
+
+// TestValidateMessage_StillRejectsEmptyConversationID confirms that the
+// refactoring of ValidateMessage into validateMessageContent + ConversationID
+// check did not break the native-path check. Coverage successor for the
+// original TestValidateMessage_MissingConversationID.
+func TestValidateMessage_StillRejectsEmptyConversationID(t *testing.T) {
+	msg := validTextMessage()
+	msg.ConversationID = ""
+	err := ValidateMessage(msg)
+	if err == nil {
+		t.Fatal("ValidateMessage must still reject an empty ConversationID on the native path")
+	}
+	if !strings.Contains(err.Error(), "conversation_id") {
+		t.Fatalf("error should mention conversation_id, got: %v", err)
+	}
+}


### PR DESCRIPTION
Tranche D, phase D1.

`ValidateLegacyMessage` ran before conversation attribution on 7 of its 8 call sites, so the legacy adapter fabricated `ConversationID = "legacy-pending"` to satisfy the required-field check in `ValidateMessage`. That made the check dead on every legacy path.

Splits the choke point so each check runs where its input exists: `validateMessageContent` (shared core, no ConversationID check), `ValidateMessage` (unchanged behaviour), `ValidateAttributed` (new, post-attribution). Sentinel deleted. The reachability gate is updated in the same commit as the split.

Known and deliberate: `ValidateAttributed` cannot fire today. While B10 holds, attribution failure stays non-fatal and attribution success returns a uuid-derived ID that is never empty. It is structural pre-placement that becomes load-bearing at Tranche G. Documented rather than hidden, because a check that looks live and is not would be worse than the dead check it replaces.

Endpoint diff vs main: 8 files, +215/-25, zero test deletions