### PR TITLE
fix(cli): hoist preconditions above conversation resolve (DEF-48)

### DIFF
--- a/cmd/message.go
+++ b/cmd/message.go
@@ -672,6 +672,18 @@ func sendMessageViaConversation(hubCtx *HubContext, ref *messaging.Reference, me
 		PrintUsingHub(hubCtx.Endpoint)
 	}
 
+	// @email precondition: SCION_AGENT_NAME depends only on the environment
+	// and nothing computed by this function. Evaluate it before any I/O
+	// (resolveSenderIdentity makes a network call) so a guaranteed failure
+	// does not waste a round trip.
+	var emailSenderAgent string
+	if ref.Kind == messaging.RefEmail {
+		emailSenderAgent = os.Getenv("SCION_AGENT_NAME")
+		if emailSenderAgent == "" {
+			return fmt.Errorf("sending messages to users via @<email> is only supported from within an agent container (SCION_AGENT_NAME not set)")
+		}
+	}
+
 	sender := resolveSenderIdentity(hubCtx)
 
 	projectID, err := GetProjectID(hubCtx)
@@ -690,17 +702,6 @@ func sendMessageViaConversation(hubCtx *HubContext, ref *messaging.Reference, me
 		agentMsg = buildStructuredMessage(sender, "agent:"+ref.Value, message)
 		if err := messaging.ValidateLegacyMessage(agentMsg); err != nil {
 			return fmt.Errorf("message validation failed: %w", err)
-		}
-	}
-
-	// DEF-48 (same pattern): for @email references, the agent-context
-	// precondition (SCION_AGENT_NAME) depends on nothing from the resolve.
-	// Failing after resolve orphans the row identically to the validation case.
-	var emailSenderAgent string
-	if ref.Kind == messaging.RefEmail {
-		emailSenderAgent = os.Getenv("SCION_AGENT_NAME")
-		if emailSenderAgent == "" {
-			return fmt.Errorf("sending messages to users via @<email> is only supported from within an agent container (SCION_AGENT_NAME not set)")
 		}
 	}
 

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -679,6 +679,31 @@ func sendMessageViaConversation(hubCtx *HubContext, ref *messaging.Reference, me
 		return wrapHubError(err)
 	}
 
+	// DEF-48: For @agent references, build and validate the message before
+	// resolving the conversation. ResolveConversation can CREATE a row, and
+	// if validation fails afterward, the row survives with no message —
+	// orphaning it. buildStructuredMessage does not need ConversationID, and
+	// ValidateLegacyMessage does not check it (DEF-41), so the message is
+	// fully validatable before resolution.
+	var agentMsg *messages.StructuredMessage
+	if ref.Kind == messaging.RefAgent {
+		agentMsg = buildStructuredMessage(sender, "agent:"+ref.Value, message)
+		if err := messaging.ValidateLegacyMessage(agentMsg); err != nil {
+			return fmt.Errorf("message validation failed: %w", err)
+		}
+	}
+
+	// DEF-48 (same pattern): for @email references, the agent-context
+	// precondition (SCION_AGENT_NAME) depends on nothing from the resolve.
+	// Failing after resolve orphans the row identically to the validation case.
+	var emailSenderAgent string
+	if ref.Kind == messaging.RefEmail {
+		emailSenderAgent = os.Getenv("SCION_AGENT_NAME")
+		if emailSenderAgent == "" {
+			return fmt.Errorf("sending messages to users via @<email> is only supported from within an agent container (SCION_AGENT_NAME not set)")
+		}
+	}
+
 	if !isJSONOutput() {
 		fmt.Printf("Resolving conversation reference %q...\n", ref.Raw)
 	}
@@ -711,12 +736,8 @@ func sendMessageViaConversation(hubCtx *HubContext, ref *messaging.Reference, me
 	// the conversation_id set.
 	if ref.Kind == messaging.RefAgent {
 		agentSvc := hubCtx.Client.ProjectAgents(projectID)
-		msg := buildStructuredMessage(sender, "agent:"+ref.Value, message)
-		msg.ConversationID = resolveResp.ConversationID
-		if err := messaging.ValidateLegacyMessage(msg); err != nil {
-			return fmt.Errorf("message validation failed: %w", err)
-		}
-		if _, err := agentSvc.SendStructuredMessage(ctx, ref.Value, msg, interrupt, false, wake); err != nil {
+		agentMsg.ConversationID = resolveResp.ConversationID
+		if _, err := agentSvc.SendStructuredMessage(ctx, ref.Value, agentMsg, interrupt, false, wake); err != nil {
 			return wrapHubError(fmt.Errorf("failed to send message to agent '%s' via Hub: %w", ref.Value, err))
 		}
 		if !isJSONOutput() {
@@ -725,17 +746,13 @@ func sendMessageViaConversation(hubCtx *HubContext, ref *messaging.Reference, me
 		return nil
 	}
 
-	// For conv:<uuid> and #<thread> references, the conversation is resolved
-	// but we don't know which agent to deliver to. The message is persisted
-	// with the conversation_id. For threads, delivery depends on the
-	// conversation's default agent (if any).
+	// @email path: no StructuredMessage is constructed, so there is no
+	// ValidateLegacyMessage to hoist. The agent-context precondition
+	// (SCION_AGENT_NAME) is hoisted above resolve alongside the @agent
+	// validation — same orphan-row pattern.
 	//
 	// For @<email> references, route as outbound user message with conversation_id.
 	if ref.Kind == messaging.RefEmail {
-		senderAgent := os.Getenv("SCION_AGENT_NAME")
-		if senderAgent == "" {
-			return fmt.Errorf("sending messages to users via @<email> is only supported from within an agent container (SCION_AGENT_NAME not set)")
-		}
 		agentSvc := hubCtx.Client.ProjectAgents(projectID)
 		outMsg := &hubclient.OutboundMessageRequest{
 			Recipient: "user:" + ref.Value,
@@ -744,7 +761,7 @@ func sendMessageViaConversation(hubCtx *HubContext, ref *messaging.Reference, me
 			Urgent:    interrupt,
 			Metadata:  map[string]string{"conversation_id": resolveResp.ConversationID},
 		}
-		if err := agentSvc.SendOutboundMessage(ctx, senderAgent, outMsg); err != nil {
+		if err := agentSvc.SendOutboundMessage(ctx, emailSenderAgent, outMsg); err != nil {
 			return wrapHubError(fmt.Errorf("failed to send message to %s: %w", ref.Raw, err))
 		}
 		if !isJSONOutput() {

--- a/cmd/message_convref_test.go
+++ b/cmd/message_convref_test.go
@@ -414,3 +414,81 @@ func TestBackwardCompat_BareAgentName(t *testing.T) {
 	assert.Equal(t, "old-agent-name", (*sent)[0].AgentName)
 	assert.Equal(t, "hello world", (*sent)[0].Message)
 }
+
+// TestSendMessageViaConversation_ValidationBeforeResolve verifies DEF-48:
+// a message that fails validation must NOT trigger ResolveConversation.
+// Before this fix, validation ran after resolve, orphaning the row on failure.
+func TestSendMessageViaConversation_ValidationBeforeResolve(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	projectID := "proj-convref-val-before-resolve"
+	server, sent, resolves, _ := newConvRefMockHubServer(t, projectID)
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
+	}
+
+	ref := &messaging.Reference{
+		Kind:  messaging.RefAgent,
+		Value: "builder",
+		Raw:   "@builder",
+	}
+
+	// Send an empty message body — ValidateLegacyMessage rejects this because
+	// "msg field is required" when there are no attachments.
+	err = sendMessageViaConversation(hubCtx, ref, "", false, false)
+	require.Error(t, err, "empty message must fail validation")
+	assert.Contains(t, err.Error(), "validation failed")
+
+	// DEF-48 AC-D-4: ResolveConversation must NOT have been called.
+	// Before this fix, resolve ran first (potentially creating a row),
+	// and validation failure afterward orphaned it.
+	assert.Len(t, *resolves, 0, "ResolveConversation must not be called when validation fails (DEF-48)")
+	assert.Len(t, *sent, 0, "no messages should be sent when validation fails")
+}
+
+// TestSendMessageViaConversation_EmailPreconditionBeforeResolve verifies DEF-48
+// for the @email path: when SCION_AGENT_NAME is unset (human CLI context),
+// the precondition must fail before ResolveConversation runs.
+func TestSendMessageViaConversation_EmailPreconditionBeforeResolve(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+
+	// Explicitly unset SCION_AGENT_NAME to simulate human CLI context.
+	t.Setenv("SCION_AGENT_NAME", "")
+
+	projectID := "proj-convref-email-precond"
+	server, sent, resolves, outbound := newConvRefMockHubServer(t, projectID)
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
+	}
+
+	ref := &messaging.Reference{
+		Kind:  messaging.RefEmail,
+		Value: "user@example.com",
+		Raw:   "@user@example.com",
+	}
+
+	err = sendMessageViaConversation(hubCtx, ref, "should fail before resolve", false, false)
+	require.Error(t, err, "email ref without agent context must fail")
+	assert.Contains(t, err.Error(), "only supported from within an agent container")
+
+	// DEF-48: ResolveConversation must NOT have been called.
+	assert.Len(t, *resolves, 0, "ResolveConversation must not be called when email precondition fails (DEF-48)")
+	assert.Len(t, *sent, 0, "no agent messages should be sent")
+	assert.Len(t, *outbound, 0, "no outbound messages should be sent")
+}


### PR DESCRIPTION
sendMessageViaConversation resolved the conversation before checking preconditions that could return early. ResolveConversation can CREATE a conversation row, so a precondition failing afterward left the row with no message.

Two preconditions hoisted above the resolve:
1. @agent: build and validate the StructuredMessage. Validatable pre-resolve because ValidateLegacyMessage no longer checks ConversationID (DEF-41, #1401).
2. @email: the SCION_AGENT_NAME agent-context check reads one env var and depends on nothing from the resolve.

The third post-resolve return ("unsupported ref kind") is unreachable: conv:<uuid> and #<thread> are gated at CLI entry (cmd/message.go:154-155).

Also removes a 4-line stale comment that claimed conv:/#thread reach this function and are persisted here. They never arrive; it contradicted the unreachability comment 25 lines below.

Tests: TestSendMessageViaConversation_ValidationBeforeResolve and TestSendMessageViaConversation_EmailPreconditionBeforeResolve, both asserting zero resolves. Verified red with the fix reverted and green with it, by the reviewer.

2 files, +110/-15. cmd/message.go: 15 deletions (11 mechanical relocation/rename, 4 stale comment). No assertions deleted