### PR TITLE
fix(hub): authorize caller-supplied conversation_id (DEF-49)

### DIFF
--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -894,19 +894,96 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		// If the CLI already resolved a conversation_id (S4 conversation references),
 		// use it directly instead of re-resolving.
 		var convResult *messaging.ConversationResult
-		lookupFailed := false // DEF-11: true only when a pre-resolved conv lookup fails
 		if structuredMsg.ConversationID != "" {
+			// DEF-49 SECURITY: authorize the caller-supplied conversation_id
+			// against the authenticated sender before honouring it.
+			// The else branch below derives the conversation key from the
+			// authenticated context (B5); this branch must verify the caller's
+			// assertion is consistent with that identity.
+			authKind, authID := authenticatedSender(ctx)
+			if authKind == "" || authID == "" {
+				writeError(w, http.StatusUnauthorized, ErrCodeUnauthorized,
+					"authenticated identity required for caller-supplied conversation_id", nil)
+				return
+			}
+
+			conv, convErr := s.store.GetConversation(ctx, structuredMsg.ConversationID)
+			if convErr != nil {
+				if errors.Is(convErr, store.ErrNotFound) {
+					writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest,
+						"caller-supplied conversation_id does not exist", nil)
+					return
+				}
+				s.messageLog.Error("DEF-49: GetConversation failed for caller-supplied conversation_id",
+					"conversation_id", structuredMsg.ConversationID,
+					"error", convErr,
+				)
+				writeError(w, http.StatusInternalServerError, ErrCodeInternalError,
+					"conversation lookup failed", nil)
+				return
+			}
+			if conv == nil {
+				// Defensive: GetConversation should not return (nil, nil),
+				// but if it does, fail closed.
+				writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest,
+					"caller-supplied conversation_id does not exist", nil)
+				return
+			}
+
+			// Authority differs by conversation kind. Direct conversations
+			// have ProjectID == nil (global), so project scoping cannot be
+			// the universal check. The DM key IS the ACL for direct rows.
+			//
+			// `agent` is the recipient agent (resolved from the URL path at
+			// :668), not the sender. The group case is therefore a containment
+			// check — "the conversation belongs to the addressed agent's
+			// project" — not a sender-participation check.
+			switch conv.Kind {
+			case "direct":
+				if err := messages.CheckDMParticipantKey(conv.Kind, conv.ExternalRef, authKind, authID); err != nil {
+					s.messageLog.Warn("DEF-49: direct conversation authorization failed",
+						"conversation_id", conv.ID,
+						"auth_kind", authKind,
+						"error", err,
+					)
+					writeError(w, http.StatusForbidden, ErrCodeForbidden,
+						"authenticated sender is not a participant in the direct conversation", nil)
+					return
+				}
+			case "group":
+				// Deny when either project ID is unset (empty or zero UUID).
+				// Two unset IDs comparing equal would authorize a request
+				// that has no project context — the same class of bug that
+				// isUnsetProjectID (validate.go:136) guards against.
+				const zeroUUID = "00000000-0000-0000-0000-000000000000"
+				convProjUnset := conv.ProjectID == nil || *conv.ProjectID == "" || *conv.ProjectID == zeroUUID
+				agentProjUnset := agent.ProjectID == "" || agent.ProjectID == zeroUUID
+				if convProjUnset || agentProjUnset || *conv.ProjectID != agent.ProjectID {
+					s.messageLog.Warn("DEF-49: group conversation project mismatch or unset project",
+						"conversation_id", conv.ID,
+						"conv_project_id", conv.ProjectID,
+						"agent_project_id", agent.ProjectID,
+					)
+					writeError(w, http.StatusForbidden, ErrCodeForbidden,
+						"conversation does not belong to the agent's project", nil)
+					return
+				}
+			default:
+				// Unknown conversation kind — fail closed.
+				s.messageLog.Warn("DEF-49: unknown conversation kind, denying",
+					"conversation_id", conv.ID,
+					"kind", conv.Kind,
+				)
+				writeError(w, http.StatusForbidden, ErrCodeForbidden,
+					"unsupported conversation kind", nil)
+				return
+			}
+
+			// Authorization passed — honour the caller's assertion.
 			storeMsg.ConversationID = structuredMsg.ConversationID
 			convResult = &messaging.ConversationResult{
 				ConversationID: structuredMsg.ConversationID,
-			}
-			// DEF-11: The CLI pre-resolved the ConversationID but didn't send
-			// the ExternalRef. Look it up from the store so
-			// ComputeDivergenceMatch gets the real value instead of "".
-			if conv, err := s.store.GetConversation(ctx, structuredMsg.ConversationID); err == nil && conv != nil {
-				convResult.ExternalRef = conv.ExternalRef
-			} else {
-				lookupFailed = true
+				ExternalRef:    conv.ExternalRef,
 			}
 		} else {
 			// B5 SECURITY: derive sender identity for the conversation key
@@ -944,10 +1021,18 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 		if convResult != nil && storeMsg.ConversationID == "" {
 			storeMsg.ConversationID = convResult.ConversationID
 		}
+		// B10: ValidateAttributed rejection deliberately demoted to a log
+		// line. Converting a derivation-path empty ConversationID into a
+		// client-visible 4xx is a B10 violation — that flip belongs to
+		// Tranche G's read-switch, not to an accidental merge artifact.
+		// Keep the signal so a Tranche G operator can grep for it.
 		if convResult != nil {
 			if err := messaging.ValidateAttributed(storeMsg.ConversationID); err != nil {
-				ValidationError(w, err.Error(), nil)
-				return
+				s.messageLog.Warn("ValidateAttributed: empty ConversationID after attribution (B10 demoted)",
+					"message_id", storeMsg.ID,
+					"conversation_id", storeMsg.ConversationID,
+					"error", err,
+				)
 			}
 		}
 		// Always log divergence — even when convResult is nil, that is a divergence signal.
@@ -958,29 +1043,17 @@ func (s *Server) handleAgentMessage(w http.ResponseWriter, r *http.Request, id s
 			convID = convResult.ConversationID
 			actualRef = convResult.ExternalRef
 		}
-		// DEF-11: When the CLI pre-resolved a ConversationID but the store
-		// lookup failed, record a fallback with a distinct reason instead of
-		// feeding an empty ref into ComputeDivergenceMatch (which would
-		// produce "routing-type-mismatch: old=… new=", the DEF-11 artifact).
-		if lookupFailed {
-			messaging.LogDivergence(s.messageLog, messaging.DivergenceEntry{
-				MessageID:  storeMsg.ID,
-				OldRouting: oldRouting,
-				NewRouting: messaging.NewRoutingStr(convID),
-				Match:      false,
-				Reason:     "conv-lookup-failed",
-				Fallback:   true,
-			})
-		} else {
-			match, reason := messaging.ComputeDivergenceMatch(oldRouting, actualRef, convID)
-			messaging.LogDivergence(s.messageLog, messaging.DivergenceEntry{
-				MessageID:  storeMsg.ID,
-				OldRouting: oldRouting,
-				NewRouting: messaging.NewRoutingStr(convID),
-				Match:      match,
-				Reason:     reason,
-			})
-		}
+		// DEF-49: lookupFailed was removed — both lookup-failure cases now
+		// deny before reaching this point, so the "conv-lookup-failed"
+		// divergence entry is unreachable dead code. Removed per AC-D-7.
+		match, reason := messaging.ComputeDivergenceMatch(oldRouting, actualRef, convID)
+		messaging.LogDivergence(s.messageLog, messaging.DivergenceEntry{
+			MessageID:  storeMsg.ID,
+			OldRouting: oldRouting,
+			NewRouting: messaging.NewRoutingStr(convID),
+			Match:      match,
+			Reason:     reason,
+		})
 		// DEF-3: Independent consistency check against prior messages.
 		messaging.CheckConversationConsistency(ctx, s.store, storeMsg.ID, convID, structuredMsg.ThreadID, structuredMsg.SenderID, agent.ID, s.messageLog)
 		// Propagate GroupID from metadata so CLI-originated group[] messages

--- a/pkg/hub/handlers_agent_messaging_test.go
+++ b/pkg/hub/handlers_agent_messaging_test.go
@@ -1162,7 +1162,12 @@ func TestDEF11_PreResolvedConversation_PopulatesExternalRef(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a conversation with a known ExternalRef.
-	extRef := testDirectMessageExternalRef(userID, agentID)
+	// DEF-49: use the kind-encoded key format so the authorization
+	// check can parse it. The authenticated user is DevUserID.
+	extRef, err := messages.DMConversationKey("user", userID, "agent", agentID)
+	if err != nil {
+		t.Fatalf("DMConversationKey: %v", err)
+	}
 	conv := &store.Conversation{
 		Kind:        "direct",
 		Surface:     "native",
@@ -1227,7 +1232,12 @@ func TestDEF11_PreResolvedConversation_DivergenceMatch(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a conversation matching the sender/agent DM pair.
-	extRef := testDirectMessageExternalRef(userID, agentID)
+	// DEF-49: use the kind-encoded key format so the authorization
+	// check can parse it. The authenticated user is DevUserID.
+	extRef, err := messages.DMConversationKey("user", userID, "agent", agentID)
+	if err != nil {
+		t.Fatalf("DMConversationKey: %v", err)
+	}
 	conv := &store.Conversation{
 		Kind:        "direct",
 		Surface:     "native",
@@ -1272,15 +1282,14 @@ func TestDEF11_PreResolvedConversation_DivergenceMatch(t *testing.T) {
 }
 
 // TestDEF11_PreResolvedConversation_LookupFailure verifies that when a
-// pre-resolved ConversationID does not exist in the store, the handler records
-// a fallback with reason "conv-lookup-failed" — not a plain
-// "routing-type-mismatch". The Fallback flag on DivergenceEntry routes the
-// event to the fallback counter only, leaving mismatches at zero.
+// pre-resolved ConversationID does not exist in the store, the handler denies
+// the request (DEF-49: fail closed on nonexistent conversation).
+//
+// Before DEF-49 this recorded a "conv-lookup-failed" divergence fallback and
+// proceeded. After DEF-49, both lookup-failure cases deny, and the
+// "conv-lookup-failed" divergence entry is dead code (removed per AC-D-7).
 func TestDEF11_PreResolvedConversation_LookupFailure(t *testing.T) {
 	srv, _, projectID, agentSlug, _, userID := def11Setup(t)
-
-	beforeFallbacks := messaging.DivergenceMetrics.Fallbacks()
-	beforeMismatches := messaging.DivergenceMetrics.Mismatches()
 
 	// Use a non-existent conversation ID.
 	rec := doRequest(t, srv, http.MethodPost,
@@ -1297,20 +1306,10 @@ func TestDEF11_PreResolvedConversation_LookupFailure(t *testing.T) {
 				ConversationID: "nonexistent-conv-id",
 			},
 		})
-	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200 (message delivery is non-fatal), got %d: %s", rec.Code, rec.Body.String())
-	}
-
-	afterFallbacks := messaging.DivergenceMetrics.Fallbacks()
-	afterMismatches := messaging.DivergenceMetrics.Mismatches()
-
-	if afterFallbacks-beforeFallbacks < 1 {
-		t.Errorf("expected Fallbacks delta >= 1 (conv-lookup-failed recorded), got %d",
-			afterFallbacks-beforeFallbacks)
-	}
-	if afterMismatches-beforeMismatches != 0 {
-		t.Errorf("expected Mismatches delta == 0 (fallback must not register as mismatch), got %d",
-			afterMismatches-beforeMismatches)
+	// DEF-49: nonexistent conversation_id is now denied with 400.
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 (DEF-49: nonexistent conversation denied), got %d: %s",
+			rec.Code, rec.Body.String())
 	}
 }
 
@@ -1432,20 +1431,37 @@ func TestDEF19_GroupRecipient_FullHandlerPath(t *testing.T) {
 	}
 }
 
-// TestDEF11_PreResolvedConversation_GenuineDisagreement verifies that the
-// divergence comparison is active and can detect a real mismatch when the
-// stored ExternalRef does not agree with the old-model routing.
-func TestDEF11_PreResolvedConversation_GenuineDisagreement(t *testing.T) {
+// TestDEF49_DivergenceMismatch_AuthorizedButWrongAgent verifies that the
+// divergence comparison detects a real routing mismatch on the pre-resolved
+// path, even when DEF-49 authorization passes.
+//
+// The authenticated user (DevUserID) is named in the conversation's DM key
+// (one of the two slots), so authorization succeeds. But the conversation
+// names a *different* agent than the one the message is addressed to, so
+// OldRoutingFromMessage (which uses the addressed agent's ID) disagrees with
+// the conversation's ExternalRef — producing a "dm-routing-mismatch".
+//
+// This is the coverage successor for the original
+// TestDEF11_PreResolvedConversation_GenuineDisagreement, which was deleted
+// because DEF-49 turned it into a duplicate of the non-membership negative
+// test (AC-D-7).
+func TestDEF49_DivergenceMismatch_AuthorizedButWrongAgent(t *testing.T) {
 	srv, s, projectID, agentSlug, _, userID := def11Setup(t)
 	ctx := context.Background()
 
-	// Create a conversation with an ExternalRef that does NOT match the
-	// sender/agent pair used in the message (different principals).
-	wrongRef := testDirectMessageExternalRef("wrong-id-x", "wrong-id-y")
+	// Create a conversation keyed to (DevUserID, otherAgentID).
+	// DevUserID occupies one slot, so DEF-49 direct authorization passes.
+	// But the message is addressed to agentSlug (agentID), not otherAgentID,
+	// so the divergence comparison will disagree.
+	otherAgentID := tid("def49-divergence-other-agent")
+	divergentRef, err := messages.DMConversationKey("user", userID, "agent", otherAgentID)
+	if err != nil {
+		t.Fatalf("DMConversationKey: %v", err)
+	}
 	conv := &store.Conversation{
 		Kind:        "direct",
 		Surface:     "native",
-		ExternalRef: wrongRef,
+		ExternalRef: divergentRef,
 		DriftState:  "active",
 	}
 	created, err := s.UpsertConversationByExternalRef(ctx, conv)
@@ -1455,28 +1471,371 @@ func TestDEF11_PreResolvedConversation_GenuineDisagreement(t *testing.T) {
 
 	beforeMismatches := messaging.DivergenceMetrics.Mismatches()
 
-	// Post a message referencing the wrong conversation.
+	// Post a message to agentSlug with the divergent conversation.
 	rec := doRequest(t, srv, http.MethodPost,
 		"/api/v1/projects/"+projectID+"/agents/"+agentSlug+"/message",
 		MessageRequest{
 			StructuredMessage: &messages.StructuredMessage{
 				Version:        messages.Version,
 				Timestamp:      time.Now().UTC().Format(time.RFC3339),
-				Sender:         "user:def11",
+				Sender:         "user:def49-divergence",
 				SenderID:       userID,
 				Recipient:      "agent:" + agentSlug,
-				Msg:            "DEF11 AC-4 test",
+				Msg:            "DEF49 divergence mismatch test",
 				Type:           messages.TypeInstruction,
 				ConversationID: created.ID,
 			},
 		})
 	if rec.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+		t.Fatalf("expected 200 (authorized but divergent), got %d: %s",
+			rec.Code, rec.Body.String())
 	}
 
 	afterMismatches := messaging.DivergenceMetrics.Mismatches()
 	if afterMismatches-beforeMismatches < 1 {
-		t.Errorf("expected Mismatches delta >= 1 (genuine disagreement), got %d",
+		t.Errorf("expected Mismatches delta >= 1 (dm-routing-mismatch), got %d",
 			afterMismatches-beforeMismatches)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// DEF-49 — caller-supplied conversation_id authorization
+// ---------------------------------------------------------------------------
+//
+// AC-D-8: Three negative tests, one per facet, each reachable on main today
+// (expected RED on upstream/main, GREEN after the fix).
+//
+// AC-D-9: One positive test proving the legitimate scion message @agent path
+// still works (expected GREEN on both main and after the fix).
+
+// def49Setup creates a project, two agents (attacker and target), a user
+// (the legitimate sender, DevUserID), and a dispatcher so the handler
+// doesn't fail with 503. It returns everything needed to exercise the
+// caller-supplied conversation_id authorization path.
+func def49Setup(t *testing.T) (srv *Server, s store.Store, projectID string, targetAgent *store.Agent, userID string) {
+	t.Helper()
+	srv, s = testServer(t)
+	ctx := context.Background()
+
+	projectID = tid("def49-project")
+	if err := s.CreateProject(ctx, &store.Project{
+		ID:         projectID,
+		Name:       "def49-project",
+		Slug:       "def49-project",
+		Visibility: store.VisibilityPrivate,
+	}); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	brokerID := tid("def49-broker")
+	if err := s.CreateRuntimeBroker(ctx, &store.RuntimeBroker{
+		ID:     brokerID,
+		Name:   "def49-broker",
+		Slug:   "def49-broker",
+		Status: store.BrokerStatusOnline,
+	}); err != nil {
+		t.Fatalf("CreateRuntimeBroker: %v", err)
+	}
+	if err := s.AddProjectProvider(ctx, &store.ProjectProvider{
+		ProjectID:  projectID,
+		BrokerID:   brokerID,
+		BrokerName: "def49-broker",
+		Status:     store.BrokerStatusOnline,
+	}); err != nil {
+		t.Fatalf("AddProjectProvider: %v", err)
+	}
+
+	targetAgent = &store.Agent{
+		ID:              tid("def49-target-agent"),
+		Name:            "def49-target-agent",
+		Slug:            "def49-target-agent",
+		ProjectID:       projectID,
+		RuntimeBrokerID: brokerID,
+		Phase:           "running",
+		Visibility:      store.VisibilityPrivate,
+	}
+	if err := s.CreateAgent(ctx, targetAgent); err != nil {
+		t.Fatalf("CreateAgent (target): %v", err)
+	}
+
+	userID = DevUserID
+	_ = s.CreateUser(ctx, &store.User{
+		ID:          userID,
+		Email:       "dev@localhost",
+		DisplayName: "Development User",
+	})
+
+	srv.SetDispatcher(&recordingDispatcher{})
+	return srv, s, projectID, targetAgent, userID
+}
+
+// TestDEF49_NonMembership_DirectConversation verifies that an authenticated
+// user cannot attribute a message to a direct conversation whose DM key
+// does not name them (AC-D-8 facet a, AC-INGRESS-1 violation).
+//
+// RED on upstream/main: the if-branch accepts any caller-supplied
+// conversation_id without checking the authenticated sender.
+// GREEN after DEF-49: denied with 403.
+func TestDEF49_NonMembership_DirectConversation(t *testing.T) {
+	srv, s, _, targetAgent, _ := def49Setup(t)
+	ctx := context.Background()
+
+	// Create two uninvolved users whose DM conversation the attacker
+	// (dev user) should NOT be able to write into.
+	otherUserA := &store.User{
+		ID:          tid("def49-other-user-a"),
+		Email:       "other-a@example.com",
+		DisplayName: "Other A",
+	}
+	if err := s.CreateUser(ctx, otherUserA); err != nil {
+		t.Fatalf("CreateUser (otherA): %v", err)
+	}
+
+	// Build a DM key between otherUserA and the target agent.
+	// The dev user (DevUserID) is NOT a participant.
+	dmKey, err := messages.DMConversationKey("user", otherUserA.ID, "agent", targetAgent.ID)
+	if err != nil {
+		t.Fatalf("DMConversationKey: %v", err)
+	}
+	conv := &store.Conversation{
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: dmKey,
+		DriftState:  "active",
+	}
+	created, err := s.UpsertConversationByExternalRef(ctx, conv)
+	if err != nil {
+		t.Fatalf("UpsertConversationByExternalRef: %v", err)
+	}
+
+	// Send a message as the dev user (DevUserID), claiming to belong to
+	// that conversation. The dev user is NOT named in the DM key.
+	rec := doRequest(t, srv, http.MethodPost,
+		"/api/v1/projects/"+targetAgent.ProjectID+"/agents/"+targetAgent.Slug+"/message",
+		MessageRequest{
+			StructuredMessage: &messages.StructuredMessage{
+				Version:        messages.Version,
+				Timestamp:      time.Now().UTC().Format(time.RFC3339),
+				Sender:         "user:dev",
+				SenderID:       DevUserID,
+				Recipient:      "agent:" + targetAgent.Slug,
+				Msg:            "DEF49 non-membership test",
+				Type:           messages.TypeInstruction,
+				ConversationID: created.ID,
+			},
+		})
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("DEF-49 facet (a): expected 403 Forbidden for non-member "+
+			"direct conversation attribution, got %d: %s",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// TestDEF49_NonExistent_ConversationID verifies that an authenticated user
+// cannot attribute a message to a conversation ID that does not exist in the
+// store (AC-D-8 facet b).
+//
+// RED on upstream/main: the if-branch sets lookupFailed=true and proceeds.
+// GREEN after DEF-49: denied with 400.
+func TestDEF49_NonExistent_ConversationID(t *testing.T) {
+	srv, _, _, targetAgent, _ := def49Setup(t)
+
+	// Use a valid-looking UUID that does not correspond to any conversation.
+	fakeConvID := tid("def49-nonexistent-conv")
+
+	rec := doRequest(t, srv, http.MethodPost,
+		"/api/v1/projects/"+targetAgent.ProjectID+"/agents/"+targetAgent.Slug+"/message",
+		MessageRequest{
+			StructuredMessage: &messages.StructuredMessage{
+				Version:        messages.Version,
+				Timestamp:      time.Now().UTC().Format(time.RFC3339),
+				Sender:         "user:dev",
+				SenderID:       DevUserID,
+				Recipient:      "agent:" + targetAgent.Slug,
+				Msg:            "DEF49 nonexistent conversation test",
+				Type:           messages.TypeInstruction,
+				ConversationID: fakeConvID,
+			},
+		})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("DEF-49 facet (b): expected 400 Bad Request for nonexistent "+
+			"conversation_id, got %d: %s",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// TestDEF49_CrossProject_GroupConversation verifies that an authenticated
+// user cannot attribute a message to a group conversation that belongs to a
+// different project than the target agent (AC-D-8 facet c).
+//
+// RED on upstream/main: the if-branch accepts any conversation_id regardless
+// of project. GREEN after DEF-49: denied with 403.
+func TestDEF49_CrossProject_GroupConversation(t *testing.T) {
+	srv, s, _, targetAgent, _ := def49Setup(t)
+	ctx := context.Background()
+
+	// Create a second project that the target agent does NOT belong to.
+	otherProjectID := tid("def49-other-project")
+	if err := s.CreateProject(ctx, &store.Project{
+		ID:         otherProjectID,
+		Name:       "def49-other-project",
+		Slug:       "def49-other-project",
+		Visibility: store.VisibilityPrivate,
+	}); err != nil {
+		t.Fatalf("CreateProject (other): %v", err)
+	}
+
+	// Create a group conversation in the OTHER project.
+	conv := &store.Conversation{
+		Kind:        "group",
+		Surface:     "native",
+		ExternalRef: "group:" + otherProjectID + ":general",
+		ProjectID:   &otherProjectID,
+		DriftState:  "active",
+	}
+	created, err := s.UpsertConversationByExternalRef(ctx, conv)
+	if err != nil {
+		t.Fatalf("UpsertConversationByExternalRef: %v", err)
+	}
+
+	// Send a message to the target agent (in the first project), claiming
+	// the conversation belongs to the other project.
+	rec := doRequest(t, srv, http.MethodPost,
+		"/api/v1/projects/"+targetAgent.ProjectID+"/agents/"+targetAgent.Slug+"/message",
+		MessageRequest{
+			StructuredMessage: &messages.StructuredMessage{
+				Version:        messages.Version,
+				Timestamp:      time.Now().UTC().Format(time.RFC3339),
+				Sender:         "user:dev",
+				SenderID:       DevUserID,
+				Recipient:      "agent:" + targetAgent.Slug,
+				Msg:            "DEF49 cross-project test",
+				Type:           messages.TypeInstruction,
+				ConversationID: created.ID,
+			},
+		})
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("DEF-49 facet (c): expected 403 Forbidden for cross-project "+
+			"group conversation attribution, got %d: %s",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// TestDEF49_LegitimatePreResolved_DirectConversation verifies that the
+// legitimate scion message @agent path — where the CLI resolves the
+// conversation and supplies the id — is still accepted after the DEF-49
+// authorization check (AC-D-9).
+//
+// The authenticated user (DevUserID) sends a message with a pre-resolved
+// conversation_id for a direct conversation whose DM key DOES name them.
+// Expected: 200 OK (or 503 if dispatcher is missing, but we set one).
+func TestDEF49_LegitimatePreResolved_DirectConversation(t *testing.T) {
+	srv, s, _, targetAgent, userID := def49Setup(t)
+	ctx := context.Background()
+
+	// Create a direct conversation between the authenticated user (DevUserID)
+	// and the target agent — exactly what `scion message @agent` would produce.
+	dmKey, err := messages.DMConversationKey("user", userID, "agent", targetAgent.ID)
+	if err != nil {
+		t.Fatalf("DMConversationKey: %v", err)
+	}
+	conv := &store.Conversation{
+		Kind:        "direct",
+		Surface:     "native",
+		ExternalRef: dmKey,
+		DriftState:  "active",
+	}
+	created, err := s.UpsertConversationByExternalRef(ctx, conv)
+	if err != nil {
+		t.Fatalf("UpsertConversationByExternalRef: %v", err)
+	}
+
+	// Send a message with the pre-resolved ConversationID — the legitimate path.
+	rec := doRequest(t, srv, http.MethodPost,
+		"/api/v1/projects/"+targetAgent.ProjectID+"/agents/"+targetAgent.Slug+"/message",
+		MessageRequest{
+			StructuredMessage: &messages.StructuredMessage{
+				Version:        messages.Version,
+				Timestamp:      time.Now().UTC().Format(time.RFC3339),
+				Sender:         "user:dev",
+				SenderID:       userID,
+				Recipient:      "agent:" + targetAgent.Slug,
+				Msg:            "DEF49 legitimate pre-resolved test",
+				Type:           messages.TypeInstruction,
+				ConversationID: created.ID,
+			},
+		})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("DEF-49 AC-D-9: expected 200 OK for legitimate pre-resolved "+
+			"conversation_id (the scion message @agent path), got %d: %s",
+			rec.Code, rec.Body.String())
+	}
+
+	// Verify the message was persisted in the correct conversation.
+	msgResult, err := s.ListMessages(ctx, store.MessageFilter{
+		ConversationID: created.ID,
+	}, store.ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMessages: %v", err)
+	}
+	if len(msgResult.Items) == 0 {
+		t.Error("expected at least one message persisted in the conversation")
+	}
+}
+
+// TestDEF49_GroupConversation_UnsetProjectID verifies that a group
+// conversation with an unset project ID (nil or the zero UUID) is
+// denied even when the agent has a real project ID. This prevents the
+// "two unset IDs compare equal" class of bug (see isUnsetProjectID in
+// validate.go:136).
+func TestDEF49_GroupConversation_UnsetProjectID(t *testing.T) {
+	srv, s, _, targetAgent, _ := def49Setup(t)
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name      string
+		projectID *string // nil or a zero-value UUID pointer
+	}{
+		{"nil project ID", nil},
+		{"zero UUID", strPtr("00000000-0000-0000-0000-000000000000")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conv := &store.Conversation{
+				Kind:        "group",
+				Surface:     "native",
+				ExternalRef: "group:unset-" + tc.name + ":general",
+				ProjectID:   tc.projectID,
+				DriftState:  "active",
+			}
+			created, err := s.UpsertConversationByExternalRef(ctx, conv)
+			if err != nil {
+				t.Fatalf("UpsertConversationByExternalRef: %v", err)
+			}
+
+			rec := doRequest(t, srv, http.MethodPost,
+				"/api/v1/projects/"+targetAgent.ProjectID+"/agents/"+targetAgent.Slug+"/message",
+				MessageRequest{
+					StructuredMessage: &messages.StructuredMessage{
+						Version:        messages.Version,
+						Timestamp:      time.Now().UTC().Format(time.RFC3339),
+						Sender:         "user:dev",
+						SenderID:       DevUserID,
+						Recipient:      "agent:" + targetAgent.Slug,
+						Msg:            "DEF49 unset project test",
+						Type:           messages.TypeInstruction,
+						ConversationID: created.ID,
+					},
+				})
+
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("expected 403 for conversation with unset project ID (%s), got %d: %s",
+					tc.name, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }


### PR DESCRIPTION
`handleAgentMessage` honoured a caller-supplied `conversation_id` with no authorization. Any authenticated caller could attribute a message into any conversation by ID.

Authority differs by kind, since direct rows have a nil ProjectID:

- `direct` — the DM key is the ACL. Delegates to the canonical `messages.CheckDMParticipantKey`. Parse failure denies; no repair or fallback.
- `group` — containment: the conversation must belong to the addressed agent's project. Denies when either project ID is unset.
- unknown kind, missing row, no authenticated identity — fail closed.

Derivation (`else`) branch untouched; B10 stands.

Also demotes the `ValidateAttributed` rejection from suggestion-commit c881db655 to a Warn log: unreachable today, but it turned a derivation failure into a 4xx, which belongs to Tranche G.

Tests: three negative tests verified RED on unmodified main; one positive test for the legitimate `@agent` path, GREEN on main; plus a divergence-mismatch test replacing coverage lost when a DEF-11 test was reworked.

Note: direct rows with unparseable `external_ref` are now denied when referenced by ID. Intended — a keyless direct row has no ACL