### PR TITLE
fix(hub): guard webChatStore reads with s.mu (DEF-42)

### DIFF
--- a/pkg/hub/handlers_agent_messaging.go
+++ b/pkg/hub/handlers_agent_messaging.go
@@ -191,8 +191,11 @@ func (s *Server) handleAgentOutboundMessage(w http.ResponseWriter, r *http.Reque
 	// (recipient, project, agent) triple. If a row exists, route to the
 	// channel the user last spoke from. If no row exists, leave channel
 	// empty so the message fans out to all spokes (today's default behavior).
-	if req.Channel == "" && recipientID != "" && s.webChatStore != nil && s.GetMessageBrokerProxy() != nil {
-		if lastCh, err := s.webChatStore.GetLastChannel(ctx, recipientID, agent.ProjectID, agent.ID); err != nil {
+	s.mu.RLock()
+	wcsAffinity := s.webChatStore
+	s.mu.RUnlock()
+	if req.Channel == "" && recipientID != "" && wcsAffinity != nil && s.GetMessageBrokerProxy() != nil {
+		if lastCh, err := wcsAffinity.GetLastChannel(ctx, recipientID, agent.ProjectID, agent.ID); err != nil {
 			s.messageLog.Error("Failed to look up reply affinity",
 				"recipient_id", recipientID, "agent_id", agent.ID, "error", err)
 			// Non-fatal: fall through to fan-out-to-all behavior.

--- a/pkg/hub/handlers_broker_inbound.go
+++ b/pkg/hub/handlers_broker_inbound.go
@@ -403,15 +403,18 @@ func (s *Server) handleBrokerInbound(w http.ResponseWriter, r *http.Request) {
 	// Record reply-affinity context so that the agent's next untagged reply
 	// can be routed back to the channel the user last spoke from (AC22).
 	// Only record for user-identity senders with a known channel.
-	if s.webChatStore != nil && req.Message.Channel != "" && strings.HasPrefix(req.Message.Sender, "user:") {
+	s.mu.RLock()
+	wcsAffinity := s.webChatStore
+	s.mu.RUnlock()
+	if wcsAffinity != nil && req.Message.Channel != "" && strings.HasPrefix(req.Message.Sender, "user:") {
 		if senderUserID != "" {
-			if err := s.webChatStore.RecordChannel(r.Context(), senderUserID, agent.ProjectID, agent.ID, req.Message.Channel, now); err != nil {
+			if err := wcsAffinity.RecordChannel(r.Context(), senderUserID, agent.ProjectID, agent.ID, req.Message.Channel, now); err != nil {
 				log.Error("Failed to record conversation context for broker inbound",
 					"user_id", senderUserID, "agent_id", agent.ID, "channel", req.Message.Channel, "error", err)
 			}
 			// Update the thread watermark so the Phase 5 thread rail reflects
 			// inbound broker messages (last_activity_at / last_message_id).
-			if err := s.webChatStore.TouchThread(r.Context(), senderUserID, agent.ProjectID, agent.ID, storeMsg.ID, now); err != nil {
+			if err := wcsAffinity.TouchThread(r.Context(), senderUserID, agent.ProjectID, agent.ID, storeMsg.ID, now); err != nil {
 				log.Error("Failed to update thread watermark for broker inbound",
 					"user_id", senderUserID, "agent_id", agent.ID, "error", err)
 			}

--- a/pkg/hub/handlers_chat.go
+++ b/pkg/hub/handlers_chat.go
@@ -44,7 +44,11 @@ func (s *Server) handleChatThreads(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.webChatStore == nil {
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
 		writeJSON(w, http.StatusOK, chatThreadsResponse{Threads: []chatThreadEntry{}})
 		return
 	}
@@ -73,7 +77,7 @@ func (s *Server) handleChatThreads(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	threads, err := s.webChatStore.GetThreads(r.Context(), user.ID(), projectID, limit)
+	threads, err := wcs.GetThreads(r.Context(), user.ID(), projectID, limit)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to fetch threads"})
 		return
@@ -201,7 +205,11 @@ func (s *Server) handleChatThreadRoutes(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if s.webChatStore == nil {
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 		return
 	}
@@ -216,7 +224,7 @@ func (s *Server) handleChatThreadRoutes(w http.ResponseWriter, r *http.Request) 
 	// DEPRECATED(wave-1): Writes to webchat_thread (wave-1 table). V2 UI uses
 	// handleConversationRead which writes to webchat_read_state instead.
 	// When v2 flag is ON, the frontend never calls this endpoint.
-	if err := s.webChatStore.MarkThreadRead(r.Context(), user.ID(), projectID, agentID); err != nil {
+	if err := wcs.MarkThreadRead(r.Context(), user.ID(), projectID, agentID); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to mark thread read"})
 		return
 	}

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -600,14 +600,18 @@ func (s *Server) createProjectGroup(ctx context.Context, project *store.Project)
 // the webchat store is configured. Best-effort: failures are logged but do not
 // block project creation.
 func (s *Server) ensureProjectGeneralTopic(ctx context.Context, project *store.Project) {
-	if s.webChatStore == nil {
+	s.mu.RLock()
+	wcs := s.webChatStore
+	s.mu.RUnlock()
+
+	if wcs == nil {
 		return
 	}
 	createdBy := project.CreatedBy
 	if createdBy == "" {
 		createdBy = "system"
 	}
-	topicID, created, err := s.webChatStore.EnsureGeneralTopic(ctx, project.ID, createdBy)
+	topicID, created, err := wcs.EnsureGeneralTopic(ctx, project.ID, createdBy)
 	if err != nil {
 		s.projectsLogger().Warn("failed to create #general topic for project",
 			"project_id", project.ID, "error", err)
@@ -620,7 +624,7 @@ func (s *Server) ensureProjectGeneralTopic(ctx context.Context, project *store.P
 	if !created {
 		return
 	}
-	topic, err := s.webChatStore.GetTopic(ctx, topicID)
+	topic, err := wcs.GetTopic(ctx, topicID)
 	if err != nil || topic == nil {
 		return
 	}

--- a/pkg/hub/webchatstore_race_test.go
+++ b/pkg/hub/webchatstore_race_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// noopWebChatStore is a minimal WebChatStore that returns zero values for every
+// method. It exists solely to exercise the read path under the race detector.
+type noopWebChatStore struct{ WebChatStore }
+
+func (noopWebChatStore) GetThreads(context.Context, string, string, int) ([]WebChatThread, error) {
+	return nil, nil
+}
+func (noopWebChatStore) MarkThreadRead(context.Context, string, string, string) error { return nil }
+func (noopWebChatStore) GetLastChannel(context.Context, string, string, string) (string, error) {
+	return "", nil
+}
+func (noopWebChatStore) RecordChannel(context.Context, string, string, string, string, time.Time) error {
+	return nil
+}
+func (noopWebChatStore) TouchThread(context.Context, string, string, string, string, time.Time) error {
+	return nil
+}
+func (noopWebChatStore) EnsureGeneralTopic(context.Context, string, string) (string, bool, error) {
+	return "", false, nil
+}
+func (noopWebChatStore) GetTopic(context.Context, string) (*WebChatTopic, error) { return nil, nil }
+
+// TestWebChatStoreRace verifies that concurrent SetWebChatStore calls do not
+// race with handler reads of s.webChatStore. Running under `go test -race`
+// would fail before the fix (DEF-42) because handlers read the field without
+// holding s.mu.
+func TestWebChatStoreRace(t *testing.T) {
+	srv, _ := testServer(t)
+
+	const goroutines = 8
+	const iterations = 200
+
+	// Build a context with an authenticated user so handlers reach the
+	// webChatStore access instead of bailing at the identity check.
+	userIdent := NewAuthenticatedUser("u-1", "race@test", "Race Tester", "admin", "test")
+	userCtx := contextWithIdentity(context.Background(), userIdent)
+
+	var wg sync.WaitGroup
+
+	// Writer goroutines: toggle webChatStore between a live store and nil.
+	for i := 0; i < goroutines/2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			noop := noopWebChatStore{}
+			for j := 0; j < iterations; j++ {
+				if j%2 == 0 {
+					srv.SetWebChatStore(noop)
+				} else {
+					srv.SetWebChatStore(nil)
+				}
+			}
+		}()
+	}
+
+	// Reader goroutines: call handleChatThreads concurrently.
+	// The handler reads s.webChatStore twice — once for the nil guard and
+	// once for GetThreads — so a concurrent write must trigger the race
+	// detector when the snapshot-under-lock fix is absent.
+	for i := 0; i < goroutines/2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				req, _ := http.NewRequestWithContext(userCtx, http.MethodGet,
+					"/api/v1/chat/threads?projectId=nonexistent", nil)
+				w := httptest.NewRecorder()
+				srv.handleChatThreads(w, req)
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/pkg/hub/webchatstore_race_test.go
+++ b/pkg/hub/webchatstore_race_test.go
@@ -51,6 +51,17 @@ func (noopWebChatStore) GetTopic(context.Context, string) (*WebChatTopic, error)
 // race with handler reads of s.webChatStore. Running under `go test -race`
 // would fail before the fix (DEF-42) because handlers read the field without
 // holding s.mu.
+//
+// WARNING: This test is a no-op without the race detector. A green run
+// under `go test ./pkg/hub/` (no -race) proves nothing — the test
+// exercises a concurrency window that only the race detector can observe.
+// To get a meaningful result, run:
+//
+//   go test ./pkg/hub/ -run TestWebChatStoreRace -race
+//
+// CI does not currently pass -race, so this test does not gate merges.
+// It exists for local verification and will become load-bearing if/when
+// a -race CI job is added.
 func TestWebChatStoreRace(t *testing.T) {
 	srv, _ := testServer(t)
 

--- a/pkg/hub/webchatstore_race_test.go
+++ b/pkg/hub/webchatstore_race_test.go
@@ -57,7 +57,7 @@ func (noopWebChatStore) GetTopic(context.Context, string) (*WebChatTopic, error)
 // exercises a concurrency window that only the race detector can observe.
 // To get a meaningful result, run:
 //
-//   go test ./pkg/hub/ -run TestWebChatStoreRace -race
+//	go test ./pkg/hub/ -run TestWebChatStoreRace -race
 //
 // CI does not currently pass -race, so this test does not gate merges.
 // It exists for local verification and will become load-bearing if/when


### PR DESCRIPTION
Twelve reads of `s.webChatStore` in the hub handlers were unsynchronised while `SetWebChatStore` writes the field under `s.mu.Lock()`. Startup order varies, so the writer can land after handlers are serving.

Each read now uses the existing snapshot-under-RLock idiom from `handlers_chat_v2.go:91`: RLock, copy to a local, unlock, then nil-check and use the local. This also fixes a second-order bug — `handleChatThreads` read the field twice, so the nil guard and the call could disagree.

`server.go:2408` is deliberately untouched: it already holds `s.mu.Lock()`, and RWMutex is not reentrant, so an RLock there would deadlock.

Verification on unmodified main with the new test applied:

    without -race:  ok
    with -race:     DATA RACE at handlers_chat.go:47

Known limitation, stated in the test comment: CI passes `-race` nowhere, so this test does not gate merges — it is green with or without the fix. The comment says so rather than implying coverage it lacks. A `-race` job is a CI gate change, tracked separately as DEF-52.

All 12 deletions are 1:1 replacements of the unguarded read lines