### PR TITLE
fix(cli): validate @email messages before conversation resolve (DEF-51)

### DIFF
--- a/cmd/message.go
+++ b/cmd/message.go
@@ -705,6 +705,37 @@ func sendMessageViaConversation(hubCtx *HubContext, ref *messaging.Reference, me
 		}
 	}
 
+	// DEF-51: for @email references, construct the OutboundMessageRequest
+	// before resolve and validate it through the legacy choke point. The
+	// probe is derived from outMsg's actual fields — not from
+	// buildStructuredMessage — so the validated envelope matches the sent
+	// envelope by construction. Fields the @email path does not send
+	// (Channel, ThreadID, Attachments) are zero in both outMsg and probe,
+	// which closes two divergence directions:
+	//   - thread_id-without-channel cannot fire (no false rejection)
+	//   - empty-msg-with-attachments cannot pass (no missed rejection)
+	// Metadata.conversation_id is set after resolve; it is not validated.
+	var outMsg *hubclient.OutboundMessageRequest
+	if ref.Kind == messaging.RefEmail {
+		outMsg = &hubclient.OutboundMessageRequest{
+			Recipient: "user:" + ref.Value,
+			Msg:       message,
+			Type:      "instruction",
+			Urgent:    interrupt,
+		}
+		probe := &messages.StructuredMessage{
+			Version:   messages.Version,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			Sender:    emailSenderAgent,
+			Recipient: outMsg.Recipient,
+			Msg:       outMsg.Msg,
+			Type:      outMsg.Type,
+		}
+		if err := messaging.ValidateLegacyMessage(probe); err != nil {
+			return fmt.Errorf("message validation failed: %w", err)
+		}
+	}
+
 	if !isJSONOutput() {
 		fmt.Printf("Resolving conversation reference %q...\n", ref.Raw)
 	}
@@ -747,21 +778,11 @@ func sendMessageViaConversation(hubCtx *HubContext, ref *messaging.Reference, me
 		return nil
 	}
 
-	// @email path: no StructuredMessage is constructed, so there is no
-	// ValidateLegacyMessage to hoist. The agent-context precondition
-	// (SCION_AGENT_NAME) is hoisted above resolve alongside the @agent
-	// validation — same orphan-row pattern.
-	//
-	// For @<email> references, route as outbound user message with conversation_id.
+	// @email send: outMsg was constructed and validated before resolve
+	// (DEF-51). Set the conversation_id that resolve produced and send.
 	if ref.Kind == messaging.RefEmail {
+		outMsg.Metadata = map[string]string{"conversation_id": resolveResp.ConversationID}
 		agentSvc := hubCtx.Client.ProjectAgents(projectID)
-		outMsg := &hubclient.OutboundMessageRequest{
-			Recipient: "user:" + ref.Value,
-			Msg:       message,
-			Type:      "instruction",
-			Urgent:    interrupt,
-			Metadata:  map[string]string{"conversation_id": resolveResp.ConversationID},
-		}
 		if err := agentSvc.SendOutboundMessage(ctx, emailSenderAgent, outMsg); err != nil {
 			return wrapHubError(fmt.Errorf("failed to send message to %s: %w", ref.Raw, err))
 		}

--- a/cmd/message_convref_test.go
+++ b/cmd/message_convref_test.go
@@ -492,3 +492,99 @@ func TestSendMessageViaConversation_EmailPreconditionBeforeResolve(t *testing.T)
 	assert.Len(t, *sent, 0, "no agent messages should be sent")
 	assert.Len(t, *outbound, 0, "no outbound messages should be sent")
 }
+
+// TestSendMessageViaConversation_EmailThreadIDWithoutChannel verifies that
+// --thread-id without --channel does NOT cause a false rejection on the @email
+// path. The @email path drops both fields (they are not in OutboundMessageRequest
+// as constructed), so the thread_id-requires-channel rule must not fire.
+// DEF-51 Direction 1: false rejection.
+func TestSendMessageViaConversation_EmailThreadIDWithoutChannel(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+	restoreFlags := resetMessageFlags()
+	defer restoreFlags()
+
+	// Set thread-id without channel — would fail ValidateLegacyMessage if
+	// those CLI flags leaked into the validation probe.
+	msgThreadID = "some-thread"
+	msgChannel = ""
+
+	t.Setenv("SCION_AGENT_NAME", "test-sender-agent")
+
+	projectID := "proj-convref-email-threadid"
+	server, sent, resolves, outbound := newConvRefMockHubServer(t, projectID)
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
+	}
+
+	ref := &messaging.Reference{
+		Kind:  messaging.RefEmail,
+		Value: "user@example.com",
+		Raw:   "@user@example.com",
+	}
+
+	err = sendMessageViaConversation(hubCtx, ref, "hello with thread", false, false)
+	require.NoError(t, err, "thread-id without channel must not be rejected on @email path")
+
+	// Resolve was called (message is valid, send proceeds).
+	assert.Len(t, *resolves, 1, "ResolveConversation should be called for valid email message")
+	assert.Len(t, *outbound, 1, "outbound message should be delivered")
+	assert.Len(t, *sent, 0, "no agent messages should be sent on email path")
+}
+
+// TestSendMessageViaConversation_EmailEmptyMsgBeforeResolve verifies DEF-51:
+// an empty message body on the @email path must fail validation before
+// ResolveConversation runs, even when --attach is set. The @email path drops
+// attachments, so the empty-body waiver (which requires attachments) must not
+// apply — the validated probe must reflect the sent envelope.
+// DEF-51 Direction 2: missed rejection.
+func TestSendMessageViaConversation_EmailEmptyMsgBeforeResolve(t *testing.T) {
+	orig := saveMessageTestState()
+	defer orig.restore()
+	restoreFlags := resetMessageFlags()
+	defer restoreFlags()
+
+	// Set attachments via CLI flag — buildStructuredMessage would include
+	// them, but the @email OutboundMessageRequest does not carry them.
+	msgAttach = []string{"/workspace/x.png"}
+
+	t.Setenv("SCION_AGENT_NAME", "test-sender-agent")
+
+	projectID := "proj-convref-email-empty-msg"
+	server, sent, resolves, outbound := newConvRefMockHubServer(t, projectID)
+	defer server.Close()
+
+	client, err := hubclient.New(server.URL)
+	require.NoError(t, err)
+
+	hubCtx := &HubContext{
+		Client:    client,
+		Endpoint:  server.URL,
+		ProjectID: projectID,
+	}
+
+	ref := &messaging.Reference{
+		Kind:  messaging.RefEmail,
+		Value: "user@example.com",
+		Raw:   "@user@example.com",
+	}
+
+	// Empty message body with attachments — ValidateLegacyMessage waives
+	// empty-body when attachments are present, but the @email path does not
+	// send attachments. The probe must reflect the sent envelope.
+	err = sendMessageViaConversation(hubCtx, ref, "", false, false)
+	require.Error(t, err, "empty message on @email path must fail validation")
+	assert.Contains(t, err.Error(), "validation failed")
+
+	// DEF-51: ResolveConversation must NOT have been called.
+	assert.Len(t, *resolves, 0, "ResolveConversation must not be called when email validation fails (DEF-51)")
+	assert.Len(t, *sent, 0, "no agent messages should be sent")
+	assert.Len(t, *outbound, 0, "no outbound messages should be sent")
+}


### PR DESCRIPTION
`ResolveConversation` can CREATE a row, and on the `@email` path it ran before the send. A server-side rejection after that left the row orphaned.

DEF-48 hoisted the `@agent` validation above the resolve but reasoned per *mechanism* — "no StructuredMessage is constructed, so nothing to hoist" — rather than per *call order*, which is what produces the orphan. That comment is deleted here.

`OutboundMessageRequest` is now built before the resolve and validated through the existing choke point. The probe derives its fields from `outMsg`, not `buildStructuredMessage`, so the validated envelope is the sent envelope by construction. That matters in both directions, since `buildStructuredMessage` fills Channel/ThreadID/Attachments from flags the `@email` path drops:

- False rejection: `--thread-id` without `--channel` would fail on a field never sent.
- Missed rejection: empty msg + `--attach` passes the validator (empty-body waived when attachments present) but the hub rejects unconditionally — the orphan would have survived the fix.

`EmptyMsgBeforeResolve` asserts `ResolveConversation` is never called — the row's absence, not just the error. Verified red on unmodified main.

13 deletions: 6 comments, 7 lines of `outMsg` relocated