### PR TITLE
fix: add Allow header to 405 MethodNotAllowed responses

### DIFF
--- a/pkg/hub/admin_validate.go
+++ b/pkg/hub/admin_validate.go
@@ -24,7 +24,7 @@ import (
 // resources (templates and harness-configs). Requires admin role.
 func (s *Server) handleAdminValidateResources(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodGet)
 		return
 	}
 

--- a/pkg/hub/errors.go
+++ b/pkg/hub/errors.go
@@ -219,7 +219,11 @@ func InternalError(w http.ResponseWriter) {
 }
 
 // MethodNotAllowed writes a 405 Method Not Allowed response.
-func MethodNotAllowed(w http.ResponseWriter) {
+// If allowedMethods are provided, an Allow header is set per RFC 9110 §15.5.6.
+func MethodNotAllowed(w http.ResponseWriter, allowedMethods ...string) {
+	if len(allowedMethods) > 0 {
+		w.Header().Set("Allow", strings.Join(allowedMethods, ", "))
+	}
 	writeError(w, http.StatusMethodNotAllowed, "method_not_allowed",
 		"Method not allowed", nil)
 }

--- a/pkg/hub/errors_test.go
+++ b/pkg/hub/errors_test.go
@@ -60,6 +60,50 @@ func TestWriteErrorFromErr_PermissionError(t *testing.T) {
 	}
 }
 
+func TestMethodNotAllowed_WithAllowedMethods(t *testing.T) {
+	rr := httptest.NewRecorder()
+	MethodNotAllowed(rr, http.MethodGet, http.MethodPost)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
+	}
+
+	allow := rr.Header().Get("Allow")
+	if allow != "GET, POST" {
+		t.Errorf("expected Allow header %q, got %q", "GET, POST", allow)
+	}
+
+	var resp ErrorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Error.Code != "method_not_allowed" {
+		t.Errorf("expected error code %q, got %q", "method_not_allowed", resp.Error.Code)
+	}
+}
+
+func TestMethodNotAllowed_WithoutAllowedMethods(t *testing.T) {
+	rr := httptest.NewRecorder()
+	MethodNotAllowed(rr)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, rr.Code)
+	}
+
+	allow := rr.Header().Get("Allow")
+	if allow != "" {
+		t.Errorf("expected no Allow header, got %q", allow)
+	}
+
+	var resp ErrorResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Error.Code != "method_not_allowed" {
+		t.Errorf("expected error code %q, got %q", "method_not_allowed", resp.Error.Code)
+	}
+}
+
 func TestWriteErrorFromErr_GenericError_Still500(t *testing.T) {
 	// A generic error that is NOT a PermissionError should still be 500
 	err := fmt.Errorf("something went wrong")

--- a/pkg/hub/handlers_runtime_brokers.go
+++ b/pkg/hub/handlers_runtime_brokers.go
@@ -62,7 +62,7 @@ func (s *Server) handleRuntimeBrokers(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		s.listRuntimeBrokers(w, r)
 	default:
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodGet)
 	}
 }
 
@@ -267,7 +267,7 @@ func (s *Server) handleRuntimeBrokerByIDInternal(w http.ResponseWriter, r *http.
 	case http.MethodDelete:
 		s.deleteRuntimeBroker(w, r, id)
 	default:
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodGet, http.MethodPatch, http.MethodDelete)
 	}
 }
 
@@ -293,7 +293,7 @@ func (s *Server) handleRuntimeBrokerByID(w http.ResponseWriter, r *http.Request)
 	case http.MethodDelete:
 		s.deleteRuntimeBroker(w, r, id)
 	default:
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodGet, http.MethodPatch, http.MethodDelete)
 	}
 }
 

--- a/pkg/hub/handlers_shared_dirs.go
+++ b/pkg/hub/handlers_shared_dirs.go
@@ -117,7 +117,7 @@ func (s *Server) handleProjectSharedDirs(w http.ResponseWriter, r *http.Request,
 		writeJSON(w, http.StatusCreated, newDir)
 
 	default:
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodGet, http.MethodPost)
 	}
 }
 
@@ -208,6 +208,6 @@ func (s *Server) handleProjectSharedDirByName(w http.ResponseWriter, r *http.Req
 		w.WriteHeader(http.StatusNoContent)
 
 	default:
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodDelete)
 	}
 }

--- a/pkg/hub/handlers_teams_manifest.go
+++ b/pkg/hub/handlers_teams_manifest.go
@@ -100,7 +100,7 @@ type teamsBotCommand struct {
 // Authorization: route guard checks hub.teams_manifest.read.
 func (s *Server) handleTeamsManifestDownload(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodGet)
 		return
 	}
 

--- a/pkg/hub/project_settings_handlers.go
+++ b/pkg/hub/project_settings_handlers.go
@@ -244,7 +244,7 @@ func (s *Server) handleProjectSettings(w http.ResponseWriter, r *http.Request, p
 		writeJSON(w, http.StatusOK, projectSettingsFromAnnotations(project))
 
 	default:
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodGet, http.MethodPut)
 	}
 }
 

--- a/pkg/hub/system_handlers.go
+++ b/pkg/hub/system_handlers.go
@@ -82,7 +82,7 @@ func GatherDiagnostics(ctx context.Context, cfg *config.VersionedSettings) []Dia
 
 func (s *Server) handleSystemCheck(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodGet)
 		return
 	}
 
@@ -138,7 +138,7 @@ func (s *Server) handleSystemRuntime(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPut:
 		s.handlePutRuntime(w, r)
 	default:
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodGet, http.MethodPut)
 	}
 }
 
@@ -250,7 +250,7 @@ type putRegistryResponse struct {
 
 func (s *Server) handleSystemRegistry(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPut {
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodPut)
 		return
 	}
 
@@ -419,7 +419,7 @@ func (s *Server) computeOnboardingStatus(ctx context.Context) OnboardingStatus {
 
 func (s *Server) handleSystemStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodGet)
 		return
 	}
 
@@ -445,7 +445,7 @@ type systemInitResponse struct {
 
 func (s *Server) handleSystemInit(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodPost)
 		return
 	}
 
@@ -583,7 +583,7 @@ type imagePullResponse struct {
 
 func (s *Server) handleSystemImagesPull(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodPost)
 		return
 	}
 
@@ -699,7 +699,7 @@ func resolveBuildScript() string {
 
 func (s *Server) handleSystemImagesBuild(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodPost)
 		return
 	}
 
@@ -813,7 +813,7 @@ type fsListResponse struct {
 
 func (s *Server) handleFSList(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodGet)
 		return
 	}
 
@@ -902,7 +902,7 @@ type fsMkdirResponse struct {
 
 func (s *Server) handleFSMkdir(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodPost)
 		return
 	}
 
@@ -988,7 +988,7 @@ type fsValidatePathResponse struct {
 // ClassifyPath's managed-path overlap check and the assertLoopback guard.
 func (s *Server) handleFSValidatePath(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodPost)
 		return
 	}
 
@@ -1045,7 +1045,7 @@ func (s *Server) handleAppleDNS(w http.ResponseWriter, r *http.Request) {
 	case http.MethodPost:
 		s.handleAppleDNSSetup(w, r)
 	default:
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodGet, http.MethodPost)
 	}
 }
 
@@ -1086,7 +1086,7 @@ type workstationSettingsRequest struct {
 // It allows toggling workstation-level settings without requiring admin role.
 func (s *Server) handleWorkstationSettings(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPatch {
-		MethodNotAllowed(w)
+		MethodNotAllowed(w, http.MethodPatch)
 		return
 	}
 


### PR DESCRIPTION
Fixes ptone/scion#1379 - MethodNotAllowed missing Allow header (RFC 9110)

- Add variadic allowedMethods to MethodNotAllowed helper
- Update all 20 call sites with correct supported methods
- PR #1380, CI green, reviewer APPROVE