### PR TITLE
feat(hub): extend admin-status endpoint with per-resource permissions array

### DIFF
--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -650,16 +650,19 @@ func (s *Server) handleAuthAdminStatus(w http.ResponseWriter, r *http.Request) {
 			store.RoleScopeSystem, "",
 		)
 		if err != nil {
-			slog.Warn("failed to resolve effective permissions for admin-status",
+			slog.Error("failed to resolve effective permissions for admin-status",
 				"user_id", user.ID(), "error", err)
-		} else {
-			perms = effective
+			InternalError(w)
+			return
 		}
+		perms = effective
 	}
 
 	// Ensure JSON serializes as [] rather than null when there are no permissions.
 	if perms == nil {
 		perms = []string{}
+	} else {
+		sort.Strings(perms)
 	}
 
 	writeJSON(w, http.StatusOK, AdminStatusResponse{

--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -610,14 +610,16 @@ func (s *Server) handleAuthMe(w http.ResponseWriter, r *http.Request) {
 
 // AdminStatusResponse is the response for GET /api/v1/auth/admin-status.
 type AdminStatusResponse struct {
-	IsAdmin      bool `json:"isAdmin"`
-	IsSuperAdmin bool `json:"isSuperAdmin"`
+	IsAdmin      bool     `json:"isAdmin"`
+	IsSuperAdmin bool     `json:"isSuperAdmin"`
+	Permissions  []string `json:"permissions"`
 }
 
 // handleAuthAdminStatus handles GET /api/v1/auth/admin-status.
-// Returns whether the current user has hub-admin or super-admin capabilities.
-// This is used by the frontend to decide whether to show admin navigation
-// and allow access to admin routes.
+// Returns whether the current user has hub-admin or super-admin capabilities,
+// along with their effective system-scoped permission IDs.
+// This is used by the frontend to decide whether to show admin navigation,
+// which admin sections are visible, and to allow access to admin routes.
 func (s *Server) handleAuthAdminStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("Allow", http.MethodGet)
@@ -632,14 +634,38 @@ func (s *Server) handleAuthAdminStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	isSuperAdmin := IsUnscopedLocalPlatformAdmin(user)
-	isHubAdmin := false
-	if s.authzService != nil {
-		isHubAdmin = s.authzService.IsHubAdmin(r.Context(), user.ID())
+
+	var perms []string
+	if isSuperAdmin {
+		// Super-admin has all permissions — populate from registry so the
+		// frontend shows all UI elements without a separate code path.
+		perms = allPermissionIDs()
+	} else if s.authzService != nil {
+		// Resolve effective permissions from all system-scoped role bindings
+		// for this user. This handles both the built-in hub-admin role and
+		// any custom roles with partial permissions.
+		effective, err := s.authzService.getEffectivePermissions(
+			r.Context(),
+			store.RoleBindingPrincipalUser, user.ID(),
+			store.RoleScopeSystem, "",
+		)
+		if err != nil {
+			slog.Warn("failed to resolve effective permissions for admin-status",
+				"user_id", user.ID(), "error", err)
+		} else {
+			perms = effective
+		}
+	}
+
+	// Ensure JSON serializes as [] rather than null when there are no permissions.
+	if perms == nil {
+		perms = []string{}
 	}
 
 	writeJSON(w, http.StatusOK, AdminStatusResponse{
-		IsAdmin:      isSuperAdmin || isHubAdmin,
+		IsAdmin:      isSuperAdmin || len(perms) > 0,
 		IsSuperAdmin: isSuperAdmin,
+		Permissions:  perms,
 	})
 }
 

--- a/pkg/hub/handlers_auth_test.go
+++ b/pkg/hub/handlers_auth_test.go
@@ -1242,6 +1242,22 @@ func TestHandleAuthAdminStatus_SuperAdmin(t *testing.T) {
 	if !resp.IsSuperAdmin {
 		t.Error("expected isSuperAdmin=true for super-admin")
 	}
+
+	// Super-admin should receive all permission IDs from the registry.
+	allIDs := allPermissionIDs()
+	if len(resp.Permissions) != len(allIDs) {
+		t.Errorf("expected %d permissions for super-admin, got %d", len(allIDs), len(resp.Permissions))
+	}
+	// Verify every registry permission is present in the response.
+	permSet := make(map[string]bool, len(resp.Permissions))
+	for _, p := range resp.Permissions {
+		permSet[p] = true
+	}
+	for _, id := range allIDs {
+		if !permSet[id] {
+			t.Errorf("super-admin permissions missing registry ID %q", id)
+		}
+	}
 }
 
 func TestHandleAuthAdminStatus_HubAdmin(t *testing.T) {
@@ -1288,6 +1304,21 @@ func TestHandleAuthAdminStatus_HubAdmin(t *testing.T) {
 	if resp.IsSuperAdmin {
 		t.Error("expected isSuperAdmin=false for hub-admin (non-super-admin) user")
 	}
+
+	// Hub-admin should have the curated hub-admin permission set.
+	expectedPerms := hubAdminPermissionIDs()
+	if len(resp.Permissions) != len(expectedPerms) {
+		t.Errorf("expected %d permissions for hub-admin, got %d", len(expectedPerms), len(resp.Permissions))
+	}
+	permSet := make(map[string]bool, len(resp.Permissions))
+	for _, p := range resp.Permissions {
+		permSet[p] = true
+	}
+	for _, id := range expectedPerms {
+		if !permSet[id] {
+			t.Errorf("hub-admin permissions missing expected ID %q", id)
+		}
+	}
 }
 
 func TestHandleAuthAdminStatus_PlainMember(t *testing.T) {
@@ -1320,6 +1351,126 @@ func TestHandleAuthAdminStatus_PlainMember(t *testing.T) {
 	}
 	if resp.IsSuperAdmin {
 		t.Error("expected isSuperAdmin=false for plain member")
+	}
+
+	// Plain member should have an empty permissions array (not null).
+	if resp.Permissions == nil {
+		t.Error("expected permissions to be an empty array, got nil")
+	}
+	if len(resp.Permissions) != 0 {
+		t.Errorf("expected 0 permissions for plain member, got %d: %v", len(resp.Permissions), resp.Permissions)
+	}
+}
+
+func TestHandleAuthAdminStatus_CustomRole(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// Create a custom role with only template permissions.
+	customRole, err := s.CreateRoleDefinition(ctx, &store.RoleDefinition{
+		Name:        "template-manager",
+		Description: "Can manage templates only",
+		ScopeType:   store.RoleScopeSystem,
+		Permissions: []string{"template.list", "template.read", "template.create", "template.update", "template.delete"},
+		System:      false,
+	})
+	require.NoError(t, err)
+
+	// Create a non-admin user and bind the custom role.
+	userID := tid("custom-role-handler")
+	require.NoError(t, s.CreateUser(ctx, &store.User{
+		ID: userID, Email: "customrole@test.com", DisplayName: "CustomRole", Role: "member", Status: "active",
+	}))
+	_, err = s.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: customRole.ID,
+		PrincipalType:    store.RoleBindingPrincipalUser,
+		PrincipalID:      userID,
+		ScopeType:        store.RoleScopeSystem,
+		ScopeID:          "",
+		CreatedBy:        "test",
+	})
+	require.NoError(t, err)
+
+	token, _, _, err := srv.userTokenService.GenerateTokenPair(
+		userID, "customrole@test.com", "CustomRole", "member", ClientTypeWeb,
+	)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/admin-status", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "response body: %s", rec.Body.String())
+
+	var resp AdminStatusResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	// Custom role with permissions → isAdmin=true, isSuperAdmin=false.
+	if !resp.IsAdmin {
+		t.Error("expected isAdmin=true for user with custom role permissions")
+	}
+	if resp.IsSuperAdmin {
+		t.Error("expected isSuperAdmin=false for user with custom role")
+	}
+
+	// Permissions should contain exactly the template permission IDs.
+	expectedPerms := map[string]bool{
+		"template.list":   true,
+		"template.read":   true,
+		"template.create": true,
+		"template.update": true,
+		"template.delete": true,
+	}
+	if len(resp.Permissions) != len(expectedPerms) {
+		t.Fatalf("expected %d permissions, got %d: %v", len(expectedPerms), len(resp.Permissions), resp.Permissions)
+	}
+	for _, p := range resp.Permissions {
+		if !expectedPerms[p] {
+			t.Errorf("unexpected permission %q in custom role response", p)
+		}
+	}
+	for p := range expectedPerms {
+		found := false
+		for _, rp := range resp.Permissions {
+			if rp == p {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing expected permission %q in custom role response", p)
+		}
+	}
+}
+
+func TestHandleAuthAdminStatus_PermissionsSerializedAsEmptyArray(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	// A plain member with no role bindings should serialize permissions as []
+	// (JSON empty array), NOT null.
+	userID := tid("empty-perms-handler")
+	require.NoError(t, s.CreateUser(ctx, &store.User{
+		ID: userID, Email: "emptyperms@test.com", DisplayName: "EmptyPerms", Role: "member", Status: "active",
+	}))
+
+	token, _, _, err := srv.userTokenService.GenerateTokenPair(
+		userID, "emptyperms@test.com", "EmptyPerms", "member", ClientTypeWeb,
+	)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/admin-status", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify the raw JSON contains "permissions":[] not "permissions":null.
+	body := rec.Body.String()
+	if !strings.Contains(body, `"permissions":[]`) {
+		t.Errorf("expected permissions to serialize as empty array [], got body: %s", body)
 	}
 }
 

--- a/pkg/hub/handlers_auth_test.go
+++ b/pkg/hub/handlers_auth_test.go
@@ -1245,19 +1245,7 @@ func TestHandleAuthAdminStatus_SuperAdmin(t *testing.T) {
 
 	// Super-admin should receive all permission IDs from the registry.
 	allIDs := allPermissionIDs()
-	if len(resp.Permissions) != len(allIDs) {
-		t.Errorf("expected %d permissions for super-admin, got %d", len(allIDs), len(resp.Permissions))
-	}
-	// Verify every registry permission is present in the response.
-	permSet := make(map[string]bool, len(resp.Permissions))
-	for _, p := range resp.Permissions {
-		permSet[p] = true
-	}
-	for _, id := range allIDs {
-		if !permSet[id] {
-			t.Errorf("super-admin permissions missing registry ID %q", id)
-		}
-	}
+	require.ElementsMatch(t, allIDs, resp.Permissions)
 }
 
 func TestHandleAuthAdminStatus_HubAdmin(t *testing.T) {
@@ -1307,18 +1295,7 @@ func TestHandleAuthAdminStatus_HubAdmin(t *testing.T) {
 
 	// Hub-admin should have the curated hub-admin permission set.
 	expectedPerms := hubAdminPermissionIDs()
-	if len(resp.Permissions) != len(expectedPerms) {
-		t.Errorf("expected %d permissions for hub-admin, got %d", len(expectedPerms), len(resp.Permissions))
-	}
-	permSet := make(map[string]bool, len(resp.Permissions))
-	for _, p := range resp.Permissions {
-		permSet[p] = true
-	}
-	for _, id := range expectedPerms {
-		if !permSet[id] {
-			t.Errorf("hub-admin permissions missing expected ID %q", id)
-		}
-	}
+	require.ElementsMatch(t, expectedPerms, resp.Permissions)
 }
 
 func TestHandleAuthAdminStatus_PlainMember(t *testing.T) {
@@ -1415,33 +1392,14 @@ func TestHandleAuthAdminStatus_CustomRole(t *testing.T) {
 	}
 
 	// Permissions should contain exactly the template permission IDs.
-	expectedPerms := map[string]bool{
-		"template.list":   true,
-		"template.read":   true,
-		"template.create": true,
-		"template.update": true,
-		"template.delete": true,
+	expectedPerms := []string{
+		"template.list",
+		"template.read",
+		"template.create",
+		"template.update",
+		"template.delete",
 	}
-	if len(resp.Permissions) != len(expectedPerms) {
-		t.Fatalf("expected %d permissions, got %d: %v", len(expectedPerms), len(resp.Permissions), resp.Permissions)
-	}
-	for _, p := range resp.Permissions {
-		if !expectedPerms[p] {
-			t.Errorf("unexpected permission %q in custom role response", p)
-		}
-	}
-	for p := range expectedPerms {
-		found := false
-		for _, rp := range resp.Permissions {
-			if rp == p {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("missing expected permission %q in custom role response", p)
-		}
-	}
+	require.ElementsMatch(t, expectedPerms, resp.Permissions)
 }
 
 func TestHandleAuthAdminStatus_PermissionsSerializedAsEmptyArray(t *testing.T) {


### PR DESCRIPTION
Extends GET /api/v1/auth/admin-status to return the caller's effective system-scoped permissions, enabling per-resource admin UI visibility (Phase 1 of 3).