### PR TITLE
feat(web): replace binary admin gate with per-resource permission checks

### DIFF
--- a/web/src/client/main.ts
+++ b/web/src/client/main.ts
@@ -32,6 +32,12 @@ import { CHAT_DM_ROUTE, CHAT_SPACE_ROUTE, CHAT_THREAD_ROUTE } from './chat-route
 import { chatNotifications } from './chat-notifications.js';
 import { chatUnread } from './chat-unread.js';
 import { isFeatureEnabled, setFeatureFlag } from '../utils/feature-flags.js';
+import {
+  type AdminStatus,
+  hasAnyPermission,
+  ROUTE_PERMISSION_MAP,
+  SUPERADMIN_ROUTES,
+} from '../lib/admin-permissions.js';
 
 /**
  * Strip the Vite base path prefix from a URL pathname so the client-side
@@ -129,19 +135,25 @@ let ssrPageData: PageData | null = null;
  * Cached admin-status flags, fetched once on init from
  * GET /api/v1/auth/admin-status. Used by the route guard to allow
  * hub-admin users (not just super-admins) to access admin pages.
+ * Includes the permissions array for per-route permission checks.
  */
-let cachedAdminStatus: { isAdmin: boolean; isSuperAdmin: boolean } | null = null;
+let cachedAdminStatus: AdminStatus | null = null;
 
 /**
  * Fetch the current user's admin status from the backend.
  * Returns null when the user is not authenticated or the fetch fails.
+ * Includes the permissions array for per-resource permission checks.
  */
-async function fetchAdminStatus(): Promise<{ isAdmin: boolean; isSuperAdmin: boolean } | null> {
+async function fetchAdminStatus(): Promise<AdminStatus | null> {
   try {
     const res = await fetch('/api/v1/auth/admin-status', { credentials: 'include' });
     if (!res.ok) return null;
     const data = await res.json();
-    return { isAdmin: data.isAdmin === true, isSuperAdmin: data.isSuperAdmin === true };
+    return {
+      isAdmin: data.isAdmin === true,
+      isSuperAdmin: data.isSuperAdmin === true,
+      permissions: Array.isArray(data.permissions) ? data.permissions : [],
+    };
   } catch {
     return null;
   }
@@ -807,11 +819,24 @@ async function renderRoute(path: string): Promise<void> {
   // than being cached for the entire SPA lifetime. The init-time fetch
   // remains for nav.ts's initial render; this call replaces the cache so
   // the route guard always uses a fresh result.
+  //
+  // Per-route permission checks: super-admin-only routes (Diagnostics,
+  // Maintenance) require isSuperAdmin; other admin routes require at least
+  // one matching permission from ROUTE_PERMISSION_MAP.
   if (ADMIN_ROUTES.has(tag)) {
     cachedAdminStatus = await fetchAdminStatus();
-    if (!(cachedAdminStatus?.isAdmin)) {
-      navigateTo('/');
-      return;
+
+    if (SUPERADMIN_ROUTES.has(tag)) {
+      if (!cachedAdminStatus?.isSuperAdmin) {
+        navigateTo('/');
+        return;
+      }
+    } else {
+      const requiredPerms = ROUTE_PERMISSION_MAP[tag];
+      if (!requiredPerms || !hasAnyPermission(cachedAdminStatus, requiredPerms)) {
+        navigateTo('/');
+        return;
+      }
     }
   }
 

--- a/web/src/components/shared/nav.ts
+++ b/web/src/components/shared/nav.ts
@@ -25,6 +25,11 @@ import { customElement, property, state } from 'lit/decorators.js';
 
 import type { User } from '../../shared/types.js';
 import { apiFetch } from '../../client/api.js';
+import {
+  type AdminStatus,
+  hasAnyPermission,
+  NAV_PERMISSION_MAP,
+} from '../../lib/admin-permissions.js';
 
 interface NavItem {
   path: string;
@@ -112,12 +117,12 @@ export class ScionNav extends LitElement {
   hideCollapse = false;
 
   /**
-   * Whether the current user has admin capabilities (hub-admin or super-admin).
-   * Detected by probing an admin endpoint — the backend enforces access control,
-   * so showing the nav is purely a UX convenience.
+   * The current user's admin status including per-resource permissions.
+   * null when the user is not an admin or status has not been checked yet.
+   * The nav uses this to show only the admin items the user has permissions for.
    */
   @state()
-  private hasAdminCapabilities = false;
+  private adminStatus: AdminStatus | null = null;
 
   /** Tracks the user ID for which admin capabilities were last checked. */
   private adminCheckUserId: string | null = null;
@@ -131,12 +136,11 @@ export class ScionNav extends LitElement {
   /**
    * Detect whether the current user has admin capabilities by calling
    * the dedicated admin-status endpoint, which returns explicit boolean
-   * flags for hub-admin and super-admin status.
+   * flags for hub-admin and super-admin status plus a permissions array.
    *
    * Super-admin users are detected directly via `user.role === 'admin'`
-   * and skip the API call. For hub-admin users (who have admin role
-   * bindings but not the super-admin role), the endpoint determines
-   * nav visibility.
+   * and skip the API call. For hub-admin and custom-role users, the
+   * endpoint determines which nav items are visible.
    */
   private async checkAdminCapabilities(): Promise<void> {
     const userId = this.user?.id ?? null;
@@ -145,33 +149,43 @@ export class ScionNav extends LitElement {
     if (userId === this.adminCheckUserId) return;
     this.adminCheckUserId = userId;
 
-    // Super-admins always have admin capabilities
+    // Super-admins always have admin capabilities — create an AdminStatus
+    // with isSuperAdmin: true so hasAnyPermission() short-circuits.
     if (this.user?.role === 'admin') {
-      this.hasAdminCapabilities = true;
+      this.adminStatus = { isAdmin: true, isSuperAdmin: true, permissions: [] };
       return;
     }
 
     // No user = no admin access
     if (!this.user) {
-      this.hasAdminCapabilities = false;
+      this.adminStatus = null;
       return;
     }
 
-    // Call the dedicated admin-status endpoint to detect hub-admin status.
+    // Call the dedicated admin-status endpoint to detect admin status
+    // and retrieve per-resource permissions.
     try {
       const res = await apiFetch('/api/v1/auth/admin-status');
       // Only apply result if user hasn't changed during the fetch
       if (this.adminCheckUserId === userId) {
         if (res.ok) {
           const data = await res.json();
-          this.hasAdminCapabilities = data.isAdmin === true;
+          if (data.isAdmin === true) {
+            this.adminStatus = {
+              isAdmin: true,
+              isSuperAdmin: data.isSuperAdmin === true,
+              permissions: Array.isArray(data.permissions) ? data.permissions : [],
+            };
+          } else {
+            this.adminStatus = null;
+          }
         } else {
-          this.hasAdminCapabilities = false;
+          this.adminStatus = null;
         }
       }
     } catch {
       if (this.adminCheckUserId === userId) {
-        this.hasAdminCapabilities = false;
+        this.adminStatus = null;
       }
     }
   }
@@ -440,12 +454,16 @@ export class ScionNav extends LitElement {
             </div>
           `
         )}
-        ${this.hasAdminCapabilities
+        ${this.adminStatus?.isAdmin
           ? html`
               <div class="nav-section admin-section">
                 <div class="nav-section-title">Admin</div>
                 <ul class="nav-list">
-                  ${ADMIN_SCOPEABLE_ITEMS.map(
+                  ${ADMIN_SCOPEABLE_ITEMS.filter(
+                    (item) =>
+                      NAV_PERMISSION_MAP[item.path] &&
+                      hasAnyPermission(this.adminStatus, NAV_PERMISSION_MAP[item.path])
+                  ).map(
                     (item) => html`
                       <li class="nav-item">
                         <a

--- a/web/src/lib/admin-permissions.ts
+++ b/web/src/lib/admin-permissions.ts
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Shared permission utilities for admin UI progressive exposure.
+ *
+ * Centralizes the AdminStatus type, permission checking helper, and
+ * static mappings from nav items / routes to gate permissions. All nav,
+ * route guard, and settings page changes import from this module.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Enhanced admin status returned by GET /api/v1/auth/admin-status.
+ * Phase 1 added the `permissions` array to the response.
+ */
+export interface AdminStatus {
+  isAdmin: boolean;
+  isSuperAdmin: boolean;
+  permissions: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Permission checker
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether the user holds ANY of the specified gate permissions.
+ * Super-admin users always pass (they hold all permissions implicitly).
+ *
+ * @param adminStatus - The user's admin status, or null if unauthenticated.
+ * @param requiredPermissions - One or more permission IDs; the check uses
+ *   OR logic (any single match is sufficient).
+ * @returns true if the user should be granted access.
+ */
+export function hasAnyPermission(
+  adminStatus: AdminStatus | null,
+  requiredPermissions: string[]
+): boolean {
+  if (!adminStatus) return false;
+  if (adminStatus.isSuperAdmin) return true;
+  return requiredPermissions.some((p) => adminStatus.permissions?.includes(p));
+}
+
+// ---------------------------------------------------------------------------
+// Settings tab gate permissions (union used for the /settings nav item)
+// ---------------------------------------------------------------------------
+
+/**
+ * The complete set of permissions that gate individual settings tabs.
+ * The `/settings` nav item is visible when the user holds ANY of these.
+ */
+const SETTINGS_PERMISSIONS: string[] = [
+  'hub.settings.read',
+  'template.list',
+  'template.read',
+  'harness_config.list',
+  'harness_config.read',
+  'hub.lifecycle_hooks.read',
+  'gcp_service_account.list',
+  'gcp_service_account.read',
+  'skill.list',
+  'skill.read',
+  'hub.project_defaults.read',
+];
+
+// ---------------------------------------------------------------------------
+// Nav-item-to-permission mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps each admin-scopeable nav item path to the gate permissions that
+ * control its visibility. An item is shown when the user holds ANY of
+ * its gate permissions (OR logic).
+ */
+export const NAV_PERMISSION_MAP: Record<string, string[]> = {
+  '/settings': SETTINGS_PERMISSIONS,
+  '/admin/server-config': ['hub.config.read'],
+  '/admin/federation': ['hub.federation.read'],
+  '/admin/integrations': ['hub.integrations.read'],
+  '/admin/scheduler': ['hub.scheduler.read'],
+  '/admin/users': ['user.read', 'user.list'],
+  '/admin/groups': ['group.read', 'group.list'],
+  '/admin/roles': ['role.read'],
+  '/admin/role-bindings': ['role_binding.read'],
+  '/admin/quotas': ['quota.read'],
+  '/health': ['hub.health.read'],
+  '/admin/skill-registries': ['skill.register'],
+};
+
+// ---------------------------------------------------------------------------
+// Route-to-permission mapping (keyed by component tag)
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps each admin route's component tag to the gate permissions that
+ * control access. Mirrors the nav mapping but uses component tags for
+ * route-guard integration.
+ */
+export const ROUTE_PERMISSION_MAP: Record<string, string[]> = {
+  'scion-page-settings': SETTINGS_PERMISSIONS,
+  'scion-page-admin-server-config': ['hub.config.read'],
+  'scion-page-admin-federation': ['hub.federation.read'],
+  'scion-page-admin-integrations': ['hub.integrations.read'],
+  'scion-page-admin-scheduler': ['hub.scheduler.read'],
+  'scion-page-admin-users': ['user.read', 'user.list'],
+  'scion-page-admin-groups': ['group.read', 'group.list'],
+  'scion-page-admin-group-detail': ['group.read', 'group.list'],
+  'scion-page-admin-roles': ['role.read'],
+  'scion-page-admin-role-bindings': ['role_binding.read'],
+  'scion-page-admin-quotas': ['quota.read'],
+  'scion-page-health-dashboard': ['hub.health.read'],
+  'scion-page-admin-skill-registries': ['skill.register'],
+  'scion-page-admin-skill-registry-detail': ['skill.register'],
+};
+
+// ---------------------------------------------------------------------------
+// Super-admin-only routes
+// ---------------------------------------------------------------------------
+
+/**
+ * Routes that require super-admin (`user.role === 'admin'`).
+ * These are not gated by the permissions array — only super-admins
+ * may access them.
+ */
+export const SUPERADMIN_ROUTES = new Set([
+  'scion-page-diagnostics',
+  'scion-page-admin-maintenance',
+]);


### PR DESCRIPTION
Replaces the binary admin nav/route guard with per-item permission checks driven by the Phase 1 permissions array (Phase 2 of 3).