### PR TITLE
feat(web): gate settings page tabs by user permissions

### DIFF
--- a/web/src/components/pages/settings.ts
+++ b/web/src/components/pages/settings.ts
@@ -22,10 +22,15 @@
  * mirror the project settings Resources section for consistency.
  */
 
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 import type { PageData } from '../../shared/types.js';
+import {
+  type AdminStatus,
+  hasAnyPermission,
+  TAB_PERMISSION_MAP,
+} from '../../lib/admin-permissions.js';
 import '../shared/env-var-list.js';
 import '../shared/gcp-service-account-list.js';
 import '../shared/secret-list.js';
@@ -34,6 +39,18 @@ import '../shared/resource-import.js';
 import '../shared/injected-skills-panel.js';
 import '../shared/pre-start-hook-list.js';
 import '../shared/project-template-list.js';
+
+/** All known tab panel names in display order. */
+const ALL_TABS = [
+  'env-vars',
+  'secrets',
+  'templates',
+  'harness-configs',
+  'pre-start-hooks',
+  'service-accounts',
+  'skills',
+  'project-templates',
+] as const;
 
 @customElement('scion-page-settings')
 export class ScionPageSettings extends LitElement {
@@ -44,9 +61,37 @@ export class ScionPageSettings extends LitElement {
   @state()
   private activeTab = 'env-vars';
 
-  /** Hub admins get mutating affordances; everyone else sees a read-only list. */
-  private get isAdmin(): boolean {
-    return this.pageData?.user?.role === 'admin';
+  /** Admin status with permissions array, fetched from /api/v1/auth/admin-status. */
+  @state()
+  private adminStatus: AdminStatus | null = null;
+
+  /** Whether the admin-status fetch has completed (prevents flash of empty state). */
+  @state()
+  private statusLoaded = false;
+
+  /**
+   * Compute the set of tabs visible to the current user.
+   * Super-admins see all tabs; other users see only tabs matching their permissions.
+   */
+  private get visibleTabs(): string[] {
+    if (!this.adminStatus) return [];
+    return ALL_TABS.filter((tab) =>
+      hasAnyPermission(this.adminStatus, TAB_PERMISSION_MAP[tab] ?? [])
+    );
+  }
+
+  /** Whether a given tab is visible to the current user. */
+  private isTabVisible(tab: string): boolean {
+    return this.visibleTabs.includes(tab);
+  }
+
+  /**
+   * Whether the user can mutate pre-start hooks.
+   * Replaces the old `user.role === 'admin'` check with permission-based logic
+   * so that hub-admin role holders (not just super-admins) get write access.
+   */
+  private get canEditPreStartHooks(): boolean {
+    return hasAnyPermission(this.adminStatus, ['hub.lifecycle_hooks.update']);
   }
 
   static override styles = css`
@@ -123,6 +168,36 @@ export class ScionPageSettings extends LitElement {
         this.activeTab = tab;
       }
     }
+    void this.fetchAdminStatus();
+  }
+
+  /**
+   * Fetch the current user's admin status (including permissions array).
+   * Once loaded, validates the active tab against visible tabs and falls
+   * back to the first visible tab when the requested tab is not accessible.
+   */
+  private async fetchAdminStatus(): Promise<void> {
+    try {
+      const res = await fetch('/api/v1/auth/admin-status', { credentials: 'include' });
+      if (res.ok) {
+        const data = await res.json();
+        this.adminStatus = {
+          isAdmin: data.isAdmin === true,
+          isSuperAdmin: data.isSuperAdmin === true,
+          permissions: Array.isArray(data.permissions) ? data.permissions : [],
+        };
+      }
+    } catch {
+      // Auth endpoint unavailable — leave adminStatus null.
+    }
+    this.statusLoaded = true;
+
+    // If the requested tab (from URL or default) is not visible to this user,
+    // silently fall back to the first visible tab.
+    const visible = this.visibleTabs;
+    if (visible.length > 0 && !visible.includes(this.activeTab)) {
+      this.activeTab = visible[0];
+    }
   }
 
   /** Refresh a resource list (by element id) after an import. */
@@ -134,6 +209,36 @@ export class ScionPageSettings extends LitElement {
   }
 
   override render() {
+    // While the admin-status fetch is in flight, show nothing to prevent a
+    // flash of all-tabs or empty-state before permissions are known.
+    if (!this.statusLoaded) {
+      return html`
+        <div class="header">
+          <sl-icon name="gear"></sl-icon>
+          <h1>Hub Resources</h1>
+        </div>
+        <div class="section">
+          <sl-spinner></sl-spinner>
+        </div>
+      `;
+    }
+
+    const visible = this.visibleTabs;
+
+    // Edge case: no visible tabs (should not happen because the route guard
+    // already checks settings permissions, but handle gracefully).
+    if (visible.length === 0) {
+      return html`
+        <div class="header">
+          <sl-icon name="gear"></sl-icon>
+          <h1>Hub Resources</h1>
+        </div>
+        <div class="section">
+          <p>You do not have permission to view any hub resources.</p>
+        </div>
+      `;
+    }
+
     return html`
       <div class="header">
         <sl-icon name="gear"></sl-icon>
@@ -149,133 +254,167 @@ export class ScionPageSettings extends LitElement {
             this.activeTab = (e.detail as { name: string }).name;
           }}
         >
-          <sl-tab slot="nav" panel="env-vars" ?active=${this.activeTab === 'env-vars'}
-            >Environment Variables</sl-tab
-          >
-          <sl-tab slot="nav" panel="secrets" ?active=${this.activeTab === 'secrets'}
-            >Secrets</sl-tab
-          >
-          <sl-tab slot="nav" panel="templates" ?active=${this.activeTab === 'templates'}
-            >Templates</sl-tab
-          >
-          <sl-tab slot="nav" panel="harness-configs" ?active=${this.activeTab === 'harness-configs'}
-            >Harness Configs</sl-tab
-          >
-          <sl-tab slot="nav" panel="pre-start-hooks" ?active=${this.activeTab === 'pre-start-hooks'}
-            >Pre-Start Hooks</sl-tab
-          >
-          <sl-tab
-            slot="nav"
-            panel="service-accounts"
-            ?active=${this.activeTab === 'service-accounts'}
-            >Service Accounts</sl-tab
-          >
-          <sl-tab slot="nav" panel="skills" ?active=${this.activeTab === 'skills'}>Skills</sl-tab>
-          <sl-tab
-            slot="nav"
-            panel="project-templates"
-            ?active=${this.activeTab === 'project-templates'}
-            >Project Templates</sl-tab
-          >
-
-          <sl-tab-panel name="env-vars">
-            <scion-env-var-list scope="hub" apiBasePath="/api/v1" compact></scion-env-var-list>
-          </sl-tab-panel>
-
-          <sl-tab-panel name="secrets">
-            <scion-secret-list scope="hub" apiBasePath="/api/v1" compact></scion-secret-list>
-          </sl-tab-panel>
-
-          <sl-tab-panel name="templates">
-            <p class="tab-intro">Global agent templates. Open one to browse and edit its files.</p>
-            <scion-resource-import
-              kind="template"
-              scope="global"
-              canImport
-              @resource-changed=${() => this.refreshList('templates-list')}
-            ></scion-resource-import>
-            <scion-resource-list
-              id="templates-list"
-              kind="template"
-              scope="global"
-              detailBasePath="/settings"
-              canClone
-              canDelete
-              @resource-changed=${() => this.refreshList('templates-list')}
-            ></scion-resource-list>
-          </sl-tab-panel>
-
-          <sl-tab-panel name="harness-configs">
-            <p class="tab-intro">
-              Global harness configurations. Open one to browse and edit its files.
-            </p>
-            <scion-resource-import
-              kind="harness-config"
-              scope="global"
-              canImport
-              @resource-changed=${() => this.refreshList('harness-configs-list')}
-            ></scion-resource-import>
-            <scion-resource-list
-              id="harness-configs-list"
-              kind="harness-config"
-              scope="global"
-              detailBasePath="/settings"
-              canClone
-              canDelete
-              @resource-changed=${() => this.refreshList('harness-configs-list')}
-            ></scion-resource-list>
-          </sl-tab-panel>
-
-          <sl-tab-panel name="pre-start-hooks">
-            <p class="tab-intro">
-              Hub-wide default pre-start hook. Staged for any agent whose project has no
-              project-level hook active.
-            </p>
-            <scion-pre-start-hook-list
-              apiBasePath="/api/v1"
-              ?readonly=${!this.isAdmin}
-            ></scion-pre-start-hook-list>
-          </sl-tab-panel>
-
-          <!--
-            THE COPY HERE STATES WHAT IS TRUE TODAY, NOT WHAT THE SCOPE IMPLIES.
-            An earlier draft said these accounts "are usable from every project".
-            The Hub does accept a hub-scoped account at agent creation, but no
-            agent-creation picker offers one yet, so that sentence promised a
-            capability a user cannot reach and would have read as a bug rather
-            than as unfinished work. Both gaps below are part of step 5's
-            definition of done; when the picker lands, this paragraph shrinks.
-          -->
-          <sl-tab-panel name="service-accounts">
-            <p class="tab-intro">
-              GCP service accounts registered at hub scope. They belong to the hub rather than to
-              any one project, which is why they are managed here.
-            </p>
-            <p class="tab-intro">
-              Two things are not available yet. Registering a hub-scoped account — use a project's
-              settings to register an account for that project. And selecting a hub-scoped account
-              when creating an agent, so an account listed here is not yet offered on any project's
-              agent form.
-            </p>
-            <scion-gcp-service-account-list scope="hub"></scion-gcp-service-account-list>
-          </sl-tab-panel>
-
-          <sl-tab-panel name="skills">
-            <p class="tab-intro">
-              Skills automatically injected into all agents on this hub. System entries are seeded
-              from built-in platform skills and are read-only. User-defined entries can be added and
-              removed by hub admins.
-            </p>
-            <scion-injected-skills-panel scope="hub"></scion-injected-skills-panel>
-          </sl-tab-panel>
-
-          <sl-tab-panel name="project-templates">
-            <p class="tab-intro">
-              Project templates for quick project setup. Create a template from any existing
-              project, then use it to create new projects with pre-configured settings.
-            </p>
-            <scion-project-template-list></scion-project-template-list>
-          </sl-tab-panel>
+          ${this.isTabVisible('env-vars')
+            ? html`<sl-tab slot="nav" panel="env-vars" ?active=${this.activeTab === 'env-vars'}
+                >Environment Variables</sl-tab
+              >`
+            : nothing}
+          ${this.isTabVisible('secrets')
+            ? html`<sl-tab slot="nav" panel="secrets" ?active=${this.activeTab === 'secrets'}
+                >Secrets</sl-tab
+              >`
+            : nothing}
+          ${this.isTabVisible('templates')
+            ? html`<sl-tab slot="nav" panel="templates" ?active=${this.activeTab === 'templates'}
+                >Templates</sl-tab
+              >`
+            : nothing}
+          ${this.isTabVisible('harness-configs')
+            ? html`<sl-tab
+                slot="nav"
+                panel="harness-configs"
+                ?active=${this.activeTab === 'harness-configs'}
+                >Harness Configs</sl-tab
+              >`
+            : nothing}
+          ${this.isTabVisible('pre-start-hooks')
+            ? html`<sl-tab
+                slot="nav"
+                panel="pre-start-hooks"
+                ?active=${this.activeTab === 'pre-start-hooks'}
+                >Pre-Start Hooks</sl-tab
+              >`
+            : nothing}
+          ${this.isTabVisible('service-accounts')
+            ? html`<sl-tab
+                slot="nav"
+                panel="service-accounts"
+                ?active=${this.activeTab === 'service-accounts'}
+                >Service Accounts</sl-tab
+              >`
+            : nothing}
+          ${this.isTabVisible('skills')
+            ? html`<sl-tab slot="nav" panel="skills" ?active=${this.activeTab === 'skills'}
+                >Skills</sl-tab
+              >`
+            : nothing}
+          ${this.isTabVisible('project-templates')
+            ? html`<sl-tab
+                slot="nav"
+                panel="project-templates"
+                ?active=${this.activeTab === 'project-templates'}
+                >Project Templates</sl-tab
+              >`
+            : nothing}
+          ${this.isTabVisible('env-vars')
+            ? html`<sl-tab-panel name="env-vars">
+                <scion-env-var-list scope="hub" apiBasePath="/api/v1" compact></scion-env-var-list>
+              </sl-tab-panel>`
+            : nothing}
+          ${this.isTabVisible('secrets')
+            ? html`<sl-tab-panel name="secrets">
+                <scion-secret-list scope="hub" apiBasePath="/api/v1" compact></scion-secret-list>
+              </sl-tab-panel>`
+            : nothing}
+          ${this.isTabVisible('templates')
+            ? html`<sl-tab-panel name="templates">
+                <p class="tab-intro">
+                  Global agent templates. Open one to browse and edit its files.
+                </p>
+                <scion-resource-import
+                  kind="template"
+                  scope="global"
+                  canImport
+                  @resource-changed=${() => this.refreshList('templates-list')}
+                ></scion-resource-import>
+                <scion-resource-list
+                  id="templates-list"
+                  kind="template"
+                  scope="global"
+                  detailBasePath="/settings"
+                  canClone
+                  canDelete
+                  @resource-changed=${() => this.refreshList('templates-list')}
+                ></scion-resource-list>
+              </sl-tab-panel>`
+            : nothing}
+          ${this.isTabVisible('harness-configs')
+            ? html`<sl-tab-panel name="harness-configs">
+                <p class="tab-intro">
+                  Global harness configurations. Open one to browse and edit its files.
+                </p>
+                <scion-resource-import
+                  kind="harness-config"
+                  scope="global"
+                  canImport
+                  @resource-changed=${() => this.refreshList('harness-configs-list')}
+                ></scion-resource-import>
+                <scion-resource-list
+                  id="harness-configs-list"
+                  kind="harness-config"
+                  scope="global"
+                  detailBasePath="/settings"
+                  canClone
+                  canDelete
+                  @resource-changed=${() => this.refreshList('harness-configs-list')}
+                ></scion-resource-list>
+              </sl-tab-panel>`
+            : nothing}
+          ${this.isTabVisible('pre-start-hooks')
+            ? html`<sl-tab-panel name="pre-start-hooks">
+                <p class="tab-intro">
+                  Hub-wide default pre-start hook. Staged for any agent whose project has no
+                  project-level hook active.
+                </p>
+                <scion-pre-start-hook-list
+                  apiBasePath="/api/v1"
+                  ?readonly=${!this.canEditPreStartHooks}
+                ></scion-pre-start-hook-list>
+              </sl-tab-panel>`
+            : nothing}
+          ${this.isTabVisible('service-accounts')
+            ? html`<!--
+                THE COPY HERE STATES WHAT IS TRUE TODAY, NOT WHAT THE SCOPE IMPLIES.
+                An earlier draft said these accounts "are usable from every project".
+                The Hub does accept a hub-scoped account at agent creation, but no
+                agent-creation picker offers one yet, so that sentence promised a
+                capability a user cannot reach and would have read as a bug rather
+                than as unfinished work. Both gaps below are part of step 5's
+                definition of done; when the picker lands, this paragraph shrinks.
+              -->
+                <sl-tab-panel name="service-accounts">
+                  <p class="tab-intro">
+                    GCP service accounts registered at hub scope. They belong to the hub rather than
+                    to any one project, which is why they are managed here.
+                  </p>
+                  <p class="tab-intro">
+                    Two things are not available yet. Registering a hub-scoped account — use a
+                    project's settings to register an account for that project. And selecting a
+                    hub-scoped account when creating an agent, so an account listed here is not yet
+                    offered on any project's agent form.
+                  </p>
+                  <scion-gcp-service-account-list scope="hub"></scion-gcp-service-account-list>
+                </sl-tab-panel>`
+            : nothing}
+          ${this.isTabVisible('skills')
+            ? html`<sl-tab-panel name="skills">
+                <p class="tab-intro">
+                  Skills automatically injected into all agents on this hub. System entries are
+                  seeded from built-in platform skills and are read-only. User-defined entries can
+                  be added and removed by hub admins.
+                </p>
+                <scion-injected-skills-panel scope="hub"></scion-injected-skills-panel>
+              </sl-tab-panel>`
+            : nothing}
+          ${this.isTabVisible('project-templates')
+            ? html`<sl-tab-panel name="project-templates">
+                <p class="tab-intro">
+                  Project templates for quick project setup. Create a template from any existing
+                  project, then use it to create new projects with pre-configured settings.
+                </p>
+                <scion-project-template-list></scion-project-template-list>
+              </sl-tab-panel>`
+            : nothing}
         </sl-tab-group>
       </div>
     `;

--- a/web/src/components/pages/settings.ts
+++ b/web/src/components/pages/settings.ts
@@ -69,6 +69,10 @@ export class ScionPageSettings extends LitElement {
   @state()
   private statusLoaded = false;
 
+  /** Whether the admin-status fetch failed (network error or non-OK response). */
+  @state()
+  private fetchFailed = false;
+
   /**
    * Compute the set of tabs visible to the current user.
    * Super-admins see all tabs; other users see only tabs matching their permissions.
@@ -186,9 +190,11 @@ export class ScionPageSettings extends LitElement {
           isSuperAdmin: data.isSuperAdmin === true,
           permissions: Array.isArray(data.permissions) ? data.permissions : [],
         };
+      } else {
+        this.fetchFailed = true;
       }
     } catch {
-      // Auth endpoint unavailable — leave adminStatus null.
+      this.fetchFailed = true;
     }
     this.statusLoaded = true;
 
@@ -219,6 +225,20 @@ export class ScionPageSettings extends LitElement {
         </div>
         <div class="section">
           <sl-spinner></sl-spinner>
+        </div>
+      `;
+    }
+
+    // If the fetch failed, show a distinct error so users can tell the
+    // difference between "no permissions" and "we couldn't check."
+    if (this.fetchFailed) {
+      return html`
+        <div class="header">
+          <sl-icon name="gear"></sl-icon>
+          <h1>Hub Resources</h1>
+        </div>
+        <div class="section">
+          <p>Failed to load your permissions. Please refresh the page.</p>
         </div>
       `;
     }

--- a/web/src/components/shared/nav.ts
+++ b/web/src/components/shared/nav.ts
@@ -454,7 +454,13 @@ export class ScionNav extends LitElement {
             </div>
           `
         )}
-        ${this.adminStatus?.isAdmin
+        ${this.adminStatus?.isAdmin &&
+        (isSuperAdmin ||
+          ADMIN_SCOPEABLE_ITEMS.some(
+            (item) =>
+              NAV_PERMISSION_MAP[item.path] &&
+              hasAnyPermission(this.adminStatus, NAV_PERMISSION_MAP[item.path])
+          ))
           ? html`
               <div class="nav-section admin-section">
                 <div class="nav-section-title">Admin</div>

--- a/web/src/lib/admin-permissions.ts
+++ b/web/src/lib/admin-permissions.ts
@@ -131,6 +131,26 @@ export const ROUTE_PERMISSION_MAP: Record<string, string[]> = {
 };
 
 // ---------------------------------------------------------------------------
+// Settings tab gate permissions
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps each settings tab panel name to the gate permissions that control
+ * its visibility. A tab is shown when the user holds ANY of its gate
+ * permissions (OR logic). Super-admin users see all tabs.
+ */
+export const TAB_PERMISSION_MAP: Record<string, string[]> = {
+  'env-vars': ['hub.settings.read'],
+  secrets: ['hub.settings.read'],
+  templates: ['template.list', 'template.read'],
+  'harness-configs': ['harness_config.list', 'harness_config.read'],
+  'pre-start-hooks': ['hub.lifecycle_hooks.read'],
+  'service-accounts': ['gcp_service_account.list', 'gcp_service_account.read'],
+  skills: ['skill.list', 'skill.read'],
+  'project-templates': ['hub.project_defaults.read'],
+};
+
+// ---------------------------------------------------------------------------
 // Super-admin-only routes
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Gates individual Hub Resources settings tabs by the user's actual permissions, delivering the primary use case: a template-only role sees only the Templates tab (Phase 3 of 3, closes #1377).