### PR TITLE
feat(hub): add group as RoleBinding principal type

### DIFF
--- a/pkg/ent/migrate/schema.go
+++ b/pkg/ent/migrate/schema.go
@@ -1409,7 +1409,7 @@ var (
 	// RoleBindingsColumns holds the columns for the "role_bindings" table.
 	RoleBindingsColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeUUID},
-		{Name: "principal_type", Type: field.TypeEnum, Enums: []string{"user", "agent"}},
+		{Name: "principal_type", Type: field.TypeEnum, Enums: []string{"user", "agent", "group"}},
 		{Name: "principal_id", Type: field.TypeString},
 		{Name: "scope_type", Type: field.TypeEnum, Enums: []string{"system", "project"}},
 		{Name: "scope_id", Type: field.TypeString, Default: ""},

--- a/pkg/ent/rolebinding/rolebinding.go
+++ b/pkg/ent/rolebinding/rolebinding.go
@@ -83,6 +83,7 @@ type PrincipalType string
 const (
 	PrincipalTypeUser  PrincipalType = "user"
 	PrincipalTypeAgent PrincipalType = "agent"
+	PrincipalTypeGroup PrincipalType = "group"
 )
 
 func (pt PrincipalType) String() string {
@@ -92,7 +93,7 @@ func (pt PrincipalType) String() string {
 // PrincipalTypeValidator is a validator for the "principal_type" field enum values. It is called by the builders before save.
 func PrincipalTypeValidator(pt PrincipalType) error {
 	switch pt {
-	case PrincipalTypeUser, PrincipalTypeAgent:
+	case PrincipalTypeUser, PrincipalTypeAgent, PrincipalTypeGroup:
 		return nil
 	default:
 		return fmt.Errorf("rolebinding: invalid enum value for principal_type field: %q", pt)

--- a/pkg/ent/schema/rolebinding.go
+++ b/pkg/ent/schema/rolebinding.go
@@ -25,7 +25,7 @@ import (
 )
 
 // RoleBinding holds the schema definition for the RoleBinding entity.
-// A role binding connects a principal (user or agent) to a role definition,
+// A role binding connects a principal (user, agent, or group) to a role definition,
 // optionally scoped to a specific project.
 type RoleBinding struct {
 	ent.Schema
@@ -41,7 +41,7 @@ func (RoleBinding) Fields() []ent.Field {
 			Optional().
 			Nillable(),
 		field.Enum("principal_type").
-			Values("user", "agent"),
+			Values("user", "agent", "group"),
 		field.String("principal_id").
 			NotEmpty(),
 		field.Enum("scope_type").

--- a/pkg/hub/authz.go
+++ b/pkg/hub/authz.go
@@ -1156,8 +1156,10 @@ func (a *AuthzService) getAllRoleBindings(ctx context.Context, principalType, pr
 		return bindings, nil
 	}
 	if err != nil {
-		a.logger.Warn("failed to get effective groups for role binding expansion",
-			"principalType", principalType, "principalID", principalID, "error", err)
+		if !errors.Is(err, store.ErrNotFound) {
+			a.logger.Warn("failed to get effective groups for role binding expansion",
+				"principalType", principalType, "principalID", principalID, "error", err)
+		}
 		return bindings, nil // Fall back to direct bindings only.
 	}
 

--- a/pkg/hub/authz.go
+++ b/pkg/hub/authz.go
@@ -1051,26 +1051,55 @@ func projectIDForResource(r Resource) string {
 }
 
 // isProjectOwnerOrAdmin reports whether the user has project-owner or
-// project-admin role in the given project. Uses role bindings as the sole
-// source of truth (Phase 1F: legacy group-based fallback removed).
+// project-admin role in the given project. Checks direct membership first,
+// then group-expanded role bindings.
 func (a *AuthzService) isProjectOwnerOrAdmin(ctx context.Context, userID, projectID string) bool {
 	if userID == "" || projectID == "" {
 		return false
 	}
 
+	// 1. Direct user membership (existing behavior).
 	membership, err := a.store.GetProjectMembership(ctx, projectID, userID)
-	if err != nil || membership == nil {
+	if err == nil && membership != nil {
+		if membership.Role == store.ProjectRoleOwner || membership.Role == store.ProjectRoleAdmin {
+			return true
+		}
+	}
+
+	// 2. Group-expanded: check if any of the user's groups have owner/admin
+	//    role binding on this project.
+	groupIDs, err := a.store.GetEffectiveGroups(ctx, userID)
+	if err != nil || len(groupIDs) == 0 {
 		return false
 	}
-	return membership.Role == store.ProjectRoleOwner || membership.Role == store.ProjectRoleAdmin
+	for _, gid := range groupIDs {
+		groupBindings, err := a.store.ListRoleBindingsForPrincipal(ctx, store.RoleBindingPrincipalGroup, gid)
+		if err != nil {
+			continue
+		}
+		for _, b := range groupBindings {
+			if b.ScopeType != store.RoleScopeProject || b.ScopeID != projectID {
+				continue
+			}
+			rd, err := a.store.GetRoleDefinition(ctx, b.RoleDefinitionID)
+			if err != nil {
+				continue
+			}
+			if rd.Name == store.ProjectRoleOwner || rd.Name == store.ProjectRoleAdmin {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // getEffectivePermissions resolves the set of permission IDs granted to a
-// principal via role bindings. It collects all bindings for the principal,
-// filters by scope, resolves each binding's role definition, and returns a
-// deduplicated list of permission IDs.
+// principal via role bindings. It collects all bindings for the principal
+// (including group-expanded bindings), filters by scope, resolves each
+// binding's role definition, and returns a deduplicated list of permission IDs.
 func (a *AuthzService) getEffectivePermissions(ctx context.Context, principalType, principalID string, scopeType, scopeID string) ([]string, error) {
-	bindings, err := a.store.ListRoleBindingsForPrincipal(ctx, principalType, principalID)
+	// Collect all role bindings: direct + group-expanded.
+	allBindings, err := a.getAllRoleBindings(ctx, principalType, principalID)
 	if err != nil {
 		return nil, err
 	}
@@ -1078,7 +1107,7 @@ func (a *AuthzService) getEffectivePermissions(ctx context.Context, principalTyp
 	seen := make(map[string]bool)
 	var result []string
 
-	for _, b := range bindings {
+	for _, b := range allBindings {
 		// Filter by scope: system bindings always apply; project bindings
 		// apply only if the scope matches.
 		if b.ScopeType == store.RoleScopeProject {
@@ -1106,6 +1135,43 @@ func (a *AuthzService) getEffectivePermissions(ctx context.Context, principalTyp
 	return result, nil
 }
 
+// getAllRoleBindings returns direct role bindings for the principal PLUS
+// role bindings for all groups the principal belongs to (transitive via BFS).
+func (a *AuthzService) getAllRoleBindings(ctx context.Context, principalType, principalID string) ([]*store.RoleBinding, error) {
+	// 1. Direct bindings for the principal.
+	bindings, err := a.store.ListRoleBindingsForPrincipal(ctx, principalType, principalID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. Group-expanded bindings.
+	var groupIDs []string
+	switch principalType {
+	case store.RoleBindingPrincipalUser:
+		groupIDs, err = a.store.GetEffectiveGroups(ctx, principalID)
+	case store.RoleBindingPrincipalAgent:
+		groupIDs, err = a.store.GetEffectiveGroupsForAgent(ctx, principalID)
+	default:
+		// For "group" principal type, no further expansion needed.
+		return bindings, nil
+	}
+	if err != nil {
+		a.logger.Warn("failed to get effective groups for role binding expansion",
+			"principalType", principalType, "principalID", principalID, "error", err)
+		return bindings, nil // Fall back to direct bindings only.
+	}
+
+	for _, gid := range groupIDs {
+		groupBindings, err := a.store.ListRoleBindingsForPrincipal(ctx, store.RoleBindingPrincipalGroup, gid)
+		if err != nil {
+			a.logger.Warn("failed to get group role bindings", "groupID", gid, "error", err)
+			continue
+		}
+		bindings = append(bindings, groupBindings...)
+	}
+	return bindings, nil
+}
+
 // IsSystemAdmin checks whether the given user has a system-scoped super-admin
 // role binding. This is the role-binding-based authority check (Phase 1F),
 // complementing the fast-path IsUnscopedLocalPlatformAdmin which uses
@@ -1114,8 +1180,8 @@ func (a *AuthzService) IsSystemAdmin(ctx context.Context, userID string) bool {
 	if userID == "" {
 		return false
 	}
-	// Check if the user has a super-admin role binding directly.
-	bindings, err := a.store.ListRoleBindingsForPrincipal(ctx, store.RoleBindingPrincipalUser, userID)
+	// Check direct + group-expanded role bindings.
+	bindings, err := a.getAllRoleBindings(ctx, store.RoleBindingPrincipalUser, userID)
 	if err != nil {
 		return false
 	}
@@ -1143,7 +1209,8 @@ func (a *AuthzService) IsHubAdmin(ctx context.Context, userID string) bool {
 	if userID == "" {
 		return false
 	}
-	bindings, err := a.store.ListRoleBindingsForPrincipal(ctx, store.RoleBindingPrincipalUser, userID)
+	// Check direct + group-expanded role bindings.
+	bindings, err := a.getAllRoleBindings(ctx, store.RoleBindingPrincipalUser, userID)
 	if err != nil {
 		return false
 	}

--- a/pkg/hub/authz_test.go
+++ b/pkg/hub/authz_test.go
@@ -786,3 +786,363 @@ type failingRoleBindingStore struct {
 func (f *failingRoleBindingStore) ListRoleBindingsForPrincipal(_ context.Context, _, _ string) ([]*store.RoleBinding, error) {
 	return nil, errors.New("store unavailable")
 }
+
+func (f *failingRoleBindingStore) GetEffectiveGroups(_ context.Context, _ string) ([]string, error) {
+	return nil, errors.New("store unavailable")
+}
+
+// =============================================================================
+// Group-based RoleBinding Tests
+// =============================================================================
+
+func TestGetEffectivePermissions_GroupRoleBinding(t *testing.T) {
+	authz, s := authzTestSetup(t)
+	ctx := context.Background()
+
+	// Create user
+	require.NoError(t, s.CreateUser(ctx, &store.User{
+		ID: tid("grp-perm-user"), Email: "grpperm@test.com", DisplayName: "GrpPerm", Role: "member", Status: "active",
+	}))
+
+	// Create group and add user to it
+	require.NoError(t, s.CreateGroup(ctx, &store.Group{
+		ID: tid("grp-perm-group"), Slug: "grp-perm-group", Name: "GrpPerm Group",
+	}))
+	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
+		GroupID:    tid("grp-perm-group"),
+		MemberID:  tid("grp-perm-user"),
+		MemberType: store.GroupMemberTypeUser,
+		Role:       store.GroupMemberRoleMember,
+	}))
+
+	// Create a custom role with a permission
+	rd := createTestRoleDefinition(t, s, "grp-test-role", store.RoleScopeSystem, []string{"agent.read"})
+
+	// Bind the role to the GROUP (not the user)
+	_, err := s.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: rd.ID,
+		PrincipalType:    store.RoleBindingPrincipalGroup,
+		PrincipalID:      tid("grp-perm-group"),
+		ScopeType:        store.RoleScopeSystem,
+		CreatedBy:        "test",
+	})
+	require.NoError(t, err)
+
+	// The user should get the group's permissions via expansion
+	perms, err := authz.getEffectivePermissions(ctx, store.RoleBindingPrincipalUser, tid("grp-perm-user"), store.RoleScopeSystem, "")
+	require.NoError(t, err)
+	assert.Contains(t, perms, "agent.read", "user should inherit permissions from group role binding")
+}
+
+func TestIsProjectOwnerOrAdmin_ViaGroup(t *testing.T) {
+	authz, s := authzTestSetup(t)
+	ctx := context.Background()
+
+	// Create user (no direct project membership)
+	require.NoError(t, s.CreateUser(ctx, &store.User{
+		ID: tid("grp-proj-user"), Email: "grpproj@test.com", DisplayName: "GrpProj", Role: "member", Status: "active",
+	}))
+
+	// Create project
+	require.NoError(t, s.CreateProject(ctx, &store.Project{
+		ID: tid("grp-proj"), Name: "Group Project", Slug: "grp-proj",
+	}))
+
+	// Create group and add user
+	require.NoError(t, s.CreateGroup(ctx, &store.Group{
+		ID: tid("grp-proj-group"), Slug: "grp-proj-group", Name: "GrpProj Group",
+	}))
+	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
+		GroupID:    tid("grp-proj-group"),
+		MemberID:  tid("grp-proj-user"),
+		MemberType: store.GroupMemberTypeUser,
+		Role:       store.GroupMemberRoleMember,
+	}))
+
+	// Get the project-owner role definition
+	rd, err := s.GetRoleDefinitionByName(ctx, store.ProjectRoleOwner, store.RoleScopeProject)
+	require.NoError(t, err)
+
+	// Bind project-owner to the group, scoped to this project
+	_, err = s.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: rd.ID,
+		PrincipalType:    store.RoleBindingPrincipalGroup,
+		PrincipalID:      tid("grp-proj-group"),
+		ScopeType:        store.RoleScopeProject,
+		ScopeID:          tid("grp-proj"),
+		CreatedBy:        "test",
+	})
+	require.NoError(t, err)
+
+	result := authz.isProjectOwnerOrAdmin(ctx, tid("grp-proj-user"), tid("grp-proj"))
+	assert.True(t, result, "user should be project owner via group membership")
+}
+
+func TestIsProjectOwnerOrAdmin_DirectStillWorks(t *testing.T) {
+	authz, s := authzTestSetup(t)
+	ctx := context.Background()
+
+	userID := tid("direct-proj-user")
+	projectID := tid("direct-proj")
+
+	// Create user and project
+	require.NoError(t, s.CreateUser(ctx, &store.User{
+		ID: userID, Email: "directproj@test.com", DisplayName: "DirectProj", Role: "member", Status: "active",
+	}))
+	require.NoError(t, s.CreateProject(ctx, &store.Project{
+		ID: projectID, Name: "Direct Project", Slug: "direct-proj",
+	}))
+
+	// Get the project-owner role definition and bind directly to user
+	rd, err := s.GetRoleDefinitionByName(ctx, store.ProjectRoleOwner, store.RoleScopeProject)
+	require.NoError(t, err)
+
+	_, err = s.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: rd.ID,
+		PrincipalType:    store.RoleBindingPrincipalUser,
+		PrincipalID:      userID,
+		ScopeType:        store.RoleScopeProject,
+		ScopeID:          projectID,
+		CreatedBy:        "test",
+	})
+	require.NoError(t, err)
+
+	result := authz.isProjectOwnerOrAdmin(ctx, userID, projectID)
+	assert.True(t, result, "direct user binding should still work (regression test)")
+}
+
+func TestIsSystemAdmin_ViaGroup(t *testing.T) {
+	authz, s := authzTestSetup(t)
+	ctx := context.Background()
+
+	// Create user (non-admin)
+	require.NoError(t, s.CreateUser(ctx, &store.User{
+		ID: tid("grp-sysadmin-user"), Email: "grpsysadmin@test.com", DisplayName: "GrpSysAdmin", Role: "member", Status: "active",
+	}))
+
+	// Create group and add user
+	require.NoError(t, s.CreateGroup(ctx, &store.Group{
+		ID: tid("grp-sysadmin-group"), Slug: "grp-sysadmin-group", Name: "GrpSysAdmin Group",
+	}))
+	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
+		GroupID:    tid("grp-sysadmin-group"),
+		MemberID:  tid("grp-sysadmin-user"),
+		MemberType: store.GroupMemberTypeUser,
+		Role:       store.GroupMemberRoleMember,
+	}))
+
+	// Bind super-admin role to the group
+	rd, err := s.GetRoleDefinitionByName(ctx, store.SystemRoleSuperAdmin, store.RoleScopeSystem)
+	require.NoError(t, err)
+
+	_, err = s.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: rd.ID,
+		PrincipalType:    store.RoleBindingPrincipalGroup,
+		PrincipalID:      tid("grp-sysadmin-group"),
+		ScopeType:        store.RoleScopeSystem,
+		CreatedBy:        store.SystemReconcileCreatedBy,
+	})
+	require.NoError(t, err)
+
+	result := authz.IsSystemAdmin(ctx, tid("grp-sysadmin-user"))
+	assert.True(t, result, "user should be system admin via group membership")
+}
+
+func TestIsHubAdmin_ViaGroup(t *testing.T) {
+	authz, s := authzTestSetup(t)
+	ctx := context.Background()
+
+	// Create user
+	require.NoError(t, s.CreateUser(ctx, &store.User{
+		ID: tid("grp-hubadmin-user"), Email: "grphubadmin@test.com", DisplayName: "GrpHubAdmin", Role: "member", Status: "active",
+	}))
+
+	// Create group and add user
+	require.NoError(t, s.CreateGroup(ctx, &store.Group{
+		ID: tid("grp-hubadmin-group"), Slug: "grp-hubadmin-group", Name: "GrpHubAdmin Group",
+	}))
+	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
+		GroupID:    tid("grp-hubadmin-group"),
+		MemberID:  tid("grp-hubadmin-user"),
+		MemberType: store.GroupMemberTypeUser,
+		Role:       store.GroupMemberRoleMember,
+	}))
+
+	// Bind hub-admin role to the group
+	rd, err := s.GetRoleDefinitionByName(ctx, store.SystemRoleHubAdmin, store.RoleScopeSystem)
+	require.NoError(t, err)
+
+	_, err = s.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: rd.ID,
+		PrincipalType:    store.RoleBindingPrincipalGroup,
+		PrincipalID:      tid("grp-hubadmin-group"),
+		ScopeType:        store.RoleScopeSystem,
+		CreatedBy:        "test",
+	})
+	require.NoError(t, err)
+
+	result := authz.IsHubAdmin(ctx, tid("grp-hubadmin-user"))
+	assert.True(t, result, "user should be hub admin via group membership")
+}
+
+func TestGetEffectivePermissions_NestedGroup(t *testing.T) {
+	authz, s := authzTestSetup(t)
+	ctx := context.Background()
+
+	// Create user
+	require.NoError(t, s.CreateUser(ctx, &store.User{
+		ID: tid("nested-grp-user"), Email: "nestedgrp@test.com", DisplayName: "NestedGrp", Role: "member", Status: "active",
+	}))
+
+	// Create parent and child groups
+	require.NoError(t, s.CreateGroup(ctx, &store.Group{
+		ID: tid("parent-group"), Slug: "parent-group", Name: "Parent Group",
+	}))
+	require.NoError(t, s.CreateGroup(ctx, &store.Group{
+		ID: tid("child-group"), Slug: "child-group", Name: "Child Group",
+		ParentID: tid("parent-group"),
+	}))
+
+	// Add child group to parent group
+	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
+		GroupID:    tid("parent-group"),
+		MemberID:  tid("child-group"),
+		MemberType: store.GroupMemberTypeGroup,
+		Role:       store.GroupMemberRoleMember,
+	}))
+
+	// Add user to child group
+	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
+		GroupID:    tid("child-group"),
+		MemberID:  tid("nested-grp-user"),
+		MemberType: store.GroupMemberTypeUser,
+		Role:       store.GroupMemberRoleMember,
+	}))
+
+	// Create a role with permission and bind to parent group
+	rd := createTestRoleDefinition(t, s, "nested-test-role", store.RoleScopeSystem, []string{"project.read"})
+	_, err := s.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: rd.ID,
+		PrincipalType:    store.RoleBindingPrincipalGroup,
+		PrincipalID:      tid("parent-group"),
+		ScopeType:        store.RoleScopeSystem,
+		CreatedBy:        "test",
+	})
+	require.NoError(t, err)
+
+	// The user in the child group should get permissions from the parent's binding (transitive)
+	perms, err := authz.getEffectivePermissions(ctx, store.RoleBindingPrincipalUser, tid("nested-grp-user"), store.RoleScopeSystem, "")
+	require.NoError(t, err)
+	assert.Contains(t, perms, "project.read", "user in nested group should inherit parent group's role binding permissions")
+}
+
+func TestGetEffectivePermissions_DirectAndGroupMerge(t *testing.T) {
+	authz, s := authzTestSetup(t)
+	ctx := context.Background()
+
+	// Create user
+	require.NoError(t, s.CreateUser(ctx, &store.User{
+		ID: tid("merge-user"), Email: "merge@test.com", DisplayName: "MergeUser", Role: "member", Status: "active",
+	}))
+
+	// Create group and add user
+	require.NoError(t, s.CreateGroup(ctx, &store.Group{
+		ID: tid("merge-group"), Slug: "merge-group", Name: "Merge Group",
+	}))
+	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
+		GroupID:    tid("merge-group"),
+		MemberID:  tid("merge-user"),
+		MemberType: store.GroupMemberTypeUser,
+		Role:       store.GroupMemberRoleMember,
+	}))
+
+	// Create role with agent.read and bind DIRECTLY to user
+	rdDirect := createTestRoleDefinition(t, s, "merge-direct-role", store.RoleScopeSystem, []string{"agent.read"})
+	_, err := s.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: rdDirect.ID,
+		PrincipalType:    store.RoleBindingPrincipalUser,
+		PrincipalID:      tid("merge-user"),
+		ScopeType:        store.RoleScopeSystem,
+		CreatedBy:        "test",
+	})
+	require.NoError(t, err)
+
+	// Create role with project.read and bind to GROUP
+	rdGroup := createTestRoleDefinition(t, s, "merge-group-role", store.RoleScopeSystem, []string{"project.read"})
+	_, err = s.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: rdGroup.ID,
+		PrincipalType:    store.RoleBindingPrincipalGroup,
+		PrincipalID:      tid("merge-group"),
+		ScopeType:        store.RoleScopeSystem,
+		CreatedBy:        "test",
+	})
+	require.NoError(t, err)
+
+	// User should get both direct AND group-granted permissions
+	perms, err := authz.getEffectivePermissions(ctx, store.RoleBindingPrincipalUser, tid("merge-user"), store.RoleScopeSystem, "")
+	require.NoError(t, err)
+	assert.Contains(t, perms, "agent.read", "user should have direct permission")
+	assert.Contains(t, perms, "project.read", "user should have group-granted permission")
+}
+
+func TestRealTimeGroupExpansion(t *testing.T) {
+	authz, s := authzTestSetup(t)
+	ctx := context.Background()
+
+	// Create user (NOT yet in any group)
+	require.NoError(t, s.CreateUser(ctx, &store.User{
+		ID: tid("realtime-user"), Email: "realtime@test.com", DisplayName: "Realtime", Role: "member", Status: "active",
+	}))
+
+	// Create project
+	require.NoError(t, s.CreateProject(ctx, &store.Project{
+		ID: tid("realtime-proj"), Name: "Realtime Project", Slug: "realtime-proj",
+	}))
+
+	// Create group
+	require.NoError(t, s.CreateGroup(ctx, &store.Group{
+		ID: tid("realtime-group"), Slug: "realtime-group", Name: "Realtime Group",
+	}))
+
+	// Bind the project-owner role to the group BEFORE the user joins
+	rd, err := s.GetRoleDefinitionByName(ctx, store.ProjectRoleOwner, store.RoleScopeProject)
+	require.NoError(t, err)
+	_, err = s.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: rd.ID,
+		PrincipalType:    store.RoleBindingPrincipalGroup,
+		PrincipalID:      tid("realtime-group"),
+		ScopeType:        store.RoleScopeProject,
+		ScopeID:          tid("realtime-proj"),
+		CreatedBy:        "test",
+	})
+	require.NoError(t, err)
+
+	// Verify user is NOT project owner yet (no group membership)
+	result := authz.isProjectOwnerOrAdmin(ctx, tid("realtime-user"), tid("realtime-proj"))
+	assert.False(t, result, "user should NOT be project owner before joining the group")
+
+	// NOW add the user to the group
+	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
+		GroupID:    tid("realtime-group"),
+		MemberID:  tid("realtime-user"),
+		MemberType: store.GroupMemberTypeUser,
+		Role:       store.GroupMemberRoleMember,
+	}))
+
+	// Verify user IS project owner now (real-time — no restart needed)
+	result = authz.isProjectOwnerOrAdmin(ctx, tid("realtime-user"), tid("realtime-proj"))
+	assert.True(t, result, "user should IMMEDIATELY be project owner after joining group (real-time expansion)")
+}
+
+// createTestRoleDefinition creates a custom role definition for tests.
+func createTestRoleDefinition(t *testing.T, s store.Store, name, scopeType string, permissions []string) *store.RoleDefinition {
+	t.Helper()
+	ctx := context.Background()
+	rd, err := s.CreateRoleDefinition(ctx, &store.RoleDefinition{
+		Name:        name,
+		ScopeType:   scopeType,
+		Permissions: permissions,
+	})
+	require.NoError(t, err)
+	return rd
+}

--- a/pkg/hub/authz_test.go
+++ b/pkg/hub/authz_test.go
@@ -810,7 +810,7 @@ func TestGetEffectivePermissions_GroupRoleBinding(t *testing.T) {
 	}))
 	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
 		GroupID:    tid("grp-perm-group"),
-		MemberID:  tid("grp-perm-user"),
+		MemberID:   tid("grp-perm-user"),
 		MemberType: store.GroupMemberTypeUser,
 		Role:       store.GroupMemberRoleMember,
 	}))
@@ -854,7 +854,7 @@ func TestIsProjectOwnerOrAdmin_ViaGroup(t *testing.T) {
 	}))
 	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
 		GroupID:    tid("grp-proj-group"),
-		MemberID:  tid("grp-proj-user"),
+		MemberID:   tid("grp-proj-user"),
 		MemberType: store.GroupMemberTypeUser,
 		Role:       store.GroupMemberRoleMember,
 	}))
@@ -926,7 +926,7 @@ func TestIsSystemAdmin_ViaGroup(t *testing.T) {
 	}))
 	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
 		GroupID:    tid("grp-sysadmin-group"),
-		MemberID:  tid("grp-sysadmin-user"),
+		MemberID:   tid("grp-sysadmin-user"),
 		MemberType: store.GroupMemberTypeUser,
 		Role:       store.GroupMemberRoleMember,
 	}))
@@ -963,7 +963,7 @@ func TestIsHubAdmin_ViaGroup(t *testing.T) {
 	}))
 	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
 		GroupID:    tid("grp-hubadmin-group"),
-		MemberID:  tid("grp-hubadmin-user"),
+		MemberID:   tid("grp-hubadmin-user"),
 		MemberType: store.GroupMemberTypeUser,
 		Role:       store.GroupMemberRoleMember,
 	}))
@@ -1006,7 +1006,7 @@ func TestGetEffectivePermissions_NestedGroup(t *testing.T) {
 	// Add child group to parent group
 	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
 		GroupID:    tid("parent-group"),
-		MemberID:  tid("child-group"),
+		MemberID:   tid("child-group"),
 		MemberType: store.GroupMemberTypeGroup,
 		Role:       store.GroupMemberRoleMember,
 	}))
@@ -1014,7 +1014,7 @@ func TestGetEffectivePermissions_NestedGroup(t *testing.T) {
 	// Add user to child group
 	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
 		GroupID:    tid("child-group"),
-		MemberID:  tid("nested-grp-user"),
+		MemberID:   tid("nested-grp-user"),
 		MemberType: store.GroupMemberTypeUser,
 		Role:       store.GroupMemberRoleMember,
 	}))
@@ -1051,7 +1051,7 @@ func TestGetEffectivePermissions_DirectAndGroupMerge(t *testing.T) {
 	}))
 	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
 		GroupID:    tid("merge-group"),
-		MemberID:  tid("merge-user"),
+		MemberID:   tid("merge-user"),
 		MemberType: store.GroupMemberTypeUser,
 		Role:       store.GroupMemberRoleMember,
 	}))
@@ -1124,7 +1124,7 @@ func TestRealTimeGroupExpansion(t *testing.T) {
 	// NOW add the user to the group
 	require.NoError(t, s.AddGroupMember(ctx, &store.GroupMember{
 		GroupID:    tid("realtime-group"),
-		MemberID:  tid("realtime-user"),
+		MemberID:   tid("realtime-user"),
 		MemberType: store.GroupMemberTypeUser,
 		Role:       store.GroupMemberRoleMember,
 	}))

--- a/pkg/hub/handlers_groups.go
+++ b/pkg/hub/handlers_groups.go
@@ -104,6 +104,7 @@ func (s *Server) listGroups(w http.ResponseWriter, r *http.Request) {
 		ParentID:  query.Get("parentId"),
 		GroupType: query.Get("groupType"),
 		ProjectID: query.Get("projectId"),
+		Search:    query.Get("search"),
 	}
 
 	identity := GetIdentityFromContext(ctx)

--- a/pkg/hub/handlers_roles.go
+++ b/pkg/hub/handlers_roles.go
@@ -483,8 +483,8 @@ func (s *Server) createRoleBinding(w http.ResponseWriter, r *http.Request, user 
 		BadRequest(w, "principalType is required")
 		return
 	}
-	if req.PrincipalType != store.RoleBindingPrincipalUser && req.PrincipalType != store.RoleBindingPrincipalAgent {
-		BadRequest(w, "principalType must be \"user\" or \"agent\"")
+	if req.PrincipalType != store.RoleBindingPrincipalUser && req.PrincipalType != store.RoleBindingPrincipalAgent && req.PrincipalType != store.RoleBindingPrincipalGroup {
+		BadRequest(w, "principalType must be \"user\", \"agent\", or \"group\"")
 		return
 	}
 	if req.PrincipalID == "" {
@@ -508,6 +508,15 @@ func (s *Server) createRoleBinding(w http.ResponseWriter, r *http.Request, user 
 			return
 		}
 		req.PrincipalID = resolvedUser.ID
+	}
+
+	// Verify group exists for group principals.
+	if req.PrincipalType == store.RoleBindingPrincipalGroup {
+		_, err := s.store.GetGroup(r.Context(), req.PrincipalID)
+		if err != nil {
+			BadRequest(w, "group not found: "+req.PrincipalID)
+			return
+		}
 	}
 
 	if req.ScopeType != store.RoleScopeSystem && req.ScopeType != store.RoleScopeProject {

--- a/pkg/hub/handlers_roles.go
+++ b/pkg/hub/handlers_roles.go
@@ -514,7 +514,11 @@ func (s *Server) createRoleBinding(w http.ResponseWriter, r *http.Request, user 
 	if req.PrincipalType == store.RoleBindingPrincipalGroup {
 		_, err := s.store.GetGroup(r.Context(), req.PrincipalID)
 		if err != nil {
-			BadRequest(w, "group not found: "+req.PrincipalID)
+			if errors.Is(err, store.ErrNotFound) {
+				BadRequest(w, "group not found: "+req.PrincipalID)
+			} else {
+				writeErrorFromErr(w, err, "")
+			}
 			return
 		}
 	}

--- a/pkg/hub/handlers_roles.go
+++ b/pkg/hub/handlers_roles.go
@@ -511,16 +511,26 @@ func (s *Server) createRoleBinding(w http.ResponseWriter, r *http.Request, user 
 	}
 
 	// Verify group exists for group principals.
+	// Try UUID first, fall back to slug lookup (mirrors email→UUID for users).
 	if req.PrincipalType == store.RoleBindingPrincipalGroup {
-		_, err := s.store.GetGroup(r.Context(), req.PrincipalID)
+		g, err := s.store.GetGroup(r.Context(), req.PrincipalID)
 		if err != nil {
 			if errors.Is(err, store.ErrNotFound) {
-				BadRequest(w, "group not found: "+req.PrincipalID)
+				g, err = s.store.GetGroupBySlug(r.Context(), req.PrincipalID)
+				if err != nil {
+					if errors.Is(err, store.ErrNotFound) {
+						BadRequest(w, "group not found: "+req.PrincipalID)
+					} else {
+						writeErrorFromErr(w, err, "")
+					}
+					return
+				}
 			} else {
 				writeErrorFromErr(w, err, "")
+				return
 			}
-			return
 		}
+		req.PrincipalID = g.ID
 	}
 
 	if req.ScopeType != store.RoleScopeSystem && req.ScopeType != store.RoleScopeProject {

--- a/pkg/hub/handlers_roles_test.go
+++ b/pkg/hub/handlers_roles_test.go
@@ -328,8 +328,8 @@ func TestRolesAPI_CreateRoleBinding_InvalidPrincipalType(t *testing.T) {
 
 	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/role-bindings", createRoleBindingRequest{
 		RoleDefinitionID: "some-id",
-		PrincipalType:    "group",
-		PrincipalID:      "g1",
+		PrincipalType:    "organization",
+		PrincipalID:      "o1",
 		ScopeType:        "system",
 	})
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -580,6 +580,53 @@ func TestRolesAPI_CreateRoleBinding_AgentPrincipal(t *testing.T) {
 	assert.Equal(t, "agent", binding.PrincipalType)
 	assert.Equal(t, "some-agent-id", binding.PrincipalID)
 	assert.Equal(t, "project", binding.ScopeType)
+}
+
+func TestRolesAPI_CreateRoleBinding_GroupPrincipal(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := t.Context()
+
+	// Create a group so the group existence check passes
+	require.NoError(t, s.CreateGroup(ctx, &store.Group{
+		ID: tid("rb-test-group"), Slug: "rb-test-group", Name: "RB Test Group",
+	}))
+
+	role := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "group-binding-role",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+
+	binding := createBindingViaAPI(t, srv, createRoleBindingRequest{
+		RoleDefinitionID: role.ID,
+		PrincipalType:    "group",
+		PrincipalID:      tid("rb-test-group"),
+		ScopeType:        "system",
+	})
+
+	assert.Equal(t, "group", binding.PrincipalType)
+	assert.Equal(t, tid("rb-test-group"), binding.PrincipalID)
+	assert.Equal(t, "system", binding.ScopeType)
+}
+
+func TestRolesAPI_CreateRoleBinding_GroupPrincipal_NotFound(t *testing.T) {
+	srv, _ := testServer(t)
+
+	role := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "group-notfound-role",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+
+	// Try to create a binding for a non-existent group
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/role-bindings", createRoleBindingRequest{
+		RoleDefinitionID: role.ID,
+		PrincipalType:    "group",
+		PrincipalID:      "00000000-0000-0000-0000-000000000099",
+		ScopeType:        "system",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "group not found")
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/hub/handlers_roles_test.go
+++ b/pkg/hub/handlers_roles_test.go
@@ -629,6 +629,53 @@ func TestRolesAPI_CreateRoleBinding_GroupPrincipal_NotFound(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "group not found")
 }
 
+func TestRolesAPI_CreateRoleBinding_GroupPrincipal_BySlug(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := t.Context()
+
+	// Create a group with a known slug.
+	require.NoError(t, s.CreateGroup(ctx, &store.Group{
+		ID: tid("slug-resolve-group"), Slug: "my-team-slug", Name: "Slug Resolve Group",
+	}))
+
+	role := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "slug-resolve-role",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+
+	// Use the slug as principalId — should resolve to the UUID.
+	binding := createBindingViaAPI(t, srv, createRoleBindingRequest{
+		RoleDefinitionID: role.ID,
+		PrincipalType:    "group",
+		PrincipalID:      "my-team-slug",
+		ScopeType:        "system",
+	})
+
+	assert.Equal(t, "group", binding.PrincipalType)
+	assert.Equal(t, tid("slug-resolve-group"), binding.PrincipalID, "principalId should be resolved to UUID")
+}
+
+func TestRolesAPI_CreateRoleBinding_GroupPrincipal_NeitherUUIDNorSlug(t *testing.T) {
+	srv, _ := testServer(t)
+
+	role := createRoleViaAPI(t, srv, createRoleDefinitionRequest{
+		Name:        "neither-uuid-nor-slug-role",
+		ScopeType:   "system",
+		Permissions: []string{"agent.read"},
+	})
+
+	// A non-UUID string that also doesn't match any slug.
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/admin/role-bindings", createRoleBindingRequest{
+		RoleDefinitionID: role.ID,
+		PrincipalType:    "group",
+		PrincipalID:      "nonexistent-slug",
+		ScopeType:        "system",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "group not found")
+}
+
 // ---------------------------------------------------------------------------
 // Tests: Update role definition with invalid permissions
 // ---------------------------------------------------------------------------

--- a/pkg/store/entadapter/group_store.go
+++ b/pkg/store/entadapter/group_store.go
@@ -324,6 +324,12 @@ func (s *GroupStore) ListGroups(ctx context.Context, filter store.GroupFilter, o
 		}
 		query.Where(group.ProjectIDEQ(projectUID))
 	}
+	if filter.Search != "" {
+		query.Where(group.Or(
+			group.NameContainsFold(filter.Search),
+			group.SlugContainsFold(filter.Search),
+		))
+	}
 
 	// Get total count before pagination unless this is a bounded scan.
 	totalCount := 0

--- a/pkg/store/models.go
+++ b/pkg/store/models.go
@@ -2493,6 +2493,7 @@ const (
 const (
 	RoleBindingPrincipalUser  = "user"
 	RoleBindingPrincipalAgent = "agent"
+	RoleBindingPrincipalGroup = "group"
 )
 
 // =============================================================================

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -898,6 +898,7 @@ type GroupFilter struct {
 	ParentID  string // Filter by parent group
 	GroupType string // Filter by group type ("explicit" or "project_agents")
 	ProjectID string // Filter by project ID (for project_agents groups)
+	Search    string // Case-insensitive match on name or slug
 }
 
 // PrincipalRef identifies a principal by type and ID.

--- a/web/src/components/pages/admin-role-bindings.ts
+++ b/web/src/components/pages/admin-role-bindings.ts
@@ -695,11 +695,12 @@ export class ScionPageAdminRoleBindings extends LitElement {
           >
             <sl-option value="user">User</sl-option>
             <sl-option value="agent">Agent</sl-option>
+            <sl-option value="group">Group</sl-option>
           </sl-select>
         </div>
         <div class="form-group">
           <scion-principal-picker
-            .principalType=${this.formPrincipalType as 'user' | 'agent'}
+            .principalType=${this.formPrincipalType as 'user' | 'agent' | 'group'}
             @principal-change=${(e: CustomEvent<PrincipalChangeDetail>) => {
               this.formPrincipalId = e.detail.principalId;
             }}

--- a/web/src/components/shared/principal-picker.ts
+++ b/web/src/components/shared/principal-picker.ts
@@ -41,8 +41,8 @@ export interface PrincipalChangeDetail {
 
 @customElement('scion-principal-picker')
 export class ScionPrincipalPicker extends LitElement {
-  /** Controls which input mode to show: 'user' (autocomplete) or 'agent' (plain text). */
-  @property() principalType: 'user' | 'agent' = 'user';
+  /** Controls which input mode to show: 'user' (autocomplete), 'agent' (plain text), or 'group' (autocomplete). */
+  @property() principalType: 'user' | 'agent' | 'group' = 'user';
 
   /** Current selected principal ID. */
   @property() value = '';
@@ -71,6 +71,8 @@ export class ScionPrincipalPicker extends LitElement {
     super.disconnectedCallback();
     if (this.searchDebounceTimer) clearTimeout(this.searchDebounceTimer);
     if (this.blurTimeoutId) clearTimeout(this.blurTimeoutId);
+    if (this.groupSearchDebounceTimer) clearTimeout(this.groupSearchDebounceTimer);
+    if (this.groupBlurTimeoutId) clearTimeout(this.groupBlurTimeoutId);
   }
 
   static override styles = css`
@@ -140,17 +142,34 @@ export class ScionPrincipalPicker extends LitElement {
       this.searchQuery = '';
       this.searchResults = [];
       this.searchOpen = false;
+      this.groupSearchQuery = '';
+      this.groupSearchResults = [];
+      this.groupSearchOpen = false;
     }
   }
 
+  // Group search autocomplete state
+  @state() private groupSearchQuery = '';
+  @state() private groupSearchResults: Array<{ id: string; name: string; slug: string }> = [];
+  @state() private groupSearchLoading = false;
+  @state() private groupSearchOpen = false;
+  private groupSearchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private groupBlurTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private groupSearchRequestId = 0;
+  private groupSelectedViaDropdown = false;
+
   private get resolvedLabel(): string {
     if (this.label) return this.label;
-    return this.principalType === 'user' ? 'User' : 'Agent ID';
+    if (this.principalType === 'user') return 'User';
+    if (this.principalType === 'group') return 'Group';
+    return 'Agent ID';
   }
 
   private get resolvedPlaceholder(): string {
     if (this.placeholder) return this.placeholder;
-    return this.principalType === 'user' ? 'Search by name or email...' : 'Enter agent ID';
+    if (this.principalType === 'user') return 'Search by name or email...';
+    if (this.principalType === 'group') return 'Search by group name...';
+    return 'Enter agent ID';
   }
 
   // ---------------------------------------------------------------------------
@@ -244,6 +263,9 @@ export class ScionPrincipalPicker extends LitElement {
     if (this.principalType === 'user') {
       return this.renderUserSearch();
     }
+    if (this.principalType === 'group') {
+      return this.renderGroupSearch();
+    }
     return this.renderAgentInput();
   }
 
@@ -297,6 +319,117 @@ export class ScionPrincipalPicker extends LitElement {
                             ${user.displayName
                               ? html`<span class="user-email">${user.email}</span>`
                               : nothing}
+                          </div>
+                        `
+                      )}
+              </div>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Group search logic
+  // ---------------------------------------------------------------------------
+
+  private handleGroupSearchInput(e: Event): void {
+    const value = (e.target as HTMLInputElement).value;
+    this.groupSearchQuery = value;
+    this.groupSelectedViaDropdown = false;
+
+    if (this.groupSearchDebounceTimer) {
+      clearTimeout(this.groupSearchDebounceTimer);
+    }
+
+    if (value.trim().length < 2) {
+      this.groupSearchResults = [];
+      this.groupSearchOpen = false;
+      this.emitChange(value.trim(), value.trim());
+      return;
+    }
+
+    this.groupSearchDebounceTimer = setTimeout(() => {
+      void this.searchGroups(value.trim());
+      this.emitChange(value.trim(), '');
+    }, 250);
+  }
+
+  private async searchGroups(query: string): Promise<void> {
+    const requestId = ++this.groupSearchRequestId;
+    this.groupSearchLoading = true;
+    this.groupSearchOpen = true;
+    try {
+      const response = await apiFetch(`/api/v1/groups?search=${encodeURIComponent(query)}&limit=10`);
+      if (requestId !== this.groupSearchRequestId) return;
+      if (response.ok) {
+        const data = (await response.json()) as {
+          groups?: Array<{ id: string; name: string; slug: string }>;
+        };
+        this.groupSearchResults = data.groups || [];
+      }
+    } catch (err) {
+      if (requestId !== this.groupSearchRequestId) return;
+      console.error('Failed to search groups:', err);
+      this.groupSearchResults = [];
+    } finally {
+      if (requestId === this.groupSearchRequestId) {
+        this.groupSearchLoading = false;
+      }
+    }
+  }
+
+  private selectGroup(group: { id: string; name: string; slug: string }): void {
+    this.groupSearchQuery = `${group.name} (${group.slug})`;
+    this.groupSearchOpen = false;
+    this.groupSearchResults = [];
+    this.groupSelectedViaDropdown = true;
+    this.emitChange(group.id, group.name);
+  }
+
+  private renderGroupSearch() {
+    return html`
+      <div class="user-search-container">
+        <sl-input
+          label=${this.resolvedLabel}
+          placeholder=${this.resolvedPlaceholder}
+          value=${this.groupSearchQuery}
+          type="text"
+          autocomplete="off"
+          ?disabled=${this.disabled}
+          @sl-input=${this.handleGroupSearchInput}
+          @sl-focus=${() => {
+            if (this.groupSearchResults.length > 0) this.groupSearchOpen = true;
+          }}
+          @sl-blur=${() => {
+            this.groupBlurTimeoutId = setTimeout(() => {
+              this.groupSearchOpen = false;
+              if (!this.groupSelectedViaDropdown && this.groupSearchQuery.trim()) {
+                this.emitChange(this.groupSearchQuery.trim(), '');
+              }
+            }, 200);
+          }}
+        ></sl-input>
+        ${this.groupSearchOpen
+          ? html`
+              <div class="user-search-dropdown">
+                ${this.groupSearchLoading
+                  ? html`<div class="user-search-loading">
+                      <sl-spinner></sl-spinner> Searching...
+                    </div>`
+                  : this.groupSearchResults.length === 0
+                    ? html`<div class="user-search-empty">No groups found</div>`
+                    : this.groupSearchResults.map(
+                        (group) => html`
+                          <div
+                            class="user-search-option"
+                            @mousedown=${(e: Event) => {
+                              e.preventDefault();
+                              this.selectGroup(group);
+                            }}
+                          >
+                            <span class="user-name">${group.name}</span>
+                            <span class="user-email">${group.slug}</span>
                           </div>
                         `
                       )}


### PR DESCRIPTION
Adds group support to RoleBinding (principal_type), with transitive group-membership expansion wired into isProjectOwnerOrAdmin, getEffectivePermissions, IsSystemAdmin, and IsHubAdmin.