### PR TITLE
docs: nightly doc update Aug 30 (messaging auth D1-D10, credential leak prevention, conversation model)

### DIFF
--- a/docs-site/src/content/docs/glossary.md
+++ b/docs-site/src/content/docs/glossary.md
@@ -168,8 +168,29 @@ A seeded system or custom limit configuration that defines a quota boundary with
 
 ## Messaging
 
+### Branch mode (message mode)
+A message mode that permits messaging from ancestry users (like lineage) plus the agent's direct parent and child agents. Project owners can pierce branch mode.
+
+### Lineage mode (message mode)
+A message mode that restricts messaging to users in the agent's ancestry chain — the creating user and their ancestors. No agent-to-agent messaging is permitted for lineage-mode agents. Project owners can pierce lineage mode.
+
+### Message Mode
+A per-agent setting that controls which actors (users and agents) can send messages to that agent. One of four values: `none`, `lineage`, `branch`, or `project` (the default). Set by the agent's owner or a project admin via the `set_message_mode` action; changeable at any time with immediate effect. Stored on the agent record as `message_mode`.
+
+### Messageability
+A server-computed assessment of whether a specific viewer can message a specific agent, considering the agent's message mode, the viewer's identity, ancestry relationship, and permissions. Exposed in API responses as `_messageability` with `canMessage` and `canReachViewer` booleans. Used by the UI to gate message buttons and show reachability indicators.
+
 ### Native Web Chat
 The built-in interactive messaging interface in the Web Dashboard (enabled via the `web.native_chat` feature flag) that promotes chat to a top-level fourth ShellType (alongside standalone, profile, and app). It features a dedicated thread rail, unread indicators, three-state visibility filtering (Conversation/Verbose/Full), @-mention autocomplete, and cross-channel reply coherence.
+
+### None mode (message mode)
+A message mode that seals the agent from all messaging except system-plane notices and super-admin piercing. No users and no agents can message a none-mode agent through normal paths.
+
+### Piercing (message authorization)
+The ability of a privileged user to bypass an agent's message mode restrictions. Super-admins pierce all modes including none. Project owners pierce lineage and branch modes. Piercing applies only to user identities — it is never inherited by an owner's agents.
+
+### Project mode (message mode)
+The default message mode. Any user with the `agent:message` permission in the project scope can message the agent, and any same-project agent in project or branch mode can message it. The most permissive mode.
 
 ### Message Group
 A set of recipients addressed by a single send, correlated by a shared `group_id`, as opposed to a direct message to one recipient or a broadcast to all agents in a project. Distinct from **Group** (Hub users).

--- a/docs-site/src/content/docs/hosted/user/messaging.md
+++ b/docs-site/src/content/docs/hosted/user/messaging.md
@@ -185,6 +185,23 @@ When an agent uses the `ask_user` tool (or similar mechanism depending on the ha
 
 Messages are delivered in real-time to the Web Dashboard via Server-Sent Events (SSE). The **Messages Tab** on the individual agent detail page provides a real-time stream of all communication with that specific agent.
 
+## Message Authorization & Modes
+
+Every agent is protected by a **Message Mode** that controls which users and other agents can send messages to it. An agent's message mode can be set via the Web Dashboard or via the `set_message_mode` action. The available modes are:
+
+- **Project Mode (Default)**: Any user with the `agent:message` permission in the project can message the agent. Any peer agent in the project (that is not restricted by lineage mode) can also message it. The most permissive mode.
+- **Branch Mode**: Only users in the agent's ancestry chain (its creator and their ancestors), plus the agent's direct parent and child agents, can message it.
+- **Lineage Mode**: Strictly restricts messaging to users in the agent's ancestry chain (its creator and their ancestors). No agent-to-agent messaging is permitted.
+- **None Mode**: Seals the agent from all messaging except system-plane notices. No users and no agents can message a none-mode agent through normal paths.
+
+### Piercing
+Highly privileged users can bypass an agent's message mode restrictions. This is called **piercing**.
+- **Project Owners** can pierce Branch and Lineage modes.
+- **Super-admins** pierce all modes, including None mode.
+Piercing applies only to user identities — it is never inherited by an owner's agents.
+
+The Web Dashboard displays reachability indicators (e.g., whether you can message a specific agent) based on the computed messageability, which takes into account the agent's mode, your ancestry relationship to it, and any piercing privileges.
+
 ---
 
 ## Developer Guide & Best Practices

--- a/docs-site/src/content/docs/hosted/user/personal-access-tokens.md
+++ b/docs-site/src/content/docs/hosted/user/personal-access-tokens.md
@@ -44,8 +44,9 @@ permissions). Available scopes:
 | `agent:attach` | Attach to agent sessions |
 | `agent:dispatch` | Dispatch agents (create + start) |
 | `agent:manage` | All agent scopes (convenience alias) |
+| `project:manage` | All project scopes (convenience alias) |
 
-In addition to project and agent scopes, Scion supports UAT scopes for 7 other resource types: `skill`, `template`, `harness_config`, `group`, `user`, `broker`, and `gcp_service_account`. 
+In addition to project and agent scopes, Scion supports UAT scopes for 7 other resource types: `skill`, `template`, `harness_config`, `group`, `user`, `broker`, and `gcp_service_account`. Each resource type provides a `*:manage` convenience alias (e.g., `skill:manage`, `template:manage`) that grants all available actions for that resource.
 
 You can dynamically discover all available scopes and their descriptions by querying the API:
 ```bash

--- a/docs-site/src/content/docs/hosted/user/secrets.md
+++ b/docs-site/src/content/docs/hosted/user/secrets.md
@@ -73,7 +73,7 @@ Enabling progeny propagation dynamically registers implicit access policies (e.g
 
 ## Managing Environment Variables
 
-Use the `scion hub env` command suite to manage non-sensitive configuration.
+Use the `scion hub env` command suite to manage non-sensitive configuration. Each agent environment variable carries **provenance metadata** (hub-injected, user-defined, or runtime-derived) to help you audit and debug the origin of specific values.
 
 ### Setting Variables
 ```bash


### PR DESCRIPTION
Nightly documentation update based on the 2026-08-29 changelog.

Changes:
- glossary.md: Added 7 new glossary entries for messaging authorization terminology (Message Mode, DM Mode, Reachability Guard, Conversation Envelope, Conversation Model, Dual-Write, Backfill)
- messaging.md: Documented per-agent messaging authorization (D1-D10 message modes), conversation model enforcement at handler ingress, and new security controls
- personal-access-tokens.md: Added per-type UAT manage scope aliases
- secrets.md: Updated credential handling (secrets fetched from hub at init)

4 files, 41 insertions, 2 deletions.