### PR TITLE
hub: add read-only messaging divergence board (admin diagnostics)

### DIFF
--- a/pkg/hub/admin_messaging_divergence.go
+++ b/pkg/hub/admin_messaging_divergence.go
@@ -64,10 +64,11 @@ var divergenceCaveats = divergenceBoardCaveats{
 	NotGoNoGo: "This board is NOT the Tranche G go/no-go input. " +
 		"The offline recomputation report is the artifact that answers " +
 		"the go/no-go question.",
-	CounterSnapshot: "matches, mismatches, and comparisons are read-consistent " +
-		"(comparisons = matches + mismatches from one snapshot). fallbacks is " +
-		"an independent atomic read and may reflect a slightly different point " +
-		"in time under concurrent traffic.",
+	CounterSnapshot: "All counters are read independently via separate atomic loads " +
+		"and may not correspond to a single instant. comparisons is computed as " +
+		"matches + mismatches from those independent reads, so the triple is " +
+		"arithmetically consistent but not a true snapshot. Ratios derived from " +
+		"these values (e.g. mismatch rate, fallback percentage) are approximate.",
 }
 
 // handleAdminMessagingDivergence handles GET /api/v1/admin/messaging/divergence.

--- a/pkg/hub/admin_messaging_divergence.go
+++ b/pkg/hub/admin_messaging_divergence.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/messaging"
+)
+
+// divergenceBoardCaveats contains the machine-readable caveats that accompany
+// every divergence board response. They are constant — the board's structural
+// limitations do not change at runtime.
+type divergenceBoardCaveats struct {
+	Scope                      string `json:"scope"`
+	ScopeDetail                string `json:"scope_detail"`
+	MismatchComposition        string `json:"mismatch_composition"`
+	ConsistencyCheckFailsOpen  string `json:"consistency_check_fails_open"`
+	NotGoNoGo                  string `json:"not_go_no_go"`
+	CounterSnapshot            string `json:"counter_snapshot"`
+}
+
+// divergenceBoardResponse is the JSON shape returned by
+// GET /api/v1/admin/messaging/divergence.
+type divergenceBoardResponse struct {
+	HubID            string                 `json:"hub_id"`
+	ProcessStartTime string                 `json:"process_start_time"`
+	ProcessUptime    string                 `json:"process_uptime"`
+	Matches          int64                  `json:"matches"`
+	Mismatches       int64                  `json:"mismatches"`
+	Comparisons      int64                  `json:"comparisons"`
+	Fallbacks        int64                  `json:"fallbacks"`
+	Caveats          divergenceBoardCaveats `json:"caveats"`
+}
+
+// caveats is the singleton caveat block. These are structural properties of
+// the counter, not runtime values — they never change.
+var divergenceCaveats = divergenceBoardCaveats{
+	Scope:       "per_replica_since_boot",
+	ScopeDetail: "These counters live in process memory and reset when the replica restarts. They reflect only this replica's traffic, identified by hub_id.",
+	MismatchComposition: "The mismatches count conflates two unrelated signals: " +
+		"routing-key disagreement (ComputeDivergenceMatch) and prior-message " +
+		"conversation_id inconsistency (CheckConversationConsistency). " +
+		"This board cannot separate them.",
+	ConsistencyCheckFailsOpen: "CheckConversationConsistency returns true " +
+		"(no mismatch increment) on ListMessages query errors, on empty " +
+		"resolved conversation IDs, and when insufficient data prevents " +
+		"lookup. A low mismatch count does not imply agreement — it is " +
+		"equally consistent with agreement, query errors, or insufficient " +
+		"lookup data.",
+	NotGoNoGo: "This board is NOT the Tranche G go/no-go input. " +
+		"The offline recomputation report is the artifact that answers " +
+		"the go/no-go question.",
+	CounterSnapshot: "matches, mismatches, and comparisons are read-consistent " +
+		"(comparisons = matches + mismatches from one snapshot). fallbacks is " +
+		"an independent atomic read and may reflect a slightly different point " +
+		"in time under concurrent traffic.",
+}
+
+// handleAdminMessagingDivergence handles GET /api/v1/admin/messaging/divergence.
+// It returns a read-only snapshot of the in-memory divergence counters with
+// structural caveats about what the numbers mean and do not mean.
+//
+// Authorization: enforced by routeGuard via hub.diagnostics.read permission.
+func (s *Server) handleAdminMessagingDivergence(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		MethodNotAllowed(w)
+		return
+	}
+
+	// Load matches and mismatches once so that comparisons = matches + mismatches
+	// is arithmetically consistent in the response. Each is an atomic load from
+	// DivergenceMetrics; loading them separately means a concurrent Inc could
+	// land between the two reads, but the triple is internally consistent.
+	m := messaging.DivergenceMetrics
+	matches := m.Matches()
+	mismatches := m.Mismatches()
+	fallbacks := m.Fallbacks()
+
+	writeJSON(w, http.StatusOK, divergenceBoardResponse{
+		HubID:            s.HubID(),
+		ProcessStartTime: s.startTime.UTC().Format(time.RFC3339),
+		ProcessUptime:    time.Since(s.startTime).Round(time.Second).String(),
+		Matches:          matches,
+		Mismatches:       mismatches,
+		Comparisons:      matches + mismatches,
+		Fallbacks:        fallbacks,
+		Caveats:          divergenceCaveats,
+	})
+}

--- a/pkg/hub/admin_messaging_divergence.go
+++ b/pkg/hub/admin_messaging_divergence.go
@@ -25,12 +25,12 @@ import (
 // every divergence board response. They are constant — the board's structural
 // limitations do not change at runtime.
 type divergenceBoardCaveats struct {
-	Scope                      string `json:"scope"`
-	ScopeDetail                string `json:"scope_detail"`
-	MismatchComposition        string `json:"mismatch_composition"`
-	ConsistencyCheckFailsOpen  string `json:"consistency_check_fails_open"`
-	NotGoNoGo                  string `json:"not_go_no_go"`
-	CounterSnapshot            string `json:"counter_snapshot"`
+	Scope                     string `json:"scope"`
+	ScopeDetail               string `json:"scope_detail"`
+	MismatchComposition       string `json:"mismatch_composition"`
+	ConsistencyCheckFailsOpen string `json:"consistency_check_fails_open"`
+	NotGoNoGo                 string `json:"not_go_no_go"`
+	CounterSnapshot           string `json:"counter_snapshot"`
 }
 
 // divergenceBoardResponse is the JSON shape returned by

--- a/pkg/hub/admin_messaging_divergence_test.go
+++ b/pkg/hub/admin_messaging_divergence_test.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/messaging"
+)
+
+func TestHandleAdminMessagingDivergence_GET(t *testing.T) {
+	// Seed the global counter so we can verify the handler reads it.
+	// DivergenceMetrics is a package-level var; tests run serially within
+	// the package so this is safe.
+	messaging.DivergenceMetrics = &messaging.DivergenceCounter{}
+	messaging.DivergenceMetrics.Inc(true)  // 1 match
+	messaging.DivergenceMetrics.Inc(true)  // 2 matches
+	messaging.DivergenceMetrics.Inc(false) // 1 mismatch
+	messaging.DivergenceMetrics.IncFallback()
+	messaging.DivergenceMetrics.IncFallback()
+
+	srv := &Server{
+		startTime: time.Date(2026, 8, 30, 0, 0, 0, 0, time.UTC),
+	}
+	srv.SetHubID("test-hub-id")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/messaging/divergence", nil)
+	rr := httptest.NewRecorder()
+	srv.handleAdminMessagingDivergence(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	ct := rr.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+
+	var resp divergenceBoardResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// Verify counter values.
+	if resp.Matches != 2 {
+		t.Errorf("expected matches=2, got %d", resp.Matches)
+	}
+	if resp.Mismatches != 1 {
+		t.Errorf("expected mismatches=1, got %d", resp.Mismatches)
+	}
+	if resp.Comparisons != 3 {
+		t.Errorf("expected comparisons=3, got %d", resp.Comparisons)
+	}
+	if resp.Fallbacks != 2 {
+		t.Errorf("expected fallbacks=2, got %d", resp.Fallbacks)
+	}
+
+	// Arithmetic consistency: comparisons must equal matches + mismatches.
+	if resp.Comparisons != resp.Matches+resp.Mismatches {
+		t.Errorf("comparisons (%d) != matches (%d) + mismatches (%d)",
+			resp.Comparisons, resp.Matches, resp.Mismatches)
+	}
+
+	// Verify identity fields.
+	if resp.HubID != "test-hub-id" {
+		t.Errorf("expected hub_id=test-hub-id, got %q", resp.HubID)
+	}
+	if resp.ProcessStartTime == "" {
+		t.Error("expected process_start_time to be non-empty")
+	}
+	if resp.ProcessUptime == "" {
+		t.Error("expected process_uptime to be non-empty")
+	}
+}
+
+// TestHandleAdminMessagingDivergence_CaveatKeysPresent asserts the presence
+// of load-bearing caveat keys by name. These caveats are the only thing
+// preventing a reader from misinterpreting the counter values. Removing them
+// is a semantic regression — this test turns "please keep these" into a
+// build-enforced invariant.
+func TestHandleAdminMessagingDivergence_CaveatKeysPresent(t *testing.T) {
+	messaging.DivergenceMetrics = &messaging.DivergenceCounter{}
+
+	srv := &Server{
+		startTime: time.Now(),
+	}
+	srv.SetHubID("test-hub")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/messaging/divergence", nil)
+	rr := httptest.NewRecorder()
+	srv.handleAdminMessagingDivergence(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	// Decode into a raw map so we assert key presence independently of the
+	// Go struct — a struct change that drops a field will fail here.
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(rr.Body).Decode(&raw); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	caveatsRaw, ok := raw["caveats"]
+	if !ok {
+		t.Fatal("response missing top-level 'caveats' key")
+	}
+
+	var caveats map[string]string
+	if err := json.Unmarshal(caveatsRaw, &caveats); err != nil {
+		t.Fatalf("failed to decode caveats: %v", err)
+	}
+
+	// These are the load-bearing keys. If you are here because this test
+	// broke, do NOT remove the assertion — read the caveat text to understand
+	// why it exists, and preserve or replace it with an equivalent disclosure.
+	requiredKeys := []string{
+		"scope",
+		"scope_detail",
+		"mismatch_composition",
+		"consistency_check_fails_open",
+		"not_go_no_go",
+		"counter_snapshot",
+	}
+	for _, key := range requiredKeys {
+		val, present := caveats[key]
+		if !present {
+			t.Errorf("caveats missing required key %q", key)
+		} else if val == "" {
+			t.Errorf("caveat %q is present but empty", key)
+		}
+	}
+}
+
+// TestHandleAdminMessagingDivergence_ReadOnly asserts that the endpoint
+// rejects all non-GET methods. The handler must never mutate the counter.
+func TestHandleAdminMessagingDivergence_ReadOnly(t *testing.T) {
+	srv := &Server{
+		startTime: time.Now(),
+	}
+
+	for _, method := range []string{
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodPatch,
+		http.MethodDelete,
+	} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/api/v1/admin/messaging/divergence", nil)
+			rr := httptest.NewRecorder()
+			srv.handleAdminMessagingDivergence(rr, req)
+
+			if rr.Code != http.StatusMethodNotAllowed {
+				t.Errorf("%s: expected 405, got %d", method, rr.Code)
+			}
+		})
+	}
+}

--- a/pkg/hub/admin_messaging_divergence_test.go
+++ b/pkg/hub/admin_messaging_divergence_test.go
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Tests in this file reinitialise the package-global messaging.DivergenceMetrics
+// counter and assert on its values. Because the counter is shared mutable state
+// (a package-level *DivergenceCounter backed by atomic.Int64 fields), concurrent
+// tests that each reset and increment it would observe each other's writes and
+// fail intermittently. These tests MUST run serially — do not add t.Parallel().
 package hub
 
 import (

--- a/pkg/hub/route_classification_test.go
+++ b/pkg/hub/route_classification_test.go
@@ -122,6 +122,7 @@ var routePermissionClassifications = map[string]string{
 	"/api/v1/admin/diagnostics/logs/stream":     "hub-admin:diagnostics",
 	"/api/v1/admin/diagnostics/logs":            "hub-admin:diagnostics",
 	"/api/v1/admin/health/summary":              "hub-admin:health",
+	"/api/v1/admin/messaging/divergence":        "hub-admin:diagnostics",
 	"/api/v1/metrics/":                          "hub-admin:metrics-dashboard",
 	"/api/v1/admin/metrics-dashboard":           "hub-admin:metrics-dashboard",
 	"/api/v1/notifications":                     "authenticated:notifications",

--- a/pkg/hub/route_metadata.go
+++ b/pkg/hub/route_metadata.go
@@ -718,6 +718,11 @@ var routeMetadataTable = map[string]RouteMetadata{
 		Classification: RouteHubAdmin,
 		Permission:     "hub.health.read", Resource: "hub", Action: "read",
 	},
+	"/api/v1/admin/messaging/divergence": {
+		Pattern: "/api/v1/admin/messaging/divergence", RouteID: "admin.messaging.divergence",
+		Classification: RouteHubAdmin,
+		Permission:     "hub.diagnostics.read", Resource: "hub", Action: "read",
+	},
 	"/api/v1/metrics/": {
 		Pattern: "/api/v1/metrics/", RouteID: "admin.metricsDashboard",
 		Classification: RouteHubAdmin,

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3862,6 +3862,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/admin/diagnostics/logs/stream", s.guarded("/api/v1/admin/diagnostics/logs/stream", s.handleDiagnosticsLogsStream))
 	s.mux.HandleFunc("/api/v1/admin/diagnostics/logs", s.guarded("/api/v1/admin/diagnostics/logs", s.handleDiagnosticsLogs))
 	s.mux.HandleFunc("/api/v1/admin/health/summary", s.guarded("/api/v1/admin/health/summary", s.handleHealthSummary))
+	s.mux.HandleFunc("/api/v1/admin/messaging/divergence", s.guarded("/api/v1/admin/messaging/divergence", s.handleAdminMessagingDivergence))
 	s.mux.HandleFunc("/api/v1/metrics/", s.guarded("/api/v1/metrics/", s.handleMetricsDashboard))
 	s.mux.HandleFunc("/api/v1/admin/metrics-dashboard", s.guarded("/api/v1/admin/metrics-dashboard", s.handleAdminMetricsDashboard)) // legacy backward-compat
 


### PR DESCRIPTION
Read-only admin endpoint exposing the messaging divergence counters.

Route: RouteHubAdmin + hub.diagnostics.read, matching the existing diagnostics/logs routes.

Ships five machine-readable caveat fields, each asserted by name in tests: per-replica, since-boot, mismatch-composition, fails-open, and an explicit "this is NOT the go/no-go input" pointing at the offline report.

The caveats are load-bearing. DivergenceMetrics has three writers and CheckConversationConsistency fails open on query error, so a low mismatch count is not evidence of agreement. counter_snapshot also discloses that the three counters are read via independent atomic loads and do not correspond to a single instant, so derived ratios are approximate.

Read-only enforced at the handler. No lock on the counter: it would sit on the write path of every message that logs a divergence.

291 added, 0 deleted. Independently reviewed: APPROVE, risk LOW