### PR TITLE
fix(messaging): backfill entry point (DEF-12) + resume data-loss fix (DEF-81)

### DIFF
--- a/cmd/server_backfill.go
+++ b/cmd/server_backfill.go
@@ -1,0 +1,268 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/config"
+	"github.com/GoogleCloudPlatform/scion/pkg/ent/entc"
+	"github.com/GoogleCloudPlatform/scion/pkg/messaging"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/GoogleCloudPlatform/scion/pkg/store/entadapter"
+	"github.com/spf13/cobra"
+)
+
+var (
+	backfillExecute    bool
+	backfillProject    string
+	backfillBatchSize  int
+	backfillCheckpoint string
+	backfillDB         string
+)
+
+var serverBackfillCmd = &cobra.Command{
+	Use:   "backfill",
+	Short: "Backfill conversation_id for historical messages",
+	Long: `Scan messages that predate the conversation model and assign them
+to conversations based on their thread, sender, and recipient metadata.
+
+By default runs in DRY-RUN mode — scans and reports what would change
+without modifying the database. Pass --execute to apply changes.
+
+The backfill is idempotent: messages already attributed to a conversation
+are skipped, so re-running is safe. It supports resume via --checkpoint.
+
+Examples:
+  # Preview what would change (dry-run, all projects):
+  scion server backfill
+
+  # Backfill a specific project:
+  scion server backfill --project <project-id> --execute
+
+  # Resume an interrupted run:
+  scion server backfill --execute --checkpoint <cursor>`,
+	RunE: runServerBackfill,
+}
+
+func init() {
+	serverCmd.AddCommand(serverBackfillCmd)
+	serverBackfillCmd.Flags().BoolVar(&backfillExecute, "execute", false, "Apply changes (default: dry-run)")
+	serverBackfillCmd.Flags().StringVar(&backfillProject, "project", "", "Backfill a specific project ID (default: all)")
+	serverBackfillCmd.Flags().IntVar(&backfillBatchSize, "batch-size", 0, "Messages per batch (0 = default 100)")
+	// Note: checkpoint cursors are project-scoped. Using a cursor from one project
+	// with a different --project flag may produce incorrect results. When running
+	// without --project (all projects), checkpoint is not used (cleared for multi-project runs).
+	serverBackfillCmd.Flags().StringVar(&backfillCheckpoint, "checkpoint", "",
+		"Resume from this pagination cursor (from a previous run's output; project-scoped)")
+	serverBackfillCmd.Flags().StringVar(&backfillDB, "db", "", "Database DSN (overrides config/env)")
+}
+
+func runServerBackfill(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	out := cmd.OutOrStdout()
+
+	s, err := openBackfillStore(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = s.Close() }()
+
+	// Determine which projects to backfill.
+	var projectIDs []string
+	if backfillProject != "" {
+		projectIDs = []string{backfillProject}
+	} else {
+		cursor := ""
+		for {
+			projects, err := s.ListProjects(ctx, store.ProjectFilter{}, store.ListOptions{Limit: 500, Cursor: cursor})
+			if err != nil {
+				return fmt.Errorf("listing projects: %w", err)
+			}
+			for _, p := range projects.Items {
+				projectIDs = append(projectIDs, p.ID)
+			}
+			if projects.NextCursor == "" {
+				break
+			}
+			cursor = projects.NextCursor
+		}
+		if len(projectIDs) == 0 {
+			_, _ = fmt.Fprintln(out, "No projects found.")
+			return nil
+		}
+	}
+
+	// Build the backfill config once; per-project runs share it.
+	cfg := messaging.BackfillConfig{
+		DryRun:     !backfillExecute,
+		BatchSize:  backfillBatchSize,
+		Checkpoint: backfillCheckpoint,
+	}
+
+	// Aggregate results across all projects.
+	total := &messaging.BackfillResult{}
+
+	for _, pid := range projectIDs {
+		cfg.ProjectID = pid
+		result, err := runBackfillWithStore(ctx, s, cfg)
+		if err != nil {
+			return fmt.Errorf("backfill project %s: %w", pid, err)
+		}
+		mergeBackfillResult(total, result)
+	}
+
+	// Checkpoint is only meaningful for single-project runs.
+	if len(projectIDs) > 1 {
+		total.LastCheckpoint = ""
+	}
+
+	// Print report.
+	printBackfillReport(out, total, projectIDs)
+
+	if len(total.Errors) > 0 {
+		return fmt.Errorf("backfill completed with %d error(s)", len(total.Errors))
+	}
+	return nil
+}
+
+// runBackfillWithStore is the testable core: given a store and config, run
+// the backfill for a single project and return the result.
+func runBackfillWithStore(ctx context.Context, s store.Store, cfg messaging.BackfillConfig) (*messaging.BackfillResult, error) {
+	svc := messaging.NewBackfillService(s, s, s)
+	return svc.Run(ctx, cfg)
+}
+
+// openBackfillStore resolves the database DSN and returns a CompositeStore.
+// Precedence: --db flag > config file (via LoadGlobalConfig).
+func openBackfillStore(ctx context.Context) (*entadapter.CompositeStore, error) {
+	cfg, err := config.LoadGlobalConfig(serverConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading config: %w", err)
+	}
+
+	// --db flag overrides config.
+	if backfillDB != "" {
+		cfg.Database.URL = backfillDB
+		// Auto-detect driver from DSN.
+		if strings.HasPrefix(backfillDB, "postgres://") || strings.HasPrefix(backfillDB, "postgresql://") {
+			cfg.Database.Driver = "postgres"
+		} else {
+			cfg.Database.Driver = "sqlite"
+		}
+	}
+
+	if cfg.Database.URL == "" {
+		return nil, fmt.Errorf("no database configured: set --db, SCION_SERVER_DATABASE_URL env, or database.url in server config")
+	}
+
+	var s *entadapter.CompositeStore
+
+	switch cfg.Database.Driver {
+	case "sqlite":
+		dsn := cfg.Database.URL
+		if !strings.HasPrefix(dsn, "file:") {
+			dsn = "file:" + dsn
+		}
+		if !strings.Contains(dsn, "?") {
+			dsn += "?cache=shared"
+		} else if !strings.Contains(dsn, "cache=") {
+			dsn += "&cache=shared"
+		}
+		client, err := entc.OpenSQLite(dsn, entc.PoolConfig{})
+		if err != nil {
+			return nil, fmt.Errorf("opening sqlite: %w", err)
+		}
+		if err := entc.AutoMigrate(ctx, client); err != nil {
+			_ = client.Close()
+			return nil, fmt.Errorf("running migrations: %w", err)
+		}
+		s = entadapter.NewCompositeStore(client)
+
+	case "postgres":
+		client, err := entc.OpenPostgres(cfg.Database.URL, entc.PoolConfig{MaxOpenConns: 10, MaxIdleConns: 5})
+		if err != nil {
+			return nil, fmt.Errorf("opening postgres: connection failed (verify DSN and network connectivity)")
+		}
+		if err := entc.AutoMigrate(ctx, client); err != nil {
+			_ = client.Close()
+			return nil, fmt.Errorf("running migrations: %w", err)
+		}
+		s = entadapter.NewCompositeStore(client)
+
+	default:
+		return nil, fmt.Errorf("unsupported database driver: %s", cfg.Database.Driver)
+	}
+
+	return s, nil
+}
+
+// mergeBackfillResult adds the counts from src into dst.
+func mergeBackfillResult(dst, src *messaging.BackfillResult) {
+	dst.TotalProcessed += src.TotalProcessed
+	dst.Attributed += src.Attributed
+	dst.Inferred += src.Inferred
+	dst.Skipped += src.Skipped
+	dst.ConversationsCreated += src.ConversationsCreated
+	dst.HazardAEmailCount += src.HazardAEmailCount
+	dst.HazardBSlugCount += src.HazardBSlugCount
+	if src.LastCheckpoint != "" {
+		dst.LastCheckpoint = src.LastCheckpoint
+	}
+	dst.Errors = append(dst.Errors, src.Errors...)
+}
+
+// printBackfillReport writes a human-readable summary to out.
+func printBackfillReport(out io.Writer, r *messaging.BackfillResult, projectIDs []string) {
+	mode := "dry-run"
+	if backfillExecute {
+		mode = "execute"
+	}
+
+	projectLabel := backfillProject
+	if projectLabel == "" {
+		projectLabel = fmt.Sprintf("all (%d projects)", len(projectIDs))
+	}
+
+	_, _ = fmt.Fprintln(out, "Conversation Backfill Report")
+	_, _ = fmt.Fprintln(out, "============================")
+	_, _ = fmt.Fprintf(out, "Mode:                  %s\n", mode)
+	_, _ = fmt.Fprintf(out, "Project:               %s\n", projectLabel)
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintf(out, "Messages processed:    %d\n", r.TotalProcessed)
+	_, _ = fmt.Fprintf(out, "  Attributed:          %d\n", r.Attributed)
+	_, _ = fmt.Fprintf(out, "  Inferred (hazard-a): %d\n", r.Inferred)
+	_, _ = fmt.Fprintf(out, "  Skipped:             %d\n", r.Skipped)
+	_, _ = fmt.Fprintf(out, "Conversations created: %d\n", r.ConversationsCreated)
+	_, _ = fmt.Fprintf(out, "Hazard-b (slug refs):  %d\n", r.HazardBSlugCount)
+	_, _ = fmt.Fprintf(out, "Errors:                %d\n", len(r.Errors))
+	if r.LastCheckpoint != "" {
+		_, _ = fmt.Fprintf(out, "Last checkpoint:       %s\n", r.LastCheckpoint)
+	}
+	if len(projectIDs) > 1 {
+		_, _ = fmt.Fprintln(out, "  (checkpoint valid for single-project runs only)")
+	}
+
+	if len(r.Errors) > 0 {
+		_, _ = fmt.Fprintln(out)
+		_, _ = fmt.Fprintln(out, "Errors:")
+		for _, e := range r.Errors {
+			_, _ = fmt.Fprintf(out, "  - %s\n", e)
+		}
+	}
+}

--- a/cmd/server_backfill.go
+++ b/cmd/server_backfill.go
@@ -73,6 +73,16 @@ func init() {
 	serverBackfillCmd.Flags().StringVar(&backfillDB, "db", "", "Database DSN (overrides config/env)")
 }
 
+// backfillConfigFromFlags builds the BackfillConfig from command flags.
+// Extracted so the dry-run default is assertable without a database.
+func backfillConfigFromFlags() messaging.BackfillConfig {
+	return messaging.BackfillConfig{
+		DryRun:     !backfillExecute,
+		BatchSize:  backfillBatchSize,
+		Checkpoint: backfillCheckpoint,
+	}
+}
+
 func runServerBackfill(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
 	out := cmd.OutOrStdout()
@@ -109,11 +119,7 @@ func runServerBackfill(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Build the backfill config once; per-project runs share it.
-	cfg := messaging.BackfillConfig{
-		DryRun:     !backfillExecute,
-		BatchSize:  backfillBatchSize,
-		Checkpoint: backfillCheckpoint,
-	}
+	cfg := backfillConfigFromFlags()
 
 	// Aggregate results across all projects.
 	total := &messaging.BackfillResult{}

--- a/cmd/server_backfill.go
+++ b/cmd/server_backfill.go
@@ -203,7 +203,7 @@ func openBackfillStore(ctx context.Context) (*entadapter.CompositeStore, error) 
 	case "postgres":
 		client, err := entc.OpenPostgres(cfg.Database.URL, entc.PoolConfig{MaxOpenConns: 10, MaxIdleConns: 5})
 		if err != nil {
-			return nil, fmt.Errorf("opening postgres: connection failed (verify DSN and network connectivity)")
+			return nil, fmt.Errorf("opening postgres (verify DSN and network connectivity): %w", err)
 		}
 		if err := entc.AutoMigrate(ctx, client); err != nil {
 			_ = client.Close()

--- a/cmd/server_backfill_safety_test.go
+++ b/cmd/server_backfill_safety_test.go
@@ -39,26 +39,24 @@ func TestBackfillExecuteFlagDefaultIsFalse(t *testing.T) {
 	}
 }
 
-// TestBackfillDryRunDerivation verifies that the DryRun config field is
-// the logical inverse of backfillExecute. A wiring bug that sets
-// DryRun = backfillExecute (instead of !backfillExecute) would make the
-// default (execute=false) perform mutations.
+// TestBackfillDryRunDerivation calls the production backfillConfigFromFlags
+// function and asserts DryRun is the logical inverse of backfillExecute.
+// A wiring bug that sets DryRun = backfillExecute (instead of
+// !backfillExecute) would make the default perform mutations.
 func TestBackfillDryRunDerivation(t *testing.T) {
 	// Save and restore the global.
 	orig := backfillExecute
 	defer func() { backfillExecute = orig }()
 
-	// Default state: --execute not passed → backfillExecute is false.
+	// Default state: --execute not passed → DryRun must be true.
 	backfillExecute = false
-	dryRun := !backfillExecute
-	if !dryRun {
+	if !backfillConfigFromFlags().DryRun {
 		t.Fatal("DryRun must be true when backfillExecute is false (default)")
 	}
 
-	// Explicit --execute → backfillExecute is true.
+	// Explicit --execute → DryRun must be false.
 	backfillExecute = true
-	dryRun = !backfillExecute
-	if dryRun {
+	if backfillConfigFromFlags().DryRun {
 		t.Fatal("DryRun must be false when backfillExecute is true (--execute passed)")
 	}
 }

--- a/cmd/server_backfill_safety_test.go
+++ b/cmd/server_backfill_safety_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NO build tag — this file runs in every CI lane, including
+// `go test -tags no_sqlite ./...` (the blocking lane). It guards the
+// single most dangerous property: that `scion server backfill` defaults
+// to dry-run. The companion TestBackfillDefaultIsDryRun_FlagWiring in
+// server_backfill_test.go verifies end-to-end with a real store but
+// lives behind !no_sqlite (advisory lane). This test needs no store.
+
+package cmd
+
+import (
+	"testing"
+)
+
+// TestBackfillExecuteFlagDefaultIsFalse asserts that the --execute flag
+// on the backfill command defaults to "false". If someone changes the
+// flag registration to default true, an operator typing
+// `scion server backfill` to preview would silently mutate the database.
+func TestBackfillExecuteFlagDefaultIsFalse(t *testing.T) {
+	f := serverBackfillCmd.Flags().Lookup("execute")
+	if f == nil {
+		t.Fatal("--execute flag not registered on serverBackfillCmd")
+	}
+	if f.DefValue != "false" {
+		t.Fatalf("--execute default must be \"false\" (dry-run); got %q", f.DefValue)
+	}
+}
+
+// TestBackfillDryRunDerivation verifies that the DryRun config field is
+// the logical inverse of backfillExecute. A wiring bug that sets
+// DryRun = backfillExecute (instead of !backfillExecute) would make the
+// default (execute=false) perform mutations.
+func TestBackfillDryRunDerivation(t *testing.T) {
+	// Save and restore the global.
+	orig := backfillExecute
+	defer func() { backfillExecute = orig }()
+
+	// Default state: --execute not passed → backfillExecute is false.
+	backfillExecute = false
+	dryRun := !backfillExecute
+	if !dryRun {
+		t.Fatal("DryRun must be true when backfillExecute is false (default)")
+	}
+
+	// Explicit --execute → backfillExecute is true.
+	backfillExecute = true
+	dryRun = !backfillExecute
+	if dryRun {
+		t.Fatal("DryRun must be false when backfillExecute is true (--execute passed)")
+	}
+}

--- a/cmd/server_backfill_test.go
+++ b/cmd/server_backfill_test.go
@@ -1,0 +1,423 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/messaging"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testEncodeCursor replicates the store's cursor format for test use.
+// Format: base64(RFC3339Nano + "," + uuid)
+func testEncodeCursor(created time.Time, id string) string {
+	raw := created.Format(time.RFC3339Nano) + "," + id
+	return base64.URLEncoding.EncodeToString([]byte(raw))
+}
+
+// seedBackfillProject creates a project and returns its ID.
+func seedBackfillProject(t *testing.T, ctx context.Context, s store.Store) string {
+	t.Helper()
+	projectID := uuid.NewString()
+	err := s.CreateProject(ctx, &store.Project{
+		ID:         projectID,
+		Name:       "backfill-test",
+		Slug:       "backfill-test-" + projectID[:8],
+		Visibility: "private",
+	})
+	require.NoError(t, err)
+	return projectID
+}
+
+// seedDMMessage creates a message with a DM-style ThreadID between two UUIDs.
+// The message is created without a ConversationID, simulating pre-conversation data.
+func seedDMMessage(t *testing.T, ctx context.Context, s store.Store, projectID string, senderID, recipientID string, createdAt time.Time) string {
+	t.Helper()
+	msgID := uuid.NewString()
+	err := s.CreateMessage(ctx, &store.Message{
+		ID:          msgID,
+		ProjectID:   projectID,
+		Sender:      "user:" + senderID,
+		SenderID:    senderID,
+		Recipient:   "agent:" + recipientID,
+		RecipientID: recipientID,
+		Msg:         "test message",
+		Type:        "instruction",
+		CreatedAt:   createdAt,
+	})
+	require.NoError(t, err)
+	return msgID
+}
+
+// TestBackfillDryRunMutatesNothing verifies AC-12-2: dry-run mode reports
+// what would change without modifying any database rows.
+func TestBackfillDryRunMutatesNothing(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	projectID := seedBackfillProject(t, ctx, s)
+	senderID := uuid.NewString()
+	recipientID := uuid.NewString()
+
+	// Seed messages without conversation_id.
+	now := time.Now()
+	msgIDs := make([]string, 3)
+	for i := 0; i < 3; i++ {
+		msgIDs[i] = seedDMMessage(t, ctx, s, projectID, senderID, recipientID, now.Add(time.Duration(i)*time.Second))
+	}
+
+	// Run backfill in dry-run mode.
+	result, err := runBackfillWithStore(ctx, s, messaging.BackfillConfig{
+		DryRun:    true,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+
+	// Report should show what would change.
+	assert.Equal(t, 3, result.TotalProcessed, "should process all messages")
+	assert.True(t, result.Attributed+result.Inferred > 0, "should report attributions")
+	assert.Equal(t, 0, result.Skipped, "no messages should be skipped (none have conversation_id)")
+
+	// Verify messages still have NO conversation_id.
+	for _, msgID := range msgIDs {
+		msg, err := s.GetMessage(ctx, msgID)
+		require.NoError(t, err)
+		assert.Empty(t, msg.ConversationID, "dry-run should not set conversation_id on message %s", msgID)
+	}
+}
+
+// TestBackfillExecuteAndIdempotent verifies AC-12-3: a real run attributes
+// messages to conversations, and a second run is idempotent (all skipped).
+func TestBackfillExecuteAndIdempotent(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	projectID := seedBackfillProject(t, ctx, s)
+	senderID := uuid.NewString()
+	recipientID := uuid.NewString()
+
+	// Seed messages without conversation_id.
+	now := time.Now()
+	msgIDs := make([]string, 3)
+	for i := 0; i < 3; i++ {
+		msgIDs[i] = seedDMMessage(t, ctx, s, projectID, senderID, recipientID, now.Add(time.Duration(i)*time.Second))
+	}
+
+	// First run: execute mode.
+	result1, err := runBackfillWithStore(ctx, s, messaging.BackfillConfig{
+		DryRun:    false,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, result1.TotalProcessed)
+	assert.True(t, result1.Attributed+result1.Inferred > 0, "should attribute messages")
+	assert.Equal(t, 1, result1.ConversationsCreated, "should create one conversation for the DM pair")
+
+	// Verify messages now have a conversation_id.
+	for _, msgID := range msgIDs {
+		msg, err := s.GetMessage(ctx, msgID)
+		require.NoError(t, err)
+		assert.NotEmpty(t, msg.ConversationID, "execute should set conversation_id on message %s", msgID)
+	}
+
+	// Second run: should be idempotent (all skipped).
+	result2, err := runBackfillWithStore(ctx, s, messaging.BackfillConfig{
+		DryRun:    false,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, result2.TotalProcessed)
+	assert.Equal(t, 3, result2.Skipped, "idempotent re-run should skip all messages")
+	assert.Equal(t, 0, result2.Attributed, "idempotent re-run should attribute nothing new")
+	assert.Equal(t, 0, result2.ConversationsCreated, "idempotent re-run should create no conversations")
+}
+
+// TestBackfillResumeViaCheckpoint verifies AC-12-4: the cursor-based checkpoint
+// mechanism allows resuming a backfill from where pagination left off.
+func TestBackfillResumeViaCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	projectID := seedBackfillProject(t, ctx, s)
+	senderID := uuid.NewString()
+	recipientID := uuid.NewString()
+
+	// Seed 6 messages with distinct timestamps.
+	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 6; i++ {
+		seedDMMessage(t, ctx, s, projectID, senderID, recipientID, baseTime.Add(time.Duration(i)*time.Minute))
+	}
+
+	// Run with batch size 2 → 3 pages (DESC order: newest first).
+	// All messages get processed; LastCheckpoint records the cursor of the
+	// second-to-last completed page.
+	result1, err := runBackfillWithStore(ctx, s, messaging.BackfillConfig{
+		DryRun:    false,
+		ProjectID: projectID,
+		BatchSize: 2,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 6, result1.TotalProcessed)
+	assert.NotEmpty(t, result1.LastCheckpoint, "multi-page run should record a checkpoint")
+
+	// All messages should be attributed after the full run.
+	msgs, err := s.ListMessages(ctx, store.MessageFilter{ProjectID: projectID}, store.ListOptions{Limit: 100})
+	require.NoError(t, err)
+	for _, msg := range msgs.Items {
+		assert.NotEmpty(t, msg.ConversationID,
+			"all messages should have conversation_id after full backfill")
+	}
+
+	// Resume from checkpoint: the remaining messages (those after the cursor
+	// in DESC pagination order) were already attributed, so they are skipped.
+	result2, err := runBackfillWithStore(ctx, s, messaging.BackfillConfig{
+		DryRun:     false,
+		Checkpoint: result1.LastCheckpoint,
+		ProjectID:  projectID,
+		BatchSize:  2,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, result2.Skipped, result2.TotalProcessed,
+		"resume after completed run should skip all remaining messages (idempotent)")
+}
+
+// TestBackfillResumeViaCheckpoint_SameTimestamp is the KEY regression test
+// for the cursor-based checkpoint fix. It verifies that messages sharing an
+// identical created_at timestamp are NOT silently skipped when resuming from
+// a checkpoint cursor.
+//
+// Unlike the prior version of this test, NO prior backfill run is performed.
+// Instead, a cursor is manually constructed pointing at a middle message,
+// and the checkpoint's behaviour is the ONLY thing determining whether the
+// remaining same-timestamp messages get processed.
+//
+// On FIXED code (cursor-based): the store paginates past the cursor position
+// using (created, id) keyset, so same-timestamp siblings after the cursor
+// are returned → TotalProcessed = 2.
+//
+// On BUGGY code (fda9977f, filter.After = T): the checkpoint is resolved to
+// a timestamp and "created > T" filters out ALL same-timestamp messages
+// → the test fails (either via error or TotalProcessed = 0).
+//
+// NOTE: This test guards the STORE-LAYER mutation site (the (created, id)
+// tuple comparison in message_store.go:406-411). The companion test
+// TestBackfill_SameTimestampMessages in pkg/messaging guards the SERVICE-LAYER
+// mutation site (the filter.After form of the bug) against a mock store.
+// Neither is redundant — they guard different layers. Do not remove one
+// believing the other covers it.
+func TestBackfillResumeViaCheckpoint_SameTimestamp(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	projectID := seedBackfillProject(t, ctx, s)
+	senderID := uuid.NewString()
+
+	// 5 messages at IDENTICAL timestamp, different recipients.
+	same := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var ids []string
+	for i := 0; i < 5; i++ {
+		ids = append(ids, seedDMMessage(t, ctx, s, projectID, senderID, uuid.NewString(), same))
+	}
+
+	// Sort IDs to get deterministic ordering. ListMessages uses DESC by (created, id).
+	// So sorted ascending: ids[0] < ids[1] < ids[2] < ids[3] < ids[4]
+	// DESC order: ids[4], ids[3], ids[2], ids[1], ids[0]
+	sort.Strings(ids)
+
+	// Construct a cursor pointing at ids[2] — the middle message.
+	// This simulates "we already processed ids[4] and ids[3] (first page in DESC),
+	// and the cursor is positioned at ids[2]."
+	// Messages after the cursor in DESC: ids[1], ids[0] — these should be processed.
+	//
+	// NO prior backfill run — all messages still have empty conversation_id.
+	cursor := testEncodeCursor(same, ids[2])
+
+	result, err := runBackfillWithStore(ctx, s, messaging.BackfillConfig{
+		DryRun:     false,
+		ProjectID:  projectID,
+		Checkpoint: cursor,
+	})
+	require.NoError(t, err)
+
+	// EXACT counts — this is the regression guard.
+	// Fixed code (cursor-based): processes ids[1] and ids[0] — 2 messages at same timestamp.
+	// Buggy code (filter.After = T): "created > T" matches 0 messages. TotalProcessed = 0.
+	assert.Equal(t, 2, result.TotalProcessed,
+		"cursor-based resume must process same-timestamp messages after cursor position")
+	assert.Equal(t, 2, result.Attributed+result.Inferred,
+		"should attribute the 2 same-timestamp messages after cursor")
+	assert.Equal(t, 0, result.Skipped,
+		"no messages should be skipped (none have conversation_id)")
+}
+
+// TestBackfillDefaultIsDryRun_FlagWiring exercises the flag-to-config wiring
+// in runServerBackfill. It verifies that when backfillExecute is false (the
+// default, meaning --execute was NOT passed), the config sent to the backfill
+// engine has DryRun=true and messages are NOT stamped.
+//
+// Mutation guard: if someone changes `!backfillExecute` to `backfillExecute`
+// on line ~109 of server_backfill.go, DryRun becomes false and the assertion
+// on ConversationID will fail.
+func TestBackfillDefaultIsDryRun_FlagWiring(t *testing.T) {
+	// Save and restore all global flags that runServerBackfill reads.
+	origExecute := backfillExecute
+	origDB := backfillDB
+	origProject := backfillProject
+	origBatch := backfillBatchSize
+	origCheckpoint := backfillCheckpoint
+	origConfigPath := serverConfigPath
+	defer func() {
+		backfillExecute = origExecute
+		backfillDB = origDB
+		backfillProject = origProject
+		backfillBatchSize = origBatch
+		backfillCheckpoint = origCheckpoint
+		serverConfigPath = origConfigPath
+	}()
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	// Seed data through a direct store connection.
+	backfillDB = dbPath
+	serverConfigPath = filepath.Join(tmpDir, "nonexistent.yaml")
+	seedStore, err := openBackfillStore(ctx)
+	require.NoError(t, err)
+
+	projectID := seedBackfillProject(t, ctx, seedStore)
+	senderID := uuid.NewString()
+	recipientID := uuid.NewString()
+	seedDMMessage(t, ctx, seedStore, projectID, senderID, recipientID, time.Now())
+	require.NoError(t, seedStore.Close())
+
+	// Set global flags to their defaults (no --execute).
+	backfillExecute = false // default: should produce DryRun=true
+	backfillDB = dbPath
+	backfillProject = projectID
+	backfillBatchSize = 0
+	backfillCheckpoint = ""
+
+	// Call runServerBackfill — the actual production code path where the
+	// flag-to-config wiring lives.
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err = runServerBackfill(cmd, nil)
+	require.NoError(t, err)
+
+	// Re-open and verify messages were NOT stamped.
+	verifyStore, err := openBackfillStore(ctx)
+	require.NoError(t, err)
+	defer func() { _ = verifyStore.Close() }()
+
+	msgs, err := verifyStore.ListMessages(ctx, store.MessageFilter{ProjectID: projectID}, store.ListOptions{Limit: 100})
+	require.NoError(t, err)
+	require.True(t, len(msgs.Items) > 0, "should have seeded at least one message")
+	for _, msg := range msgs.Items {
+		assert.Empty(t, msg.ConversationID,
+			"default (no --execute) must be dry-run: message %s should not be stamped", msg.ID)
+	}
+}
+
+// TestBackfillMalformedThreadID verifies AC-12-5: messages with malformed
+// ThreadIDs produce errors in the result without crashing.
+func TestBackfillMalformedThreadID(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	projectID := seedBackfillProject(t, ctx, s)
+
+	// Seed a message with a malformed DM ThreadID.
+	msgID := uuid.NewString()
+	err := s.CreateMessage(ctx, &store.Message{
+		ID:          msgID,
+		ProjectID:   projectID,
+		Sender:      "user:" + uuid.NewString(),
+		SenderID:    uuid.NewString(),
+		Recipient:   "agent:" + uuid.NewString(),
+		RecipientID: uuid.NewString(),
+		Msg:         "test message with bad thread",
+		Type:        "instruction",
+		ThreadID:    "dm:invalid:bad:format",
+		CreatedAt:   time.Now(),
+	})
+	require.NoError(t, err)
+
+	// Run backfill.
+	result, err := runBackfillWithStore(ctx, s, messaging.BackfillConfig{
+		DryRun:    true,
+		ProjectID: projectID,
+	})
+	require.NoError(t, err)
+
+	// The malformed ThreadID should produce an error entry.
+	assert.NotEmpty(t, result.Errors, "malformed ThreadID should produce errors")
+	assert.Equal(t, 1, result.TotalProcessed, "should still process the message")
+}
+
+// TestBackfillMergeResult verifies the result aggregation helper.
+func TestBackfillMergeResult(t *testing.T) {
+	dst := &messaging.BackfillResult{
+		TotalProcessed:       10,
+		Attributed:           5,
+		Inferred:             2,
+		Skipped:              3,
+		ConversationsCreated: 1,
+		HazardAEmailCount:    1,
+		HazardBSlugCount:     0,
+		LastCheckpoint:       "old-cp",
+		Errors:               []string{"err1"},
+	}
+	src := &messaging.BackfillResult{
+		TotalProcessed:       20,
+		Attributed:           15,
+		Inferred:             3,
+		Skipped:              2,
+		ConversationsCreated: 4,
+		HazardAEmailCount:    2,
+		HazardBSlugCount:     1,
+		LastCheckpoint:       "new-cp",
+		Errors:               []string{"err2", "err3"},
+	}
+
+	mergeBackfillResult(dst, src)
+
+	assert.Equal(t, 30, dst.TotalProcessed)
+	assert.Equal(t, 20, dst.Attributed)
+	assert.Equal(t, 5, dst.Inferred)
+	assert.Equal(t, 5, dst.Skipped)
+	assert.Equal(t, 5, dst.ConversationsCreated)
+	assert.Equal(t, 3, dst.HazardAEmailCount)
+	assert.Equal(t, 1, dst.HazardBSlugCount)
+	assert.Equal(t, "new-cp", dst.LastCheckpoint)
+	assert.Equal(t, []string{"err1", "err2", "err3"}, dst.Errors)
+}

--- a/cmd/server_backfill_test.go
+++ b/cmd/server_backfill_test.go
@@ -420,3 +420,33 @@ func TestBackfillMergeResult(t *testing.T) {
 	assert.Equal(t, "new-cp", dst.LastCheckpoint)
 	assert.Equal(t, []string{"err1", "err2", "err3"}, dst.Errors)
 }
+
+// TestBackfillPreUpgradeCheckpointRejected ensures that a pre-upgrade
+// checkpoint — a bare message ID saved under the old GetMessage-based
+// checkpoint mechanism — is rejected with a loud error, not silently
+// treated as "start from zero" or as a no-op. The real store's
+// decodeCursor validates the cursor format and returns "invalid cursor"
+// on a malformed value. This is the store-layer complement to
+// TestBackfill_UnrecognizedCheckpointServiceLayer in pkg/messaging.
+func TestBackfillPreUpgradeCheckpointRejected(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	projectID := seedBackfillProject(t, ctx, s)
+
+	// Seed one message so the store is not empty.
+	senderID := uuid.NewString()
+	seedDMMessage(t, ctx, s, projectID, senderID, uuid.NewString(), time.Now())
+
+	// A bare UUID is what the old mechanism would have saved as a checkpoint.
+	// Under cursor-based semantics, this is not a valid cursor.
+	preUpgradeCheckpoint := uuid.NewString()
+
+	_, err := runBackfillWithStore(ctx, s, messaging.BackfillConfig{
+		DryRun:     false,
+		ProjectID:  projectID,
+		Checkpoint: preUpgradeCheckpoint,
+	})
+	require.Error(t, err, "pre-upgrade checkpoint (bare message ID) must be rejected")
+	assert.Contains(t, err.Error(), "listing messages",
+		"error should come from the store's cursor validation")
+}

--- a/cmd/server_backfill_test.go
+++ b/cmd/server_backfill_test.go
@@ -48,7 +48,6 @@ func seedBackfillProject(t *testing.T, ctx context.Context, s store.Store) strin
 		ID:         projectID,
 		Name:       "backfill-test",
 		Slug:       "backfill-test-" + projectID[:8],
-		Visibility: "private",
 	})
 	require.NoError(t, err)
 	return projectID

--- a/cmd/server_backfill_test.go
+++ b/cmd/server_backfill_test.go
@@ -45,9 +45,9 @@ func seedBackfillProject(t *testing.T, ctx context.Context, s store.Store) strin
 	t.Helper()
 	projectID := uuid.NewString()
 	err := s.CreateProject(ctx, &store.Project{
-		ID:         projectID,
-		Name:       "backfill-test",
-		Slug:       "backfill-test-" + projectID[:8],
+		ID:   projectID,
+		Name: "backfill-test",
+		Slug: "backfill-test-" + projectID[:8],
 	})
 	require.NoError(t, err)
 	return projectID

--- a/cmd/server_backfill_volume_test.go
+++ b/cmd/server_backfill_volume_test.go
@@ -1,0 +1,286 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build volume_test && !no_sqlite
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/messages"
+	"github.com/GoogleCloudPlatform/scion/pkg/messaging"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedVolumeMessages creates count messages with a realistic distribution:
+//
+//	~60% DM-style ThreadIDs (canonical dm:<kind>:<uuid>:<kind>:<uuid>)
+//	~15% non-DM ThreadIDs (topic/thread style)
+//	~10% malformed DM ThreadIDs (parse failures)
+//	~10% empty ThreadID (legacy — derive key from sender/recipient)
+//	~5%  pre-backfilled (ConversationID already set)
+//
+// It uses deterministic seeding for reproducibility and at least 20 distinct
+// sender/recipient pairs to create multiple conversation groups.
+func seedVolumeMessages(t *testing.T, ctx context.Context, s store.Store, projectID string, count int) (malformedCount, preBackfilledCount int) {
+	t.Helper()
+
+	// 20 distinct user→agent pairs.
+	type principalPair struct {
+		senderID    string // user UUID
+		recipientID string // agent UUID
+	}
+
+	rng := rand.New(rand.NewSource(42)) // deterministic
+
+	const numPairs = 20
+	pairs := make([]principalPair, numPairs)
+	for i := range pairs {
+		pairs[i] = principalPair{
+			senderID:    uuid.NewString(),
+			recipientID: uuid.NewString(),
+		}
+	}
+
+	// Pre-compute canonical DM keys for each pair.
+	dmKeys := make([]string, numPairs)
+	for i, p := range pairs {
+		key, err := messages.DMConversationKey("user", p.senderID, "agent", p.recipientID)
+		require.NoError(t, err)
+		dmKeys[i] = key
+	}
+
+	malformedThreadIDs := []string{
+		"dm:invalid:bad:format",
+		"dm:not-a-uuid:also-not",
+		"dm:user:notauuid:agent:alsonotauuid",
+		"dm:foo:bar:baz:qux",
+		"dm:user:123:agent:456",
+	}
+
+	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Distribute categories uniformly via modular arithmetic so any
+	// page of results contains a representative mix of all types.
+	for i := 0; i < count; i++ {
+		pairIdx := rng.Intn(numPairs)
+		p := pairs[pairIdx]
+
+		msg := &store.Message{
+			ID:          uuid.NewString(),
+			ProjectID:   projectID,
+			Sender:      "user:" + p.senderID,
+			SenderID:    p.senderID,
+			Recipient:   "agent:" + p.recipientID,
+			RecipientID: p.recipientID,
+			Msg:         "volume test message",
+			Type:        "instruction",
+			CreatedAt:   baseTime.Add(time.Duration(i) * time.Millisecond),
+		}
+
+		category := i % 100
+		switch {
+		case category < 60:
+			// 60% — DM-style ThreadID in canonical form.
+			msg.ThreadID = dmKeys[pairIdx]
+
+		case category < 75:
+			// 15% — non-DM ThreadID (topic/thread style).
+			msg.ThreadID = fmt.Sprintf("topic-%d", rng.Intn(50))
+
+		case category < 85:
+			// 10% — malformed DM ThreadID → key-derivation errors.
+			msg.ThreadID = malformedThreadIDs[rng.Intn(len(malformedThreadIDs))]
+			malformedCount++
+
+		case category < 95:
+			// 10% — empty ThreadID (legacy), key derived from sender/recipient.
+			msg.ThreadID = ""
+
+		default:
+			// 5% — pre-backfilled, ConversationID already set.
+			msg.ConversationID = uuid.NewString()
+			preBackfilledCount++
+		}
+
+		err := s.CreateMessage(ctx, msg)
+		require.NoError(t, err, "creating message %d", i)
+	}
+
+	return malformedCount, preBackfilledCount
+}
+
+// TestBackfillVolume exercises the backfill pipeline with 50 000 messages
+// across the full spectrum of ThreadID shapes. It validates dry-run fidelity,
+// execute correctness, and idempotency in three sequential phases.
+//
+// Run explicitly:
+//
+//	go test ./cmd/... -run TestBackfillVolume -tags volume_test -v -count=1 -timeout 300s
+func TestBackfillVolume(t *testing.T) {
+	const totalMessages = 50_000
+
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	projectID := seedBackfillProject(t, ctx, s)
+
+	// ── Seed ───────────────────────────────────────────────────────────────
+	t.Log("Seeding messages...")
+	seedStart := time.Now()
+	malformedCount, preBackfilledCount := seedVolumeMessages(t, ctx, s, projectID, totalMessages)
+	t.Logf("Seed:                 %v, %d messages (%d malformed, %d pre-backfilled)",
+		time.Since(seedStart), totalMessages, malformedCount, preBackfilledCount)
+
+	// Sanity-check seed counts.
+	require.Greater(t, malformedCount, 0, "seed should produce malformed messages")
+	require.Greater(t, preBackfilledCount, 0, "seed should produce pre-backfilled messages")
+
+	// Use a larger batch size to reduce round-trip overhead with 50k rows.
+	const batchSize = 1000
+
+	// ── Phase 1: Dry-run ───────────────────────────────────────────────────
+	t.Log("Phase 1: dry-run...")
+	phase1Start := time.Now()
+	result1, err := runBackfillWithStore(ctx, s, messaging.BackfillConfig{
+		DryRun:    true,
+		ProjectID: projectID,
+		BatchSize: batchSize,
+	})
+	phase1Elapsed := time.Since(phase1Start)
+	require.NoError(t, err)
+
+	t.Logf("Phase 1 (dry-run):    %v, processed %d messages", phase1Elapsed, result1.TotalProcessed)
+
+	assert.Equal(t, totalMessages, result1.TotalProcessed, "dry-run should process all messages")
+	// Invariant: every message is either attributed, inferred, skipped, or errored.
+	assert.Equal(t, result1.TotalProcessed,
+		result1.Attributed+result1.Inferred+result1.Skipped+len(result1.Errors),
+		"attributed+inferred+skipped+errors should equal total processed")
+	assert.Equal(t, malformedCount, len(result1.Errors),
+		"error count should match malformed message count")
+	assert.Greater(t, result1.ConversationsCreated, 0,
+		"dry-run should report conversations that would be created")
+
+	// Dry-run must not stamp any messages. Sample 100 random un-backfilled
+	// messages and verify they still have no ConversationID.
+	verifyNoStamping(t, ctx, s, projectID, 100)
+
+	// ── Phase 2: Execute ───────────────────────────────────────────────────
+	t.Log("Phase 2: execute...")
+	phase2Start := time.Now()
+	result2, err := runBackfillWithStore(ctx, s, messaging.BackfillConfig{
+		DryRun:    false,
+		ProjectID: projectID,
+		BatchSize: batchSize,
+	})
+	phase2Elapsed := time.Since(phase2Start)
+	require.NoError(t, err)
+
+	t.Logf("Phase 2 (execute):    %v, processed %d messages, %d conversations",
+		phase2Elapsed, result2.TotalProcessed, result2.ConversationsCreated)
+
+	assert.Equal(t, totalMessages, result2.TotalProcessed, "execute should process all messages")
+	assert.Greater(t, result2.Attributed+result2.Inferred, 0, "execute should attribute messages")
+	assert.Equal(t, preBackfilledCount, result2.Skipped,
+		"execute should skip exactly the pre-backfilled messages")
+	assert.Equal(t, malformedCount, len(result2.Errors),
+		"error count should match malformed messages")
+	assert.Greater(t, result2.ConversationsCreated, 0,
+		"execute should create conversations")
+	// Invariant holds for execute too.
+	assert.Equal(t, result2.TotalProcessed,
+		result2.Attributed+result2.Inferred+result2.Skipped+len(result2.Errors),
+		"attributed+inferred+skipped+errors should equal total processed")
+
+	// Verify a sample of messages now have ConversationID.
+	verifyStamped(t, ctx, s, projectID, 100)
+
+	// ── Phase 3: Re-execute (idempotency) ──────────────────────────────────
+	t.Log("Phase 3: re-execute (idempotency)...")
+	phase3Start := time.Now()
+	result3, err := runBackfillWithStore(ctx, s, messaging.BackfillConfig{
+		DryRun:    false,
+		ProjectID: projectID,
+		BatchSize: batchSize,
+	})
+	phase3Elapsed := time.Since(phase3Start)
+	require.NoError(t, err)
+
+	t.Logf("Phase 3 (re-execute): %v, processed %d messages, %d skipped",
+		phase3Elapsed, result3.TotalProcessed, result3.Skipped)
+
+	assert.Equal(t, totalMessages, result3.TotalProcessed, "re-execute should process all messages")
+	// Everything except malformed should be skipped (they already have ConversationID).
+	expectedSkipped := totalMessages - malformedCount
+	assert.Equal(t, expectedSkipped, result3.Skipped,
+		"re-execute should skip all non-malformed messages")
+	assert.Equal(t, malformedCount, len(result3.Errors),
+		"re-execute errors should match malformed messages")
+	assert.Equal(t, 0, result3.Attributed,
+		"re-execute should attribute nothing new")
+	assert.Equal(t, 0, result3.Inferred,
+		"re-execute should infer nothing new")
+	assert.Equal(t, 0, result3.ConversationsCreated,
+		"re-execute should create no new conversations")
+
+	// ── Summary ────────────────────────────────────────────────────────────
+	t.Log("─── Volume test summary ───")
+	t.Logf("  Seed:       %d messages (%d malformed, %d pre-backfilled)", totalMessages, malformedCount, preBackfilledCount)
+	t.Logf("  Phase 1:    %v  (dry-run, %d conversations would be created)", phase1Elapsed, result1.ConversationsCreated)
+	t.Logf("  Phase 2:    %v  (execute, %d conversations created, %d attributed)", phase2Elapsed, result2.ConversationsCreated, result2.Attributed+result2.Inferred)
+	t.Logf("  Phase 3:    %v  (re-execute, %d skipped, %d errors)", phase3Elapsed, result3.Skipped, len(result3.Errors))
+	t.Logf("  Total wall: %v", phase1Elapsed+phase2Elapsed+phase3Elapsed)
+}
+
+// verifyNoStamping samples messages that originally had no ConversationID and
+// confirms they still lack one (proving dry-run did not mutate the database).
+func verifyNoStamping(t *testing.T, ctx context.Context, s store.Store, projectID string, sampleSize int) {
+	t.Helper()
+	msgs, err := s.ListMessages(ctx, store.MessageFilter{ProjectID: projectID}, store.ListOptions{Limit: sampleSize})
+	require.NoError(t, err)
+
+	unstamped := 0
+	for _, msg := range msgs.Items {
+		if msg.ConversationID == "" {
+			unstamped++
+		}
+	}
+	// After dry-run, non-pre-backfilled messages should still have empty ConversationID.
+	assert.Greater(t, unstamped, 0, "dry-run: at least some sampled messages should have no ConversationID")
+}
+
+// verifyStamped samples messages and confirms that a meaningful fraction now
+// have ConversationID set (proving execute actually persisted changes).
+func verifyStamped(t *testing.T, ctx context.Context, s store.Store, projectID string, sampleSize int) {
+	t.Helper()
+	msgs, err := s.ListMessages(ctx, store.MessageFilter{ProjectID: projectID}, store.ListOptions{Limit: sampleSize})
+	require.NoError(t, err)
+
+	stamped := 0
+	for _, msg := range msgs.Items {
+		if msg.ConversationID != "" {
+			stamped++
+		}
+	}
+	assert.Greater(t, stamped, 0, "execute: at least some sampled messages should have ConversationID")
+}

--- a/cmd/server_foreground.go
+++ b/cmd/server_foreground.go
@@ -1215,6 +1215,8 @@ func initStore(ctx context.Context, cfg *config.GlobalConfig) (store.Store, *ent
 		return nil, nil, fmt.Errorf("failed to run migrations: %w", err)
 	}
 
+	maybeWarnUnbackfilledMessages(ctx, s)
+
 	if err := s.Ping(ctx); err != nil {
 		_ = s.Close()
 		return nil, nil, fmt.Errorf("database ping failed: %w", err)
@@ -1299,6 +1301,27 @@ func runWithAdvisoryLock(ctx context.Context, s store.Store, key store.AdvisoryL
 	}
 	defer func() { _ = release() }()
 	fn()
+}
+
+// maybeWarnUnbackfilledMessages checks whether any messages lack a
+// conversation_id and, if so, logs a warning with remediation guidance.
+// It is called once at startup after migrations succeed. Errors are
+// non-fatal: a failed count is logged but does not prevent boot.
+func maybeWarnUnbackfilledMessages(ctx context.Context, s store.Store) {
+	tCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	count, err := s.CountUnbackfilledMessages(tCtx, "")
+	if err != nil {
+		slog.Warn("Failed to check for unbackfilled messages", "error", err)
+		return
+	}
+	if count == 0 {
+		return
+	}
+	slog.Warn("Messages without conversation attribution detected",
+		"count", count,
+		"action", "Run 'scion server backfill --execute' to attribute historical messages to conversations. Use 'scion server backfill' (default: dry-run) to preview first.",
+	)
 }
 
 // maybeMigrateLegacySQLite detects a legacy raw-SQL hub.db at path and, unless

--- a/cmd/server_foreground_backfill_test.go
+++ b/cmd/server_foreground_backfill_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// backfillStubStore is a minimal store.Store stub for testing
+// maybeWarnUnbackfilledMessages. Only CountUnbackfilledMessages is implemented;
+// all other methods panic if called, which is fine because the function under
+// test only calls that single method.
+type backfillStubStore struct {
+	store.Store // embed nil interface to satisfy the type
+	count       int
+	err         error
+}
+
+func (s *backfillStubStore) CountUnbackfilledMessages(_ context.Context, _ string) (int, error) {
+	return s.count, s.err
+}
+
+// captureWarnLogs installs a slog handler that captures WARN-level output into
+// the returned buffer, and returns a cleanup function that restores the default.
+func captureWarnLogs(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	return buf, func() { slog.SetDefault(prev) }
+}
+
+// AC-12-1 positive: when unbackfilled messages exist, a warning IS logged with
+// count and remediation command.
+func TestMaybeWarnUnbackfilledMessages_Positive(t *testing.T) {
+	buf, cleanup := captureWarnLogs(t)
+	defer cleanup()
+
+	stub := &backfillStubStore{count: 42}
+	maybeWarnUnbackfilledMessages(context.Background(), stub)
+
+	out := buf.String()
+	if !strings.Contains(out, "Messages without conversation attribution detected") {
+		t.Fatalf("expected warning about unbackfilled messages, got: %s", out)
+	}
+	if !strings.Contains(out, "42") {
+		t.Fatalf("expected count=42 in warning, got: %s", out)
+	}
+	if !strings.Contains(out, "scion server backfill") {
+		t.Fatalf("expected remediation command in warning, got: %s", out)
+	}
+}
+
+// AC-12-1 negative: when all messages have a conversation_id, NO warning is
+// logged (no spurious warning).
+func TestMaybeWarnUnbackfilledMessages_NoSpuriousWarning(t *testing.T) {
+	buf, cleanup := captureWarnLogs(t)
+	defer cleanup()
+
+	stub := &backfillStubStore{count: 0}
+	maybeWarnUnbackfilledMessages(context.Background(), stub)
+
+	out := buf.String()
+	if strings.Contains(out, "Messages without conversation attribution detected") {
+		t.Fatalf("expected no warning when count=0, got: %s", out)
+	}
+}
+
+// AC-12-7 mutation test: if CountUnbackfilledMessages always returns 0, the
+// positive AC-12-1 case above (TestMaybeWarnUnbackfilledMessages_Positive)
+// fails. This test proves that by confirming a count > 0 is required to
+// trigger the warning; a zero-count stub produces no warning.
+func TestMaybeWarnUnbackfilledMessages_MutationGuard(t *testing.T) {
+	buf, cleanup := captureWarnLogs(t)
+	defer cleanup()
+
+	// Simulate the mutation: CountUnbackfilledMessages always returns 0.
+	stub := &backfillStubStore{count: 0}
+	maybeWarnUnbackfilledMessages(context.Background(), stub)
+
+	out := buf.String()
+	if strings.Contains(out, "Messages without conversation attribution detected") {
+		t.Fatal("mutation guard failed: warning appeared even with count=0, " +
+			"meaning the positive test cannot catch a mutation that forces count to 0")
+	}
+}
+
+// TestMaybeWarnUnbackfilledMessages_ErrorHandling verifies that a store error
+// is handled gracefully (warning logged, no panic).
+func TestMaybeWarnUnbackfilledMessages_ErrorHandling(t *testing.T) {
+	buf, cleanup := captureWarnLogs(t)
+	defer cleanup()
+
+	stub := &backfillStubStore{err: context.DeadlineExceeded}
+	maybeWarnUnbackfilledMessages(context.Background(), stub)
+
+	out := buf.String()
+	if !strings.Contains(out, "Failed to check for unbackfilled messages") {
+		t.Fatalf("expected error warning, got: %s", out)
+	}
+	// Must NOT contain the backfill action message on error path.
+	if strings.Contains(out, "Messages without conversation attribution detected") {
+		t.Fatalf("should not show backfill warning on error, got: %s", out)
+	}
+}

--- a/pkg/messaging/backfill.go
+++ b/pkg/messaging/backfill.go
@@ -33,8 +33,9 @@ type BackfillConfig struct {
 	DryRun bool
 	// BatchSize is the page size for scanning messages (default 100).
 	BatchSize int
-	// Checkpoint is the ID of the last message processed in a previous run.
-	// When set, only messages created after that message are processed.
+	// Checkpoint is a pagination cursor from a previous run's LastCheckpoint.
+	// When set, the backfill resumes from this position in the message stream.
+	// This is an opaque string produced by ListMessages' cursor mechanism.
 	Checkpoint string
 	// ProjectID scopes the backfill to a single project.
 	ProjectID string
@@ -42,15 +43,18 @@ type BackfillConfig struct {
 
 // BackfillResult summarises what a backfill run did (or would do in dry-run).
 type BackfillResult struct {
-	TotalProcessed       int      `json:"totalProcessed"`
-	Attributed           int      `json:"attributed"`
-	Inferred             int      `json:"inferred"`
-	Skipped              int      `json:"skipped"`
-	ConversationsCreated int      `json:"conversationsCreated"`
-	HazardAEmailCount    int      `json:"hazardAEmailCount"`
-	HazardBSlugCount     int      `json:"hazardBSlugCount"`
-	LastCheckpoint       string   `json:"lastCheckpoint,omitempty"`
-	Errors               []string `json:"errors,omitempty"`
+	TotalProcessed       int `json:"totalProcessed"`
+	Attributed           int `json:"attributed"`
+	Inferred             int `json:"inferred"`
+	Skipped              int `json:"skipped"`
+	ConversationsCreated int `json:"conversationsCreated"`
+	HazardAEmailCount    int `json:"hazardAEmailCount"`
+	HazardBSlugCount     int `json:"hazardBSlugCount"`
+	// LastCheckpoint is the pagination cursor of the last completed page.
+	// Pass this value as BackfillConfig.Checkpoint to resume from this position.
+	// Empty when the backfill completed in a single page (no more data to process).
+	LastCheckpoint string   `json:"lastCheckpoint,omitempty"`
+	Errors         []string `json:"errors,omitempty"`
 }
 
 // conversationGroup collects messages that belong to the same conversation.
@@ -101,19 +105,10 @@ func (s *BackfillService) Run(ctx context.Context, cfg BackfillConfig) (*Backfil
 
 	result := &BackfillResult{}
 
-	// If a checkpoint is provided, resolve it to a time boundary.
-	filter := store.MessageFilter{ProjectID: cfg.ProjectID}
-	if cfg.Checkpoint != "" {
-		cpMsg, err := s.msgStore.GetMessage(ctx, cfg.Checkpoint)
-		if err != nil {
-			return nil, fmt.Errorf("resolving checkpoint message %s: %w", cfg.Checkpoint, err)
-		}
-		filter.After = cpMsg.CreatedAt
-	}
-
 	// Phase 1: Scan all messages and group by conversation key.
+	filter := store.MessageFilter{ProjectID: cfg.ProjectID}
 	groups := make(map[string]*conversationGroup)
-	cursor := ""
+	cursor := cfg.Checkpoint // empty string = start from beginning; cursor string = resume
 
 	for {
 		page, err := s.msgStore.ListMessages(ctx, filter, store.ListOptions{
@@ -140,9 +135,6 @@ func (s *BackfillService) Run(ctx context.Context, cfg BackfillConfig) (*Backfil
 				continue
 			}
 
-			// Track the last message we looked at for checkpointing.
-			result.LastCheckpoint = msg.ID
-
 			g := s.groupForMessage(msg, cfg.ProjectID, groups)
 			if g == nil {
 				result.Errors = append(result.Errors, fmt.Sprintf("message %s: key derivation failed", msg.ID))
@@ -155,6 +147,7 @@ func (s *BackfillService) Run(ctx context.Context, cfg BackfillConfig) (*Backfil
 			break
 		}
 		cursor = page.NextCursor
+		result.LastCheckpoint = cursor
 	}
 
 	// Phase 2: Resolve agent references and determine drift state for groups.

--- a/pkg/messaging/backfill_test.go
+++ b/pkg/messaging/backfill_test.go
@@ -16,7 +16,7 @@ package messaging
 
 import (
 	"context"
-	"errors"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -679,56 +679,56 @@ func TestBackfill_Resumable(t *testing.T) {
 
 	now := time.Now()
 
-	// Three messages at distinct times.
-	msg1 := newTestMessage(projectID, "user:alice", userID, "agent:bot", agentID, now.Add(-3*time.Minute))
-	msg2 := newTestMessage(projectID, "user:alice", userID, "agent:bot", agentID, now.Add(-2*time.Minute))
-	msg3 := newTestMessage(projectID, "user:alice", userID, "agent:bot", agentID, now.Add(-1*time.Minute))
+	// Four messages at distinct times.
+	msg1 := newTestMessage(projectID, "user:alice", userID, "agent:bot", agentID, now.Add(-4*time.Minute))
+	msg2 := newTestMessage(projectID, "user:alice", userID, "agent:bot", agentID, now.Add(-3*time.Minute))
+	msg3 := newTestMessage(projectID, "user:alice", userID, "agent:bot", agentID, now.Add(-2*time.Minute))
+	msg4 := newTestMessage(projectID, "user:alice", userID, "agent:bot", agentID, now.Add(-1*time.Minute))
 
-	msgStore := &mockMessageStore{messages: []store.Message{msg1, msg2, msg3}}
+	msgStore := &mockMessageStore{messages: []store.Message{msg1, msg2, msg3, msg4}}
 	convStore := &mockConversationStore{}
 	agents := &mockAgentLookup{}
 
 	svc := NewBackfillService(convStore, msgStore, agents)
 
-	// First run with batch size 1 — process all but use msg1 as checkpoint for next run.
-	// We'll manually process only msg1, then resume from msg1.
-
-	// Run full backfill first.
+	// Full run with batch size 2 → forces 2 pages in DESC order:
+	//   Page 1: [msg4, msg3]  → cursor = msg3.ID, LastCheckpoint = cursor
+	//   Page 2: [msg2, msg1]  → NextCursor="" → break
 	result1, err := svc.Run(ctx, BackfillConfig{ProjectID: projectID, BatchSize: 2})
 	require.NoError(t, err)
-	assert.Equal(t, 3, result1.TotalProcessed)
-	assert.Equal(t, 3, result1.Attributed)
+	assert.Equal(t, 4, result1.TotalProcessed)
+	assert.Equal(t, 4, result1.Attributed)
+	assert.NotEmpty(t, result1.LastCheckpoint, "multi-page run should record a checkpoint")
 
-	// Reset messages to unprocessed state for testing resumption.
+	// Reset all messages to simulate an interrupted run that only completed page 1.
 	for i := range msgStore.messages {
 		msgStore.messages[i].ConversationID = ""
 	}
+	convStore.mu.Lock()
+	convStore.conversations = nil
+	convStore.participants = nil
+	convStore.mu.Unlock()
 
-	// Process with a small batch, all messages.
-	result2, err := svc.Run(ctx, BackfillConfig{ProjectID: projectID, BatchSize: 10})
-	require.NoError(t, err)
-	assert.Equal(t, 3, result2.TotalProcessed)
-
-	// Reset and resume from msg2 — only msg3 should be processed (after msg2's time).
-	for i := range msgStore.messages {
-		msgStore.messages[i].ConversationID = ""
-	}
-
-	result3, err := svc.Run(ctx, BackfillConfig{
+	// Resume from checkpoint — should process only page 2 (the remaining older messages).
+	result2, err := svc.Run(ctx, BackfillConfig{
 		ProjectID:  projectID,
-		Checkpoint: msg2.ID,
+		Checkpoint: result1.LastCheckpoint,
+		BatchSize:  10,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, 1, result3.TotalProcessed, "only messages after checkpoint should be processed")
-	assert.Equal(t, 1, result3.Attributed)
+	assert.Equal(t, 2, result2.TotalProcessed,
+		"resume should process only messages after the checkpoint cursor position")
+	assert.Equal(t, 2, result2.Attributed)
 
-	// Verify only msg3 was stamped.
-	stampedMsg1, _ := msgStore.GetMessage(ctx, msg1.ID)
-	stampedMsg2, _ := msgStore.GetMessage(ctx, msg2.ID)
-	stampedMsg3, _ := msgStore.GetMessage(ctx, msg3.ID)
-	assert.Empty(t, stampedMsg1.ConversationID, "msg1 before checkpoint — should not be stamped")
-	assert.Empty(t, stampedMsg2.ConversationID, "msg2 is checkpoint — should not be re-processed")
-	assert.NotEmpty(t, stampedMsg3.ConversationID, "msg3 after checkpoint — should be stamped")
+	// Verify only the older messages (msg1, msg2) were stamped.
+	stamped1, _ := msgStore.GetMessage(ctx, msg1.ID)
+	stamped2, _ := msgStore.GetMessage(ctx, msg2.ID)
+	stamped3, _ := msgStore.GetMessage(ctx, msg3.ID)
+	stamped4, _ := msgStore.GetMessage(ctx, msg4.ID)
+	assert.NotEmpty(t, stamped1.ConversationID, "msg1 after cursor — should be stamped")
+	assert.NotEmpty(t, stamped2.ConversationID, "msg2 after cursor — should be stamped")
+	assert.Empty(t, stamped3.ConversationID, "msg3 before cursor — should not be stamped")
+	assert.Empty(t, stamped4.ConversationID, "msg4 before cursor — should not be stamped")
 }
 
 func TestBackfill_DefaultBatchSize(t *testing.T) {
@@ -916,21 +916,39 @@ func TestBackfill_HazardB_InvalidAgentRef(t *testing.T) {
 	assert.Equal(t, 1, result.Inferred, "invalid agent ref should mark messages as inferred")
 }
 
-func TestBackfill_CheckpointNotFound(t *testing.T) {
+// TestBackfill_UnrecognizedCheckpointServiceLayer verifies the backfill service
+// passes an unrecognized cursor through to the store's ListMessages. The mock
+// store does not validate cursors — an unknown cursor silently returns all
+// messages (restart-from-zero). In production, the real store
+// (entadapter/message_store.go) validates cursors via decodeCursor and returns
+// "invalid cursor" on malformed input.
+//
+// COVERAGE GAP: the "bad checkpoint → loud error" property is NOT tested here
+// because the mock cannot produce cursor-validation errors. That property is
+// tested in cmd/server_backfill_test.go (TestBackfillPreUpgradeCheckpointRejected)
+// against the real SQLite store.
+func TestBackfill_UnrecognizedCheckpointServiceLayer(t *testing.T) {
 	ctx := context.Background()
 	projectID := uuid.NewString()
+	userID := uuid.NewString()
+	agentID := uuid.NewString()
 
-	msgStore := &mockMessageStore{}
+	msg := newTestMessage(projectID, "user:alice", userID, "agent:bot", agentID, time.Now())
+
+	msgStore := &mockMessageStore{messages: []store.Message{msg}}
 	convStore := &mockConversationStore{}
 	agents := &mockAgentLookup{}
 
 	svc := NewBackfillService(convStore, msgStore, agents)
-	_, err := svc.Run(ctx, BackfillConfig{
+	// The mock ignores unrecognized cursors (returns all messages).
+	// This only tests that the service does not crash — the validation
+	// property is in the store layer.
+	result, err := svc.Run(ctx, BackfillConfig{
 		ProjectID:  projectID,
-		Checkpoint: uuid.NewString(), // non-existent message
+		Checkpoint: "bogus-cursor-value",
 	})
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, store.ErrNotFound))
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.TotalProcessed)
 }
 
 func TestBackfill_EmptyProjectID(t *testing.T) {
@@ -961,12 +979,114 @@ func TestBackfill_LastCheckpointTracked(t *testing.T) {
 	agents := &mockAgentLookup{}
 
 	svc := NewBackfillService(convStore, msgStore, agents)
+
+	// Use BatchSize=1 to force multi-page pagination and checkpoint tracking.
+	// With default batch size both messages fit on a single page and
+	// LastCheckpoint would remain empty (single-page run).
+	result, err := svc.Run(ctx, BackfillConfig{ProjectID: projectID, BatchSize: 1})
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, result.LastCheckpoint, "multi-page run should track a checkpoint")
+
+	// LastCheckpoint is an opaque page cursor, not a message ID.
+	// Verify it can be used for a resume run without error.
+	result2, err := svc.Run(ctx, BackfillConfig{
+		ProjectID:  projectID,
+		Checkpoint: result.LastCheckpoint,
+	})
+	require.NoError(t, err)
+	// The remaining message was already attributed, so resume should skip it.
+	assert.Equal(t, 1, result2.TotalProcessed)
+	assert.Equal(t, 1, result2.Skipped)
+}
+
+func TestBackfill_SinglePageNoCheckpoint(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.NewString()
+	userID := uuid.NewString()
+	agentID := uuid.NewString()
+
+	msg := newTestMessage(projectID, "user:alice", userID, "agent:bot", agentID, time.Now())
+
+	msgStore := &mockMessageStore{messages: []store.Message{msg}}
+	convStore := &mockConversationStore{}
+	agents := &mockAgentLookup{}
+
+	svc := NewBackfillService(convStore, msgStore, agents)
 	result, err := svc.Run(ctx, BackfillConfig{ProjectID: projectID})
 	require.NoError(t, err)
 
-	assert.NotEmpty(t, result.LastCheckpoint, "should track last checkpoint")
-	// The last checkpoint should be one of the message IDs.
-	assert.True(t, result.LastCheckpoint == msg1.ID || result.LastCheckpoint == msg2.ID)
+	assert.Empty(t, result.LastCheckpoint,
+		"single-page run should have empty checkpoint (all data processed)")
+}
+
+// TestBackfill_SameTimestampMessages is the service-level regression test for
+// the cursor-based checkpoint fix. It uses a manually constructed checkpoint
+// (a message ID, which is the mock store's cursor format) on FRESH data — no
+// prior backfill — so the checkpoint's behaviour is the ONLY thing determining
+// whether same-timestamp messages get processed.
+//
+// On FIXED code: checkpoint is used as cursor → mock skips to after that
+// position → remaining same-timestamp messages are processed.
+//
+// On BUGGY code (fda9977f): checkpoint is resolved via GetMessage, then
+// filter.After = CreatedAt → "created > T" excludes ALL same-timestamp
+// messages → TotalProcessed = 0.
+//
+// NOTE: This test guards the SERVICE-LAYER mutation site (the filter.After
+// form of the bug) against a mock store. The companion test
+// TestBackfillResumeViaCheckpoint_SameTimestamp in cmd/ guards the
+// STORE-LAYER mutation site (the (created, id) tuple comparison in
+// message_store.go). Neither is redundant — they guard different layers.
+// Do not remove one believing the other covers it.
+func TestBackfill_SameTimestampMessages(t *testing.T) {
+	ctx := context.Background()
+	projectID := uuid.NewString()
+	senderID := uuid.NewString()
+
+	// 5 messages at IDENTICAL timestamp, different recipients.
+	same := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var msgs []store.Message
+	var ids []string
+	for i := 0; i < 5; i++ {
+		msg := newTestMessage(projectID, "user:alice", senderID,
+			"agent:bot", uuid.NewString(), same)
+		msgs = append(msgs, msg)
+		ids = append(ids, msg.ID)
+	}
+
+	// Sort IDs to get deterministic ordering. The mock sorts DESC by (created, id).
+	// Sorted ascending: ids[0] < ids[1] < ids[2] < ids[3] < ids[4]
+	// DESC order: ids[4], ids[3], ids[2], ids[1], ids[0]
+	sort.Strings(ids)
+
+	msgStore := &mockMessageStore{messages: msgs}
+	convStore := &mockConversationStore{}
+	agents := &mockAgentLookup{}
+
+	svc := NewBackfillService(convStore, msgStore, agents)
+
+	// Use ids[2] as the checkpoint — the mock's cursor format is a message ID.
+	// This simulates resuming after processing ids[4] and ids[3] (the first
+	// page in DESC order), with the cursor positioned at ids[2].
+	// Messages after the cursor in DESC: ids[1], ids[0] — these should be processed.
+	//
+	// NO prior backfill run — all messages still have empty conversation_id.
+	result, err := svc.Run(ctx, BackfillConfig{
+		ProjectID:  projectID,
+		Checkpoint: ids[2],
+	})
+	require.NoError(t, err)
+
+	// EXACT counts — this is the regression guard.
+	// Fixed code (cursor-based): processes ids[1] and ids[0] → TotalProcessed = 2.
+	// Buggy code (filter.After = T): "created > T" matches 0 messages → TotalProcessed = 0.
+	assert.Equal(t, 2, result.TotalProcessed,
+		"cursor-based resume must process same-timestamp messages after cursor position")
+	assert.Equal(t, 2, result.Attributed,
+		"should attribute the 2 same-timestamp messages after cursor")
+	assert.Equal(t, 0, result.Skipped,
+		"no messages should be skipped (none have conversation_id)")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Phase 4 of the messaging refactor. Two commits.

**DEF-12** — `pkg/messaging/backfill.go` was complete, reviewed, and called by nothing. Adds `scion server backfill` (dry-run default, `--execute` to apply) and a startup warning naming the count of messages lacking conversation attribution. Ported from `scion/messaging-v2`.

**DEF-81** — resume silently dropped rows. The checkpoint resolved to a timestamp filtered with `After` = `CreatedGT`, strictly greater than, so resuming from message M skipped every message sharing M's exact `created` timestamp, permanently, while reporting success. Now uses the store's compound `(created, id)` keyset cursor. Regression guard lands in the blocking lane.

DELETIONS-JUSTIFIED, zero on all `cmd/` files: `backfill.go` -25 (GetMessage checkpoint resolution, per-message LastCheckpoint) and `backfill_test.go` -43 (three test bodies re-aimed to cursor semantics; no assertion dropped).

Build, cmd, messaging, lint, and all three guard scripts from main: exit 0. Three new guards proven non-vacuous by mutate/fail/revert/pass.

Deliberate gaps: no run against a populated database (AC-12-6, held for the scheduled snapshot/restore exercise); no multi-project backfill coverage (DEF-82)