### PR TITLE
fix: make GitCloneConfig.Depth *int so 0 means full clone

### DIFF
--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -1556,6 +1556,7 @@ func gitCloneWorkspace(uid, gid int, agentHome string) error {
 	if err != nil {
 		log.Info("WARNING: SCION_GIT_DEPTH is not a valid integer (%q), defaulting to 1", depthStr)
 		depth = 1
+		depthStr = "1"
 	}
 	agentName := os.Getenv("SCION_AGENT_NAME")
 

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -1550,8 +1550,9 @@ func gitCloneWorkspace(uid, gid int, agentHome string) error {
 	}
 	depthStr := os.Getenv("SCION_GIT_DEPTH")
 	if depthStr == "" {
-		depthStr = "1"
+		depthStr = "1" // default: shallow clone
 	}
+	depth, _ := strconv.Atoi(depthStr) // 0 on parse error = full clone
 	agentName := os.Getenv("SCION_AGENT_NAME")
 
 	// Helper to configure a git command: run as the scion user and disable
@@ -1599,10 +1600,16 @@ func gitCloneWorkspace(uid, gid int, agentHome string) error {
 		return fmt.Errorf("git remote add failed: %s", sanitizeGitOutput(string(out), token))
 	}
 
-	// fetchBranch attempts a shallow fetch of a single branch from origin.
+	// fetchBranch attempts to fetch a single branch from origin.
+	// When depth > 0, a shallow fetch is performed; depth 0 means full clone (no --depth flag).
 	// Returns sanitized stderr and whether the fetch succeeded.
 	fetchBranch := func(branchToFetch string) (string, bool) {
-		fetchCmd := exec.Command("git", "-C", workspacePath, "fetch", "--depth", depthStr, "origin", branchToFetch)
+		fetchArgs := []string{"-C", workspacePath, "fetch"}
+		if depth > 0 {
+			fetchArgs = append(fetchArgs, "--depth", depthStr)
+		}
+		fetchArgs = append(fetchArgs, "origin", branchToFetch)
+		fetchCmd := exec.Command("git", fetchArgs...)
 		setupGitCmd(fetchCmd)
 		var stderr bytes.Buffer
 		fetchCmd.Stderr = &stderr

--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -1552,7 +1552,11 @@ func gitCloneWorkspace(uid, gid int, agentHome string) error {
 	if depthStr == "" {
 		depthStr = "1" // default: shallow clone
 	}
-	depth, _ := strconv.Atoi(depthStr) // 0 on parse error = full clone
+	depth, err := strconv.Atoi(depthStr)
+	if err != nil {
+		log.Info("WARNING: SCION_GIT_DEPTH is not a valid integer (%q), defaulting to 1", depthStr)
+		depth = 1
+	}
 	agentName := os.Getenv("SCION_AGENT_NAME")
 
 	// Helper to configure a git command: run as the scion user and disable

--- a/cmd/sciontool/commands/provision.go
+++ b/cmd/sciontool/commands/provision.go
@@ -85,10 +85,11 @@ func runProvision(ctx context.Context) error {
 
 	var gc *api.GitCloneConfig
 	if cloneURL != "" {
+		depthVal := provisionDepth
 		gc = &api.GitCloneConfig{
 			URL:    cloneURL,
 			Branch: cloneBranch,
-			Depth:  &provisionDepth,
+			Depth:  &depthVal,
 		}
 	}
 

--- a/cmd/sciontool/commands/provision.go
+++ b/cmd/sciontool/commands/provision.go
@@ -62,7 +62,7 @@ func init() {
 	provisionCmd.Flags().StringVar(&provisionMode, "mode", "shared-plain",
 		"Workspace sharing mode (shared-plain, worktree-per-agent)")
 	provisionCmd.Flags().IntVar(&provisionDepth, "depth", 1,
-		"Git clone depth (1=shallow, 0=full, -1=no depth flag)")
+		"Git clone depth (0=full clone, >0=that depth; default 1=shallow)")
 	provisionCmd.Flags().IntVar(&provisionUID, "uid", 1000,
 		"UID for chown of provisioned files")
 	provisionCmd.Flags().IntVar(&provisionGID, "gid", 1000,
@@ -88,7 +88,7 @@ func runProvision(ctx context.Context) error {
 		gc = &api.GitCloneConfig{
 			URL:    cloneURL,
 			Branch: cloneBranch,
-			Depth:  provisionDepth,
+			Depth:  &provisionDepth,
 		}
 	}
 

--- a/pkg/agent/delete_test.go
+++ b/pkg/agent/delete_test.go
@@ -302,7 +302,7 @@ func TestDeleteAgentFiles_WorktreePerAgent_DeletesOnlyTargetWorktree(t *testing.
 	t.Setenv("HOME", tmpDir)
 
 	bare := initBareRepo(t)
-	gc := &api.GitCloneConfig{URL: bare, Branch: "main", Depth: 0}
+	gc := &api.GitCloneConfig{URL: bare, Branch: "main", Depth: intPtr(0)}
 
 	// Set up a hub-managed project layout: projectPath with .scion inside.
 	projectPath := filepath.Join(tmpDir, "proj")
@@ -427,7 +427,7 @@ func TestDeleteAgentFiles_SharedWorktree_DeleteCreatorWhileJoinerRemains(t *test
 	t.Setenv("HOME", tmpDir)
 
 	bare := initBareRepo(t)
-	gc := &api.GitCloneConfig{URL: bare, Branch: "main", Depth: 0}
+	gc := &api.GitCloneConfig{URL: bare, Branch: "main", Depth: intPtr(0)}
 
 	projectPath := filepath.Join(tmpDir, "proj")
 	scionDir := filepath.Join(projectPath, config.DotScion)
@@ -532,7 +532,7 @@ func TestDeleteAgentFiles_SharedWorktree_DeleteLastSharer_RemovesWorktree(t *tes
 	t.Setenv("HOME", tmpDir)
 
 	bare := initBareRepo(t)
-	gc := &api.GitCloneConfig{URL: bare, Branch: "main", Depth: 0}
+	gc := &api.GitCloneConfig{URL: bare, Branch: "main", Depth: intPtr(0)}
 
 	projectPath := filepath.Join(tmpDir, "proj")
 	scionDir := filepath.Join(projectPath, config.DotScion)
@@ -617,7 +617,7 @@ func TestDeleteAgentFiles_SharedWorktree_SoleSharer_DeleteRemoves(t *testing.T) 
 	t.Setenv("HOME", tmpDir)
 
 	bare := initBareRepo(t)
-	gc := &api.GitCloneConfig{URL: bare, Branch: "main", Depth: 0}
+	gc := &api.GitCloneConfig{URL: bare, Branch: "main", Depth: intPtr(0)}
 
 	projectPath := filepath.Join(tmpDir, "proj")
 	scionDir := filepath.Join(projectPath, config.DotScion)
@@ -675,3 +675,5 @@ func TestDeleteAgentFiles_SharedWorktree_SoleSharer_DeleteRemoves(t *testing.T) 
 		t.Errorf("shared base .git should survive: %v", err)
 	}
 }
+
+func intPtr(i int) *int { return &i }

--- a/pkg/agent/provision_test.go
+++ b/pkg/agent/provision_test.go
@@ -921,7 +921,7 @@ func TestProvisionAgentGitClone_ClearsStaleWorktreeWorkspace(t *testing.T) {
 	gitClone := &api.GitCloneConfig{
 		URL:    "https://github.com/example/repo.git",
 		Branch: "main",
-		Depth:  1,
+		Depth:  intPtr(1),
 	}
 	ctx := api.ContextWithGitClone(context.Background(), gitClone)
 
@@ -982,7 +982,7 @@ func TestProvisionAgentGitClone_PreservesExistingClone(t *testing.T) {
 	gitClone := &api.GitCloneConfig{
 		URL:    "https://github.com/example/repo.git",
 		Branch: "main",
-		Depth:  1,
+		Depth:  intPtr(1),
 	}
 	ctx := api.ContextWithGitClone(context.Background(), gitClone)
 
@@ -1046,7 +1046,7 @@ func TestGetAgentGitClone_ClearsExistingWorkspace(t *testing.T) {
 	gitClone := &api.GitCloneConfig{
 		URL:    "https://github.com/example/repo.git",
 		Branch: "main",
-		Depth:  1,
+		Depth:  intPtr(1),
 	}
 	ctx := api.ContextWithGitClone(context.Background(), gitClone)
 
@@ -2947,7 +2947,7 @@ func TestProvisionAgent_RelativeWorkspace_GitClone_Rejected(t *testing.T) {
 	gitClone := &api.GitCloneConfig{
 		URL:    "https://github.com/example/repo.git",
 		Branch: "main",
-		Depth:  1,
+		Depth:  intPtr(1),
 	}
 	ctx := api.ContextWithGitClone(context.Background(), gitClone)
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -842,7 +842,7 @@ func ClassifyEnvKey(classifications map[string]EnvKind, key string) (EnvKind, bo
 type GitCloneConfig struct {
 	URL    string `json:"url"`              // HTTPS clone URL (without credentials)
 	Branch string `json:"branch,omitempty"` // Branch to clone (default: main)
-	Depth  int    `json:"depth,omitempty"`  // Clone depth (default: 1, 0 = full)
+	Depth  *int   `json:"depth,omitempty"`  // Clone depth (nil/omitted = shallow depth 1, 0 = full clone, >0 = that depth)
 }
 
 type gitCloneContextKey struct{}

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -139,10 +139,11 @@ func (s *Server) populateAgentConfig(ctx context.Context, agent *store.Agent, pr
 		if defaultBranch == "" {
 			defaultBranch = "main"
 		}
+		defaultDepth := 1
 		agent.AppliedConfig.GitClone = &api.GitCloneConfig{
 			URL:    cloneURL,
 			Branch: defaultBranch,
-			Depth:  1,
+			Depth:  &defaultDepth,
 		}
 	}
 

--- a/pkg/hub/handlers_agent_test.go
+++ b/pkg/hub/handlers_agent_test.go
@@ -1761,7 +1761,7 @@ func TestCreateAgent_GitAnchoredProjectPopulatesGitClone(t *testing.T) {
 	require.NotNil(t, persisted.AppliedConfig.GitClone, "GitClone should be populated for git-anchored project")
 	assert.Equal(t, "https://github.com/example/myrepo.git", persisted.AppliedConfig.GitClone.URL)
 	assert.Equal(t, "develop", persisted.AppliedConfig.GitClone.Branch)
-	assert.Equal(t, 1, persisted.AppliedConfig.GitClone.Depth)
+	assert.Equal(t, intPtr(1), persisted.AppliedConfig.GitClone.Depth)
 }
 
 func TestCreateAgent_NonGitProjectNoGitClone(t *testing.T) {
@@ -1836,7 +1836,7 @@ func TestCreateProjectAgent_GitAnchoredProjectPopulatesGitClone(t *testing.T) {
 	require.NotNil(t, persisted.AppliedConfig.GitClone, "GitClone should be populated for git-anchored project")
 	assert.Equal(t, "https://github.com/example/myrepo.git", persisted.AppliedConfig.GitClone.URL)
 	assert.Equal(t, "develop", persisted.AppliedConfig.GitClone.Branch)
-	assert.Equal(t, 1, persisted.AppliedConfig.GitClone.Depth)
+	assert.Equal(t, intPtr(1), persisted.AppliedConfig.GitClone.Depth)
 }
 
 func TestCreateProjectAgent_NonGitProjectNoGitClone(t *testing.T) {
@@ -1912,7 +1912,7 @@ func TestCreateAgent_GitProjectCloneURLFallback(t *testing.T) {
 	assert.Equal(t, "https://github.com/example/fallback-repo.git", persisted.AppliedConfig.GitClone.URL,
 		"clone URL should be constructed from gitRemote when scion.dev/clone-url label is absent")
 	assert.Equal(t, "develop", persisted.AppliedConfig.GitClone.Branch)
-	assert.Equal(t, 1, persisted.AppliedConfig.GitClone.Depth)
+	assert.Equal(t, intPtr(1), persisted.AppliedConfig.GitClone.Depth)
 }
 
 func TestCreateAgent_GitProjectSchemelessCloneURL(t *testing.T) {
@@ -1963,7 +1963,7 @@ func TestCreateAgent_GitProjectSchemelessCloneURL(t *testing.T) {
 	assert.Equal(t, "https://github.com/example/schemeless-repo.git", persisted.AppliedConfig.GitClone.URL,
 		"schemeless clone-url label should be normalized to https:// with .git suffix")
 	assert.Equal(t, "main", persisted.AppliedConfig.GitClone.Branch)
-	assert.Equal(t, 1, persisted.AppliedConfig.GitClone.Depth)
+	assert.Equal(t, intPtr(1), persisted.AppliedConfig.GitClone.Depth)
 }
 
 func TestCreateAgent_GitProjectDefaultBranchFallback(t *testing.T) {
@@ -2014,7 +2014,7 @@ func TestCreateAgent_GitProjectDefaultBranchFallback(t *testing.T) {
 	// default-branch label is missing, so branch should default to "main"
 	assert.Equal(t, "main", persisted.AppliedConfig.GitClone.Branch,
 		"branch should default to 'main' when scion.dev/default-branch label is absent")
-	assert.Equal(t, 1, persisted.AppliedConfig.GitClone.Depth)
+	assert.Equal(t, intPtr(1), persisted.AppliedConfig.GitClone.Depth)
 }
 
 func TestCreateAgent_ProfileStoredInAppliedConfig(t *testing.T) {

--- a/pkg/hub/httpdispatcher_test.go
+++ b/pkg/hub/httpdispatcher_test.go
@@ -1973,7 +1973,7 @@ func TestHTTPAgentDispatcher_DispatchAgentCreate_PropagatesGitClone(t *testing.T
 			GitClone: &api.GitCloneConfig{
 				URL:    "https://github.com/example/repo.git",
 				Branch: "develop",
-				Depth:  1,
+				Depth:  intPtr(1),
 			},
 		},
 	}
@@ -2000,8 +2000,8 @@ func TestHTTPAgentDispatcher_DispatchAgentCreate_PropagatesGitClone(t *testing.T
 		t.Errorf("expected GitClone Branch 'develop', got '%s'",
 			mockClient.lastCreateReq.Config.GitClone.Branch)
 	}
-	if mockClient.lastCreateReq.Config.GitClone.Depth != 1 {
-		t.Errorf("expected GitClone Depth 1, got %d",
+	if mockClient.lastCreateReq.Config.GitClone.Depth == nil || *mockClient.lastCreateReq.Config.GitClone.Depth != 1 {
+		t.Errorf("expected GitClone Depth 1, got %v",
 			mockClient.lastCreateReq.Config.GitClone.Depth)
 	}
 }
@@ -2267,7 +2267,7 @@ func TestHTTPAgentDispatcher_DispatchAgentCreate_NoProjectSlug_LocalPathProject(
 			GitClone: &api.GitCloneConfig{
 				URL:    "https://github.com/example/local-project.git",
 				Branch: "main",
-				Depth:  1,
+				Depth:  intPtr(1),
 			},
 		},
 	}
@@ -4586,3 +4586,5 @@ func TestDispatchAgentCreate_IncludesHubName(t *testing.T) {
 		t.Errorf("SCION_HUB_NAME = %q, want %q", got, "create-hub")
 	}
 }
+
+func intPtr(i int) *int { return &i }

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -305,14 +305,15 @@ func gitCloneWorkspace(ctx context.Context, in ProvisionInput) error {
 	runClone := func() ([]byte, error) {
 		args := []string{"clone"}
 
-		// Set depth (default: 1 for shallow clone, 0 = full).
-		depth := gc.Depth
-		if depth == 0 {
-			depth = 1
+		// Set depth: nil/omitted = shallow depth 1, 0 = full clone (no --depth), >0 = that depth.
+		depth := 1 // default: shallow
+		if gc.Depth != nil {
+			depth = *gc.Depth
 		}
 		if depth > 0 {
 			args = append(args, "--depth", fmt.Sprintf("%d", depth))
 		}
+		// depth == 0 means full clone: no --depth flag
 
 		// Set branch if specified.
 		if gc.Branch != "" {

--- a/pkg/provision/provision_test.go
+++ b/pkg/provision/provision_test.go
@@ -297,7 +297,6 @@ func TestProvision_WorktreePerAgent(t *testing.T) {
 		GitClone: &api.GitCloneConfig{
 			URL:    bareRepo,
 			Branch: "main",
-			Depth:  0,
 		},
 	})
 	if err != nil {
@@ -368,7 +367,6 @@ func TestProvision_WorktreePerAgent_TwoAgents(t *testing.T) {
 		GitClone: &api.GitCloneConfig{
 			URL:    bareRepo,
 			Branch: "main",
-			Depth:  0,
 		},
 	})
 	if err != nil {
@@ -386,7 +384,6 @@ func TestProvision_WorktreePerAgent_TwoAgents(t *testing.T) {
 		GitClone: &api.GitCloneConfig{
 			URL:    bareRepo,
 			Branch: "main",
-			Depth:  0,
 		},
 	})
 	if err != nil {
@@ -451,7 +448,7 @@ func TestProvision_WorktreePerAgent_TwoProjects(t *testing.T) {
 		AgentName: "alpha-agent",
 		Mode:      store.SharingModeWorktreePerAgent,
 		Locker:    locker,
-		GitClone:  &api.GitCloneConfig{URL: bareRepoA, Branch: "main", Depth: 0},
+		GitClone:  &api.GitCloneConfig{URL: bareRepoA, Branch: "main", },
 	})
 	if err != nil {
 		t.Fatalf("Provision project A: %v", err)
@@ -472,7 +469,7 @@ func TestProvision_WorktreePerAgent_TwoProjects(t *testing.T) {
 		AgentName: "beta-agent",
 		Mode:      store.SharingModeWorktreePerAgent,
 		Locker:    locker,
-		GitClone:  &api.GitCloneConfig{URL: bareRepoB, Branch: "main", Depth: 0},
+		GitClone:  &api.GitCloneConfig{URL: bareRepoB, Branch: "main", },
 	})
 	if err != nil {
 		t.Fatalf("Provision project B: %v", err)
@@ -528,7 +525,7 @@ func TestProvision_WorktreePerAgent_ConcurrentSameProject(t *testing.T) {
 				GitClone: &api.GitCloneConfig{
 					URL:    bareRepo,
 					Branch: "main",
-					Depth:  0,
+					
 				},
 			})
 		}(i)
@@ -564,7 +561,7 @@ func TestProvision_WorktreePerAgent_FullCloneDepth(t *testing.T) {
 	projectDir := t.TempDir()
 	hostPath := filepath.Join(projectDir, "workspace")
 
-	// Depth -1 means full clone (no --depth flag).
+	// Depth 0 means full clone (no --depth flag).
 	err := ProvisionShared(ProvisionInput{
 		Resolved:  ResolvedWorkspace{HostPath: hostPath, Backend: "local"},
 		ProjectID: "proj-depth-1",
@@ -575,11 +572,11 @@ func TestProvision_WorktreePerAgent_FullCloneDepth(t *testing.T) {
 		GitClone: &api.GitCloneConfig{
 			URL:    bareRepo,
 			Branch: "main",
-			Depth:  -1,
+			Depth:  intPtr(0),
 		},
 	})
 	if err != nil {
-		t.Fatalf("Provision with Depth=-1: %v", err)
+		t.Fatalf("Provision with Depth=0 (full clone): %v", err)
 	}
 
 	// Verify the clone is NOT shallow (full history).
@@ -617,7 +614,7 @@ func TestProvision_WorktreePerAgent_CreateAndJoin(t *testing.T) {
 		AgentName: "shared-branch",
 		Mode:      store.SharingModeWorktreePerAgent,
 		Locker:    locker,
-		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: -1},
+		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: intPtr(0)},
 	})
 	require.NoError(t, err)
 
@@ -639,7 +636,7 @@ func TestProvision_WorktreePerAgent_CreateAndJoin(t *testing.T) {
 		AgentName: "shared-branch",
 		Mode:      store.SharingModeWorktreePerAgent,
 		Locker:    locker,
-		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: -1},
+		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: intPtr(0)},
 	})
 	require.NoError(t, err)
 
@@ -673,7 +670,7 @@ func TestProvision_WorktreePerAgent_UniqueBranches_SoleSharers(t *testing.T) {
 		AgentName: "agent-alpha",
 		Mode:      store.SharingModeWorktreePerAgent,
 		Locker:    locker,
-		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: -1},
+		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: intPtr(0)},
 	})
 	require.NoError(t, err)
 
@@ -685,7 +682,7 @@ func TestProvision_WorktreePerAgent_UniqueBranches_SoleSharers(t *testing.T) {
 		AgentName: "agent-beta",
 		Mode:      store.SharingModeWorktreePerAgent,
 		Locker:    locker,
-		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: -1},
+		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: intPtr(0)},
 	})
 	require.NoError(t, err)
 
@@ -724,7 +721,7 @@ func TestProvision_WorktreePerAgent_ExistingRegistration_Idempotent(t *testing.T
 		AgentName: "idem-branch",
 		Mode:      store.SharingModeWorktreePerAgent,
 		Locker:    locker,
-		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: -1},
+		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: intPtr(0)},
 	})
 	require.NoError(t, err)
 
@@ -736,7 +733,7 @@ func TestProvision_WorktreePerAgent_ExistingRegistration_Idempotent(t *testing.T
 		AgentName: "idem-branch",
 		Mode:      store.SharingModeWorktreePerAgent,
 		Locker:    locker,
-		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: -1},
+		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: intPtr(0)},
 	})
 	require.NoError(t, err)
 
@@ -745,3 +742,5 @@ func TestProvision_WorktreePerAgent_ExistingRegistration_Idempotent(t *testing.T
 	require.NoError(t, err)
 	assert.Equal(t, []string{"agent-a"}, sharers)
 }
+
+func intPtr(i int) *int { return &i }

--- a/pkg/provision/provision_test.go
+++ b/pkg/provision/provision_test.go
@@ -448,7 +448,7 @@ func TestProvision_WorktreePerAgent_TwoProjects(t *testing.T) {
 		AgentName: "alpha-agent",
 		Mode:      store.SharingModeWorktreePerAgent,
 		Locker:    locker,
-		GitClone:  &api.GitCloneConfig{URL: bareRepoA, Branch: "main", },
+		GitClone:  &api.GitCloneConfig{URL: bareRepoA, Branch: "main"},
 	})
 	if err != nil {
 		t.Fatalf("Provision project A: %v", err)
@@ -469,7 +469,7 @@ func TestProvision_WorktreePerAgent_TwoProjects(t *testing.T) {
 		AgentName: "beta-agent",
 		Mode:      store.SharingModeWorktreePerAgent,
 		Locker:    locker,
-		GitClone:  &api.GitCloneConfig{URL: bareRepoB, Branch: "main", },
+		GitClone:  &api.GitCloneConfig{URL: bareRepoB, Branch: "main"},
 	})
 	if err != nil {
 		t.Fatalf("Provision project B: %v", err)
@@ -525,7 +525,6 @@ func TestProvision_WorktreePerAgent_ConcurrentSameProject(t *testing.T) {
 				GitClone: &api.GitCloneConfig{
 					URL:    bareRepo,
 					Branch: "main",
-					
 				},
 			})
 		}(i)

--- a/pkg/runtime/common_test.go
+++ b/pkg/runtime/common_test.go
@@ -474,7 +474,7 @@ func TestBuildCommonRunArgs(t *testing.T) {
 				GitClone: &api.GitCloneConfig{
 					URL:    "https://github.com/example/repo.git",
 					Branch: "main",
-					Depth:  1,
+					Depth:  intPtr(1),
 				},
 			},
 			wantIn: []string{

--- a/pkg/runtime/k8s_nfs_test.go
+++ b/pkg/runtime/k8s_nfs_test.go
@@ -341,15 +341,12 @@ func TestNFSProvisionCommand_NilConfig(t *testing.T) {
 func TestNFSProvisionCommand_DefaultDepth(t *testing.T) {
 	gc := &api.GitCloneConfig{
 		URL: "https://github.com/example/repo.git",
-		// Depth nil → default shallow (depth 1)
+		// Depth nil → no --depth flag; CLI defaults to shallow (depth 1)
 	}
 
 	cmd := nfsProvisionCommand(gc)
 
-	assert.Equal(t, "sciontool", cmd[0])
-	assert.Equal(t, "provision", cmd[1])
-	assert.Contains(t, cmd, "--depth")
-	assert.Contains(t, cmd, "1")
+	assert.Equal(t, []string{"sciontool", "provision"}, cmd)
 }
 
 func TestNFSProvisionCommand_FullClone(t *testing.T) {
@@ -360,7 +357,7 @@ func TestNFSProvisionCommand_FullClone(t *testing.T) {
 
 	cmd := nfsProvisionCommand(gc)
 
-	assert.Equal(t, []string{"sciontool", "provision"}, cmd)
+	assert.Equal(t, []string{"sciontool", "provision", "--depth", "0"}, cmd)
 }
 
 func TestNFSProvisionEnv(t *testing.T) {

--- a/pkg/runtime/k8s_nfs_test.go
+++ b/pkg/runtime/k8s_nfs_test.go
@@ -196,7 +196,7 @@ func TestBuildPod_NFSBackend_InitContainer_Present(t *testing.T) {
 		GitCloneForInit: &api.GitCloneConfig{
 			URL:    "https://github.com/example/repo.git",
 			Branch: "main",
-			Depth:  1,
+			Depth:  intPtr(1),
 		},
 	}
 
@@ -316,7 +316,7 @@ func TestNFSProvisionCommand_ShallowClone(t *testing.T) {
 	gc := &api.GitCloneConfig{
 		URL:    "https://github.com/example/repo.git",
 		Branch: "main",
-		Depth:  1,
+		Depth:  intPtr(1),
 	}
 
 	cmd := nfsProvisionCommand(gc)
@@ -338,10 +338,10 @@ func TestNFSProvisionCommand_NilConfig(t *testing.T) {
 	assert.Equal(t, []string{"sciontool", "provision"}, cmd)
 }
 
-func TestNFSProvisionCommand_FullClone(t *testing.T) {
+func TestNFSProvisionCommand_DefaultDepth(t *testing.T) {
 	gc := &api.GitCloneConfig{
-		URL:   "https://github.com/example/repo.git",
-		Depth: -1,
+		URL: "https://github.com/example/repo.git",
+		// Depth nil → default shallow (depth 1)
 	}
 
 	cmd := nfsProvisionCommand(gc)
@@ -349,7 +349,18 @@ func TestNFSProvisionCommand_FullClone(t *testing.T) {
 	assert.Equal(t, "sciontool", cmd[0])
 	assert.Equal(t, "provision", cmd[1])
 	assert.Contains(t, cmd, "--depth")
-	assert.Contains(t, cmd, "-1")
+	assert.Contains(t, cmd, "1")
+}
+
+func TestNFSProvisionCommand_FullClone(t *testing.T) {
+	gc := &api.GitCloneConfig{
+		URL:   "https://github.com/example/repo.git",
+		Depth: intPtr(0),
+	}
+
+	cmd := nfsProvisionCommand(gc)
+
+	assert.Equal(t, []string{"sciontool", "provision"}, cmd)
 }
 
 func TestNFSProvisionEnv(t *testing.T) {
@@ -421,7 +432,7 @@ func nfsBaseConfig(name string) RunConfig {
 		GitCloneForInit: &api.GitCloneConfig{
 			URL:    "https://github.com/example/repo.git",
 			Branch: "main",
-			Depth:  1,
+			Depth:  intPtr(1),
 		},
 	}
 }

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -2473,15 +2473,17 @@ func nfsProvisionCommand(gc *api.GitCloneConfig) []string {
 		return []string{"sciontool", "provision"}
 	}
 
-	depth := gc.Depth
-	if depth == 0 {
-		depth = 1
+	depth := 1 // default: shallow
+	if gc.Depth != nil {
+		depth = *gc.Depth
 	}
 
-	return []string{
-		"sciontool", "provision",
-		"--depth", fmt.Sprintf("%d", depth),
+	cmd := []string{"sciontool", "provision"}
+	if depth > 0 {
+		cmd = append(cmd, "--depth", fmt.Sprintf("%d", depth))
 	}
+	// depth == 0 means full clone: no --depth flag
+	return cmd
 }
 
 // nfsProvisionEnv returns the environment variables for the NFS init

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -2479,10 +2479,9 @@ func nfsProvisionCommand(gc *api.GitCloneConfig) []string {
 	}
 
 	cmd := []string{"sciontool", "provision"}
-	if depth > 0 {
+	if gc.Depth != nil {
 		cmd = append(cmd, "--depth", fmt.Sprintf("%d", depth))
 	}
-	// depth == 0 means full clone: no --depth flag
 	return cmd
 }
 

--- a/pkg/runtime/k8s_runtime.go
+++ b/pkg/runtime/k8s_runtime.go
@@ -2473,14 +2473,9 @@ func nfsProvisionCommand(gc *api.GitCloneConfig) []string {
 		return []string{"sciontool", "provision"}
 	}
 
-	depth := 1 // default: shallow
-	if gc.Depth != nil {
-		depth = *gc.Depth
-	}
-
 	cmd := []string{"sciontool", "provision"}
 	if gc.Depth != nil {
-		cmd = append(cmd, "--depth", fmt.Sprintf("%d", depth))
+		cmd = append(cmd, "--depth", fmt.Sprintf("%d", *gc.Depth))
 	}
 	return cmd
 }

--- a/pkg/runtime/workspace_provision_test.go
+++ b/pkg/runtime/workspace_provision_test.go
@@ -207,7 +207,7 @@ func TestNFSProvision_SharedPlain_GitClone(t *testing.T) {
 		GitClone: &api.GitCloneConfig{
 			URL:    bareRepo,
 			Branch: "main",
-			Depth:  1,
+			Depth:  intPtr(1),
 		},
 	})
 	if err != nil {
@@ -255,7 +255,7 @@ func TestNFSProvision_Idempotent(t *testing.T) {
 		GitClone: &api.GitCloneConfig{
 			URL:    bareRepo,
 			Branch: "main",
-			Depth:  1,
+			Depth:  intPtr(1),
 		},
 	}
 
@@ -344,7 +344,7 @@ func TestNFSProvision_WorktreePerAgent(t *testing.T) {
 		GitClone: &api.GitCloneConfig{
 			URL:    bareRepo,
 			Branch: "main",
-			Depth:  0, // full clone needed for worktrees
+			Depth:  intPtr(0), // full clone needed for worktrees
 		},
 	})
 	if err != nil {
@@ -392,7 +392,7 @@ func TestNFSProvision_WorktreePerAgent_TwoAgents(t *testing.T) {
 		GitClone: &api.GitCloneConfig{
 			URL:    bareRepo,
 			Branch: "main",
-			Depth:  0,
+			Depth:  intPtr(0),
 		},
 	})
 	if err != nil {
@@ -410,7 +410,7 @@ func TestNFSProvision_WorktreePerAgent_TwoAgents(t *testing.T) {
 		GitClone: &api.GitCloneConfig{
 			URL:    bareRepo,
 			Branch: "main",
-			Depth:  0,
+			Depth:  intPtr(0),
 		},
 	})
 	if err != nil {
@@ -641,7 +641,7 @@ func TestNFSProvision_CustomSentinelDir_Idempotent(t *testing.T) {
 		GitClone: &api.GitCloneConfig{
 			URL:    bareRepo,
 			Branch: "main",
-			Depth:  1,
+			Depth:  intPtr(1),
 		},
 	}
 
@@ -698,7 +698,7 @@ func TestNFSWorktreePerAgent_E2E_FullValidation(t *testing.T) {
 		GitClone: &api.GitCloneConfig{
 			URL:    bareRepo,
 			Branch: "main",
-			Depth:  0,
+			Depth:  intPtr(0),
 		},
 	})
 	if err != nil {
@@ -818,7 +818,7 @@ func TestNFSWorktreePerAgent_E2E_TwoAgentsDistinctWorktrees(t *testing.T) {
 		t.Fatalf("Resolve: %v", err)
 	}
 
-	gitClone := &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: 0}
+	gitClone := &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: intPtr(0)}
 
 	// First agent: triggers base clone + worktree.
 	err = ProvisionShared(ProvisionInput{
@@ -938,7 +938,7 @@ func TestNFSWorktreePerAgent_E2E_WorktreeNestedNoEscape(t *testing.T) {
 		AgentName: "nested-agent",
 		Mode:      store.SharingModeWorktreePerAgent,
 		Locker:    locker,
-		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: 0},
+		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: intPtr(0)},
 	})
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
@@ -1059,7 +1059,7 @@ func TestNFSWorktreePerAgent_E2E_SentinelLayoutMatchesNFS(t *testing.T) {
 		AgentName: "sentinel-agent",
 		Mode:      store.SharingModeWorktreePerAgent,
 		Locker:    locker,
-		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: 0},
+		GitClone:  &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: intPtr(0)},
 	})
 	if err != nil {
 		t.Fatalf("Provision: %v", err)
@@ -1097,7 +1097,7 @@ func TestNFSWorktreePerAgent_E2E_SecondAgentSkipsClone(t *testing.T) {
 		t.Fatalf("Resolve: %v", err)
 	}
 
-	gitClone := &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: 0}
+	gitClone := &api.GitCloneConfig{URL: bareRepo, Branch: "main", Depth: intPtr(0)}
 
 	// First agent: clone + worktree.
 	err = ProvisionShared(ProvisionInput{
@@ -1151,3 +1151,5 @@ func TestNFSWorktreePerAgent_E2E_SecondAgentSkipsClone(t *testing.T) {
 
 	_ = gitModTime // mtime check is informational; git worktree add may touch .git/
 }
+
+func intPtr(i int) *int { return &i }

--- a/pkg/runtimebroker/start_context.go
+++ b/pkg/runtimebroker/start_context.go
@@ -609,8 +609,8 @@ func (s *Server) buildStartContext(ctx context.Context, in startContextInputs) (
 			env["SCION_GIT_BRANCH"] = gc.Branch
 			classifyBrokerEnv("SCION_GIT_BRANCH", api.EnvKindPlain)
 		}
-		if gc.Depth > 0 {
-			env["SCION_GIT_DEPTH"] = strconv.Itoa(gc.Depth)
+		if gc.Depth != nil {
+			env["SCION_GIT_DEPTH"] = strconv.Itoa(*gc.Depth)
 			classifyBrokerEnv("SCION_GIT_DEPTH", api.EnvKindPlain)
 		}
 		if in.Config.Branch != "" {
@@ -931,10 +931,11 @@ func resolveWorktreeProvision(in worktreeProvisionInput) worktreeProvisionResult
 	worktreePath := provision.WorktreePath(resolved.HostPath, in.AgentID)
 
 	// Copy GitClone config so we don't mutate the shared pointer, and force a
-	// full clone (Depth -1 ≡ no --depth flag). The shared base needs full
+	// full clone (Depth 0 = no --depth flag). The shared base needs full
 	// history for coordinator merges, git log, and git blame (design §4.2a).
+	fullCloneDepth := 0
 	gcCopy := *in.GitClone
-	gcCopy.Depth = -1
+	gcCopy.Depth = &fullCloneDepth
 
 	return worktreeProvisionResult{
 		ShouldProvision: true,

--- a/pkg/runtimebroker/start_context_test.go
+++ b/pkg/runtimebroker/start_context_test.go
@@ -1352,7 +1352,7 @@ func TestTryProvisionWorktree_JoinResolvesSharedPath(t *testing.T) {
 	srv := newTestServerForStartContext(t, cfg)
 
 	bare := initBareRepoWithCommit(t)
-	gc := &api.GitCloneConfig{URL: bare, Branch: "main", }
+	gc := &api.GitCloneConfig{URL: bare, Branch: "main"}
 
 	projectPath := filepath.Join(t.TempDir(), "proj")
 	if err := os.MkdirAll(projectPath, 0o755); err != nil {
@@ -1438,7 +1438,7 @@ func TestWorktreeWorkspace_RepoRootDerivesToBase(t *testing.T) {
 	t.Setenv("SCION_HOST_UID", "")
 
 	bare := initBareRepoWithCommit(t)
-	gc := &api.GitCloneConfig{URL: bare, Branch: "main", }
+	gc := &api.GitCloneConfig{URL: bare, Branch: "main"}
 
 	projectPath := filepath.Join(t.TempDir(), "proj")
 	if err := os.MkdirAll(projectPath, 0o755); err != nil {

--- a/pkg/runtimebroker/start_context_test.go
+++ b/pkg/runtimebroker/start_context_test.go
@@ -354,7 +354,7 @@ func TestBuildStartContext_GitClone(t *testing.T) {
 			GitClone: &api.GitCloneConfig{
 				URL:    "https://github.com/org/repo.git",
 				Branch: "main",
-				Depth:  1,
+				Depth:  intPtr(1),
 			},
 		},
 		HTTPRequest: r,
@@ -1053,7 +1053,7 @@ func TestResolveWorktreeProvision_Eligible(t *testing.T) {
 		GitClone: &api.GitCloneConfig{
 			URL:    "https://github.com/org/repo.git",
 			Branch: "main",
-			Depth:  1,
+			Depth:  intPtr(1),
 		},
 		ProjectPath: projectDir,
 		ProjectID:   "proj-1",
@@ -1169,7 +1169,7 @@ func TestResolveWorktreeProvision_GitTooOld_Fallback(t *testing.T) {
 		GitClone: &api.GitCloneConfig{
 			URL:    "https://github.com/org/repo.git",
 			Branch: "main",
-			Depth:  1,
+			Depth:  intPtr(1),
 		},
 		ProjectPath: projectDir,
 		ProjectID:   "proj-1",
@@ -1288,7 +1288,7 @@ func TestResolveWorktreeProvision_FullCloneDepth(t *testing.T) {
 	originalGC := &api.GitCloneConfig{
 		URL:    "https://github.com/org/repo.git",
 		Branch: "main",
-		Depth:  1,
+		Depth:  intPtr(1),
 	}
 
 	result := resolveWorktreeProvision(worktreeProvisionInput{
@@ -1304,12 +1304,12 @@ func TestResolveWorktreeProvision_FullCloneDepth(t *testing.T) {
 		t.Fatalf("expected ShouldProvision=true, reason: %s", result.Reason)
 	}
 
-	if result.ProvisionInput.GitClone.Depth != -1 {
-		t.Errorf("expected GitClone.Depth=-1 (full clone), got %d", result.ProvisionInput.GitClone.Depth)
+	if result.ProvisionInput.GitClone.Depth == nil || *result.ProvisionInput.GitClone.Depth != 0 {
+		t.Errorf("expected GitClone.Depth=0 (full clone), got %v", result.ProvisionInput.GitClone.Depth)
 	}
 
-	if originalGC.Depth != 1 {
-		t.Errorf("original GitClone.Depth was mutated: got %d, want 1", originalGC.Depth)
+	if originalGC.Depth == nil || *originalGC.Depth != 1 {
+		t.Errorf("original GitClone.Depth was mutated: got %v, want 1", originalGC.Depth)
 	}
 }
 
@@ -1352,7 +1352,7 @@ func TestTryProvisionWorktree_JoinResolvesSharedPath(t *testing.T) {
 	srv := newTestServerForStartContext(t, cfg)
 
 	bare := initBareRepoWithCommit(t)
-	gc := &api.GitCloneConfig{URL: bare, Branch: "main", Depth: 0}
+	gc := &api.GitCloneConfig{URL: bare, Branch: "main", }
 
 	projectPath := filepath.Join(t.TempDir(), "proj")
 	if err := os.MkdirAll(projectPath, 0o755); err != nil {
@@ -1438,7 +1438,7 @@ func TestWorktreeWorkspace_RepoRootDerivesToBase(t *testing.T) {
 	t.Setenv("SCION_HOST_UID", "")
 
 	bare := initBareRepoWithCommit(t)
-	gc := &api.GitCloneConfig{URL: bare, Branch: "main", Depth: 0}
+	gc := &api.GitCloneConfig{URL: bare, Branch: "main", }
 
 	projectPath := filepath.Join(t.TempDir(), "proj")
 	if err := os.MkdirAll(projectPath, 0o755); err != nil {
@@ -1813,3 +1813,5 @@ func TestBuildStartContext_EnvClassificationsCarried(t *testing.T) {
 		}
 	})
 }
+
+func intPtr(i int) *int { return &i }


### PR DESCRIPTION
Fixes #1274 - clone depth zero not producing full clone

- Change Depth from int to *int
- Fix nfsProvisionCommand CLI serialization boundary
- Rebased onto current main, CI green