### PR TITLE
fix: hydrate embedded default template when absent from disk

### DIFF
--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -393,6 +392,30 @@ func FindTemplateInProjectPath(name, projectPath string) (*Template, error) {
 	return nil, fmt.Errorf("template %s not found", name)
 }
 
+// findOrHydrateDefaultTemplate resolves the default template, seeding it from the
+// embedded copy into the global templates directory when it is absent from the
+// filesystem. Broker instances have no seeded ~/.scion/templates/default, so without
+// this the default template — and the common home files it carries (.tmux.conf,
+// .zshrc, .gitconfig) — would be silently dropped from every template chain.
+// Seeding never overwrites existing files, so user customizations are preserved.
+func findOrHydrateDefaultTemplate(projectPath string) (*Template, error) {
+	tpl, err := FindTemplateInProjectPath("default", projectPath)
+	if err == nil {
+		return tpl, nil
+	}
+
+	globalDir, gErr := GetGlobalTemplatesDir()
+	if gErr != nil {
+		return nil, err
+	}
+	if sErr := SeedAgnosticTemplate(filepath.Join(globalDir, "default"), false); sErr != nil {
+		util.Debugf("failed to hydrate embedded default template: %v", sErr)
+		return nil, err
+	}
+
+	return FindTemplateInProjectPath("default", projectPath)
+}
+
 // GetTemplateChainInProject returns a list of templates in inheritance order,
 // using a specific project path for template resolution instead of CWD.
 // For non-default templates, the default template is automatically prepended
@@ -402,27 +425,25 @@ func GetTemplateChainInProject(name, projectPath string) ([]*Template, error) {
 
 	// For non-default templates, prepend the default template as a base layer
 	if name != "default" {
-		defaultTpl, err := FindTemplateInProjectPath("default", projectPath)
+		defaultTpl, err := findOrHydrateDefaultTemplate(projectPath)
 		if err == nil {
 			chain = append(chain, defaultTpl)
 		}
-		// If default template is not found, proceed without it
+		// If the default template cannot be resolved, proceed without it
 	}
 
 	tpl, err := FindTemplateInProjectPath(name, projectPath)
 	if err != nil {
 		if name == "default" {
-			// The default template was not found locally. This produces an
-			// empty template chain, which means no template home files
-			// (.tmux.conf, .zshrc, .gitconfig) will be copied into the agent
-			// home. ProvisionAgent falls back to embedded defaults, but log
-			// the miss so the resolution gap is visible.
-			slog.Warn("default template not found — template chain is empty; "+
-				"agent home will use embedded defaults only",
-				"projectPath", projectPath, "error", err)
-			return chain, nil
+			tpl, err = findOrHydrateDefaultTemplate(projectPath)
+			if err != nil {
+				// When the default template cannot be resolved, proceed without it
+				// (e.g. hub-dispatched agents on brokers with no local templates)
+				return chain, nil
+			}
+		} else {
+			return nil, err
 		}
-		return nil, err
 	}
 	chain = append(chain, tpl)
 

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
 	"github.com/GoogleCloudPlatform/scion/pkg/util"
@@ -398,6 +399,14 @@ func FindTemplateInProjectPath(name, projectPath string) (*Template, error) {
 // this the default template — and the common home files it carries (.tmux.conf,
 // .zshrc, .gitconfig) — would be silently dropped from every template chain.
 // Seeding never overwrites existing files, so user customizations are preserved.
+//
+// Hydration is published atomically: the embedded copy is seeded into a staging
+// directory and renamed into place, so concurrent callers never observe a
+// partially-seeded default template. defaultHydrationMu de-duplicates hydration
+// within the process (broker creates run up to 20-ways concurrent); the staging
+// directory plus rename covers cross-process races.
+var defaultHydrationMu sync.Mutex
+
 func findOrHydrateDefaultTemplate(projectPath string) (*Template, error) {
 	tpl, err := FindTemplateInProjectPath("default", projectPath)
 	if err == nil {
@@ -408,9 +417,34 @@ func findOrHydrateDefaultTemplate(projectPath string) (*Template, error) {
 	if gErr != nil {
 		return nil, err
 	}
-	if sErr := SeedAgnosticTemplate(filepath.Join(globalDir, "default"), false); sErr != nil {
+
+	defaultHydrationMu.Lock()
+	defer defaultHydrationMu.Unlock()
+
+	// Another goroutine may have hydrated while we waited.
+	if tpl, rErr := FindTemplateInProjectPath("default", projectPath); rErr == nil {
+		return tpl, nil
+	}
+
+	if mErr := os.MkdirAll(globalDir, 0755); mErr != nil {
+		util.Debugf("failed to prepare global templates dir: %v", mErr)
+		return nil, err
+	}
+	staging, tErr := os.MkdirTemp(globalDir, ".default-hydrate-")
+	if tErr != nil {
+		util.Debugf("failed to stage default template: %v", tErr)
+		return nil, err
+	}
+	defer func() { _ = os.RemoveAll(staging) }()
+
+	if sErr := SeedAgnosticTemplate(staging, false); sErr != nil {
 		util.Debugf("failed to hydrate embedded default template: %v", sErr)
 		return nil, err
+	}
+	// Atomic publish. ENOTEMPTY/EEXIST means another process won the race — fine,
+	// the retry below picks up their copy.
+	if rErr := os.Rename(staging, filepath.Join(globalDir, "default")); rErr != nil {
+		util.Debugf("failed to publish hydrated default template: %v", rErr)
 	}
 
 	return FindTemplateInProjectPath("default", projectPath)
@@ -421,29 +455,28 @@ func findOrHydrateDefaultTemplate(projectPath string) (*Template, error) {
 // For non-default templates, the default template is automatically prepended
 // to the chain so that common home files and config are inherited.
 func GetTemplateChainInProject(name, projectPath string) ([]*Template, error) {
+	if name == "default" {
+		tpl, err := findOrHydrateDefaultTemplate(projectPath)
+		if err != nil {
+			// When the default template cannot be resolved, proceed without it
+			// (e.g. hub-dispatched agents on brokers with no local templates)
+			return nil, nil
+		}
+		return []*Template{tpl}, nil
+	}
+
 	var chain []*Template
 
 	// For non-default templates, prepend the default template as a base layer
-	if name != "default" {
-		defaultTpl, err := findOrHydrateDefaultTemplate(projectPath)
-		if err == nil {
-			chain = append(chain, defaultTpl)
-		}
-		// If the default template cannot be resolved, proceed without it
+	defaultTpl, err := findOrHydrateDefaultTemplate(projectPath)
+	if err == nil {
+		chain = append(chain, defaultTpl)
 	}
+	// If the default template cannot be resolved, proceed without it
 
 	tpl, err := FindTemplateInProjectPath(name, projectPath)
 	if err != nil {
-		if name == "default" {
-			tpl, err = findOrHydrateDefaultTemplate(projectPath)
-			if err != nil {
-				// When the default template cannot be resolved, proceed without it
-				// (e.g. hub-dispatched agents on brokers with no local templates)
-				return chain, nil
-			}
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 	chain = append(chain, tpl)
 

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -415,7 +415,7 @@ func findOrHydrateDefaultTemplate(projectPath string) (*Template, error) {
 
 	globalDir, gErr := GetGlobalTemplatesDir()
 	if gErr != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting global templates dir: %w", gErr)
 	}
 
 	defaultHydrationMu.Lock()
@@ -428,7 +428,7 @@ func findOrHydrateDefaultTemplate(projectPath string) (*Template, error) {
 
 	if mErr := os.MkdirAll(globalDir, 0755); mErr != nil {
 		util.Debugf("failed to prepare global templates dir: %v", mErr)
-		return nil, err
+		return nil, fmt.Errorf("preparing global templates dir: %w", mErr)
 	}
 	// Stage outside globalDir: ListTemplates scans every directory entry there, so a
 	// staging dir leaked by a SIGKILL mid-seed would surface as a template forever.
@@ -436,12 +436,12 @@ func findOrHydrateDefaultTemplate(projectPath string) (*Template, error) {
 	scionDir, sdErr := GetGlobalDir()
 	if sdErr != nil {
 		util.Debugf("failed to resolve scion dir for staging: %v", sdErr)
-		return nil, err
+		return nil, fmt.Errorf("resolving scion dir for staging: %w", sdErr)
 	}
 	staging, tErr := os.MkdirTemp(scionDir, ".default-hydrate-")
 	if tErr != nil {
 		util.Debugf("failed to stage default template: %v", tErr)
-		return nil, err
+		return nil, fmt.Errorf("creating staging dir for default template: %w", tErr)
 	}
 	defer func() { _ = os.RemoveAll(staging) }()
 	// MkdirTemp creates 0700 and SeedAgnosticTemplate's MkdirAll is a no-op on an
@@ -451,7 +451,7 @@ func findOrHydrateDefaultTemplate(projectPath string) (*Template, error) {
 
 	if sErr := SeedAgnosticTemplate(staging, false); sErr != nil {
 		util.Debugf("failed to hydrate embedded default template: %v", sErr)
-		return nil, err
+		return nil, fmt.Errorf("seeding default template: %w", sErr)
 	}
 	// Atomic publish. ENOTEMPTY/EEXIST means another process won the race — fine,
 	// the retry below picks up their copy.

--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -430,12 +430,24 @@ func findOrHydrateDefaultTemplate(projectPath string) (*Template, error) {
 		util.Debugf("failed to prepare global templates dir: %v", mErr)
 		return nil, err
 	}
-	staging, tErr := os.MkdirTemp(globalDir, ".default-hydrate-")
+	// Stage outside globalDir: ListTemplates scans every directory entry there, so a
+	// staging dir leaked by a SIGKILL mid-seed would surface as a template forever.
+	// ~/.scion is on the same filesystem, so the publish rename stays atomic.
+	scionDir, sdErr := GetGlobalDir()
+	if sdErr != nil {
+		util.Debugf("failed to resolve scion dir for staging: %v", sdErr)
+		return nil, err
+	}
+	staging, tErr := os.MkdirTemp(scionDir, ".default-hydrate-")
 	if tErr != nil {
 		util.Debugf("failed to stage default template: %v", tErr)
 		return nil, err
 	}
 	defer func() { _ = os.RemoveAll(staging) }()
+	// MkdirTemp creates 0700 and SeedAgnosticTemplate's MkdirAll is a no-op on an
+	// existing dir, so without this the published default diverges from every other
+	// seeding path, which yields 0755.
+	_ = os.Chmod(staging, 0755)
 
 	if sErr := SeedAgnosticTemplate(staging, false); sErr != nil {
 		util.Debugf("failed to hydrate embedded default template: %v", sErr)

--- a/pkg/config/templates_test.go
+++ b/pkg/config/templates_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -807,50 +808,60 @@ func TestGetTemplateChainInProject_ExistingDefaultIsNotReseeded(t *testing.T) {
 
 // Hydration is published atomically, so concurrent callers must each receive a
 // fully-seeded default template rather than one mid-write.
+//
+// The per-caller failure rate against the pre-fix implementation is only ~7%, so a
+// single 16-way trial detects a regression roughly one run in five. Repeating the
+// trial takes detection to reliable. The fresh HOME per trial is load-bearing:
+// reusing one HOME yields exactly one hydration no matter how many trials run.
 func TestGetTemplateChainInProject_ConcurrentHydration(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Setenv("HOME", tmpDir)
-	t.Chdir(tmpDir)
+	const trials = 20
+	for trial := 0; trial < trials; trial++ {
+		t.Run(fmt.Sprintf("trial-%d", trial), func(t *testing.T) {
+			tmpDir := t.TempDir()
+			t.Setenv("HOME", tmpDir)
+			t.Chdir(tmpDir)
 
-	const goroutines = 16
-	var wg sync.WaitGroup
-	var start sync.WaitGroup
-	errs := make([]error, goroutines)
-	chains := make([][]*Template, goroutines)
-	// The template contents must be observed inside the goroutine, immediately
-	// after the call returns: waiting until every goroutine has finished would
-	// let the slowest seeder complete the tree and mask a torn read.
-	statErrs := make([]error, goroutines)
+			const goroutines = 16
+			var wg sync.WaitGroup
+			var start sync.WaitGroup
+			errs := make([]error, goroutines)
+			chains := make([][]*Template, goroutines)
+			// The template contents must be observed inside the goroutine, immediately
+			// after the call returns: waiting until every goroutine has finished would
+			// let the slowest seeder complete the tree and mask a torn read.
+			statErrs := make([]error, goroutines)
 
-	start.Add(1)
-	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
-		go func(idx int) {
-			defer wg.Done()
-			start.Wait()
-			chain, err := GetTemplateChainInProject("default", "")
-			errs[idx] = err
-			chains[idx] = chain
-			if err == nil && len(chain) == 1 {
-				_, statErrs[idx] = os.Stat(filepath.Join(chain[0].Path, "home", ".tmux.conf"))
+			start.Add(1)
+			wg.Add(goroutines)
+			for i := 0; i < goroutines; i++ {
+				go func(idx int) {
+					defer wg.Done()
+					start.Wait()
+					chain, err := GetTemplateChainInProject("default", "")
+					errs[idx] = err
+					chains[idx] = chain
+					if err == nil && len(chain) == 1 {
+						_, statErrs[idx] = os.Stat(filepath.Join(chain[0].Path, "home", ".tmux.conf"))
+					}
+				}(i)
 			}
-		}(i)
-	}
-	start.Done()
-	wg.Wait()
+			start.Done()
+			wg.Wait()
 
-	for i := 0; i < goroutines; i++ {
-		if errs[i] != nil {
-			t.Errorf("goroutine %d: GetTemplateChainInProject failed: %v", i, errs[i])
-			continue
-		}
-		if len(chains[i]) != 1 {
-			t.Errorf("goroutine %d: expected 1 template, got %d", i, len(chains[i]))
-			continue
-		}
-		if statErrs[i] != nil {
-			t.Errorf("goroutine %d: hydrated default template missing .tmux.conf: %v", i, statErrs[i])
-		}
+			for i := 0; i < goroutines; i++ {
+				if errs[i] != nil {
+					t.Errorf("goroutine %d: GetTemplateChainInProject failed: %v", i, errs[i])
+					continue
+				}
+				if len(chains[i]) != 1 {
+					t.Errorf("goroutine %d: expected 1 template, got %d", i, len(chains[i]))
+					continue
+				}
+				if statErrs[i] != nil {
+					t.Errorf("goroutine %d: hydrated default template missing .tmux.conf: %v", i, statErrs[i])
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/config/templates_test.go
+++ b/pkg/config/templates_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/scion/pkg/api"
@@ -709,6 +710,7 @@ func TestGetTemplateChainInProjectWithDefault(t *testing.T) {
 func TestGetTemplateChainInProject_HydratesDefaultFromEmbedded(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
+	t.Chdir(tmpDir)
 
 	// Global templates dir holds a custom template but no default.
 	customTplDir := filepath.Join(tmpDir, GlobalDir, "templates", "my-custom")
@@ -744,6 +746,7 @@ func TestGetTemplateChainInProject_HydratesDefaultFromEmbedded(t *testing.T) {
 func TestGetTemplateChainInProject_HydratesDefaultWhenPrimary(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
+	t.Chdir(tmpDir)
 
 	// No templates at all — default should be hydrated from the embedded copy.
 	chain, err := GetTemplateChainInProject("default", "")
@@ -763,10 +766,12 @@ func TestGetTemplateChainInProject_HydratesDefaultWhenPrimary(t *testing.T) {
 	}
 }
 
-// Hydration must never clobber a user-customized default template.
-func TestGetTemplateChainInProject_HydrationPreservesExistingFiles(t *testing.T) {
+// An existing default template short-circuits hydration entirely: the lookup fast
+// path finds the directory, so seeding never runs and the user's tree is untouched.
+func TestGetTemplateChainInProject_ExistingDefaultIsNotReseeded(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
+	t.Chdir(tmpDir)
 
 	defaultHome := filepath.Join(tmpDir, GlobalDir, "templates", "default", "home")
 	if err := os.MkdirAll(defaultHome, 0755); err != nil {
@@ -784,12 +789,68 @@ func TestGetTemplateChainInProject_HydrationPreservesExistingFiles(t *testing.T)
 		t.Fatalf("expected 1 template in chain, got %d", len(chain))
 	}
 
+	// Verify the user's .tmux.conf was not overwritten.
 	data, err := os.ReadFile(filepath.Join(defaultHome, ".tmux.conf"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(data) != "user-custom" {
 		t.Errorf("existing .tmux.conf was overwritten, got %q", string(data))
+	}
+
+	// Verify seeding did NOT run — .zshrc should be absent because the fast path
+	// found the directory and skipped hydration entirely.
+	if _, err := os.Stat(filepath.Join(defaultHome, ".zshrc")); err == nil {
+		t.Error(".zshrc exists — SeedAgnosticTemplate ran despite existing default template")
+	}
+}
+
+// Hydration is published atomically, so concurrent callers must each receive a
+// fully-seeded default template rather than one mid-write.
+func TestGetTemplateChainInProject_ConcurrentHydration(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Chdir(tmpDir)
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	var start sync.WaitGroup
+	errs := make([]error, goroutines)
+	chains := make([][]*Template, goroutines)
+	// The template contents must be observed inside the goroutine, immediately
+	// after the call returns: waiting until every goroutine has finished would
+	// let the slowest seeder complete the tree and mask a torn read.
+	statErrs := make([]error, goroutines)
+
+	start.Add(1)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			start.Wait()
+			chain, err := GetTemplateChainInProject("default", "")
+			errs[idx] = err
+			chains[idx] = chain
+			if err == nil && len(chain) == 1 {
+				_, statErrs[idx] = os.Stat(filepath.Join(chain[0].Path, "home", ".tmux.conf"))
+			}
+		}(i)
+	}
+	start.Done()
+	wg.Wait()
+
+	for i := 0; i < goroutines; i++ {
+		if errs[i] != nil {
+			t.Errorf("goroutine %d: GetTemplateChainInProject failed: %v", i, errs[i])
+			continue
+		}
+		if len(chains[i]) != 1 {
+			t.Errorf("goroutine %d: expected 1 template, got %d", i, len(chains[i]))
+			continue
+		}
+		if statErrs[i] != nil {
+			t.Errorf("goroutine %d: hydrated default template missing .tmux.conf: %v", i, statErrs[i])
+		}
 	}
 }
 

--- a/pkg/config/templates_test.go
+++ b/pkg/config/templates_test.go
@@ -630,15 +630,21 @@ func TestGetTemplateChainInProject(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// No default template exists on disk, so it is hydrated from the embedded
+	// copy into the global templates dir and prepended to the chain.
 	chain, err := GetTemplateChainInProject("test-tpl", projectPath)
 	if err != nil {
 		t.Fatalf("GetTemplateChainInProject failed: %v", err)
 	}
-	if len(chain) != 1 {
-		t.Fatalf("expected chain length 1, got %d", len(chain))
+	if len(chain) != 2 {
+		t.Fatalf("expected chain length 2, got %d", len(chain))
 	}
-	if chain[0].Path != projectTplDir {
-		t.Errorf("expected path %q, got %q", projectTplDir, chain[0].Path)
+	hydratedDefault := filepath.Join(tmpDir, GlobalDir, "templates", "default")
+	if chain[0].Path != hydratedDefault {
+		t.Errorf("expected chain[0] path %q, got %q", hydratedDefault, chain[0].Path)
+	}
+	if chain[1].Path != projectTplDir {
+		t.Errorf("expected chain[1] path %q, got %q", projectTplDir, chain[1].Path)
 	}
 }
 
@@ -694,6 +700,96 @@ func TestGetTemplateChainInProjectWithDefault(t *testing.T) {
 	}
 	if chain[0].Path != defaultTplDir {
 		t.Errorf("expected path %q, got %q", defaultTplDir, chain[0].Path)
+	}
+}
+
+// Broker instances have no seeded ~/.scion/templates/default. The chain must still
+// carry the default template — hydrated from the embedded copy — so that its home
+// files (.tmux.conf, .zshrc, .gitconfig) reach provisioned agents.
+func TestGetTemplateChainInProject_HydratesDefaultFromEmbedded(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Global templates dir holds a custom template but no default.
+	customTplDir := filepath.Join(tmpDir, GlobalDir, "templates", "my-custom")
+	if err := os.MkdirAll(filepath.Join(customTplDir, "home"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(customTplDir, "home", "custom-file"), []byte("custom"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	chain, err := GetTemplateChainInProject("my-custom", "")
+	if err != nil {
+		t.Fatalf("GetTemplateChainInProject failed: %v", err)
+	}
+
+	if len(chain) != 2 {
+		t.Fatalf("expected 2 templates in chain, got %d", len(chain))
+	}
+	if chain[0].Name != "default" {
+		t.Errorf("expected first template to be 'default', got %q", chain[0].Name)
+	}
+	if chain[1].Name != "my-custom" {
+		t.Errorf("expected second template to be 'my-custom', got %q", chain[1].Name)
+	}
+
+	// The hydrated default must carry the common home files.
+	tmuxPath := filepath.Join(chain[0].Path, "home", ".tmux.conf")
+	if _, err := os.Stat(tmuxPath); err != nil {
+		t.Errorf("hydrated default template is missing .tmux.conf: %v", err)
+	}
+}
+
+func TestGetTemplateChainInProject_HydratesDefaultWhenPrimary(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// No templates at all — default should be hydrated from the embedded copy.
+	chain, err := GetTemplateChainInProject("default", "")
+	if err != nil {
+		t.Fatalf("GetTemplateChainInProject failed: %v", err)
+	}
+
+	if len(chain) != 1 {
+		t.Fatalf("expected 1 template in chain, got %d", len(chain))
+	}
+	if chain[0].Name != "default" {
+		t.Errorf("expected template to be 'default', got %q", chain[0].Name)
+	}
+	tmuxPath := filepath.Join(chain[0].Path, "home", ".tmux.conf")
+	if _, err := os.Stat(tmuxPath); err != nil {
+		t.Errorf("hydrated default template is missing .tmux.conf: %v", err)
+	}
+}
+
+// Hydration must never clobber a user-customized default template.
+func TestGetTemplateChainInProject_HydrationPreservesExistingFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	defaultHome := filepath.Join(tmpDir, GlobalDir, "templates", "default", "home")
+	if err := os.MkdirAll(defaultHome, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(defaultHome, ".tmux.conf"), []byte("user-custom"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	chain, err := GetTemplateChainInProject("default", "")
+	if err != nil {
+		t.Fatalf("GetTemplateChainInProject failed: %v", err)
+	}
+	if len(chain) != 1 {
+		t.Fatalf("expected 1 template in chain, got %d", len(chain))
+	}
+
+	data, err := os.ReadFile(filepath.Join(defaultHome, ".tmux.conf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "user-custom" {
+		t.Errorf("existing .tmux.conf was overwritten, got %q", string(data))
 	}
 }
 


### PR DESCRIPTION
Fixes #923 - broker agents lose default template home files

- Hydrate embedded default template when absent from disk
- Atomic publish for hydration
- Race condition test
- Rebased onto current main, CI green