### PR TITLE
fix: change GCP token audit log level from Info to Debug

### DIFF
--- a/pkg/hub/audit.go
+++ b/pkg/hub/audit.go
@@ -368,7 +368,7 @@ func (l *LogAuditLogger) LogInviteAuditEvent(ctx context.Context, event *InviteA
 
 // LogGCPTokenEvent logs a GCP token generation event to the standard logger.
 func (l *LogAuditLogger) LogGCPTokenEvent(ctx context.Context, event *GCPTokenEvent) error {
-	level := slog.LevelInfo
+	level := slog.LevelDebug
 	if !event.Success {
 		level = slog.LevelWarn
 	}


### PR DESCRIPTION
Changes the default log level for successful GCP token audit events from slog.LevelInfo to slog.LevelDebug to reduce log noise for routine token generation events. Failure events remain at Warn level