### PR TITLE
feat(harness/antigravity): add GEMINI_API_KEY auth support

### DIFF
--- a/harnesses/antigravity/config.yaml
+++ b/harnesses/antigravity/config.yaml
@@ -57,7 +57,7 @@ capabilities:
     system_prompt: { support: "partial", reason: "System prompt is downgraded to GEMINI.md preamble" }
     agent_instructions: { support: "yes" }
   auth:
-    api_key: { support: "yes" }
+    api_key: { support: "yes", reason: "Via GEMINI_API_KEY with modelProvider=gemini in settings.json" }
     auth_file: { support: "yes", reason: "Via AGY_TOKEN file secret at ~/.gemini/antigravity-cli/antigravity-oauth-token" }
     oauth_token: { support: "no", reason: "AGY uses file-based OAuth token, not raw token injection" }
     vertex_ai: { support: "yes", reason: "GCP mode via ADC (GOOGLE_APPLICATION_CREDENTIALS) + GOOGLE_CLOUD_PROJECT, requires AGY CLI >= 1.1.10" }
@@ -82,7 +82,7 @@ auth:
           target_suffix: "/.gemini/antigravity-cli/antigravity-oauth-token"
     api-key:
       required_env:
-        - any_of: ["GEMINI_API_KEY"]
+        - any_of: ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
     vertex-ai:
       required_env:
         - any_of: ["GOOGLE_CLOUD_PROJECT"]
@@ -98,6 +98,7 @@ auth:
   autodetect:
     env:
       GEMINI_API_KEY: api-key
+      GOOGLE_API_KEY: api-key
       AGY_TOKEN: oauth-token
       GOOGLE_CLOUD_PROJECT: vertex-ai
     files:

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -170,8 +170,8 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
 
     elif method == "api-key":
         api_key_name = resolved.env_key or "GEMINI_API_KEY"
-        api_key = ctx.read_secret(api_key_name, env_fallback=True)
-        if not api_key:
+        # Validate key exists and is non-empty; overlay uses shell interpolation.
+        if not ctx.read_secret(api_key_name, env_fallback=True):
             raise scion_harness.ProvisionError(f"{api_key_name} secret is empty")
         env_overlay[api_key_name] = f"${{{api_key_name}}}"
         ctx.info(f"api-key auth: {api_key_name} configured")
@@ -294,7 +294,7 @@ def _set_model_provider(home: str, provider: str) -> None:
                 scion_harness.atomic_write_json(settings_path, data)
                 return
         except (OSError, json.JSONDecodeError):
-            pass
+            pass  # Fall through; _prestage_onboarding handles initial creation.
     # File doesn't exist yet — _prestage_onboarding creates it.
     # modelProvider will be set there when auth_method == "api-key".
 

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -253,14 +253,6 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
         thinking_tier=thinking_tier, auth_method=method,
     )
 
-    # Set modelProvider for API key auth (after _prestage_onboarding creates
-    # settings.json). Belt-and-suspenders: _prestage_onboarding sets this on
-    # initial creation, but we re-apply here to guarantee it is present even
-    # when settings.json was created by an earlier provision run or external
-    # tooling.
-    if method == "api-key":
-        _set_model_provider(ctx.home, "gemini")
-
     _apply_mcp(ctx)
 
     ctx.info(f"method={method}")
@@ -279,24 +271,6 @@ def _read_agy_token(ctx: scion_harness.ProvisionContext) -> str:
 
 
 # ---- Native functions below: keyring, hooks, onboarding, MCP ----
-
-
-def _set_model_provider(home: str, provider: str) -> None:
-    """Set modelProvider in settings.json for API key auth."""
-    settings_path = os.path.join(
-        home, ".gemini", "antigravity-cli", "settings.json"
-    )
-    if os.path.isfile(settings_path):
-        try:
-            data = scion_harness.load_json(settings_path)
-            if isinstance(data, dict):
-                data["modelProvider"] = provider
-                scion_harness.atomic_write_json(settings_path, data)
-                return
-        except (OSError, json.JSONDecodeError):
-            pass  # Fall through; _prestage_onboarding handles initial creation.
-    # File doesn't exist yet — _prestage_onboarding creates it.
-    # modelProvider will be set there when auth_method == "api-key".
 
 
 def _generate_hooks_json(home: str) -> None:

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -73,23 +73,22 @@ ANTIGRAVITY_AUTH = scion_harness.AuthSpec(
     "antigravity",
     [
         scion_harness.env_method(
-            "api-key",
-            any_of=["GEMINI_API_KEY"],
-            env_fallback=True,
-            hint="set GEMINI_API_KEY",
-        ),
-        scion_harness.env_method(
             "vertex-ai",
-            all_of=["GOOGLE_CLOUD_PROJECT"],
+            all_of=["AGY_TOKEN", "GOOGLE_CLOUD_PROJECT"],
             any_of=["GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION"],
             env_fallback=True,
-            hint="set GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION with gcloud-adc",
+            hint="set AGY_TOKEN, GOOGLE_CLOUD_PROJECT, and GOOGLE_CLOUD_LOCATION",
         ),
         scion_harness.env_method(
             "oauth-token",
             any_of=["AGY_TOKEN"],
             env_fallback=True,
             hint="set AGY_TOKEN",
+        ),
+        scion_harness.env_method(
+            "api-key",
+            any_of=["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+            hint="set GEMINI_API_KEY or GOOGLE_API_KEY",
         ),
     ],
     fallback_to_none_on_error=True,
@@ -170,11 +169,12 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
         ctx.info(f"vertex-ai ADC auth: AGY version {'.'.join(str(v) for v in ver)}")
 
     elif method == "api-key":
-        api_key = ctx.read_secret("GEMINI_API_KEY", env_fallback=True)
+        api_key_name = resolved.env_key or "GEMINI_API_KEY"
+        api_key = ctx.read_secret(api_key_name, env_fallback=True)
         if not api_key:
-            raise scion_harness.ProvisionError("GEMINI_API_KEY secret is empty")
-        env_overlay["GEMINI_API_KEY"] = api_key
-        ctx.info("api-key auth: GEMINI_API_KEY configured")
+            raise scion_harness.ProvisionError(f"{api_key_name} secret is empty")
+        env_overlay[api_key_name] = api_key
+        ctx.info(f"api-key auth: {api_key_name} configured")
 
     elif method == "oauth-token":
         token_raw = _read_agy_token(ctx)

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -74,10 +74,10 @@ ANTIGRAVITY_AUTH = scion_harness.AuthSpec(
     [
         scion_harness.env_method(
             "vertex-ai",
-            all_of=["AGY_TOKEN", "GOOGLE_CLOUD_PROJECT"],
+            all_of=["GOOGLE_CLOUD_PROJECT"],
             any_of=["GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION"],
             env_fallback=True,
-            hint="set AGY_TOKEN, GOOGLE_CLOUD_PROJECT, and GOOGLE_CLOUD_LOCATION",
+            hint="set GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION with gcloud-adc",
         ),
         scion_harness.env_method(
             "oauth-token",
@@ -173,7 +173,7 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
         api_key = ctx.read_secret(api_key_name, env_fallback=True)
         if not api_key:
             raise scion_harness.ProvisionError(f"{api_key_name} secret is empty")
-        env_overlay[api_key_name] = api_key
+        env_overlay[api_key_name] = f"${{{api_key_name}}}"
         ctx.info(f"api-key auth: {api_key_name} configured")
 
     elif method == "oauth-token":

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -252,6 +252,15 @@ def provision(ctx: scion_harness.ProvisionContext) -> None:
         ctx.home, enterprise=is_enterprise, model=model,
         thinking_tier=thinking_tier, auth_method=method,
     )
+
+    # Set modelProvider for API key auth (after _prestage_onboarding creates
+    # settings.json). Belt-and-suspenders: _prestage_onboarding sets this on
+    # initial creation, but we re-apply here to guarantee it is present even
+    # when settings.json was created by an earlier provision run or external
+    # tooling.
+    if method == "api-key":
+        _set_model_provider(ctx.home, "gemini")
+
     _apply_mcp(ctx)
 
     ctx.info(f"method={method}")
@@ -270,6 +279,24 @@ def _read_agy_token(ctx: scion_harness.ProvisionContext) -> str:
 
 
 # ---- Native functions below: keyring, hooks, onboarding, MCP ----
+
+
+def _set_model_provider(home: str, provider: str) -> None:
+    """Set modelProvider in settings.json for API key auth."""
+    settings_path = os.path.join(
+        home, ".gemini", "antigravity-cli", "settings.json"
+    )
+    if os.path.isfile(settings_path):
+        try:
+            data = scion_harness.load_json(settings_path)
+            if isinstance(data, dict):
+                data["modelProvider"] = provider
+                scion_harness.atomic_write_json(settings_path, data)
+                return
+        except (OSError, json.JSONDecodeError):
+            pass
+    # File doesn't exist yet — _prestage_onboarding creates it.
+    # modelProvider will be set there when auth_method == "api-key".
 
 
 def _generate_hooks_json(home: str) -> None:


### PR DESCRIPTION
Add api-key as an auth method for the antigravity harness, accepting both
GEMINI_API_KEY and GOOGLE_API_KEY. When api-key auth resolves, writes
modelProvider: "gemini" to settings.json so AGY uses the Gemini API directly.

Changes:
- Add api-key as lowest-priority auth method (vertex-ai > oauth-token > api-key)
- Accept both GEMINI_API_KEY and GOOGLE_API_KEY for api-key auth
- Set modelProvider in settings.json via _set_model_provider and _prestage_onboarding
- Use shell variable interpolation for env overlay (matching gemini-cli pattern)
- Update config.yaml capabilities, required_env, and autodetect

Key files:
- harnesses/antigravity/provision.py
- harnesses/antigravity/config.yaml

Ref: ptone/scion#1398