### PR TITLE
fix(metadata): add instance/ and project/ directory listings to emulator

### DIFF
--- a/pkg/sciontool/metadata/server.go
+++ b/pkg/sciontool/metadata/server.go
@@ -793,8 +793,14 @@ func (s *Server) handleMetadata(w http.ResponseWriter, r *http.Request) {
 	case path == "project/project-id":
 		_, _ = fmt.Fprint(w, s.config.ProjectID)
 
+	case path == "project" || path == "project/":
+		_, _ = fmt.Fprint(w, "project-id\nnumeric-project-id\n")
+
 	case path == "project/numeric-project-id":
 		_, _ = fmt.Fprint(w, "0")
+
+	case path == "instance" || path == "instance/":
+		_, _ = fmt.Fprint(w, "service-accounts/\n")
 
 	case path == "instance/service-accounts/" || path == "instance/service-accounts":
 		s.handleServiceAccountList(w, r)

--- a/pkg/sciontool/metadata/server_test.go
+++ b/pkg/sciontool/metadata/server_test.go
@@ -197,6 +197,68 @@ func TestMetadataServer_NumericProjectID(t *testing.T) {
 	}
 }
 
+func TestMetadataServer_InstanceDirectoryListing(t *testing.T) {
+	port := freePort(t)
+	srv := New(Config{
+		Mode:      "block",
+		Port:      port,
+		ProjectID: "test-project",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := srv.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Stop()
+	time.Sleep(50 * time.Millisecond)
+
+	for _, path := range []string{
+		"/computeMetadata/v1/instance",
+		"/computeMetadata/v1/instance/",
+	} {
+		resp, body := metadataGet(t, port, path)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET %s: expected 200, got %d", path, resp.StatusCode)
+		}
+		if body != "service-accounts/\n" {
+			t.Fatalf("GET %s: expected %q, got %q", path, "service-accounts/\n", body)
+		}
+	}
+}
+
+func TestMetadataServer_ProjectDirectoryListing(t *testing.T) {
+	port := freePort(t)
+	srv := New(Config{
+		Mode:      "block",
+		Port:      port,
+		ProjectID: "test-project",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := srv.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Stop()
+	time.Sleep(50 * time.Millisecond)
+
+	for _, path := range []string{
+		"/computeMetadata/v1/project",
+		"/computeMetadata/v1/project/",
+	} {
+		resp, body := metadataGet(t, port, path)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("GET %s: expected 200, got %d", path, resp.StatusCode)
+		}
+		if body != "project-id\nnumeric-project-id\n" {
+			t.Fatalf("GET %s: expected %q, got %q", path, "project-id\nnumeric-project-id\n", body)
+		}
+	}
+}
+
 func TestMetadataServer_BlockMode(t *testing.T) {
 	port := freePort(t)
 	srv := New(Config{


### PR DESCRIPTION
Add instance/ and project/ directory listing handlers to the metadata emulator. The Node.js gcp-metadata library probes GET /computeMetadata/v1/instance to detect GCE; the emulator was returning 404, causing ADC detection to fail in non-BIOS environments like Cloud Run sandboxes.