### PR TITLE
fix: configure Cloud Run sandbox to run as non-root user

### DIFF
--- a/pkg/runtime/cloudrun_sandbox_runtime.go
+++ b/pkg/runtime/cloudrun_sandbox_runtime.go
@@ -315,20 +315,10 @@ func prepareScionLayout(rootDir, slug string, cfg RunConfig) (scionPaths, error)
 		workspace: filepath.Join(rootDir, "agents", slug, "workspace"),
 	}
 
-	// Create all directories and chown them to the sandbox user.
-	// The launcher runs as root on Cloud Run, so directories default to
-	// root:root. The sandbox process drops to sandboxUID:sandboxGID via
-	// sciontool init, and needs these directories writable from the start
-	// (they are bind-mounted into the sandbox). Chowning here also
-	// naturally resolves /workspace writability: previously the workspace
-	// was root-owned and the sandbox ran as root; now both are scion-owned.
+	// Create agent home and workspace directories.
 	for _, d := range []string{p.agentHome, p.workspace} {
 		if err := os.MkdirAll(d, 0755); err != nil {
 			return p, fmt.Errorf("mkdir %s: %w", d, err)
-		}
-		if err := os.Chown(d, sandboxUID, sandboxGID); err != nil {
-			runtimeLog.Warn("failed to chown directory to sandbox user",
-				"dir", d, "uid", sandboxUID, "gid", sandboxGID, "error", err)
 		}
 	}
 
@@ -370,6 +360,34 @@ func prepareScionLayout(rootDir, slug string, cfg RunConfig) (scionPaths, error)
 			if err := os.MkdirAll(iwPath, 0755); err != nil {
 				runtimeLog.Warn("failed to create in-workspace shared dir",
 					"name", sd.Name, "path", iwPath, "error", err)
+			}
+		}
+	}
+
+	// Recursively chown agent home and workspace to the sandbox user.
+	// This runs AFTER all file setup (directory creation, relocation,
+	// workspace copy) so that every file — including those created by
+	// relocateToScion and copyDirContents — is owned by the sandbox user.
+	//
+	// Guard: only chown when running as root (Cloud Run). In non-root
+	// environments (local dev, CI) os.Chown fails with EPERM, so skip it.
+	//
+	// Lchown is used instead of Chown to avoid following symlinks: if a
+	// relocated directory contains symlinks, we change the link's ownership
+	// rather than the target's (which may be outside our mount).
+	if os.Getuid() == 0 {
+		for _, d := range []string{p.agentHome, p.workspace} {
+			if walkErr := filepath.WalkDir(d, func(path string, entry fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if chownErr := os.Lchown(path, sandboxUID, sandboxGID); chownErr != nil {
+					runtimeLog.Warn("failed to chown path to sandbox user",
+						"path", path, "uid", sandboxUID, "gid", sandboxGID, "error", chownErr)
+				}
+				return nil
+			}); walkErr != nil {
+				runtimeLog.Warn("failed to walk directory for chown", "dir", d, "error", walkErr)
 			}
 		}
 	}

--- a/pkg/runtime/cloudrun_sandbox_runtime.go
+++ b/pkg/runtime/cloudrun_sandbox_runtime.go
@@ -83,6 +83,17 @@ const sandboxWorkspace = "/workspace"
 // output; when it fails the file holds the error output that explains why.
 const entrypointLogFile = ".scion-entrypoint.log"
 
+// sandboxUID and sandboxGID are the UID/GID passed to the sandbox via
+// SCION_HOST_UID / SCION_HOST_GID. They correspond to the `scion` user
+// created by the omni-image Dockerfile (useradd -u 1000 scion).
+//
+// On Cloud Run the launcher runs as root (UID 0). Passing 0 would make
+// sciontool init keep the sandbox process as root, which Claude Code
+// ≥ 2.1.246 rejects. Hardcoding 1000 ensures the sandbox always drops
+// privileges to the scion user regardless of the launcher's own UID.
+const sandboxUID = 1000
+const sandboxGID = 1000
+
 // SandboxLauncherAvailable reports whether the Cloud Run Sandbox launcher
 // binary is present on the filesystem.
 func SandboxLauncherAvailable() bool {
@@ -304,10 +315,20 @@ func prepareScionLayout(rootDir, slug string, cfg RunConfig) (scionPaths, error)
 		workspace: filepath.Join(rootDir, "agents", slug, "workspace"),
 	}
 
-	// Create all directories.
+	// Create all directories and chown them to the sandbox user.
+	// The launcher runs as root on Cloud Run, so directories default to
+	// root:root. The sandbox process drops to sandboxUID:sandboxGID via
+	// sciontool init, and needs these directories writable from the start
+	// (they are bind-mounted into the sandbox). Chowning here also
+	// naturally resolves /workspace writability: previously the workspace
+	// was root-owned and the sandbox ran as root; now both are scion-owned.
 	for _, d := range []string{p.agentHome, p.workspace} {
 		if err := os.MkdirAll(d, 0755); err != nil {
 			return p, fmt.Errorf("mkdir %s: %w", d, err)
+		}
+		if err := os.Chown(d, sandboxUID, sandboxGID); err != nil {
+			runtimeLog.Warn("failed to chown directory to sandbox user",
+				"dir", d, "uid", sandboxUID, "gid", sandboxGID, "error", err)
 		}
 	}
 
@@ -534,9 +555,19 @@ func envFor(cfg RunConfig, paths scionPaths) map[string]string {
 	}
 
 	// Host UID/GID for container user synchronisation.
-	uid, gid := os.Getuid(), os.Getgid()
-	env["SCION_HOST_UID"] = strconv.Itoa(uid)
-	env["SCION_HOST_GID"] = strconv.Itoa(gid)
+	//
+	// On Cloud Run the launcher (and therefore os.Getuid()) runs as root
+	// (UID 0). Passing UID 0 to the sandbox causes sciontool init's
+	// setupHostUser to keep the process running as root, which makes
+	// Claude Code ≥ 2.1.246 refuse to start ("--dangerously-skip-permissions
+	// cannot be used with root/sudo privileges for security reasons").
+	//
+	// The omni-image creates a `scion` user at UID 1000 (see
+	// image-build/scion-base/Dockerfile). Pass that UID/GID so that
+	// sciontool init drops privileges to the scion user inside the
+	// sandbox, regardless of the launcher's own UID.
+	env["SCION_HOST_UID"] = strconv.Itoa(sandboxUID)
+	env["SCION_HOST_GID"] = strconv.Itoa(sandboxGID)
 
 	// Set HOME, USER and LOGNAME explicitly for the sandbox.
 	// supervisor.go:113 only sets HOME when (UID > 0 || Rootless). On

--- a/pkg/runtime/cloudrun_sandbox_runtime_test.go
+++ b/pkg/runtime/cloudrun_sandbox_runtime_test.go
@@ -1117,7 +1117,8 @@ func TestPrepareScionLayout_CreatesInWorkspaceSharedDirs(t *testing.T) {
 }
 
 // TestPrepareScionLayout_ChownsDirectories verifies that prepareScionLayout
-// chowns agent home and workspace to sandboxUID:sandboxGID.
+// recursively chowns agent home and workspace to sandboxUID:sandboxGID,
+// including files created during relocation and workspace copy.
 // This test only runs as root (like on Cloud Run) because chown requires
 // CAP_CHOWN.
 func TestPrepareScionLayout_ChownsDirectories(t *testing.T) {
@@ -1129,22 +1130,69 @@ func TestPrepareScionLayout_ChownsDirectories(t *testing.T) {
 	}
 
 	rootDir := t.TempDir()
-	paths, err := prepareScionLayout(rootDir, "chown-agent", RunConfig{})
+
+	// Create a HomeDir with nested content to verify recursive chown.
+	homeDir := t.TempDir()
+	subDir := filepath.Join(homeDir, "subdir")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(homeDir, "agent-info.json"), []byte(`{}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "nested.txt"), []byte("nested"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := RunConfig{HomeDir: homeDir}
+	paths, err := prepareScionLayout(rootDir, "chown-agent", cfg)
 	if err != nil {
 		t.Fatalf("prepareScionLayout() error = %v", err)
 	}
 
-	for _, dir := range []string{paths.agentHome, paths.workspace} {
-		info, statErr := os.Stat(dir)
+	// Verify recursive chown: check the directory, a top-level file,
+	// and a nested file are all owned by sandboxUID:sandboxGID.
+	checkPaths := []string{
+		paths.agentHome,
+		filepath.Join(paths.agentHome, "agent-info.json"),
+		filepath.Join(paths.agentHome, "subdir"),
+		filepath.Join(paths.agentHome, "subdir", "nested.txt"),
+		paths.workspace,
+	}
+	for _, p := range checkPaths {
+		info, statErr := os.Lstat(p)
 		if statErr != nil {
-			t.Fatalf("stat %s: %v", dir, statErr)
+			t.Fatalf("lstat %s: %v", p, statErr)
 		}
 		stat := info.Sys().(*syscall.Stat_t)
 		if int(stat.Uid) != sandboxUID {
-			t.Errorf("dir %s owned by UID %d, want %d", dir, stat.Uid, sandboxUID)
+			t.Errorf("path %s owned by UID %d, want %d", p, stat.Uid, sandboxUID)
 		}
 		if int(stat.Gid) != sandboxGID {
-			t.Errorf("dir %s owned by GID %d, want %d", dir, stat.Gid, sandboxGID)
+			t.Errorf("path %s owned by GID %d, want %d", p, stat.Gid, sandboxGID)
+		}
+	}
+}
+
+// TestPrepareScionLayout_SkipsChownNonRoot verifies that prepareScionLayout
+// does NOT call os.Chown when not running as root, preventing EPERM errors
+// in non-root environments (local dev, CI).
+func TestPrepareScionLayout_SkipsChownNonRoot(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("this test verifies non-root behavior; skipping when running as root")
+	}
+
+	rootDir := t.TempDir()
+	paths, err := prepareScionLayout(rootDir, "nonroot-agent", RunConfig{})
+	if err != nil {
+		t.Fatalf("prepareScionLayout() error = %v", err)
+	}
+
+	// In non-root mode, directories should still be created successfully.
+	// The test passes if no EPERM error was returned (chown was skipped).
+	for _, dir := range []string{paths.agentHome, paths.workspace} {
+		if _, statErr := os.Stat(dir); os.IsNotExist(statErr) {
+			t.Errorf("directory not created: %s", dir)
 		}
 	}
 }

--- a/pkg/runtime/cloudrun_sandbox_runtime_test.go
+++ b/pkg/runtime/cloudrun_sandbox_runtime_test.go
@@ -23,6 +23,7 @@ import (
 	"runtime"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -674,12 +675,18 @@ func TestEnvFor_BasicEnv(t *testing.T) {
 		t.Errorf("SCION_GROVE_ID = %q, want %q", env["SCION_GROVE_ID"], "proj-123")
 	}
 
-	// Check UID/GID are set.
+	// Check UID/GID are set to the scion user (non-root).
 	if env["SCION_HOST_UID"] == "" {
 		t.Error("SCION_HOST_UID not set")
 	}
 	if env["SCION_HOST_GID"] == "" {
 		t.Error("SCION_HOST_GID not set")
+	}
+	if env["SCION_HOST_UID"] != "1000" {
+		t.Errorf("SCION_HOST_UID = %q, want %q (non-root scion user)", env["SCION_HOST_UID"], "1000")
+	}
+	if env["SCION_HOST_GID"] != "1000" {
+		t.Errorf("SCION_HOST_GID = %q, want %q (non-root scion user)", env["SCION_HOST_GID"], "1000")
 	}
 }
 
@@ -733,6 +740,35 @@ func TestEnvFor_WorkspaceBackend(t *testing.T) {
 	env := envFor(cfg, paths)
 	if env["SCION_WORKSPACE_BACKEND"] != "nfs" {
 		t.Errorf("SCION_WORKSPACE_BACKEND = %q, want %q", env["SCION_WORKSPACE_BACKEND"], "nfs")
+	}
+}
+
+// TestEnvFor_NonRootUID verifies that SCION_HOST_UID and SCION_HOST_GID
+// are always set to the scion user (UID 1000), NOT to os.Getuid(). On
+// Cloud Run the launcher runs as root; passing UID 0 would keep the
+// sandbox process as root, which Claude Code ≥ 2.1.246 rejects.
+func TestEnvFor_NonRootUID(t *testing.T) {
+	cfg := RunConfig{}
+	paths := scionPaths{}
+
+	env := envFor(cfg, paths)
+
+	// Must use the scion user's UID/GID (1000), not the process UID.
+	if env["SCION_HOST_UID"] != "1000" {
+		t.Errorf("SCION_HOST_UID = %q, want %q; sandbox must run as non-root scion user",
+			env["SCION_HOST_UID"], "1000")
+	}
+	if env["SCION_HOST_GID"] != "1000" {
+		t.Errorf("SCION_HOST_GID = %q, want %q; sandbox must run as non-root scion user",
+			env["SCION_HOST_GID"], "1000")
+	}
+
+	// Verify the constants match the expected scion user UID.
+	if sandboxUID != 1000 {
+		t.Errorf("sandboxUID = %d, want 1000 (scion user from omni Dockerfile)", sandboxUID)
+	}
+	if sandboxGID != 1000 {
+		t.Errorf("sandboxGID = %d, want 1000 (scion user from omni Dockerfile)", sandboxGID)
 	}
 }
 
@@ -1076,6 +1112,39 @@ func TestPrepareScionLayout_CreatesInWorkspaceSharedDirs(t *testing.T) {
 		sdPath := filepath.Join(rootDir, "shared", name)
 		if _, err := os.Stat(sdPath); os.IsNotExist(err) {
 			t.Errorf("shared dir not created: %s", sdPath)
+		}
+	}
+}
+
+// TestPrepareScionLayout_ChownsDirectories verifies that prepareScionLayout
+// chowns agent home and workspace to sandboxUID:sandboxGID.
+// This test only runs as root (like on Cloud Run) because chown requires
+// CAP_CHOWN.
+func TestPrepareScionLayout_ChownsDirectories(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("chown test requires root; skipping in non-root test environment")
+	}
+	if runtime.GOOS != "linux" {
+		t.Skip("chown ownership check uses syscall.Stat_t (Linux only)")
+	}
+
+	rootDir := t.TempDir()
+	paths, err := prepareScionLayout(rootDir, "chown-agent", RunConfig{})
+	if err != nil {
+		t.Fatalf("prepareScionLayout() error = %v", err)
+	}
+
+	for _, dir := range []string{paths.agentHome, paths.workspace} {
+		info, statErr := os.Stat(dir)
+		if statErr != nil {
+			t.Fatalf("stat %s: %v", dir, statErr)
+		}
+		stat := info.Sys().(*syscall.Stat_t)
+		if int(stat.Uid) != sandboxUID {
+			t.Errorf("dir %s owned by UID %d, want %d", dir, stat.Uid, sandboxUID)
+		}
+		if int(stat.Gid) != sandboxGID {
+			t.Errorf("dir %s owned by GID %d, want %d", dir, stat.Gid, sandboxGID)
 		}
 	}
 }


### PR DESCRIPTION
Configure Cloud Run sandbox to run as non-root user (UID 1000, scion user). Claude Code v2.1.246 rejects --dangerously-skip-permissions as root. Sets SCION_HOST_UID/GID to 1000 instead of os.Getuid() and chowns agent directories so they are writable by the non-root sandbox process.