### PR TITLE
docs: fix Gemini review findings (scheduler permissions count, env var nil wording)

### DIFF
--- a/docs-site/src/content/docs/local/workspace.md
+++ b/docs-site/src/content/docs/local/workspace.md
@@ -150,7 +150,7 @@ By default, git projects use a shallow clone with `depth=1` for fast startup.
 |----------|-------------|---------|
 | `SCION_GIT_CLONE_URL` | HTTPS URL of the repository to clone | *(required)* |
 | `SCION_GIT_BRANCH` | Branch to clone | `main` |
-| `SCION_GIT_DEPTH` | Clone depth (set to `0` for full clone, omission or `nil` defaults to shallow depth `1`) | `1` |
+| `SCION_GIT_DEPTH` | Clone depth (set to `0` for full clone, omission defaults to shallow depth `1`) | `1` |
 
 Authentication is handled via the `GITHUB_TOKEN` environment variable, injected from the project's secrets or your local environment through the env-gather flow.
 

--- a/docs-site/src/content/docs/release-notes/2026-08-24.md
+++ b/docs-site/src/content/docs/release-notes/2026-08-24.md
@@ -49,4 +49,4 @@ The GKE Helm chart underwent significant security and operational hardening. Pha
 ## 🖥️ Permissions & Web UI
 - **Permission-gated administrative UI:** Dynamically disabled navigation and settings tabs based on caller credentials, preventing users from seeing tabs (such as Templates or Quotas) for which they lack permissions.
 - **User and group pickers:** Added reusable principal pickers and detailed view-permissions modals to ease role binding assignments for admins.
-- **Scheduler access controls:** Enforced owner-based permission boundaries on scheduled events and schedules, backed by 8 new fine-grained permissions.
+- **Scheduler access controls:** Enforced owner-based permission boundaries on scheduled events and schedules, backed by 7 new fine-grained permissions.


### PR DESCRIPTION
Fix two Gemini review findings from PR #1440:

- release-notes/2026-08-24.md: correct scheduler permissions count from 8 to 7 (verified against permissions.md which lists the 7 permissions)
- local/workspace.md: remove "nil" from SCION_GIT_DEPTH description — environment variables are set or unset, not nil