### PR TITLE
fix: persist workspace-mode label for per-agent projects

### DIFF
--- a/pkg/hub/handlers_project_test.go
+++ b/pkg/hub/handlers_project_test.go
@@ -1545,12 +1545,17 @@ func TestCreateProject_SharedWorkspace_SetsLabelAndInitFilesystem(t *testing.T) 
 	assert.NoError(t, err, ".scion directory should exist for shared-workspace project")
 }
 
-func TestCreateProject_PerAgentGit_NoWorkspaceLabel(t *testing.T) {
+// TestCreateProject_GitNoExplicitMode_NoWorkspaceLabel verifies that a git
+// project created WITHOUT an explicit WorkspaceMode field does not receive a
+// workspace-mode label. The downstream ResolveWorkspaceSharingMode defaults
+// empty labels to shared-plain, which is the backward-compatible behavior for
+// projects that predate workspace-mode support.
+func TestCreateProject_GitNoExplicitMode_NoWorkspaceLabel(t *testing.T) {
 	srv, _ := testServer(t)
 
 	body := CreateProjectRequest{
-		Name:      "Per-Agent Git Project",
-		GitRemote: "github.com/test/per-agent",
+		Name:      "No Mode Git Project",
+		GitRemote: "github.com/test/no-mode",
 	}
 
 	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects", body)
@@ -1560,8 +1565,33 @@ func TestCreateProject_PerAgentGit_NoWorkspaceLabel(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&project))
 
 	assert.Empty(t, project.Labels[store.LabelWorkspaceMode],
-		"per-agent git project should not have workspace mode label")
+		"git project without explicit workspace mode should not have label")
 	assert.False(t, project.IsSharedWorkspace())
+}
+
+// TestCreateProject_ExplicitPerAgent_StampsLabel verifies that creating a git
+// project with WorkspaceMode: "per-agent" correctly persists the
+// scion.dev/workspace-mode label so downstream dispatch resolves
+// clone-per-agent instead of defaulting to shared-plain.
+func TestCreateProject_ExplicitPerAgent_StampsLabel(t *testing.T) {
+	srv, _ := testServer(t)
+
+	body := CreateProjectRequest{
+		Name:          "Per-Agent Git Project",
+		GitRemote:     "github.com/test/per-agent",
+		WorkspaceMode: "per-agent",
+	}
+
+	rec := doRequest(t, srv, http.MethodPost, "/api/v1/projects", body)
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+
+	var project store.Project
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&project))
+
+	assert.Equal(t, store.WorkspaceModePerAgent, project.Labels[store.LabelWorkspaceMode],
+		"per-agent label should be stamped when workspace mode is explicitly set")
+	assert.False(t, project.IsSharedWorkspace(), "per-agent project should not report as shared workspace")
+	assert.False(t, project.IsWorktreePerAgent(), "per-agent project should not report as worktree-per-agent")
 }
 
 func TestCreateProject_WorktreePerAgent_StampsLabel(t *testing.T) {

--- a/pkg/hub/handlers_projects_core.go
+++ b/pkg/hub/handlers_projects_core.go
@@ -358,7 +358,7 @@ func (s *Server) createProject(w http.ResponseWriter, r *http.Request) {
 	// Apply workspace mode label for git projects with explicit workspace mode.
 	if normalizedRemote != "" {
 		switch req.WorkspaceMode {
-		case store.WorkspaceModeShared, store.WorkspaceModeWorktreePerAgent:
+		case store.WorkspaceModeShared, store.WorkspaceModePerAgent, store.WorkspaceModeWorktreePerAgent:
 			if req.Labels == nil {
 				req.Labels = make(map[string]string)
 			}

--- a/pkg/hub/project_clone.go
+++ b/pkg/hub/project_clone.go
@@ -177,7 +177,7 @@ func (s *Server) handleProjectClone(w http.ResponseWriter, r *http.Request, proj
 			srcMode = src.Labels[store.LabelWorkspaceMode]
 		}
 		switch srcMode {
-		case store.WorkspaceModeShared, store.WorkspaceModeWorktreePerAgent:
+		case store.WorkspaceModeShared, store.WorkspaceModePerAgent, store.WorkspaceModeWorktreePerAgent:
 			if clone.Labels == nil {
 				clone.Labels = make(map[string]string)
 			}

--- a/web/src/components/pages/project-create.ts
+++ b/web/src/components/pages/project-create.ts
@@ -603,6 +603,9 @@ export class ScionPageProjectCreate extends LitElement {
         if (this.gitWorkspaceMode === 'shared') {
           labels['scion.dev/workspace-mode'] = 'shared';
           body.workspaceMode = 'shared';
+        } else if (this.gitWorkspaceMode === 'per-agent') {
+          labels['scion.dev/workspace-mode'] = 'per-agent';
+          body.workspaceMode = 'per-agent';
         } else if (this.gitWorkspaceMode === 'worktree-per-agent') {
           labels['scion.dev/workspace-mode'] = 'worktree-per-agent';
           body.workspaceMode = 'worktree-per-agent';


### PR DESCRIPTION
Fixes the SCION_WORKSPACE_MODE defect where clone-per-agent projects reported shared-plain. The per-agent case was missing from workspace-mode persistence logic in project create (Go+TS) and project clone handlers. Agents on per-agent projects now correctly receive SCION_WORKSPACE_MODE=clone-per-agent