### PR TITLE
fix: add access_constraints fixture row for TestFixtureCoverage

### DIFF
--- a/internal/fixturegen/fixturegen_test.go
+++ b/internal/fixturegen/fixturegen_test.go
@@ -31,7 +31,7 @@ import (
 // expectedTableCount is the number of domain tables in the hub schema
 // (excluding the schema_migrations bookkeeping table). The fixture must cover
 // every one of them.
-const expectedTableCount = 58
+const expectedTableCount = 59
 
 // TestFixtureCoverage is the CI coverage gate: it generates the fixture and
 // fails if any domain table has zero rows.

--- a/internal/fixturegen/spec.go
+++ b/internal/fixturegen/spec.go
@@ -151,6 +151,17 @@ func Spec() []TableFixture {
 				"group_id": groupID, "agent_id": agentID, "role": "member", "added_at": baseTime,
 			},
 		}},
+		{Table: "access_constraints", Rows: []row{
+			{
+				"id": "ac100000-0000-0000-0000-000000000001", "name": "fixture-max-perms",
+				"subject_kind": "principal", "subject_principal_type": "user",
+				"subject_principal_id": userID,
+				"scope_type": "system", "scope_id": "",
+				"maximum_permissions": `["agent.read","agent.list"]`,
+				"disabled": false,
+				"created": baseTime, "updated": baseTime,
+			},
+		}},
 		{Table: "access_policies", Rows: []row{
 			{
 				"id": policyID, "name": "Allow Read", "description": "read agents",

--- a/internal/fixturegen/spec.go
+++ b/internal/fixturegen/spec.go
@@ -156,10 +156,10 @@ func Spec() []TableFixture {
 				"id": "ac100000-0000-0000-0000-000000000001", "name": "fixture-max-perms",
 				"subject_kind": "principal", "subject_principal_type": "user",
 				"subject_principal_id": userID,
-				"scope_type": "system", "scope_id": "",
+				"scope_type":           "system", "scope_id": "",
 				"maximum_permissions": `["agent.read","agent.list"]`,
-				"disabled": false,
-				"created": baseTime, "updated": baseTime,
+				"disabled":            false,
+				"created":             baseTime, "updated": baseTime,
 			},
 		}},
 		{Table: "access_policies", Rows: []row{


### PR DESCRIPTION
## Summary

- Add fixture row for `access_constraints` table in internal/fixturegen/spec.go
- Bump expectedTableCount from 58 to 59 in fixturegen_test.go

## Why

TestFixtureCoverage has been failing on main since the access_constraints table was added without a fixture row. Fixing this is a prerequisite for any future discussion about making that job blocking.

Refs ptone/scion#1408
