### PR TITLE
fix(web): change default harness fallback from gemini-cli to antigravity

### DIFF
--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -67,7 +67,7 @@ export class ScionPageAgentCreate extends LitElement {
   @state() private name = '';
   @state() private projectId = '';
   @state() private templateId = '';
-  @state() private harness = 'gemini-cli';
+  @state() private harness = 'antigravity';
   @state() private customHarness = '';
   @state() private brokerId = '';
   @state() private profile = '';
@@ -574,7 +574,7 @@ export class ScionPageAgentCreate extends LitElement {
     const visible = this.filteredTemplates;
 
     const settings = this.projectId ? await this.fetchProjectSettings(this.projectId) : null;
-    const harnessDefault = settings?.defaultHarnessConfig || 'gemini-cli';
+    const harnessDefault = settings?.defaultHarnessConfig || 'antigravity';
 
     const harnessFor = (t: { defaultHarnessConfig?: string; harness?: string }) =>
       t.defaultHarnessConfig || t.harness || harnessDefault;


### PR DESCRIPTION
The agent creation form in the web UI hardcodes gemini-cli as the fallback harness config. When no project-level defaultHarnessConfig is set (common on fresh deployments), users see gemini-cli instead of antigravity in the new agent form.

Changes:
- Update initial harness state from gemini-cli to antigravity
- Update selectDefaultTemplate fallback from gemini-cli to antigravity

The backend embedded default_settings.yaml already specifies antigravity, but the frontend has its own independent fallback chain that was not updated.

Fork PR: https://github.com/ptone/scion/pull/1413
Fork issue: https://github.com/ptone/scion/issues/1412