### PR TITLE
docs: nightly doc update Sep 1 (authorization refactor, Cloud Run sandbox, antigravity auth)

### DIFF
--- a/docs-site/src/content/docs/hosted/ha/permissions.md
+++ b/docs-site/src/content/docs/hosted/ha/permissions.md
@@ -3,14 +3,14 @@ title: Permissions & Policy
 description: Designing access control for Scion projects and agents.
 ---
 
-Scion implements a robust, principal-based access control system to manage resources across distributed projects and teams. The system is built on the **Permissions Foundation Phase 1** architecture, providing deterministic policy evaluation, declarative route guards, and comprehensive auditing.
+Scion implements a robust, principal-based access control system to manage resources across distributed projects and teams. The system is built on the **Permissions Foundation** architecture, providing deterministic authorization evaluation, declarative route guards, and comprehensive auditing.
 
-For a detailed technical specification of the policy language and agent identity claims, see the [Policy & Permissions Reference](/scion/reference/permissions-policy/).
+For a detailed technical specification of the permissions model, role definitions, access constraints, and agent identity claims, see the [Permissions & Access Constraints Reference](/scion/reference/permissions-policy/).
 
 ## Core Concepts
 
 ### Unified Authorization
-Scion uses a `UnifiedAuthMiddleware` to enforce declarative route guards across the Hub. Every request undergoes deterministic policy evaluation via a Decide path before reaching the handler, ensuring no resource can be accessed without explicit permission. Engine internals, settings handlers, User Access Token (UAT) endpoints, user management, integrations, and operations have all been converted to explicit permission-based checks, deprecating the legacy `requireAdmin` fallback.
+Scion uses a `UnifiedAuthMiddleware` to enforce declarative route guards across the Hub. Every request undergoes deterministic authorization evaluation via a Decide path before reaching the handler, ensuring no resource can be accessed without explicit permission. Engine internals, settings handlers, User Access Token (UAT) endpoints, user management, integrations, and operations have all been converted to explicit permission-based checks, deprecating the legacy `requireAdmin` fallback.
 
 ### Roles and Bindings
 Access is granted through explicit role assignments:
@@ -45,9 +45,9 @@ Scion uses a standardized set of actions:
 - **Administrative**: `manage`.
 - **Resource-Specific**: `start`, `stop`, `attach`, `message`.
 
-## Policy-Based Authorization
+## Access Control & Authorization
 
-Scion enforces strict policy-based authorization for all agent operations:
+Scion enforces strict role-binding-based authorization for all agent operations:
 - **Agent Creation**: Requires active membership in the target project.
 - **Agent Interaction**: Interacting with an agent (e.g., via PTY/terminal or structured messaging) is restricted to the agent's owner (the creator) or system administrators.
 - **Agent Deletion**: Only the agent's owner, a system administrator, or authorized agent callers can delete an agent. For an agent caller to perform a deletion, it must have `project:agent:lifecycle` (associated with the `full` role) and must target an agent within its own project (which closes a cross-project agent deletion vulnerability).
@@ -55,14 +55,14 @@ Scion enforces strict policy-based authorization for all agent operations:
 ### Membership-Based Project Access (Visibility Eradication)
 
 The legacy, non-functional project `Visibility` field (e.g., `private`, `team`, or `public`) has been completely eradicated. Instead, access control is governed entirely by membership-based policies.
-- **Project Scope Governance**: Access to a project and its associated resources is restricted to principals belonging to the project's member group (i.e. `project:<slug>:members`). This group is dynamically bound to per-project read policies (such as `project:<slug>:member-read-project` and `project:<slug>:member-read-agent`).
+- **Project Scope Governance**: Access to a project and its associated resources is restricted to principals belonging to the project's member group (i.e. `project:<slug>:members`). This group is bound to per-project read and access roles using Project-scoped RoleBindings (such as `project:<slug>:member-read-project` and `project:<slug>:member-read-agent` mappings).
 - **Fail-Closed Retrieval (404 Gate)**: Project read access is verified via a `CheckAccess` gate on retrieval. If a caller is not authorized to read the project, the API responds with a standard `404 Not Found` (rather than a `403 Forbidden`) to prevent callers from probing the existence of private projects.
 
 ### Scheduler Authorization & Owner-Based Access Control
 
-Scheduled events and recurring schedules are strictly protected using an **Owner-Based Access Control** model, combined with dedicated permissions and dynamic policy bindings:
+Scheduled events and recurring schedules are strictly protected using an **Owner-Based Access Control** model, combined with dedicated permissions and dynamic RoleBindings:
 - **Owner-Based Protection**: Only the creator (the owner) of a schedule/event, or a system-wide administrator, has the authority to view, update, delete, or otherwise manage a scheduled event or recurring schedule. This is enforced via creator/owner ID validation at the API handlers layer.
-- **Project Member Bindings**: During project creation or template synchronization, Scion backfills/seeds project-scoped scheduled event policies bound to the project's members group. This grants members the capability to schedule events within their project space.
+- **Project Member Bindings**: During project creation or template synchronization, Scion backfills/seeds project-scoped scheduled event RoleBindings bound to the project's members group. This grants members the capability to schedule events within their project space.
 - **Scheduler Permissions**: A set of 7 dedicated permissions are enforced across scheduler endpoints:
   - `scheduled_event.read`: Permission to read a scheduled event or recurring schedule.
   - `scheduled_event.list`: Permission to list scheduled events and recurring schedules.
@@ -72,46 +72,38 @@ Scheduled events and recurring schedules are strictly protected using an **Owner
   - `hub.scheduler.read`: Permission to read hub-wide scheduler configurations.
   - `hub.scheduler.update`: Permission to update hub-wide scheduler configurations.
 
-Scion uses a **Hierarchical Override Model** for policies. Policies can be attached at three levels:
+## Positive Authority & Monotonic Restrictions
 
-1.  **Hub Level**: Global policies applying to all resources.
-2.  **Project Level**: Policies applying to all resources within a specific project.
-3.  **Resource Level**: Policies applying to a single specific agent or template.
+Scion operates on a single positive-authority model using **RoleBindings** to grant permissions, supplemented by **AccessConstraints** to enforce maximum boundaries.
 
-### Resolution Logic
-When an action is attempted, Scion resolves effective permissions by traversing the hierarchy from the most specific to the most general:
-- A policy at the **Resource level** overrides a policy at the **Project level**.
-- A policy at the **Project level** overrides a global **Hub level** policy.
+### Positive-Authority (RoleBindings)
+All permissions in Scion are additive and must be explicitly granted via a RoleBinding.
+- **RoleDefinition**: A named set of allowed permissions (e.g., `project:viewer`, `project:developer`, `hub-admin`).
+- **RoleBinding**: Connects a principal (User, Agent, or Group) to a RoleDefinition.
+- **Scope**: RoleBindings exist at either `system` scope (system-wide permissions across the entire Hub) or `project` scope (permissions restricted to a single project space).
 
-This model allows for granular delegation, where project owners can manage their own team's access without global administrator intervention.
+### Monotonic Restrictions (AccessConstraints)
+An **AccessConstraint** is a maximum-permissions boundary that can only *reduce* (never widen) a principal's granted authority. It acts as an absolute ceiling.
+- **Ceiling Enforcement**: If a RoleBinding grants a principal 10 permissions, but an AccessConstraint limits that principal to a maximum of 3 specific permissions, the principal will only have those 3 permissions.
+- **Targeting**: AccessConstraints can target specific principals, entire group closures (a group and all its subgroups), or all principals (`all_principals`).
+- **Offline Recovery**: Under `disabled: true`, an AccessConstraint is deactivated. This is used in offline recovery to restore administrator access in the event of a lockout.
+
+### Resolution & Evaluation Logic
+On any authorization request (evaluated via the Hub's `Decide` endpoint):
+1. **Load Bindings**: The engine loads all active RoleBindings for the principal (including group memberships and synthetic agent scopes).
+2. **Resolve Allowed Set**: The union of all permissions from these RoleBindings is compiled into an "allowed permissions" set.
+3. **Apply AccessConstraints**: The engine queries and loads all non-disabled AccessConstraints that apply to the principal (matching on direct principal ID, group memberships, or `all_principals`).
+4. **Calculate Intersection**: The effective permission set is the intersection of the resolved allowed set and the AccessConstraints' `maximum_permissions` ceilings. If no positive RoleBinding grants the permission, or if an AccessConstraint excludes it, access is denied (**fail-closed**).
 
 ## Capability-Based Access Control
 
 The Hub API and Web UI utilize a capability gating system. Resource responses from the API include `_capabilities` annotations. These annotations explicitly state the actions the authenticated user is permitted to perform on that specific resource. This ensures granular UI controls (e.g., disabling the "Delete" button if the user lacks permission) and provides a secondary layer of API-level enforcement.
 
-## Policy Structure
-
-A policy defines the rules for access:
-
-```json
-{
-  "name": "Project Developer Policy",
-  "scopeType": "project",
-  "scopeId": "project-uuid",
-  "resourceType": "agent",
-  "actions": ["create", "read", "start", "stop"],
-  "effect": "allow"
-}
-```
-
-- **Effect**: Can be `allow` or `deny`.
-- **Conditions**: (Future) Optional rules based on resource labels or time-of-day.
-
 ## GCP Service Account Assignment Gates
 
 To prevent lateral privilege escalation—where an agent with low privileges creates a child agent with high privileges, or a user assigns a highly privileged GCP service account they shouldn't have access to—Scion implements a secure, **two-layer gate** for binding a GCP service account to any agent:
 
-1. **Layer 1: Scion Hub Policy**: The Hub's built-in policy engine verifies the caller has the `ActionAssign` permission on the GCP service account resource within Scion.
+1. **Layer 1: Scion Hub Authorization**: The Hub's built-in authorization engine verifies the caller has the `ActionAssign` permission on the GCP service account resource within Scion.
 2. **Layer 2: GCP IAM Policy (`actAs`)**: If `gcp_iam_check_mode` is set to `enforce` (see [Server Configuration Reference](/scion/reference/server-config/)), the Hub evaluates Google Cloud's IAM delegation model via the **GCP Policy Troubleshooter v3 API**. It verifies that the caller's GCP principal possesses `iam.serviceAccounts.actAs` permission on the target service account.
 
 ### The `actAs` Validation Gate
@@ -120,7 +112,7 @@ The `actAs` (impersonation) check is critical because binding a service account 
 
 | Layer | Checked Authority | Action | Checked Principal |
 | :--- | :--- | :--- | :--- |
-| **Hub Policy** | Inside Scion | `ActionAssign` | Scion User/Agent |
+| **Hub Authorization** | Inside Scion | `ActionAssign` | Scion User/Agent |
 | **GCP IAM** | Inside Google Cloud | `iam.serviceAccounts.actAs` | Caller's GCP Principal |
 
 *Note: The Hub's own `roles/iam.serviceAccountTokenCreator` permission is used to perform impersonated credential probes. It is NOT the permission checked on the caller. The permission evaluated on the caller is `iam.serviceAccounts.actAs` (typically granted via `roles/iam.serviceAccountUser`).*

--- a/docs-site/src/content/docs/hosted/single-node/hub-setup-cloudrun.md
+++ b/docs-site/src/content/docs/hosted/single-node/hub-setup-cloudrun.md
@@ -383,6 +383,28 @@ to other remotes will fail. This is a known limitation
 
 ---
 
+## Sandbox Runtime & Volumes
+
+When running agents as Cloud Run Sandboxes, Scion enforces security hardening and standardized mounting conventions to guarantee compatibility with modern harnesses.
+
+### Non-Root Execution (UID 1000)
+To align with secure-by-default execution practices, the Cloud Run Sandbox runtime executes agents as **non-root users** (`UID 1000`, matching the built-in `scion` user inside the base images), even though the host-side launcher process executes as `root` (UID 0).
+
+* **Harness Compatibility**: This hardening is critical for newer harnesses like Claude Code (≥ 2.1.246), which explicitly refuse to start with `root` or `sudo` privileges (even when configured with `--dangerously-skip-permissions`).
+* **Environment Injection**: The runtime explicitly maps and configures:
+  * `SCION_HOST_UID` & `SCION_HOST_GID` to `1000` so that `sciontool init` drops privileges.
+  * `HOME` directed to the agent-specific sandbox-mounted directory (e.g. `~/.gemini`).
+  * `USER` and `LOGNAME` environment variables forced to `scion`.
+* **Writability**: The broker ensures all agent homes, workspaces, and cached directories are pre-chowned to UID 1000 so the non-root runner can write and modify code without permission blocks.
+
+### Standardized Shared Volume Mounts
+Shared directories within the Cloud Run Sandbox are mounted at standard paths matching the Kubernetes runtime conventions, ensuring configuration portability across Single-Node and HA environments.
+
+* **Standard Mount Path**: All shared directories are mapped to `/scion-volumes/<name>` inside the sandbox container.
+* **Workspace & Read-Only Support**: The sandbox runtime fully supports mounting shared volumes within the workspace directory tree (using `in_workspace: true` to mount at `/workspace/.scion-volumes/<name>`) and enforces read-only locks when specified.
+
+---
+
 ## 6. Teardown
 
 Delete the Instance:

--- a/docs-site/src/content/docs/local/agent-credentials.md
+++ b/docs-site/src/content/docs/local/agent-credentials.md
@@ -138,6 +138,7 @@ This is the simplest method, relying on standard environment variables to provid
 **Required Sources:**
 - **Claude**: `ANTHROPIC_API_KEY`
 - **Gemini**: `GEMINI_API_KEY` or `GOOGLE_API_KEY`
+- **Antigravity**: `GEMINI_API_KEY` or `GOOGLE_API_KEY` (lowest-priority fallback method)
 - **OpenCode**: `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` (Anthropic preferred)
 - **Codex**: `CODEX_API_KEY` or `OPENAI_API_KEY` (Codex-specific key preferred)
 - **Hermes**: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY` (in that order)
@@ -229,6 +230,10 @@ For the Claude harness, Scion automatically translates `GOOGLE_CLOUD_PROJECT` to
 
 :::tip[Antigravity Vertex AI & ADC]
 For the Antigravity harness, `vertex-ai` authentication is powered entirely by Google Cloud Application Default Credentials (ADC) plus the Google Cloud project (`GOOGLE_CLOUD_PROJECT`) and location/region (`GOOGLE_CLOUD_LOCATION` or `GOOGLE_CLOUD_REGION`) environment variables, and no longer requires `AGY_TOKEN`. At runtime, Scion sets the `AGY_ADC_AUTH` environment variable to `true` and maps `gcloud-adc` (if uploaded) to `GOOGLE_APPLICATION_CREDENTIALS`. This mode requires AGY CLI >= 1.1.10.
+:::
+
+:::tip[Antigravity API Key Fallback]
+In addition to Vertex AI and OAuth refresh tokens, the Antigravity harness supports direct API Key authentication. Evaluation priority is `vertex-ai` > `oauth-token` > `api-key`. If either `GEMINI_API_KEY` or `GOOGLE_API_KEY` is set and no higher-priority auth is resolved, the provisioner automatically configures `modelProvider: "Gemini"` inside the agent's `settings.json` and authenticates using this key.
 :::
 
 :::caution[Defensive Auth Protection]

--- a/docs-site/src/content/docs/reference/permissions-policy.md
+++ b/docs-site/src/content/docs/reference/permissions-policy.md
@@ -1,16 +1,19 @@
 ---
-title: Policy & Permissions Reference
-description: Technical reference for the Scion policy language and permission system.
+title: Permissions & Access Constraints Reference
+description: Technical reference for the Scion role-binding and access constraint authorization architecture.
 ---
 
 ## Overview
 
-Scion employs a rigorous, claim-based access control system to secure the interactions between Agents, Users, and the Hub. Built on the **Permissions Foundation Phase 1** architecture, this system goes beyond simple role-based access control (RBAC) by evaluating cryptographically signed claims embedded in an agent's identity token and enforcing deterministic, policy-driven route guards via a unified authentication middleware.
+Scion employs a rigorous, positive-authority authorization architecture with monotonic restrictions to secure interactions between agents, users, and the Hub. 
 
-This enables sophisticated security postures, such as:
-*   "An agent can only read secrets belonging to the user who created it."
-*   "Agents created from the `security-auditor` template have read-only access to the codebase."
-*   "Only agents running on trusted brokers can access production database credentials."
+The legacy YAML/JSON `Policy` and `PolicyBinding` resource paths have been fully removed. Instead, authorization is governed by two complementary constructs:
+1. **Positive Authority (RoleBindings)**: Additive grants that map a principal (user, group, or agent) to a `RoleDefinition` within a specific scope.
+2. **Monotonic Restrictions (AccessConstraints)**: Absolute maximum-permissions boundaries that can only reduce (never widen) the authority granted by positive RoleBindings.
+
+This architecture ensures a deterministic, fail-closed evaluation model, and includes robust safety features such as delegation protection and an offline maintenance recovery path.
+
+---
 
 ## Agent Identity
 
@@ -41,85 +44,106 @@ The agent identity token contains standard JWT claims alongside Scion-specific m
 
 Crucially, the identity token includes **provenance claims** that attest to the agent's origin. These claims are signed by the Hub and cannot be forged by the agent or the user.
 
-| Claim | Description | Usage in Policy |
+| Claim | Description | Usage in Evaluation |
 | :--- | :--- | :--- |
-| `creator_user_id` | The ID of the user who requested the agent's creation. | Restrict agent access to resources owned by the creator. |
-| `template_id` | The ID and version of the template used. | Enforce least-privilege based on the agent's role (e.g., QA vs. Dev). |
-| `project_id` | The project workspace the agent belongs to. | Isolate agents to their specific project scope. |
-| `broker_id` | The identity of the Runtime Broker executing the agent. | Restrict sensitive tasks to trusted hardware/locations. |
+| `creator_user_id` | The ID of the user who requested the agent's creation. | Restricts agent access to resources owned by the creator. |
+| `template_id` | The ID and version of the template used. | Restricts capabilities (e.g. baseline vs. full) based on template roles. |
+| `project_id` | The project workspace the agent belongs to. | Restricts agent operations to its specific project scope. |
+| `broker_id` | The identity of the Runtime Broker executing the agent. | Validates that execution occurs in a trusted environment. |
 
-## Policy Language
+---
 
-Scion policies are defined in JSON or YAML and are evaluated at the Hub whenever an API request is made. A policy binds a **Principal** (User or Agent) to a set of allowed **Actions** on a **Resource**, subject to **Conditions**.
+## RoleBindings (Positive Authority)
 
-### Policy Structure
+Access to any resource or operation in Scion must be explicitly authorized by a **RoleBinding**. RoleBindings are strictly positive-only grants; there are no explicit "deny" bindings.
 
-```yaml
-apiVersion: scion.dev/v1alpha1
-kind: Policy
-metadata:
-  name: "limit-auditor-agents"
-spec:
-  # The scope of the policy (e.g., global, project-specific)
-  scope: "project:12345"
-  
-  # Who is being regulated?
-  principal:
-    type: "agent"
-    match:
-      # Match agents created from the 'security-auditor' template
-      claims.template_id: "template:security-auditor:*"
+A `RoleBinding` contains the following fields:
 
-  # What are they allowed to do?
-  allow:
-    - action: "secret.read"
-      resource: "secret:prod-db-*"
-      condition:
-        # CEL (Common Expression Language) expression
-        expression: "request.auth.claims.creator_user_id == resource.owner"
+* **Role Definition ID**: The UUID of the `RoleDefinition` being granted. Role definitions contain specific permission IDs (e.g., `agent.create`, `project.read`).
+* **Principal Type**: The category of principal (`user`, `agent`, or `group`).
+* **Principal ID**: The identifier of the specific principal.
+* **Scope Type**: The scope bounds, either `system` (global permissions) or `project` (project-restricted permissions).
+* **Scope ID**: Empty for `system` scope, or the specific project ID for `project` scope.
+* **Activation Window (`not_before` / `expires_at`)**: Optional time bounds during which the binding is active.
+
+### Agent Synthetic RoleBindings
+At runtime, agents do not require static RoleBindings to be manually created. Instead, the authorization engine dynamically extracts the agent's JWT claims and scopes and constructs **synthetic project-scoped role bindings** so that agent actions can be evaluated through the unified authorization pipeline.
+
+---
+
+## AccessConstraints (Monotonic Restrictions)
+
+An **AccessConstraint** is a monotonic restriction that defines a **maximum-permissions boundary** (permission ceiling). It can only reduce (never widen) the authority granted by positive RoleBindings.
+
+An `AccessConstraint` contains the following fields:
+
+* **Name**: A unique name per scope.
+* **Subject Kind**: Specifies who is constrained:
+  - `principal`: A single user, agent, or group. Requires setting `subject_principal_type` and `subject_principal_id`.
+  - `group_closure`: A group and all its nested subgroups. Requires setting `subject_group_id`.
+  - `all_principals`: Constrains every principal across the targeted scope.
+* **Scope Type / Scope ID**: Can be `system` (system-wide boundary) or `project` (restricting actions within a single project).
+* **Maximum Permissions**: A JSON array of permission IDs that targeted principals are allowed to hold. If a permission is not listed in this array, targeted principals **cannot** exercise it, regardless of their positive RoleBindings.
+* **Time Bounds (`not_before` / `expires_at`)**: Optional time window during which the constraint is active.
+* **Disabled**: A boolean flag (`true`/`false`) used to deactivate the constraint. This is primarily used for **offline recovery** in lockout scenarios.
+
+---
+
+## Authorization Evaluation Logic (AK1 Kernel)
+
+Whenever an API request is made, the Hub's `Decide` endpoint processes the authorization request using the **AK1 Kernel** to resolve the effective permissions:
+
+```
+[Principal Identity] ─► [Active RoleBindings] ─► [Positive Permission Set]
+                                                          │
+                                                (Calculate Intersection) ◄─── [AccessConstraints (Ceilings)]
+                                                          │
+                                                          ▼
+                                              [Effective Permissions]
 ```
 
-### Evaluation Logic
+1. **Authentication**: The caller is authenticated, establishing their principal type, principal ID, group memberships, and credentials (such as token type/scope).
+2. **Retrieve Positive Grants**: The engine retrieves all active, time-valid RoleBindings that apply to the principal directly, or to any groups they belong to.
+3. **Union Allowed Permissions**: The union of all permission IDs granted by these bindings forms the positive "allowed permissions" set.
+4. **Load Applicable AccessConstraints**: The engine queries all active, non-disabled AccessConstraints that match the principal (by principal ID, group closure, or `all_principals`) within the targeted scope.
+5. **Intersect Permissions**: The effective permission set is calculated as the intersection of the positive set and the maximum permitted ceilings.
+6. **Verdict**: If the requested permission is present in the final intersection set, access is **Allowed**. If it is missing from the positive set, or excluded by an active AccessConstraint, access is **Denied** (fail-closed).
 
-1.  **Authentication**: The request is validated. If the requester is an Agent, its JWT is verified and unpacked.
-2.  **Policy Matching**: The Hub retrieves all active policies relevant to the request's Scope (Global + Project).
-3.  **Condition Check**: For each matching policy, the `condition` expression is evaluated against the request context.
-4.  **Decision**:
-    *   **Deny Override**: If *any* matching policy explicitly denies the action, the request is rejected.
-    *   **Allow**: If at least one policy allows the action (and no denies exist), the request proceeds.
-    *   **Default Deny**: If no policies match, the request is rejected.
+---
 
-## Access Scenarios
+## Offline Authorization Recovery
 
-### Scenario 1: User-Bound Secrets
+If an administrator misconfigures an AccessConstraint (e.g., applying an overly restrictive `all_principals` constraint at `system` scope), all administrators may become locked out of the Hub API.
 
-**Goal:** Allow an agent to access a secret only if the agent was created by the secret's owner.
+To resolve this without performing risky database edits, Scion provides an **Offline Authorization Recovery** command.
 
-**Policy:**
-```yaml
-principal: { type: "agent" }
-action: "secret.access"
-condition: "request.auth.claims.creator_user_id == resource.labels.owner_id"
-```
-**Mechanism:** The Hub compares the `creator_user_id` claim from the agent's signed JWT against the `owner_id` label on the stored Secret resource.
+### The `recover-authz` Utility
 
-### Scenario 2: Immutable Audit Logs
+The `scion server recover-authz` command allows a platform operator to bypass the active HTTP server and de-escalate access constraints directly via the storage adapter.
 
-**Goal:** Ensure `audit-logger` agents can write logs but never read or delete them.
+#### Security Safeguards
+* **Direct Database Connection**: The command bypasses the active HTTP authorization checks by communicating directly with the database.
+* **Exclusive Maintenance Lock**: It acquires an exclusive lock and will fail to execute if an active Scion Hub server or another recovery process is running.
+* **Nuclear Warning**: Disabling all constraints requires passing a specific confirmation phrase.
+* **Audit Trail**: Every recovery action records a permanent mutation audit log entry.
+* **Grants Prevention**: The command **never** creates users, roles, or RoleBindings. It only removes restrictive boundaries so that pre-existing positive grants can function.
 
-**Policy:**
-```yaml
-principal:
-  match: { claims.template_id: "template:audit-logger" }
-allow:
-  - action: "log.write"
-deny:
-  - action: "log.read"
-  - action: "log.delete"
+#### Usage Examples
+
+**Deactivate a specific constraint by ID:**
+```bash
+scion server recover-authz --disable-constraint "36f9036a-2ea2-4a0b-936d-978118b518bc"
 ```
 
-## Future Work
+**Deactivate all access constraints (the nuclear recovery option):**
+```bash
+scion server recover-authz --disable-all-constraints \
+  --confirm "I understand this disables all access constraints"
+```
 
-*   **Runtime Attestation**: Integrating lower-level hardware attestation (TPM/Enclave) into the `broker_id` claim.
-*   **Just-in-Time Grants**: Generating short-lived policies for specific user sessions (e.g., "Allow this agent to deploy for the next 5 minutes").
-*   **Policy Simulation**: Tooling to test policy changes against historical traffic before enforcement.
+**Specify database URL and operator manually:**
+```bash
+scion server recover-authz --disable-constraint "36f9036a-2ea2-4a0b-936d-978118b518bc" \
+  --db "postgres://localhost:5432/scion" \
+  --operator "admin-recovery@example.com"
+```

--- a/docs-site/src/content/docs/supported-harnesses.md
+++ b/docs-site/src/content/docs/supported-harnesses.md
@@ -198,11 +198,11 @@ a containerized workspace agent; choose the managed agent for repo-less, broker-
 :::
 
 ### Authentication
-Antigravity supports three authentication methods:
+Antigravity supports three authentication methods, evaluated in priority order (`vertex-ai` > `oauth-token` > `api-key`):
 
-- **API Key** (`api-key`): Provide an environment secret named `GEMINI_API_KEY`. The provisioner will set `modelProvider` in the agent's `settings.json` and authenticate using this key.
-- **OAuth token** (`oauth-token`): provide a JSON file secret named `AGY_TOKEN` containing a `refresh_token`. Scion stages it at `~/.gemini/antigravity-cli/antigravity-oauth-token` and injects it into the container's gnome-keyring at launch.
 - **Vertex AI** (`vertex-ai`): Google Cloud's Vertex AI mode using Google Cloud Application Default Credentials (ADC) plus `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` (or `GOOGLE_CLOUD_REGION`). This mode no longer requires `AGY_TOKEN`. It uses the `gcloud-adc` file secret or automatically resolves ADC via the assigned GCP Service Account (Hub-managed GCP Identity). Requires AGY CLI >= 1.1.10.
+- **OAuth token** (`oauth-token`): Provide a JSON file secret named `AGY_TOKEN` containing a `refresh_token`. Scion stages it at `~/.gemini/antigravity-cli/antigravity-oauth-token` and injects it into the container's gnome-keyring at launch.
+- **API Key** (`api-key`): The lowest-priority fallback method. Accepts either the `GEMINI_API_KEY` or `GOOGLE_API_KEY` environment secret. The provisioner will automatically set `modelProvider` to `Gemini` in the agent's `settings.json` and authenticate using this key.
 
 If no token is available, run `agy` interactively to log in, then capture the credential with
 the Antigravity bundle's `capture_auth.py` (which can also extract the token from gnome-keyring).


### PR DESCRIPTION
Nightly documentation update for Aug 31 changelog.

- permissions.md & permissions-policy.md: authorization foundation refactor from dual Policy+RoleBinding to single RoleBinding-only model with AccessConstraints
- hub-setup-cloudrun.md: Cloud Run sandbox non-root execution and shared volume mounts
- supported-harnesses.md: antigravity GEMINI_API_KEY auth fallback
- agent-credentials.md: antigravity added to API key harness list

5 files changed, 158 insertions, 115 deletions.