### PR TITLE
fix: prevent webchat migration race on multi-replica cold start

### DIFF
--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -1010,14 +1010,17 @@ func (s *pgWebChatStore) GetTopicConversationIDIncludingDeleted(ctx context.Cont
 // A Postgres session-level advisory lock prevents concurrent replicas from
 // racing through the check-then-mark migration pattern.
 func (s *pgWebChatStore) runMigrations() error {
-	conn, err := s.db.Conn(context.Background())
+	acquireCtx, cancelAcquire := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelAcquire()
+
+	conn, err := s.db.Conn(acquireCtx)
 	if err != nil {
 		return fmt.Errorf("webchat migration conn: %w", err)
 	}
 	defer func() { _ = conn.Close() }()
 
 	var acquired bool
-	if err := conn.QueryRowContext(context.Background(),
+	if err := conn.QueryRowContext(acquireCtx,
 		"SELECT pg_try_advisory_lock($1)", int64(store.LockWebchatMigration),
 	).Scan(&acquired); err != nil {
 		return fmt.Errorf("webchat advisory lock: %w", err)
@@ -1027,7 +1030,9 @@ func (s *pgWebChatStore) runMigrations() error {
 		return nil
 	}
 	defer func() {
-		if _, err := conn.ExecContext(context.Background(),
+		unlockCtx, cancelUnlock := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancelUnlock()
+		if _, err := conn.ExecContext(unlockCtx,
 			"SELECT pg_advisory_unlock($1)", int64(store.LockWebchatMigration)); err != nil {
 			slog.Warn("Failed to release webchat migration lock", "error", err)
 		}

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -1014,7 +1014,7 @@ func (s *pgWebChatStore) runMigrations() error {
 	if err != nil {
 		return fmt.Errorf("webchat migration conn: %w", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	var acquired bool
 	if err := conn.QueryRowContext(context.Background(),

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -1010,8 +1010,16 @@ func (s *pgWebChatStore) GetTopicConversationIDIncludingDeleted(ctx context.Cont
 // A Postgres session-level advisory lock prevents concurrent replicas from
 // racing through the check-then-mark migration pattern.
 func (s *pgWebChatStore) runMigrations() error {
+	conn, err := s.db.Conn(context.Background())
+	if err != nil {
+		return fmt.Errorf("webchat migration conn: %w", err)
+	}
+	defer conn.Close()
+
 	var acquired bool
-	if err := s.db.QueryRow("SELECT pg_try_advisory_lock($1)", int64(store.LockWebchatMigration)).Scan(&acquired); err != nil {
+	if err := conn.QueryRowContext(context.Background(),
+		"SELECT pg_try_advisory_lock($1)", int64(store.LockWebchatMigration),
+	).Scan(&acquired); err != nil {
 		return fmt.Errorf("webchat advisory lock: %w", err)
 	}
 	if !acquired {
@@ -1019,7 +1027,10 @@ func (s *pgWebChatStore) runMigrations() error {
 		return nil
 	}
 	defer func() {
-		_, _ = s.db.Exec("SELECT pg_advisory_unlock($1)", int64(store.LockWebchatMigration))
+		if _, err := conn.ExecContext(context.Background(),
+			"SELECT pg_advisory_unlock($1)", int64(store.LockWebchatMigration)); err != nil {
+			slog.Warn("Failed to release webchat migration lock", "error", err)
+		}
 	}()
 
 	if err := s.migrateThreadIDs(DefaultMigrationBatchSize); err != nil {

--- a/pkg/hub/webchannel_store_postgres.go
+++ b/pkg/hub/webchannel_store_postgres.go
@@ -1007,7 +1007,21 @@ func (s *pgWebChatStore) GetTopicConversationIDIncludingDeleted(ctx context.Cont
 }
 
 // runMigrations executes idempotent data migrations.
+// A Postgres session-level advisory lock prevents concurrent replicas from
+// racing through the check-then-mark migration pattern.
 func (s *pgWebChatStore) runMigrations() error {
+	var acquired bool
+	if err := s.db.QueryRow("SELECT pg_try_advisory_lock($1)", int64(store.LockWebchatMigration)).Scan(&acquired); err != nil {
+		return fmt.Errorf("webchat advisory lock: %w", err)
+	}
+	if !acquired {
+		slog.Info("Webchat migration lock held by another replica, skipping")
+		return nil
+	}
+	defer func() {
+		_, _ = s.db.Exec("SELECT pg_advisory_unlock($1)", int64(store.LockWebchatMigration))
+	}()
+
 	if err := s.migrateThreadIDs(DefaultMigrationBatchSize); err != nil {
 		return fmt.Errorf("thread_id backfill: %w", err)
 	}
@@ -1151,8 +1165,10 @@ func (s *pgWebChatStore) migrationCompleted(name string) (bool, error) {
 }
 
 // markMigrationCompleted records a migration as done.
+// The ON CONFLICT clause makes this idempotent so concurrent replicas
+// cold-starting together do not fail with a primary-key violation.
 func (s *pgWebChatStore) markMigrationCompleted(name string) error {
-	const query = `INSERT INTO webchat_migrations (name, completed_at) VALUES ($1, NOW())`
+	const query = `INSERT INTO webchat_migrations (name, completed_at) VALUES ($1, NOW()) ON CONFLICT (name) DO NOTHING`
 	_, err := s.db.Exec(query, name)
 	return err
 }

--- a/pkg/store/concurrency.go
+++ b/pkg/store/concurrency.go
@@ -114,6 +114,10 @@ const (
 	// that deletes expired entries from the chat_link_codes table.
 	LockChatLinkCodeEviction AdvisoryLockKey = 0x5C100013
 
+	// LockWebchatMigration guards webchat store data migrations so only
+	// one replica runs them during multi-replica cold start.
+	LockWebchatMigration AdvisoryLockKey = 0x5C100014
+
 	// LockWorkspaceProvision is the CLASS ID for per-project workspace
 	// provisioning locks. It is used with the two-int advisory lock form
 	// pg_try_advisory_lock(classid, objid), where classid is this constant


### PR DESCRIPTION
Fixes a race condition where two Postgres replicas cold-starting together can race through the webchat migration check-then-mark pattern, causing one replica Init() to fail with a primary key violation.

Two fixes:
- markMigrationCompleted: added ON CONFLICT (name) DO NOTHING to make the INSERT idempotent
- runMigrations: added a session-level Postgres advisory lock (pg_try_advisory_lock) on a pinned sql.Conn so only one replica runs migrations during cold start

New LockWebchatMigration key (0x5C100014) added to pkg/store/concurrency.go