### PR TITLE
fix: agent-create template list empty (limit exceeds backend max)

### DIFF
--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -405,7 +405,7 @@ export class ScionPageAgentCreate extends LitElement {
         await Promise.all([
           fetch('/api/v1/projects?mine=true&limit=200', { credentials: 'include' }),
           fetch('/api/v1/runtime-brokers?limit=200', { credentials: 'include' }),
-          fetch('/api/v1/templates?status=active&limit=200', { credentials: 'include' }),
+          fetch('/api/v1/templates?status=active&limit=100', { credentials: 'include' }),
           fetch('/api/v1/settings/public', { credentials: 'include' }),
           apiFetch('/api/v1/harness-configs?status=active&limit=100'),
         ]);

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -405,7 +405,7 @@ export class ScionPageAgentCreate extends LitElement {
         await Promise.all([
           fetch('/api/v1/projects?mine=true&limit=200', { credentials: 'include' }),
           fetch('/api/v1/runtime-brokers?limit=200', { credentials: 'include' }),
-          fetch('/api/v1/templates?status=active&limit=100', { credentials: 'include' }),
+          apiFetch('/api/v1/templates?status=active&limit=100'),
           fetch('/api/v1/settings/public', { credentials: 'include' }),
           apiFetch('/api/v1/harness-configs?status=active&limit=100'),
         ]);


### PR DESCRIPTION
The agent-create form requests templates with limit=200, but the backend authorized list validator caps limit at 100 and returns HTTP 400. The raw fetch() silently swallows the error, leaving the template dropdown empty.

Fix: change limit=200 to limit=100 on the templates fetch in agent-create.ts