### PR TITLE
docs: nightly doc update Sep 3 (template list fix, message formatting, API reference)

### DIFF
--- a/docs-site/src/content/docs/hosted/user/messaging.md
+++ b/docs-site/src/content/docs/hosted/user/messaging.md
@@ -154,6 +154,37 @@ scion message @tech-lead "See the test results." --attach ./results.json
 scion message @tech-lead "Debug trace attached." --visibility verbose
 ```
 
+### Message Formatting
+
+The `scion message` CLI delivers the body argument **verbatim** — it performs no escape expansion, no markdown rendering, and no character substitution. Whatever bytes you pass are exactly what the recipient sees.
+
+To include newlines, use real newlines inside shell quoted strings or heredocs. Do **not** use JSON-encoded bodies or literal backslash-n (`\n`) sequences — those will appear as literal characters in the delivered message.
+
+**Correct** — real newlines in a quoted string:
+```bash
+scion message --non-interactive @reviewer "PR #42 is ready for review.
+
+Branch: fix/auth-bug
+CI: all green"
+```
+
+**Correct** — heredoc for longer messages:
+```bash
+scion message --non-interactive @reviewer "$(cat <<'EOF'
+PR #42 is ready for review.
+
+Branch: fix/auth-bug
+CI: all green
+EOF
+)"
+```
+
+**Wrong** — JSON-encoded body with literal `\n`:
+```bash
+# BAD: literal \n chars appear in the delivered message
+scion message --non-interactive @reviewer "PR #42 is ready for review.\n\nBranch: fix/auth-bug\nCI: all green"
+```
+
 ### Related Commands
 
 - **`scion broadcast`**: Send a message to all agents in the current project, or use `--all` for a global broadcast. This replaces the old `--broadcast` flag on `scion message`.

--- a/docs-site/src/content/docs/reference/api.md
+++ b/docs-site/src/content/docs/reference/api.md
@@ -73,7 +73,7 @@ Status codes:
 The stored MIME type is derived from the file's content plus its extension; the `Content-Type` a client declares on the part is ignored. Executable extensions (`.exe`, `.sh`, `.js`, `.ps1`, and their peers) and markup extensions (`.html`, `.svg`, and their peers) are refused whatever the content is.
 
 #### Templates (`/api/v1/templates`)
-- `GET /`: List available agent templates.
+- `GET /`: List available agent templates. The authorized list validator caps list requests at a maximum limit of **100** templates per page (default is 50). Requests specifying a `limit` query parameter greater than 100 will fail with HTTP 400 Bad Request.
 - `POST /`: Upload a new template or version.
 
 #### Auth (`/api/v1/auth`)

--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -143,6 +143,36 @@ Sends a message to a running agent or user.
     - `--in <duration>`: *(Deprecated — use `scion schedule create --in` instead.)* Schedule message delivery after a duration.
     - `--at <time>`: *(Deprecated — use `scion schedule create --at` instead.)* Schedule message delivery at an absolute time.
 
+- **Message Body Formatting:**
+  The command delivers the `<message>` argument **verbatim** — it performs no escape expansion, no markdown rendering, and no character substitution. Whatever bytes you pass are exactly what the recipient receives.
+  
+  To include newlines, use real newlines inside shell quoted strings or heredocs. Do **not** use JSON-encoded bodies or literal backslash-n (`\n`) sequences — those will appear as literal characters in the delivered message.
+
+  * **Correct (real newlines in a quoted string):**
+    ```bash
+    scion message --non-interactive @reviewer "PR #42 is ready for review.
+
+    Branch: fix/auth-bug
+    CI: all green"
+    ```
+
+  * **Correct (heredoc for longer messages):**
+    ```bash
+    scion message --non-interactive @reviewer "$(cat <<'EOF'
+    PR #42 is ready for review.
+
+    Branch: fix/auth-bug
+    CI: all green
+    EOF
+    )"
+    ```
+
+  * **Wrong (JSON-encoded body with literal `\n`):**
+    ```bash
+    # BAD: literal \n chars appear in the delivered message
+    scion message --non-interactive @reviewer "PR #42 is ready for review.\n\nBranch: fix/auth-bug\nCI: all green"
+    ```
+
 ### `scion broadcast`
 
 Sends a message to all running agents in the current project (or across all projects).


### PR DESCRIPTION
Nightly documentation update for Sep 2 changelog.

- messaging.md: added message formatting section with verbatim delivery guidance
- api.md: aligned template list endpoint with backend limit cap
- cli.md: added message formatting reference

3 files changed, 62 insertions, 1 deletion.