### PR TITLE
feat(harness/antigravity): bump default model from 3.7 flash to 3.8 flash

### DIFF
--- a/docs-site/src/content/docs/supported-harnesses.md
+++ b/docs-site/src/content/docs/supported-harnesses.md
@@ -213,7 +213,7 @@ the Antigravity bundle's `capture_auth.py` (which can also extract the token fro
 - **MCP**: `~/.gemini/config/mcp_config.json`.
 - **Hooks**: Antigravity ships a hook dialect (`dialect.yaml`) mapping `agy` events to Scion lifecycle events. Hooks fire **project-locally** (wired via `/workspace/.agents/hooks.json`).
 - **Runtime**: requires gnome-keyring and D-Bus in the container (provided by the base image); a generated wrapper script bootstraps the keyring and injects the token before launching `agy`.
-- **Default model**: `Gemini 3.7 Flash (Medium)` (override via `AGY_MODEL`).
+- **Default model**: `Gemini 3.8 Flash (Medium)` (override via `AGY_MODEL`).
 
 ### Known Limitations
 - **System Prompt**: approximated via `GEMINI.md` (no native override).

--- a/harnesses/antigravity/config.yaml
+++ b/harnesses/antigravity/config.yaml
@@ -32,7 +32,7 @@ env_template:
 
 model_aliases:
   small: "Gemini 3.1 Flash Lite"
-  medium: "Gemini 3.7 Flash (Medium)"
+  medium: "Gemini 3.8 Flash (Medium)"
   large: "Gemini 3.1 Pro (Low)"
   extra-large: "Gemini 3.1 Pro (Low)"
 

--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -31,7 +31,7 @@ assert scion_harness.INTERFACE_VERSION >= 2, (
 
 PROVISION_VERSION = "2026-07-09T01:00:00Z"
 
-FLASH_MODEL = "Gemini 3.7 Flash (Medium)"
+FLASH_MODEL = "Gemini 3.8 Flash (Medium)"
 PRO_MODEL = "Gemini 3.1 Pro (Low)"
 
 


### PR DESCRIPTION
Bump the antigravity harness default model from Gemini 3.7 Flash to Gemini 3.8 Flash. Updates config.yaml model alias, FLASH_MODEL constant in provision.py, and docs.