### PR TITLE
fix(runtime): revert sandbox UID to 0 + add CAP_SETUID safety net

### DIFF
--- a/cmd/sciontool/commands/init.go
+++ b/cmd/sciontool/commands/init.go
@@ -1282,6 +1282,16 @@ func setupHostUser() (int, int, bool) {
 		return 0, 0, false
 	}
 
+	// Safety net: detect restricted capability environments (e.g. gVisor
+	// sandboxes on Cloud Run) where CAP_SETUID is absent. In these
+	// environments, setuid/setgid syscalls return EPERM. Fall back to
+	// rootless-equivalent mode: no privilege drop, no usermod.
+	if !hasCapSetUID() {
+		log.Info("Running as root but CAP_SETUID is absent (restricted sandbox); " +
+			"skipping privilege operations — process will remain UID 0")
+		return 0, 0, true
+	}
+
 	hostUID := os.Getenv("SCION_HOST_UID")
 	hostGID := os.Getenv("SCION_HOST_GID")
 
@@ -2160,4 +2170,32 @@ func cleanGcloudConfigForMetadata(gcloudDir string) {
 			log.Debug("Could not remove gcloud config entry %s: %v", p, err)
 		}
 	}
+}
+
+// hasCapSetUID checks whether the current process has CAP_SETUID (bit 7)
+// in its effective capability set by reading /proc/self/status.
+// Returns true if the capability is present, false if absent or on error
+// (safe default: assume restricted, skip privilege operations).
+func hasCapSetUID() bool {
+	data, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return false
+	}
+	return parseCapSetUID(string(data))
+}
+
+// parseCapSetUID parses the content of /proc/self/status and returns true
+// if CAP_SETUID (bit 7) is present in the effective capability set.
+func parseCapSetUID(statusContent string) bool {
+	for _, line := range strings.Split(statusContent, "\n") {
+		if strings.HasPrefix(line, "CapEff:") {
+			hexStr := strings.TrimSpace(strings.TrimPrefix(line, "CapEff:"))
+			caps, err := strconv.ParseUint(hexStr, 16, 64)
+			if err != nil {
+				return false
+			}
+			return caps&(1<<7) != 0 // CAP_SETUID = bit 7
+		}
+	}
+	return false
 }

--- a/cmd/sciontool/commands/init_test.go
+++ b/cmd/sciontool/commands/init_test.go
@@ -1003,3 +1003,65 @@ func TestResolveIsSharedGitWorkspace(t *testing.T) {
 		})
 	}
 }
+
+func TestParseCapSetUID(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    bool
+	}{
+		{
+			name: "full capabilities (typical Docker root)",
+			// CapEff with all bits set — includes CAP_SETUID (bit 7).
+			input: "Name:\tinit\nCapEff:\t000001ffffffffff\n",
+			want:  true,
+		},
+		{
+			name: "CAP_SETUID present among limited caps",
+			// Bits 0-7 set (0xff) — CAP_SETUID (bit 7) is present.
+			input: "Name:\tinit\nCapInh:\t0000000000000000\nCapEff:\t00000000000000ff\n",
+			want:  true,
+		},
+		{
+			name: "CAP_SETUID absent (gVisor restricted sandbox)",
+			// Only bits 0-6 set (0x7f) — CAP_SETUID (bit 7) is missing.
+			input: "Name:\tinit\nCapEff:\t000000000000007f\n",
+			want:  false,
+		},
+		{
+			name: "no capabilities at all",
+			input: "Name:\tinit\nCapEff:\t0000000000000000\n",
+			want:  false,
+		},
+		{
+			name: "no CapEff line",
+			input: "Name:\tinit\nCapInh:\t0000000000000000\n",
+			want:  false,
+		},
+		{
+			name: "empty input",
+			input: "",
+			want:  false,
+		},
+		{
+			name: "malformed hex value",
+			input: "CapEff:\tnotahexvalue\n",
+			want:  false,
+		},
+		{
+			name: "only CAP_SETUID bit set",
+			// Only bit 7 set (0x80).
+			input: "CapEff:\t0000000000000080\n",
+			want:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseCapSetUID(tc.input)
+			if got != tc.want {
+				t.Errorf("parseCapSetUID() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/runtime/cloudrun_sandbox_runtime.go
+++ b/pkg/runtime/cloudrun_sandbox_runtime.go
@@ -83,16 +83,23 @@ const sandboxWorkspace = "/workspace"
 // output; when it fails the file holds the error output that explains why.
 const entrypointLogFile = ".scion-entrypoint.log"
 
-// sandboxUID and sandboxGID are the UID/GID passed to the sandbox via
-// SCION_HOST_UID / SCION_HOST_GID. They correspond to the `scion` user
-// created by the omni-image Dockerfile (useradd -u 1000 scion).
+// sandboxUID and sandboxGID control the UID/GID passed to the sandbox via
+// SCION_HOST_UID / SCION_HOST_GID.
 //
-// On Cloud Run the launcher runs as root (UID 0). Passing 0 would make
-// sciontool init keep the sandbox process as root, which Claude Code
-// ≥ 2.1.246 rejects. Hardcoding 1000 ensures the sandbox always drops
-// privileges to the scion user regardless of the launcher's own UID.
-const sandboxUID = 1000
-const sandboxGID = 1000
+// Ideally these would be 1000 (the scion user) to match Docker/Podman
+// behaviour, but Cloud Run's gVisor sandbox does not grant CAP_SETUID or
+// CAP_SETGID, making runtime privilege drops impossible. Until the sandbox
+// CLI gains a --user flag (or the capability bounding set is extended),
+// the sandbox process must run as root (UID 0).
+//
+// Running as UID 0 means:
+//   - Harnesses that reject root (e.g. Claude Code's --dangerously-skip-permissions)
+//     will not work on this runtime.
+//   - Harnesses that accept root (e.g. antigravity, gemini-cli) work normally.
+//
+// TODO(single-node): Switch back to 1000 when the sandbox CLI supports --user.
+const sandboxUID = 0
+const sandboxGID = 0
 
 // SandboxLauncherAvailable reports whether the Cloud Run Sandbox launcher
 // binary is present on the filesystem.
@@ -369,13 +376,15 @@ func prepareScionLayout(rootDir, slug string, cfg RunConfig) (scionPaths, error)
 	// workspace copy) so that every file — including those created by
 	// relocateToScion and copyDirContents — is owned by the sandbox user.
 	//
-	// Guard: only chown when running as root (Cloud Run). In non-root
-	// environments (local dev, CI) os.Chown fails with EPERM, so skip it.
+	// Guard: only chown when running as root (Cloud Run) AND the target
+	// UID is non-zero. When sandboxUID is 0 (root), files are already
+	// root-owned and chown-to-self is a no-op that wastes syscalls on
+	// large directory trees.
 	//
 	// Lchown is used instead of Chown to avoid following symlinks: if a
 	// relocated directory contains symlinks, we change the link's ownership
 	// rather than the target's (which may be outside our mount).
-	if os.Getuid() == 0 {
+	if os.Getuid() == 0 && sandboxUID > 0 {
 		for _, d := range []string{p.agentHome, p.workspace} {
 			if walkErr := filepath.WalkDir(d, func(path string, entry fs.DirEntry, err error) error {
 				if err != nil {

--- a/pkg/runtime/cloudrun_sandbox_runtime_test.go
+++ b/pkg/runtime/cloudrun_sandbox_runtime_test.go
@@ -682,11 +682,11 @@ func TestEnvFor_BasicEnv(t *testing.T) {
 	if env["SCION_HOST_GID"] == "" {
 		t.Error("SCION_HOST_GID not set")
 	}
-	if env["SCION_HOST_UID"] != "1000" {
-		t.Errorf("SCION_HOST_UID = %q, want %q (non-root scion user)", env["SCION_HOST_UID"], "1000")
+	if env["SCION_HOST_UID"] != "0" {
+		t.Errorf("SCION_HOST_UID = %q, want %q (root — CAP_SETUID unavailable in gVisor)", env["SCION_HOST_UID"], "0")
 	}
-	if env["SCION_HOST_GID"] != "1000" {
-		t.Errorf("SCION_HOST_GID = %q, want %q (non-root scion user)", env["SCION_HOST_GID"], "1000")
+	if env["SCION_HOST_GID"] != "0" {
+		t.Errorf("SCION_HOST_GID = %q, want %q (root — CAP_SETGID unavailable in gVisor)", env["SCION_HOST_GID"], "0")
 	}
 }
 
@@ -743,32 +743,33 @@ func TestEnvFor_WorkspaceBackend(t *testing.T) {
 	}
 }
 
-// TestEnvFor_NonRootUID verifies that SCION_HOST_UID and SCION_HOST_GID
-// are always set to the scion user (UID 1000), NOT to os.Getuid(). On
-// Cloud Run the launcher runs as root; passing UID 0 would keep the
-// sandbox process as root, which Claude Code ≥ 2.1.246 rejects.
-func TestEnvFor_NonRootUID(t *testing.T) {
+// TestEnvFor_RootUID verifies that SCION_HOST_UID and SCION_HOST_GID
+// are set to 0 (root). Cloud Run's gVisor sandbox does not grant
+// CAP_SETUID or CAP_SETGID, making runtime privilege drops impossible.
+// Until the sandbox CLI supports --user, the sandbox process must run
+// as root.
+func TestEnvFor_RootUID(t *testing.T) {
 	cfg := RunConfig{}
 	paths := scionPaths{}
 
 	env := envFor(cfg, paths)
 
-	// Must use the scion user's UID/GID (1000), not the process UID.
-	if env["SCION_HOST_UID"] != "1000" {
-		t.Errorf("SCION_HOST_UID = %q, want %q; sandbox must run as non-root scion user",
-			env["SCION_HOST_UID"], "1000")
+	// Must use UID 0 (root) — CAP_SETUID is absent in gVisor.
+	if env["SCION_HOST_UID"] != "0" {
+		t.Errorf("SCION_HOST_UID = %q, want %q; sandbox must run as root (gVisor lacks CAP_SETUID)",
+			env["SCION_HOST_UID"], "0")
 	}
-	if env["SCION_HOST_GID"] != "1000" {
-		t.Errorf("SCION_HOST_GID = %q, want %q; sandbox must run as non-root scion user",
-			env["SCION_HOST_GID"], "1000")
+	if env["SCION_HOST_GID"] != "0" {
+		t.Errorf("SCION_HOST_GID = %q, want %q; sandbox must run as root (gVisor lacks CAP_SETGID)",
+			env["SCION_HOST_GID"], "0")
 	}
 
-	// Verify the constants match the expected scion user UID.
-	if sandboxUID != 1000 {
-		t.Errorf("sandboxUID = %d, want 1000 (scion user from omni Dockerfile)", sandboxUID)
+	// Verify the constants match the expected root UID.
+	if sandboxUID != 0 {
+		t.Errorf("sandboxUID = %d, want 0 (root — gVisor lacks CAP_SETUID)", sandboxUID)
 	}
-	if sandboxGID != 1000 {
-		t.Errorf("sandboxGID = %d, want 1000 (scion user from omni Dockerfile)", sandboxGID)
+	if sandboxGID != 0 {
+		t.Errorf("sandboxGID = %d, want 0 (root — gVisor lacks CAP_SETGID)", sandboxGID)
 	}
 }
 


### PR DESCRIPTION
Cloud Run gVisor sandbox does not grant CAP_SETUID or CAP_SETGID, causing sciontool init to fail with EPERM when attempting privilege drops (DOA since PR #1439).

Changes:
- Revert sandboxUID/sandboxGID from 1000 to 0
- Guard chown in prepareScionLayout() to skip when sandboxUID is 0
- Add hasCapSetUID() helper reading /proc/self/status CapEff
- Add CAP_SETUID check in setupHostUser() before privilege ops
- Unit tests for parseCapSetUID() parsing logic (8 cases)

Key files:
- pkg/runtime/cloudrun_sandbox_runtime.go (constants, chown guard)
- cmd/sciontool/commands/init.go (CAP_SETUID detection)

Fork PR: https://github.com/ptone/scion/pull/1431
Fork issue: https://github.com/ptone/scion/issues/1430