### PR TITLE
fix(web): route message_mode actions to correct API path

### DIFF
--- a/cmd/sciontool/commands/init_test.go
+++ b/cmd/sciontool/commands/init_test.go
@@ -1006,9 +1006,9 @@ func TestResolveIsSharedGitWorkspace(t *testing.T) {
 
 func TestParseCapSetUID(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		want    bool
+		name  string
+		input string
+		want  bool
 	}{
 		{
 			name: "full capabilities (typical Docker root)",
@@ -1029,22 +1029,22 @@ func TestParseCapSetUID(t *testing.T) {
 			want:  false,
 		},
 		{
-			name: "no capabilities at all",
+			name:  "no capabilities at all",
 			input: "Name:\tinit\nCapEff:\t0000000000000000\n",
 			want:  false,
 		},
 		{
-			name: "no CapEff line",
+			name:  "no CapEff line",
 			input: "Name:\tinit\nCapInh:\t0000000000000000\n",
 			want:  false,
 		},
 		{
-			name: "empty input",
+			name:  "empty input",
 			input: "",
 			want:  false,
 		},
 		{
-			name: "malformed hex value",
+			name:  "malformed hex value",
 			input: "CapEff:\tnotahexvalue\n",
 			want:  false,
 		},

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -1872,10 +1872,10 @@ export class ScionPageAgentDetail extends LitElement {
 
     // Apply the mode change via API
     try {
-      const response = await apiFetch(`/api/v1/agents/${agent.id}/actions`, {
+      const response = await apiFetch(`/api/v1/agents/${agent.id}/set_message_mode`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'set_message_mode', mode: newMode }),
+        body: JSON.stringify({ mode: newMode }),
       });
 
       if (!response.ok) {

--- a/web/src/components/shared/cascade-mode-dialog.ts
+++ b/web/src/components/shared/cascade-mode-dialog.ts
@@ -201,12 +201,11 @@ export class ScionCascadeModeDialog extends LitElement {
 
     try {
       const response = await apiFetch(
-        `/api/v1/agents/${this.agentId}/actions?dryRun=true`,
+        `/api/v1/agents/${this.agentId}/set_message_mode?dryRun=true`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            action: 'set_message_mode',
             mode: this.selectedMode,
             cascade: true,
           }),
@@ -241,12 +240,11 @@ export class ScionCascadeModeDialog extends LitElement {
 
     try {
       const response = await apiFetch(
-        `/api/v1/agents/${this.agentId}/actions`,
+        `/api/v1/agents/${this.agentId}/set_message_mode`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            action: 'set_message_mode',
             mode: this.selectedMode,
             cascade: true,
           }),


### PR DESCRIPTION
The hub server extracts the action name from the URL path segment, not the POST body. The web UI was sending requests to `/actions` which the hub parsed as action="actions" and returned 404. Move the action name into the path (`/set_message_mode`) and remove the redundant `action` key from the request body.

Fixes the message mode toggle and cascade mode dialog.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
