### PR TITLE
fix(hubclient): remove dead GetWSTicket client code

### DIFF
--- a/cmd/hub_auth_test.go
+++ b/cmd/hub_auth_test.go
@@ -51,9 +51,6 @@ func (m *mockHubAuthService) Refresh(ctx context.Context, refreshToken string) (
 func (m *mockHubAuthService) Me(ctx context.Context) (*hubclient.User, error) {
 	return nil, mockHubAuthNotImplementedError{}
 }
-func (m *mockHubAuthService) GetWSTicket(ctx context.Context) (*hubclient.WSTicketResponse, error) {
-	return nil, mockHubAuthNotImplementedError{}
-}
 func (m *mockHubAuthService) GetAuthProviders(ctx context.Context, clientType string) (*hubclient.AuthProvidersResponse, error) {
 	return m.providersResp, m.providersErr
 }

--- a/cmd/sciontool/commands/init_test.go
+++ b/cmd/sciontool/commands/init_test.go
@@ -1006,9 +1006,9 @@ func TestResolveIsSharedGitWorkspace(t *testing.T) {
 
 func TestParseCapSetUID(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		want    bool
+		name  string
+		input string
+		want  bool
 	}{
 		{
 			name: "full capabilities (typical Docker root)",
@@ -1029,22 +1029,22 @@ func TestParseCapSetUID(t *testing.T) {
 			want:  false,
 		},
 		{
-			name: "no capabilities at all",
+			name:  "no capabilities at all",
 			input: "Name:\tinit\nCapEff:\t0000000000000000\n",
 			want:  false,
 		},
 		{
-			name: "no CapEff line",
+			name:  "no CapEff line",
 			input: "Name:\tinit\nCapInh:\t0000000000000000\n",
 			want:  false,
 		},
 		{
-			name: "empty input",
+			name:  "empty input",
 			input: "",
 			want:  false,
 		},
 		{
-			name: "malformed hex value",
+			name:  "malformed hex value",
 			input: "CapEff:\tnotahexvalue\n",
 			want:  false,
 		},

--- a/pkg/hub/auth/device_flow_test.go
+++ b/pkg/hub/auth/device_flow_test.go
@@ -56,9 +56,6 @@ func (m *mockAuthService) Refresh(ctx context.Context, refreshToken string) (*hu
 func (m *mockAuthService) Me(ctx context.Context) (*hubclient.User, error) {
 	return nil, fmt.Errorf("not implemented")
 }
-func (m *mockAuthService) GetWSTicket(ctx context.Context) (*hubclient.WSTicketResponse, error) {
-	return nil, fmt.Errorf("not implemented")
-}
 func (m *mockAuthService) GetAuthProviders(ctx context.Context, clientType string) (*hubclient.AuthProvidersResponse, error) {
 	return nil, mockDeviceFlowNotImplementedError{}
 }

--- a/pkg/hubclient/auth.go
+++ b/pkg/hubclient/auth.go
@@ -66,9 +66,6 @@ type AuthService interface {
 	// Me returns the current authenticated user.
 	Me(ctx context.Context) (*User, error)
 
-	// GetWSTicket gets a short-lived WebSocket authentication ticket.
-	GetWSTicket(ctx context.Context) (*WSTicketResponse, error)
-
 	// GetAuthProviders returns configured OAuth providers for a client type.
 	GetAuthProviders(ctx context.Context, clientType string) (*AuthProvidersResponse, error)
 
@@ -109,12 +106,6 @@ type TokenResponse struct {
 	AccessToken  string `json:"accessToken"`
 	RefreshToken string `json:"refreshToken,omitempty"`
 	ExpiresAt    string `json:"expiresAt"`
-}
-
-// WSTicketResponse is the response for WebSocket ticket.
-type WSTicketResponse struct {
-	Ticket    string `json:"ticket"`
-	ExpiresAt string `json:"expiresAt"`
 }
 
 // AuthURLResponse is the response containing the OAuth authorization URL.
@@ -176,15 +167,6 @@ func (s *authService) Me(ctx context.Context) (*User, error) {
 		return nil, err
 	}
 	return apiclient.DecodeResponse[User](resp)
-}
-
-// GetWSTicket gets a short-lived WebSocket authentication ticket.
-func (s *authService) GetWSTicket(ctx context.Context) (*WSTicketResponse, error) {
-	resp, err := s.c.post(ctx, "/api/v1/auth/ws-ticket", nil, nil)
-	if err != nil {
-		return nil, err
-	}
-	return apiclient.DecodeResponse[WSTicketResponse](resp)
 }
 
 // GetAuthProviders returns configured OAuth providers for a client type.


### PR DESCRIPTION
The GetWSTicket() method on AuthService posts to POST /api/v1/auth/ws-ticket, but no such route is registered on the hub server. No production code calls GetWSTicket(), and WebSocket connections (e.g. the PTY terminal) authenticate via session cookies on the same origin — no ticket exchange is needed.

Remove the dead interface method, its implementation, the WSTicketResponse type, and the corresponding mock stubs in test files.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
