### PR TITLE
fix(demo): grant roles/monitoring.viewer in gce-demo-provision.sh

### DIFF
--- a/scripts/starter-hub/gce-demo-provision.sh
+++ b/scripts/starter-hub/gce-demo-provision.sh
@@ -162,6 +162,9 @@ gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
     --role "roles/monitoring.metricWriter" > /dev/null
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
     --member "serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
+    --role "roles/monitoring.viewer" > /dev/null
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+    --member "serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role "roles/cloudtrace.agent" > /dev/null
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
     --member "serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \


### PR DESCRIPTION
The provision script grants logging.viewer and monitoring.metricWriter but never monitoring.viewer. The service account can write metrics but cannot read them back, so the metrics dashboard fails with a permissions error.