### PR TITLE
fix(web): let the chat sidebar terminal link navigate in-app

### DIFF
--- a/web/src/components/shared/chat/chat-members.ts
+++ b/web/src/components/shared/chat/chat-members.ts
@@ -511,7 +511,6 @@ export class ScionChatMembers extends LitElement {
         </div>
         <a
           href="/agents/${a.id}/terminal"
-          target="_blank"
           class="agent-terminal"
           title="Open terminal"
           @click=${(e: Event) => e.stopPropagation()}

--- a/web/src/components/shared/chat/chat-members.ts
+++ b/web/src/components/shared/chat/chat-members.ts
@@ -32,6 +32,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import type { PropertyValues } from 'lit';
 import { ACTIVITY_DISPLAY } from '../../../shared/agent-state-display.js';
+import { navigateTo } from '../../../client/main.js';
 import './chat-avatar.js';
 import '../status-badge.js';
 
@@ -513,7 +514,11 @@ export class ScionChatMembers extends LitElement {
           href="/agents/${a.id}/terminal"
           class="agent-terminal"
           title="Open terminal"
-          @click=${(e: Event) => e.stopPropagation()}
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            e.preventDefault();
+            navigateTo(`/agents/${a.id}/terminal`);
+          }}
         >
           <sl-icon name="terminal" style="font-size: 0.75rem;"></sl-icon>
         </a>


### PR DESCRIPTION
The terminal link in the chat members sidebar opened in a new tab despite having no pop-out affordance. Remove target=_blank so it navigates in-app, matching the visual distinction between the terminal icon and the adjacent pop-out icon.