### PR TITLE
fix(runtime): build authenticated clone URLs with net/url instead of string replace

### DIFF
--- a/pkg/runtime/cloudrun_sandbox_runtime_test.go
+++ b/pkg/runtime/cloudrun_sandbox_runtime_test.go
@@ -1430,6 +1430,17 @@ func TestCloudRunSandboxRuntime_Run_BuildsCommand(t *testing.T) {
 		watchCancels: make(map[string]context.CancelFunc),
 	}
 
+	// Cancel the background watchSandbox goroutine on test exit so it cannot
+	// write to the state file after t.TempDir() cleanup begins, which would
+	// cause a "directory not empty" failure.
+	t.Cleanup(func() {
+		rt.watchMu.Lock()
+		for _, cancel := range rt.watchCancels {
+			cancel()
+		}
+		rt.watchMu.Unlock()
+	})
+
 	cfg := RunConfig{
 		Name:      "test-agent",
 		HomeDir:   homeDir,

--- a/pkg/util/git.go
+++ b/pkg/util/git.go
@@ -590,10 +590,7 @@ func authenticatedCloneURL(cloneURL, token string) string {
 // If the requested branch does not exist on the remote, the clone falls back to
 // the remote's default branch and creates the requested branch locally.
 func CloneSharedWorkspace(workspacePath, cloneURL, branch, token string) error {
-	authURL := cloneURL
-	if token != "" {
-		authURL = authenticatedCloneURL(cloneURL, token)
-	}
+	authURL := authenticatedCloneURL(cloneURL, token)
 
 	args := []string{"clone"}
 	if branch != "" {

--- a/pkg/util/git.go
+++ b/pkg/util/git.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -555,6 +556,33 @@ func ExtractOrgRepo(gitURL string) (org, repo string) {
 	return parts[len(parts)-2], parts[len(parts)-1]
 }
 
+// authenticatedCloneURL embeds OAuth2 credentials in an HTTPS clone URL.
+//
+// It parses the URL rather than substituting on the scheme prefix: a remote
+// that already carries userinfo (Azure DevOps emits
+// "https://org@dev.azure.com/org/project/_git/repo") would otherwise end up
+// with two "@" separators and fail to resolve. url.UserPassword also escapes
+// tokens containing reserved characters.
+//
+// Only https remotes are rewritten. The previous implementation keyed off the
+// literal "https://" prefix, so ssh:// and git:// remotes were left alone;
+// url.Parse alone would happily inject an OAuth token into those, so the
+// scheme is checked explicitly to preserve that behaviour.
+//
+// The original URL is returned unchanged when there is no token, when it
+// cannot be parsed, and when it is not https.
+func authenticatedCloneURL(cloneURL, token string) string {
+	if token == "" {
+		return cloneURL
+	}
+	parsed, err := url.Parse(cloneURL)
+	if err != nil || parsed.Scheme != "https" {
+		return cloneURL
+	}
+	parsed.User = url.UserPassword("oauth2", token)
+	return parsed.String()
+}
+
 // CloneSharedWorkspace clones a git repository into the specified workspace path
 // for use as a shared workspace project. It configures git identity and optionally
 // uses a token for authentication.
@@ -564,7 +592,7 @@ func ExtractOrgRepo(gitURL string) (org, repo string) {
 func CloneSharedWorkspace(workspacePath, cloneURL, branch, token string) error {
 	authURL := cloneURL
 	if token != "" {
-		authURL = strings.Replace(cloneURL, "https://", "https://oauth2:"+token+"@", 1)
+		authURL = authenticatedCloneURL(cloneURL, token)
 	}
 
 	args := []string{"clone"}

--- a/pkg/util/git_test.go
+++ b/pkg/util/git_test.go
@@ -894,3 +894,81 @@ func TestGitError_UserGuidance(t *testing.T) {
 		}
 	}
 }
+
+func TestAuthenticatedCloneURL(t *testing.T) {
+	const token = "ghp_exampletoken"
+
+	tests := []struct {
+		name     string
+		cloneURL string
+		token    string
+		want     string
+	}{
+		{
+			name:     "plain https remote gets credentials",
+			cloneURL: "https://github.com/org/repo.git",
+			token:    token,
+			want:     "https://oauth2:" + token + "@github.com/org/repo.git",
+		},
+		{
+			name:     "remote that already carries userinfo is not doubled up",
+			cloneURL: "https://org@dev.azure.com/org/project/_git/repo",
+			token:    token,
+			want:     "https://oauth2:" + token + "@dev.azure.com/org/project/_git/repo",
+		},
+		{
+			name:     "empty token leaves the URL alone",
+			cloneURL: "https://github.com/org/repo.git",
+			token:    "",
+			want:     "https://github.com/org/repo.git",
+		},
+		{
+			name:     "token with reserved characters is escaped",
+			cloneURL: "https://github.com/org/repo.git",
+			token:    "p@ss/word",
+			want:     "https://oauth2:p%40ss%2Fword@github.com/org/repo.git",
+		},
+		{
+			name:     "non-default port is preserved",
+			cloneURL: "https://host.example.com:8443/org/repo.git",
+			token:    token,
+			want:     "https://oauth2:" + token + "@host.example.com:8443/org/repo.git",
+		},
+		{
+			name:     "scp-style ssh remote is left alone",
+			cloneURL: "git@github.com:org/repo.git",
+			token:    token,
+			want:     "git@github.com:org/repo.git",
+		},
+		{
+			name:     "ssh scheme is left alone rather than given an oauth token",
+			cloneURL: "ssh://git@github.com/org/repo.git",
+			token:    token,
+			want:     "ssh://git@github.com/org/repo.git",
+		},
+		{
+			name:     "plain http is left alone",
+			cloneURL: "http://internal.example.com/org/repo.git",
+			token:    token,
+			want:     "http://internal.example.com/org/repo.git",
+		},
+		{
+			name:     "unparseable remote is returned unchanged",
+			cloneURL: "not a url",
+			token:    token,
+			want:     "not a url",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := authenticatedCloneURL(tt.cloneURL, tt.token)
+			if got != tt.want {
+				t.Errorf("authenticatedCloneURL(%q, token) = %q, want %q", tt.cloneURL, got, tt.want)
+			}
+			if tt.token != "" && strings.Count(got, "@") > 1 {
+				t.Errorf("result contains more than one @ separator: %q", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
CloneSharedWorkspace injected credentials by substituting on the https:// prefix, which assumes the remote carries no userinfo. Azure DevOps clone URLs carry userinfo, producing a URL with two @ signs that git rejects. Use net/url parsing to properly set Userinfo.