### PR TITLE
feat(build): allow image builds to use an internal npm registry

### DIFF
--- a/harnesses/claude/Dockerfile
+++ b/harnesses/claude/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,6 +73,7 @@ RUN chmod +x /usr/local/bin/init-firewall.sh && \
 # RUN curl -fsSL https://claude.ai/install.sh | bash
 # ENV PATH=/home/scion/.local/bin:$PATH
 
-RUN npm cache clean --force \
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    npm cache clean --force \
   && npm install -g @anthropic-ai/claude-code@latest \
   && npm cache clean --force

--- a/harnesses/codex/Dockerfile
+++ b/harnesses/codex/Dockerfile
@@ -22,7 +22,8 @@ RUN mkdir -p /home/scion/.codex /home/scion/.codex/skills && \
   chown -R scion:scion /home/scion/.codex
 
 # install codex, expose it on standard shell PATH, and clean up
-RUN npm install -g @openai/codex@${CODEX_CLI_VERSION} \
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    npm install -g @openai/codex@${CODEX_CLI_VERSION} \
   && ln -sf /usr/local/share/npm-global/bin/codex /usr/local/bin/codex \
   && npm cache clean --force
 

--- a/harnesses/gemini-cli/Dockerfile
+++ b/harnesses/gemini-cli/Dockerfile
@@ -25,7 +25,8 @@ RUN mkdir -p /home/scion/.gemini /home/scion/.gemini/skills && \
   chown -R scion:scion /home/scion/.gemini
 
 # Install gemini-cli and clean up
-RUN npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} \
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    npm install -g @google/gemini-cli@${GEMINI_CLI_VERSION} \
   && npm cache clean --force
 
 # Default entrypoint when none specified

--- a/harnesses/opencode/Dockerfile
+++ b/harnesses/opencode/Dockerfile
@@ -21,7 +21,8 @@ RUN mkdir -p /home/scion/.local/share/opencode && \
 
 # Install OpenCode
 # RUN curl -fsSL https://opencode.ai/install | bash
-RUN npm install -g opencode-ai \
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    npm install -g opencode-ai \
   && npm cache clean --force
 # Ensure opencode is in PATH
 # ENV PATH="/home/scion/.opencode/bin:${PATH}"

--- a/image-build/README.md
+++ b/image-build/README.md
@@ -157,6 +157,38 @@ or removing a harness Dockerfile under `harnesses/<name>/`, update those
 aggregate YAMLs too. Individual harness bundles can also carry their own
 `harnesses/<name>/cloudbuild.yaml` for one-off builds.
 
+## Package Registries
+
+By default the images install npm packages from the public registry. On a network
+where `registry.npmjs.org` is unreachable, point the build at an internal mirror
+(Artifactory, Nexus, Verdaccio) with two optional environment variables:
+
+| Variable | Purpose |
+|---|---|
+| `NPM_REGISTRY` | Registry URL. Passed to `core-base` as a build-arg and exported as `NPM_CONFIG_REGISTRY`, so `scion-base`, the harness images, and agents at runtime all inherit it. |
+| `NPM_CONFIG_FILE` | Path to an `.npmrc` holding credentials for that registry. Mounted as a BuildKit secret, never written to an image layer. |
+
+```bash
+export NPM_REGISTRY=https://artifactory.example.com/artifactory/api/npm/npm-repos/
+export NPM_CONFIG_FILE="$HOME/.npmrc"
+image-build/scripts/build-images.sh --target common
+```
+
+Both are optional and independent. Unset, the build uses the public registry
+unauthenticated, exactly as before. `NPM_REGISTRY` without `NPM_CONFIG_FILE`
+works for a mirror that allows anonymous reads.
+
+Credentials go in as a BuildKit secret rather than a build-arg deliberately: a
+build-arg is recoverable from `docker history` on the resulting image, whereas a
+secret mount is available only during the `RUN` that requests it. The mounts are
+declared `required=false`, so builds without a secret are unaffected.
+
+Supported by the `local-docker` and `local-podman` builders.
+
+**Not yet covered:** pip. The `hermes` image installs Python packages from PyPI
+and has no equivalent knob, so it cannot currently be built behind a proxy that
+blocks PyPI.
+
 ## Authentication
 
 The orchestrator and builders assume the caller is already authenticated to the target registry (via `docker login`, `podman login`, `gcloud auth configure-docker`, etc.) and to any required cloud APIs. No login steps are performed inside the script.

--- a/image-build/core-base/Dockerfile
+++ b/image-build/core-base/Dockerfile
@@ -162,16 +162,25 @@ RUN ARCH=$(dpkg --print-architecture) && \
 # Setup npm global directory
 RUN mkdir -p /usr/local/share/npm-global
 ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+
+# Optional npm mirror. Corporate networks commonly block registry.npmjs.org;
+# point this at an internal proxy (Artifactory, Nexus, Verdaccio) to build
+# behind one. Defaults to the public registry, so behaviour is unchanged when
+# unset. Inherited by scion-base, every harness image, and agents at runtime.
+ARG NPM_REGISTRY=https://registry.npmjs.org/
+ENV NPM_CONFIG_REGISTRY=${NPM_REGISTRY}
 ENV PATH=/usr/local/share/npm-global/bin:/usr/local/go/bin:/usr/local/gcloud/google-cloud-sdk/bin:$PATH
 ENV LC_ALL=C.UTF-8
 ENV EDITOR=nano
 ENV VISUAL=nano
 
 # Install Chrome DevTools MCP server globally
-RUN npm install -g chrome-devtools-mcp
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    npm install -g chrome-devtools-mcp
 
 # Install playwright CLI
-RUN npm install -g @playwright/cli@latest
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    npm install -g @playwright/cli@latest
 
 # Default to bash - no scion-specific entrypoint
 CMD ["bash"]

--- a/image-build/omni/Dockerfile
+++ b/image-build/omni/Dockerfile
@@ -37,7 +37,8 @@ ENV CGO_ENABLED=1
 
 # 1. Build web frontend
 COPY web/ ./web/
-RUN cd web && npm install && npm run build
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    cd web && npm install && npm run build
 
 # 2. Prepare Go build
 COPY go.mod go.sum ./

--- a/image-build/scripts/builders/local-docker.sh
+++ b/image-build/scripts/builders/local-docker.sh
@@ -104,6 +104,13 @@ builder_build() {
     cmd+=(--build-arg "${arg}")
   done
 
+  # Optional npm credentials for private or mirrored registries. Mounted as a
+  # BuildKit secret so the token is available during RUN but never written to
+  # an image layer. Unset = no secret, unauthenticated build.
+  if [[ -n "${NPM_CONFIG_FILE:-}" ]]; then
+    cmd+=(--secret "id=npmrc,src=${NPM_CONFIG_FILE}")
+  fi
+
   cmd+=(-f "${dockerfile}")
 
   if [[ "${push}" == "true" ]]; then

--- a/image-build/scripts/builders/local-podman.sh
+++ b/image-build/scripts/builders/local-podman.sh
@@ -80,6 +80,13 @@ builder_build() {
     cmd+=(--build-arg "${arg}")
   done
 
+  # Optional npm credentials for private or mirrored registries. Mounted as a
+  # BuildKit secret so the token is available during RUN but never written to
+  # an image layer. Unset = no secret, unauthenticated build.
+  if [[ -n "${NPM_CONFIG_FILE:-}" ]]; then
+    cmd+=(--secret "id=npmrc,src=${NPM_CONFIG_FILE}")
+  fi
+
   cmd+=(-f "${dockerfile}" "${context_dir}")
 
   echo "==> [local-podman] building ${image_name}..."

--- a/image-build/scripts/lib/targets.sh
+++ b/image-build/scripts/lib/targets.sh
@@ -214,7 +214,11 @@ step_build_args() {
   fi
   case "$1" in
     core-base)
-      # No build-args.
+      # Optional npm mirror passthrough (see core-base/Dockerfile). Unset =
+      # public registry, i.e. no build-arg emitted and default behaviour.
+      if [[ -n "${NPM_REGISTRY:-}" ]]; then
+        echo "NPM_REGISTRY=${NPM_REGISTRY}"
+      fi
       ;;
     thick-prep)
       # No build-args — BASE_IMAGE default is in the Dockerfile ARG.

--- a/pkg/runtime/cloudrun_sandbox_runtime_test.go
+++ b/pkg/runtime/cloudrun_sandbox_runtime_test.go
@@ -1451,6 +1451,19 @@ func TestCloudRunSandboxRuntime_Run_BuildsCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
+
+	// Cancel the watcher goroutine started by Run() so its state-file
+	// writes don't race with TempDir cleanup (t.Cleanup runs LIFO, so
+	// this fires before RemoveAll).
+	t.Cleanup(func() {
+		rt.watchMu.Lock()
+		for _, cancel := range rt.watchCancels {
+			cancel()
+		}
+		rt.watchCancels = make(map[string]context.CancelFunc)
+		rt.watchMu.Unlock()
+	})
+
 	if id != "test-agent" {
 		t.Errorf("Run() returned id = %q, want %q", id, "test-agent")
 	}


### PR DESCRIPTION
Behind a corporate proxy with registry.npmjs.org blocked, no image builds succeed. Add NPM_REGISTRY build arg for the registry URL and NPM_CONFIG_FILE BuildKit secret for credentials. Backward compatible: defaults to the public registry when not set.