### PR TITLE
fix: correct agy effort flag and thinking tier mapping (#1444)

### DIFF
--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -36,15 +36,13 @@ PRO_MODEL = "Gemini 3.1 Pro (Low)"
 
 
 def _resolve_thinking_tier(level: int) -> str:
-    """Map a thinking level (0-100) to one of AGY's 4 CLI tiers."""
+    """Map a thinking level (0-100) to one of AGY's 3 CLI tiers."""
     level = max(0, min(100, level))
     if level >= 75:
-        return "High"
+        return "high"
     if level >= 50:
-        return "Medium"
-    if level >= 25:
-        return "Low"
-    return "Minimal"
+        return "medium"
+    return "low"
 
 AGY_MCP_MAPPING: dict[str, Any] = {
     "global_config_file": ".gemini/config/mcp_config.json",
@@ -492,7 +490,7 @@ print('agy-wrapper: marked enterprise onboarding complete', file=sys.stderr)
 fi
 
 # Exec AGY with all arguments passed through
-exec agy --dangerously-skip-permissions{f' --thinking-level {thinking_tier}' if thinking_tier else ''} "$@"
+exec agy --dangerously-skip-permissions{f' --effort {thinking_tier}' if thinking_tier else ''} "$@"
 """
 
     wrapper_path = os.path.join(home, ".scion", "harness", "agy-wrapper.sh")


### PR DESCRIPTION
## Summary
Fixes antigravity harness crash on startup when thinking level is set. Two bugs:
1. Wrong CLI flag: --thinking-level should be --effort
2. Wrong tier mapping: 4 mixed-case tiers (High/Medium/Low/Minimal) collapsed to 3 lowercase (high/medium/low) matching agy expectations

## Test plan
- Syntax verified with ast.parse
- Manual verification of both changes in diff