### PR TITLE
fix: create super-admin RoleBinding at first admin login (cold-start)

### DIFF
--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -1331,6 +1331,13 @@ func (s *Server) provisionUser(ctx context.Context, info *ExternalUserInfo) (*st
 		if err := s.store.CreateUser(ctx, user); err != nil {
 			return nil, fmt.Errorf("create user: %w", err)
 		}
+		// Cold-start fix: when a new user is provisioned as admin,
+		// immediately create the system-scoped super-admin RoleBinding.
+		// ReconcileSuperAdminBindings already ran at startup against an
+		// empty store and won't run again until the next restart.
+		if user.Role == "admin" {
+			s.ensureSuperAdminBinding(ctx, user.ID)
+		}
 	} else {
 		// Reject suspended users (covers both OAuth and proxy auth paths)
 		if user.Status == "suspended" {
@@ -1353,6 +1360,8 @@ func (s *Server) provisionUser(ctx context.Context, info *ExternalUserInfo) (*st
 			user.Role = s.getUserRole(info.Email, user.Role)
 			if oldRole == "admin" && user.Role != "admin" {
 				s.deleteSuperAdminBinding(ctx, user.ID)
+			} else if user.Role == "admin" && oldRole != "admin" {
+				s.ensureSuperAdminBinding(ctx, user.ID)
 			}
 			LogInviteAudit(ctx, s.auditLogger, InviteAuditUserActivated, info.Email, "", user.ID, info.Email, nil)
 		} else {
@@ -1376,6 +1385,8 @@ func (s *Server) provisionUser(ctx context.Context, info *ExternalUserInfo) (*st
 				user.Role = newRole
 				if oldRole == "admin" {
 					s.deleteSuperAdminBinding(ctx, user.ID)
+				} else if newRole == "admin" {
+					s.ensureSuperAdminBinding(ctx, user.ID)
 				}
 			}
 		}
@@ -1736,5 +1747,37 @@ func (s *Server) deleteSuperAdminBinding(ctx context.Context, userID string) {
 					"user_id", userID, "binding_id", b.ID)
 			}
 		}
+	}
+}
+
+// ensureSuperAdminBinding idempotently creates a system-scoped super-admin
+// RoleBinding for the given user. This closes the cold-start gap where
+// provisionUser assigns Role="admin" but ReconcileSuperAdminBindings has
+// already run against an empty user store and will not run again until the
+// next restart. Without this, AuthzService.IsSystemAdmin returns false for
+// the first admin until the hub is restarted.
+func (s *Server) ensureSuperAdminBinding(ctx context.Context, userID string) {
+	rd, err := s.store.GetRoleDefinitionByName(ctx, store.SystemRoleSuperAdmin, store.RoleScopeSystem)
+	if err != nil {
+		slog.Warn("ensureSuperAdminBinding: super-admin role definition not found — "+
+			"binding will be created on next restart by ReconcileSuperAdminBindings",
+			"user_id", userID, "error", err)
+		return
+	}
+
+	_, err = s.store.CreateRoleBinding(ctx, &store.RoleBinding{
+		RoleDefinitionID: rd.ID,
+		PrincipalType:    store.RoleBindingPrincipalUser,
+		PrincipalID:      userID,
+		ScopeType:        store.RoleScopeSystem,
+		ScopeID:          "",
+		CreatedBy:        store.SystemReconcileCreatedBy,
+	})
+	if err != nil && !errors.Is(err, store.ErrAlreadyExists) {
+		slog.Error("ensureSuperAdminBinding: failed to create super-admin binding",
+			"user_id", userID, "error", err)
+	} else if err == nil {
+		slog.Info("created super-admin binding at login-time provisioning",
+			"user_id", userID)
 	}
 }

--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -1345,6 +1345,12 @@ func (s *Server) provisionUser(ctx context.Context, info *ExternalUserInfo) (*st
 			return nil, ErrUserSuspended
 		}
 
+		// Track whether we need to create or delete a super-admin
+		// RoleBinding. The actual mutation is deferred until after
+		// UpdateUser succeeds so that a failed UpdateUser cannot leave
+		// the binding state diverged from User.Role.
+		var bindingSuperAdmin string // "", "ensure", or "delete"
+
 		if user.Status == store.UserStatusInvited {
 			// Transition invited → active on first login
 			slog.Info("user activated from invited state", "email", info.Email, "user_id", user.ID)
@@ -1359,9 +1365,9 @@ func (s *Server) provisionUser(ctx context.Context, info *ExternalUserInfo) (*st
 			oldRole := user.Role
 			user.Role = s.getUserRole(info.Email, user.Role)
 			if oldRole == "admin" && user.Role != "admin" {
-				s.deleteSuperAdminBinding(ctx, user.ID)
+				bindingSuperAdmin = "delete"
 			} else if user.Role == "admin" && oldRole != "admin" {
-				s.ensureSuperAdminBinding(ctx, user.ID)
+				bindingSuperAdmin = "ensure"
 			}
 			LogInviteAudit(ctx, s.auditLogger, InviteAuditUserActivated, info.Email, "", user.ID, info.Email, nil)
 		} else {
@@ -1384,15 +1390,22 @@ func (s *Server) provisionUser(ctx context.Context, info *ExternalUserInfo) (*st
 				slog.Info("User role changed on login", "email", info.Email, "old_role", oldRole, "new_role", newRole)
 				user.Role = newRole
 				if oldRole == "admin" {
-					s.deleteSuperAdminBinding(ctx, user.ID)
+					bindingSuperAdmin = "delete"
 				} else if newRole == "admin" {
-					s.ensureSuperAdminBinding(ctx, user.ID)
+					bindingSuperAdmin = "ensure"
 				}
 			}
 		}
 		if err := s.store.UpdateUser(ctx, user); err != nil {
 			slog.Error("failed to update user on login", "email", info.Email, "user_id", user.ID, "error", err)
 			return nil, fmt.Errorf("update user: %w", err)
+		}
+		// Apply binding changes only after UpdateUser has succeeded.
+		switch bindingSuperAdmin {
+		case "ensure":
+			s.ensureSuperAdminBinding(ctx, user.ID)
+		case "delete":
+			s.deleteSuperAdminBinding(ctx, user.ID)
 		}
 	}
 
@@ -1762,6 +1775,12 @@ func (s *Server) ensureSuperAdminBinding(ctx context.Context, userID string) {
 		slog.Warn("ensureSuperAdminBinding: super-admin role definition not found — "+
 			"binding will be created on next restart by ReconcileSuperAdminBindings",
 			"user_id", userID, "error", err)
+		return
+	}
+	if rd == nil {
+		slog.Error("ensureSuperAdminBinding: GetRoleDefinitionByName returned nil without error — "+
+			"binding will be created on next restart by ReconcileSuperAdminBindings",
+			"user_id", userID)
 		return
 	}
 

--- a/pkg/hub/handlers_auth_test.go
+++ b/pkg/hub/handlers_auth_test.go
@@ -1117,6 +1117,94 @@ func TestProvisionUser(t *testing.T) {
 	})
 }
 
+// TestColdStartSuperAdminBinding verifies that when the first admin user logs
+// in on a fresh hub (empty user store), provisionUser creates both the
+// User.Role="admin" AND the system-scoped super-admin RoleBinding immediately.
+// Without the fix, ReconcileSuperAdminBindings runs at startup against an empty
+// store, finds no matching users, and the binding is never created until the
+// next restart.
+func TestColdStartSuperAdminBinding(t *testing.T) {
+	ctx := context.Background()
+
+	s, err := newTestStore(":memory:")
+	if err != nil {
+		if strings.Contains(err.Error(), "sqlite driver not registered") {
+			t.Skip("Skipping test because sqlite driver is not registered")
+		}
+		t.Fatalf("failed to create test store: %v", err)
+	}
+	if err := s.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	_ = s.DeleteHubSetting(ctx, "migration_delegation_edge_backfill_v1")
+
+	cfg := DefaultServerConfig()
+	cfg.DevAuthToken = "test-token"
+	cfg.DevUserConfig = DevUserConfig{
+		Username:    "dev",
+		DisplayName: "Development User",
+		Email:       "dev@localhost",
+	}
+	// Configure the admin email BEFORE server creation. On a fresh start
+	// ReconcileSuperAdminBindings will find zero users and create nothing.
+	cfg.AdminEmails = []string{"first-admin@example.com"}
+	srv, err := New(cfg, s)
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+	srv.SetHubID("test-hub-id")
+	t.Cleanup(func() {
+		_ = srv.Shutdown(ctx)
+		_ = s.Close()
+	})
+
+	// Simulate the cold-start scenario: the admin user does not exist yet.
+	// ReconcileSuperAdminBindings already ran at server startup and found no
+	// matching users. Now the admin logs in for the first time.
+	user, err := srv.provisionUser(ctx, &ExternalUserInfo{
+		Email:       "first-admin@example.com",
+		DisplayName: "First Admin",
+	})
+	if err != nil {
+		t.Fatalf("provisionUser: %v", err)
+	}
+
+	// The user should have been assigned the admin role.
+	if user.Role != "admin" {
+		t.Fatalf("expected role 'admin', got %q", user.Role)
+	}
+
+	// Key assertion: the super-admin RoleBinding must exist IMMEDIATELY,
+	// without requiring a second ReconcileSuperAdminBindings call or a hub
+	// restart. This is the cold-start deadlock that this fix addresses.
+	rd, err := s.GetRoleDefinitionByName(ctx, store.SystemRoleSuperAdmin, store.RoleScopeSystem)
+	if err != nil {
+		t.Fatalf("super-admin role definition not found: %v", err)
+	}
+
+	bindings, err := s.ListRoleBindingsForPrincipal(ctx, store.RoleBindingPrincipalUser, user.ID)
+	if err != nil {
+		t.Fatalf("failed to list bindings: %v", err)
+	}
+
+	var found bool
+	for _, b := range bindings {
+		if b.RoleDefinitionID == rd.ID && b.ScopeType == store.RoleScopeSystem {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("cold-start deadlock: super-admin RoleBinding was NOT created at first login — " +
+			"IsSystemAdmin will return false until the next hub restart")
+	}
+
+	// Double-check via AuthzService to confirm the full auth stack works.
+	if !srv.authzService.IsSystemAdmin(ctx, user.ID) {
+		t.Fatal("IsSystemAdmin must return true for the first admin immediately after provisioning")
+	}
+}
+
 // D11-fix2: After login-time demotion (admin removed from AdminEmails),
 // IsSystemAdmin must return false because the super-admin binding is deleted.
 func TestD11Fix2_LoginDemotionDeletesBinding(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes cold-start bootstrap race: ReconcileSuperAdminBindings runs at startup before any users exist, so the first configured admin gets User.Role=admin but no system-scoped super-admin RoleBinding
- Adds ensureSuperAdminBinding() to provisionUser, called at all three admin-role assignment paths (new user creation, invited-to-active transition, existing user promotion)
- Idempotent (ErrAlreadyExists silenced), fail-closed (errors logged, not swallowed)
- Includes TestColdStartSuperAdminBinding reproducing the exact scenario

## Key files
- pkg/hub/handlers_auth.go (ensureSuperAdminBinding + 3 call sites)
- pkg/hub/handlers_auth_test.go (cold-start reproduction test)

## Test notes
- go test -tags sqlite ./pkg/hub/... passes (full suite)
- go build ./... clean

Ref: ptone/scion#1406