### PR TITLE
fix: pass as_needed secret keys to broker for env-gather autodetect (#1447)

### DIFF
--- a/pkg/hub/as_needed_resolution_test.go
+++ b/pkg/hub/as_needed_resolution_test.go
@@ -919,7 +919,7 @@ func TestResolveSecrets_FileTypePassesThroughAsNeeded(t *testing.T) {
 		ProjectID: "project-file-test",
 	}
 
-	result, err := d.resolveSecrets(ctx, agent)
+	result, _, err := d.resolveSecrets(ctx, agent)
 	if err != nil {
 		t.Fatalf("resolveSecrets: %v", err)
 	}

--- a/pkg/hub/envgather_hubscope_regression_test.go
+++ b/pkg/hub/envgather_hubscope_regression_test.go
@@ -198,7 +198,7 @@ func TestResolveSecrets_HubScope_AsNeeded_Filtered(t *testing.T) {
 		},
 	})
 
-	resolved, err := d.resolveSecrets(ctx, agent)
+	resolved, asNeededKeys, err := d.resolveSecrets(ctx, agent)
 	if err != nil {
 		t.Fatalf("resolveSecrets: %v", err)
 	}
@@ -218,5 +218,17 @@ func TestResolveSecrets_HubScope_AsNeeded_Filtered(t *testing.T) {
 		t.Error("ALWAYS_HUB_SECRET (hub scope, always) should be present")
 	} else if r.Value != "always-hub-value" {
 		t.Errorf("ALWAYS_HUB_SECRET value = %q, want %q", r.Value, "always-hub-value")
+	}
+
+	// Filtered as_needed key should be returned in asNeededKeys
+	found := false
+	for _, k := range asNeededKeys {
+		if k == "GEMINI_API_KEY" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("asNeededKeys should contain GEMINI_API_KEY, got %v", asNeededKeys)
 	}
 }

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -661,7 +661,7 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 
 	// Resolve type-aware secrets from all applicable scopes
 	if !noAuth {
-		resolvedSecrets, err := d.resolveSecrets(ctx, agent)
+		resolvedSecrets, asNeededKeys, err := d.resolveSecrets(ctx, agent)
 		if err != nil {
 			if d.debug {
 				d.log.Warn("Failed to resolve secrets", "agent_id", agent.ID, "error", err)
@@ -691,6 +691,11 @@ func (d *HTTPAgentDispatcher) buildCreateRequest(ctx context.Context, agent *sto
 					}
 				}
 			}
+		}
+		// Populate as_needed env-type secret targets so the broker's
+		// autodetect can consider them when selecting auth type (#1447).
+		if len(asNeededKeys) > 0 {
+			req.AvailableAsNeededKeys = asNeededKeys
 		}
 	}
 
@@ -1908,7 +1913,7 @@ func (d *HTTPAgentDispatcher) DispatchAgentStart(ctx context.Context, agent *sto
 	}
 
 	// Resolve type-aware secrets and inject environment-type secrets
-	resolvedSecrets, err := d.resolveSecrets(ctx, agent)
+	resolvedSecrets, _, err := d.resolveSecrets(ctx, agent)
 	if err != nil {
 		if d.debug {
 			d.log.Warn("DispatchAgentStart: failed to resolve secrets", "error", err)
@@ -2216,7 +2221,7 @@ func (d *HTTPAgentDispatcher) DispatchAgentRestart(ctx context.Context, agent *s
 
 	// Resolve type-aware secrets and inject environment-type secrets —
 	// same as DispatchAgentStart.
-	resolvedSecrets, secretErr := d.resolveSecrets(ctx, agent)
+	resolvedSecrets, _, secretErr := d.resolveSecrets(ctx, agent)
 	if secretErr != nil {
 		if d.debug {
 			d.log.Warn("DispatchAgentRestart: failed to resolve secrets", "error", secretErr)
@@ -2728,12 +2733,12 @@ func (d *HTTPAgentDispatcher) deferredLifecycle(
 //
 // This matches envScopePrecedence (see above). The divergence previously
 // tracked in issue #624 was corrected in PR #1227.
-func (d *HTTPAgentDispatcher) resolveSecrets(ctx context.Context, agent *store.Agent) ([]ResolvedSecret, error) {
+func (d *HTTPAgentDispatcher) resolveSecrets(ctx context.Context, agent *store.Agent) ([]ResolvedSecret, []string, error) {
 	if d.secretBackend == nil {
 		if d.debug {
 			d.log.Debug("resolveSecrets: secretBackend is nil, skipping secret resolution")
 		}
-		return nil, nil
+		return nil, nil, nil
 	}
 	if d.debug {
 		d.log.Debug("resolveSecrets: querying secret backend",
@@ -2769,15 +2774,25 @@ func (d *HTTPAgentDispatcher) resolveSecrets(ctx context.Context, agent *store.A
 
 	resolved, err := d.secretBackend.Resolve(ctx, agent.OwnerID, agent.ProjectID, agent.RuntimeBrokerID, resolveOpts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	result := make([]ResolvedSecret, 0, len(resolved))
+	var asNeededKeys []string
 	for _, sv := range resolved {
 		// Only skip as_needed environment-type secrets (handled by the
 		// two-pass env-gather flow). File-type and variable-type secrets
 		// should always be placed regardless of injection mode — the
 		// as_needed concept does not apply to them.
 		if sv.InjectionMode == store.InjectionModeAsNeeded && (sv.SecretType == store.SecretTypeEnvironment || sv.SecretType == "") {
+			// Collect the target key name so the broker's autodetect can
+			// consider it when selecting auth type (closes #1447).
+			target := sv.Target
+			if target == "" {
+				target = sv.Name
+			}
+			if target != "" {
+				asNeededKeys = append(asNeededKeys, target)
+			}
 			continue
 		}
 		result = append(result, ResolvedSecret{
@@ -2794,9 +2809,10 @@ func (d *HTTPAgentDispatcher) resolveSecrets(ctx context.Context, agent *store.A
 		for i, r := range result {
 			names[i] = r.Name
 		}
-		d.log.Debug("resolveSecrets: resolved secrets", "count", len(result), "names", names)
+		d.log.Debug("resolveSecrets: resolved secrets", "count", len(result), "names", names,
+			"asNeededKeys", asNeededKeys)
 	}
-	return result, nil
+	return result, asNeededKeys, nil
 }
 
 // classifyEnv sets the classification for an env key in the given map,

--- a/pkg/hub/httpdispatcher_injection_mode_test.go
+++ b/pkg/hub/httpdispatcher_injection_mode_test.go
@@ -205,7 +205,7 @@ func TestResolveSecrets_InjectionMode(t *testing.T) {
 		},
 	})
 
-	resolved, err := d.resolveSecrets(ctx, agent)
+	resolved, _, err := d.resolveSecrets(ctx, agent)
 	if err != nil {
 		t.Fatalf("resolveSecrets: %v", err)
 	}

--- a/pkg/hub/resolve_secrets_test.go
+++ b/pkg/hub/resolve_secrets_test.go
@@ -101,7 +101,7 @@ func TestResolveSecrets(t *testing.T) {
 		ProjectID: tid("project-1"),
 	}
 
-	resolved, err := dispatcher.resolveSecrets(ctx, agent)
+	resolved, _, err := dispatcher.resolveSecrets(ctx, agent)
 	if err != nil {
 		t.Fatalf("resolveSecrets failed: %v", err)
 	}
@@ -219,7 +219,7 @@ func TestResolveSecrets_WithBackend(t *testing.T) {
 		ProjectID: tid("project-1"),
 	}
 
-	resolved, err := dispatcher.resolveSecrets(ctx, agent)
+	resolved, _, err := dispatcher.resolveSecrets(ctx, agent)
 	if err != nil {
 		t.Fatalf("resolveSecrets with backend failed: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestResolveSecrets_NoOwner(t *testing.T) {
 		Name: "test-agent",
 	}
 
-	resolved, err := dispatcher.resolveSecrets(ctx, agent)
+	resolved, _, err := dispatcher.resolveSecrets(ctx, agent)
 	if err != nil {
 		t.Fatalf("resolveSecrets failed: %v", err)
 	}
@@ -356,7 +356,7 @@ func TestResolveSecrets_HubScope(t *testing.T) {
 		ProjectID: tid("project-1"),
 	}
 
-	resolved, err := dispatcher.resolveSecrets(ctx, agent)
+	resolved, _, err := dispatcher.resolveSecrets(ctx, agent)
 	if err != nil {
 		t.Fatalf("resolveSecrets failed: %v", err)
 	}
@@ -423,7 +423,7 @@ func TestResolveSecrets_NoBackend(t *testing.T) {
 		ProjectID: tid("project-1"),
 	}
 
-	resolved, err := dispatcher.resolveSecrets(ctx, agent)
+	resolved, _, err := dispatcher.resolveSecrets(ctx, agent)
 	if err != nil {
 		t.Fatalf("resolveSecrets failed: %v", err)
 	}

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -523,6 +523,14 @@ type RemoteCreateAgentRequest struct {
 	// If required keys are missing, the broker returns HTTP 202 with env requirements.
 	GatherEnv bool `json:"gatherEnv,omitempty"`
 
+	// AvailableAsNeededKeys lists the target key names of as_needed
+	// environment-type secrets that the Hub filtered out of ResolvedSecrets
+	// but could resolve in a second pass if the broker reports them as needed.
+	// This lets the broker's autodetect consider these keys when selecting
+	// auth type, closing the chicken-and-egg gap where autodetect only sees
+	// already-resolved keys.
+	AvailableAsNeededKeys []string `json:"availableAsNeededKeys,omitempty"`
+
 	// RequiredSecrets contains declared secrets from the template config.
 	// Passed to the broker so it can include them in env-gather requirements.
 	RequiredSecrets []api.RequiredSecret `json:"requiredSecrets,omitempty"`

--- a/pkg/runtimebroker/handlers.go
+++ b/pkg/runtimebroker/handlers.go
@@ -2222,6 +2222,12 @@ func (s *Server) extractRequiredEnvKeys(req CreateAgentRequest, hydratedHarnessC
 					}
 				}
 			}
+			// Include as_needed secret targets the hub could resolve in
+			// pass 2. Without this, autodetect cannot see deferred keys
+			// and falls back to default_type, losing the credentials (#1447).
+			for _, k := range req.AvailableAsNeededKeys {
+				resolvedEnvKeys[k] = struct{}{}
+			}
 			if detected := harness.DetectAuthTypeFromEnvVarsFromConfig(authMeta, resolvedEnvKeys); detected != "" {
 				authType = detected
 			}

--- a/pkg/runtimebroker/handlers_envgather_test.go
+++ b/pkg/runtimebroker/handlers_envgather_test.go
@@ -95,6 +95,42 @@ const geminiAuthBlock = `auth:
       gcloud-adc: vertex-ai
 `
 
+// antigravityAuthBlock mirrors the production antigravity harness config.
+// default_type is oauth-token (which has no env requirements), so autodetect
+// must see GEMINI_API_KEY to select api-key instead.
+const antigravityAuthBlock = `auth:
+  default_type: oauth-token
+  types:
+    oauth-token:
+      required_files:
+        - name: AGY_TOKEN
+          type: file
+          description: "Antigravity OAuth token JSON file"
+          target_suffix: "/.gemini/antigravity-cli/antigravity-oauth-token"
+    api-key:
+      required_env:
+        - any_of: ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
+    vertex-ai:
+      required_env:
+        - any_of: ["GOOGLE_CLOUD_PROJECT"]
+        - any_of: ["GOOGLE_CLOUD_LOCATION", "GOOGLE_CLOUD_REGION"]
+      required_files:
+        - name: gcloud-adc
+          type: file
+          description: "Google Cloud ADC file for vertex-ai authentication"
+          alternative_env_keys: ["GOOGLE_APPLICATION_CREDENTIALS"]
+          skipped_when_gcp_service_account_assigned: true
+          required: true
+  autodetect:
+    env:
+      GEMINI_API_KEY: api-key
+      GOOGLE_API_KEY: api-key
+      AGY_TOKEN: oauth-token
+      GOOGLE_CLOUD_PROJECT: vertex-ai
+    files:
+      gcloud-adc: vertex-ai
+`
+
 // newTestServerWithProjectPath creates a test server with a temporary project path
 // that has versioned settings with declared env vars.
 func newTestServerWithProjectPath(t *testing.T, settingsYAML string) (*Server, *envCapturingManager, string) {
@@ -2223,4 +2259,144 @@ profiles:
 			}
 		})
 	}
+}
+
+// TestEnvGather_AvailableAsNeededKeys_AutodetectAPIKey is a regression test for
+// #1447. When a harness has default_type: oauth-token (like antigravity) and
+// GEMINI_API_KEY is an as_needed hub secret, autodetect must still see the key
+// via AvailableAsNeededKeys and select api-key auth rather than falling through
+// to oauth-token (which has no env requirements and causes the agent to start
+// without credentials).
+func TestEnvGather_AvailableAsNeededKeys_AutodetectAPIKey(t *testing.T) {
+	// Use antigravity-like harness: default_type is oauth-token,
+	// autodetect.env maps GEMINI_API_KEY → api-key.
+	srv, _, projectDir := newTestServerWithHarnessConfig(t, "antigravity",
+		"harness: antigravity\nimage: test-image\nuser: scion\n"+antigravityAuthBlock,
+		`
+schema_version: "1"
+harness_configs:
+  antigravity:
+    harness: antigravity
+profiles:
+  default:
+    runtime: mock
+`)
+
+	// Create template so FindTemplateInProjectPath can resolve it.
+	tplDir := filepath.Join(projectDir, "templates", "antigravity")
+	if err := os.MkdirAll(tplDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tplDir, "scion-agent.yaml"),
+		[]byte("harness_config: antigravity\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Send request with GEMINI_API_KEY in availableAsNeededKeys (simulating a
+	// hub secret with injection_mode=as_needed) but NOT in resolvedEnv or
+	// resolvedSecrets.
+	body := `{
+		"name": "test-agent-asneeded-autodetect",
+		"id": "agent-uuid-asneeded",
+		"gatherEnv": true,
+		"grovePath": "` + projectDir + `",
+		"availableAsNeededKeys": ["GEMINI_API_KEY"],
+		"config": {"template": "antigravity", "profile": "default"}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(w, req)
+
+	// Autodetect should see GEMINI_API_KEY via AvailableAsNeededKeys and select
+	// api-key auth. GEMINI_API_KEY is not in resolvedEnv, so it should appear
+	// in the needs list (returned as 202).
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202 (GEMINI_API_KEY needed), got %d: %s", w.Code, w.Body.String())
+	}
+
+	var envReqs EnvRequirementsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &envReqs); err != nil {
+		t.Fatal("failed to decode response:", err)
+	}
+
+	// GEMINI_API_KEY should be in the required/needs list because autodetect
+	// selected api-key auth (not oauth-token, which has no env requirements).
+	needsMap := make(map[string]struct{})
+	for _, k := range envReqs.Needs {
+		needsMap[k] = struct{}{}
+	}
+	requiredMap := make(map[string]struct{})
+	for _, k := range envReqs.Required {
+		requiredMap[k] = struct{}{}
+	}
+	if _, ok := requiredMap["GEMINI_API_KEY"]; !ok {
+		t.Errorf("expected GEMINI_API_KEY in required (autodetect should pick api-key), got required=%v needs=%v", envReqs.Required, envReqs.Needs)
+	}
+	if _, ok := needsMap["GEMINI_API_KEY"]; !ok {
+		t.Errorf("expected GEMINI_API_KEY in needs (not yet resolved), got needs=%v", envReqs.Needs)
+	}
+}
+
+// TestEnvGather_NoAvailableAsNeededKeys_FallsBackToDefault is a complementary
+// test for #1447: without AvailableAsNeededKeys, autodetect has no env-var
+// signals and falls back to default_type (oauth-token), which has no env
+// requirements. This demonstrates the pre-fix behavior.
+func TestEnvGather_NoAvailableAsNeededKeys_FallsBackToDefault(t *testing.T) {
+	srv, _, projectDir := newTestServerWithHarnessConfig(t, "antigravity",
+		"harness: antigravity\nimage: test-image\nuser: scion\n"+antigravityAuthBlock,
+		`
+schema_version: "1"
+harness_configs:
+  antigravity:
+    harness: antigravity
+profiles:
+  default:
+    runtime: mock
+`)
+
+	tplDir := filepath.Join(projectDir, "templates", "antigravity")
+	if err := os.MkdirAll(tplDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tplDir, "scion-agent.yaml"),
+		[]byte("harness_config: antigravity\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Same request but WITHOUT availableAsNeededKeys — autodetect has no
+	// env-var signals and falls back to default_type (oauth-token).
+	body := `{
+		"name": "test-agent-no-asneeded",
+		"id": "agent-uuid-no-asneeded",
+		"gatherEnv": true,
+		"grovePath": "` + projectDir + `",
+		"config": {"template": "antigravity", "profile": "default"}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(w, req)
+
+	// Without AvailableAsNeededKeys, autodetect doesn't see GEMINI_API_KEY,
+	// so it falls back to oauth-token. oauth-token only requires file secrets
+	// (AGY_TOKEN) which are file-type, not env-type. The env-gather phase
+	// sees no env keys needed and the agent should proceed past env-gather.
+	// The broker returns 202 for the AGY_TOKEN file secret requirement.
+	if w.Code == http.StatusAccepted {
+		var envReqs EnvRequirementsResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &envReqs); err != nil {
+			t.Fatal("failed to decode response:", err)
+		}
+		// GEMINI_API_KEY should NOT appear in required/needs
+		for _, k := range envReqs.Required {
+			if k == "GEMINI_API_KEY" {
+				t.Errorf("GEMINI_API_KEY should NOT be in required without AvailableAsNeededKeys, got required=%v", envReqs.Required)
+			}
+		}
+	}
+	// Either 201 (started) or 202 (needs file secret AGY_TOKEN) is acceptable —
+	// the point is that GEMINI_API_KEY is NOT required.
 }

--- a/pkg/runtimebroker/handlers_envgather_test.go
+++ b/pkg/runtimebroker/handlers_envgather_test.go
@@ -2299,7 +2299,7 @@ profiles:
 		"name": "test-agent-asneeded-autodetect",
 		"id": "agent-uuid-asneeded",
 		"gatherEnv": true,
-		"grovePath": "` + projectDir + `",
+		"projectPath": "` + projectDir + `",
 		"availableAsNeededKeys": ["GEMINI_API_KEY"],
 		"config": {"template": "antigravity", "profile": "default"}
 	}`
@@ -2371,7 +2371,7 @@ profiles:
 		"name": "test-agent-no-asneeded",
 		"id": "agent-uuid-no-asneeded",
 		"gatherEnv": true,
-		"grovePath": "` + projectDir + `",
+		"projectPath": "` + projectDir + `",
 		"config": {"template": "antigravity", "profile": "default"}
 	}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents", strings.NewReader(body))

--- a/pkg/runtimebroker/types.go
+++ b/pkg/runtimebroker/types.go
@@ -315,6 +315,14 @@ type CreateAgentRequest struct {
 	// instead of starting the agent, allowing the caller to gather and submit the missing values.
 	GatherEnv bool `json:"gatherEnv,omitempty"`
 
+	// AvailableAsNeededKeys lists the target key names of as_needed
+	// environment-type secrets that the Hub filtered out of ResolvedSecrets
+	// but could resolve in a second pass if the broker reports them as needed.
+	// This lets the broker's autodetect consider these keys when selecting
+	// auth type, closing the chicken-and-egg gap where autodetect only sees
+	// already-resolved keys.
+	AvailableAsNeededKeys []string `json:"availableAsNeededKeys,omitempty"`
+
 	// RequiredSecrets contains declared secrets from the template config.
 	// Passed by the Hub so the broker can include them in env-gather requirements.
 	RequiredSecrets []api.RequiredSecret `json:"requiredSecrets,omitempty"`


### PR DESCRIPTION
## Summary
Fixes env-gather autodetect chicken-and-egg bug where as_needed hub-level secrets (e.g. GEMINI_API_KEY) are invisible to the broker autodetect when the harness default_type does not require them (e.g. antigravity with default_type=oauth-token). The broker never reports the key as needed, so the hub never resolves it, and the agent starts without credentials.

Adds AvailableAsNeededKeys field to CreateAgentRequest so the hub can tell the broker which as_needed env-type secret targets exist. The broker includes these in the autodetect key set, enabling correct auth type selection.

## Test plan
- Added regression tests for autodetect with/without available as_needed keys
- Extended existing TestResolveSecrets_HubScope_AsNeeded_Filtered
- go test ./pkg/hub/... and ./pkg/runtimebroker/... pass