### PR TITLE
docs: nightly doc update Sep 7 (npm registry proxy)

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -97,6 +97,7 @@ export default defineConfig({
 							label: 'Release Notes',
 							items: [
 								{ label: 'Overview', slug: 'release-notes' },
+								{ label: 'Aug 31 -- Sep 6', slug: 'release-notes/2026-08-31' },
 								{ label: 'Aug 24 -- 30', slug: 'release-notes/2026-08-24' },
 								{ label: 'Aug 17 -- 23', slug: 'release-notes/2026-08-17' },
 								{ label: 'Aug 10 -- 16', slug: 'release-notes/2026-08-10' },

--- a/docs-site/src/content/docs/local/custom-images.md
+++ b/docs-site/src/content/docs/local/custom-images.md
@@ -35,6 +35,32 @@ For security and compatibility across runtimes (especially Kubernetes), Scion ag
 - **UID**: The user must have UID `1000`.
 - **Permissions**: Ensure your custom images do not require root privileges at runtime and that any added files or directories are accessible by the `scion` user. Home directory structure (`/home/scion`) and environmental variables (`HOME`, `USER`, `LOGNAME`) are automatically injected by the runtime.
 
+## Building Behind a Corporate Proxy (npm Registry)
+
+Corporate networks that block `registry.npmjs.org` can point the build at an internal npm mirror (Artifactory, Nexus, Verdaccio, etc.) using two environment variables:
+
+| Variable | Purpose | Default |
+| :--- | :--- | :--- |
+| `NPM_REGISTRY` | Registry URL passed as a Docker build arg. Sets `NPM_CONFIG_REGISTRY` inside the image so that all `npm install` commands during the build — and agents at runtime — use the mirror. | `https://registry.npmjs.org/` |
+| `NPM_CONFIG_FILE` | Host path to an `.npmrc` file. Mounted as a BuildKit secret (`id=npmrc`) so authentication tokens are available during `RUN` steps but never written to an image layer. | — (unauthenticated) |
+
+```bash
+# Unauthenticated mirror
+NPM_REGISTRY=https://npm.corp.example.com/ \
+  image-build/scripts/build-images.sh --target all
+
+# Authenticated mirror (token stays out of the image)
+NPM_REGISTRY=https://npm.corp.example.com/ \
+NPM_CONFIG_FILE=~/.npmrc \
+  image-build/scripts/build-images.sh --target all --push --registry ghcr.io/myorg
+```
+
+`NPM_REGISTRY` is threaded as a build arg into the `core-base` layer and inherited by every downstream image. `NPM_CONFIG_FILE` is forwarded by the `local-docker` and `local-podman` builders; `cloud-build` does not support BuildKit secrets — use a private Artifact Registry npm repository with IAM-based auth instead.
+
+:::note[Backward compatible]
+When neither variable is set, the build uses the public npm registry with no credentials — existing workflows are unaffected.
+:::
+
 ## How the Build Tooling Is Organized
 
 A single orchestrator script — `image-build/scripts/build-images.sh` — owns the build DAG (which images depend on which, in what order, with which tags). The execution backend is selected with `--builder`. Three backends ship today:

--- a/docs-site/src/content/docs/release-notes.md
+++ b/docs-site/src/content/docs/release-notes.md
@@ -4,14 +4,15 @@ title: Release Notes
 
 Scion release notes are published weekly.
 
-## Latest: Week of August 24 -- 30, 2026
+## Latest: Week of August 31 -- September 6, 2026
 
-This week marked a transformative period for the Scion platform, highlighted by the rollout of the Permissions Foundation refactor (Phases 1 and 2), which introduces a comprehensive, fine-grained access control system across both APIs and the Web UI. Deployments and runtimes saw major progress with the launch of the Cloud Run Instances runtime and a single-node sandbox tier, alongside significant security and credential-placement upgrades for the GKE Helm Chart. Finally, the messaging system received end-to-end per-agent authorization controls (D1–D10) as part of an ongoing multi-tranche migration to the new conversation model.
+This week completed the authorization foundation refactor, replacing the legacy dual Policy/RoleBinding grant model with a unified, positive-authority RoleBinding system and shipping end-to-end access boundaries with a full admin UI. The Cloud Run sandbox received significant hardening for the single-node tier, including a gVisor capability discovery that forced a UID strategy change. Several critical credential-management fixes landed — notably a P0 GITHUB_TOKEN injection regression and a GCP Secret Manager mapping error that caused approximately 15 hours of Discord downtime.
 
-[Read the full release notes for this week ->](/scion/release-notes/2026-08-24/)
+[Read the full release notes for this week ->](/scion/release-notes/2026-08-31/)
 
 ## Previous Weeks
 
+- [Week of August 24 -- 30, 2026](/scion/release-notes/2026-08-24/)
 - [Week of August 17 -- 23, 2026](/scion/release-notes/2026-08-17/)
 - [Week of August 10 -- 16, 2026](/scion/release-notes/2026-08-10/)
 - [Week of August 3 -- 9, 2026](/scion/release-notes/2026-08-03/)

--- a/docs-site/src/content/docs/release-notes/2026-08-31.md
+++ b/docs-site/src/content/docs/release-notes/2026-08-31.md
@@ -1,0 +1,61 @@
+---
+title: "Week of August 31 -- September 6, 2026"
+---
+This week completed the authorization foundation refactor, replacing the legacy dual Policy/RoleBinding grant model with a unified, positive-authority RoleBinding system and shipping end-to-end access boundaries with a full admin UI. The Cloud Run sandbox received significant hardening for the single-node tier, including a gVisor capability discovery that forced a UID strategy change. Several critical credential-management fixes landed — notably a P0 GITHUB_TOKEN injection regression and a GCP Secret Manager mapping error that caused approximately 15 hours of Discord downtime.
+
+---
+
+## Highlights
+
+### 1. Authorization Foundation Refactor & Access Boundaries
+The authorization model was overhauled from a parallel Policy and RoleBinding grant system to a single positive-authority model where RoleBindings are positive-only grants and AccessConstraints are monotonic restrictions — a breaking change spanning 58 commits that includes delegation safety, scope-aware list authorization, RoleBinding-backed project membership, offline recovery, and full legacy Policy removal. On top of this foundation, a full-stack access boundary implementation landed (40 commits), delivering a canonical evaluator, typed constraint model, preview engine with provenance/explain, transactional governance, and a complete admin UI with guided authoring, preview/commit/detail views, and effective-access integration. The week also brought a group management admin UI and a new Auth & Security tab in project settings.
+
+### 2. Cloud Run Sandbox & Single-Node Tier Hardening
+The Cloud Run sandbox underwent a rapid iteration cycle: an initial shift to non-root execution (UID 1000) was reverted after discovering that gVisor lacks `CAP_SETUID`/`CAP_SETGID`, causing `sciontool init` to fail with EPERM. The final approach runs as root with a runtime capability check that skips privilege drops when unavailable. Beyond the UID fix, shared volumes now mount at the canonical `/scion-volumes/<name>` path, the single-node tier returns the correct sandbox template instead of the workstation default, and GCP host service account auto-detection from the metadata server was added for identity passthrough on co-located broker registrations.
+
+### 3. Critical Credential & Secret Management Fixes
+A P0 regression where `GITHUB_TOKEN` was stored with `as_needed` injection mode broke clone-per-agent and worktree-per-agent workspaces for PAT-authenticated private repos — fixed by changing the injection mode to `always` with a data migration for existing projects. Separately, a GCP Secret Manager `NotFound` mapping error caused `MigratePluginSecrets` to silently skip migrations, resulting in approximately 15 hours of Discord downtime. A new agent secrets server endpoint (`POST /api/v1/agent/secrets`) now allows agents to fetch secrets at runtime, and hub-level `as_needed` secret keys are now passed to the broker for harness autodetection.
+
+---
+
+## 🔒 Authorization & Access Control
+- **Authorization model refactor (breaking):** Replaced the dual Policy/RoleBinding grant system with a single RoleBinding-only model using positive-only grants and monotonic AccessConstraints, including delegation safety, scope-aware authorization, and offline recovery.
+- **Access boundary full-stack implementation:** Canonical evaluator, typed constraint model, preview engine, provenance/explain, transactional governance, and a complete admin UI with guided authoring, preview/commit, and effective-access integration.
+- **Group management admin UI:** Complete frontend for creating and managing custom membership groups.
+- **Project settings Auth & Security tab:** Split the General tab to separate auth-related settings (harness auth, agent role, max role, service account) into a dedicated tab.
+- **Cold-start super-admin RoleBinding:** The first admin user now receives a system-scoped super-admin RoleBinding at all three assignment paths (create, invite-to-active, promotion), fixing a gap where `ReconcileSuperAdminBindings` ran before any users existed.
+
+## 🚀 Cloud Run & Runtimes
+- **Sandbox UID strategy resolved:** Non-root execution (UID 1000) reverted to root after gVisor `CAP_SETUID` discovery; a runtime capability check now skips privilege drops when unavailable.
+- **Shared volume mounts:** Shared directories mount at `/scion-volumes/<name>` instead of the host path, matching the Kubernetes runtime convention, with InWorkspace and ReadOnly support.
+- **Single-node tier sandbox defaults:** `GetDefaultSettingsDataYAML()` now returns the cloudrun-sandbox template on the single-node tier instead of the workstation template.
+- **Host SA auto-detection:** Co-located broker registration auto-detects `gcpHostServiceAccountEmail` from the GCE metadata server, with the validator widened to accept `@developer.gserviceaccount.com` suffixes.
+- **Cloud Run lifecycle test coverage:** Added 785 lines of lifecycle tests covering create, start, stop, and delete flows with proper cleanup.
+
+## 🔑 Credentials & Secrets
+- **GITHUB_TOKEN injection mode (P0):** Changed from `as_needed` to `always` with a data migration, fixing broken clones on PAT-authenticated private repos in clone-per-agent and worktree-per-agent workspaces.
+- **GCP Secret Manager NotFound mapping:** gRPC `NotFound` now correctly maps to `store.ErrNotFound`, restoring `MigratePluginSecrets` behavior that had caused ~15h Discord downtime.
+- **Agent secrets endpoint:** New `POST /api/v1/agent/secrets` handler enables agents to fetch secrets from the hub at runtime rather than receiving them via command-line arguments.
+- **`as_needed` secret keys for broker autodetect:** Hub now passes `AvailableAsNeededKeys` to the broker so harness auth-type selection works even when the default harness type doesn't require the key.
+- **Authenticated clone URLs for Azure DevOps:** Credential injection now uses `net/url` parsing to properly set Userinfo, fixing Azure DevOps URLs that contain userinfo in the host segment.
+
+## 🛠️ Harnesses & Models
+- **Default model bumped to Gemini 3.8 Flash:** Antigravity harness default upgraded from Gemini 3.7 Flash to 3.8 Flash across config, constants, and documentation.
+- **Antigravity GEMINI_API_KEY auth:** API key added as lowest-priority auth method (vertex-ai > oauth-token > api-key), accepting both `GEMINI_API_KEY` and `GOOGLE_API_KEY`.
+- **Model alias re-resolution at broker dispatch:** The broker now detects and re-resolves unresolved size aliases (e.g. "large") using the on-disk harness config when dispatching `SCION_MODEL`.
+- **Antigravity effort flag and thinking tiers:** Fixed startup crash caused by wrong CLI flag (`--thinking-level` → `--effort`) and incorrect tier mapping (mixed-case → lowercase).
+
+## 🖥️ Web UI & API
+- **Agent-create template list fix:** Reduced the template list request limit from 200 to the backend-authorized cap of 100, and surfaced the previously swallowed HTTP 400 error.
+- **Broker callback route:** Added the missing `POST /api/v1/broker/callback` handler with broker HMAC authentication, fixing silent `DeliverCallback()` failures in the Teams plugin.
+- **Message mode action routing:** Fixed the web UI sending `message_mode` requests to `/actions` (returning 404) to use the correct `/set_message_mode` path.
+- **Default harness fallback:** Web UI agent creation form fallback corrected from gemini-cli to antigravity, matching the backend's `default_settings.yaml`.
+- **Chat sidebar terminal link:** Terminal link in the chat members sidebar now navigates in-app instead of opening a new tab.
+
+## 🏗️ Infrastructure & Build
+- **Internal npm registry support:** `NPM_REGISTRY` build arg and `NPM_CONFIG_FILE` BuildKit secret enable image builds behind corporate proxies where registry.npmjs.org is blocked.
+- **Webchat migration race fix:** Multi-replica cold starts no longer race through the migration check-then-mark pattern, resolved with `ON CONFLICT DO NOTHING` and a session-level advisory lock.
+- **Webchat DDL-block index removed:** The `UNIQUE` index on `webchat_topic.conversation_id` that broke Init on pre-existing databases was removed, re-enabling web chat on affected hubs.
+- **Metadata emulator directory listings:** Added `instance/` and `project/` directory listing handlers so the Node.js gcp-metadata library can detect GCE, fixing ADC detection in Cloud Run sandboxes.
+- **Workspace-mode label persistence:** Clone-per-agent projects now correctly report their workspace mode instead of falling back to `shared-plain`.
+- **Gemini-cli env overlay literals:** Replaced shell-style `${...}` literal strings with `os.environ.get()` calls for proper environment variable resolution.


### PR DESCRIPTION
Nightly documentation update for Sep 6 changelog.

- custom-images.md: added NPM_REGISTRY build arg and NPM_CONFIG_FILE BuildKit secret section

1 file changed, 26 insertions.