### PR TITLE
feat(build): allow image builds to use an internal Python package index

### DIFF
--- a/harnesses/hermes/Dockerfile
+++ b/harnesses/hermes/Dockerfile
@@ -40,7 +40,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3-pip \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Hermes Agent with Vertex AI support (google-auth for ADC)
-RUN if [ -n "${HERMES_VERSION}" ]; then \
+RUN --mount=type=secret,id=pipconf,target=/etc/pip.conf,required=false \
+    if [ -n "${HERMES_VERSION}" ]; then \
       pip install --no-cache-dir --break-system-packages "hermes-agent[vertex]==${HERMES_VERSION}"; \
     else \
       pip install --no-cache-dir --break-system-packages "hermes-agent[vertex]"; \

--- a/image-build/README.md
+++ b/image-build/README.md
@@ -159,24 +159,41 @@ aggregate YAMLs too. Individual harness bundles can also carry their own
 
 ## Package Registries
 
-By default the images install npm packages from the public registry. On a network
-where `registry.npmjs.org` is unreachable, point the build at an internal mirror
-(Artifactory, Nexus, Verdaccio) with two optional environment variables:
+By default the images install packages from the public npm registry and PyPI. On
+a network where `registry.npmjs.org` or `pypi.org` is unreachable, point the
+build at internal mirrors (Artifactory, Nexus, Verdaccio, devpi) with four
+optional environment variables:
 
 | Variable | Purpose |
 |---|---|
-| `NPM_REGISTRY` | Registry URL. Passed to `core-base` as a build-arg and exported as `NPM_CONFIG_REGISTRY`, so `scion-base`, the harness images, and agents at runtime all inherit it. |
+| `NPM_REGISTRY` | npm registry URL. Passed to `core-base` as a build-arg and exported as `NPM_CONFIG_REGISTRY`, so `scion-base`, the harness images, and agents at runtime all inherit it. |
 | `NPM_CONFIG_FILE` | Path to an `.npmrc` holding credentials for that registry. Mounted as a BuildKit secret, never written to an image layer. |
+| `PIP_INDEX_URL` | Python package index URL. Same handling: a `core-base` build-arg, exported as `PIP_INDEX_URL` and inherited the same way. Used by the `hermes` image, and by anything an agent pip-installs at runtime. |
+| `PIP_CONFIG_FILE` | Path to a `pip.conf` holding credentials for that index. Mounted as a BuildKit secret at `/etc/pip.conf`. |
 
 ```bash
 export NPM_REGISTRY=https://artifactory.example.com/artifactory/api/npm/npm-repos/
 export NPM_CONFIG_FILE="$HOME/.npmrc"
+export PIP_INDEX_URL=https://artifactory.example.com/artifactory/api/pypi/pypi-repos/simple
+export PIP_CONFIG_FILE="$HOME/.config/pip/pip.conf"
 image-build/scripts/build-images.sh --target common
 ```
 
-Both are optional and independent. Unset, the build uses the public registry
-unauthenticated, exactly as before. `NPM_REGISTRY` without `NPM_CONFIG_FILE`
-works for a mirror that allows anonymous reads.
+A minimal `pip.conf` for an index requiring basic auth:
+
+```ini
+[global]
+index-url = https://USER:TOKEN@artifactory.example.com/artifactory/api/pypi/pypi-repos/simple
+```
+
+All four are optional and independent. Unset, the build uses the public
+registries unauthenticated, exactly as before. `NPM_REGISTRY` or
+`PIP_INDEX_URL` without its credentials file works for a mirror that allows
+anonymous reads.
+
+Put credentials in the secret file rather than in `PIP_INDEX_URL`: that variable
+is baked into the image as `ENV`, so a token embedded in the URL would persist
+in the image and show up in `docker inspect`.
 
 Credentials go in as a BuildKit secret rather than a build-arg deliberately: a
 build-arg is recoverable from `docker history` on the resulting image, whereas a
@@ -185,9 +202,10 @@ declared `required=false`, so builds without a secret are unaffected.
 
 Supported by the `local-docker` and `local-podman` builders.
 
-**Not yet covered:** pip. The `hermes` image installs Python packages from PyPI
-and has no equivalent knob, so it cannot currently be built behind a proxy that
-blocks PyPI.
+**Still not covered:** apt. The `hermes` image installs Node.js from
+`deb.nodesource.com` via an apt source, which no build-arg here redirects. A host
+that blocks that domain will fail on that layer regardless of the index settings
+above.
 
 ## Authentication
 

--- a/image-build/core-base/Dockerfile
+++ b/image-build/core-base/Dockerfile
@@ -169,6 +169,15 @@ ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
 # unset. Inherited by scion-base, every harness image, and agents at runtime.
 ARG NPM_REGISTRY=https://registry.npmjs.org/
 ENV NPM_CONFIG_REGISTRY=${NPM_REGISTRY}
+
+# Optional Python package index, for the same reason as NPM_REGISTRY above:
+# corporate networks commonly block pypi.org. Point this at an internal proxy
+# (Artifactory, Nexus, devpi). Defaults to the public index, so behaviour is
+# unchanged when unset. Inherited by scion-base, every harness image, and
+# agents at runtime. Credentials do NOT belong here - a value baked into ENV
+# persists in the image; use the pipconf build secret instead.
+ARG PIP_INDEX_URL=https://pypi.org/simple
+ENV PIP_INDEX_URL=${PIP_INDEX_URL}
 ENV PATH=/usr/local/share/npm-global/bin:/usr/local/go/bin:/usr/local/gcloud/google-cloud-sdk/bin:$PATH
 ENV LC_ALL=C.UTF-8
 ENV EDITOR=nano

--- a/image-build/scripts/builders/local-docker.sh
+++ b/image-build/scripts/builders/local-docker.sh
@@ -111,6 +111,12 @@ builder_build() {
     cmd+=(--secret "id=npmrc,src=${NPM_CONFIG_FILE}")
   fi
 
+  # Optional pip credentials, same handling as npm above: a mounted secret so
+  # an index token is available during RUN but never lands in an image layer.
+  if [[ -n "${PIP_CONFIG_FILE:-}" ]]; then
+    cmd+=(--secret "id=pipconf,src=${PIP_CONFIG_FILE}")
+  fi
+
   cmd+=(-f "${dockerfile}")
 
   if [[ "${push}" == "true" ]]; then

--- a/image-build/scripts/builders/local-podman.sh
+++ b/image-build/scripts/builders/local-podman.sh
@@ -87,6 +87,12 @@ builder_build() {
     cmd+=(--secret "id=npmrc,src=${NPM_CONFIG_FILE}")
   fi
 
+  # Optional pip credentials, same handling as npm above: a mounted secret so
+  # an index token is available during RUN but never lands in an image layer.
+  if [[ -n "${PIP_CONFIG_FILE:-}" ]]; then
+    cmd+=(--secret "id=pipconf,src=${PIP_CONFIG_FILE}")
+  fi
+
   cmd+=(-f "${dockerfile}" "${context_dir}")
 
   echo "==> [local-podman] building ${image_name}..."

--- a/image-build/scripts/lib/targets.sh
+++ b/image-build/scripts/lib/targets.sh
@@ -219,6 +219,10 @@ step_build_args() {
       if [[ -n "${NPM_REGISTRY:-}" ]]; then
         echo "NPM_REGISTRY=${NPM_REGISTRY}"
       fi
+      # Same for the Python package index.
+      if [[ -n "${PIP_INDEX_URL:-}" ]]; then
+        echo "PIP_INDEX_URL=${PIP_INDEX_URL}"
+      fi
       ;;
     thick-prep)
       # No build-args — BASE_IMAGE default is in the Dockerfile ARG.


### PR DESCRIPTION
Mirrors the existing npm internal registry plumbing to add pip/PyPI support. core-base gains PIP_INDEX_URL build-arg, hermes Dockerfile gets BuildKit secret mount for pip.conf, and build scripts pass the secret when PIP_CONFIG_FILE is set. Ref: miller79/scion#49