### PR TITLE
fix(hub): fix progeny secret inheritance with three stacked authz defects

### DIFF
--- a/pkg/hub/authz_delegation_ceiling.go
+++ b/pkg/hub/authz_delegation_ceiling.go
@@ -268,8 +268,16 @@ func (a *AuthzService) walkDelegationChain(
 			})
 		}
 
-		// Resolve the permission ID from the request action and resource.
-		permissionID := resolvePermissionID(req.Resource, req.Action)
+		// Resolve the permission ID. Honour an explicit request permission the
+		// way Decide does: when a caller names the permission, deriving a
+		// different one here silently denies. Agent secret resolution is the
+		// case in point - it asks for project.secret_read, while deriving from
+		// (resource="secret", action="read") produces "secret.read", which is
+		// not in the registry and maps to no agent scope.
+		permissionID := req.Permission
+		if permissionID == "" {
+			permissionID = resolvePermissionID(req.Resource, req.Action)
+		}
 
 		if edge.DelegatorType == store.DelegationPrincipalUser {
 			allowed, reason, err := a.checkUserHoldsPermission(ctx, edge.DelegatorID, permissionID, edge.ScopeType, edge.ScopeID, explain)

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -42,6 +42,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// permissionProjectSecretRead is the registry permission ID that governs an
+// agent reading secrets during resolution (pkg/hub/permissions/registry.go).
+// It is declared on ResourceProject, so it cannot be derived from a
+// resource type of "secret".
+const permissionProjectSecretRead = "project.secret_read"
+
 // HTTPRuntimeBrokerClient is an HTTP-based implementation of RuntimeBrokerClient.
 // It communicates with remote runtime brokers via their REST API.
 type HTTPRuntimeBrokerClient struct {
@@ -1722,19 +1728,41 @@ func (d *HTTPAgentDispatcher) resolveAsNeededForKeys(
 		if len(agent.Ancestry) > 1 && d.authzService != nil {
 			agentID := agent.ID
 			ancestry := agent.Ancestry
+			// The synthetic identity must carry the agent's real scopes.
+			// Agent authority is derived from JWT scopes (buildAgentSyntheticBindings),
+			// and agentScopeRestriction denies everything when the scope list is
+			// empty, so an identity built without them can never be allowed.
+			role, additionalScopes := agentRoleAndScopes(agent)
+			scopes := append(ScopesForRole(role), additionalScopes...)
 			resolveOpts = &secret.ResolveOpts{
 				AgentAncestry: ancestry,
 				AuthzCheck: func(s secret.SecretMeta) bool {
-					decision := d.authzService.CheckAccess(ctx, &agentIdentityWrapper{
+					ident := &agentIdentityWrapper{
 						AgentTokenClaims: &AgentTokenClaims{
 							Claims:    jwt.Claims{Subject: agentID},
 							ProjectID: agent.ProjectID,
 							Ancestry:  ancestry,
+							Scopes:    scopes,
 						},
-					}, Resource{
-						Type: "secret",
-						ID:   s.ID,
-					}, ActionRead)
+					}
+					// Name the permission explicitly. Deriving it from
+					// (resource="secret", action="read") finds no registry entry -
+					// agent secret access is registered as project.secret_read on
+					// ResourceProject - so derivePermissionID falls through to its
+					// "<resource>.<action>" fallback and asks for "secret.read",
+					// which no role grants and which does not exist in the registry.
+					decision := d.authzService.Decide(ctx, AuthzRequest{
+						Principal:  principalContextForIdentity(ident),
+						Credential: credentialContextForIdentity(ident),
+						Resource:   Resource{Type: "secret", ID: s.ID},
+						Action:     ActionRead,
+						Permission: permissionProjectSecretRead,
+					})
+					if !decision.Allowed && d.debug {
+						d.log.Debug("progeny secret denied by authz",
+							"agent_id", agentID, "secret", s.Name, "secret_id", s.ID,
+							"reason", decision.Reason, "scopes", len(scopes))
+					}
 					return decision.Allowed
 				},
 			}
@@ -2754,19 +2782,46 @@ func (d *HTTPAgentDispatcher) resolveSecrets(ctx context.Context, agent *store.A
 	if len(agent.Ancestry) > 1 && d.authzService != nil {
 		agentID := agent.ID
 		ancestry := agent.Ancestry
+		// The synthetic identity must carry the agent's real scopes.
+		// Agent authority is derived from JWT scopes (buildAgentSyntheticBindings),
+		// and agentScopeRestriction denies everything when the scope list is
+		// empty, so an identity built without them can never be allowed.
+		role, additionalScopes := agentRoleAndScopes(agent)
+		scopes := append(ScopesForRole(role), additionalScopes...)
+		if d.debug {
+			d.log.Debug("resolveSecrets: progeny resolution enabled",
+				"agent_id", agentID, "ancestry_len", len(ancestry),
+				"role", string(role), "scopes", len(scopes))
+		}
 		resolveOpts = &secret.ResolveOpts{
 			AgentAncestry: ancestry,
 			AuthzCheck: func(s secret.SecretMeta) bool {
-				decision := d.authzService.CheckAccess(ctx, &agentIdentityWrapper{
+				ident := &agentIdentityWrapper{
 					AgentTokenClaims: &AgentTokenClaims{
 						Claims:    jwt.Claims{Subject: agentID},
 						ProjectID: agent.ProjectID,
 						Ancestry:  ancestry,
+						Scopes:    scopes,
 					},
-				}, Resource{
-					Type: "secret",
-					ID:   s.ID,
-				}, ActionRead)
+				}
+				// Name the permission explicitly. Deriving it from
+				// (resource="secret", action="read") finds no registry entry -
+				// agent secret access is registered as project.secret_read on
+				// ResourceProject - so derivePermissionID falls through to its
+				// "<resource>.<action>" fallback and asks for "secret.read",
+				// which no role grants and which does not exist in the registry.
+				decision := d.authzService.Decide(ctx, AuthzRequest{
+					Principal:  principalContextForIdentity(ident),
+					Credential: credentialContextForIdentity(ident),
+					Resource:   Resource{Type: "secret", ID: s.ID},
+					Action:     ActionRead,
+					Permission: permissionProjectSecretRead,
+				})
+				if !decision.Allowed && d.debug {
+					d.log.Debug("progeny secret denied by authz",
+						"agent_id", agentID, "secret", s.Name, "secret_id", s.ID,
+						"reason", decision.Reason, "scopes", len(scopes))
+				}
 				return decision.Allowed
 			},
 		}


### PR DESCRIPTION
Fixes three stacked authorization defects preventing progeny agents from receiving inherited secrets: (1) missing scopes on synthetic identity, (2) wrong permission derivation via CheckAccess, (3) walkDelegationChain ignoring explicit Permission field. Ref: miller79/scion#53