### PR TITLE
fix(web): gate agent Start/Stop on a capability the Hub can actually emit

### DIFF
--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -38,6 +38,7 @@ import type {
 } from '../../shared/types.js';
 import {
   can,
+  canLifecycle,
   isTerminalAvailable,
   getAgentDisplayStatus,
   isAgentRunning,
@@ -1233,7 +1234,7 @@ export class ScionPageAgentDetail extends LitElement {
             : nothing}
           ${isAgentRunning(agent)
             ? html`
-                ${can(agent._capabilities, 'stop')
+                ${canLifecycle(agent._capabilities)
                   ? html`
                       ${agent.harnessCapabilities?.resume?.support !== 'no'
                         ? html`
@@ -1265,7 +1266,7 @@ export class ScionPageAgentDetail extends LitElement {
                   : nothing}
               `
             : agent.phase === 'suspended'
-              ? can(agent._capabilities, 'start')
+              ? canLifecycle(agent._capabilities)
                 ? html`
                     <sl-button
                       variant="success"
@@ -1279,7 +1280,7 @@ export class ScionPageAgentDetail extends LitElement {
                     </sl-button>
                   `
                 : nothing
-              : can(agent._capabilities, 'start')
+              : canLifecycle(agent._capabilities)
                 ? html`
                     <sl-button
                       variant="success"

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -32,6 +32,7 @@ import type {
 } from '../../shared/types.js';
 import {
   can,
+  canLifecycle,
   isTerminalAvailable,
   getAgentDisplayStatus,
   isAgentRunning,
@@ -1162,7 +1163,7 @@ export class ScionPageAgents extends LitElement {
           `
         : nothing}
       ${isAgentRunning(agent)
-        ? can(agent._capabilities, 'stop')
+        ? canLifecycle(agent._capabilities)
           ? html`
               ${agent.harnessCapabilities?.resume?.support !== 'no'
                 ? html`
@@ -1199,7 +1200,7 @@ export class ScionPageAgents extends LitElement {
             `
           : nothing
         : agent.phase === 'suspended'
-          ? can(agent._capabilities, 'start')
+          ? canLifecycle(agent._capabilities)
             ? html`
                 <sl-tooltip content="Resume">
                   <sl-button
@@ -1217,7 +1218,7 @@ export class ScionPageAgents extends LitElement {
                 </sl-tooltip>
               `
             : nothing
-          : can(agent._capabilities, 'start')
+          : canLifecycle(agent._capabilities)
             ? html`
                 <sl-tooltip content="Start">
                   <sl-button

--- a/web/src/components/pages/project-detail.ts
+++ b/web/src/components/pages/project-detail.ts
@@ -34,6 +34,7 @@ import type {
 import {
   can,
   canAny,
+  canLifecycle,
   getAgentDisplayStatus,
   isAgentRunning,
   isTerminalAvailable,
@@ -2255,7 +2256,7 @@ export class ScionPageProjectDetail extends LitElement {
                 `
               : nothing}
             ${isAgentRunning(agent)
-              ? can(agent._capabilities, 'stop')
+              ? canLifecycle(agent._capabilities)
                 ? html`
                     ${agent.harnessCapabilities?.resume?.support !== 'no'
                       ? html`
@@ -2290,7 +2291,7 @@ export class ScionPageProjectDetail extends LitElement {
                   `
                 : nothing
               : agent.phase === 'suspended'
-                ? can(agent._capabilities, 'start')
+                ? canLifecycle(agent._capabilities)
                   ? html`
                       <sl-tooltip content="Resume">
                         <sl-button
@@ -2307,7 +2308,7 @@ export class ScionPageProjectDetail extends LitElement {
                       </sl-tooltip>
                     `
                   : nothing
-                : can(agent._capabilities, 'start')
+                : canLifecycle(agent._capabilities)
                   ? html`
                       <sl-tooltip content="Start">
                         <sl-button
@@ -2400,7 +2401,7 @@ export class ScionPageProjectDetail extends LitElement {
               `
             : nothing}
           ${isAgentRunning(agent)
-            ? can(agent._capabilities, 'stop')
+            ? canLifecycle(agent._capabilities)
               ? html`
                   ${agent.harnessCapabilities?.resume?.support !== 'no'
                     ? html`
@@ -2435,7 +2436,7 @@ export class ScionPageProjectDetail extends LitElement {
                 `
               : nothing
             : agent.phase === 'suspended'
-              ? can(agent._capabilities, 'start')
+              ? canLifecycle(agent._capabilities)
                 ? html`
                     <sl-tooltip content="Resume">
                       <sl-button
@@ -2452,7 +2453,7 @@ export class ScionPageProjectDetail extends LitElement {
                     </sl-tooltip>
                   `
                 : nothing
-              : can(agent._capabilities, 'start')
+              : canLifecycle(agent._capabilities)
                 ? html`
                     <sl-tooltip content="Start">
                       <sl-button

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -832,6 +832,26 @@ export function can(capabilities: Capabilities | undefined, action: string): boo
 }
 
 /**
+ * Whether the viewer may run agent lifecycle actions (start, stop, suspend,
+ * resume).
+ *
+ * These are authorized server-side by `authorizeAgentLifecycle`, the same gate
+ * that governs `attach` (see handlers_projects_core.go, where AgentActionStart
+ * and AgentActionStop route through it). The permission registry defines no
+ * `agent.start` and no per-agent `agent.stop` - only the scope-level
+ * `agent.stop_all` - so `ComputeCapabilities` can never emit "start" or "stop",
+ * and gating on those names hides the controls from every user including
+ * super-admins.
+ *
+ * Gating on the capability the Hub actually enforces keeps the UI truthful. If
+ * start/stop should become separately governed, that needs registry entries
+ * plus role updates, and this helper is the single place to change.
+ */
+export function canLifecycle(capabilities: Capabilities | undefined): boolean {
+  return can(capabilities, 'attach');
+}
+
+/**
  * Check whether a capability set permits any of the given actions.
  * Returns false (fail-closed) when capabilities are undefined.
  */


### PR DESCRIPTION
Start/Stop buttons never rendered because the UI checked for capability names the backend cannot produce. Gates on attach instead, matching server-side authorizeAgentLifecycle semantics. Adds canLifecycle() helper, updates 12 call sites. Ref: miller79/scion#54