### PR TITLE
fix(hub): bypass authorization kernel for broker reads on templates and harness configs

### DIFF
--- a/pkg/hub/broker_read_bypass_test.go
+++ b/pkg/hub/broker_read_bypass_test.go
@@ -1,0 +1,193 @@
+//go:build !no_sqlite
+
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// TestBrokerCanGetTemplateByID verifies that an authenticated broker identity
+// can read a template by ID. Brokers authenticate via HMAC middleware and are
+// not user principals — the authorization kernel hard-denies them. The broker
+// read bypass allows template hydration during agent creation.
+func TestBrokerCanGetTemplateByID(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	tmpl := &store.Template{
+		ID:         tid("tmpl_broker1"),
+		Slug:       "broker-test-tmpl",
+		Name:       "Broker Test Template",
+		Scope:      "global",
+		Visibility: store.VisibilityPublic,
+		Status:     store.TemplateStatusActive,
+		Created:    time.Now(),
+		Updated:    time.Now(),
+	}
+	if err := s.CreateTemplate(ctx, tmpl); err != nil {
+		t.Fatalf("failed to create template: %v", err)
+	}
+
+	brokerIdent := NewBrokerIdentity("test-broker-tmpl")
+
+	// Build request with broker identity in context, mirroring what
+	// BrokerAuthMiddleware does for a real HMAC-authenticated request.
+	// The middleware sets both brokerIdentityContextKey and identityContextKey.
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/templates/%s", tid("tmpl_broker1")), nil)
+	reqCtx := contextWithBrokerIdentity(req.Context(), brokerIdent)
+	reqCtx = contextWithIdentity(reqCtx, brokerIdent)
+	req = req.WithContext(reqCtx)
+
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200 for broker GET template, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var result TemplateWithCapabilities
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if result.Template.Name != "Broker Test Template" {
+		t.Errorf("expected template name %q, got %q", "Broker Test Template", result.Template.Name)
+	}
+}
+
+// TestBrokerCanGetHarnessConfigByID verifies that an authenticated broker
+// identity can read a harness config by ID. Same rationale as template reads.
+func TestBrokerCanGetHarnessConfigByID(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	hc := &store.HarnessConfig{
+		ID:         tid("hc_broker1"),
+		Slug:       "broker-test-hc",
+		Name:       "Broker Test HC",
+		Harness:    "claude",
+		Scope:      "global",
+		Visibility: store.VisibilityPublic,
+		Status:     store.HarnessConfigStatusActive,
+		Created:    time.Now(),
+		Updated:    time.Now(),
+	}
+	if err := s.CreateHarnessConfig(ctx, hc); err != nil {
+		t.Fatalf("failed to create harness config: %v", err)
+	}
+
+	brokerIdent := NewBrokerIdentity("test-broker-hc")
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/harness-configs/%s", tid("hc_broker1")), nil)
+	reqCtx := contextWithBrokerIdentity(req.Context(), brokerIdent)
+	reqCtx = contextWithIdentity(reqCtx, brokerIdent)
+	req = req.WithContext(reqCtx)
+
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200 for broker GET harness config, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var result HarnessConfigWithCapabilities
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if result.HarnessConfig.Name != "Broker Test HC" {
+		t.Errorf("expected harness config name %q, got %q", "Broker Test HC", result.HarnessConfig.Name)
+	}
+}
+
+// TestNonBrokerWithoutPermissionDeniedTemplate verifies that a non-broker
+// identity without read permission is still denied access to templates.
+// This ensures the SECURITY-GATE is preserved for non-broker callers.
+func TestNonBrokerWithoutPermissionDeniedTemplate(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	tmpl := &store.Template{
+		ID:         tid("tmpl_deny1"),
+		Slug:       "deny-test-tmpl",
+		Name:       "Deny Test Template",
+		Scope:      "project",
+		ScopeID:    tid("project_deny"),
+		Visibility: store.VisibilityPrivate,
+		Status:     store.TemplateStatusActive,
+		Created:    time.Now(),
+		Updated:    time.Now(),
+	}
+	if err := s.CreateTemplate(ctx, tmpl); err != nil {
+		t.Fatalf("failed to create template: %v", err)
+	}
+
+	// Create a non-admin user identity with no role bindings — the authz
+	// kernel should deny read access.
+	noPermsUser := NewAuthenticatedUser(tid("user_noperms"), "noperms@test", "No Perms", "member", "api")
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/templates/%s", tid("tmpl_deny1")), nil)
+	reqCtx := contextWithIdentity(req.Context(), noPermsUser)
+	req = req.WithContext(reqCtx)
+
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected status 403 for non-admin user without read permission, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestNonBrokerWithoutPermissionDeniedHarnessConfig verifies the same deny
+// behavior for harness config endpoints.
+func TestNonBrokerWithoutPermissionDeniedHarnessConfig(t *testing.T) {
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	hc := &store.HarnessConfig{
+		ID:         tid("hc_deny1"),
+		Slug:       "deny-test-hc",
+		Name:       "Deny Test HC",
+		Harness:    "claude",
+		Scope:      "project",
+		ScopeID:    tid("project_deny"),
+		Visibility: store.VisibilityPrivate,
+		Status:     store.HarnessConfigStatusActive,
+		Created:    time.Now(),
+		Updated:    time.Now(),
+	}
+	if err := s.CreateHarnessConfig(ctx, hc); err != nil {
+		t.Fatalf("failed to create harness config: %v", err)
+	}
+
+	noPermsUser := NewAuthenticatedUser(tid("user_noperms"), "noperms@test", "No Perms", "member", "api")
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/harness-configs/%s", tid("hc_deny1")), nil)
+	reqCtx := contextWithIdentity(req.Context(), noPermsUser)
+	req = req.WithContext(reqCtx)
+
+	rec := httptest.NewRecorder()
+	srv.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("expected status 403 for non-admin user without read permission, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -421,7 +421,7 @@ func (s *Server) getHarnessConfig(w http.ResponseWriter, r *http.Request, id str
 	// They pass HMAC auth via middleware but are not user principals, so the
 	// authorization kernel cannot evaluate them. Allow read access for brokers;
 	// the HMAC credential is the trust basis.
-	if _, isBroker := GetIdentityFromContext(ctx).(BrokerIdentity); !isBroker {
+	if GetBrokerIdentityFromContext(ctx) == nil {
 		// SECURITY-GATE: authorize read access to this specific harness config.
 		// The list endpoint filters via AuthorizeReadBatch; without this check
 		// a caller could bypass list filtering by addressing the config by ID.

--- a/pkg/hub/harness_config_handlers.go
+++ b/pkg/hub/harness_config_handlers.go
@@ -417,11 +417,17 @@ func (s *Server) getHarnessConfig(w http.ResponseWriter, r *http.Request, id str
 		return
 	}
 
-	// SECURITY-GATE: authorize read access to this specific harness config.
-	// The list endpoint filters via AuthorizeReadBatch; without this check
-	// a caller could bypass list filtering by addressing the config by ID.
-	if !s.authorize(w, r, harnessConfigResource(hc), ActionRead) {
-		return
+	// Authenticated runtime brokers read harness configs during agent creation.
+	// They pass HMAC auth via middleware but are not user principals, so the
+	// authorization kernel cannot evaluate them. Allow read access for brokers;
+	// the HMAC credential is the trust basis.
+	if _, isBroker := GetIdentityFromContext(ctx).(BrokerIdentity); !isBroker {
+		// SECURITY-GATE: authorize read access to this specific harness config.
+		// The list endpoint filters via AuthorizeReadBatch; without this check
+		// a caller could bypass list filtering by addressing the config by ID.
+		if !s.authorize(w, r, harnessConfigResource(hc), ActionRead) {
+			return
+		}
 	}
 
 	resp := HarnessConfigWithCapabilities{HarnessConfig: *hc}

--- a/pkg/hub/permissions/registry.go
+++ b/pkg/hub/permissions/registry.go
@@ -135,16 +135,16 @@ var Registry = []Permission{
 	{ID: "skill.list", Resource: ResourceSkill, Action: ActionList, CapabilityKind: CapabilityScope, UATScope: "skill:list", Description: "List skills", Enforcement: []string{"pkg/hub/skill_handlers.go"}},
 
 	{ID: "template.create", Resource: ResourceTemplate, Action: ActionCreate, CapabilityKind: CapabilityScope, UATScope: "template:create", Description: "Create templates", Enforcement: []string{"pkg/hub/template_handlers.go"}},
-	{ID: "template.read", Resource: ResourceTemplate, Action: ActionRead, CapabilityKind: CapabilityResource, UATScope: "template:read", Description: "Read templates", Enforcement: []string{"pkg/hub/template_handlers.go"}},
+	{ID: "template.read", Resource: ResourceTemplate, Action: ActionRead, CapabilityKind: CapabilityResource, UATScope: "template:read", AgentScopes: []string{"project:read"}, Description: "Read templates", Enforcement: []string{"pkg/hub/template_handlers.go"}},
 	{ID: "template.update", Resource: ResourceTemplate, Action: ActionUpdate, CapabilityKind: CapabilityResource, UATScope: "template:update", Description: "Update templates", Enforcement: []string{"pkg/hub/template_handlers.go"}},
 	{ID: "template.delete", Resource: ResourceTemplate, Action: ActionDelete, CapabilityKind: CapabilityResource, UATScope: "template:delete", Description: "Delete templates", Enforcement: []string{"pkg/hub/template_handlers.go"}},
-	{ID: "template.list", Resource: ResourceTemplate, Action: ActionList, CapabilityKind: CapabilityScope, UATScope: "template:list", Description: "List templates", Enforcement: []string{"pkg/hub/template_handlers.go"}},
+	{ID: "template.list", Resource: ResourceTemplate, Action: ActionList, CapabilityKind: CapabilityScope, UATScope: "template:list", AgentScopes: []string{"project:read"}, Description: "List templates", Enforcement: []string{"pkg/hub/template_handlers.go"}},
 
 	{ID: "harness_config.create", Resource: ResourceHarnessConfig, Action: ActionCreate, CapabilityKind: CapabilityScope, UATScope: "harness_config:create", Description: "Create harness configs", Enforcement: []string{"pkg/hub/harness_config_handlers.go"}},
-	{ID: "harness_config.read", Resource: ResourceHarnessConfig, Action: ActionRead, CapabilityKind: CapabilityResource, UATScope: "harness_config:read", Description: "Read harness configs", Enforcement: []string{"pkg/hub/harness_config_handlers.go"}},
+	{ID: "harness_config.read", Resource: ResourceHarnessConfig, Action: ActionRead, CapabilityKind: CapabilityResource, UATScope: "harness_config:read", AgentScopes: []string{"project:read"}, Description: "Read harness configs", Enforcement: []string{"pkg/hub/harness_config_handlers.go"}},
 	{ID: "harness_config.update", Resource: ResourceHarnessConfig, Action: ActionUpdate, CapabilityKind: CapabilityResource, UATScope: "harness_config:update", Description: "Update harness configs", Enforcement: []string{"pkg/hub/harness_config_handlers.go"}},
 	{ID: "harness_config.delete", Resource: ResourceHarnessConfig, Action: ActionDelete, CapabilityKind: CapabilityResource, UATScope: "harness_config:delete", Description: "Delete harness configs", Enforcement: []string{"pkg/hub/harness_config_handlers.go"}},
-	{ID: "harness_config.list", Resource: ResourceHarnessConfig, Action: ActionList, CapabilityKind: CapabilityScope, UATScope: "harness_config:list", Description: "List harness configs", Enforcement: []string{"pkg/hub/harness_config_handlers.go"}},
+	{ID: "harness_config.list", Resource: ResourceHarnessConfig, Action: ActionList, CapabilityKind: CapabilityScope, UATScope: "harness_config:list", AgentScopes: []string{"project:read"}, Description: "List harness configs", Enforcement: []string{"pkg/hub/harness_config_handlers.go"}},
 
 	{ID: "group.create", Resource: ResourceGroup, Action: ActionCreate, CapabilityKind: CapabilityScope, UATScope: "group:create", Description: "Create groups", Enforcement: []string{"pkg/hub/handlers_groups.go"}},
 	{ID: "group.read", Resource: ResourceGroup, Action: ActionRead, CapabilityKind: CapabilityResource, UATScope: "group:read", Description: "Read groups", Enforcement: []string{"pkg/hub/handlers_groups.go"}},

--- a/pkg/hub/template_handlers.go
+++ b/pkg/hub/template_handlers.go
@@ -470,11 +470,17 @@ func (s *Server) getTemplateV2(w http.ResponseWriter, r *http.Request, id string
 		return
 	}
 
-	// SECURITY-GATE: authorize read access to this specific template.
-	// The list endpoint filters via AuthorizeReadBatch; without this check
-	// a caller could bypass list filtering by addressing the template by ID.
-	if !s.authorize(w, r, templateResource(template), ActionRead) {
-		return
+	// Authenticated runtime brokers read templates during agent creation
+	// (template hydration). They pass HMAC auth via middleware but are not
+	// user principals, so the authorization kernel cannot evaluate them.
+	// Allow read access for brokers; the HMAC credential is the trust basis.
+	if _, isBroker := GetIdentityFromContext(ctx).(BrokerIdentity); !isBroker {
+		// SECURITY-GATE: authorize read access to this specific template.
+		// The list endpoint filters via AuthorizeReadBatch; without this check
+		// a caller could bypass list filtering by addressing the template by ID.
+		if !s.authorize(w, r, templateResource(template), ActionRead) {
+			return
+		}
 	}
 
 	resp := TemplateWithCapabilities{Template: *template}

--- a/pkg/hub/template_handlers.go
+++ b/pkg/hub/template_handlers.go
@@ -474,7 +474,7 @@ func (s *Server) getTemplateV2(w http.ResponseWriter, r *http.Request, id string
 	// (template hydration). They pass HMAC auth via middleware but are not
 	// user principals, so the authorization kernel cannot evaluate them.
 	// Allow read access for brokers; the HMAC credential is the trust basis.
-	if _, isBroker := GetIdentityFromContext(ctx).(BrokerIdentity); !isBroker {
+	if GetBrokerIdentityFromContext(ctx) == nil {
 		// SECURITY-GATE: authorize read access to this specific template.
 		// The list endpoint filters via AuthorizeReadBatch; without this check
 		// a caller could bypass list filtering by addressing the template by ID.


### PR DESCRIPTION
Fix P0: broker and agent-scoped reads of templates and harness configs denied by authorization kernel after ptone/scion#1487 merged. Adds broker-identity bypass before SECURITY-GATE authorize() in getTemplateV2 and getHarnessConfig handlers. Adds AgentScopes to template and harness-config read/list permissions in the registry. Includes 4 tests.