### PR TITLE
fix(web): stop duplicate access-denied toasts from page-load fetches

### DIFF
--- a/web/src/components/pages/metrics-dashboard.ts
+++ b/web/src/components/pages/metrics-dashboard.ts
@@ -265,7 +265,13 @@ export class ScionPageMetrics extends LitElement {
       const basePath = this.projectId
         ? `/api/v1/projects/${this.projectId}/metrics`
         : `/api/v1/metrics/`;
-      const response = await apiFetch(`${basePath}?view=${view}&period=${this.periodDays}`);
+      // suppressAccessDeniedToast: a failure is surfaced in this.error and
+      // rendered by the page. Each view is a separate request and the dashboard
+      // reloads on a timer, so leaving the toast on produces a stream of
+      // duplicates rather than one actionable message.
+      const response = await apiFetch(`${basePath}?view=${view}&period=${this.periodDays}`, {
+        suppressAccessDeniedToast: true,
+      });
 
       if (!response.ok) {
         throw new Error(await extractApiError(response, `HTTP ${response.status}`));

--- a/web/src/components/pages/project-create.ts
+++ b/web/src/components/pages/project-create.ts
@@ -122,7 +122,10 @@ export class ScionPageProjectCreate extends LitElement {
 
   private async checkGitHubApp(): Promise<void> {
     try {
-      const res = await apiFetch('/api/v1/github-app');
+      // suppressAccessDeniedToast: this is a speculative probe on page load.
+      // A non-admin cannot read the GitHub App config, and the section is
+      // simply not shown — the user has nothing to act on, so a toast is noise.
+      const res = await apiFetch('/api/v1/github-app', { suppressAccessDeniedToast: true });
       if (!res.ok) return;
       const data = (await res.json()) as { configured: boolean; installation_url?: string };
       if (data.configured && data.installation_url) {

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -893,8 +893,12 @@ export class ScionPageProjectSettings extends LitElement {
     this.boundaryError = '';
 
     try {
+      // suppressAccessDeniedToast: access constraints are admin-only. A
+      // project owner without access_constraint.read gets an empty section,
+      // which is the intended degraded state — no toast needed.
       const res = await apiFetch(
-        `/api/v1/admin/access-constraints?scopeType=project&scopeId=${encodeURIComponent(this.projectId)}`
+        `/api/v1/admin/access-constraints?scopeType=project&scopeId=${encodeURIComponent(this.projectId)}`,
+        { suppressAccessDeniedToast: true }
       );
 
       const items: AccessBoundarySummary[] = res.ok
@@ -941,7 +945,9 @@ export class ScionPageProjectSettings extends LitElement {
   private async checkGitHubAppConfigured(): Promise<void> {
     this.githubAppLoading = true;
     try {
-      const res = await apiFetch('/api/v1/github-app');
+      // suppressAccessDeniedToast: hub.github_app.read is admin-only; the
+      // section is hidden for everyone else (see the catch below).
+      const res = await apiFetch('/api/v1/github-app', { suppressAccessDeniedToast: true });
       if (res.ok) {
         const data = (await res.json()) as { configured: boolean; installation_url?: string };
         this.githubAppConfigured = data.configured;

--- a/web/src/components/shared/effective-access-boundary-notice.ts
+++ b/web/src/components/shared/effective-access-boundary-notice.ts
@@ -195,7 +195,10 @@ export class ScionEffectiveAccessBoundaryNotice extends LitElement {
         url = `/api/v1/admin/effective-access?principalType=${encodeURIComponent(this.contextType)}&principalId=${encodeURIComponent(this.contextId)}`;
       }
 
-      const res = await apiFetch(url);
+      // suppressAccessDeniedToast: this notice is a non-critical enhancement
+      // that renders nothing unless it loads (see render()); a 403 must stay
+      // as quiet as the catch below already is.
+      const res = await apiFetch(url, { suppressAccessDeniedToast: true });
       if (res.ok) {
         const data = (await res.json()) as BoundaryCountResponse;
         this.boundaryCount = data.count ?? data.boundaries?.length ?? 0;

--- a/web/src/components/shared/effective-role-provenance.ts
+++ b/web/src/components/shared/effective-role-provenance.ts
@@ -456,13 +456,17 @@ export class ScionEffectiveRoleProvenance extends LitElement {
     try {
       // Fetch role bindings for this principal (direct and group-derived)
       const url = `/api/v1/admin/role-bindings?principalType=${encodeURIComponent(this.principalType)}&principalId=${encodeURIComponent(this.principalId)}&includeGroupDerived=true`;
-      const res = await apiFetch(url);
+      // suppressAccessDeniedToast: this component renders the failure inline
+      // ("Insufficient permissions" with a Retry button), so a global toast is
+      // a duplicate notification — the same RC-C rationale as the mutation
+      // probes below.
+      const res = await apiFetch(url, { suppressAccessDeniedToast: true });
 
       if (!res.ok) {
         // Fall back to fetching just the direct bindings without the
         // includeGroupDerived parameter (which may not be supported yet).
         const fallbackUrl = `/api/v1/admin/role-bindings?principalType=${encodeURIComponent(this.principalType)}&principalId=${encodeURIComponent(this.principalId)}`;
-        const fallbackRes = await apiFetch(fallbackUrl);
+        const fallbackRes = await apiFetch(fallbackUrl, { suppressAccessDeniedToast: true });
 
         if (!fallbackRes.ok) {
           throw new Error(await extractApiError(fallbackRes, `HTTP ${fallbackRes.status}`));


### PR DESCRIPTION
Adds suppressAccessDeniedToast to 7 apiFetch calls for admin-only page-load requests that already degrade gracefully on 403. Authorization is correct in every case — purely a UX fix. Ref: miller79/scion#55