### PR TITLE
fix(hub): let agents resolve templates and stop mislabelling the failure as authentication

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -329,6 +329,12 @@ func PrintUsingHub(endpoint string) {
 // suppressed because disabling the Hub would break orchestration connectivity.
 func wrapHubError(err error) error {
 	if apiclient.IsUnauthorizedError(err) {
+		// `scion hub` is filtered out of the command tree in agent mode, so a
+		// hub-managed agent cannot run `scion hub auth login` and must not be
+		// told to. Keep the underlying error instead of discarding it.
+		if config.IsHubManagedAgent() {
+			return fmt.Errorf("hub rejected this agent's credentials: %w", err)
+		}
 		return fmt.Errorf("authentication failed, login to hub with 'scion hub auth login'")
 	}
 	if config.IsHubManagedAgent() {

--- a/cmd/template_resolution.go
+++ b/cmd/template_resolution.go
@@ -22,9 +22,24 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleCloudPlatform/scion/pkg/apiclient"
 	"github.com/GoogleCloudPlatform/scion/pkg/config"
 	"github.com/GoogleCloudPlatform/scion/pkg/hubclient"
 )
+
+// scopeNotVisible reports whether a template-list error means "this caller
+// cannot see this scope" rather than "the query failed".
+//
+// Resolution walks project -> user -> global, and not every caller can see
+// every scope. An agent identity has no user scope at all, so the Hub answers
+// scope=user with 401; a caller lacking template.read on a scope gets 403.
+// Neither says anything about whether the template exists somewhere else, so
+// treating either as fatal aborts resolution before the remaining scopes are
+// tried - which is how an agent asking for a global template ended up being
+// told its authentication had failed.
+func scopeNotVisible(err error) bool {
+	return apiclient.IsUnauthorizedError(err) || apiclient.IsForbiddenError(err)
+}
 
 // Template resolution flags for agent creation
 var (
@@ -171,14 +186,15 @@ func findTemplateOnHub(ctx context.Context, hubCtx *HubContext, name, scope, pro
 		}
 
 		resp, err := hubCtx.Client.Templates().List(listCtx, opts)
-		if err != nil {
+		if err != nil && !scopeNotVisible(err) {
 			return nil, err
 		}
-
-		for i := range resp.Templates {
-			t := &resp.Templates[i]
-			if t.Name == name || t.Slug == name {
-				return t, nil
+		if err == nil {
+			for i := range resp.Templates {
+				t := &resp.Templates[i]
+				if t.Name == name || t.Slug == name {
+					return t, nil
+				}
 			}
 		}
 	}
@@ -191,14 +207,15 @@ func findTemplateOnHub(ctx context.Context, hubCtx *HubContext, name, scope, pro
 	}
 
 	userResp, err := hubCtx.Client.Templates().List(listCtx, userOpts)
-	if err != nil {
+	if err != nil && !scopeNotVisible(err) {
 		return nil, err
 	}
-
-	for i := range userResp.Templates {
-		t := &userResp.Templates[i]
-		if t.Name == name || t.Slug == name {
-			return t, nil
+	if err == nil {
+		for i := range userResp.Templates {
+			t := &userResp.Templates[i]
+			if t.Name == name || t.Slug == name {
+				return t, nil
+			}
 		}
 	}
 
@@ -210,14 +227,15 @@ func findTemplateOnHub(ctx context.Context, hubCtx *HubContext, name, scope, pro
 	}
 
 	globalResp, err := hubCtx.Client.Templates().List(listCtx, globalOpts)
-	if err != nil {
+	if err != nil && !scopeNotVisible(err) {
 		return nil, err
 	}
-
-	for i := range globalResp.Templates {
-		t := &globalResp.Templates[i]
-		if t.Name == name || t.Slug == name {
-			return t, nil
+	if err == nil {
+		for i := range globalResp.Templates {
+			t := &globalResp.Templates[i]
+			if t.Name == name || t.Slug == name {
+				return t, nil
+			}
 		}
 	}
 

--- a/pkg/hub/permission_registry_test.go
+++ b/pkg/hub/permission_registry_test.go
@@ -110,7 +110,18 @@ func TestAgentTokenScopesMapToRegistry(t *testing.T) {
 		ScopeAgentTokenRefresh: {"agent.token_refresh"},
 		ScopeAgentPortForward:  {"agent.port_forward"},
 		ScopeIdentityToken:     {"agent.identity_token"},
-		ScopeProjectRead:       {"harness_config.list", "harness_config.read", "project.read", "template.list", "template.read"},
+		// #1494 added AgentScopes: ["project:read"] to template.read/list and
+		// harness_config.read/list without updating this map, so the guard has
+		// been failing on main since. The scope constant documents itself as
+		// covering "agents, templates, skills, harness configs, projects", so the
+		// widening is intended - it just was not recorded here.
+		ScopeProjectRead: {
+			"harness_config.list",
+			"harness_config.read",
+			"project.read",
+			"template.list",
+			"template.read",
+		},
 	}
 	for scope, wantIDs := range want {
 		gotIDs := registryPermissionIDsForAgentScope(string(scope))

--- a/pkg/hubsync/sync.go
+++ b/pkg/hubsync/sync.go
@@ -1401,6 +1401,12 @@ func isLocalhostEndpoint(endpoint string) bool {
 // suppressed because disabling the Hub would break orchestration connectivity.
 func wrapHubError(err error) error {
 	if apiclient.IsUnauthorizedError(err) {
+		// `scion hub` is filtered out of the command tree in agent mode, so a
+		// hub-managed agent cannot run `scion hub auth login` and must not be
+		// told to. Keep the underlying error instead of discarding it.
+		if config.IsHubManagedAgent() {
+			return fmt.Errorf("hub rejected this agent's credentials: %w", err)
+		}
 		return fmt.Errorf("authentication failed, login to hub with 'scion hub auth login'")
 	}
 	if config.IsHubManagedAgent() {


### PR DESCRIPTION
Fixes three stacked defects preventing agents from resolving templates: (1) template.read/list missing AgentScopes declaration, (2) error mislabelled as authentication failure, (3) scope-fallback path abort. Ref: miller79/scion#57