### PR TITLE
fix(hub): let full-role agents create and update templates in their own project

### DIFF
--- a/pkg/hub/agentrole.go
+++ b/pkg/hub/agentrole.go
@@ -62,6 +62,7 @@ func ScopesForRole(role AgentRole) []AgentTokenScope {
 			ScopeAgentCreate,
 			ScopeAgentLifecycle,
 			ScopeProjectSecretRead,
+			ScopeProjectTemplateWrite,
 		}
 	case "":
 		return ScopesForRole(AgentRoleNone)

--- a/pkg/hub/agentrole_test.go
+++ b/pkg/hub/agentrole_test.go
@@ -47,11 +47,12 @@ func TestScopesForRole_Baseline(t *testing.T) {
 	assert.NotContains(t, scopes, ScopeAgentCreate)
 	assert.NotContains(t, scopes, ScopeAgentLifecycle)
 	assert.NotContains(t, scopes, ScopeProjectSecretRead)
+	assert.NotContains(t, scopes, ScopeProjectTemplateWrite)
 }
 
 func TestScopesForRole_Full(t *testing.T) {
 	scopes := ScopesForRole(AgentRoleFull)
-	require.Len(t, scopes, 8)
+	require.Len(t, scopes, 9)
 
 	// Must include everything in baseline
 	assert.Contains(t, scopes, ScopeProjectRead)
@@ -64,6 +65,7 @@ func TestScopesForRole_Full(t *testing.T) {
 	assert.Contains(t, scopes, ScopeAgentCreate)
 	assert.Contains(t, scopes, ScopeAgentLifecycle)
 	assert.Contains(t, scopes, ScopeProjectSecretRead)
+	assert.Contains(t, scopes, ScopeProjectTemplateWrite)
 }
 
 func TestScopesForRole_InvalidDefault(t *testing.T) {

--- a/pkg/hub/agenttoken.go
+++ b/pkg/hub/agenttoken.go
@@ -67,6 +67,15 @@ const (
 	// ScopeProjectRead grants read access to project resources (agents, templates,
 	// skills, harness configs, projects). Enforced by checkAgentReadScope().
 	ScopeProjectRead AgentTokenScope = "project:read"
+	// ScopeProjectTemplateWrite allows the agent to create and update templates
+	// within its own project. Deliberately excludes deletion: publishing a
+	// template is recoverable, removing one another agent depends on is not.
+	//
+	// Granted only to agent-role-full, whose holders can already create agents.
+	// An agent that can spawn progeny can already determine what those agents
+	// do; being able to publish the template it spawns them from is the same
+	// authority expressed once instead of per-agent.
+	ScopeProjectTemplateWrite AgentTokenScope = "project:template:write"
 	// ScopeGCPTokenPrefix is the prefix for GCP token scopes.
 	// Full scope format: "project:gcp:token:<sa-id>"
 	ScopeGCPTokenPrefix = "project:gcp:token:"

--- a/pkg/hub/permission_registry_test.go
+++ b/pkg/hub/permission_registry_test.go
@@ -122,6 +122,9 @@ func TestAgentTokenScopesMapToRegistry(t *testing.T) {
 			"template.list",
 			"template.read",
 		},
+		// Write access to templates within the agent's own project.
+		// Deliberately excludes template.delete - see the scope declaration.
+		ScopeProjectTemplateWrite: {"template.create", "template.update"},
 	}
 	for scope, wantIDs := range want {
 		gotIDs := registryPermissionIDsForAgentScope(string(scope))

--- a/pkg/hub/permissions/registry.go
+++ b/pkg/hub/permissions/registry.go
@@ -134,9 +134,9 @@ var Registry = []Permission{
 	{ID: "skill.delete", Resource: ResourceSkill, Action: ActionDelete, CapabilityKind: CapabilityResource, UATScope: "skill:delete", Description: "Delete skills", Enforcement: []string{"pkg/hub/skill_handlers.go"}},
 	{ID: "skill.list", Resource: ResourceSkill, Action: ActionList, CapabilityKind: CapabilityScope, UATScope: "skill:list", Description: "List skills", Enforcement: []string{"pkg/hub/skill_handlers.go"}},
 
-	{ID: "template.create", Resource: ResourceTemplate, Action: ActionCreate, CapabilityKind: CapabilityScope, UATScope: "template:create", Description: "Create templates", Enforcement: []string{"pkg/hub/template_handlers.go"}},
+	{ID: "template.create", Resource: ResourceTemplate, Action: ActionCreate, CapabilityKind: CapabilityScope, UATScope: "template:create", AgentScopes: []string{"project:template:write"}, Description: "Create templates", Enforcement: []string{"pkg/hub/template_handlers.go"}},
 	{ID: "template.read", Resource: ResourceTemplate, Action: ActionRead, CapabilityKind: CapabilityResource, UATScope: "template:read", AgentScopes: []string{"project:read"}, Description: "Read templates", Enforcement: []string{"pkg/hub/template_handlers.go"}},
-	{ID: "template.update", Resource: ResourceTemplate, Action: ActionUpdate, CapabilityKind: CapabilityResource, UATScope: "template:update", Description: "Update templates", Enforcement: []string{"pkg/hub/template_handlers.go"}},
+	{ID: "template.update", Resource: ResourceTemplate, Action: ActionUpdate, CapabilityKind: CapabilityResource, UATScope: "template:update", AgentScopes: []string{"project:template:write"}, Description: "Update templates", Enforcement: []string{"pkg/hub/template_handlers.go"}},
 	{ID: "template.delete", Resource: ResourceTemplate, Action: ActionDelete, CapabilityKind: CapabilityResource, UATScope: "template:delete", Description: "Delete templates", Enforcement: []string{"pkg/hub/template_handlers.go"}},
 	{ID: "template.list", Resource: ResourceTemplate, Action: ActionList, CapabilityKind: CapabilityScope, UATScope: "template:list", AgentScopes: []string{"project:read"}, Description: "List templates", Enforcement: []string{"pkg/hub/template_handlers.go"}},
 


### PR DESCRIPTION
Adds project:template:write scope for template.create and template.update, granted only to agent-role-full. Deliberately excludes deletion. Depends on fix-agent-template-resolution. Ref: miller79/scion#62