### PR TITLE
fix: add ensureSuperAdminBinding to WebServer login paths

### DIFF
--- a/pkg/hub/authzop/catalog.go
+++ b/pkg/hub/authzop/catalog.go
@@ -2676,9 +2676,9 @@ var MutationClassifications = []MutationClassification{
 	// -----------------------------------------------------------------------
 	{File: "pkg/hub/handlers_auth.go", Function: "provisionUser", Symbol: "CreateUser", Exemption: &MutationExemption{Kind: ExemptionAuthenticationOnly, Reason: "User provisioning during auth login flow, pre-authorization", Scope: "pkg/hub/handlers_auth.go"}},
 	{File: "pkg/hub/handlers_auth.go", Function: "provisionUser", Symbol: "UpdateUser", Exemption: &MutationExemption{Kind: ExemptionAuthenticationOnly, Reason: "User record update during auth login flow", Scope: "pkg/hub/handlers_auth.go"}},
-	{File: "pkg/hub/handlers_auth.go", Function: "ensureSuperAdminBinding", Symbol: "CreateRoleBinding", Exemption: &MutationExemption{Kind: ExemptionAuthenticationOnly, Reason: "Idempotent super-admin binding during authorized user provisioning", Scope: "pkg/hub/handlers_auth.go"}},
+	{File: "pkg/hub/handlers_auth.go", Function: "ensureSuperAdminRoleBinding", Symbol: "CreateRoleBinding", Exemption: &MutationExemption{Kind: ExemptionAuthenticationOnly, Reason: "Idempotent super-admin binding during authorized user provisioning", Scope: "pkg/hub/handlers_auth.go"}},
 	{File: "pkg/hub/handlers_auth.go", Function: "handleAuthRefresh", Symbol: "UpdateUser", Exemption: &MutationExemption{Kind: ExemptionAuthenticationOnly, Reason: "User last-login update during token refresh", Scope: "pkg/hub/handlers_auth.go"}},
-	{File: "pkg/hub/handlers_auth.go", Function: "deleteSuperAdminBinding", Symbol: "DeleteRoleBinding", Exemption: &MutationExemption{Kind: ExemptionHubAdmin, Reason: "Super-admin self-demotion, hub-admin operation", Scope: "pkg/hub/handlers_auth.go"}},
+	{File: "pkg/hub/handlers_auth.go", Function: "deleteSuperAdminRoleBinding", Symbol: "DeleteRoleBinding", Exemption: &MutationExemption{Kind: ExemptionHubAdmin, Reason: "Super-admin self-demotion, hub-admin operation", Scope: "pkg/hub/handlers_auth.go"}},
 
 	// -----------------------------------------------------------------------
 	// pkg/hub/web.go — OAuth/session middleware

--- a/pkg/hub/handlers_auth.go
+++ b/pkg/hub/handlers_auth.go
@@ -1783,13 +1783,32 @@ func (s *Server) handleAuthScopes(w http.ResponseWriter, r *http.Request) {
 // IsUnscopedLocalPlatformAdmin. Best-effort: errors are logged but do not fail
 // the login — the next startup reconciliation will clean up.
 func (s *Server) deleteSuperAdminBinding(ctx context.Context, userID string) {
-	rd, err := s.store.GetRoleDefinitionByName(ctx, store.SystemRoleSuperAdmin, store.RoleScopeSystem)
+	deleteSuperAdminRoleBinding(ctx, s.store, userID)
+}
+
+// ensureSuperAdminBinding idempotently creates a system-scoped super-admin
+// RoleBinding for the given user. This closes the cold-start gap where
+// provisionUser assigns Role="admin" but ReconcileSuperAdminBindings has
+// already run against an empty user store and will not run again until the
+// next restart. Without this, AuthzService.IsSystemAdmin returns false for
+// the first admin until the hub is restarted.
+func (s *Server) ensureSuperAdminBinding(ctx context.Context, userID string) {
+	ensureSuperAdminRoleBinding(ctx, s.store, userID)
+}
+
+// deleteSuperAdminRoleBinding removes the system-scoped super-admin role binding
+// for a user, if one exists. This is a package-level function so it can be
+// called from both Server (API auth) and WebServer (browser auth) login paths.
+// Best-effort: errors are logged but do not fail the login — the next startup
+// reconciliation will clean up.
+func deleteSuperAdminRoleBinding(ctx context.Context, st store.Store, userID string) {
+	rd, err := st.GetRoleDefinitionByName(ctx, store.SystemRoleSuperAdmin, store.RoleScopeSystem)
 	if err != nil {
 		slog.Warn("deleteSuperAdminBinding: super-admin role definition not found", "user_id", userID, "error", err)
 		return
 	}
 
-	bindings, err := s.store.ListRoleBindingsForPrincipal(ctx, store.RoleBindingPrincipalUser, userID)
+	bindings, err := st.ListRoleBindingsForPrincipal(ctx, store.RoleBindingPrincipalUser, userID)
 	if err != nil {
 		slog.Warn("deleteSuperAdminBinding: failed to list bindings", "user_id", userID, "error", err)
 		return
@@ -1797,7 +1816,7 @@ func (s *Server) deleteSuperAdminBinding(ctx context.Context, userID string) {
 
 	for _, b := range bindings {
 		if b.ScopeType == store.RoleScopeSystem && b.RoleDefinitionID == rd.ID {
-			if err := s.store.DeleteRoleBinding(ctx, b.ID); err != nil {
+			if err := st.DeleteRoleBinding(ctx, b.ID); err != nil {
 				slog.Warn("deleteSuperAdminBinding: failed to delete binding",
 					"user_id", userID, "binding_id", b.ID, "error", err)
 			} else {
@@ -1808,14 +1827,14 @@ func (s *Server) deleteSuperAdminBinding(ctx context.Context, userID string) {
 	}
 }
 
-// ensureSuperAdminBinding idempotently creates a system-scoped super-admin
-// RoleBinding for the given user. This closes the cold-start gap where
-// provisionUser assigns Role="admin" but ReconcileSuperAdminBindings has
-// already run against an empty user store and will not run again until the
-// next restart. Without this, AuthzService.IsSystemAdmin returns false for
-// the first admin until the hub is restarted.
-func (s *Server) ensureSuperAdminBinding(ctx context.Context, userID string) {
-	rd, err := s.store.GetRoleDefinitionByName(ctx, store.SystemRoleSuperAdmin, store.RoleScopeSystem)
+// ensureSuperAdminRoleBinding idempotently creates a system-scoped super-admin
+// RoleBinding for the given user. This is a package-level function so it can be
+// called from both Server (API auth) and WebServer (browser auth) login paths.
+// It closes the cold-start gap where user provisioning assigns Role="admin" but
+// ReconcileSuperAdminBindings has already run against an empty user store and
+// will not run again until the next restart.
+func ensureSuperAdminRoleBinding(ctx context.Context, st store.Store, userID string) {
+	rd, err := st.GetRoleDefinitionByName(ctx, store.SystemRoleSuperAdmin, store.RoleScopeSystem)
 	if err != nil {
 		slog.Warn("ensureSuperAdminBinding: super-admin role definition not found — "+
 			"binding will be created on next restart by ReconcileSuperAdminBindings",
@@ -1829,7 +1848,7 @@ func (s *Server) ensureSuperAdminBinding(ctx context.Context, userID string) {
 		return
 	}
 
-	_, err = s.store.CreateRoleBinding(ctx, &store.RoleBinding{
+	_, err = st.CreateRoleBinding(ctx, &store.RoleBinding{
 		RoleDefinitionID: rd.ID,
 		PrincipalType:    store.RoleBindingPrincipalUser,
 		PrincipalID:      userID,

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -1752,20 +1752,39 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 			// the binding state diverged from User.Role.
 			var bindingSuperAdmin string // "", "ensure", or "delete"
 
-			// Update last login and backfill profile
-			user.LastLogin = time.Now()
-			if proxyUser.DisplayName != "" && user.DisplayName == "" {
-				user.DisplayName = proxyUser.DisplayName
-			}
-			// Re-evaluate admin status on every login (matches handleOAuthCallback / provisionUser)
-			if newRole := determineUserRole(proxyUser.Email, ws.adminEmails(), user.Role, ws.isDemotionSafe()); user.Role != newRole {
+			if user.Status == store.UserStatusInvited {
+				// Transition invited → active on first login
+				// (mirrors handleOAuthCallback's invited→active block)
+				ws.logger().Info("user activated from invited state via proxy auth", "email", proxyUser.Email, "user_id", user.ID)
+				user.Status = store.UserStatusActive
+				if proxyUser.DisplayName != "" {
+					user.DisplayName = proxyUser.DisplayName
+				}
+				user.LastLogin = time.Now()
 				oldRole := user.Role
-				ws.logger().Info("User role changed on proxy login", "email", proxyUser.Email, "old_role", oldRole, "new_role", newRole)
-				user.Role = newRole
-				if oldRole == "admin" {
+				user.Role = determineUserRole(proxyUser.Email, ws.adminEmails(), user.Role, ws.isDemotionSafe())
+				if oldRole == "admin" && user.Role != "admin" {
 					bindingSuperAdmin = "delete"
-				} else if newRole == "admin" {
+				} else if user.Role == "admin" {
 					bindingSuperAdmin = "ensure"
+				}
+				ws.logger().Info("invite audit: user_activated", "email", proxyUser.Email, "user_id", user.ID)
+			} else {
+				// Update last login and backfill profile
+				user.LastLogin = time.Now()
+				if proxyUser.DisplayName != "" && user.DisplayName == "" {
+					user.DisplayName = proxyUser.DisplayName
+				}
+				// Re-evaluate admin status on every login (matches handleOAuthCallback / provisionUser)
+				if newRole := determineUserRole(proxyUser.Email, ws.adminEmails(), user.Role, ws.isDemotionSafe()); user.Role != newRole {
+					oldRole := user.Role
+					ws.logger().Info("User role changed on proxy login", "email", proxyUser.Email, "old_role", oldRole, "new_role", newRole)
+					user.Role = newRole
+					if oldRole == "admin" {
+						bindingSuperAdmin = "delete"
+					} else if newRole == "admin" {
+						bindingSuperAdmin = "ensure"
+					}
 				}
 			}
 			if err := ws.store.UpdateUser(ctx, user); err != nil {
@@ -2079,7 +2098,7 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 			user.Role = determineUserRole(userInfo.Email, ws.adminEmails(), user.Role, ws.isDemotionSafe())
 			if oldRole == "admin" && user.Role != "admin" {
 				bindingSuperAdmin = "delete"
-			} else if user.Role == "admin" && oldRole != "admin" {
+			} else if user.Role == "admin" {
 				bindingSuperAdmin = "ensure"
 			}
 			// Log the activation via slog (WebServer does not have a structured

--- a/pkg/hub/web.go
+++ b/pkg/hub/web.go
@@ -1732,6 +1732,12 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 				return
 			}
 			ws.logger().Info("Proxy auth: created new user", "email", proxyUser.Email, "user_id", user.ID)
+			// Cold-start fix: when a new user is provisioned as admin,
+			// immediately create the system-scoped super-admin RoleBinding
+			// (mirrors provisionUser in handlers_auth.go).
+			if user.Role == "admin" {
+				ensureSuperAdminRoleBinding(ctx, ws.store, user.ID)
+			}
 		} else {
 			// Reject suspended users
 			if user.Status == "suspended" {
@@ -1739,6 +1745,13 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 				ws.serveSuspendedResponse(w, r, proxyUser.Email)
 				return
 			}
+
+			// Track whether we need to create or delete a super-admin
+			// RoleBinding. The actual mutation is deferred until after
+			// UpdateUser succeeds so that a failed UpdateUser cannot leave
+			// the binding state diverged from User.Role.
+			var bindingSuperAdmin string // "", "ensure", or "delete"
+
 			// Update last login and backfill profile
 			user.LastLogin = time.Now()
 			if proxyUser.DisplayName != "" && user.DisplayName == "" {
@@ -1746,11 +1759,25 @@ func (ws *WebServer) proxyAuthMiddleware(next http.Handler) http.Handler {
 			}
 			// Re-evaluate admin status on every login (matches handleOAuthCallback / provisionUser)
 			if newRole := determineUserRole(proxyUser.Email, ws.adminEmails(), user.Role, ws.isDemotionSafe()); user.Role != newRole {
-				ws.logger().Info("User role changed on proxy login", "email", proxyUser.Email, "old_role", user.Role, "new_role", newRole)
+				oldRole := user.Role
+				ws.logger().Info("User role changed on proxy login", "email", proxyUser.Email, "old_role", oldRole, "new_role", newRole)
 				user.Role = newRole
+				if oldRole == "admin" {
+					bindingSuperAdmin = "delete"
+				} else if newRole == "admin" {
+					bindingSuperAdmin = "ensure"
+				}
 			}
 			if err := ws.store.UpdateUser(ctx, user); err != nil {
 				ws.logger().Warn("Failed to update user via proxy auth", "email", proxyUser.Email, "error", err)
+			} else {
+				// Apply binding changes only after UpdateUser has succeeded.
+				switch bindingSuperAdmin {
+				case "ensure":
+					ensureSuperAdminRoleBinding(ctx, ws.store, user.ID)
+				case "delete":
+					deleteSuperAdminRoleBinding(ctx, ws.store, user.ID)
+				}
 			}
 		}
 
@@ -2015,6 +2042,12 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 			http.Redirect(w, r, "/login?error=user_create_failed", http.StatusFound)
 			return
 		}
+		// Cold-start fix: when a new user is provisioned as admin,
+		// immediately create the system-scoped super-admin RoleBinding
+		// (mirrors provisionUser in handlers_auth.go).
+		if user.Role == "admin" {
+			ensureSuperAdminRoleBinding(ctx, ws.store, user.ID)
+		}
 	} else {
 		// Reject suspended users
 		if user.Status == store.UserStatusSuspended {
@@ -2022,6 +2055,12 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 			http.Redirect(w, r, "/login?error=suspended", http.StatusFound)
 			return
 		}
+
+		// Track whether we need to create or delete a super-admin
+		// RoleBinding. The actual mutation is deferred until after
+		// UpdateUser succeeds so that a failed UpdateUser cannot leave
+		// the binding state diverged from User.Role.
+		var bindingSuperAdmin string // "", "ensure", or "delete"
 
 		if user.Status == store.UserStatusInvited {
 			// Transition invited → active on first login
@@ -2036,7 +2075,13 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 				user.AvatarURL = userInfo.AvatarURL
 			}
 			user.LastLogin = time.Now()
+			oldRole := user.Role
 			user.Role = determineUserRole(userInfo.Email, ws.adminEmails(), user.Role, ws.isDemotionSafe())
+			if oldRole == "admin" && user.Role != "admin" {
+				bindingSuperAdmin = "delete"
+			} else if user.Role == "admin" && oldRole != "admin" {
+				bindingSuperAdmin = "ensure"
+			}
 			// Log the activation via slog (WebServer does not have a structured
 			// audit logger; the hub.Server audit path covers API/CLI auth).
 			ws.logger().Info("invite audit: user_activated", "email", userInfo.Email, "user_id", user.ID)
@@ -2052,12 +2097,26 @@ func (ws *WebServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request)
 			// Re-evaluate admin status on every login
 			newRole := determineUserRole(userInfo.Email, ws.adminEmails(), user.Role, ws.isDemotionSafe())
 			if user.Role != newRole {
-				ws.logger().Info("User role changed on login", "email", userInfo.Email, "old_role", user.Role, "new_role", newRole)
+				oldRole := user.Role
+				ws.logger().Info("User role changed on login", "email", userInfo.Email, "old_role", oldRole, "new_role", newRole)
 				user.Role = newRole
+				if oldRole == "admin" {
+					bindingSuperAdmin = "delete"
+				} else if newRole == "admin" {
+					bindingSuperAdmin = "ensure"
+				}
 			}
 		}
 		if err := ws.store.UpdateUser(ctx, user); err != nil {
 			ws.logger().Warn("Failed to update user on login", "email", userInfo.Email, "error", err)
+		} else {
+			// Apply binding changes only after UpdateUser has succeeded.
+			switch bindingSuperAdmin {
+			case "ensure":
+				ensureSuperAdminRoleBinding(ctx, ws.store, user.ID)
+			case "delete":
+				deleteSuperAdminRoleBinding(ctx, ws.store, user.ID)
+			}
 		}
 	}
 

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -54,11 +54,31 @@ func (m *mockProxyAuthenticator) Name() string { return "mock" }
 // proxyAuthStore is a minimal store that supports the proxy auth user provisioning path.
 type proxyAuthStore struct {
 	store.Store // embed interface to satisfy all methods
-	users       map[string]*store.User
+	users          map[string]*store.User
+	roleBindings   map[string]*store.RoleBinding
+	roleDefinitions map[string]*store.RoleDefinition
 }
 
 func newProxyAuthStore() *proxyAuthStore {
-	return &proxyAuthStore{users: make(map[string]*store.User)}
+	return &proxyAuthStore{
+		users:          make(map[string]*store.User),
+		roleBindings:   make(map[string]*store.RoleBinding),
+		roleDefinitions: make(map[string]*store.RoleDefinition),
+	}
+}
+
+// newProxyAuthStoreWithRoles returns a proxyAuthStore pre-seeded with the
+// super-admin role definition so that ensureSuperAdminRoleBinding /
+// deleteSuperAdminRoleBinding can create and remove bindings.
+func newProxyAuthStoreWithRoles() *proxyAuthStore {
+	s := newProxyAuthStore()
+	s.roleDefinitions["rd-super-admin"] = &store.RoleDefinition{
+		ID:        "rd-super-admin",
+		Name:      store.SystemRoleSuperAdmin,
+		ScopeType: store.RoleScopeSystem,
+		System:    true,
+	}
+	return s
 }
 
 func (s *proxyAuthStore) GetUserByEmail(_ context.Context, email string) (*store.User, error) {
@@ -93,6 +113,66 @@ func (s *proxyAuthStore) GetUser(_ context.Context, id string) (*store.User, err
 		return u, nil
 	}
 	return nil, store.ErrNotFound
+}
+
+func (s *proxyAuthStore) GetRoleDefinitionByName(_ context.Context, name string, scopeType string) (*store.RoleDefinition, error) {
+	for _, rd := range s.roleDefinitions {
+		if rd.Name == name && rd.ScopeType == scopeType {
+			return rd, nil
+		}
+	}
+	return nil, store.ErrNotFound
+}
+
+func (s *proxyAuthStore) CreateRoleBinding(_ context.Context, rb *store.RoleBinding) (*store.RoleBinding, error) {
+	// Check for duplicate (same role definition + principal + scope)
+	for _, existing := range s.roleBindings {
+		if existing.RoleDefinitionID == rb.RoleDefinitionID &&
+			existing.PrincipalType == rb.PrincipalType &&
+			existing.PrincipalID == rb.PrincipalID &&
+			existing.ScopeType == rb.ScopeType &&
+			existing.ScopeID == rb.ScopeID {
+			return nil, store.ErrAlreadyExists
+		}
+	}
+	id := generateID()
+	rb.ID = id
+	s.roleBindings[id] = rb
+	return rb, nil
+}
+
+func (s *proxyAuthStore) ListRoleBindingsForPrincipal(_ context.Context, principalType, principalID string) ([]*store.RoleBinding, error) {
+	var result []*store.RoleBinding
+	for _, rb := range s.roleBindings {
+		if rb.PrincipalType == principalType && rb.PrincipalID == principalID {
+			result = append(result, rb)
+		}
+	}
+	return result, nil
+}
+
+func (s *proxyAuthStore) DeleteRoleBinding(_ context.Context, id string) error {
+	if _, ok := s.roleBindings[id]; !ok {
+		return store.ErrNotFound
+	}
+	delete(s.roleBindings, id)
+	return nil
+}
+
+// hasSuperAdminBinding returns true if the store contains a system-scoped
+// super-admin role binding for the given user.
+func (s *proxyAuthStore) hasSuperAdminBinding(userID string) bool {
+	for _, rb := range s.roleBindings {
+		if rb.PrincipalType == store.RoleBindingPrincipalUser &&
+			rb.PrincipalID == userID &&
+			rb.ScopeType == store.RoleScopeSystem {
+			// Check if this binding references the super-admin role definition
+			if rd, ok := s.roleDefinitions[rb.RoleDefinitionID]; ok && rd.Name == store.SystemRoleSuperAdmin {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // staticAccessSettings is a test implementation of AccessSettingsProvider
@@ -3396,6 +3476,384 @@ func TestProxyAuthMiddleware_ExistingSession_NoUpdateWhenRoleUnchanged(t *testin
 		}
 	}
 	assert.False(t, sessionReSet, "session cookie should NOT be re-set when role is unchanged")
+}
+
+// ---------------------------------------------------------------------------
+// Super-admin RoleBinding management in WebServer login paths
+// ---------------------------------------------------------------------------
+
+func TestProxyAuthMiddleware_NewAdminUser_GetsSuperAdminBinding(t *testing.T) {
+	// When a new user is provisioned as admin via proxy auth, a system-scoped
+	// super-admin RoleBinding must be created (cold-start fix).
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject:     "sa-1",
+			Email:       "admin@example.com",
+			DisplayName: "Admin User",
+			Domain:      "example.com",
+		},
+	}
+
+	st := newProxyAuthStoreWithRoles()
+
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+	})
+	ws.SetAccessSettingsProvider(&staticAccessSettings{
+		adminEmails: []string{"admin@example.com"},
+	})
+	ws.SetStore(st)
+
+	req := httptest.NewRequest("GET", "/projects", nil)
+	req.Header.Set("Accept", "text/html")
+	rec := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(rec, req)
+
+	// Verify user was created as admin
+	user, err := st.GetUserByEmail(context.Background(), "admin@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "admin", user.Role)
+
+	// Verify super-admin binding was created
+	assert.True(t, st.hasSuperAdminBinding(user.ID),
+		"new admin user provisioned via proxy auth must get a super-admin RoleBinding")
+}
+
+func TestProxyAuthMiddleware_NewMemberUser_NoSuperAdminBinding(t *testing.T) {
+	// A non-admin user provisioned via proxy auth must NOT get a super-admin binding.
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject: "sa-2",
+			Email:   "member@example.com",
+			Domain:  "example.com",
+		},
+	}
+
+	st := newProxyAuthStoreWithRoles()
+
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+	})
+	ws.SetAccessSettingsProvider(&staticAccessSettings{
+		adminEmails: []string{"other-admin@example.com"},
+	})
+	ws.SetStore(st)
+
+	req := httptest.NewRequest("GET", "/projects", nil)
+	req.Header.Set("Accept", "text/html")
+	rec := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(rec, req)
+
+	user, err := st.GetUserByEmail(context.Background(), "member@example.com")
+	require.NoError(t, err)
+	assert.NotEqual(t, "admin", user.Role)
+	assert.False(t, st.hasSuperAdminBinding(user.ID),
+		"non-admin user must NOT get a super-admin RoleBinding")
+}
+
+func TestProxyAuthMiddleware_Promotion_CreatesSuperAdminBinding(t *testing.T) {
+	// An existing member promoted to admin on proxy login must get a super-admin binding.
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject: "sa-3",
+			Email:   "promoted@example.com",
+			Domain:  "example.com",
+		},
+	}
+
+	st := newProxyAuthStoreWithRoles()
+	_ = st.CreateUser(context.Background(), &store.User{
+		ID:      "u-promote",
+		Email:   "promoted@example.com",
+		Role:    "member",
+		Status:  "active",
+		Created: time.Now(),
+	})
+
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+	})
+	ws.SetAccessSettingsProvider(&staticAccessSettings{
+		adminEmails: []string{"promoted@example.com"},
+	})
+	ws.SetStore(st)
+
+	req := httptest.NewRequest("GET", "/projects", nil)
+	req.Header.Set("Accept", "text/html")
+	rec := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(rec, req)
+
+	user, err := st.GetUserByEmail(context.Background(), "promoted@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "admin", user.Role)
+	assert.True(t, st.hasSuperAdminBinding(user.ID),
+		"member promoted to admin via proxy auth must get a super-admin RoleBinding")
+}
+
+func TestProxyAuthMiddleware_Demotion_DeletesSuperAdminBinding(t *testing.T) {
+	// An existing admin demoted on proxy login must have the super-admin binding removed.
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject: "sa-4",
+			Email:   "demoted@example.com",
+			Domain:  "example.com",
+		},
+	}
+
+	st := newProxyAuthStoreWithRoles()
+	_ = st.CreateUser(context.Background(), &store.User{
+		ID:      "u-demote",
+		Email:   "demoted@example.com",
+		Role:    "admin",
+		Status:  "active",
+		Created: time.Now(),
+	})
+	// Pre-create the super-admin binding
+	_, _ = st.CreateRoleBinding(context.Background(), &store.RoleBinding{
+		RoleDefinitionID: "rd-super-admin",
+		PrincipalType:    store.RoleBindingPrincipalUser,
+		PrincipalID:      "u-demote",
+		ScopeType:        store.RoleScopeSystem,
+		ScopeID:          "",
+		CreatedBy:        store.SystemReconcileCreatedBy,
+	})
+	require.True(t, st.hasSuperAdminBinding("u-demote"), "precondition: binding must exist")
+
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+	})
+	// AdminEmails does NOT include demoted@example.com
+	ws.SetAccessSettingsProvider(&staticAccessSettings{
+		adminEmails: []string{"other@example.com"},
+	})
+	ws.SetStore(st)
+	var safe atomic.Bool
+	safe.Store(true)
+	ws.SetDemotionSafe(&safe)
+
+	req := httptest.NewRequest("GET", "/projects", nil)
+	req.Header.Set("Accept", "text/html")
+	rec := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(rec, req)
+
+	user, err := st.GetUserByEmail(context.Background(), "demoted@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "member", user.Role)
+	assert.False(t, st.hasSuperAdminBinding("u-demote"),
+		"admin demoted via proxy auth must have super-admin RoleBinding removed")
+}
+
+func TestOAuthCallback_NewAdminUser_GetsSuperAdminBinding(t *testing.T) {
+	// When a new user is provisioned as admin via OAuth callback, a
+	// super-admin RoleBinding must be created.
+	const secret = "test-session-secret-for-binding-test-1234567890"
+	adminEmail := "oauth-admin@example.com"
+
+	ws := newTestWebServer(t, WebServerConfig{
+		SessionSecret: secret,
+		BaseURL:       "http://localhost:8080",
+	})
+
+	ws.oauthService = NewOAuthService(OAuthConfig{
+		Web: OAuthClientConfig{
+			Google: OAuthProviderConfig{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+			},
+		},
+	}, nil)
+	ws.oauthService.httpClient = &http.Client{
+		Transport: &mockOAuthTransport{
+			tokenJSON:    `{"access_token":"mock-token","token_type":"Bearer","expires_in":3600}`,
+			userinfoJSON: `{"id":"new-admin-id","email":"` + adminEmail + `","verified_email":true,"name":"OAuth Admin"}`,
+		},
+	}
+
+	st := newProxyAuthStoreWithRoles()
+	ws.store = st
+	ws.SetAccessSettingsProvider(&staticAccessSettings{
+		adminEmails: []string{adminEmail},
+	})
+
+	// Pre-seed session with valid OAuth state
+	reqSetup := httptest.NewRequest(http.MethodGet, "/auth/login/google", nil)
+	recSetup := httptest.NewRecorder()
+	sess, err := ws.sessionStore.Get(reqSetup, webSessionName)
+	require.NoError(t, err)
+	oauthState := "test-state-binding"
+	sess.Values[sessKeyOAuthState] = oauthState
+	require.NoError(t, sess.Save(reqSetup, recSetup))
+	cookies := recSetup.Result().Cookies()
+	require.NotEmpty(t, cookies)
+
+	// Make the OAuth callback request
+	callbackURL := "/auth/callback/google?code=test-code&state=" + oauthState
+	reqCallback := httptest.NewRequest(http.MethodGet, callbackURL, nil)
+	for _, c := range cookies {
+		reqCallback.AddCookie(c)
+	}
+	recCallback := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(recCallback, reqCallback)
+
+	resp := recCallback.Result()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+	assert.Equal(t, "/", resp.Header.Get("Location"),
+		"OAuth callback must redirect to '/' on success")
+
+	// Verify user was created as admin with a super-admin binding
+	user, err := st.GetUserByEmail(context.Background(), adminEmail)
+	require.NoError(t, err)
+	assert.Equal(t, "admin", user.Role)
+	assert.True(t, st.hasSuperAdminBinding(user.ID),
+		"new admin user provisioned via OAuth must get a super-admin RoleBinding")
+}
+
+func TestOAuthCallback_ExistingUser_Promotion_CreatesSuperAdminBinding(t *testing.T) {
+	// An existing member promoted to admin during OAuth login must get a binding.
+	const secret = "test-session-secret-for-promotion-test-123456789"
+	memberEmail := "promoted-via-oauth@example.com"
+
+	ws := newTestWebServer(t, WebServerConfig{
+		SessionSecret: secret,
+		BaseURL:       "http://localhost:8080",
+	})
+
+	ws.oauthService = NewOAuthService(OAuthConfig{
+		Web: OAuthClientConfig{
+			Google: OAuthProviderConfig{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+			},
+		},
+	}, nil)
+	ws.oauthService.httpClient = &http.Client{
+		Transport: &mockOAuthTransport{
+			tokenJSON:    `{"access_token":"mock-token","token_type":"Bearer","expires_in":3600}`,
+			userinfoJSON: `{"id":"promo-id","email":"` + memberEmail + `","verified_email":true,"name":"Promoted User"}`,
+		},
+	}
+
+	st := newProxyAuthStoreWithRoles()
+	_ = st.CreateUser(context.Background(), &store.User{
+		ID:      "u-oauth-promote",
+		Email:   memberEmail,
+		Role:    "member",
+		Status:  "active",
+		Created: time.Now(),
+	})
+	ws.store = st
+	ws.SetAccessSettingsProvider(&staticAccessSettings{
+		adminEmails: []string{memberEmail},
+	})
+
+	// Pre-seed session
+	reqSetup := httptest.NewRequest(http.MethodGet, "/auth/login/google", nil)
+	recSetup := httptest.NewRecorder()
+	sess, err := ws.sessionStore.Get(reqSetup, webSessionName)
+	require.NoError(t, err)
+	oauthState := "test-state-promote"
+	sess.Values[sessKeyOAuthState] = oauthState
+	require.NoError(t, sess.Save(reqSetup, recSetup))
+	cookies := recSetup.Result().Cookies()
+	require.NotEmpty(t, cookies)
+
+	callbackURL := "/auth/callback/google?code=test-code&state=" + oauthState
+	reqCallback := httptest.NewRequest(http.MethodGet, callbackURL, nil)
+	for _, c := range cookies {
+		reqCallback.AddCookie(c)
+	}
+	recCallback := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(recCallback, reqCallback)
+
+	resp := recCallback.Result()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	user, err := st.GetUserByEmail(context.Background(), memberEmail)
+	require.NoError(t, err)
+	assert.Equal(t, "admin", user.Role)
+	assert.True(t, st.hasSuperAdminBinding(user.ID),
+		"member promoted to admin via OAuth must get a super-admin RoleBinding")
+}
+
+func TestOAuthCallback_InvitedUser_PromotedToAdmin_GetsSuperAdminBinding(t *testing.T) {
+	// An invited user who transitions to active with admin role must get a binding.
+	const secret = "test-session-secret-for-invited-test-1234567890"
+	invitedEmail := "invited-admin@example.com"
+
+	ws := newTestWebServer(t, WebServerConfig{
+		SessionSecret: secret,
+		BaseURL:       "http://localhost:8080",
+	})
+
+	ws.oauthService = NewOAuthService(OAuthConfig{
+		Web: OAuthClientConfig{
+			Google: OAuthProviderConfig{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+			},
+		},
+	}, nil)
+	ws.oauthService.httpClient = &http.Client{
+		Transport: &mockOAuthTransport{
+			tokenJSON:    `{"access_token":"mock-token","token_type":"Bearer","expires_in":3600}`,
+			userinfoJSON: `{"id":"invited-id","email":"` + invitedEmail + `","verified_email":true,"name":"Invited Admin"}`,
+		},
+	}
+
+	st := newProxyAuthStoreWithRoles()
+	// Pre-create user as invited member (not admin yet)
+	_ = st.CreateUser(context.Background(), &store.User{
+		ID:      "u-invited",
+		Email:   invitedEmail,
+		Role:    "member",
+		Status:  store.UserStatusInvited,
+		Created: time.Now(),
+	})
+	ws.store = st
+	ws.SetAccessSettingsProvider(&staticAccessSettings{
+		adminEmails: []string{invitedEmail},
+	})
+
+	// Pre-seed session
+	reqSetup := httptest.NewRequest(http.MethodGet, "/auth/login/google", nil)
+	recSetup := httptest.NewRecorder()
+	sess, err := ws.sessionStore.Get(reqSetup, webSessionName)
+	require.NoError(t, err)
+	oauthState := "test-state-invited"
+	sess.Values[sessKeyOAuthState] = oauthState
+	require.NoError(t, sess.Save(reqSetup, recSetup))
+	cookies := recSetup.Result().Cookies()
+	require.NotEmpty(t, cookies)
+
+	callbackURL := "/auth/callback/google?code=test-code&state=" + oauthState
+	reqCallback := httptest.NewRequest(http.MethodGet, callbackURL, nil)
+	for _, c := range cookies {
+		reqCallback.AddCookie(c)
+	}
+	recCallback := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(recCallback, reqCallback)
+
+	resp := recCallback.Result()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	user, err := st.GetUserByEmail(context.Background(), invitedEmail)
+	require.NoError(t, err)
+	assert.Equal(t, "admin", user.Role)
+	assert.Equal(t, store.UserStatusActive, user.Status,
+		"invited user must transition to active")
+	assert.True(t, st.hasSuperAdminBinding(user.ID),
+		"invited user promoted to admin on first login must get a super-admin RoleBinding")
 }
 
 // Live operational settings propagation — regression tests for issue #1270

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -3856,6 +3856,169 @@ func TestOAuthCallback_InvitedUser_PromotedToAdmin_GetsSuperAdminBinding(t *test
 		"invited user promoted to admin on first login must get a super-admin RoleBinding")
 }
 
+func TestOAuthCallback_InvitedAdmin_AlreadyAdmin_GetsSuperAdminBinding(t *testing.T) {
+	// An invited user who ALREADY has role "admin" (set at invite time) must
+	// still get a super-admin RoleBinding on first login, even though the role
+	// doesn't change during the invited→active transition.
+	const secret = "test-session-secret-for-invited-admin-test-123456"
+	invitedEmail := "invited-already-admin@example.com"
+
+	ws := newTestWebServer(t, WebServerConfig{
+		SessionSecret: secret,
+		BaseURL:       "http://localhost:8080",
+	})
+
+	ws.oauthService = NewOAuthService(OAuthConfig{
+		Web: OAuthClientConfig{
+			Google: OAuthProviderConfig{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+			},
+		},
+	}, nil)
+	ws.oauthService.httpClient = &http.Client{
+		Transport: &mockOAuthTransport{
+			tokenJSON:    `{"access_token":"mock-token","token_type":"Bearer","expires_in":3600}`,
+			userinfoJSON: `{"id":"invited-admin-id","email":"` + invitedEmail + `","verified_email":true,"name":"Already Admin"}`,
+		},
+	}
+
+	st := newProxyAuthStoreWithRoles()
+	// Pre-create user as invited with admin role already assigned
+	_ = st.CreateUser(context.Background(), &store.User{
+		ID:      "u-invited-admin",
+		Email:   invitedEmail,
+		Role:    "admin",
+		Status:  store.UserStatusInvited,
+		Created: time.Now(),
+	})
+	ws.store = st
+	ws.SetAccessSettingsProvider(&staticAccessSettings{
+		adminEmails: []string{invitedEmail},
+	})
+
+	// Pre-seed session with OAuth state
+	reqSetup := httptest.NewRequest(http.MethodGet, "/auth/login/google", nil)
+	recSetup := httptest.NewRecorder()
+	sess, err := ws.sessionStore.Get(reqSetup, webSessionName)
+	require.NoError(t, err)
+	oauthState := "test-state-invited-admin"
+	sess.Values[sessKeyOAuthState] = oauthState
+	require.NoError(t, sess.Save(reqSetup, recSetup))
+	cookies := recSetup.Result().Cookies()
+	require.NotEmpty(t, cookies)
+
+	callbackURL := "/auth/callback/google?code=test-code&state=" + oauthState
+	reqCallback := httptest.NewRequest(http.MethodGet, callbackURL, nil)
+	for _, c := range cookies {
+		reqCallback.AddCookie(c)
+	}
+	recCallback := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(recCallback, reqCallback)
+
+	resp := recCallback.Result()
+	require.Equal(t, http.StatusFound, resp.StatusCode)
+
+	user, err := st.GetUserByEmail(context.Background(), invitedEmail)
+	require.NoError(t, err)
+	assert.Equal(t, "admin", user.Role)
+	assert.Equal(t, store.UserStatusActive, user.Status,
+		"invited user must transition to active")
+	assert.True(t, st.hasSuperAdminBinding(user.ID),
+		"invited user who already has admin role must get super-admin RoleBinding on first login")
+}
+
+func TestProxyAuthMiddleware_InvitedUser_TransitionsToActive(t *testing.T) {
+	// An invited user logging in via proxy auth must transition from
+	// "invited" to "active" status.
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject:     "sa-invited-1",
+			Email:       "invited-proxy@example.com",
+			DisplayName: "Invited Proxy User",
+			Domain:      "example.com",
+		},
+	}
+
+	st := newProxyAuthStoreWithRoles()
+	_ = st.CreateUser(context.Background(), &store.User{
+		ID:      "u-invited-proxy",
+		Email:   "invited-proxy@example.com",
+		Role:    "member",
+		Status:  store.UserStatusInvited,
+		Created: time.Now(),
+	})
+
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+	})
+	ws.SetAccessSettingsProvider(&staticAccessSettings{
+		adminEmails: []string{"other@example.com"},
+	})
+	ws.SetStore(st)
+
+	req := httptest.NewRequest("GET", "/projects", nil)
+	req.Header.Set("Accept", "text/html")
+	rec := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(rec, req)
+
+	user, err := st.GetUserByEmail(context.Background(), "invited-proxy@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, store.UserStatusActive, user.Status,
+		"invited user must transition to active via proxy auth")
+	assert.Equal(t, "Invited Proxy User", user.DisplayName,
+		"display name should be populated from proxy identity on activation")
+}
+
+func TestProxyAuthMiddleware_InvitedAdmin_AlreadyAdmin_GetsSuperAdminBinding(t *testing.T) {
+	// An invited user who already has role "admin" must get a super-admin
+	// RoleBinding when transitioning from invited to active via proxy auth,
+	// even though the role doesn't change.
+	mockAuth := &mockProxyAuthenticator{
+		user: &ProxyUserInfo{
+			Subject:     "sa-invited-admin",
+			Email:       "invited-admin-proxy@example.com",
+			DisplayName: "Invited Admin",
+			Domain:      "example.com",
+		},
+	}
+
+	st := newProxyAuthStoreWithRoles()
+	_ = st.CreateUser(context.Background(), &store.User{
+		ID:      "u-invited-admin-proxy",
+		Email:   "invited-admin-proxy@example.com",
+		Role:    "admin",
+		Status:  store.UserStatusInvited,
+		Created: time.Now(),
+	})
+
+	ws := newTestWebServer(t, WebServerConfig{
+		AuthMode:           "proxy",
+		ProxyAuthenticator: mockAuth,
+	})
+	ws.SetAccessSettingsProvider(&staticAccessSettings{
+		adminEmails: []string{"invited-admin-proxy@example.com"},
+	})
+	ws.SetStore(st)
+
+	req := httptest.NewRequest("GET", "/projects", nil)
+	req.Header.Set("Accept", "text/html")
+	rec := httptest.NewRecorder()
+
+	ws.Handler().ServeHTTP(rec, req)
+
+	user, err := st.GetUserByEmail(context.Background(), "invited-admin-proxy@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "admin", user.Role)
+	assert.Equal(t, store.UserStatusActive, user.Status,
+		"invited user must transition to active via proxy auth")
+	assert.True(t, st.hasSuperAdminBinding(user.ID),
+		"invited user who already has admin role must get super-admin RoleBinding via proxy auth")
+}
+
 // Live operational settings propagation — regression tests for issue #1270
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
The WebServer has two independent login paths (proxyAuthMiddleware and handleOAuthCallback) that duplicate user provisioning without calling ensureSuperAdminBinding. When users log in via the web UI, the super-admin RoleBinding is never created, causing AuthzService.IsSystemAdmin to return false despite the user having Role="admin".

Extract ensureSuperAdminBinding/deleteSuperAdminBinding into package-level functions (ensureSuperAdminRoleBinding/deleteSuperAdminRoleBinding) that accept a store.Store parameter, enabling both Server and WebServer to call them. Add binding management to:

- proxyAuthMiddleware: new user creation, and role changes on existing users
- handleOAuthCallback: new user creation, invited->active transitions, and role changes on existing users

Mirrors the deferred-binding pattern from Server.provisionUser: binding mutations are applied only after UpdateUser succeeds, preventing divergence between User.Role and binding state.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
