### PR TITLE
fix(hub): translate GCP passthrough to assign on cloudrun-sandbox run…

### DIFF
--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -1266,7 +1266,7 @@ func (s *Server) createAgentInProject(
 		agent.AppliedConfig.GCPIdentity.MetadataMode == store.GCPMetadataModePassthrough &&
 		runtimeBrokerID != "" {
 		if err := s.translatePassthroughForSandbox(ctx, agent, runtimeBrokerID); err != nil {
-			slog.Error("passthrough-to-assign translation failed",
+			slog.ErrorContext(ctx, "passthrough-to-assign translation failed",
 				"agent", agent.Name, "broker", runtimeBrokerID, "error", err)
 			writeError(w, http.StatusInternalServerError, ErrCodeRuntimeError,
 				"failed to configure GCP identity for sandbox runtime: "+err.Error(), nil)
@@ -2358,7 +2358,7 @@ func (s *Server) updateAgent(w http.ResponseWriter, r *http.Request, id string) 
 			// Passthrough-to-assign translation for cloudrun-sandbox runtimes
 			// (same logic as the create path — see createAgentInProject).
 			if err := s.translatePassthroughForSandbox(ctx, agent, agent.RuntimeBrokerID); err != nil {
-				slog.Error("passthrough-to-assign translation failed (PATCH)",
+				slog.ErrorContext(ctx, "passthrough-to-assign translation failed (PATCH)",
 					"agent", agent.ID, "broker", agent.RuntimeBrokerID, "error", err)
 				writeError(w, http.StatusInternalServerError, ErrCodeRuntimeError,
 					"failed to configure GCP identity for sandbox runtime: "+err.Error(), nil)
@@ -3182,6 +3182,10 @@ func (s *Server) translatePassthroughForSandbox(
 		return nil
 	}
 
+	if brokerID == "" {
+		return fmt.Errorf("cannot translate passthrough: no broker ID")
+	}
+
 	broker, err := s.store.GetRuntimeBroker(ctx, brokerID)
 	if err != nil {
 		return fmt.Errorf("load broker %s: %w", brokerID, err)
@@ -3195,7 +3199,7 @@ func (s *Server) translatePassthroughForSandbox(
 		// have caught this for explicit passthrough requests; for project-
 		// default passthrough the gate doesn't run. Log and leave as-is —
 		// the agent won't get credentials, same as the pre-fix behavior.
-		slog.Warn("cloudrun-sandbox broker has no host SA — cannot translate passthrough to assign",
+		slog.WarnContext(ctx, "cloudrun-sandbox broker has no host SA — cannot translate passthrough to assign",
 			"broker_id", broker.ID, "broker_name", broker.Name)
 		return nil
 	}
@@ -3206,7 +3210,7 @@ func (s *Server) translatePassthroughForSandbox(
 		return fmt.Errorf("ensure host SA record: %w", err)
 	}
 
-	slog.Info("translated passthrough to assign for cloudrun-sandbox",
+	slog.InfoContext(ctx, "translated passthrough to assign for cloudrun-sandbox",
 		"agent", agent.Name, "broker", broker.Name,
 		"sa_email", sa.Email, "sa_id", sa.ID)
 
@@ -3255,12 +3259,17 @@ func (s *Server) ensureHostSARecord(
 	// ScopeID is provenance for hub-scoped accounts (which hub instance
 	// registered it). Use the broker ID as provenance — more specific than
 	// the hub ID and stable across redeployments.
+	projectID := broker.GCPHostProjectID
+	if projectID == "" {
+		projectID = projectIDFromServiceAccountEmail(broker.GCPHostServiceAccountEmail)
+	}
+
 	sa := &store.GCPServiceAccount{
 		ID:      gouuid.New().String(),
 		Scope:   store.ScopeHub,
 		ScopeID: broker.ID,
 		Email:       broker.GCPHostServiceAccountEmail,
-		ProjectID:   broker.GCPHostProjectID,
+		ProjectID:   projectID,
 		DisplayName: fmt.Sprintf("Broker host SA (%s)", broker.Name),
 		DefaultScopes: []string{
 			"https://www.googleapis.com/auth/cloud-platform",
@@ -3293,7 +3302,7 @@ func (s *Server) ensureHostSARecord(
 		return nil, fmt.Errorf("create SA %s: %w", broker.GCPHostServiceAccountEmail, err)
 	}
 
-	slog.Info("created hub-scoped GCPServiceAccount for broker host SA",
+	slog.InfoContext(ctx, "created hub-scoped GCPServiceAccount for broker host SA",
 		"sa_id", sa.ID, "sa_email", sa.Email, "broker", broker.Name)
 	return sa, nil
 }

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -1250,6 +1250,30 @@ func (s *Server) createAgentInProject(
 		}
 	}
 
+	// Passthrough-to-assign translation for cloudrun-sandbox runtimes.
+	//
+	// gVisor sandboxes cannot reach the real GCE metadata server at
+	// 169.254.169.254, so passthrough mode produces no credentials. When
+	// the target broker runs a cloudrun-sandbox profile, translate
+	// passthrough to assign using the broker's host service account —
+	// semantically equivalent (same identity) and the assign machinery
+	// works inside the sandbox.
+	//
+	// The translation runs after both the explicit and project-default
+	// identity paths, so it covers every surface that sets passthrough.
+	if agent.AppliedConfig != nil &&
+		agent.AppliedConfig.GCPIdentity != nil &&
+		agent.AppliedConfig.GCPIdentity.MetadataMode == store.GCPMetadataModePassthrough &&
+		runtimeBrokerID != "" {
+		if err := s.translatePassthroughForSandbox(ctx, agent, runtimeBrokerID); err != nil {
+			slog.Error("passthrough-to-assign translation failed",
+				"agent", agent.Name, "broker", runtimeBrokerID, "error", err)
+			writeError(w, http.StatusInternalServerError, ErrCodeRuntimeError,
+				"failed to configure GCP identity for sandbox runtime: "+err.Error(), nil)
+			return
+		}
+	}
+
 	if req.Config != nil {
 		agent.Image = req.Config.Image
 		if req.Config.Detached != nil {
@@ -2331,6 +2355,15 @@ func (s *Server) updateAgent(w http.ResponseWriter, r *http.Request, id string) 
 			agent.AppliedConfig.GCPIdentity = &store.GCPIdentityConfig{
 				MetadataMode: store.GCPMetadataModePassthrough,
 			}
+			// Passthrough-to-assign translation for cloudrun-sandbox runtimes
+			// (same logic as the create path — see createAgentInProject).
+			if err := s.translatePassthroughForSandbox(ctx, agent, agent.RuntimeBrokerID); err != nil {
+				slog.Error("passthrough-to-assign translation failed (PATCH)",
+					"agent", agent.ID, "broker", agent.RuntimeBrokerID, "error", err)
+				writeError(w, http.StatusInternalServerError, ErrCodeRuntimeError,
+					"failed to configure GCP identity for sandbox runtime: "+err.Error(), nil)
+				return
+			}
 		case store.GCPMetadataModeAssign:
 			if updates.GCPIdentity.ServiceAccountID == "" {
 				ValidationError(w, "service_account_id is required when metadata_mode is 'assign'", nil)
@@ -3100,4 +3133,167 @@ func (s *Server) recordDelegationEdgeWithType(ctx context.Context, agentID, proj
 			"project_id", projectID,
 			"error", err)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Passthrough-to-assign translation for cloudrun-sandbox runtimes
+// ---------------------------------------------------------------------------
+
+// brokerHasCloudRunSandboxProfile reports whether any profile on the broker has
+// the "cloudrun-sandbox" runtime type. This indicates the broker runs gVisor
+// sandboxes that cannot reach the real GCE metadata server.
+func brokerHasCloudRunSandboxProfile(broker *store.RuntimeBroker) bool {
+	for _, p := range broker.Profiles {
+		if p.Type == "cloudrun-sandbox" {
+			return true
+		}
+	}
+	return false
+}
+
+// translatePassthroughForSandbox translates a passthrough GCP identity config
+// to assign mode when the target broker runs a cloudrun-sandbox runtime.
+//
+// Inside gVisor sandboxes the real GCE metadata server at 169.254.169.254 is
+// unreachable, so passthrough mode produces no credentials. The translation
+// uses the broker's registered host service account — semantically equivalent
+// to passthrough (same identity) — and the assign machinery (metadata
+// emulator → hub gcp-token endpoint → IAM impersonation) works inside the
+// sandbox.
+//
+// The method is a no-op when:
+//   - the agent's config is not passthrough,
+//   - the broker has no cloudrun-sandbox profile, or
+//   - the broker has no host SA registered (leaves passthrough as-is with a
+//     warning — identical to pre-fix behavior).
+//
+// On success the agent's AppliedConfig.GCPIdentity is rewritten in place to
+// assign mode with the broker's host SA, and a GCPServiceAccount record is
+// created if one does not already exist for the email.
+func (s *Server) translatePassthroughForSandbox(
+	ctx context.Context,
+	agent *store.Agent,
+	brokerID string,
+) error {
+	if agent.AppliedConfig == nil || agent.AppliedConfig.GCPIdentity == nil {
+		return nil
+	}
+	if agent.AppliedConfig.GCPIdentity.MetadataMode != store.GCPMetadataModePassthrough {
+		return nil
+	}
+
+	broker, err := s.store.GetRuntimeBroker(ctx, brokerID)
+	if err != nil {
+		return fmt.Errorf("load broker %s: %w", brokerID, err)
+	}
+	if !brokerHasCloudRunSandboxProfile(broker) {
+		return nil // not a sandbox runtime — passthrough works as-is
+	}
+
+	if broker.GCPHostServiceAccountEmail == "" {
+		// The broker has no host SA registered. The passthrough gate should
+		// have caught this for explicit passthrough requests; for project-
+		// default passthrough the gate doesn't run. Log and leave as-is —
+		// the agent won't get credentials, same as the pre-fix behavior.
+		slog.Warn("cloudrun-sandbox broker has no host SA — cannot translate passthrough to assign",
+			"broker_id", broker.ID, "broker_name", broker.Name)
+		return nil
+	}
+
+	// Ensure a GCPServiceAccount record exists for the broker's host SA.
+	sa, err := s.ensureHostSARecord(ctx, broker)
+	if err != nil {
+		return fmt.Errorf("ensure host SA record: %w", err)
+	}
+
+	slog.Info("translated passthrough to assign for cloudrun-sandbox",
+		"agent", agent.Name, "broker", broker.Name,
+		"sa_email", sa.Email, "sa_id", sa.ID)
+
+	agent.AppliedConfig.GCPIdentity = &store.GCPIdentityConfig{
+		MetadataMode:        store.GCPMetadataModeAssign,
+		ServiceAccountID:    sa.ID,
+		ServiceAccountEmail: sa.Email,
+		ProjectID:           sa.ProjectID,
+	}
+
+	// Mark the translation so operators and the UI can distinguish a
+	// hub-translated assign from a user-requested one.
+	if agent.Annotations == nil {
+		agent.Annotations = make(map[string]string)
+	}
+	agent.Annotations["scion.dev/gcp-identity-translated-from"] = "passthrough"
+
+	return nil
+}
+
+// ensureHostSARecord looks up or creates a hub-scoped GCPServiceAccount
+// record for the broker's host service account. This is needed so that the
+// assign flow (JWT scope minting, gcp-token endpoint) works with a real
+// ServiceAccountID foreign key.
+//
+// The record is hub-scoped because the broker's host SA is an infrastructure
+// identity, not project-specific — any project dispatching to this broker
+// should be able to use it for passthrough translation.
+func (s *Server) ensureHostSARecord(
+	ctx context.Context,
+	broker *store.RuntimeBroker,
+) (*store.GCPServiceAccount, error) {
+	// Look up by email first.
+	existing, err := s.store.ListGCPServiceAccounts(ctx, store.GCPServiceAccountFilter{
+		Email: broker.GCPHostServiceAccountEmail,
+		Scope: store.ScopeHub,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("lookup SA by email %s: %w", broker.GCPHostServiceAccountEmail, err)
+	}
+	if len(existing) > 0 {
+		return &existing[0], nil
+	}
+
+	// Create a new hub-scoped record for the broker's host SA.
+	// ScopeID is provenance for hub-scoped accounts (which hub instance
+	// registered it). Use the broker ID as provenance — more specific than
+	// the hub ID and stable across redeployments.
+	sa := &store.GCPServiceAccount{
+		ID:      gouuid.New().String(),
+		Scope:   store.ScopeHub,
+		ScopeID: broker.ID,
+		Email:       broker.GCPHostServiceAccountEmail,
+		ProjectID:   broker.GCPHostProjectID,
+		DisplayName: fmt.Sprintf("Broker host SA (%s)", broker.Name),
+		DefaultScopes: []string{
+			"https://www.googleapis.com/auth/cloud-platform",
+		},
+		// The hub can already impersonate this SA (it's the broker's host
+		// identity), so mark as verified. The actAs check already passed
+		// in authorizePassthroughIdentity for explicit passthrough requests.
+		Verified:           true,
+		VerifiedAt:         time.Now(),
+		VerificationStatus: store.GCPVerificationVerified,
+		CreatedBy:          "system:passthrough-translation",
+		CreatedAt:          time.Now(),
+		Managed:            false, // not created by Hub SA provisioning
+	}
+
+	if err := s.store.CreateGCPServiceAccount(ctx, sa); err != nil {
+		// Race condition: another request may have created the record
+		// between our lookup and create. Try the lookup again.
+		existing, lookupErr := s.store.ListGCPServiceAccounts(ctx, store.GCPServiceAccountFilter{
+			Email: broker.GCPHostServiceAccountEmail,
+			Scope: store.ScopeHub,
+		})
+		if lookupErr != nil {
+			return nil, fmt.Errorf("create SA %s: %w (retry lookup: %v)",
+				broker.GCPHostServiceAccountEmail, err, lookupErr)
+		}
+		if len(existing) > 0 {
+			return &existing[0], nil
+		}
+		return nil, fmt.Errorf("create SA %s: %w", broker.GCPHostServiceAccountEmail, err)
+	}
+
+	slog.Info("created hub-scoped GCPServiceAccount for broker host SA",
+		"sa_id", sa.ID, "sa_email", sa.Email, "broker", broker.Name)
+	return sa, nil
 }

--- a/pkg/hub/passthrough_sandbox_translation_test.go
+++ b/pkg/hub/passthrough_sandbox_translation_test.go
@@ -1,0 +1,348 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !no_sqlite
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/GoogleCloudPlatform/scion/pkg/agent/state"
+	"github.com/GoogleCloudPlatform/scion/pkg/store"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// setupPassthroughSandboxServer is like setupPassthroughServer but creates a
+// broker with a cloudrun-sandbox profile so the passthrough-to-assign
+// translation fires.
+func setupPassthroughSandboxServer(
+	t *testing.T,
+	owner *store.User,
+	hostSAEmail, hostProjectID string,
+) (*Server, store.Store, *store.Project, *store.RuntimeBroker) {
+	t.Helper()
+	disp := &createAgentDispatcher{createPhase: string(state.PhaseRunning)}
+	srv, s := testServer(t)
+	ctx := context.Background()
+
+	require.NoError(t, s.CreateUser(ctx, owner))
+	ensureHubMembership(ctx, s, owner.ID)
+
+	project := &store.Project{
+		ID:        tid("project-sandbox-pt"),
+		Name:      "Sandbox PT Test Project",
+		Slug:      "sandbox-pt-test-project",
+		OwnerID:   owner.ID,
+		CreatedBy: owner.ID,
+		Created:   time.Now(),
+		Updated:   time.Now(),
+	}
+	require.NoError(t, s.CreateProject(ctx, project))
+	srv.createProjectMembersGroup(ctx, project)
+
+	broker := &store.RuntimeBroker{
+		ID:                         tid("broker-sandbox-pt"),
+		Name:                       "Sandbox PT Test Broker",
+		Slug:                       "sandbox-pt-test-broker",
+		Status:                     store.BrokerStatusOnline,
+		CreatedBy:                  owner.ID,
+		GCPHostServiceAccountEmail: hostSAEmail,
+		GCPHostProjectID:           hostProjectID,
+		Profiles: []store.BrokerProfile{
+			{Name: "default", Type: "cloudrun-sandbox", Available: true},
+		},
+	}
+	require.NoError(t, s.CreateRuntimeBroker(ctx, broker))
+	require.NoError(t, s.AddProjectProvider(ctx, &store.ProjectProvider{
+		ProjectID:  project.ID,
+		BrokerID:   broker.ID,
+		BrokerName: broker.Name,
+		Status:     store.BrokerStatusOnline,
+	}))
+	project.DefaultRuntimeBrokerID = broker.ID
+	require.NoError(t, s.UpdateProject(ctx, project))
+
+	srv.SetDispatcher(disp)
+	return srv, s, project, broker
+}
+
+// ---------------------------------------------------------------------------
+// Unit: brokerHasCloudRunSandboxProfile
+// ---------------------------------------------------------------------------
+
+func TestBrokerHasCloudRunSandboxProfile(t *testing.T) {
+	tests := []struct {
+		name     string
+		profiles []store.BrokerProfile
+		want     bool
+	}{
+		{
+			name:     "no profiles",
+			profiles: nil,
+			want:     false,
+		},
+		{
+			name: "docker only",
+			profiles: []store.BrokerProfile{
+				{Name: "default", Type: "docker", Available: true},
+			},
+			want: false,
+		},
+		{
+			name: "cloudrun-sandbox",
+			profiles: []store.BrokerProfile{
+				{Name: "default", Type: "cloudrun-sandbox", Available: true},
+			},
+			want: true,
+		},
+		{
+			name: "mixed with cloudrun-sandbox",
+			profiles: []store.BrokerProfile{
+				{Name: "local", Type: "docker", Available: true},
+				{Name: "remote", Type: "cloudrun-sandbox", Available: true},
+			},
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			broker := &store.RuntimeBroker{Profiles: tc.profiles}
+			assert.Equal(t, tc.want, brokerHasCloudRunSandboxProfile(broker))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: passthrough on cloudrun-sandbox translates to assign
+// ---------------------------------------------------------------------------
+
+func TestPassthrough_CloudRunSandbox_TranslatesToAssign(t *testing.T) {
+	hostSAEmail := "broker-host@sandbox-project.iam.gserviceaccount.com"
+	hostProjectID := "sandbox-project"
+	owner := ptUser(tid("user-sandbox-pt-1"), "sandbox-owner1@test.com", store.UserRoleMember)
+	srv, _, project, _ := setupPassthroughSandboxServer(t, owner, hostSAEmail, hostProjectID)
+
+	checker := store.NewFakeCallerPermissionChecker().AllowTarget(hostSAEmail)
+	enforceSAAssign(srv, checker)
+
+	rec := doRequestAsUser(t, srv, owner, http.MethodPost, "/api/v1/agents", CreateAgentRequest{
+		Name:      "pt-sandbox-assign",
+		ProjectID: project.ID,
+		Task:      "test passthrough on sandbox",
+		GCPIdentity: &GCPIdentityAssignment{
+			MetadataMode: "passthrough",
+		},
+	})
+
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+
+	var resp CreateAgentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Agent.AppliedConfig)
+	require.NotNil(t, resp.Agent.AppliedConfig.GCPIdentity)
+
+	gcpID := resp.Agent.AppliedConfig.GCPIdentity
+
+	// The mode must be translated to "assign", not stored as "passthrough".
+	assert.Equal(t, store.GCPMetadataModeAssign, gcpID.MetadataMode,
+		"passthrough on cloudrun-sandbox should be translated to assign")
+
+	// The SA email and project must come from the broker's host SA.
+	assert.Equal(t, hostSAEmail, gcpID.ServiceAccountEmail)
+	assert.Equal(t, hostProjectID, gcpID.ProjectID)
+
+	// A ServiceAccountID must be set (FK to GCPServiceAccount table).
+	assert.NotEmpty(t, gcpID.ServiceAccountID,
+		"translated config must have a ServiceAccountID for JWT scope minting")
+
+	// The annotation should indicate translation.
+	assert.Equal(t, "passthrough", resp.Agent.Annotations["scion.dev/gcp-identity-translated-from"])
+}
+
+// TestPassthrough_CloudRunSandbox_SARecordCreated verifies that the translation
+// creates a hub-scoped GCPServiceAccount record for the broker's host SA.
+func TestPassthrough_CloudRunSandbox_SARecordCreated(t *testing.T) {
+	hostSAEmail := "broker-host@sa-project.iam.gserviceaccount.com"
+	hostProjectID := "sa-project"
+	owner := ptUser(tid("user-sandbox-pt-2"), "sandbox-owner2@test.com", store.UserRoleMember)
+	srv, s, project, _ := setupPassthroughSandboxServer(t, owner, hostSAEmail, hostProjectID)
+
+	checker := store.NewFakeCallerPermissionChecker().AllowTarget(hostSAEmail)
+	enforceSAAssign(srv, checker)
+
+	rec := doRequestAsUser(t, srv, owner, http.MethodPost, "/api/v1/agents", CreateAgentRequest{
+		Name:      "pt-sandbox-sa-check",
+		ProjectID: project.ID,
+		Task:      "test SA creation",
+		GCPIdentity: &GCPIdentityAssignment{
+			MetadataMode: "passthrough",
+		},
+	})
+
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+
+	var resp CreateAgentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	// Verify the SA record exists in the store.
+	saID := resp.Agent.AppliedConfig.GCPIdentity.ServiceAccountID
+	sa, err := s.GetGCPServiceAccount(context.Background(), saID)
+	require.NoError(t, err, "SA record must exist in the store")
+
+	assert.Equal(t, hostSAEmail, sa.Email)
+	assert.Equal(t, hostProjectID, sa.ProjectID)
+	assert.Equal(t, store.ScopeHub, sa.Scope, "broker host SA record must be hub-scoped")
+	assert.True(t, sa.Verified, "broker host SA should be pre-verified")
+}
+
+// TestPassthrough_CloudRunSandbox_SARecordReused verifies that creating
+// two agents with passthrough on the same cloudrun-sandbox broker reuses
+// the same GCPServiceAccount record.
+func TestPassthrough_CloudRunSandbox_SARecordReused(t *testing.T) {
+	hostSAEmail := "broker-host@reuse-project.iam.gserviceaccount.com"
+	hostProjectID := "reuse-project"
+	owner := ptUser(tid("user-sandbox-pt-3"), "sandbox-owner3@test.com", store.UserRoleMember)
+	srv, _, project, _ := setupPassthroughSandboxServer(t, owner, hostSAEmail, hostProjectID)
+
+	checker := store.NewFakeCallerPermissionChecker().AllowTarget(hostSAEmail)
+	enforceSAAssign(srv, checker)
+
+	// Create first agent.
+	rec1 := doRequestAsUser(t, srv, owner, http.MethodPost, "/api/v1/agents", CreateAgentRequest{
+		Name:      "pt-sandbox-reuse-1",
+		ProjectID: project.ID,
+		Task:      "test 1",
+		GCPIdentity: &GCPIdentityAssignment{
+			MetadataMode: "passthrough",
+		},
+	})
+	require.Equal(t, http.StatusCreated, rec1.Code, "body: %s", rec1.Body.String())
+
+	// Create second agent.
+	rec2 := doRequestAsUser(t, srv, owner, http.MethodPost, "/api/v1/agents", CreateAgentRequest{
+		Name:      "pt-sandbox-reuse-2",
+		ProjectID: project.ID,
+		Task:      "test 2",
+		GCPIdentity: &GCPIdentityAssignment{
+			MetadataMode: "passthrough",
+		},
+	})
+	require.Equal(t, http.StatusCreated, rec2.Code, "body: %s", rec2.Body.String())
+
+	var resp1, resp2 CreateAgentResponse
+	require.NoError(t, json.Unmarshal(rec1.Body.Bytes(), &resp1))
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp2))
+
+	// Both agents should reference the same ServiceAccountID.
+	assert.Equal(t,
+		resp1.Agent.AppliedConfig.GCPIdentity.ServiceAccountID,
+		resp2.Agent.AppliedConfig.GCPIdentity.ServiceAccountID,
+		"two agents on the same broker should share the same SA record")
+}
+
+// TestPassthrough_NonSandboxBroker_RemainsPassthrough verifies that passthrough
+// mode is NOT translated on brokers that do not run cloudrun-sandbox.
+func TestPassthrough_NonSandboxBroker_RemainsPassthrough(t *testing.T) {
+	hostSAEmail := "broker-host@docker-project.iam.gserviceaccount.com"
+	owner := ptUser(tid("user-sandbox-pt-4"), "sandbox-owner4@test.com", store.UserRoleMember)
+	// Use the standard setup (no sandbox profiles).
+	srv, _, project, _ := setupPassthroughServer(t, owner, hostSAEmail, "docker-project")
+
+	checker := store.NewFakeCallerPermissionChecker().AllowTarget(hostSAEmail)
+	enforceSAAssign(srv, checker)
+
+	rec := doRequestAsUser(t, srv, owner, http.MethodPost, "/api/v1/agents", CreateAgentRequest{
+		Name:      "pt-docker-stays-pt",
+		ProjectID: project.ID,
+		Task:      "test passthrough on docker",
+		GCPIdentity: &GCPIdentityAssignment{
+			MetadataMode: "passthrough",
+		},
+	})
+
+	require.Equal(t, http.StatusCreated, rec.Code, "body: %s", rec.Body.String())
+
+	var resp CreateAgentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Agent.AppliedConfig.GCPIdentity)
+
+	// Passthrough should remain passthrough on a non-sandbox broker.
+	assert.Equal(t, store.GCPMetadataModePassthrough,
+		resp.Agent.AppliedConfig.GCPIdentity.MetadataMode,
+		"passthrough on non-sandbox broker should remain passthrough")
+	assert.Empty(t, resp.Agent.AppliedConfig.GCPIdentity.ServiceAccountID)
+}
+
+// TestPassthrough_CloudRunSandbox_PatchTranslates verifies that PATCH to
+// passthrough on a cloudrun-sandbox broker also translates to assign.
+func TestPassthrough_CloudRunSandbox_PatchTranslates(t *testing.T) {
+	hostSAEmail := "broker-host@patch-project.iam.gserviceaccount.com"
+	hostProjectID := "patch-project"
+	owner := ptUser(tid("user-sandbox-pt-5"), "sandbox-owner5@test.com", store.UserRoleMember)
+	srv, s, project, broker := setupPassthroughSandboxServer(t, owner, hostSAEmail, hostProjectID)
+
+	checker := store.NewFakeCallerPermissionChecker().AllowTarget(hostSAEmail)
+	enforceSAAssign(srv, checker)
+
+	// Create an agent in "created" phase (PATCH only works in created phase).
+	agent := &store.Agent{
+		ID:              tid("agent-sandbox-patch-1"),
+		Slug:            "pt-sandbox-patch",
+		Name:            "pt-sandbox-patch",
+		ProjectID:       project.ID,
+		Phase:           string(state.PhaseCreated),
+		RuntimeBrokerID: broker.ID,
+		AppliedConfig: &store.AgentAppliedConfig{
+			GCPIdentity: &store.GCPIdentityConfig{
+				MetadataMode: store.GCPMetadataModeBlock,
+			},
+		},
+		OwnerID:   owner.ID,
+		CreatedBy: owner.ID,
+		Created:   time.Now(),
+		Updated:   time.Now(),
+	}
+	require.NoError(t, s.CreateAgent(context.Background(), agent))
+
+	// PATCH to passthrough.
+	rec := doRequestAsUser(t, srv, owner, http.MethodPatch, "/api/v1/agents/"+agent.ID, map[string]interface{}{
+		"gcp_identity": map[string]string{
+			"metadata_mode": "passthrough",
+		},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	var patched store.Agent
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &patched))
+	require.NotNil(t, patched.AppliedConfig)
+	require.NotNil(t, patched.AppliedConfig.GCPIdentity)
+
+	// The mode must be translated to "assign".
+	assert.Equal(t, store.GCPMetadataModeAssign, patched.AppliedConfig.GCPIdentity.MetadataMode,
+		"PATCH passthrough on cloudrun-sandbox should translate to assign")
+	assert.Equal(t, hostSAEmail, patched.AppliedConfig.GCPIdentity.ServiceAccountEmail)
+	assert.NotEmpty(t, patched.AppliedConfig.GCPIdentity.ServiceAccountID)
+}


### PR DESCRIPTION
…times

gVisor sandboxes cannot reach the real GCE metadata server at 169.254.169.254, so passthrough mode produces no credentials on cloudrun-sandbox runtimes. When the hub stores a passthrough agent config for a broker with a cloudrun-sandbox profile, translate it to assign mode using the broker's host SA — semantically equivalent (same identity) and the assign machinery works inside the sandbox.

- Add translatePassthroughForSandbox() covering both create and PATCH
- Upsert a hub-scoped GCPServiceAccount for the broker's host SA
- Annotate translated agents for debugging visibility
- Downstream paths (JWT scope, resolvedEnv, gcp-token endpoint, restart) work automatically since stored config says "assign"

Closes #1461

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
