### PR TITLE
fix(harness/claude): remove invalid settings that block agent startup

### DIFF
--- a/harnesses/claude/home/.claude/settings.json
+++ b/harnesses/claude/home/.claude/settings.json
@@ -6,9 +6,7 @@
     "enabled": false
   },
   "permissions": {
-    "allow": [
-      "*"
-    ],
+    "allow": [],
     "deny": [
       "EnterPlanMode",
       "ExitPlanMode",
@@ -40,7 +38,6 @@
     "SubagentStop": [{"matcher": "*", "hooks": [{"name": "scion-status", "type": "command", "command": "sciontool hook --dialect=claude"}]}],
     "PreToolUse": [{"matcher": "*", "hooks": [{"name": "scion-status", "type": "command", "command": "sciontool hook --dialect=claude"}]}],
     "PostToolUse": [{"matcher": "*", "hooks": [{"name": "scion-status", "type": "command", "command": "sciontool hook --dialect=claude"}]}],
-    "ModelResponse": [{"matcher": "*", "hooks": [{"name": "scion-telemetry", "type": "command", "command": "sciontool hook --dialect=claude"}]}],
     "Notification": [{"matcher": "ToolPermission", "hooks": [{"name": "scion-status", "type": "command", "command": "sciontool hook --dialect=claude"}]}]
   }
 }


### PR DESCRIPTION
Remove two invalid entries from Claude harness settings.json that cause Claude Code 2.1.266 to present an interactive Settings Warning prompt, blocking headless agent startup indefinitely. (1) Remove wildcard '*' from permissions.allow — not supported in allow rules. (2) Remove invalid ModelResponse hook event — not a valid Claude Code hook event. Fixes ptone/scion#1466.