### PR TITLE
fix(hub): check agent GCPIdentity in auth autodetect for passthrough-translated agents

### DIFF
--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -1225,6 +1225,15 @@ func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Ag
 		if err != nil {
 			return false, err
 		}
+		// Also check agent's own GCP identity config (mirrors broker logic
+		// at handlers.go:2186-2187). Passthrough-to-assign translated agents
+		// have MetadataMode=assign but no project-scoped SA record.
+		if !gcpSAAssigned && agent.AppliedConfig.GCPIdentity != nil {
+			mode := agent.AppliedConfig.GCPIdentity.MetadataMode
+			if mode == store.GCPMetadataModeAssign || mode == store.GCPMetadataModePassthrough {
+				gcpSAAssigned = true
+			}
+		}
 		for authType := range authMeta.Types {
 			satisfied, err := s.isAuthTypeSatisfied(ctx, agent, authMeta, authType, gcpSAAssigned)
 			if err != nil {
@@ -1257,6 +1266,15 @@ func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Ag
 		gcpSAAssigned, err := s.projectHasVerifiedGCPSA(ctx, agent.ProjectID)
 		if err != nil {
 			return false, err
+		}
+		// Also check agent's own GCP identity config (mirrors broker logic
+		// at handlers.go:2186-2187). Passthrough-to-assign translated agents
+		// have MetadataMode=assign but no project-scoped SA record.
+		if !gcpSAAssigned && agent.AppliedConfig.GCPIdentity != nil {
+			mode := agent.AppliedConfig.GCPIdentity.MetadataMode
+			if mode == store.GCPMetadataModeAssign || mode == store.GCPMetadataModePassthrough {
+				gcpSAAssigned = true
+			}
 		}
 		fileSecrets := harness.RequiredAuthSecretsFromConfig(authMeta, agent.AppliedConfig.HarnessAuth, gcpSAAssigned)
 		for _, fs := range fileSecrets {

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -1207,6 +1207,17 @@ func (s *Server) findBrokerByIDOrSlug(ctx context.Context, identifier string) (*
 	return nil, store.ErrNotFound
 }
 
+// agentHasGCPIdentityAssigned returns true when the agent's own GCPIdentity
+// config has MetadataMode set to assign or passthrough, mirroring the broker's
+// check at pkg/runtimebroker/handlers.go:2186-2187.
+func agentHasGCPIdentityAssigned(agent *store.Agent) bool {
+	if agent.AppliedConfig.GCPIdentity == nil {
+		return false
+	}
+	mode := agent.AppliedConfig.GCPIdentity.MetadataMode
+	return mode == store.GCPMetadataModeAssign || mode == store.GCPMetadataModePassthrough
+}
+
 // hasRequiredAuthCredentials checks whether the required auth environment
 // variables and file secrets for the given harness type are available in the
 // agent's env, or in the hub's env/secret stores (user and project scopes).
@@ -1225,14 +1236,8 @@ func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Ag
 		if err != nil {
 			return false, err
 		}
-		// Also check agent's own GCP identity config (mirrors broker logic
-		// at handlers.go:2186-2187). Passthrough-to-assign translated agents
-		// have MetadataMode=assign but no project-scoped SA record.
-		if !gcpSAAssigned && agent.AppliedConfig.GCPIdentity != nil {
-			mode := agent.AppliedConfig.GCPIdentity.MetadataMode
-			if mode == store.GCPMetadataModeAssign || mode == store.GCPMetadataModePassthrough {
-				gcpSAAssigned = true
-			}
+		if !gcpSAAssigned {
+			gcpSAAssigned = agentHasGCPIdentityAssigned(agent)
 		}
 		for authType := range authMeta.Types {
 			satisfied, err := s.isAuthTypeSatisfied(ctx, agent, authMeta, authType, gcpSAAssigned)
@@ -1267,14 +1272,8 @@ func (s *Server) hasRequiredAuthCredentials(ctx context.Context, agent *store.Ag
 		if err != nil {
 			return false, err
 		}
-		// Also check agent's own GCP identity config (mirrors broker logic
-		// at handlers.go:2186-2187). Passthrough-to-assign translated agents
-		// have MetadataMode=assign but no project-scoped SA record.
-		if !gcpSAAssigned && agent.AppliedConfig.GCPIdentity != nil {
-			mode := agent.AppliedConfig.GCPIdentity.MetadataMode
-			if mode == store.GCPMetadataModeAssign || mode == store.GCPMetadataModePassthrough {
-				gcpSAAssigned = true
-			}
+		if !gcpSAAssigned {
+			gcpSAAssigned = agentHasGCPIdentityAssigned(agent)
 		}
 		fileSecrets := harness.RequiredAuthSecretsFromConfig(authMeta, agent.AppliedConfig.HarnessAuth, gcpSAAssigned)
 		for _, fs := range fileSecrets {

--- a/pkg/hub/handlers_agent_create_helpers.go
+++ b/pkg/hub/handlers_agent_create_helpers.go
@@ -1211,7 +1211,7 @@ func (s *Server) findBrokerByIDOrSlug(ctx context.Context, identifier string) (*
 // config has MetadataMode set to assign or passthrough, mirroring the broker's
 // check at pkg/runtimebroker/handlers.go:2186-2187.
 func agentHasGCPIdentityAssigned(agent *store.Agent) bool {
-	if agent.AppliedConfig.GCPIdentity == nil {
+	if agent == nil || agent.AppliedConfig == nil || agent.AppliedConfig.GCPIdentity == nil {
 		return false
 	}
 	mode := agent.AppliedConfig.GCPIdentity.MetadataMode

--- a/pkg/hub/handlers_agent_create_helpers_noauth_test.go
+++ b/pkg/hub/handlers_agent_create_helpers_noauth_test.go
@@ -174,3 +174,174 @@ func TestIsAuthTypeSatisfied_GCPServiceAccountSkipsEnvCheck(t *testing.T) {
 		}
 	})
 }
+
+// TestHasRequiredAuthCredentials_AgentGCPIdentityAutodetect verifies that when
+// an agent has a GCPIdentity config with MetadataMode=assign or passthrough
+// (e.g. from passthrough-to-assign translation on sandbox runtimes), the hub's
+// auth autodetect correctly picks vertex-ai even without a project-scoped
+// verified GCP service account record.
+//
+// This mirrors the broker-side logic at handlers.go:2186-2187.
+func TestHasRequiredAuthCredentials_AgentGCPIdentityAutodetect(t *testing.T) {
+	srv, memStore := testServer(t)
+	ctx := context.Background()
+
+	// Create a project with NO verified GCP service account.
+	projectID := tid("gcp-proj-noSA")
+	project := &store.Project{
+		ID:   projectID,
+		Name: "no-sa-project",
+		Slug: "no-sa-project",
+	}
+	if err := memStore.CreateProject(ctx, project); err != nil {
+		t.Fatalf("CreateProject failed: %v", err)
+	}
+
+	// Simulate the Claude harness config with vertex-ai and api-key auth types.
+	authMeta := &config.HarnessAuthMetadata{
+		Types: map[string]api.HarnessAuthTypeMetadata{
+			"vertex-ai": {
+				RequiredEnv: []api.HarnessAuthEnvRequirement{
+					{AnyOf: []string{"GOOGLE_CLOUD_PROJECT"}},
+					{AnyOf: []string{"GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION", "GOOGLE_CLOUD_LOCATION"}},
+				},
+				RequiredFiles: []api.HarnessAuthFileRequirement{
+					{
+						Name:                                 "gcloud-adc",
+						Type:                                 "file",
+						Field:                                "GoogleAppCredentials",
+						AlternativeEnvKeys:                   []string{"GOOGLE_APPLICATION_CREDENTIALS"},
+						SkippedWhenGCPServiceAccountAssigned: true,
+						Required:                             true,
+					},
+				},
+			},
+			"api-key": {
+				RequiredEnv: []api.HarnessAuthEnvRequirement{
+					{AnyOf: []string{"ANTHROPIC_API_KEY"}},
+				},
+			},
+		},
+	}
+
+	t.Run("assign mode: autodetect picks vertex-ai without project SA", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:        tid("agent-assign-noSA"),
+			Name:      "assign-agent",
+			Slug:      "assign-agent",
+			OwnerID:   tid("user-1"),
+			ProjectID: projectID,
+			AppliedConfig: &store.AgentAppliedConfig{
+				GCPIdentity: &store.GCPIdentityConfig{
+					MetadataMode: store.GCPMetadataModeAssign,
+				},
+			},
+		}
+
+		hasCreds, err := srv.hasRequiredAuthCredentials(ctx, agent, "claude", authMeta)
+		if err != nil {
+			t.Fatalf("hasRequiredAuthCredentials failed: %v", err)
+		}
+		if !hasCreds {
+			t.Error("expected hasRequiredAuthCredentials to return true — agent has GCPIdentity with assign mode, vertex-ai should be satisfied")
+		}
+	})
+
+	t.Run("passthrough mode: autodetect picks vertex-ai without project SA", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:        tid("agent-passthrough-noSA"),
+			Name:      "passthrough-agent",
+			Slug:      "passthrough-agent",
+			OwnerID:   tid("user-1"),
+			ProjectID: projectID,
+			AppliedConfig: &store.AgentAppliedConfig{
+				GCPIdentity: &store.GCPIdentityConfig{
+					MetadataMode: store.GCPMetadataModePassthrough,
+				},
+			},
+		}
+
+		hasCreds, err := srv.hasRequiredAuthCredentials(ctx, agent, "claude", authMeta)
+		if err != nil {
+			t.Fatalf("hasRequiredAuthCredentials failed: %v", err)
+		}
+		if !hasCreds {
+			t.Error("expected hasRequiredAuthCredentials to return true — agent has GCPIdentity with passthrough mode, vertex-ai should be satisfied")
+		}
+	})
+
+	t.Run("no GCPIdentity: falls back to projectHasVerifiedGCPSA (returns false)", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:            tid("agent-no-identity"),
+			Name:          "no-identity-agent",
+			Slug:          "no-identity-agent",
+			OwnerID:       tid("user-1"),
+			ProjectID:     projectID,
+			AppliedConfig: &store.AgentAppliedConfig{},
+		}
+
+		hasCreds, err := srv.hasRequiredAuthCredentials(ctx, agent, "claude", authMeta)
+		if err != nil {
+			t.Fatalf("hasRequiredAuthCredentials failed: %v", err)
+		}
+		if hasCreds {
+			t.Error("expected hasRequiredAuthCredentials to return false — no GCPIdentity and no project SA")
+		}
+	})
+
+	t.Run("block mode: does not satisfy GCP SA check", func(t *testing.T) {
+		agent := &store.Agent{
+			ID:        tid("agent-block-noSA"),
+			Name:      "block-agent",
+			Slug:      "block-agent",
+			OwnerID:   tid("user-1"),
+			ProjectID: projectID,
+			AppliedConfig: &store.AgentAppliedConfig{
+				GCPIdentity: &store.GCPIdentityConfig{
+					MetadataMode: store.GCPMetadataModeBlock,
+				},
+			},
+		}
+
+		hasCreds, err := srv.hasRequiredAuthCredentials(ctx, agent, "claude", authMeta)
+		if err != nil {
+			t.Fatalf("hasRequiredAuthCredentials failed: %v", err)
+		}
+		if hasCreds {
+			t.Error("expected hasRequiredAuthCredentials to return false — block mode should not satisfy GCP SA check")
+		}
+	})
+
+	t.Run("explicit auth type with assign mode: file secrets skipped", func(t *testing.T) {
+		// When an explicit auth type is set AND the agent has GCPIdentity with
+		// assign mode, the second gcpSAAssigned computation (file-secret check)
+		// should also detect the agent identity and skip the gcloud-adc file
+		// requirement. We provide env vars so the env-var check passes and the
+		// test reaches the file-secret check (fix site 2).
+		agent := &store.Agent{
+			ID:        tid("agent-explicit-assign"),
+			Name:      "explicit-assign-agent",
+			Slug:      "explicit-assign-agent",
+			OwnerID:   tid("user-1"),
+			ProjectID: projectID,
+			AppliedConfig: &store.AgentAppliedConfig{
+				HarnessAuth: "vertex-ai",
+				Env: map[string]string{
+					"GOOGLE_CLOUD_PROJECT": "my-project",
+					"GOOGLE_CLOUD_REGION":  "us-central1",
+				},
+				GCPIdentity: &store.GCPIdentityConfig{
+					MetadataMode: store.GCPMetadataModeAssign,
+				},
+			},
+		}
+
+		hasCreds, err := srv.hasRequiredAuthCredentials(ctx, agent, "claude", authMeta)
+		if err != nil {
+			t.Fatalf("hasRequiredAuthCredentials failed: %v", err)
+		}
+		if !hasCreds {
+			t.Error("expected hasRequiredAuthCredentials to return true — explicit vertex-ai with assign mode should skip file secrets")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

When GCP identity passthrough is translated to assign on cloudrun-sandbox runtimes (merged in #1509), the hub-side auth autodetect in `hasRequiredAuthCredentials()` does not recognize the translated agent as having a GCP SA assigned. This causes autodetect to skip vertex-ai, requiring explicit auth method configuration.

**Fix:** Added `agentHasGCPIdentityAssigned()` helper mirroring broker logic.

Related: ptone/scion#1463
