### PR TITLE
style: fix gofmt alignment drift blocking CI

### DIFF
--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -3265,9 +3265,9 @@ func (s *Server) ensureHostSARecord(
 	}
 
 	sa := &store.GCPServiceAccount{
-		ID:      gouuid.New().String(),
-		Scope:   store.ScopeHub,
-		ScopeID: broker.ID,
+		ID:          gouuid.New().String(),
+		Scope:       store.ScopeHub,
+		ScopeID:     broker.ID,
 		Email:       broker.GCPHostServiceAccountEmail,
 		ProjectID:   projectID,
 		DisplayName: fmt.Sprintf("Broker host SA (%s)", broker.Name),

--- a/pkg/hub/web_test.go
+++ b/pkg/hub/web_test.go
@@ -53,16 +53,16 @@ func (m *mockProxyAuthenticator) Name() string { return "mock" }
 
 // proxyAuthStore is a minimal store that supports the proxy auth user provisioning path.
 type proxyAuthStore struct {
-	store.Store // embed interface to satisfy all methods
-	users          map[string]*store.User
-	roleBindings   map[string]*store.RoleBinding
+	store.Store     // embed interface to satisfy all methods
+	users           map[string]*store.User
+	roleBindings    map[string]*store.RoleBinding
 	roleDefinitions map[string]*store.RoleDefinition
 }
 
 func newProxyAuthStore() *proxyAuthStore {
 	return &proxyAuthStore{
-		users:          make(map[string]*store.User),
-		roleBindings:   make(map[string]*store.RoleBinding),
+		users:           make(map[string]*store.User),
+		roleBindings:    make(map[string]*store.RoleBinding),
 		roleDefinitions: make(map[string]*store.RoleDefinition),
 	}
 }


### PR DESCRIPTION
## Summary

- Run gofmt -w on two files with struct field alignment drift on main
- handlers_agents_core.go and web_test.go

## Why

The gofmt check fails on every open PR because main itself has two unformatted files.

Refs ptone/scion#1469
