### PR TITLE
fix(hub): add broker-heartbeat-timeout scheduler (#1471)

### DIFF
--- a/pkg/hub/reaper.go
+++ b/pkg/hub/reaper.go
@@ -54,7 +54,16 @@ func (s *Server) brokerHeartbeatTimeoutHandler() func(ctx context.Context) {
 		}
 
 		for _, id := range ids {
-			s.events.PublishBrokerStatus(ctx, id, "offline")
+			providers, err := s.store.GetBrokerProjects(ctx, id)
+			if err != nil {
+				slog.Error("Scheduler: failed to get broker projects for event publishing", "brokerID", id, "error", err)
+				continue
+			}
+			projectIDs := make([]string, len(providers))
+			for i, p := range providers {
+				projectIDs[i] = p.ProjectID
+			}
+			s.events.PublishBrokerDisconnected(ctx, id, projectIDs)
 		}
 
 		if len(ids) > 0 {

--- a/pkg/hub/reaper.go
+++ b/pkg/hub/reaper.go
@@ -35,6 +35,35 @@ const (
 	dispatchMaxRetries = 3
 )
 
+// brokerHeartbeatTimeoutHandler returns a recurring handler that marks brokers
+// as offline when their last heartbeat exceeds a 5-minute threshold. It publishes
+// status events for each affected broker so SSE subscribers are informed.
+func (s *Server) brokerHeartbeatTimeoutHandler() func(ctx context.Context) {
+	return func(ctx context.Context) {
+		// Tight timeout: fail fast if DB connections are saturated rather than
+		// holding a connection while waiting, which worsens the thundering herd.
+		ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+
+		threshold := time.Now().Add(-5 * time.Minute)
+
+		ids, err := s.store.MarkStaleBrokersOffline(ctx, threshold)
+		if err != nil {
+			slog.Error("Scheduler: broker heartbeat timeout check failed", "error", err)
+			return
+		}
+
+		for _, id := range ids {
+			s.events.PublishBrokerStatus(ctx, id, "offline")
+		}
+
+		if len(ids) > 0 {
+			slog.Info("Scheduler: marked stale brokers as offline",
+				"count", len(ids), "threshold", threshold)
+		}
+	}
+}
+
 // brokerAffinityReapHandler returns a recurring handler that clears stale broker
 // affinity and re-drives (or fails) stuck dispatches. Registered as a singleton
 // so at most one replica runs it per tick.

--- a/pkg/hub/server.go
+++ b/pkg/hub/server.go
@@ -3510,6 +3510,7 @@ func (s *Server) StartBackgroundServices(ctx context.Context) {
 	s.scheduler.RegisterEventHandler("message", s.messageEventHandler())
 	s.scheduler.RegisterEventHandler("dispatch_agent", s.dispatchAgentEventHandler())
 	s.scheduler.RegisterRecurringSingleton("schedule-evaluator", 1, store.LockScheduleEvaluator, s.evaluateSchedulesHandler())
+	s.scheduler.RegisterRecurringSingleton("broker-heartbeat-timeout", 5, store.LockBrokerHeartbeatTimeout, s.brokerHeartbeatTimeoutHandler())
 	s.scheduler.RegisterRecurringSingleton("broker-affinity-reap", 5, store.LockBrokerAffinityReap, s.brokerAffinityReapHandler())
 	s.scheduler.RegisterRecurringSingleton("broker-message-sweep", 5, store.LockBrokerMessageSweep, s.brokerMessageSweepHandler())
 	s.scheduler.RegisterRecurringSingleton("exposed-ports-sweep", 5, store.LockExposedPortsSweep, s.exposedPortsSweepHandler())

--- a/pkg/store/concurrency.go
+++ b/pkg/store/concurrency.go
@@ -55,6 +55,8 @@ const (
 	LockGitHubAppHealthCheck AdvisoryLockKey = 0x5C100005
 	// LockBrokerAffinityReap guards the stale broker-affinity + stuck dispatch reaper.
 	LockBrokerAffinityReap AdvisoryLockKey = 0x5C100006
+	// LockBrokerHeartbeatTimeout guards the stale-broker → offline sweep.
+	LockBrokerHeartbeatTimeout AdvisoryLockKey = 0x5C100015
 	// LockBrokerMessageSweep guards the periodic stuck-pending-message sweep (B5-2).
 	LockBrokerMessageSweep AdvisoryLockKey = 0x5C100007
 	// LockSchemaMigration guards startup schema migration and built-in seed data

--- a/pkg/store/entadapter/project_store.go
+++ b/pkg/store/entadapter/project_store.go
@@ -1193,6 +1193,44 @@ func (s *ProjectStore) ReapStaleBrokerAffinity(ctx context.Context, staleBefore 
 	return affected, nil
 }
 
+// MarkStaleBrokersOffline sets status=offline for brokers whose last_heartbeat
+// is older than threshold and whose status is not already offline. Returns the
+// IDs of affected brokers so the caller can publish SSE events.
+func (s *ProjectStore) MarkStaleBrokersOffline(ctx context.Context, threshold time.Time) ([]string, error) {
+	// Find candidate brokers — not offline, heartbeat older than threshold.
+	candidates, err := s.client.RuntimeBroker.Query().
+		Where(
+			runtimebroker.StatusNEQ(store.BrokerStatusOffline),
+			runtimebroker.LastHeartbeatLT(threshold),
+		).
+		All(ctx)
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	now := time.Now()
+	var ids []string
+	for _, b := range candidates {
+		affected, err := s.client.RuntimeBroker.Update().
+			Where(runtimebroker.IDEQ(b.ID), runtimebroker.LockVersionEQ(b.LockVersion)).
+			SetStatus(store.BrokerStatusOffline).
+			ClearConnectedHubID().
+			ClearConnectedSessionID().
+			ClearConnectedAt().
+			SetUpdated(now).
+			AddLockVersion(1).
+			Save(ctx)
+		if err != nil {
+			return nil, mapError(err)
+		}
+		if affected == 1 {
+			ids = append(ids, b.ID.String())
+		}
+		// affected==0 means another writer raced us — skip this broker.
+	}
+	return ids, nil
+}
+
 // =============================================================================
 // ProjectProvider (project_contributors) operations
 // =============================================================================

--- a/pkg/store/entadapter/project_store.go
+++ b/pkg/store/entadapter/project_store.go
@@ -1225,6 +1225,17 @@ func (s *ProjectStore) MarkStaleBrokersOffline(ctx context.Context, threshold ti
 		}
 		if affected == 1 {
 			ids = append(ids, b.ID.String())
+			// Mirror the WebSocket disconnect handler: mark this broker's
+			// project contributor records offline so populateProjectComputed
+			// reports correct active-broker counts.
+			_, err = s.client.ProjectContributor.Update().
+				Where(projectcontributor.BrokerIDEQ(b.ID)).
+				SetStatus(store.BrokerStatusOffline).
+				SetLastSeen(now).
+				Save(ctx)
+			if err != nil {
+				return nil, mapError(err)
+			}
 		}
 		// affected==0 means another writer raced us — skip this broker.
 	}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -545,6 +545,11 @@ type RuntimeBrokerStore interface {
 	// shut down are explicitly marked offline. Returns ErrNotFound if the
 	// broker doesn't exist. No-op if the broker is already offline.
 	MarkBrokerOffline(ctx context.Context, brokerID string) error
+
+	// MarkStaleBrokersOffline sets status=offline for brokers whose
+	// last_heartbeat is older than threshold and whose status is not already
+	// offline. Returns the IDs of affected brokers for event publishing.
+	MarkStaleBrokersOffline(ctx context.Context, threshold time.Time) ([]string, error)
 }
 
 // RuntimeBrokerFilter defines criteria for filtering runtime brokers.


### PR DESCRIPTION
## Summary
- Adds broker-heartbeat-timeout recurring scheduler (5-min cycle, 5-min threshold) to mark stale brokers offline
- Prevents dispatch failures when broker WebSocket disconnect fails to fire (hub crash, network partition)
- Mirrors agent-heartbeat-timeout pattern: advisory lock, batch store query, SSE event publishing

Fork PR: https://github.com/ptone/scion/pull/1473