### PR TITLE
Fix agent delete hang on stale broker (#1474)

### DIFF
--- a/pkg/hub/dispatch_wait.go
+++ b/pkg/hub/dispatch_wait.go
@@ -35,6 +35,12 @@ var ErrDispatchFailed = errors.New("dispatch failed: rolling timeout expired wit
 // considered failed. Single tunable per design §6.4.
 const dispatchRollingTimeout = 90 * time.Second
 
+// dispatchDeleteTimeout is a shorter rolling timeout for delete operations.
+// Deletes are lightweight broker-side operations and should not block the
+// caller for the full 90-second window — a 15-second silence is sufficient
+// to conclude the broker is unreachable.
+const dispatchDeleteTimeout = 15 * time.Second
+
 // waitForAgentTransition waits for an agent's phase to reach a terminal state,
 // using a rolling timeout that resets on ANY AgentStatusEvent (phase, activity,
 // or detail change). The caller must subscribe to the agent's status events
@@ -96,16 +102,22 @@ func waitForAgentTransition(
 // passes the channel + unsub here. On event arrival (or timeout), the row is
 // read from the store — the DB row is authoritative (design §6.3), so a missed
 // event is recoverable.
+//
+// timeoutOverride, if non-zero, replaces the default dispatchRollingTimeout.
 func waitForDispatchDone(
 	ctx context.Context,
 	events <-chan Event,
 	unsub func(),
 	st store.BrokerDispatchStore,
 	dispatchID string,
+	timeoutOverride ...time.Duration,
 ) (*store.BrokerDispatch, error) {
 	defer unsub()
 
 	timeout := dispatchRollingTimeout
+	if len(timeoutOverride) > 0 && timeoutOverride[0] > 0 {
+		timeout = timeoutOverride[0]
+	}
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 

--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -2546,9 +2546,16 @@ func (s *Server) performAgentDelete(w http.ResponseWriter, r *http.Request, agen
 		}
 	}
 
+	// Phase-aware delete: agents in "created" phase were never provisioned on the
+	// broker — no container, no workspace, no branch. Skip broker dispatch entirely
+	// and go straight to hub-side cleanup. This prevents hanging on a stale broker
+	// for agents that never left the creation phase.
+	skipBrokerDispatch := agent.Phase == string(state.PhaseCreated)
+
 	// Verify broker is reachable before deleting to avoid orphaned containers.
 	// Force mode bypasses this check so stuck agents can always be cleaned up.
-	if !isManagedAgentRuntime(agent.Runtime) && !force && !s.checkBrokerAvailability(w, r, agent) {
+	// Created-phase agents skip this check since they have nothing on the broker.
+	if !isManagedAgentRuntime(agent.Runtime) && !skipBrokerDispatch && !force && !s.checkBrokerAvailability(w, r, agent) {
 		return
 	}
 
@@ -2557,8 +2564,9 @@ func (s *Server) performAgentDelete(w http.ResponseWriter, r *http.Request, agen
 
 	now := time.Now()
 
-	// If a dispatcher is available, dispatch the deletion to the runtime broker
-	if dispatcher := s.GetDispatcher(); dispatcher != nil && agent.RuntimeBrokerID != "" {
+	// If a dispatcher is available, dispatch the deletion to the runtime broker.
+	// Skip dispatch for created-phase agents — they were never provisioned.
+	if dispatcher := s.GetDispatcher(); dispatcher != nil && agent.RuntimeBrokerID != "" && !skipBrokerDispatch {
 		if err := dispatcher.DispatchAgentDelete(ctx, agent, deleteFiles, removeBranch, softDelete, now); err != nil {
 			if force {
 				// Force mode: log warning and continue with hub record deletion

--- a/pkg/hub/httpdispatcher.go
+++ b/pkg/hub/httpdispatcher.go
@@ -2679,7 +2679,13 @@ func (d *HTTPAgentDispatcher) deferredDataOpResult(
 	}
 
 	// 4. Wait for completion — reads result from the DB row (authoritative).
-	result, err := waitForDispatchDone(ctx, eventCh, unsub, d.store, dispatchID)
+	// Delete operations use a shorter timeout since they are lightweight
+	// broker-side operations and should not block the caller for 90 seconds.
+	var timeoutOverrides []time.Duration
+	if op == "delete" {
+		timeoutOverrides = append(timeoutOverrides, dispatchDeleteTimeout)
+	}
+	result, err := waitForDispatchDone(ctx, eventCh, unsub, d.store, dispatchID, timeoutOverrides...)
 	if err != nil {
 		return nil, err
 	}

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -866,7 +866,6 @@ export class ScionPageAgentDetail extends LitElement {
                 : '/agents';
               return;
             }
-            return;
           }
           throw new Error(await extractApiError(response, 'Failed to delete agent'));
         }

--- a/web/src/components/pages/agent-detail.ts
+++ b/web/src/components/pages/agent-detail.ts
@@ -845,6 +845,29 @@ export class ScionPageAgentDetail extends LitElement {
         });
 
         if (!response.ok) {
+          // If the broker is unreachable (502/503), offer a force-delete fallback.
+          if (response.status === 502 || response.status === 503) {
+            const forceConfirmed = await showConfirm(
+              'Delete failed — the broker may be unreachable. Force delete this agent? This will remove the hub record without notifying the broker.',
+              { title: 'Force Delete', confirmText: 'Force Delete', variant: 'danger' }
+            );
+            if (forceConfirmed) {
+              const forceResponse = await apiFetch(
+                `/api/v1/agents/${this.agentId}?force=true`,
+                { method: 'DELETE' }
+              );
+              if (!forceResponse.ok) {
+                throw new Error(
+                  await extractApiError(forceResponse, 'Failed to force delete agent')
+                );
+              }
+              window.location.href = this.project
+                ? `/projects/${this.project.id}`
+                : '/agents';
+              return;
+            }
+            return;
+          }
           throw new Error(await extractApiError(response, 'Failed to delete agent'));
         }
 

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -583,7 +583,6 @@ export class ScionPageAgents extends LitElement {
               this.backgroundRefresh();
               return;
             }
-            return;
           }
           throw new Error(await extractApiError(response, 'Failed to delete agent'));
         }

--- a/web/src/components/pages/agents.ts
+++ b/web/src/components/pages/agents.ts
@@ -564,6 +564,27 @@ export class ScionPageAgents extends LitElement {
         });
 
         if (!response.ok) {
+          // If the broker is unreachable (502/503), offer a force-delete fallback.
+          if (response.status === 502 || response.status === 503) {
+            const forceConfirmed = await showConfirm(
+              'Delete failed — the broker may be unreachable. Force delete this agent? This will remove the hub record without notifying the broker.',
+              { title: 'Force Delete', confirmText: 'Force Delete', variant: 'danger' }
+            );
+            if (forceConfirmed) {
+              const forceResponse = await apiFetch(`/api/v1/agents/${agentId}?force=true`, {
+                method: 'DELETE',
+              });
+              if (!forceResponse.ok) {
+                throw new Error(
+                  await extractApiError(forceResponse, 'Failed to force delete agent')
+                );
+              }
+              this.agents = this.agents.filter((a) => a.id !== agentId);
+              this.backgroundRefresh();
+              return;
+            }
+            return;
+          }
           throw new Error(await extractApiError(response, 'Failed to delete agent'));
         }
 

--- a/web/src/components/pages/broker-detail.ts
+++ b/web/src/components/pages/broker-detail.ts
@@ -604,7 +604,6 @@ export class ScionPageBrokerDetail extends LitElement {
     if (agentCount > 0) {
       parts.push("affect " + agentCount + " running agent" + (agentCount !== 1 ? "s" : ""));
     }
-    }
     const consequence = parts.length > 0 ? `\n\nThis will ${parts.join(' and ')}.` : '';
     const message = `Unregister broker "${this.broker.name}"?${consequence}`;
 


### PR DESCRIPTION
## Summary
- Phase-aware delete: skip broker dispatch for created-phase agents (never provisioned)
- Web UI force-delete fallback: 502/503 triggers confirmation dialog to retry with ?force=true
- Shorter delete timeout: 15s instead of 90s for delete operations

Fork PR: https://github.com/ptone/scion/pull/1477