### PR TITLE
docs: nightly doc update Sep 10 (default broker, broker lifecycle, GCP sandbox passthrough)

### DIFF
--- a/docs-site/src/content/docs/hosted/ha/multi-broker.md
+++ b/docs-site/src/content/docs/hosted/ha/multi-broker.md
@@ -40,7 +40,15 @@ Repeat for each machine. See [Runtime Broker](/scion/hosted/ha/runtime-broker/) 
 
 ## Broker Selection
 
-When starting an agent, the Hub selects an available broker automatically. You can override this:
+When starting an agent, the Hub resolves a broker through a priority cascade:
+
+| Priority | Source | Condition |
+| :--- | :--- | :--- |
+| 1 | **Explicit `--broker` flag** | The named broker must be a provider for the project (auto-linked if not). |
+| 2 | **Project default broker** | Set in project settings; must be online. |
+| 3 | **Hub-level default broker** | Set in [Agent Defaults](/scion/reference/admin-settings/#layout-structure) (`default_runtime_broker`); used when the project has no default. Must be a provider, online, and dispatchable. |
+| 4 | **Single-provider auto-select** | If exactly one broker provides the project and it is online, it is used automatically. |
+| 5 | **Error** | Multiple eligible brokers require explicit selection; no providers is an error. |
 
 - **Target a specific broker** with the `--broker` flag:
   ```bash

--- a/docs-site/src/content/docs/hosted/ha/runtime-broker.md
+++ b/docs-site/src/content/docs/hosted/ha/runtime-broker.md
@@ -100,9 +100,22 @@ When you register your machine as a broker:
 *   **Safe Secrets**: Sensitive API keys and environment variables managed in the Hub are injected directly into the agent container's memory at runtime. They are not saved to your local disk.
 *   **Mutual Authentication**: All communication over the Control Channel uses HMAC-SHA256 signatures, ensuring that only the authorized Hub can send commands to your machine.
 
+## Broker Health Monitoring
+
+The Hub monitors broker health via a recurring heartbeat timeout scheduler. If a broker's WebSocket control channel disconnects and the disconnect event is not received (for example, due to a Hub crash or network partition), the Hub automatically marks the broker as **offline** after approximately five minutes of missed heartbeats. This mirrors the existing agent heartbeat timeout pattern and ensures the broker selection cascade does not dispatch work to unreachable brokers.
+
+## Unregistering a Broker
+
+To permanently remove a broker from the Hub, use the **Unregister** button on the broker detail page in the Web Dashboard. Unregistering a broker:
+
+- Removes the broker's registration from the Hub.
+- Cleans up associated HMAC secrets and join tokens.
+
+Unregistration is an admin-gated action and requires confirmation. After unregistering, the broker can no longer receive agent dispatch commands. Re-registration via `scion broker register` is required to reconnect.
+
 ## Stopping the Broker
 
-If you want to stop accepting agent workloads from the Hub, you can simply stop the broker daemon:
+If you want to stop accepting agent workloads from the Hub temporarily, you can stop the broker daemon:
 
 ```bash
 scion broker stop

--- a/docs-site/src/content/docs/hosted/single-node/auth.md
+++ b/docs-site/src/content/docs/hosted/single-node/auth.md
@@ -322,6 +322,10 @@ When creating an agent, you can configure its **GCP Identity Mode**:
   - The token is then returned to the agent, allowing it to use standard GCP SDKs (Application Default Credentials) as that specific Service Account.
 - **Passthrough**: Requests are allowed to reach the actual host metadata server. Use with caution as this allows the agent to assume the identity of the underlying node. Security is tightened by restricting GCP identity passthrough to broker owners only.
 
+:::note[Sandbox runtimes]
+Sandbox runtimes (such as `cloudrun-sandbox` profiles using gVisor) cannot reach the GCE metadata server at `169.254.169.254`, so passthrough mode produces no credentials. The Hub automatically translates passthrough to **assign** mode at agent creation and PATCH time, using the broker's host service account. Downstream JWT scopes, resolved environment variables, and the `gcp-token` endpoint work automatically after translation.
+:::
+
 ### Management UI & Hub-Minted Service Accounts
 
 Administrators can manage available Service Accounts through the **Service Accounts** section in the Admin dashboard. 

--- a/docs-site/src/content/docs/reference/admin-settings.md
+++ b/docs-site/src/content/docs/reference/admin-settings.md
@@ -171,6 +171,7 @@ To streamline management of complex environments, the **General** settings tab i
 2. **Agent Defaults Card** (with dedicated sub-tabs):
    - Configures default resource constraints (`max_turns`, `max_duration`, limits). These fields can be cleared to blank in the UI, which persists them as `null` in the Hub settings database instead of preserving their previous values, allowing administrators to remove default constraints entirely.
    - Introduces **Default Model** (`default_model`), **Default Thinking Level** (`default_thinking_level`), and **Default Agent Role** (`default_agent_role`) fields directly into the agent default pipeline (with the default agent role updated from `baseline` to `full` for usability).
+   - Introduces **Default Runtime Broker** (`default_runtime_broker`), a hub-level default that participates in the broker resolution cascade (see below). When a project has no default broker and no broker is explicitly requested, the hub-level default is used if the broker is online and dispatchable.
    - Houses the **Telemetry Toggle**, which has been moved to this card to keep telemetry configuration closely aligned with operational defaults.
 3. **Project Default Settings Card**: Configures platform-level default annotations and behaviors for newly created projects.
 

--- a/docs-site/src/content/docs/reference/admin-settings.md
+++ b/docs-site/src/content/docs/reference/admin-settings.md
@@ -171,7 +171,7 @@ To streamline management of complex environments, the **General** settings tab i
 2. **Agent Defaults Card** (with dedicated sub-tabs):
    - Configures default resource constraints (`max_turns`, `max_duration`, limits). These fields can be cleared to blank in the UI, which persists them as `null` in the Hub settings database instead of preserving their previous values, allowing administrators to remove default constraints entirely.
    - Introduces **Default Model** (`default_model`), **Default Thinking Level** (`default_thinking_level`), and **Default Agent Role** (`default_agent_role`) fields directly into the agent default pipeline (with the default agent role updated from `baseline` to `full` for usability).
-   - Introduces **Default Runtime Broker** (`default_runtime_broker`), a hub-level default that participates in the broker resolution cascade (see below). When a project has no default broker and no broker is explicitly requested, the hub-level default is used if the broker is online and dispatchable.
+   - Introduces **Default Runtime Broker** (`default_runtime_broker`), a hub-level default that participates in the [broker resolution cascade](/scion/hosted/ha/multi-broker/#broker-selection). When a project has no default broker and no broker is explicitly requested, the hub-level default is used if the broker is online and dispatchable.
    - Houses the **Telemetry Toggle**, which has been moved to this card to keep telemetry configuration closely aligned with operational defaults.
 3. **Project Default Settings Card**: Configures platform-level default annotations and behaviors for newly created projects.
 


### PR DESCRIPTION
## Changes

- **admin-settings.md**: Added DefaultRuntimeBroker to Agent Defaults Card (#1521)
- **multi-broker.md**: Full 5-step broker resolution cascade table (#1521)
- **runtime-broker.md**: Broker Health Monitoring (heartbeat timeout, #1518) and Unregistering a Broker (#1515) sections
- **auth.md**: Sandbox runtimes callout for passthrough-to-assign auto-translation (#1509)

4 files, 28 insertions, 2 deletions
