### PR TITLE
fix: template pagination overflow and scope filtering

### DIFF
--- a/web/src/client/api.ts
+++ b/web/src/client/api.ts
@@ -156,6 +156,9 @@ export async function apiFetch(path: string, options?: ApiFetchOptions): Promise
  * This makes it suitable for "fetch everything" use-cases like dropdowns and
  * selector lists.
  */
+/** Safety bound to prevent infinite pagination loops (e.g. server returning the same cursor). */
+const MAX_PAGES = 50;
+
 export async function apiFetchAllPages<T>(
   baseUrl: string,
   key: string,
@@ -163,12 +166,20 @@ export async function apiFetchAllPages<T>(
 ): Promise<T[]> {
   const allItems: T[] = [];
   let cursor = '';
+  let page = 0;
 
   do {
     const sep = baseUrl.includes('?') ? '&' : '?';
     const url = cursor ? `${baseUrl}${sep}cursor=${encodeURIComponent(cursor)}` : baseUrl;
     const res = await apiFetch(url, options);
-    if (!res.ok) break;
+    if (!res.ok) {
+      if (allItems.length === 0) {
+        // First page failed — throw so callers can show error
+        throw new Error(`Failed to fetch: ${res.status} ${res.statusText}`);
+      }
+      // Subsequent pages — return what we have so far
+      break;
+    }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data = (await res.json()) as Record<string, any>;
     const items = data[key];
@@ -176,7 +187,8 @@ export async function apiFetchAllPages<T>(
       allItems.push(...(items as T[]));
     }
     cursor = (typeof data.nextCursor === 'string' && data.nextCursor) || '';
-  } while (cursor);
+    page++;
+  } while (cursor && page < MAX_PAGES);
 
   return allItems;
 }

--- a/web/src/client/api.ts
+++ b/web/src/client/api.ts
@@ -145,6 +145,43 @@ export async function apiFetch(path: string, options?: ApiFetchOptions): Promise
 }
 
 /**
+ * Fetch all pages of a cursor-paginated API endpoint.
+ *
+ * Follows `nextCursor` values returned by the server until every page has been
+ * retrieved. The caller provides a `key` that names the array property in the
+ * JSON response (e.g. `"templates"`, `"harnessConfigs"`).
+ *
+ * The helper is intentionally simple: it concatenates all items into a single
+ * array and discards per-page metadata (totalCount, capabilities, …).
+ * This makes it suitable for "fetch everything" use-cases like dropdowns and
+ * selector lists.
+ */
+export async function apiFetchAllPages<T>(
+  baseUrl: string,
+  key: string,
+  options?: ApiFetchOptions
+): Promise<T[]> {
+  const allItems: T[] = [];
+  let cursor = '';
+
+  do {
+    const sep = baseUrl.includes('?') ? '&' : '?';
+    const url = cursor ? `${baseUrl}${sep}cursor=${encodeURIComponent(cursor)}` : baseUrl;
+    const res = await apiFetch(url, options);
+    if (!res.ok) break;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data = (await res.json()) as Record<string, any>;
+    const items = data[key];
+    if (Array.isArray(items)) {
+      allItems.push(...(items as T[]));
+    }
+    cursor = (typeof data.nextCursor === 'string' && data.nextCursor) || '';
+  } while (cursor);
+
+  return allItems;
+}
+
+/**
  * Extract a human-readable error message from an API error response.
  *
  * The backend returns errors in the format: `{"error": {"code": "...", "message": "..."}}`.

--- a/web/src/client/api.ts
+++ b/web/src/client/api.ts
@@ -177,11 +177,31 @@ export async function apiFetchAllPages<T>(
         // First page failed — throw so callers can show error
         throw new Error(`Failed to fetch: ${res.status} ${res.statusText}`);
       }
-      // Subsequent pages — return what we have so far
+      // Subsequent page failed — log warning, return what we have
+      console.warn(
+        `apiFetchAllPages: page ${page + 1} failed (${res.status}), returning ${allItems.length} items from previous pages`
+      );
       break;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data = (await res.json()) as Record<string, any>;
+    let data: Record<string, any>;
+    try {
+      data = (await res.json()) as Record<string, any>;
+    } catch {
+      if (allItems.length === 0) {
+        throw new Error(`Failed to parse response from ${baseUrl}`);
+      }
+      console.warn(
+        `apiFetchAllPages: failed to parse page ${page + 1} response, returning ${allItems.length} items from previous pages`
+      );
+      break;
+    }
+    if (!data || typeof data !== 'object') {
+      if (allItems.length === 0) {
+        throw new Error(`Invalid response format from ${baseUrl}`);
+      }
+      break;
+    }
     const items = data[key];
     if (Array.isArray(items)) {
       allItems.push(...(items as T[]));

--- a/web/src/components/pages/agent-create.ts
+++ b/web/src/components/pages/agent-create.ts
@@ -41,7 +41,7 @@ import { isSharedWorkspace } from '../../shared/types.js';
 import { KNOWN_HARNESS_NAMES, harnessDisplayName } from '../../shared/harness-utils.js';
 import { normalizeModelAlias } from '../../shared/model-utils.js';
 import { MESSAGE_MODE_DISPLAY } from '../../shared/message-mode.js';
-import { apiFetch, parseApiError } from '../../client/api.js';
+import { apiFetch, apiFetchAllPages, parseApiError } from '../../client/api.js';
 import { navigateTo } from '../../client/main.js';
 import type { EnvEntry } from '../shared/env-editor.js';
 import '../shared/env-editor.js';
@@ -402,11 +402,19 @@ export class ScionPageAgentCreate extends LitElement {
     this.error = null;
 
     try {
-      const [projectsRes, brokersRes, templatesRes, settingsRes, harnessConfigsRes] =
+      // Build the templates URL — add scope filtering when a project is known
+      // (e.g. from a URL query param) to reduce the result set.
+      const tmplParams = new URLSearchParams({ status: 'active', limit: '100' });
+      if (this.projectId) {
+        tmplParams.set('projectId', this.projectId);
+      }
+      const tmplUrl = `/api/v1/templates?${tmplParams.toString()}`;
+
+      const [projectsRes, brokersRes, templates, settingsRes, harnessConfigsRes] =
         await Promise.all([
-          fetch('/api/v1/projects?mine=true&limit=200', { credentials: 'include' }),
-          fetch('/api/v1/runtime-brokers?limit=200', { credentials: 'include' }),
-          apiFetch('/api/v1/templates?status=active&limit=100'),
+          fetch('/api/v1/projects?mine=true&limit=100', { credentials: 'include' }),
+          fetch('/api/v1/runtime-brokers?limit=100', { credentials: 'include' }),
+          apiFetchAllPages<Template>(tmplUrl, 'templates'),
           fetch('/api/v1/settings/public', { credentials: 'include' }),
           apiFetch('/api/v1/harness-configs?status=active&limit=100'),
         ]);
@@ -422,10 +430,7 @@ export class ScionPageAgentCreate extends LitElement {
         this.brokers = Array.isArray(data) ? data : data.brokers || [];
       }
 
-      if (templatesRes.ok) {
-        const data = (await templatesRes.json()) as { templates?: Template[] } | Template[];
-        this.templates = Array.isArray(data) ? data : data.templates || [];
-      }
+      this.templates = templates;
 
       if (settingsRes.ok) {
         const data = (await settingsRes.json()) as {

--- a/web/src/components/pages/project-settings.ts
+++ b/web/src/components/pages/project-settings.ts
@@ -40,7 +40,7 @@ import { normalizeModelAlias } from '../../shared/model-utils.js';
 import { KNOWN_HARNESS_NAMES, harnessDisplayName } from '../../shared/harness-utils.js';
 import type { AccessBoundarySummary } from '../../shared/access-boundaries.js';
 import type { BoundarySummaryGroup } from '../shared/boundary-summary-notice.js';
-import { apiFetch, extractApiError } from '../../client/api.js';
+import { apiFetch, apiFetchAllPages, extractApiError } from '../../client/api.js';
 import { dispatchPageTitle } from '../../client/page-title.js';
 import '../shared/boundary-summary-notice.js';
 import '../shared/env-var-list.js';
@@ -983,13 +983,15 @@ export class ScionPageProjectSettings extends LitElement {
 
   private async loadDropdownTemplates(): Promise<void> {
     try {
-      const response = await apiFetch(
-        `/api/v1/templates?projectId=${encodeURIComponent(this.projectId)}&status=active`
+      const params = new URLSearchParams({
+        projectId: this.projectId,
+        status: 'active',
+        limit: '100',
+      });
+      this.dropdownTemplates = await apiFetchAllPages<Template>(
+        `/api/v1/templates?${params.toString()}`,
+        'templates'
       );
-      if (response.ok) {
-        const data = (await response.json()) as { templates?: Template[] } | Template[];
-        this.dropdownTemplates = Array.isArray(data) ? data : data.templates || [];
-      }
     } catch (err) {
       console.error('Failed to load dropdown templates:', err);
     }

--- a/web/src/components/shared/resource-list.ts
+++ b/web/src/components/shared/resource-list.ts
@@ -29,7 +29,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
-import { apiFetch, extractApiError } from '../../client/api.js';
+import { apiFetch, apiFetchAllPages, extractApiError } from '../../client/api.js';
 import { showToast } from '../../utils/toast.js';
 
 export type ResourceKind = 'template' | 'harness-config';
@@ -369,13 +369,12 @@ export class ScionResourceList extends LitElement {
       // every project's resources.
       if (this.scope === 'project' && this.scopeId) params.set('scopeId', this.scopeId);
 
-      const response = await apiFetch(`/api/v1/${this.apiResource}?${params.toString()}`);
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-      const data = (await response.json()) as Record<string, ResourceItem[]>;
-      const list = this.kind === 'template' ? data.templates : data.harnessConfigs;
-      this.items = (Array.isArray(list) ? list : [])
+      const key = this.kind === 'template' ? 'templates' : 'harnessConfigs';
+      const list = await apiFetchAllPages<ResourceItem>(
+        `/api/v1/${this.apiResource}?${params.toString()}`,
+        key
+      );
+      this.items = list
         .slice()
         .sort((a, b) => (a.displayName || a.name).localeCompare(b.displayName || b.name));
     } catch (err) {
@@ -495,13 +494,12 @@ export class ScionResourceList extends LitElement {
     this.globalItems = [];
     try {
       const params = new URLSearchParams({ status: 'active', scope: 'global', limit: '100' });
-      const response = await apiFetch(`/api/v1/${this.apiResource}?${params.toString()}`);
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-      const data = (await response.json()) as Record<string, ResourceItem[]>;
-      const list = this.kind === 'template' ? data.templates : data.harnessConfigs;
-      this.globalItems = (Array.isArray(list) ? list : [])
+      const key = this.kind === 'template' ? 'templates' : 'harnessConfigs';
+      const list = await apiFetchAllPages<ResourceItem>(
+        `/api/v1/${this.apiResource}?${params.toString()}`,
+        key
+      );
+      this.globalItems = list
         .slice()
         .sort((a, b) => (a.displayName || a.name).localeCompare(b.displayName || b.name));
     } catch (err) {
@@ -537,13 +535,12 @@ export class ScionResourceList extends LitElement {
       if (this.scope) params.set('scope', this.scope);
       if (this.scope === 'project' && this.scopeId) params.set('scopeId', this.scopeId);
 
-      const response = await apiFetch(`/api/v1/${this.apiResource}?${params.toString()}`);
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-      const data = (await response.json()) as Record<string, ResourceItem[]>;
-      const list = this.kind === 'template' ? data.templates : data.harnessConfigs;
-      this.items = (Array.isArray(list) ? list : [])
+      const key = this.kind === 'template' ? 'templates' : 'harnessConfigs';
+      const list = await apiFetchAllPages<ResourceItem>(
+        `/api/v1/${this.apiResource}?${params.toString()}`,
+        key
+      );
+      this.items = list
         .slice()
         .sort((a, b) => (a.displayName || a.name).localeCompare(b.displayName || b.name));
     } catch (err) {


### PR DESCRIPTION
## Summary
- Fixes #1504
- Lowers limit=200 to limit=100 in agent-create to stay within authorizedListMaxPageSize, preventing 400 Bad Request errors
- Adds apiFetchAllPages() helper in api.ts with MAX_PAGES safety bound and proper error handling
- Applies cursor pagination to template fetches in agent-create.ts, project-settings.ts, and resource-list.ts so hubs with 100+ templates no longer silently drop entries
- Adds projectId scope filtering to agent-create template fetch when project context is available
- Adds explicit limit + projectId to project-settings dropdown template fetch

## Changed Files
| File | Change |
|------|--------|
| web/src/client/api.ts | New apiFetchAllPages generic pagination helper with MAX_PAGES=50 safety bound |
| web/src/components/pages/agent-create.ts | limit=200->100, scope filtering, cursor pagination for templates |
| web/src/components/pages/project-settings.ts | Cursor pagination + explicit limit for dropdown templates |
| web/src/components/shared/resource-list.ts | Cursor pagination in load(), openGlobalPicker(), _reloadBackground() |
