### PR TITLE
feat(grok-build): wire missing hook events and quality improvements

### DIFF
--- a/harnesses/grok-build/config.yaml
+++ b/harnesses/grok-build/config.yaml
@@ -36,12 +36,12 @@ system_prompt_mode: native
 
 model_aliases:
   small: grok-3-mini
-  medium: grok-3
-  large: grok-4
-  extra-large: grok-4
+  medium: grok-4.5
+  large: grok-4.6
+  extra-large: grok-4.6
 
 command:
-  base: ["grok", "--yolo", "--sandbox", "off"]
+  base: ["grok", "--yolo", "--sandbox", "off", "--no-ask-user"]
   resume_flag: "-c"
   task_position: after_base_args
   system_prompt_flag: "--system-prompt-override"

--- a/harnesses/grok-build/dialect.yaml
+++ b/harnesses/grok-build/dialect.yaml
@@ -22,8 +22,12 @@ mappings:
   # Session lifecycle.
   SessionStart:
     event: session-start
+    fields:
+      source: source
   SessionEnd:
     event: session-end
+    fields:
+      reason: reason
 
   # Prompt lifecycle.
   UserPromptSubmit:
@@ -61,6 +65,27 @@ mappings:
   # Subagent lifecycle.
   SubagentStop:
     event: subagent-end
+
+  # Permission events.
+  PermissionDenied:
+    event: permission-denied
+    fields:
+      tool_name: toolName
+      tool_input: toolInput
+
+  # Subagent lifecycle (start).
+  SubagentStart:
+    event: subagent-start
+
+  # Context compaction.
+  PreCompact:
+    event: compact-start
+    fields:
+      source: source
+  PostCompact:
+    event: compact-end
+    fields:
+      source: source
 
   # Notifications.
   Notification:

--- a/harnesses/grok-build/provision.py
+++ b/harnesses/grok-build/provision.py
@@ -530,9 +530,6 @@ def _build_telemetry_env(telemetry: dict[str, Any], env: dict[str, str] | None) 
 # Hooks – sciontool event bridge
 # ---------------------------------------------------------------------------
 
-# Events that send synthetic echo payloads (no stdin from grok).
-_ECHO_EVENTS = {"SessionStart", "SessionEnd"}
-
 # All hook events.
 _GROK_HOOK_EVENTS = [
     "SessionStart",

--- a/harnesses/grok-build/provision.py
+++ b/harnesses/grok-build/provision.py
@@ -546,6 +546,10 @@ _GROK_HOOK_EVENTS = [
     "PostToolUseFailure",
     "SubagentStop",
     "Notification",
+    "PermissionDenied",
+    "SubagentStart",
+    "PreCompact",
+    "PostCompact",
 ]
 
 
@@ -561,14 +565,19 @@ def _write_hooks(home: str) -> None:
     """
     hooks: dict[str, list[dict[str, Any]]] = {}
     for event in _GROK_HOOK_EVENTS:
-        if event in _ECHO_EVENTS:
+        if event == "SessionStart":
             cmd = (
-                f"echo '{{\"hookEventName\": \"{event}\"}}' "
-                f"| sciontool hook --dialect=grok-build"
+                "echo '{\"hookEventName\": \"SessionStart\", \"source\": \"new\"}' "
+                "| sciontool hook --dialect=grok-build"
+            )
+        elif event == "SessionEnd":
+            cmd = (
+                "echo '{\"hookEventName\": \"SessionEnd\", \"reason\": \"end_turn\"}' "
+                "| sciontool hook --dialect=grok-build"
             )
         else:
             cmd = "cat | sciontool hook --dialect=grok-build"
-        timeout = 10 if event == "Stop" else 5
+        timeout = 60 if event in ("Stop", "SubagentStop") else 5
         hooks[event] = [
             {
                 "hooks": [

--- a/harnesses/grok-build/provision_test.py
+++ b/harnesses/grok-build/provision_test.py
@@ -470,9 +470,9 @@ class ModelResolutionTest(unittest.TestCase):
                 "instructions_file": "AGENTS.md",
                 "model_aliases": {
                     "small": "grok-3-mini",
-                    "medium": "grok-3",
-                    "large": "grok-4",
-                    "extra-large": "grok-4",
+                    "medium": "grok-4.5",
+                    "large": "grok-4.6",
+                    "extra-large": "grok-4.6",
                 },
             },
         })
@@ -483,14 +483,14 @@ class ModelResolutionTest(unittest.TestCase):
     def test_small_alias_resolves_to_grok_3_mini(self) -> None:
         self.assertEqual(self._resolve("small"), "grok-3-mini")
 
-    def test_medium_alias_resolves_to_grok_3(self) -> None:
-        self.assertEqual(self._resolve("medium"), "grok-3")
+    def test_medium_alias_resolves_to_grok_4_5(self) -> None:
+        self.assertEqual(self._resolve("medium"), "grok-4.5")
 
-    def test_large_alias_resolves_to_grok_4(self) -> None:
-        self.assertEqual(self._resolve("large"), "grok-4")
+    def test_large_alias_resolves_to_grok_4_6(self) -> None:
+        self.assertEqual(self._resolve("large"), "grok-4.6")
 
-    def test_extra_large_alias_resolves_to_grok_4(self) -> None:
-        self.assertEqual(self._resolve("extra-large"), "grok-4")
+    def test_extra_large_alias_resolves_to_grok_4_6(self) -> None:
+        self.assertEqual(self._resolve("extra-large"), "grok-4.6")
 
     def test_raw_model_name_passes_through(self) -> None:
         self.assertEqual(self._resolve("grok-4-turbo"), "grok-4-turbo")
@@ -500,7 +500,7 @@ class ModelResolutionTest(unittest.TestCase):
 
     def test_alias_is_case_insensitive(self) -> None:
         self.assertEqual(self._resolve("SMALL"), "grok-3-mini")
-        self.assertEqual(self._resolve("Large"), "grok-4")
+        self.assertEqual(self._resolve("Large"), "grok-4.6")
 
 
 # ---------------------------------------------------------------------------
@@ -523,7 +523,7 @@ class HookWriteTest(unittest.TestCase):
             for event in provision._GROK_HOOK_EVENTS:
                 self.assertIn(event, hooks, f"missing hook event: {event}")
 
-    def test_session_start_uses_echo(self) -> None:
+    def test_session_start_uses_echo_with_source(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             provision._write_hooks(tmp)
             hooks_path = os.path.join(tmp, ".grok", "hooks", "scion.json")
@@ -533,9 +533,10 @@ class HookWriteTest(unittest.TestCase):
             cmd = session_start[0]["hooks"][0]["command"]
             self.assertIn("echo", cmd)
             self.assertIn("SessionStart", cmd)
+            self.assertIn("source", cmd)
             self.assertIn("sciontool hook --dialect=grok-build", cmd)
 
-    def test_session_end_uses_echo(self) -> None:
+    def test_session_end_uses_echo_with_reason(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             provision._write_hooks(tmp)
             hooks_path = os.path.join(tmp, ".grok", "hooks", "scion.json")
@@ -545,6 +546,7 @@ class HookWriteTest(unittest.TestCase):
             cmd = session_end[0]["hooks"][0]["command"]
             self.assertIn("echo", cmd)
             self.assertIn("SessionEnd", cmd)
+            self.assertIn("reason", cmd)
 
     def test_pre_tool_use_uses_cat(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -565,7 +567,17 @@ class HookWriteTest(unittest.TestCase):
                 data = json.load(f)
             stop = data["hooks"]["Stop"]
             timeout = stop[0]["hooks"][0]["timeout"]
-            self.assertEqual(timeout, 10)
+            self.assertEqual(timeout, 60)
+
+    def test_subagent_stop_has_longer_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            provision._write_hooks(tmp)
+            hooks_path = os.path.join(tmp, ".grok", "hooks", "scion.json")
+            with open(hooks_path) as f:
+                data = json.load(f)
+            subagent_stop = data["hooks"]["SubagentStop"]
+            timeout = subagent_stop[0]["hooks"][0]["timeout"]
+            self.assertEqual(timeout, 60)
 
 
 # ---------------------------------------------------------------------------
@@ -1227,9 +1239,9 @@ class VertexAIAuthTest(unittest.TestCase):
                     "instructions_file": "AGENTS.md",
                     "model_aliases": {
                         "small": "grok-3-mini",
-                        "medium": "grok-3",
-                        "large": "grok-4",
-                        "extra-large": "grok-4",
+                        "medium": "grok-4.5",
+                        "large": "grok-4.6",
+                        "extra-large": "grok-4.6",
                     },
                 },
             })
@@ -1273,9 +1285,9 @@ class VertexAIAuthTest(unittest.TestCase):
                     "instructions_file": "AGENTS.md",
                     "model_aliases": {
                         "small": "grok-3-mini",
-                        "medium": "grok-3",
-                        "large": "grok-4",
-                        "extra-large": "grok-4",
+                        "medium": "grok-4.5",
+                        "large": "grok-4.6",
+                        "extra-large": "grok-4.6",
                     },
                 },
             })


### PR DESCRIPTION
Improves the grok-build harness based on comprehensive source analysis of the grok-build CLI (xai-org/grok-build at c4ea71c).

- Wire 4 missing hook events: PermissionDenied (security auditing), SubagentStart (lifecycle tracking), PreCompact/PostCompact (compaction telemetry)
- Increase Stop/SubagentStop hook timeout from 10s to 60s (source default is 600s; 10s caused premature timeouts)
- Update model aliases: medium to grok-4.5, large/extra-large to grok-4.6 (matching current grok-build defaults)
- Add --no-ask-user CLI flag for headless reliability
- Enrich SessionStart/SessionEnd echo payloads with source/reason fields
- Add dialect field mappings for all new events and enriched payloads

Ref: ptone/scion#1512