### PR TITLE
fix: remove agent.message from project-member role

### DIFF
--- a/pkg/hub/authorize_message_test.go
+++ b/pkg/hub/authorize_message_test.go
@@ -200,11 +200,11 @@ func TestAuthorizeAgentMessage_BaselineProjectMode_NoLifecycleScope(t *testing.T
 		t.Fatalf("baseline project-mode agent should be allowed to message: %s", reason)
 	}
 
-	// A project member (user) with agent.message but NOT agent.attach can message.
+	// A project member (user) without agent.message cannot message (removed from member role).
 	memberIdent := msgAuthzUserIdentity(member.ID)
-	allowed, reason = srv.authorizeAgentMessage(ctx, memberIdent, target, false)
-	if !allowed {
-		t.Fatalf("project member should be allowed to message project-mode agent: %s", reason)
+	allowed, _ = srv.authorizeAgentMessage(ctx, memberIdent, target, false)
+	if allowed {
+		t.Fatal("project member without agent.message should be denied messaging project-mode agent")
 	}
 }
 
@@ -252,8 +252,8 @@ func TestAuthorizeAgentMessage_ModeNone_DeniedExceptSuperAdmin(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Test 3: Project member without agent.attach messages a project-mode agent;
-// still cannot attach (D1)
+// Test 3: Project member without agent.message or agent.attach cannot message
+// or attach to a project-mode agent (D1)
 // ---------------------------------------------------------------------------
 
 func TestAuthorizeAgentMessage_MemberWithoutAttach(t *testing.T) {
@@ -263,14 +263,14 @@ func TestAuthorizeAgentMessage_MemberWithoutAttach(t *testing.T) {
 	target := msgAuthzAgent(t, s, "msg-only-target", projectID, store.MessageModeProject,
 		[]string{owner.ID})
 
-	// Member can message (has agent.message via project membership)
+	// Member cannot message (agent.message removed from member role)
 	memberIdent := msgAuthzUserIdentity(member.ID)
-	allowed, reason := srv.authorizeAgentMessage(ctx, memberIdent, target, false)
-	if !allowed {
-		t.Fatalf("member should be allowed to message project-mode agent: %s", reason)
+	allowed, _ := srv.authorizeAgentMessage(ctx, memberIdent, target, false)
+	if allowed {
+		t.Fatal("member without agent.message should be denied messaging project-mode agent")
 	}
 
-	// Verify the member cannot attach (separate permission axis)
+	// Verify the member also cannot attach (separate permission axis)
 	resource := agentResource(target)
 	decision := srv.authzService.CheckAccess(ctx, memberIdent, resource, ActionAttach)
 	if decision.Allowed {
@@ -791,8 +791,8 @@ func TestAuthorizeAgentMessage_IngressParity(t *testing.T) {
 		// Owner → none mode agent: denied (none sealed to non-super-admin)
 		{"owner→none", ownerIdent, noneAgent, false, false},
 
-		// Member → project mode agent: allowed (agent.message permission)
-		{"member→project", memberIdent, projectAgent, false, true},
+		// Member → project mode agent: denied (agent.message removed from member role)
+		{"member→project", memberIdent, projectAgent, false, false},
 		// Member → lineage mode agent: denied (not in ancestry, not project owner)
 		{"member→lineage", memberIdent, lineageAgent, false, false},
 		// Member → branch mode agent: denied (not in ancestry, not project owner)

--- a/pkg/hub/handlers_agent_message_mode_test.go
+++ b/pkg/hub/handlers_agent_message_mode_test.go
@@ -515,15 +515,21 @@ func TestSetMessageMode_LiveEffect(t *testing.T) {
 	agent := smmAgent(t, s, "smm-live-effect", projectID, store.MessageModeProject,
 		[]string{owner.ID})
 
-	// Verify member can message a project-mode agent.
+	// Member cannot message project-mode agent (agent.message removed from member role).
 	memberIdent := msgAuthzUserIdentity(member.ID)
-	allowed, reason := srv.authorizeAgentMessage(ctx, memberIdent, agent, false)
+	allowed, _ := srv.authorizeAgentMessage(ctx, memberIdent, agent, false)
+	if allowed {
+		t.Fatal("member without agent.message should be denied messaging project-mode agent")
+	}
+
+	// Owner CAN message project-mode agent (has agent.message via owner role).
+	ownerIdent := msgAuthzUserIdentity(owner.ID)
+	allowed, reason := srv.authorizeAgentMessage(ctx, ownerIdent, agent, false)
 	if !allowed {
-		t.Fatalf("member should message project-mode agent: %s", reason)
+		t.Fatalf("owner should message project-mode agent: %s", reason)
 	}
 
 	// Owner changes mode to none.
-	ownerIdent := msgAuthzUserIdentity(owner.ID)
 	rr := smmDoRequest(t, srv, agent.ID, SetMessageModeRequest{Mode: "none"}, ownerIdent)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
@@ -535,10 +541,10 @@ func TestSetMessageMode_LiveEffect(t *testing.T) {
 		t.Fatalf("failed to get agent: %v", err)
 	}
 
-	// Same message attempt -> DENIED (live effect).
-	allowed, _ = srv.authorizeAgentMessage(ctx, memberIdent, updatedAgent, false)
+	// Owner's message attempt -> DENIED after mode change to none (live effect).
+	allowed, _ = srv.authorizeAgentMessage(ctx, ownerIdent, updatedAgent, false)
 	if allowed {
-		t.Fatal("after mode change to none, message should be denied")
+		t.Fatal("after mode change to none, message should be denied even for owner")
 	}
 }
 

--- a/pkg/hub/seed.go
+++ b/pkg/hub/seed.go
@@ -373,7 +373,7 @@ func projectAdminPermissionIDs() []string {
 
 // projectMemberCuratedPermissionIDs returns the curated permission set for the
 // project-member role. This is an explicit list — NOT derived from registry
-// iteration. Members get create, read, list, and message actions on project-
+// iteration. Members get create, read, and list actions on project-
 // scoped resources.
 //
 // Excluded from this role:
@@ -385,10 +385,9 @@ func projectAdminPermissionIDs() []string {
 // added here and the role revision bumped.
 func projectMemberCuratedPermissionIDs() []string {
 	return []string{
-		// Agent operations (create, read, list, message)
+		// Agent operations (create, read, list)
 		"agent.create",
 		"agent.list",
-		"agent.message",
 		"agent.read",
 		// Harness config (create, read, list)
 		"harness_config.create",

--- a/pkg/hub/seed.go
+++ b/pkg/hub/seed.go
@@ -145,7 +145,7 @@ func BuiltInRoles() []BuiltInRole {
 			Name:        store.ProjectRoleMember,
 			Description: "Project member with basic project permissions",
 			ScopeType:   store.RoleScopeProject,
-			Revision:    2, // R2: remove agent.stop_all, skill.create, project.create
+			Revision:    3, // R3: remove agent.message (policy alignment with agent.attach)
 			Permissions: projectMemberCuratedPermissionIDs(),
 		},
 
@@ -377,6 +377,7 @@ func projectAdminPermissionIDs() []string {
 // scoped resources.
 //
 // Excluded from this role:
+//   - agent.message: messaging requires owner/admin role or ancestry
 //   - agent.stop_all: bulk stop is an administrative action, not basic membership
 //   - skill.create: skill creation is an admin/owner action
 //   - project.create: hub-level operation, meaningless in a project-scoped role

--- a/pkg/hub/seed.go
+++ b/pkg/hub/seed.go
@@ -825,10 +825,9 @@ func projectPermissionIDsExcluding(excludeAction string) []string {
 // project member gets: create agents, read/list most things.
 func projectMemberPermissionIDs() []string {
 	memberActions := map[string]bool{
-		"create":  true,
-		"read":    true,
-		"list":    true,
-		"message": true,
+		"create": true,
+		"read":   true,
+		"list":   true,
 	}
 	projectResources := map[string]bool{
 		permissions.ResourceAgent:          true,


### PR DESCRIPTION
Remove agent.message from project-member role. Members could previously message any project-mode agent regardless of ownership. Messaging now requires owner/admin role or ancestry (agent creator), aligning with the terminal attach permission gate.