### PR TITLE
fix: show permission error on terminal attach denied instead of generic 1006

### DIFF
--- a/pkg/hub/handlers_agents_core.go
+++ b/pkg/hub/handlers_agents_core.go
@@ -2062,8 +2062,8 @@ func (s *Server) handleAgentByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Handle PTY WebSocket connections
-	if action == "pty" && isWebSocketUpgrade(r) {
+	// Handle PTY connections (WebSocket upgrade and auth preflight)
+	if action == "pty" {
 		s.handleAgentPTY(w, r)
 		return
 	}

--- a/pkg/hub/pty_handlers.go
+++ b/pkg/hub/pty_handlers.go
@@ -60,12 +60,6 @@ func (s *Server) handleAgentPTY(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify WebSocket upgrade
-	if !isWebSocketUpgrade(r) {
-		writeError(w, http.StatusBadRequest, ErrCodeInvalidRequest, "WebSocket upgrade required", nil)
-		return
-	}
-
 	// Check authentication - support both Bearer token and ticket parameter
 	identity := GetIdentityFromContext(ctx)
 	if identity == nil {
@@ -101,6 +95,14 @@ func (s *Server) handleAgentPTY(w http.ResponseWriter, r *http.Request) {
 	// project. Attaching a PTY is not read-class, so the agent project read
 	// baseline deliberately does not reach it.
 	if !s.authorizeAgentLifecycle(w, r, agent) {
+		return
+	}
+
+	// Verify WebSocket upgrade — auth errors are already handled above
+	// for both WS and non-WS (preflight) requests. An authorized non-WS
+	// request is a preflight check: return 200 to signal "you have permission."
+	if !isWebSocketUpgrade(r) {
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 

--- a/web/src/components/pages/terminal.ts
+++ b/web/src/components/pages/terminal.ts
@@ -612,7 +612,7 @@ export class ScionPageTerminal extends LitElement {
       // Wait for render, then initialize terminal
       await this.updateComplete;
       await this.initTerminal();
-      this.connectWebSocket();
+      void this.connectWebSocket();
     } catch (err) {
       console.error('Failed to load agent:', err);
       this.error = err instanceof Error ? err.message : 'Failed to load agent';
@@ -859,8 +859,32 @@ export class ScionPageTerminal extends LitElement {
     };
   }
 
-  private connectWebSocket(): void {
+  private async connectWebSocket(): Promise<void> {
     if (!this.terminal) return;
+
+    // Preflight auth check — the browser WebSocket API hides HTTP error
+    // codes on failed upgrades (always returns close code 1006), so we
+    // cannot distinguish "permission denied" from "network error" after
+    // the fact. A preflight fetch surfaces the real HTTP status.
+    const preflightUrl = `/api/v1/agents/${this.agentId}/pty`;
+    try {
+      const resp = await fetch(preflightUrl, { credentials: 'include' });
+      if (resp.status === 403) {
+        this.error = 'You do not have permission to attach to this agent.';
+        return;
+      }
+      if (resp.status === 401) {
+        this.error = 'Authentication required to access this terminal.';
+        return;
+      }
+      if (resp.status === 404) {
+        this.error = 'Agent not found.';
+        return;
+      }
+    } catch {
+      // Network error — fall through to WebSocket attempt, which will
+      // surface its own error.
+    }
 
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     const url = `${protocol}//${window.location.host}/api/v1/agents/${this.agentId}/pty?cols=${this.terminal.cols}&rows=${this.terminal.rows}`;

--- a/web/src/components/pages/terminal.ts
+++ b/web/src/components/pages/terminal.ts
@@ -869,21 +869,32 @@ export class ScionPageTerminal extends LitElement {
     const preflightUrl = `/api/v1/agents/${this.agentId}/pty`;
     try {
       const resp = await fetch(preflightUrl, { credentials: 'include' });
-      if (resp.status === 403) {
-        this.error = 'You do not have permission to attach to this agent.';
+      if (!resp.ok) {
+        // Surface specific messages for common auth errors; fall back to
+        // the server's error body for everything else (422 no broker,
+        // 503 broker unavailable, etc.).
+        if (resp.status === 403) {
+          this.error = 'You do not have permission to attach to this agent.';
+        } else if (resp.status === 401) {
+          this.error = 'Authentication required to access this terminal.';
+        } else if (resp.status === 404) {
+          this.error = 'Agent not found.';
+        } else {
+          const message = await extractApiError(
+            resp,
+            `Terminal connection failed: ${resp.statusText}`
+          );
+          this.error = message;
+        }
         return;
       }
-      if (resp.status === 401) {
-        this.error = 'Authentication required to access this terminal.';
-        return;
-      }
-      if (resp.status === 404) {
-        this.error = 'Agent not found.';
-        return;
-      }
-    } catch {
-      // Network error — fall through to WebSocket attempt, which will
-      // surface its own error.
+    } catch (err) {
+      // Network error during preflight.
+      this.error =
+        err instanceof Error
+          ? `Could not connect to terminal: ${err.message}`
+          : 'A network error occurred while connecting to the terminal.';
+      return;
     }
 
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';


### PR DESCRIPTION
Show clear permission error instead of generic Connection closed 1006 when a user without agent.attach opens the web terminal. Adds client-side preflight auth check before WebSocket connection, and reorders server-side PTY handler so auth runs before the WebSocket upgrade gate.