### PR TITLE
feat(extras): add Cloud Run IAP reverse proxy with H2C support

### DIFF
--- a/extras/cloudrun-iap-proxy/Dockerfile
+++ b/extras/cloudrun-iap-proxy/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.26-alpine AS builder
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /app/proxy .
+
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates tzdata && \
+    adduser -D -u 10001 proxyuser
+
+WORKDIR /app
+COPY --from=builder /app/proxy /app/proxy
+
+USER 10001:10001
+
+EXPOSE 8080
+
+ENTRYPOINT ["/app/proxy"]

--- a/extras/cloudrun-iap-proxy/README.md
+++ b/extras/cloudrun-iap-proxy/README.md
@@ -1,0 +1,80 @@
+# Cloud Run IAP Reverse Proxy
+
+A lightweight Go reverse proxy designed to run on Google Cloud Run to front internal VPC services (such as a Scion Hub instance running on a GCE VM) while preserving Identity-Aware Proxy (IAP) headers and supporting HTTP/2 streaming.
+
+## Features
+
+- **IAP Header Preservation:** Forwards and logs incoming Google Identity-Aware Proxy assertion headers:
+  - `X-Goog-IAP-JWT-Assertion`
+  - `X-Goog-Authenticated-User-Email`
+  - `X-Goog-Authenticated-User-Id`
+- **Host Header Rewriting:** Sets `req.Host` to the target host to properly route to virtual hosts on the backend.
+- **HTTP/2 (H2C) Support:** Uses `golang.org/x/net/http2/h2c` to support HTTP/2 cleartext multiplexing on Cloud Run, crucial for high-concurrency event streams and Server-Sent Events (SSE).
+- **Health Check Endpoint:** Provides `/proxy-healthz` for Cloud Run and external uptime checks without proxying back to the target service.
+- **Direct VPC Egress Ready:** Easily deployed with Cloud Run Direct VPC Egress to reach internal compute instances on private RFC 1918 IPs.
+
+## Architecture
+
+```
+[User Browser / Client]
+          │
+          ▼ (HTTPS)
+ [Cloud Run (IAP Proxy)]
+          │
+          ▼ (Direct VPC Egress / Private IP)
+   [Scion Hub (GCE VM)]
+```
+
+## Configuration
+
+| Environment Variable | Description | Default | Required |
+|----------------------|-------------|---------|----------|
+| `TARGET_URL` | Destination backend URL (e.g., `http://10.128.0.2:8080`) | — | **Yes** |
+| `PORT` | Listening port for the proxy server | `8080` | No |
+
+## Deployment
+
+### Prerequisites
+
+- `gcloud` CLI authenticated with permissions to deploy Cloud Run services and configure VPC access.
+- An existing internal service (e.g. Scion Hub on GCE) with internal IP and port reachable within the VPC network.
+
+### Using `deploy.sh`
+
+```bash
+export TARGET_URL="http://<INTERNAL_IP>:8080"
+export PROJECT_ID="my-gcp-project"
+export REGION="us-central1"
+export SERVICE_NAME="scion-hub-iap-proxy"
+
+./deploy.sh
+```
+
+### Manual Deployment via `gcloud`
+
+```bash
+gcloud run deploy scion-hub-iap-proxy \
+    --project="my-gcp-project" \
+    --region="us-central1" \
+    --source="." \
+    --set-env-vars="TARGET_URL=http://<INTERNAL_IP>:8080" \
+    --network="default" \
+    --subnet="default" \
+    --vpc-egress="all-traffic" \
+    --allow-unauthenticated \
+    --port=8080
+```
+
+## Development and Testing
+
+Run unit tests locally:
+
+```bash
+go test -v ./...
+```
+
+Run proxy locally against a local backend:
+
+```bash
+TARGET_URL="http://localhost:8080" PORT=9000 go run .
+```

--- a/extras/cloudrun-iap-proxy/deploy.sh
+++ b/extras/cloudrun-iap-proxy/deploy.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# extras/cloudrun-iap-proxy/deploy.sh - Deploy Go IAP Reverse Proxy to Cloud Run
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Configuration with defaults
+PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project 2>/dev/null || true)}"
+REGION="${REGION:-us-central1}"
+SERVICE_NAME="${SERVICE_NAME:-scion-hub-iap-proxy}"
+TARGET_URL="${TARGET_URL:-}"
+VPC_NETWORK="${VPC_NETWORK:-default}"
+VPC_SUBNET="${VPC_SUBNET:-default}"
+ALLOW_UNAUTHENTICATED="${ALLOW_UNAUTHENTICATED:-true}"
+
+usage() {
+    echo "Usage: TARGET_URL=<target-url> [PROJECT_ID=<project-id>] [REGION=<region>] [SERVICE_NAME=<service-name>] $0"
+    echo ""
+    echo "Environment Variables:"
+    echo "  TARGET_URL            Target backend URL to proxy to (e.g., http://10.128.0.2:8080) [Required]"
+    echo "  PROJECT_ID            GCP project ID (default: current gcloud project: '${PROJECT_ID}')"
+    echo "  REGION                Cloud Run region (default: '${REGION}')"
+    echo "  SERVICE_NAME          Cloud Run service name (default: '${SERVICE_NAME}')"
+    echo "  VPC_NETWORK           VPC network for Direct VPC Egress (default: '${VPC_NETWORK}')"
+    echo "  VPC_SUBNET            VPC subnetwork for Direct VPC Egress (default: '${VPC_SUBNET}')"
+    echo "  ALLOW_UNAUTHENTICATED Allow unauthenticated invocation (default: '${ALLOW_UNAUTHENTICATED}')"
+    exit 1
+}
+
+if [[ -z "${TARGET_URL}" ]]; then
+    echo "ERROR: TARGET_URL is required." >&2
+    usage
+fi
+
+if [[ -z "${PROJECT_ID}" ]]; then
+    echo "ERROR: PROJECT_ID is required (set PROJECT_ID or configure active gcloud project)." >&2
+    usage
+fi
+
+echo "=== Deploying Cloud Run IAP Proxy ==="
+echo "Project:      ${PROJECT_ID}"
+echo "Region:       ${REGION}"
+echo "Service Name: ${SERVICE_NAME}"
+echo "Target URL:   ${TARGET_URL}"
+echo "VPC Network:  ${VPC_NETWORK}"
+echo "VPC Subnet:   ${VPC_SUBNET}"
+
+AUTH_FLAG="--allow-unauthenticated"
+if [[ "${ALLOW_UNAUTHENTICATED}" == "false" ]]; then
+    AUTH_FLAG="--no-allow-unauthenticated"
+fi
+
+# Deploy Cloud Run service with Direct VPC Egress
+gcloud run deploy "${SERVICE_NAME}" \
+    --project="${PROJECT_ID}" \
+    --region="${REGION}" \
+    --source="${SCRIPT_DIR}" \
+    --set-env-vars="TARGET_URL=${TARGET_URL}" \
+    --network="${VPC_NETWORK}" \
+    --subnet="${VPC_SUBNET}" \
+    --vpc-egress=all-traffic \
+    ${AUTH_FLAG} \
+    --port=8080
+
+URL=$(gcloud run services describe "${SERVICE_NAME}" --project="${PROJECT_ID}" --region="${REGION}" --format="value(status.url)")
+
+echo ""
+echo "=== Deployment Successful ==="
+echo "Cloud Run URL: ${URL}"
+echo ""
+echo "Testing Cloud Run proxy connection..."
+curl -s "${URL}/proxy-healthz" || true
+echo ""

--- a/extras/cloudrun-iap-proxy/go.mod
+++ b/extras/cloudrun-iap-proxy/go.mod
@@ -1,0 +1,7 @@
+module github.com/GoogleCloudPlatform/scion/extras/cloudrun-iap-proxy
+
+go 1.23
+
+require golang.org/x/net v0.33.0
+
+require golang.org/x/text v0.21.0 // indirect

--- a/extras/cloudrun-iap-proxy/go.sum
+++ b/extras/cloudrun-iap-proxy/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=

--- a/extras/cloudrun-iap-proxy/main.go
+++ b/extras/cloudrun-iap-proxy/main.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+)
+
+// newProxy creates a ReverseProxy that forwards traffic to targetURL,
+// preserving and logging Google Identity-Aware Proxy (IAP) headers.
+func newProxy(targetURL *url.URL) *httputil.ReverseProxy {
+	return &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = targetURL.Scheme
+			req.URL.Host = targetURL.Host
+			req.Host = targetURL.Host
+
+			// Ensure all IAP headers are explicitly preserved and logged
+			iapJWT := req.Header.Get("X-Goog-IAP-JWT-Assertion")
+			iapEmail := req.Header.Get("X-Goog-Authenticated-User-Email")
+			iapID := req.Header.Get("X-Goog-Authenticated-User-Id")
+
+			if iapJWT != "" || iapEmail != "" {
+				log.Printf("[Proxy] %s %s | IAP Auth Header Present | Email: %q | JWT Len: %d", req.Method, req.URL.Path, iapEmail, len(iapJWT))
+			} else {
+				log.Printf("[Proxy] %s %s | No IAP Auth Header Present", req.Method, req.URL.Path)
+			}
+
+			if iapJWT != "" {
+				req.Header.Set("X-Goog-IAP-JWT-Assertion", iapJWT)
+			}
+			if iapEmail != "" {
+				req.Header.Set("X-Goog-Authenticated-User-Email", iapEmail)
+			}
+			if iapID != "" {
+				req.Header.Set("X-Goog-Authenticated-User-Id", iapID)
+			}
+		},
+		FlushInterval: 100 * time.Millisecond,
+		ErrorHandler: func(w http.ResponseWriter, req *http.Request, err error) {
+			log.Printf("[Proxy Error] %s %s: %v", req.Method, req.URL.Path, err)
+			http.Error(w, "Bad Gateway (Proxy Failure)", http.StatusBadGateway)
+		},
+	}
+}
+
+// newMux returns an http.ServeMux configured with health check and reverse proxy endpoints.
+func newMux(targetURL *url.URL) *http.ServeMux {
+	proxy := newProxy(targetURL)
+	mux := http.NewServeMux()
+
+	// Cloud Run health check probe
+	mux.HandleFunc("/proxy-healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok","service":"cloudrun-iap-proxy"}`))
+	})
+
+	// Reverse proxy for all other routes
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/proxy-healthz") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"status":"ok"}`))
+			return
+		}
+		proxy.ServeHTTP(w, r)
+	})
+
+	return mux
+}
+
+// parseTargetURL validates and parses the TARGET_URL string.
+func parseTargetURL(raw string) (*url.URL, error) {
+	if raw == "" {
+		return nil, fmt.Errorf("TARGET_URL is required (e.g. http://10.128.0.10:8080)")
+	}
+	if !strings.HasPrefix(raw, "http://") && !strings.HasPrefix(raw, "https://") {
+		raw = "http://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid TARGET_URL %q: %w", raw, err)
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("TARGET_URL %q must specify a host", raw)
+	}
+	return u, nil
+}
+
+func main() {
+	targetURLStr := os.Getenv("TARGET_URL")
+	targetURL, err := parseTargetURL(targetURLStr)
+	if err != nil {
+		log.Fatalf("Configuration error: %v", err)
+	}
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	log.Printf("Starting Cloud Run IAP Reverse Proxy...")
+	log.Printf("  Listening on port: %s", port)
+	log.Printf("  Proxying to:       %s", targetURL.String())
+
+	mux := newMux(targetURL)
+
+	// Wrap handler with h2c for HTTP/2 cleartext support on Cloud Run
+	h2s := &http2.Server{}
+	h2cHandler := h2c.NewHandler(mux, h2s)
+
+	server := &http.Server{
+		Addr:         ":" + port,
+		Handler:      h2cHandler,
+		ReadTimeout:  30 * time.Minute,
+		WriteTimeout: 30 * time.Minute,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	log.Printf("Proxy server active with H2C support on :%s", port)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("Server stopped: %v", err)
+	}
+}

--- a/extras/cloudrun-iap-proxy/main_test.go
+++ b/extras/cloudrun-iap-proxy/main_test.go
@@ -1,0 +1,193 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestParseTargetURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantErr  bool
+		wantHost string
+	}{
+		{
+			name:     "valid http url",
+			input:    "http://10.128.0.10:8080",
+			wantErr:  false,
+			wantHost: "10.128.0.10:8080",
+		},
+		{
+			name:     "valid https url",
+			input:    "https://example.internal:8443",
+			wantErr:  false,
+			wantHost: "example.internal:8443",
+		},
+		{
+			name:     "missing scheme adds http",
+			input:    "10.128.0.10:8080",
+			wantErr:  false,
+			wantHost: "10.128.0.10:8080",
+		},
+		{
+			name:    "empty string fails",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			u, err := parseTargetURL(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for input %q, got nil", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for input %q: %v", tc.input, err)
+			}
+			if u.Host != tc.wantHost {
+				t.Errorf("host = %q, want %q", u.Host, tc.wantHost)
+			}
+		})
+	}
+}
+
+func TestHealthCheck(t *testing.T) {
+	target, _ := url.Parse("http://127.0.0.1:9999")
+	handler := newMux(target)
+
+	req := httptest.NewRequest(http.MethodGet, "/proxy-healthz", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode json body: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Errorf("body status = %q, want 'ok'", body["status"])
+	}
+	if body["service"] != "cloudrun-iap-proxy" {
+		t.Errorf("body service = %q, want 'cloudrun-iap-proxy'", body["service"])
+	}
+}
+
+func TestProxyForwardingAndIAPHeaders(t *testing.T) {
+	type receivedReq struct {
+		Host     string
+		Path     string
+		Query    string
+		JWT      string
+		Email    string
+		UserID   string
+		BodyText string
+	}
+
+	var received receivedReq
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		received = receivedReq{
+			Host:     r.Host,
+			Path:     r.URL.Path,
+			Query:    r.URL.RawQuery,
+			JWT:      r.Header.Get("X-Goog-IAP-JWT-Assertion"),
+			Email:    r.Header.Get("X-Goog-Authenticated-User-Email"),
+			UserID:   r.Header.Get("X-Goog-Authenticated-User-Id"),
+			BodyText: string(bodyBytes),
+		}
+		w.Header().Set("X-Backend-Reply", "pong")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("backend-response"))
+	}))
+	defer backend.Close()
+
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("failed to parse backend url: %v", err)
+	}
+
+	handler := newMux(backendURL)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents?filter=active", strings.NewReader("sample-payload"))
+	req.Header.Set("X-Goog-IAP-JWT-Assertion", "test-iap-jwt-token")
+	req.Header.Set("X-Goog-Authenticated-User-Email", "accounts.google.com:developer@example.com")
+	req.Header.Set("X-Goog-Authenticated-User-Id", "accounts.google.com:123456789")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if rr.Header().Get("X-Backend-Reply") != "pong" {
+		t.Errorf("expected X-Backend-Reply header 'pong', got %q", rr.Header().Get("X-Backend-Reply"))
+	}
+	if rr.Body.String() != "backend-response" {
+		t.Errorf("body = %q, want 'backend-response'", rr.Body.String())
+	}
+
+	if received.Host != backendURL.Host {
+		t.Errorf("forwarded Host = %q, want %q", received.Host, backendURL.Host)
+	}
+	if received.Path != "/api/v1/agents" {
+		t.Errorf("forwarded Path = %q, want '/api/v1/agents'", received.Path)
+	}
+	if received.Query != "filter=active" {
+		t.Errorf("forwarded Query = %q, want 'filter=active'", received.Query)
+	}
+	if received.JWT != "test-iap-jwt-token" {
+		t.Errorf("forwarded JWT = %q, want 'test-iap-jwt-token'", received.JWT)
+	}
+	if received.Email != "accounts.google.com:developer@example.com" {
+		t.Errorf("forwarded Email = %q, want 'accounts.google.com:developer@example.com'", received.Email)
+	}
+	if received.UserID != "accounts.google.com:123456789" {
+		t.Errorf("forwarded UserID = %q, want 'accounts.google.com:123456789'", received.UserID)
+	}
+	if received.BodyText != "sample-payload" {
+		t.Errorf("forwarded BodyText = %q, want 'sample-payload'", received.BodyText)
+	}
+}
+
+func TestProxyErrorReturns502(t *testing.T) {
+	// Point to unreachable local port
+	target, _ := url.Parse("http://127.0.0.1:54321")
+	handler := newMux(target)
+
+	req := httptest.NewRequest(http.MethodGet, "/some-route", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502 Bad Gateway, got %d", rr.Code)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `extras/cloudrun-iap-proxy/`, a lightweight Go reverse proxy designed to run on Google Cloud Run to front internal VPC services (such as a Scion Hub instance running on a private GCE VM) while preserving Identity-Aware Proxy (IAP) assertion headers and supporting HTTP/2 streaming.

## Features & Changes

- **Reverse Proxy with H2C:** Supports HTTP/2 cleartext multiplexing via `golang.org/x/net/http2/h2c`, essential for long-lived Server-Sent Events (SSE) connections and high concurrency.
- **IAP Assertion Preservation:** Explicitly captures, logs, and forwards Google Cloud IAP identity headers:
  - `X-Goog-IAP-JWT-Assertion`
  - `X-Goog-Authenticated-User-Email`
  - `X-Goog-Authenticated-User-Id`
- **Host Rewriting:** Resets `req.Host` to match the target host so backends receive the expected virtual host.
- **Health Check Probe:** Exposes `/proxy-healthz` for Cloud Run container lifecycle checks without proxying to the downstream backend.
- **Direct VPC Egress Deployment:** Includes `deploy.sh` script to deploy to Cloud Run with `--vpc-egress=all-traffic`.
- **Unit Tests:** Adds `main_test.go` covering URL parsing, health probe, IAP header forwarding, and 502 Bad Gateway handling.
- **Documentation:** Adds `README.md` with architecture, configuration, deployment, and testing instructions.

## Verification

- `go test -v ./...` in `extras/cloudrun-iap-proxy` passes.
- `make fmt-check` passes.