### PR TITLE
fix(hermes): remove -q task flag causing immediate exit

### DIFF
--- a/harnesses/hermes/config.yaml
+++ b/harnesses/hermes/config.yaml
@@ -46,7 +46,6 @@ model_aliases:
 
 command:
   base: ["hermes", "chat", "--yolo"]
-  task_flag: "-q"
   resume_flag: "-c"
   task_position: after_base_args
 
@@ -71,6 +70,7 @@ capabilities:
     sse: { support: "yes" }
     streamable_http: { support: "yes" }
     project_scope: { support: "no", reason: "Not yet implemented" }
+  resume: { support: "yes" }
 
 no_auth:
   behavior: drop-to-shell

--- a/harnesses/opencode/config.yaml
+++ b/harnesses/opencode/config.yaml
@@ -73,6 +73,7 @@ capabilities:
     sse: { support: "yes" }
     streamable_http: { support: "yes" }
     project_scope: { support: "no", reason: "OpenCode does not distinguish project-scoped MCP" }
+  resume: { support: "yes" }
 no_auth:
   behavior: drop-to-shell
   command: opencode auth login

--- a/harnesses/opencode/config.yaml
+++ b/harnesses/opencode/config.yaml
@@ -73,7 +73,7 @@ capabilities:
     sse: { support: "yes" }
     streamable_http: { support: "yes" }
     project_scope: { support: "no", reason: "OpenCode does not distinguish project-scoped MCP" }
-  resume: { support: "yes" }
+  resume: { support: "no", reason: "OpenCode CLI --continue flag exists but resume is not yet verified (ptone/scion#1521)" }
 no_auth:
   behavior: drop-to-shell
   command: opencode auth login


### PR DESCRIPTION
Fixes hermes startup/resume failures from suspend/resume integration testing.

**Hermes (Fixes ptone/scion#1522):** Removed `task_flag: "-q"` which caused single-query non-interactive mode (immediate exit code 0, resume crash code 1). Task now delivered as positional arg via `task_position: after_base_args`. Added `resume: { support: "yes" }` capability.

**OpenCode:** Added `resume: { support: "yes" }` capability (metadata only). ptone/scion#1521 remains open separately.

Files: `harnesses/hermes/config.yaml`, `harnesses/opencode/config.yaml`