### PR TITLE
fix(antigravity): catch OSError in _get_agy_version for missing binary

### DIFF
--- a/harnesses/antigravity/provision.py
+++ b/harnesses/antigravity/provision.py
@@ -63,7 +63,7 @@ def _get_agy_version() -> tuple[int, ...] | None:
         ).strip()
         parts = out.split(".")
         return tuple(int(p) for p in parts)
-    except (subprocess.SubprocessError, ValueError):
+    except (subprocess.SubprocessError, ValueError, OSError):
         return None
 
 


### PR DESCRIPTION
Fixes antigravity provisioner crash when agy binary is missing from PATH.

_get_agy_version() catches SubprocessError and ValueError but not FileNotFoundError (an OSError subclass). When vertex-ai auth is auto-detected on GCP, the provisioner calls agy --version and crashes instead of falling through to a clear ProvisionError.

Fix: add OSError to the exception handler. One-line change in harnesses/antigravity/provision.py.

Fixes ptone/scion#1525