### PR TITLE
fix(hermes): use named session to prevent resume crash on early suspend

### DIFF
--- a/harnesses/hermes/config.yaml
+++ b/harnesses/hermes/config.yaml
@@ -45,8 +45,7 @@ model_aliases:
   extra-large: anthropic/claude-opus-4
 
 command:
-  base: ["hermes", "chat", "--yolo"]
-  resume_flag: "-c"
+  base: ["hermes", "chat", "--yolo", "-c", "scion-session", "--create-if-missing"]
   task_position: after_base_args
 
 capabilities:


### PR DESCRIPTION
When an agent is suspended before the first model API response (~10s), no session exists in state.db. The bare -c flag then calls sys.exit(1) with "No previous CLI session found to continue."

Uses a named session ("scion-session") with --create-if-missing in the base command, so resume always succeeds — either continuing the existing session or creating a fresh one.

Relates-To: ptone/scion#1522