### PR TITLE
fix(agent): clean stale auth-candidates on --no-auth retry

### DIFF
--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -606,12 +606,12 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		}
 		warnings = append(warnings, fmt.Sprintf("Auth: resolved as %s", authDetail))
 	}
+authDone:
 	if opts.NoAuth {
 		// Clean up stale auth-candidates from a prior run so the
 		// provisioner sees no candidates and runs in no-auth mode.
 		_ = os.Remove(filepath.Join(agentHome, ".scion", "harness", "inputs", "auth-candidates.json"))
 	}
-authDone:
 
 	// Unconditionally clear corrupted opts.HarnessAuth. This runs even when
 	// NoAuth is true (the auth block is skipped) to prevent re-persisting

--- a/pkg/agent/run.go
+++ b/pkg/agent/run.go
@@ -606,6 +606,11 @@ func (m *AgentManager) Start(ctx context.Context, opts api.StartOptions) (*api.A
 		}
 		warnings = append(warnings, fmt.Sprintf("Auth: resolved as %s", authDetail))
 	}
+	if opts.NoAuth {
+		// Clean up stale auth-candidates from a prior run so the
+		// provisioner sees no candidates and runs in no-auth mode.
+		_ = os.Remove(filepath.Join(agentHome, ".scion", "harness", "inputs", "auth-candidates.json"))
+	}
 authDone:
 
 	// Unconditionally clear corrupted opts.HarnessAuth. This runs even when


### PR DESCRIPTION
When an agent retries with --no-auth after a previous auth-configured run (e.g., vertex-ai auto-detected on GCP), the old auth-candidates.json persists because the NoAuth path skips the entire auth block including ApplyAuthSettings(). The provisioner reads the stale file, finds explicit_type set, and fails instead of running in no-auth mode.

Removes stale auth-candidates.json when NoAuth is true, placed after the authDone label so all four no-auth entry paths (explicit flag + three goto fallbacks) reach the cleanup.

Closes ptone/scion#1528